### PR TITLE
Bump version of fission-bundle to testing20170328

### DIFF
--- a/fission-openshift.yaml
+++ b/fission-openshift.yaml
@@ -66,7 +66,7 @@ spec:
         emptyDir: {}
       containers:
       - name: controller
-        image: fission/fission-bundle:testing20170124
+        image: fission/fission-bundle:testing20170328
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--filepath", "/filestore"]
         volumeMounts:
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
       - name: router
-        image: fission/fission-bundle:testing20170124
+        image: fission/fission-bundle:testing20170328
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888"]
 
@@ -122,7 +122,7 @@ spec:
     spec:
       containers:
       - name: poolmgr
-        image: fission/fission-bundle:testing20170124
+        image: fission/fission-bundle:testing20170328
         command: ["/fission-bundle"]
         args: ["--poolmgrPort", "8888"]
       serviceAccount: poolmgr
@@ -142,7 +142,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-        image: fission/fission-bundle:testing20170124
+        image: fission/fission-bundle:testing20170328
         command: ["/fission-bundle"]
         args: ["--kubewatcher"]
 


### PR DESCRIPTION
Using the old version produces an error, just as described on #177.

Also, I kindly request this version to be uploaded to the web site, so that it can be obtained via http://fission.io/fission-openshift.yaml.
Note that the version that was placed there yesterday (as requested on #187) was missing the first paragraph.

Thanks in advance!