### PR TITLE
Bugfix for internal routes

### DIFF
--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -81,7 +81,7 @@ func (ts *HTTPTriggerSet) getRouter() *mux.Router {
 		m := fission.Metadata{Name: function.Metadata.Name}
 		fh := &functionHandler{
 			fmap:     ts.functionServiceMap,
-			Function: m,
+			Function: function.Metadata,
 			poolmgr:  ts.poolmgr,
 		}
 		muxRouter.HandleFunc(fission.UrlForFunction(&m), fh.handler)


### PR DESCRIPTION
Poolmgr removed the default-latest-version semantics to simplify
caching.  But this broke the router's internal function routes, which
are used by kubeWatcher.  The router now exposes a versionless url
and regularly updates that to point to the latest version.