### PR TITLE
Make the chart work with helm 2.2

### DIFF
--- a/charts/fission/templates/deployment.yaml
+++ b/charts/fission/templates/deployment.yaml
@@ -1,11 +1,3 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: {{ .Release.Namespace }}
-  labels:
-    name: fission
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-
 ---
 apiVersion: v1
 kind: Namespace
@@ -20,7 +12,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: controller
-  namespace: {{ .Release.Namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
@@ -41,7 +32,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: router
-  namespace: {{ .Release.Namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
@@ -62,7 +52,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: poolmgr
-  namespace: {{ .Release.Namespace }}
   labels:
     svc: poolmgr
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -78,7 +67,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: poolmgr
-  namespace: {{ .Release.Namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
@@ -99,7 +87,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kubewatcher
-  namespace: {{ .Release.Namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
@@ -120,7 +107,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: etcd
-  namespace: {{ .Release.Namespace }}
   labels:
     svc: etcd
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -136,7 +122,6 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: etcd
-  namespace: {{ .Release.Namespace }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:

--- a/charts/fission/templates/svc.yaml
+++ b/charts/fission/templates/svc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: router
-  namespace: {{ .Release.Namespace }}
   labels:
     svc: router
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
@@ -20,7 +19,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: controller
-  namespace: {{ .Release.Namespace }}
   labels:
     svc: controller
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/charts/fission/values.yaml
+++ b/charts/fission/values.yaml
@@ -20,4 +20,4 @@ routerPort: 31314
 
 ## Namespace in which to run fission functions (this is different from
 ## the release namespace)
-fissionFunctionNamespace: fission-function
+functionNamespace: fission-function


### PR DESCRIPTION
Primarily this involved removing the release namespace, which is
controlled by helm.  If you want resources in a namespace you set
--namespace= with helm install, anything else leaves helm unable
to properly manage the resources.

I think the functions namespace won't work either on a delete.