### PR TITLE
Modify the stock example to show how to change the Content-Type

### DIFF
--- a/examples/nodejs/stock.js
+++ b/examples/nodejs/stock.js
@@ -26,6 +26,9 @@ module.exports = async function (context) {
             status: 200,
             body: {
                 text: `${symbol} last traded at ${lastTrade}`
+            },
+            headers: {
+                'Content-Type': 'application/json'
             }
         };
     } catch (e) {


### PR DESCRIPTION
The example returns a JSON object, but headers are not properly set.

Also no checks or validations are performed on processing the body. This is probably a good opportunity  to show how to deal with errors.