### PR TITLE
Update router cache on new function version

### DIFF
--- a/poolmgr/api.go
+++ b/poolmgr/api.go
@@ -119,11 +119,19 @@ func (api *API) getFunctionEnv(m *fission.Metadata) (*fission.Environment, error
 }
 
 func (api *API) getServiceForFunction(m *fission.Metadata) (string, error) {
-	// Check function -> svc map
+	// Make sure we have the full metadata.  This ensures that
+	// poolmgr does not implicitly interpret empty-UID as latest
+	// version.
+	if len(m.Uid) == 0 {
+		return "", fission.MakeError(fission.ErrorInvalidArgument,
+			fmt.Sprintf("invalid metadata for function %v", m.Name))
+	}
+
+	// Check function -> svc cache
 	log.Printf("[%v] Checking for cached function service", m.Name)
 	fsvc, err := api.fsCache.GetByFunction(m)
 	if err == nil {
-		// Cached, return svc name
+		// Cached, return svc address
 		return fsvc.address, nil
 	}
 


### PR DESCRIPTION
Addresses issue #51. Makes versioning in poolmgr explicit, so its
cache needs no invalidation on version update.  Functions in poolmgr
are always cached by name and UID.

Router now updates implictly versioned routes with the latest version
of a function.

This means that users will see requests to implicitly-versioned routes
go to the latest version of a function within 3 seconds.  (Those 3 sec
will go away when we use a real watch instead of polling the
controller.)

There's no change in behaviour for routes that explictly specify a
function UID.