### PR TITLE
Ignore the vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ environments/php7/vendor/
 *.bak
 *.tmp
 *~
+
+vendor/


### PR DESCRIPTION
`vendor/` was erroneously removed from `.gitignore` in 99d6a95bc19a479bc7bbab538984f0e00de59711. This PR re-adds it