### PR TITLE
Report KeyNotFound from etcd as a 404

### DIFF
--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -43,6 +43,13 @@ func assertNameReuseFails(err error, name string) {
 	assert(fe.Code == fission.ErrorNameExists, "error must be a name exists error")
 }
 
+func assertNotFoundFails(err error, name string) {
+	assert(err != nil, "requesting a non-existent "+name+" must fail")
+	fe, ok := err.(fission.Error)
+	assert(ok, "error must be a fission Error")
+	assert(fe.Code == fission.ErrorNotFound, "error must be a not found error")
+}
+
 func TestFunctionApi(t *testing.T) {
 	log.SetFormatter(&log.TextFormatter{DisableColors: true})
 
@@ -57,6 +64,8 @@ func TestFunctionApi(t *testing.T) {
 		},
 		Code: "code1",
 	}
+	_, err := g.client.FunctionGet(&fission.Metadata{Name: "foo"})
+	assertNotFoundFails(err, "function")
 
 	m, err := g.client.FunctionCreate(testFunc)
 	panicIf(err)
@@ -129,6 +138,9 @@ func TestHTTPTriggerApi(t *testing.T) {
 			Uid:  "",
 		},
 	}
+	_, err := g.client.HTTPTriggerGet(&fission.Metadata{Name: "foo"})
+	assertNotFoundFails(err, "trigger")
+
 	m, err := g.client.HTTPTriggerCreate(testTrigger)
 	panicIf(err)
 	defer g.client.HTTPTriggerDelete(m)
@@ -169,6 +181,9 @@ func TestEnvironmentApi(t *testing.T) {
 		},
 		RunContainerImageUrl: "gcr.io/xyz",
 	}
+	_, err := g.client.EnvironmentGet(&fission.Metadata{Name: "foo"})
+	assertNotFoundFails(err, "environment")
+
 	m, err := g.client.EnvironmentCreate(testEnv)
 	panicIf(err)
 	defer g.client.EnvironmentDelete(m)
@@ -217,6 +232,9 @@ func TestWatchApi(t *testing.T) {
 		},
 		Target: "",
 	}
+	_, err := g.client.WatchGet(&fission.Metadata{Name: "foo"})
+	assertNotFoundFails(err, "watch")
+
 	m, err := g.client.WatchCreate(testWatch)
 	panicIf(err)
 	defer g.client.WatchDelete(m)

--- a/controller/resourceStore.go
+++ b/controller/resourceStore.go
@@ -263,12 +263,16 @@ func handleEtcdError(e error) error {
 	}
 	code := fission.ErrorInternal
 	msg := ee.Error()
+	simpleMsg := fmt.Sprintf("%v (%v)", ee.Message, ee.Cause)
 
 	//TODO: handle any other etcd error codes we care about
 	switch ee.Code {
 	case client.ErrorCodeNodeExist:
 		code = fission.ErrorNameExists
-		msg = fmt.Sprintf("%v (%v)", ee.Message, ee.Cause)
+		msg = simpleMsg
+	case client.ErrorCodeKeyNotFound:
+		code = fission.ErrorNotFound
+		msg = simpleMsg
 	}
 	return fission.MakeError(code, msg)
 }


### PR DESCRIPTION
This allows for proper classification of the error on the client side.