### PR TITLE
Adding fission-rbac.yml for 

### DIFF
--- a/fission-rbac.yaml
+++ b/fission-rbac.yaml
@@ -1,0 +1,180 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fission-svc
+  namespace: fission
+  labels:
+    kubernetes.io/cluster-service: "true"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: fission-admin
+  labels:
+    kubernetes.io/cluster-service: "true"
+subjects:
+  - kind: ServiceAccount
+    name: fission-svc
+    namespace: fission
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1alpha1
+metadata:
+  name: fission-function-admin
+  namespace: fission-function
+  labels:
+    kubernetes.io/cluster-service: "true"
+subjects:
+  - kind: ServiceAccount
+    name: fission-svc
+    namespace: fission
+roleRef:
+  kind: ClusterRole
+  name: admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fission
+  labels:
+    name: fission
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fission-function
+  labels:
+    name: fission-function
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: controller
+  namespace: fission
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        svc: controller
+    spec:
+      containers:
+        - name: controller
+          image: fission/fission-bundle:alpha20170328
+          command: ["/fission-bundle"]
+          args: ["--controllerPort", "8888", "--filepath", "/filestore"]
+      serviceAccountName: fission-svc
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: router
+  namespace: fission
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        svc: router
+    spec:
+      containers:
+      - name: router
+        image: fission/fission-bundle:alpha20170328
+        command: ["/fission-bundle"]
+        args: ["--routerPort", "8888"]
+      serviceAccountName: fission-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: poolmgr
+  namespace: fission
+  labels:
+    svc: poolmgr
+spec:
+  ports:
+  - port: 80
+    targetPort: 8888
+  selector:
+    svc: poolmgr
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: poolmgr
+  namespace: fission
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        svc: poolmgr
+    spec:
+      containers:
+      - name: poolmgr
+        image: fission/fission-bundle:alpha20170328
+        command: ["/fission-bundle"]
+        args: ["--poolmgrPort", "8888"]
+      serviceAccountName: fission-svc
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kubewatcher
+  namespace: fission
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        svc: kubewatcher
+    spec:
+      containers:
+      - name: kubewatcher
+        image: fission/fission-bundle:alpha20170328
+        command: ["/fission-bundle"]
+        args: ["--kubewatcher"]
+      serviceAccountName: fission-svc
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: etcd
+  namespace: fission
+  labels:
+    svc: etcd
+spec:
+  ports:
+  - port: 2379
+    targetPort: 2379
+  selector:
+    svc: etcd
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: etcd
+  namespace: fission
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        svc: etcd
+    spec:
+      containers:
+      - name: etcd
+        image: quay.io/coreos/etcd
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: ETCD_LISTEN_CLIENT_URLS
+          value: http://0.0.0.0:2379
+        - name: ETCD_ADVERTISE_CLIENT_URLS
+          value: http://etcd:2379
+      serviceAccountName: fission-svc

--- a/fission-rbac.yaml
+++ b/fission-rbac.yaml
@@ -4,15 +4,12 @@ kind: ServiceAccount
 metadata:
   name: fission-svc
   namespace: fission
-  labels:
-    kubernetes.io/cluster-service: "true"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: fission-admin
-  labels:
-    kubernetes.io/cluster-service: "true"
+  namespace: fission
 subjects:
   - kind: ServiceAccount
     name: fission-svc
@@ -27,8 +24,6 @@ apiVersion: rbac.authorization.k8s.io/v1alpha1
 metadata:
   name: fission-function-admin
   namespace: fission-function
-  labels:
-    kubernetes.io/cluster-service: "true"
 subjects:
   - kind: ServiceAccount
     name: fission-svc

--- a/fission-rbac.yaml
+++ b/fission-rbac.yaml
@@ -1,3 +1,16 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fission
+  labels:
+    name: fission
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fission-function
+  labels:
+    name: fission-function
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -32,20 +45,6 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: fission
-  labels:
-    name: fission
----
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: fission-function
-  labels:
-    name: fission-function
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
To deal with the issue of lack of RBAC permission noted in fission/fission#160 , created 'fission-rbac.yml'. Made it a separate file so that users have choice (in case they use older k8s) on whether to install with RBAC permissions or not.

If changes are approved, happy to help update documentation to reflect changes.