### PR TITLE
Return 201 for created resources

### DIFF
--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -84,6 +84,14 @@ func (c *Client) handleResponse(resp *http.Response) ([]byte, error) {
 	return body, err
 }
 
+func (c *Client) handleCreateResponse(resp *http.Response) ([]byte, error) {
+	if resp.StatusCode != 201 {
+		return nil, fission.MakeErrorFromHTTP(resp)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	return body, err
+}
+
 func (c *Client) FunctionCreate(f *fission.Function) (*fission.Metadata, error) {
 	orig := f.Code
 	f.Code = base64.StdEncoding.EncodeToString([]byte(f.Code))
@@ -100,7 +108,7 @@ func (c *Client) FunctionCreate(f *fission.Function) (*fission.Metadata, error) 
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := c.handleCreateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +240,7 @@ func (c *Client) HTTPTriggerCreate(t *fission.HTTPTrigger) (*fission.Metadata, e
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := c.handleCreateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -339,7 +347,7 @@ func (c *Client) EnvironmentCreate(env *fission.Environment) (*fission.Metadata,
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := c.handleCreateResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -446,7 +454,7 @@ func (c *Client) WatchCreate(w *fission.Watch) (*fission.Metadata, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := c.handleResponse(resp)
+	body, err := c.handleCreateResponse(resp)
 	if err != nil {
 		return nil, err
 	}

--- a/controller/environmentApi.go
+++ b/controller/environmentApi.go
@@ -71,6 +71,7 @@ func (api *API) EnvironmentApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusCreated)
 	api.respondWithSuccess(w, resp)
 }
 

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -77,6 +77,7 @@ func (api *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusCreated)
 	api.respondWithSuccess(w, resp)
 }
 

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -83,6 +83,7 @@ func (api *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusCreated)
 	api.respondWithSuccess(w, resp)
 }
 

--- a/controller/watchApi.go
+++ b/controller/watchApi.go
@@ -71,6 +71,7 @@ func (api *API) WatchApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	w.WriteHeader(http.StatusCreated)
 	api.respondWithSuccess(w, resp)
 }
 


### PR DESCRIPTION
Partially resolves #143 

One weird issue:

I was trying to set the `Location` header with 

```go
w.Header().Set("Location", "/v1/functions/"+f.Name)
```

but it always ended up being stripped out of the response for some reason. Any ideas?