### PR TITLE
bugfix (cli) Update the URL check to work with https

### DIFF
--- a/fission/common.go
+++ b/fission/common.go
@@ -35,10 +35,10 @@ func getClient(serverUrl string) *client.Client {
 		fatal("Need --server or FISSION_URL set to your fission server.")
 	}
 
-	isHttps := strings.Index(serverUrl, "https://") == 0
-	isHttp := strings.Index(serverUrl, "http://") == 0
+	isHTTPS := strings.Index(serverUrl, "https://") == 0
+	isHTTP := strings.Index(serverUrl, "http://") == 0
 
-	if !isHttp && !isHttps {
+	if !(isHTTP || isHTTPS) {
 		serverUrl = "http://" + serverUrl
 	}
 

--- a/fission/common.go
+++ b/fission/common.go
@@ -35,7 +35,12 @@ func getClient(serverUrl string) *client.Client {
 		fatal("Need --server or FISSION_URL set to your fission server.")
 	}
 
-	serverUrl = "http://" + strings.TrimPrefix(serverUrl, "http://")
+	isHttps := strings.Index(serverUrl, "https://") == 0
+	isHttp := strings.Index(serverUrl, "http://") == 0
+
+	if !isHttp && !isHttps {
+		serverUrl = "http://" + serverUrl
+	}
 
 	return client.MakeClient(serverUrl)
 }


### PR DESCRIPTION
I've added a bit of logic to allow users to specify `https` for their FISSION_URL, which is critical when exposing the services via ingress and automatic TLS certificates from vault or LetsEncrypt.