### PR TITLE
Better convey duplicate name errors to client

### DIFF
--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -36,6 +36,13 @@ var g struct {
 	client *client.Client
 }
 
+func assertNameReuseFails(err error, name string) {
+	assert(err != nil, "recreating "+name+" with same name must fail")
+	fe, ok := err.(fission.Error)
+	assert(ok, "error must be a fission Error")
+	assert(fe.Code == fission.ErrorNameExists, "error must be a name exists error")
+}
+
 func TestFunctionApi(t *testing.T) {
 	log.SetFormatter(&log.TextFormatter{DisableColors: true})
 
@@ -55,6 +62,9 @@ func TestFunctionApi(t *testing.T) {
 	panicIf(err)
 	uid1 := m.Uid
 	//log.Printf("Created function %v: %v", m.Name, m.Uid)
+
+	_, err = g.client.FunctionCreate(testFunc)
+	assertNameReuseFails(err, "function")
 
 	code, err := g.client.FunctionGetRaw(m)
 	panicIf(err)
@@ -123,6 +133,9 @@ func TestHTTPTriggerApi(t *testing.T) {
 	panicIf(err)
 	defer g.client.HTTPTriggerDelete(m)
 
+	_, err = g.client.HTTPTriggerCreate(testTrigger)
+	assertNameReuseFails(err, "trigger")
+
 	tr, err := g.client.HTTPTriggerGet(m)
 	panicIf(err)
 	testTrigger.Metadata.Uid = m.Uid
@@ -159,6 +172,9 @@ func TestEnvironmentApi(t *testing.T) {
 	m, err := g.client.EnvironmentCreate(testEnv)
 	panicIf(err)
 	defer g.client.EnvironmentDelete(m)
+
+	_, err = g.client.EnvironmentCreate(testEnv)
+	assertNameReuseFails(err, "environment")
 
 	tr, err := g.client.EnvironmentGet(m)
 	panicIf(err)
@@ -204,6 +220,9 @@ func TestWatchApi(t *testing.T) {
 	m, err := g.client.WatchCreate(testWatch)
 	panicIf(err)
 	defer g.client.WatchDelete(m)
+
+	_, err = g.client.WatchCreate(testWatch)
+	assertNameReuseFails(err, "watch")
 
 	w, err := g.client.WatchGet(m)
 	panicIf(err)

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -80,19 +80,7 @@ func (c *Client) url(relativeUrl string) string {
 
 func (c *Client) handleResponse(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode != 200 {
-		var errCode int
-		switch resp.StatusCode {
-		case 403:
-			errCode = fission.ErrorNotAuthorized
-		case 404:
-			errCode = fission.ErrorNotFound
-		case 400:
-			errCode = fission.ErrorInvalidArgument
-		default:
-			errCode = fission.ErrorInternal
-		}
-		return nil, fission.MakeError(errCode,
-			fmt.Sprintf("HTTP error %v", resp.StatusCode))
+		return nil, fission.MakeErrorFromHTTP(resp)
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	return body, err


### PR DESCRIPTION
Motivation: Creating duplicate resources currently results in a 500
error being displayed by the client, with no information about the true
nature of the failure.

Modifications:
* ResourceStore now converts any errors from the etcd client into
  fission errors, capturing the reason for the error in the case of a
  duplicate key (as ErrorNameExists)
* ErrorNameExists errors are signaled to the client with a
  422 (Unprocessable Entity) HTTP status
* MakeErrorFromHTTP() now reads the body of the error response to
  retrieve the actual error message instead of using the HTTP status
  message
* the controller client now uses MakeErrorFromHTTP() to centralize
  status code -> error code mapping
* tests for all of the resources now check that duplicate resources are
  reported properly

Result: The client can now provide more context when a duplicate name is
given

related to #112 

This doesn't address improving the output from the client to actually tell you _which_ name was duplicated, that would be the next step.

I'm also still learning go, so feel free to hit me with any feedback if these changes aren't up to snuff.