### PR TITLE
Specify full golang version in Dockerfiles and build helper script

### DIFF
--- a/environments/go/Dockerfile
+++ b/environments/go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.8.1
 
 ENV GOPATH /usr
 ENV APP	   ${GOPATH}/src/github.com/fission/fission/environments/go

--- a/environments/go/README.md
+++ b/environments/go/README.md
@@ -10,6 +10,13 @@ It's a Docker image containing a Go 1.8 runtime, along with a dynamic loader.
 docker build -t USER/go-runtime . && docker push USER/go-runtime
 ```
 
+Note that if you build the runtime, you must also build the go-builder
+image, to ensure that it's at the same version of go:
+
+```
+cd builder && docker build -t USER/go-builder . && docker push USER/go-builder
+```
+
 ## Using the image in fission
 
 You can add this customized image to fission with "fission env
@@ -27,7 +34,6 @@ fission env update --name go-runtime --image USER/go-runtime
 
 After this, fission functions that have the env parameter set to the
 same environment name as this command will use this environment.
-
 
 ## Creating functions to use this image
 

--- a/environments/go/builder/Dockerfile
+++ b/environments/go/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.8.1
 
 ENV GOPATH /usr
 RUN go get github.com/fission/fission

--- a/environments/go/builder/go-function-build
+++ b/environments/go/builder/go-function-build
@@ -8,4 +8,4 @@ else
     filename=$1
 fi
 
-docker run --rm -v $(pwd):/build -w /build fission/go-builder go build -buildmode=plugin -o function.so $filename && echo "Compiled plugin: function.so. Use 'fission function create' to upload to fission."
+docker run --rm -v $(pwd):/build -w /build fission/go-builder:1.8.1 go build -buildmode=plugin -o function.so $filename && echo "Compiled plugin: function.so. Use 'fission function create' to upload to fission."

--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -4,22 +4,28 @@ The `go` runtime uses the [`plugin` package](https://golang.org/pkg/plugin/) to 
 
 ## Requirements
 
-First, [set up your fission deployment with the go environment](https://github.com/fission/fission/blob/master/environments/go/README.md).
+First, set up your fission deployment with the go environment.
 
-To use this environment, download the [build helper
-script](https://raw.githubusercontent.com/fission/fission/master/environments/go/builder/go-function-build).
+```
+fission env create --name go-env --image fission/go-env:1.8.1
+```
 
-The script must be run in the same directory as the function you're
-building.
+To ensure that you build functions using the same version as the
+runtime, fission provides a docker image and helper script for
+building functions.
 
-## Examples
+## Example Usage
 
 ### hello.go
 
 `hello.go` is an very basic HTTP handler returning `"Hello, World!"`.
 
-```
-# Build the function as a plugin. Outputs result to 'function.so'.
+```bash
+# Download the build helper script
+$ curl https://raw.githubusercontent.com/fission/fission/master/environments/go/builder/go-function-build > go-function-build
+$ chmod +x go-function-build
+
+# Build the function as a plugin. Outputs result to 'function.so'
 $ go-function-build hello.go
 
 # Upload the function to fission


### PR DESCRIPTION
Addresses #222.

Plugins and the binaries loading them need to be built with the exact
same go version.

Also update README instructions.