### PR TITLE
Shorten name given to environment deployments

### DIFF
--- a/poolmgr/gp.go
+++ b/poolmgr/gp.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/dchest/uniuri"
@@ -309,13 +310,13 @@ func (gp *GenericPool) specializePod(pod *v1.Pod, metadata *fission.Metadata) er
 // A pool is a deployment of generic containers for an env.  This
 // creates the pool but doesn't wait for any pods to be ready.
 func (gp *GenericPool) createPool() error {
-	poolDeploymentName := fmt.Sprintf("env-%v", gp.env.Metadata.Name)
+	poolDeploymentName := fmt.Sprintf("env-%v-", strings.ToLower(gp.env.Metadata.Name))
 
 	sharedMountPath := "/userfunc"
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: v1.ObjectMeta{
-			Name:   poolDeploymentName,
-			Labels: gp.labelsForPool,
+			GenerateName: poolDeploymentName,
+			Labels:       gp.labelsForPool,
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &gp.replicas,

--- a/poolmgr/gp.go
+++ b/poolmgr/gp.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/dchest/uniuri"
@@ -310,8 +309,7 @@ func (gp *GenericPool) specializePod(pod *v1.Pod, metadata *fission.Metadata) er
 // A pool is a deployment of generic containers for an env.  This
 // creates the pool but doesn't wait for any pods to be ready.
 func (gp *GenericPool) createPool() error {
-	poolDeploymentName := fmt.Sprintf("%v-%v-%v",
-		gp.env.Metadata.Name, gp.env.Metadata.Uid, strings.ToLower(gp.poolInstanceId))
+	poolDeploymentName := fmt.Sprintf("env-%v", gp.env.Metadata.Name)
 
 	sharedMountPath := "/userfunc"
 	deployment := &v1beta1.Deployment{


### PR DESCRIPTION
This small PR is a proposal to shorten the name of the generic pods to something a bit more readable. There does not seem to be reason to add the identifiers to this name, as these are also present in the labels. It might be that I am overlooking a detail, that would invalidate this solution. Anyhow, this would also mitigate the issue #50 of pod names hitting the 64 character limit of Kubernetes. Finally, I added the `env-` as a prefix to avoid conflicts with existing components and to avoid unclear naming. 

Before:
`nodejs-1f348359-5f29-435e-b4e1-0f86b8398d64-hv6j3tek-1519022795`
After:
`env-nodejs-3126632610`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/182)
<!-- Reviewable:end -->
