### PR TITLE
Make build an actual sh script

### DIFF
--- a/fission-bundle/build.sh
+++ b/fission-bundle/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 GOOS=linux GOARCH=386 go build 


### PR DESCRIPTION
This allows it to be executed from alternative shells (fish, for
example) as `./build.sh`.