### PR TITLE
Fixed failed to delete function when function's file is not exist

### DIFF
--- a/controller/fileStore.go
+++ b/controller/fileStore.go
@@ -85,7 +85,11 @@ func (fs *FileStore) fileStoreService() {
 		case WRITE:
 			response.error = ioutil.WriteFile(path.Join(fs.root, req.fileName), req.fileContents, 0600)
 		case DELETE:
-			response.error = os.Remove(path.Join(fs.root, req.fileName))
+			response.error = nil
+			filePath := path.Join(fs.root, req.fileName)
+			if _, err := os.Stat(filePath); os.IsExist(err) {
+				response.error = os.Remove(filePath)
+			}
 		default:
 			log.Panic("bad request")
 		}

--- a/controller/fileStore.go
+++ b/controller/fileStore.go
@@ -85,10 +85,9 @@ func (fs *FileStore) fileStoreService() {
 		case WRITE:
 			response.error = ioutil.WriteFile(path.Join(fs.root, req.fileName), req.fileContents, 0600)
 		case DELETE:
-			response.error = nil
-			filePath := path.Join(fs.root, req.fileName)
-			if _, err := os.Stat(filePath); os.IsExist(err) {
-				response.error = os.Remove(filePath)
+			response.error = os.Remove(path.Join(fs.root, req.fileName))
+			if os.IsNotExist(response.error) {
+				response.error = nil
 			}
 		default:
 			log.Panic("bad request")


### PR DESCRIPTION
This PR fixed the problem that user may encounter when trying to delete a function without function file in filestore. Now, the controller checks the file existence before removing it. (https://github.com/fission/fission/issues/108)

```
$ fission fn list
NAME  UID                                  ENV
hello bdecc45c-a528-4f1f-9fca-728bdc3d86f6 nodejs
$ fission fn delete --name hello
Failed to delete function 'hello': Delete failed: remove /filestore/bdecc45c-a528-4f1f-9fca-728bdc3d86f6: no such file or directory
```