### PR TITLE
Add HTTP trigger API and client

### DIFF
--- a/controller/api.go
+++ b/controller/api.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime/debug"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/handlers"
@@ -45,7 +46,7 @@ func (api *API) respondWithSuccess(w http.ResponseWriter, resp []byte) {
 func (api *API) respondWithError(w http.ResponseWriter, err error) {
 	var code int
 	var msg string
-
+	debug.PrintStack()
 	fe, ok := err.(fission.Error)
 	if ok {
 		msg = fe.Message
@@ -83,11 +84,11 @@ func (api *API) serve(port int) {
 	r.HandleFunc("/functions/{function}", api.FunctionApiUpdate).Methods("PUT")
 	r.HandleFunc("/functions/{function}", api.FunctionApiDelete).Methods("DELETE")
 
-	// r.HandleFunc("/triggers/http", api.HTTPTriggerApiList).Methods("GET")
-	// r.HandleFunc("/triggers/http", api.HTTPTriggerApiCreate).Methods("POST")
-	// r.HandleFunc("/triggers/http/{httpTrigger}", api.HTTPTriggerApiGet).Methods("GET")
-	// r.HandleFunc("/triggers/http/{httpTrigger}", api.HTTPTriggerApiUpdate).Methods("PUT")
-	// r.HandleFunc("/triggers/http/{httpTrigger}", api.HTTPTriggerApiDelete).Methods("DELETE")
+	r.HandleFunc("/triggers/http", api.HTTPTriggerApiList).Methods("GET")
+	r.HandleFunc("/triggers/http", api.HTTPTriggerApiCreate).Methods("POST")
+	r.HandleFunc("/triggers/http/{httpTrigger}", api.HTTPTriggerApiGet).Methods("GET")
+	r.HandleFunc("/triggers/http/{httpTrigger}", api.HTTPTriggerApiUpdate).Methods("PUT")
+	r.HandleFunc("/triggers/http/{httpTrigger}", api.HTTPTriggerApiDelete).Methods("DELETE")
 
 	// r.HandleFunc("/environments", api.EnvironmentApiList).Methods("GET")
 	// r.HandleFunc("/environments", api.EnvironmentApiCreate).Methods("POST")

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+
+	"github.com/platform9/fission"
+)
+
+func (api *API) HTTPTriggerApiList(w http.ResponseWriter, r *http.Request) {
+	triggers, err := api.HTTPTriggerStore.List()
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	resp, err := json.Marshal(triggers)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	api.respondWithSuccess(w, resp)
+}
+
+func (api *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		api.respondWithError(w, err)
+	}
+
+	var t fission.HTTPTrigger
+	err = json.Unmarshal(body, &t)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	uid, err := api.HTTPTriggerStore.Create(&t)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	m := &fission.Metadata{Name: t.Name, Uid: uid}
+	resp, err := json.Marshal(m)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	api.respondWithSuccess(w, resp)
+}
+
+func (api *API) HTTPTriggerApiGet(w http.ResponseWriter, r *http.Request) {
+	var m fission.Metadata
+
+	vars := mux.Vars(r)
+	m.Name = vars["httpTrigger"]
+	m.Uid = r.FormValue("uid") // empty if uid is absent
+
+	t, err := api.HTTPTriggerStore.Get(&m)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	resp, err := json.Marshal(t)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	api.respondWithSuccess(w, resp)
+}
+
+func (api *API) HTTPTriggerApiUpdate(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	name := vars["httpTrigger"]
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		api.respondWithError(w, err)
+	}
+
+	var t fission.HTTPTrigger
+	err = json.Unmarshal(body, &t)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	if name != t.Metadata.Name {
+		err = fission.MakeError(fission.ErrorInvalidArgument, "HTTPTrigger name doesn't match URL")
+		api.respondWithError(w, err)
+		return
+	}
+
+	uid, err := api.HTTPTriggerStore.Update(&t)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	m := &fission.Metadata{Name: t.Name, Uid: uid}
+	resp, err := json.Marshal(m)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+	api.respondWithSuccess(w, resp)
+}
+
+func (api *API) HTTPTriggerApiDelete(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	var m fission.Metadata
+	m.Name = vars["httpTrigger"]
+
+	m.Uid = r.FormValue("uid") // empty if uid is absent
+	if len(m.Uid) == 0 {
+		log.WithFields(log.Fields{"httpTrigger": m.Name}).Info("Deleting all versions")
+	}
+
+	err := api.HTTPTriggerStore.Delete(m)
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+
+	api.respondWithSuccess(w, []byte(""))
+}

--- a/controller/httpTriggerStore.go
+++ b/controller/httpTriggerStore.go
@@ -26,12 +26,12 @@ type HTTPTriggerStore struct {
 	resourceStore
 }
 
-func (hts *HTTPTriggerStore) create(ht *fission.HTTPTrigger) error {
+func (hts *HTTPTriggerStore) Create(ht *fission.HTTPTrigger) (string, error) {
 	ht.Metadata.Uid = uuid.NewV4().String()
-	return hts.resourceStore.create(ht)
+	return ht.Metadata.Uid, hts.resourceStore.create(ht)
 }
 
-func (hts *HTTPTriggerStore) read(m fission.Metadata) (*fission.HTTPTrigger, error) {
+func (hts *HTTPTriggerStore) Get(m *fission.Metadata) (*fission.HTTPTrigger, error) {
 	var ht fission.HTTPTrigger
 	err := hts.resourceStore.read(m.Name, &ht)
 	if err != nil {
@@ -40,12 +40,12 @@ func (hts *HTTPTriggerStore) read(m fission.Metadata) (*fission.HTTPTrigger, err
 	return &ht, nil
 }
 
-func (hts *HTTPTriggerStore) update(ht *fission.HTTPTrigger) error {
+func (hts *HTTPTriggerStore) Update(ht *fission.HTTPTrigger) (string, error) {
 	ht.Metadata.Uid = uuid.NewV4().String()
-	return hts.resourceStore.update(ht)
+	return ht.Metadata.Uid, hts.resourceStore.update(ht)
 }
 
-func (hts *HTTPTriggerStore) delete(m fission.Metadata) error {
+func (hts *HTTPTriggerStore) Delete(m fission.Metadata) error {
 	typeName, err := getTypeName(fission.HTTPTrigger{})
 	if err != nil {
 		return err
@@ -53,7 +53,7 @@ func (hts *HTTPTriggerStore) delete(m fission.Metadata) error {
 	return hts.resourceStore.delete(typeName, m.Name)
 }
 
-func (hts *HTTPTriggerStore) list() ([]fission.HTTPTrigger, error) {
+func (hts *HTTPTriggerStore) List() ([]fission.HTTPTrigger, error) {
 	typeName, err := getTypeName(fission.HTTPTrigger{})
 	if err != nil {
 		return nil, err

--- a/controller/resourceStore.go
+++ b/controller/resourceStore.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"reflect"
 	"time"
-	
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/client"
 	"github.com/satori/go.uuid"
@@ -40,17 +40,17 @@ func makeResourceStore(fs *fileStore, ks client.KeysAPI, s serializer) *resource
 }
 
 func getEtcdKeyAPI(etcdUrls []string) client.KeysAPI {
-        cfg := client.Config{
-                Endpoints: etcdUrls,
-                Transport: client.DefaultTransport,
-                // set timeout per request to fail fast when the target endpoint is unavailable
-                HeaderTimeoutPerRequest: time.Second,
-        }
-        c, err := client.New(cfg)
-        if err != nil {
-                log.Fatalf("failed to connect to etcd: %v", err)
-        }
-        return client.NewKeysAPI(c)
+	cfg := client.Config{
+		Endpoints: etcdUrls,
+		Transport: client.DefaultTransport,
+		// set timeout per request to fail fast when the target endpoint is unavailable
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	c, err := client.New(cfg)
+	if err != nil {
+		log.Fatalf("failed to connect to etcd: %v", err)
+	}
+	return client.NewKeysAPI(c)
 }
 
 func getTypeName(r resource) (string, error) {


### PR DESCRIPTION
This implemenents create/read/update/delete/list for http triggers. This isn't quite the final implementation: you can't look up old versions by UUID since it only stores the latest update.  I'll get to that later.
