### PR TITLE
[WIP] Opentracing with Zipkin as backend

### DIFF
--- a/environments/nodejs/package.json
+++ b/environments/nodejs/package.json
@@ -19,8 +19,13 @@
     "minimist": "",
     "morgan": "",
     "mz": "~2.1.0",
+    "opentracing": "^0.14.1",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.3",
-    "underscore": ">=1.8.3"
+    "underscore": ">=1.8.3",
+    "zipkin": "^0.7.1",
+    "zipkin-context-cls": "^0.6.1",
+    "zipkin-instrumentation-express": "^0.7.1",
+    "zipkin-transport-http": "^0.7.1"
   }
 }

--- a/environments/nodejs/server.js
+++ b/environments/nodejs/server.js
@@ -8,6 +8,25 @@ const app = express();
 const bodyParser = require('body-parser');
 const morgan = require('morgan');
 
+const {Tracer, BatchRecorder, Annotation} = require('zipkin');
+const {HttpLogger} = require('zipkin-transport-http');
+const CLSContext = require('zipkin-context-cls');
+const zipkinMiddleware = require('zipkin-instrumentation-express').expressMiddleware;
+
+const ctxImpl = new CLSContext(); // if you want to use CLS
+const recorder = new BatchRecorder({
+    logger: new HttpLogger({
+        endpoint: 'http://zipkin.fission:9411/api/v1/spans'
+    })
+});
+const tracer = new Tracer({
+    recorder,
+    ctxImpl // this would typically be a CLSContext or ExplicitContext
+});
+
+const SERVICE_NAME = 'user_func';
+
+
 // Command line opts
 const argv = require('minimist')(process.argv.slice(1));
 if (!argv.codepath) {
@@ -47,9 +66,9 @@ function specialize(req, res) {
 
     // Read and load the code. It's placed there securely by the fission runtime.
     try {
-        var startTime = process.hrtime();
+        const startTime = process.hrtime();
         userFunction = require(argv.codepath);
-        var elapsed = process.hrtime(startTime);
+        const elapsed = process.hrtime(startTime);
         console.log(`user code loaded in ${elapsed[0]}sec ${elapsed[1]/1000000}ms`);
     } catch(e) {
         console.error(`user code load error: ${e}`);
@@ -59,9 +78,12 @@ function specialize(req, res) {
     res.status(202).send();
 }
 
-
+app.use(zipkinMiddleware({
+    tracer,
+    serviceName: SERVICE_NAME, // name of this application
+}));
 // Request logger
-app.use(morgan('combined'))
+app.use(morgan('combined'));
 
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
@@ -78,9 +100,22 @@ app.all('/', function (req, res) {
 
     const context = {
         request: req,
-        response: res
+        response: res,
+        tracer: null,
         // TODO: context should also have: URL template params, query string
     };
+
+    let traceId = null;
+    tracer.scoped(() => {
+        tracer.setId(tracer.createChildId());
+        traceId = tracer.id;
+        tracer.recordServiceName(SERVICE_NAME);
+        tracer.recordAnnotation(new Annotation.ClientSend());
+        tracer.recordRpc("user_func::name");
+        tracer.recordBinary('fission.user_func', 'some function name');
+        tracer.recordBinary('fission.instrumented', 'true');
+        context.tracer = tracer;
+    });
 
     function callback(status, body, headers) {
         if (!status)
@@ -91,6 +126,10 @@ app.all('/', function (req, res) {
             }
         }
         res.status(status).send(body);
+        tracer.scoped(() => {
+            tracer.setId(traceId);
+            tracer.recordAnnotation(new Annotation.ClientRecv());
+        });
     }
 
     //
@@ -100,7 +139,6 @@ app.all('/', function (req, res) {
     // you can do that here by adding properties to the context.
     //
 
-    let functionProm;
     if (userFunction.length === 1) { // One argument (context)
         // Make sure their function returns a promise
         Promise.resolve(userFunction(context)).then(function({ status, body, headers }) {

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,10 @@
-hash: 51b5eda27974aac228f42002cb0a9f89bf2f79d36a574a3694c142c2f83e4042
-updated: 2017-03-24T11:01:00.667996869+08:00
+hash: a0773661dc871c95adb06be9e69e4ab884d9dca33ce8cf9f5e197680a5ea0771
+updated: 2017-05-31T22:18:43.447163753+08:00
 imports:
+- name: github.com/apache/thrift
+  version: 72ca60debae1d9fb35d9f0085118873669006d7f
+  subpackages:
+  - lib/go/thrift
 - name: github.com/blang/semver
   version: 60ec3488bfea7cca02b021d106d9911120d25fe9
 - name: github.com/coreos/etcd
@@ -37,6 +41,14 @@ imports:
   - reference
 - name: github.com/docopt/docopt-go
   version: 784ddc588536785e7299f7272f39101f7faccc3f
+- name: github.com/eapache/go-resiliency
+  version: b86b1ec0dd4209a588dc1285cdd471e73525c0b3
+  subpackages:
+  - breaker
+- name: github.com/eapache/go-xerial-snappy
+  version: bb955e01b9346ac19dc29eb16586c90ded99a98c
+- name: github.com/eapache/queue
+  version: 44cc805cf13205b55f69e14bcb69867d1ae92f98
 - name: github.com/emicklei/go-restful
   version: 3d66f886316ac990eb502aaa89ea38546420b8b7
   subpackages:
@@ -44,6 +56,8 @@ imports:
   - swagger
 - name: github.com/ghodss/yaml
   version: 73d445a93680fa1a78ae23a5839bad48f32ba1ee
+- name: github.com/go-logfmt/logfmt
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-openapi/jsonpointer
   version: 8d96a2dc61536b690bd36b2e9df0b3c0b62825b2
 - name: github.com/go-openapi/jsonreference
@@ -64,14 +78,16 @@ imports:
   subpackages:
   - jsonpb
   - proto
+- name: github.com/golang/snappy
+  version: d9eb7a3d35ec988b8585d4a0068e462c27d28380
 - name: github.com/google/gofuzz
   version: fd52762d25a41827db7ef64c43756fd4b9f7e382
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/handlers
-  version: 3a5767ca75ece5f7f1440b1d16975247f8d8b221
+  version: a4043c62cc2329bacda331d33fc908ab11ef0ec3
 - name: github.com/gorilla/mux
-  version: 392c28fe23e1c45ddba891b0320b3b5df220beea
+  version: bcd8bc72b08df0f70df986b97f95590779502d31
 - name: github.com/influxdata/influxdb
   version: b7bb7e8359642b6e071735b50ae41f5eb343fd42
   subpackages:
@@ -82,22 +98,47 @@ imports:
   version: 2eee05ed794112d45db504eb05aa693efd2b8b09
 - name: github.com/juju/ratelimit
   version: 77ed1c8a01217656d2080ad51981f6e99adaa177
+- name: github.com/kr/logfmt
+  version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/mailru/easyjson
   version: 159cdb893c982e3d1bc6450322fedd514f9c9de3
   subpackages:
   - buffer
   - jlexer
   - jwriter
+- name: github.com/opentracing/opentracing-go
+  version: 1949ddbfd147afd4d964a9f00b24eb291e0e7c38
+  subpackages:
+  - ext
+  - log
+- name: github.com/openzipkin/zipkin-go-opentracing
+  version: 6022d4d3ed39632fad842942bda1813a9b4f63c8
+  subpackages:
+  - _thrift/gen-go/scribe
+  - _thrift/gen-go/zipkincore
+  - flag
+  - types
+  - wire
 - name: github.com/pborman/uuid
   version: 3d4f2ba23642d3cfd06bd4b54cf03d99d95c0f1b
+- name: github.com/pierrec/lz4
+  version: 5a3d2245f97fc249850e7802e3c01fad02a1c316
+- name: github.com/pierrec/xxHash
+  version: 5a004441f897722c627870a981d02b29924215fa
+  subpackages:
+  - xxHash32
 - name: github.com/PuerkitoBio/purell
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/rcrowley/go-metrics
+  version: 1f30fe9094a513ce4c700b9a54458bbb0c96996c
 - name: github.com/robfig/cron
   version: df38d32658d8788cd446ba74db4bb5375c4b0cb3
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
+- name: github.com/Shopify/sarama
+  version: c01858abb625b73a3af51d0798e4ad42c8147093
 - name: github.com/Sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,3 +34,7 @@ import:
   subpackages:
   - client/v2
 - package: github.com/robfig/cron
+- package: github.com/opentracing/opentracing-go
+  version: v1.0.2
+- package: github.com/openzipkin/zipkin-go-opentracing
+  version: v0.2.3

--- a/poolmgr/poolmgr.go
+++ b/poolmgr/poolmgr.go
@@ -21,10 +21,13 @@ import (
 	"strings"
 
 	"github.com/dchest/uniuri"
+	zipkin "github.com/openzipkin/zipkin-go-opentracing"
 	"k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/rest"
 
+	"fmt"
 	controllerclient "github.com/fission/fission/controller/client"
+	"github.com/opentracing/opentracing-go"
 )
 
 // Get a kubernetes client using the pod's service account.  This only
@@ -47,6 +50,14 @@ func getKubernetesClient() (*kubernetes.Clientset, error) {
 	return clientset, nil
 }
 
+func initTracing(svcName string, port int) {
+	collector, _ := zipkin.NewHTTPCollector(
+		fmt.Sprintf("http://%s:9411/api/v1/spans", "zipkin.fission"))
+	tracer, _ := zipkin.NewTracer(
+		zipkin.NewRecorder(collector, false, fmt.Sprintf("%v.fission:%v", svcName, port), svcName))
+	opentracing.SetGlobalTracer(tracer)
+}
+
 func StartPoolmgr(controllerUrl string, namespace string, port int) error {
 	controllerUrl = strings.TrimSuffix(controllerUrl, "/")
 	controllerClient := controllerclient.MakeClient(controllerUrl)
@@ -56,6 +67,8 @@ func StartPoolmgr(controllerUrl string, namespace string, port int) error {
 		log.Printf("Failed to get kubernetes client: %v", err)
 		return err
 	}
+
+	initTracing("poolmgr", port)
 
 	instanceId := uniuri.NewLen(8)
 	cleanupOldPoolmgrResources(kubernetesClient, namespace, instanceId)

--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,0 +1,35 @@
+# Tracing
+
+- Traces fission functions as part of a bigger solution
+- Helps troubleshoot performance problems with fission
+
+## Deployment
+
+### Fission with router, poolmgr, environment image instrumented
+
+Make sure a instrumented version of fission is deployed.
+
+In router and poolmgr, only the function call code path is instrumented.
+Trace are not sampled. Sampling could be switched on in production mode.
+Every environment image should be instrumented individually,
+currently only nodejs is instrumented.
+
+### Zipkin as tracing backend service
+
+Fission try to use OpenTracing Client API to log the trace, Zipkin supports
+the OpenTracing API and is a popular solution with client library, backend service and web ui.
+
+```bash
+# Create the Zipkin backend 
+# Zipkin service for client to discovery it by DNS
+$ kubectl create -f zipkin-deployment.yaml -f zipkin-svc.yaml
+
+# And then port forward Zipkin pod port 9411 to local
+# Visit localhost:9411 for ui
+```
+
+## Example
+
+`node-tracing-example.js` fetches `http://controller.fission` and return the response to the client.
+It uses the `tracer` in context. Other
+[instrumented libraries](https://github.com/openzipkin/zipkin-js/tree/master/packages) by Zipkin is useful.

--- a/tracing/node-tracing-example.js
+++ b/tracing/node-tracing-example.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const http = require('http');
+const { Annotation } = require('zipkin');
+
+module.exports = function (context, callback) {
+    let traceId = null;
+    const {tracer} = context;
+    tracer.scoped(() => {
+        tracer.setId(tracer.createChildId());
+        traceId = tracer.id;
+        tracer.recordServiceName("user_self");
+        tracer.recordAnnotation(new Annotation.ClientSend());
+        tracer.recordRpc("user_func::httpget");
+    });
+    http.get({
+        host: 'controller.fission',
+        path: '/',
+    }, function(response) {
+        let resp = '';
+        response.on('data', function(d) {
+            resp += d;
+        });
+        response.on('end', function() {
+            tracer.scoped(() => {
+                tracer.setId(traceId);
+                tracer.recordBinary('user_func.res', resp);
+                tracer.recordAnnotation(new Annotation.ClientRecv());
+            });
+            callback(200, resp);
+        });
+    });
+};

--- a/tracing/zipkin-deployment.yaml
+++ b/tracing/zipkin-deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: zipkin
+  namespace: fission
+  labels:
+    app: zipkin
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: zipkin
+    spec:
+      containers:
+        - image: openzipkin/zipkin:1.26
+          name: zipkin

--- a/tracing/zipkin-svc.yaml
+++ b/tracing/zipkin-svc.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: zipkin
+  namespace: fission
+  labels:
+    app: zipkin 
+spec:
+  type: NodePort
+  ports:
+  - name: zipkin
+    port: 9411
+    targetPort: 9411
+  selector:
+    app: zipkin
+


### PR DESCRIPTION
This PR for #200 is a preview of integrating Open-Tracing compatible services.
It can provide tracing for fission developer and user.

Currently only the function calling path in router, poolmgr and nodejs image is instrumented.
Below is a demo of a cold function call and a hot function call.

![image](https://cloud.githubusercontent.com/assets/2204211/26634036/e8a5b252-4647-11e7-80ec-4848007b79d9.png)
![image](https://cloud.githubusercontent.com/assets/2204211/26634059/f98d8a5e-4647-11e7-937f-60e3a15cb648.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/215)
<!-- Reviewable:end -->
