### PR TITLE
Don't wait for ready pod in MakeGenericPool

### DIFF
--- a/poolmgr/gp.go
+++ b/poolmgr/gp.go
@@ -110,13 +110,7 @@ func MakeGenericPool(
 	if err != nil {
 		return nil, err
 	}
-
-	// wait for at least one pod to be ready
-	log.Printf("[%v] Deployment created, waiting for a ready pod", env.Metadata)
-	err = gp.waitForReadyPod()
-	if err != nil {
-		return nil, err
-	}
+	log.Printf("[%v] Deployment created", env.Metadata)
 
 	go gp.choosePodService()
 


### PR DESCRIPTION
Addresses issue #113.  poolmgr.MakeGenericPool does not need to wait
for a ready pod.  Kubernetes already retries image fetching, so
there's no need to repeat the task in fission.  And if it's a
non-retriable error (like the image URL being wrong), then the
deployment will stay broken, and the user can fix the environment with
'fission env update' (or 'fission env delete' followed by 'fission env
create').