### PR TITLE
Retrieve URL params in functions (#158)

### DIFF
--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/fission/fission"
 	poolmgrClient "github.com/fission/fission/poolmgr/client"
+	"github.com/gorilla/mux"
 )
 
 type functionHandler struct {
@@ -92,6 +93,12 @@ func (fh *functionHandler) tapService(serviceUrl *url.URL) {
 
 func (fh *functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {
 	reqStartTime := time.Now()
+
+	// retrieve url params and add them to request header
+	vars := mux.Vars(request)
+	for k, v := range vars {
+		request.Header.Add(fmt.Sprintf("X-Fission-Params-%v", k), v)
+	}
 
 	// cache lookup
 	serviceUrl, err := fh.fmap.lookup(&fh.Function)

--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -25,9 +25,10 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/gorilla/mux"
+
 	"github.com/fission/fission"
 	poolmgrClient "github.com/fission/fission/poolmgr/client"
-	"github.com/gorilla/mux"
 )
 
 type functionHandler struct {


### PR DESCRIPTION
Retrieve gorilla/mux URL params in functions
Add them in HTTP headers, such as X-Fission-Params-${key}: ${value}