### PR TITLE
fission-bundle: allow setting the namespace

### DIFF
--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -75,7 +75,7 @@ Use it to start one or more of the fission servers:
 Usage:
   fission-bundle --controllerPort=<port> [--etcdUrl=<etcdUrl>] --filepath=<filepath>
   fission-bundle --routerPort=<port> [--controllerUrl=<url> --poolmgrUrl=<url>]
-  fission-bundle --poolmgrPort=<port> [--controllerUrl=<url>]
+  fission-bundle --poolmgrPort=<port> [--controllerUrl=<url> --namespace=<namespace>]
   fission-bundle --kubewatcher [--controllerUrl=<url> --routerUrl=<url>]
 Options:
   --controllerPort=<port>  Port that the controller should listen on.


### PR DESCRIPTION
Poolmgr allows setting the `namespace`in which to run function containers, but `fission-bundle` does not allow that parameter.