### PR TITLE
Upgrade node environment to Node.js 7.6.0+

### DIFF
--- a/environments/nodejs/.gitignore
+++ b/environments/nodejs/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/environments/nodejs/Dockerfile
+++ b/environments/nodejs/Dockerfile
@@ -1,6 +1,6 @@
 # A docker image for the func container.
 
-FROM node:4-onbuild
+FROM node:7-onbuild
 
 ADD server.js /usr/src/app/server.js
 

--- a/environments/nodejs/package.json
+++ b/environments/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "fission-nodejs-runtime",
-    "version": "0.0.0",
+    "version": "0.1.0",
     "author": "Soam Vasani",
     "contributors": [
         {

--- a/environments/nodejs/package.json
+++ b/environments/nodejs/package.json
@@ -10,7 +10,7 @@
     ],
     "description": "NodeJS run container for the fission framework",
     "engines": {
-        "node": ">=4.2.2"
+        "node": ">=7.6.0"
     },
     "dependencies": {
         "express": "",

--- a/environments/nodejs/package.json
+++ b/environments/nodejs/package.json
@@ -1,27 +1,26 @@
 {
-    "name": "fission-nodejs-runtime",
-    "version": "0.1.0",
-    "author": "Soam Vasani",
-    "contributors": [
-        {
-            "name": "Soam Vasani",
-            "email": "soamvasani@platform9.com"
-        }
-    ],
-    "description": "NodeJS run container for the fission framework",
-    "engines": {
-        "node": ">=7.6.0"
-    },
-    "dependencies": {
-        "express": "",
-        "minimist": "",
-        "body-parser": "",
-        "morgan": "",
-
-        "co": "~4.6.0",
-        "request": "",
-        "request-promise": "^1.0.2",
-        "mz": "~2.1.0",
-        "underscore": ">=1.8.3"
+  "name": "fission-nodejs-runtime",
+  "version": "0.1.0",
+  "author": "Soam Vasani",
+  "contributors": [
+    {
+      "name": "Soam Vasani",
+      "email": "soamvasani@platform9.com"
     }
+  ],
+  "description": "NodeJS run container for the fission framework",
+  "engines": {
+    "node": ">=7.6.0"
+  },
+  "dependencies": {
+    "body-parser": "",
+    "co": "~4.6.0",
+    "express": "",
+    "minimist": "",
+    "morgan": "",
+    "mz": "~2.1.0",
+    "request": "^2.81.0",
+    "request-promise-native": "^1.0.3",
+    "underscore": ">=1.8.3"
+  }
 }

--- a/environments/nodejs/server.js
+++ b/environments/nodejs/server.js
@@ -81,7 +81,7 @@ app.all('/', function (req, res) {
         response: res
         // TODO: context should also have: URL template params, query string
     };
-    
+
     function callback(status, body, headers) {
         if (!status)
             return;
@@ -100,8 +100,21 @@ app.all('/', function (req, res) {
     // you can do that here by adding properties to the context.
     //
 
-    // Make sure their function returns a promise
-    let functionProm = Promise.resolve(userFunction(context));
+    let functionProm;
+    if (userFunction.length === 1) { // One argument (context)
+        // Make sure their function returns a promise
+        functionProm = Promise.resolve(userFunction(context));
+    } else { // 2 arguments (context, callback)
+        functionProm = new Promise(function(resolve, reject) {
+            userFunction(context, function(status, body, headers) {
+                return resolve({
+                    status,
+                    body,
+                    headers
+                });
+            });
+        });
+    }
 
     functionProm.then(function(result) {
         callback(result.status, result.body, result.headers);

--- a/environments/nodejs/server.js
+++ b/environments/nodejs/server.js
@@ -103,25 +103,20 @@ app.all('/', function (req, res) {
     let functionProm;
     if (userFunction.length === 1) { // One argument (context)
         // Make sure their function returns a promise
-        functionProm = Promise.resolve(userFunction(context));
-    } else { // 2 arguments (context, callback)
-        functionProm = new Promise(function(resolve, reject) {
-            userFunction(context, function(status, body, headers) {
-                return resolve({
-                    status,
-                    body,
-                    headers
-                });
-            });
+        Promise.resolve(userFunction(context)).then(function(result) {
+            callback(result.status, result.body, result.headers);
+        }).catch(function(err) {
+            console.log(`Function error: ${e}`);
+            callback(500, "Internal server error");
         });
+    } else { // 2 arguments (context, callback)
+        try {
+            userFunction(context, callback);
+        } catch (err) {
+            console.log(`Function error: ${e}`);
+            callback(500, "Internal server error");
+        }
     }
-
-    functionProm.then(function(result) {
-        callback(result.status, result.body, result.headers);
-    }).catch(function(err) {
-        console.log(`Function error: ${e}`);
-        callback(500, "Internal server error")
-    });
 
 });
 

--- a/environments/nodejs/server.js
+++ b/environments/nodejs/server.js
@@ -75,11 +75,13 @@ app.all('/', function (req, res) {
         res.status(500).send("Generic container: no requests supported");
         return;
     }
+
     const context = {
         request: req,
         response: res
         // TODO: context should also have: URL template params, query string
     };
+    
     function callback(status, body, headers) {
         if (!status)
             return;
@@ -90,18 +92,24 @@ app.all('/', function (req, res) {
         }
         res.status(status).send(body);
     }
-    try {
-        //
-        // Customizing the request context
-        //
-        // If you want to modify the context to add anything to it,
-        // you can do that here by adding properties to the context.
-        //
-        userFunction(context, callback);
-    } catch(e) {
+
+    //
+    // Customizing the request context
+    //
+    // If you want to modify the context to add anything to it,
+    // you can do that here by adding properties to the context.
+    //
+
+    // Make sure their function returns a promise
+    let functionProm = Promise.resolve(userFunction(context));
+
+    functionProm.then(function(result) {
+        callback(result.status, result.body, result.headers);
+    }).catch(function(err) {
         console.log(`Function error: ${e}`);
         callback(500, "Internal server error")
-    }
+    });
+
 });
 
 app.listen(argv.port);

--- a/environments/nodejs/server.js
+++ b/environments/nodejs/server.js
@@ -103,8 +103,8 @@ app.all('/', function (req, res) {
     let functionProm;
     if (userFunction.length === 1) { // One argument (context)
         // Make sure their function returns a promise
-        Promise.resolve(userFunction(context)).then(function(result) {
-            callback(result.status, result.body, result.headers);
+        Promise.resolve(userFunction(context)).then(function({ status, body, headers }) {
+            callback(status, body, headers);
         }).catch(function(err) {
             console.log(`Function error: ${e}`);
             callback(500, "Internal server error");

--- a/environments/nodejs/test/test.js
+++ b/environments/nodejs/test/test.js
@@ -1,6 +1,9 @@
-module.exports = function (context, callback) {
+module.exports = async function (context) {
     console.log("headers=", JSON.stringify(context.request.headers));
     console.log("body=", JSON.stringify(context.request.body));
 
-    callback(200, "Hello, world !\n");
+    return {
+        status: 200,
+        body: "Hello, world !\n"
+    };
 }

--- a/examples/nodejs/hello-callback.js
+++ b/examples/nodejs/hello-callback.js
@@ -1,0 +1,4 @@
+
+module.exports = function(context, callback) {
+    callback(200, "Hello, world!\n");
+}

--- a/examples/nodejs/hello.js
+++ b/examples/nodejs/hello.js
@@ -1,4 +1,7 @@
 
-module.exports = function(context, callback) {
-    callback(200, "Hello, world!\n");
+module.exports = async function(context) {
+    return {
+        status: 200,
+        body: "Hello, world!\n"
+    };
 }

--- a/examples/nodejs/stock.js
+++ b/examples/nodejs/stock.js
@@ -2,29 +2,36 @@
 
 var http = require('http');
 
-module.exports = function (context, callback) {    
+module.exports = async function (context) {
     let body = context.request.body;
     console.log(`body text: ${body['text']}`);
 
     var symbol = body['text'].split(' ')[1];
 
-    http.get({
-        host: 'finance.google.com',
-        path: `/finance/info?q=NYSE:${symbol}`
-    }, function(response) {
-        var resp = '';
-        response.on('data', function(d) {
-            resp += d;
-        });
-        response.on('end', function() {
-
-            try {
-                var parsed = JSON.parse(resp.slice(3));
-                var lastTrade = parsed[0]['l_cur']
-                callback(200, `{ "text": "${symbol} last traded at ${lastTrade}" }`);
-            } catch (e) {
-                callback(200, `{ "text": "Error (invalid NYSE symbol?)" }`);
-            }
+    return new Promise(function(resolve, reject) {
+        http.get({
+            host: 'finance.google.com',
+            path: `/finance/info?q=NYSE:${symbol}`
+        }, function(response) {
+            var resp = '';
+            response.on('data', function(d) {
+                resp += d;
+            });
+            response.on('end', function() {
+                try {
+                    var parsed = JSON.parse(resp.slice(3));
+                    var lastTrade = parsed[0]['l_cur'];
+                    return resolve({
+                        status: 200,
+                        body: `{ "text": "${symbol} last traded at ${lastTrade}" }`
+                    });
+                } catch (e) {
+                    return resolve({
+                        status: 200,
+                        body: `{ "text": "Error (invalid NYSE symbol?)" }`
+                    });
+                }
+            });
         });
     });
 


### PR DESCRIPTION
This PR upgrades the Node.js environment to Node.js 7.6.0+. Node 7.6.0 introduced async/await without the harmony flag, which allows you to write cleaner (asynchronous) functions without the mess that is callbacks. With this change, Node environment functions now look like this:

```javascript
module.exports = async function(context) {
    const response = await request({ url: 'http://google.com'});
    const anotherResponse = await request({ url: 'http://google.com'});
    return {
        status: 200,
        body: "Hello, world!\n"
    };
}
```

Changelog:
 * Upgrade Node.js to 7.6.0+
 * Add support for `async` functions
 * Replace `request-promise` with `request-promise-native`