### PR TITLE
Drop Go 1.7, use Go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 
 language: go
 go:
-    - 1.7
+    - 1.8
     - tip
 
 install:


### PR DESCRIPTION
We use plugins in the Golang environment, it's easiest to just move to Go 1.8 for the whole project.