### PR TITLE
Allow unique HTTP route & method (#102)

### DIFF
--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -165,6 +165,10 @@ func TestHTTPTriggerApi(t *testing.T) {
 
 	testTrigger.Metadata.Name = "yyy"
 	m, err = g.client.HTTPTriggerCreate(testTrigger)
+	assert(err != nil, "duplicate trigger should not be allowed")
+
+	testTrigger.UrlPattern = "/hi2"
+	m, err = g.client.HTTPTriggerCreate(testTrigger)
 	panicIf(err)
 	defer g.client.HTTPTriggerDelete(m)
 

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -130,6 +130,20 @@ func (api *API) HTTPTriggerApiUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	triggers, err := api.HTTPTriggerStore.List()
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+	for _, url := range triggers {
+		if url.UrlPattern == t.UrlPattern && url.Method == t.Method {
+			err = fission.MakeError(fission.ErrorNameExists,
+				"HTTPTrigger with same URL & method already exists")
+			api.respondWithError(w, err)
+			return
+		}
+	}
+
 	uid, err := api.HTTPTriggerStore.Update(&t)
 	if err != nil {
 		api.respondWithError(w, err)

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -63,7 +63,7 @@ func (api *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, url := range triggers {
 		if url.UrlPattern == t.UrlPattern && url.Method == t.Method {
-			err = fission.MakeError(fission.ErrorResourceExists,
+			err = fission.MakeError(fission.ErrorNameExists,
 				"HTTPTrigger with same URL & method already exists")
 			api.respondWithError(w, err)
 			return

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -56,6 +56,20 @@ func (api *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	triggers, err := api.HTTPTriggerStore.List()
+	if err != nil {
+		api.respondWithError(w, err)
+		return
+	}
+	for _, url := range triggers {
+		if url.UrlPattern == t.UrlPattern && url.Method == t.Method {
+			err = fission.MakeError(fission.ErrorResourceExists,
+				"HTTPTrigger with same URL & method already exists")
+			api.respondWithError(w, err)
+			return
+		}
+	}
+
 	uid, err := api.HTTPTriggerStore.Create(&t)
 	if err != nil {
 		api.respondWithError(w, err)

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -130,20 +130,6 @@ func (api *API) HTTPTriggerApiUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	triggers, err := api.HTTPTriggerStore.List()
-	if err != nil {
-		api.respondWithError(w, err)
-		return
-	}
-	for _, url := range triggers {
-		if url.UrlPattern == t.UrlPattern && url.Method == t.Method {
-			err = fission.MakeError(fission.ErrorNameExists,
-				"HTTPTrigger with same URL & method already exists")
-			api.respondWithError(w, err)
-			return
-		}
-	}
-
 	uid, err := api.HTTPTriggerStore.Update(&t)
 	if err != nil {
 		api.respondWithError(w, err)

--- a/types.go
+++ b/types.go
@@ -84,4 +84,5 @@ const (
 	ErrorInvalidArgument
 	ErrorNoSpace
 	ErrorNotImplmented
+	ErrorResourceExists
 )

--- a/types.go
+++ b/types.go
@@ -84,5 +84,4 @@ const (
 	ErrorInvalidArgument
 	ErrorNoSpace
 	ErrorNotImplmented
-	ErrorResourceExists
 )


### PR DESCRIPTION
Testing Done:
$ fission route create --method POST --url /test-routes --function test-r
trigger '6b90a150-9a9f-4737-981f-3faabfef3580' created

$ fission route create --method GET --url /test-routes --function test-r
trigger 'bd48e8d6-519f-4ebd-9b86-aa985cd63c7b' created

$ fission route create --method POST --url /test-routes --function test-r
ERRO[0000] Failed to create http trigger                 err="(Error 0) HTTP error 409" name=6d0a8286-99da-4315-9aaf-775308d5d994
Failed to create HTTP trigger: (Error 0) HTTP error 409