### PR TITLE
Bash command generate an invalid hello.js

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,7 +101,7 @@ Finally, you're ready to use Fission!
 ```
   $ fission env create --name nodejs --image fission/node-env
 
-  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\\n"); }' > hello.js  
+  $ echo -E 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
 
   $ fission function create --name hello --env nodejs --code hello.js
   

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -101,7 +101,7 @@ Finally, you're ready to use Fission!
 ```
   $ fission env create --name nodejs --image fission/node-env
 
-  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
+  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\\n"); }' > hello.js  
 
   $ fission function create --name hello --env nodejs --code hello.js
   

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Usage
   $ fission env create --name nodejs --image fission/node-env
 
   # A javascript one-liner that prints "hello world"
-  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
+  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\\n"); }' > hello.js  
 
   # Upload your function code to fission
   $ fission function create --name hello --env nodejs --code hello.js
@@ -172,7 +172,7 @@ Finally, you're ready to use Fission!
 ```
   $ fission env create --name nodejs --image fission/node-env
 
-  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
+  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\\n"); }' > hello.js  
 
   $ fission function create --name hello --env nodejs --code hello.js
   

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Usage
   $ fission env create --name nodejs --image fission/node-env
 
   # A javascript one-liner that prints "hello world"
-  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\\n"); }' > hello.js  
+  $ echo -E 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
 
   # Upload your function code to fission
   $ fission function create --name hello --env nodejs --code hello.js
@@ -172,7 +172,7 @@ Finally, you're ready to use Fission!
 ```
   $ fission env create --name nodejs --image fission/node-env
 
-  $ echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\\n"); }' > hello.js  
+  $ echo -E 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js  
 
   $ fission function create --name hello --env nodejs --code hello.js
   


### PR DESCRIPTION
Resolves the problem explained in #101.

The command:
 `echo 'module.exports = function(context, callback) { callback(200, "Hello, world!\n"); }' > hello.js` 
generates a `hello.js` file with this structure:
```
echo 'module.exports = function(context, callback) { callback(200, "Hello, world!
"); }' > hello.js
``` 
as the string is split in several lines, nodejs fails thus returning an error.

When using linux a `\\n` must be used instead of `\n`