### PR TITLE
Set correct Content-Type in the http response

### DIFF
--- a/controller/api.go
+++ b/controller/api.go
@@ -47,6 +47,7 @@ func MakeAPI(rs *ResourceStore) *API {
 }
 
 func (api *API) respondWithSuccess(w http.ResponseWriter, resp []byte) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, err := w.Write(resp)
 	if err != nil {
 		// this will probably fail too, but try anyway
@@ -62,6 +63,7 @@ func (api *API) respondWithError(w http.ResponseWriter, err error) {
 }
 
 func (api *API) HomeHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	fmt.Fprintf(w, "{\"message\": \"Fission API\", \"version\": \"0.1.0\"}\n")
 }
 

--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -120,6 +120,20 @@ func TestFunctionApi(t *testing.T) {
 	assert(len(funcs) == 2,
 		"created two functions, but didn't find them")
 
+	funcs_url := g.client.Url + "/v1/functions"
+	resp, err := http.Get(funcs_url)
+	panicIf(err)
+	defer resp.Body.Close()
+	assert(resp.StatusCode == 200, "http get status code on /v1/functions")
+
+	var found bool = false
+	for _, b := range resp.Header["Content-Type"] {
+		if b == "application/json; charset=utf-8" {
+			found = true
+		}
+	}
+	assert(found, "incorrect response content type")
+
 	err = g.client.FunctionDelete(&fission.Metadata{Name: "foo"})
 	panicIf(err)
 	err = g.client.FunctionDelete(&fission.Metadata{Name: "bar"})
@@ -337,6 +351,15 @@ func TestMain(m *testing.M) {
 	resp, err := http.Get("http://localhost:8888/")
 	panicIf(err)
 	assert(resp.StatusCode == 200, "http get status code on root")
+
+	var found bool = false
+	for _, b := range resp.Header["Content-Type"] {
+		if b == "application/json; charset=utf-8" {
+			found = true
+		}
+	}
+	assert(found, "incorrect response content type")
+
 	_, err = ioutil.ReadAll(resp.Body)
 	panicIf(err)
 


### PR DESCRIPTION
When the request is handled successfully, json data is returned, this
patch changes the response Content-Type header from text/plain to
application/json

Fixes: #144