### PR TITLE
Fix s/Sirupsen/sirupsen/ for logrus

### DIFF
--- a/controller/api.go
+++ b/controller/api.go
@@ -23,7 +23,7 @@ import (
 	"runtime/debug"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 

--- a/controller/api.go
+++ b/controller/api.go
@@ -23,9 +23,9 @@ import (
 	"runtime/debug"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/fission/logdb"

--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	etcdClient "github.com/coreos/etcd/client"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	"github.com/fission/fission"

--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -24,7 +24,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	etcdClient "github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 

--- a/controller/environmentApi.go
+++ b/controller/environmentApi.go
@@ -21,8 +21,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 )

--- a/controller/environmentApi.go
+++ b/controller/environmentApi.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 
 	"github.com/fission/fission"

--- a/controller/fileStore.go
+++ b/controller/fileStore.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 type requestType int

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -24,7 +24,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 
 	"github.com/fission/fission"

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -24,8 +24,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 )

--- a/controller/functionStore.go
+++ b/controller/functionStore.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 )

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -21,8 +21,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 )

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 
 	"github.com/fission/fission"

--- a/controller/resourceStore.go
+++ b/controller/resourceStore.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/client"
 	"github.com/satori/go.uuid"
 	"golang.org/x/net/context"

--- a/controller/resourceStore.go
+++ b/controller/resourceStore.go
@@ -23,9 +23,9 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/coreos/etcd/client"
 	"github.com/satori/go.uuid"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 
 	"github.com/fission/fission"

--- a/controller/timeTriggerApi.go
+++ b/controller/timeTriggerApi.go
@@ -21,9 +21,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/robfig/cron"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 )

--- a/controller/timeTriggerApi.go
+++ b/controller/timeTriggerApi.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/robfig/cron"
 

--- a/controller/watchApi.go
+++ b/controller/watchApi.go
@@ -21,8 +21,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/fission/fission"
 )

--- a/controller/watchApi.go
+++ b/controller/watchApi.go
@@ -21,7 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/mux"
 
 	"github.com/fission/fission"

--- a/fission/logdb/logdb.go
+++ b/fission/logdb/logdb.go
@@ -19,7 +19,7 @@ package logdb
 import (
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/glide.lock
+++ b/glide.lock
@@ -98,7 +98,7 @@ imports:
   version: df38d32658d8788cd446ba74db4bb5375c4b0cb3
 - name: github.com/satori/go.uuid
   version: 879c5887cd475cd7864858769793b2ceb0d44feb
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: ba1b36c82c5e05c4f912a88eab0dcd91a171688f
 - name: github.com/spf13/pflag
   version: 08b1a584251b5b62f458943640fc8ebd4d50aaa5

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/fission/fission
 import:
-- package: github.com/Sirupsen/logrus
-  version: ^0.11.0
+- package: github.com/sirupsen/logrus
+  version: 68cec9f21fbf3ea8d8f98c044bc6ce05f17b267a
 - package: github.com/coreos/etcd
   subpackages:
   - client

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,10 +25,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/fission/fission"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/rest"
 )

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/fission/fission"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"


### PR DESCRIPTION
Because of https://github.com/sirupsen/logrus/issues/543 `glide install` fails to install `logrus` right now. This PR simply bumps us to the newest version with correct references

Used latest SHA on master for locking which obviously isn't ideal but until a new release is cut ( https://github.com/sirupsen/logrus/issues/555 ) probably good enough