### PR TITLE
Fix pool contains wrong environment metadata

### DIFF
--- a/poolmgr/gpm.go
+++ b/poolmgr/gpm.go
@@ -157,8 +157,8 @@ func (gpm *GenericPoolManager) eagerPoolCreator() {
 		// creating pools for envs that are actually used by functions.  Also we might want
 		// to keep these eagerly created pools smaller than the ones created when there are
 		// actual function calls.
-		for _, env := range envs {
-			_, err := gpm.GetPool(&env)
+		for i := range envs {
+			_, err := gpm.GetPool(&envs[i])
 			if err != nil {
 				log.Printf("eager-create pool failed: %v", err)
 			}


### PR DESCRIPTION
The generic pool manager creates a generic pool with the reference of environment metadata. Since the reference is the address of loop variable, the content of metadata will be replaced with the last element of env list. So pool manager sets up logging with the wrong env.