### PR TITLE
Refactor publisher interface

### DIFF
--- a/kubewatcher/kubewatcher.go
+++ b/kubewatcher/kubewatcher.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -36,7 +37,6 @@ import (
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/publisher"
-	"reflect"
 )
 
 type requestType int
@@ -299,7 +299,7 @@ func (ws *watchSubscription) eventDispatchLoop() {
 				"X-Kubernetes-Object-Type": reflect.TypeOf(ev.Object).Elem().Name(),
 			}
 			// Event and object type aren't in the serialized object
-			ws.publisher.Publish(buf.String(), headers, ws.Watch.Target)
+			ws.publisher.Publish(buf.String(), headers, ws.Watch.Target, nil)
 		}
 		if atomic.LoadInt32(ws.stopped) == 0 {
 			err := ws.restartWatch()

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -21,6 +21,10 @@ type (
 		// Publish an request to a "target".  Target's meaning depends on the
 		// publisher: it's a URL in the case of a webhook publisher, or a queue
 		// name in a queue-based publisher such as NATS.
-		Publish(body string, headers map[string]string, target string)
+		Publish(body string, headers map[string]string, target string, respChan chan string)
 	}
+)
+
+const (
+	StatusFunctionFailure = "function failure"
 )

--- a/timer/timer.go
+++ b/timer/timer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package timer
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/robfig/cron"
@@ -136,7 +137,10 @@ func (timer *Timer) newCron(t fission.TimeTrigger) *cron.Cron {
 		headers := map[string]string{
 			"X-Fission-Timer-Name": t.Name,
 		}
-		(*timer.publisher).Publish("", headers, fission.UrlForFunction(&t.Function))
+		respChan := make(chan string)
+		(*timer.publisher).Publish("", headers, fission.UrlForFunction(&t.Function), respChan)
+		fmt.Printf("Trigger %s get response from function: %s\n", t.Metadata.Name, <-respChan)
+		close(respChan)
 	})
 	c.Start()
 	log.Printf("Add new cron for time trigger %v", t.Name)


### PR DESCRIPTION
If we want to reply the function response back to event sender mentioned at #194, the publisher needs a way to send the response back to the trigger. 

In this PR, triggers pass a response channel to publish interface so that webhookPublisher can send function response through the channel to trigger. The trigger can decide to send the response back to event sender or just ignore it.

For demonstration, timer passes a respChan to publisher and prints out received function response. The code will be removed before merged.

How to test:

1. Create a function
```
fission fn create --name hello1 --code ~/Desktop/Fission/hello.js --env nodejs
```
2. Create a time trigger for the function
```
fission timer create --name hello1 --function hello1 --cron '@every 5s'
```
3. Check timer log
```
kubectl logs -f timer-3198201534-0nfzd
``` 
