### PR TITLE
Improve command-line client error output

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -26,8 +26,6 @@ import (
 	"net/http"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
-
 	"github.com/fission/fission"
 )
 
@@ -104,10 +102,6 @@ func (c *Client) FunctionCreate(f *fission.Function) (*fission.Metadata, error) 
 
 	body, err := c.handleResponse(resp)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"name": f.Metadata.Name,
-			"err":  err,
-		}).Error("Failed to create function")
 		return nil, err
 	}
 
@@ -240,10 +234,6 @@ func (c *Client) HTTPTriggerCreate(t *fission.HTTPTrigger) (*fission.Metadata, e
 
 	body, err := c.handleResponse(resp)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"name": t.Metadata.Name,
-			"err":  err,
-		}).Error("Failed to create http trigger")
 		return nil, err
 	}
 
@@ -351,10 +341,6 @@ func (c *Client) EnvironmentCreate(env *fission.Environment) (*fission.Metadata,
 
 	body, err := c.handleResponse(resp)
 	if err != nil {
-		log.WithFields(log.Fields{
-			"name": env.Metadata.Name,
-			"err":  err,
-		}).Error("Failed to create environment")
 		return nil, err
 	}
 

--- a/error.go
+++ b/error.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 )
 
-func (e Error) Error() string {
-	return fmt.Sprintf("(Error %v) %v", e.Code, e.Message)
+func (err Error) Error() string {
+	return fmt.Sprintf("%v - %v", err.Description(), err.Message)
 }
 
 func MakeError(code int, msg string) Error {
@@ -89,4 +89,12 @@ func GetHTTPError(err error) (int, string) {
 		msg = err.Error()
 	}
 	return code, msg
+}
+
+func (err Error) Description() string {
+	idx := int(err.Code)
+	if idx < 0 || idx > len(errorDescriptions)-1 {
+		return ""
+	}
+	return errorDescriptions[idx]
 }

--- a/types.go
+++ b/types.go
@@ -72,6 +72,7 @@ type (
 		Code    errorCode `json:"code"`
 		Message string    `json:"message"`
 	}
+
 	errorCode int
 )
 
@@ -85,3 +86,14 @@ const (
 	ErrorNoSpace
 	ErrorNotImplmented
 )
+
+// must match order and len of the above const
+var errorDescriptions = []string{
+	"Internal error",
+	"Not authorized",
+	"Resource not found",
+	"Resource exists",
+	"Invalid argument",
+	"No space",
+	"Not implemented",
+}


### PR DESCRIPTION
Motivation: The output when an error occurs shows an integer error code,
which isn't very helpful. And in the case of an error when creating a
resource, you also get a redundant log message from the controller
client.

Modifications:
* the controller client now has a flag to suppress error logging
* the CLI client uses a logger with that flag set
* the error codes enum is now typed to allow `stringer` to generate a
  String() for it
* a go:generate directive was added to run stringer automatically when
  `go generate` is called
* the generated String() allows for the enum name to be displayed in the
  error output
* the type used for an error code is now public (fission.ErrorCode) so
  it can be used as an argument to MakeError(), since the enum is now
  typed.
* the format of the error message from the CLI client was modified to
  display the error message before the error type

Related to #112 

I don't think this is quite ready to merge, but wanted to get it out there for discussion. My biggest concern with this change is the introduction of `stringer` and `go generate` into the build. This PR includes the output of the generation `errorcode_string.go`, but probably shouldn't. Including it allows other devs to build without having to install `stringer` or run `go generate`, with the chance of the generated code getting out of date. Not including it complicates the build, since it would need to be generated by each dev. This would be alleviated somewhat by having a Makefile, but it's kind of nice that one hasn't yet been needed.

Another concern is making `ErrorCode` public - was it intentionally private? Are there drawbacks to making it public? 

Any other feedback is also welcome.

