### PR TITLE
Fix function delete with uid

### DIFF
--- a/controller/resourceStore.go
+++ b/controller/resourceStore.go
@@ -139,7 +139,7 @@ func (rs *ResourceStore) delete(typename, rkey string) error {
 // getAll finds all entries under key.  If none or found or key
 // doesn't exist, returns an empty slice.
 func (rs *ResourceStore) getAll(key string) ([]string, error) {
-	resp, err := rs.KeysAPI.Get(context.Background(), key, &client.GetOptions{Recursive: true})
+	resp, err := rs.KeysAPI.Get(context.Background(), key, &client.GetOptions{Recursive: true, Sort: true})
 	if err != nil {
 		if client.IsKeyNotFound(err) {
 			return []string{}, nil


### PR DESCRIPTION
The current version may delete the function record and left some function code behind if an uid is provided.

If no uid provided, all versions of function files and record will be deleted.
If an uid provided, delete the specific version code, update the function with the latest code.