### PR TITLE
Aggregate tap service request in interval

### DIFF
--- a/poolmgr/client/client.go
+++ b/poolmgr/client/client.go
@@ -84,9 +84,7 @@ func (c *Client) service() {
 					for u := range c.tappedByUrl {
 						c._tapService(u)
 					}
-					if len(urls) > 0 {
-						log.Printf("Tapped %v services in batch", len(urls))
-					}
+					log.Printf("Tapped %v services in batch", len(urls))
 				}()
 				log.Printf("Tapped %v services in batch", len(urls))
 			}

--- a/poolmgr/client/client.go
+++ b/poolmgr/client/client.go
@@ -24,25 +24,35 @@ import (
 	"encoding/json"
 	"github.com/fission/fission"
 	"io/ioutil"
+	"log"
 	"net/url"
+	"sync"
+	"time"
 )
 
 type Client struct {
-	poolmgrUrl string
+	sync.RWMutex
+	poolmgrUrl  string
+	tappedByUrl map[string]bool
 }
 
 func MakeClient(poolmgrUrl string) *Client {
-	return &Client{poolmgrUrl: strings.TrimSuffix(poolmgrUrl, "/")}
+	c := &Client{
+		poolmgrUrl:  strings.TrimSuffix(poolmgrUrl, "/"),
+		tappedByUrl: make(map[string]bool),
+	}
+	go c.TapServiceEveryInterval()
+	return c
 }
 
 func (c *Client) GetServiceForFunction(metadata *fission.Metadata) (string, error) {
-	url := c.poolmgrUrl + "/v1/getServiceForFunction"
+	poolmgrUrl := c.poolmgrUrl + "/v1/getServiceForFunction"
 	body, err := json.Marshal(metadata)
 	if err != nil {
 		return "", err
 	}
 
-	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	resp, err := http.Post(poolmgrUrl, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return "", err
 	}
@@ -60,12 +70,33 @@ func (c *Client) GetServiceForFunction(metadata *fission.Metadata) (string, erro
 	return string(svcName), nil
 }
 
-func (c *Client) TapService(serviceUrl *url.URL) error {
-	url := c.poolmgrUrl + "/v1/tapService"
+func (c *Client) TapServiceEveryInterval() {
+	for {
+		c.Lock()
+		tappedByUrl := c.tappedByUrl
+		c.tappedByUrl = make(map[string]bool)
+		c.Unlock()
+		for u := range tappedByUrl {
+			c._tapService(u)
+		}
+		if len(tappedByUrl) > 0 {
+			log.Printf("Tapped %v services in batch", len(tappedByUrl))
+		}
+		time.Sleep(5 * time.Second)
+	}
+}
 
+func (c *Client) TapService(serviceUrl *url.URL) {
 	serviceUrlStr := serviceUrl.String()
+	c.Lock()
+	c.tappedByUrl[serviceUrlStr] = true
+	c.Unlock()
+}
 
-	resp, err := http.Post(url, "application/octet-stream", bytes.NewReader([]byte(serviceUrlStr)))
+func (c *Client) _tapService(serviceUrlStr string) error {
+	poolmgrUrl := c.poolmgrUrl + "/v1/tapService"
+
+	resp, err := http.Post(poolmgrUrl, "application/octet-stream", bytes.NewReader([]byte(serviceUrlStr)))
 	if err != nil {
 		return err
 	}

--- a/poolmgr/client/client.go
+++ b/poolmgr/client/client.go
@@ -17,31 +17,45 @@ limitations under the License.
 package client
 
 import (
-	"net/http"
-	"strings"
-
 	"bytes"
 	"encoding/json"
-	"github.com/fission/fission"
 	"io/ioutil"
 	"log"
+	"net/http"
 	"net/url"
-	"sync"
+	"strings"
 	"time"
+
+	"github.com/fission/fission"
+)
+
+const (
+	TOUCH int = iota
+	SYNC
 )
 
 type Client struct {
-	sync.RWMutex
 	poolmgrUrl  string
 	tappedByUrl map[string]bool
+	requestChan chan clientRequest
+	tapUrlChan  chan string
+}
+
+type clientRequest struct {
+	requestType int
+	serviceUrl  string
 }
 
 func MakeClient(poolmgrUrl string) *Client {
 	c := &Client{
 		poolmgrUrl:  strings.TrimSuffix(poolmgrUrl, "/"),
 		tappedByUrl: make(map[string]bool),
+		requestChan: make(chan clientRequest, 100),
+		tapUrlChan:  make(chan string, 100),
 	}
-	go c.TapServiceEveryInterval()
+	go c.tapWorker()
+	go c.timer()
+	go c.tapService()
 	return c
 }
 
@@ -70,27 +84,43 @@ func (c *Client) GetServiceForFunction(metadata *fission.Metadata) (string, erro
 	return string(svcName), nil
 }
 
-func (c *Client) TapServiceEveryInterval() {
+func (c *Client) tapService() {
 	for {
-		c.Lock()
-		tappedByUrl := c.tappedByUrl
-		c.tappedByUrl = make(map[string]bool)
-		c.Unlock()
-		for u := range tappedByUrl {
-			c._tapService(u)
+		req := <-c.requestChan
+		switch req.requestType {
+		case TOUCH:
+			c.tappedByUrl[req.serviceUrl] = true
+		case SYNC:
+			for u := range c.tappedByUrl {
+				c.tapUrlChan <- u
+			}
+			if len(c.tappedByUrl) > 0 {
+				log.Printf("Tapped %v services in batch", len(c.tappedByUrl))
+			}
+			c.tappedByUrl = make(map[string]bool)
 		}
-		if len(tappedByUrl) > 0 {
-			log.Printf("Tapped %v services in batch", len(tappedByUrl))
-		}
+	}
+}
+
+func (c *Client) tapWorker() {
+	for {
+		u := <-c.tapUrlChan
+		c._tapService(u)
+	}
+}
+
+func (c *Client) timer() {
+	for {
+		c.requestChan <- clientRequest{requestType: SYNC}
 		time.Sleep(5 * time.Second)
 	}
 }
 
 func (c *Client) TapService(serviceUrl *url.URL) {
-	serviceUrlStr := serviceUrl.String()
-	c.Lock()
-	c.tappedByUrl[serviceUrlStr] = true
-	c.Unlock()
+	c.requestChan <- clientRequest{
+		requestType: TOUCH,
+		serviceUrl:  serviceUrl.String(),
+	}
 }
 
 func (c *Client) _tapService(serviceUrlStr string) error {

--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -84,10 +84,7 @@ func (fh *functionHandler) tapService(serviceUrl *url.URL) {
 	if fh.poolmgr == nil {
 		return
 	}
-	err := fh.poolmgr.TapService(serviceUrl)
-	if err != nil {
-		log.Printf("tap service error for %v: %v", serviceUrl.String(), err)
-	}
+	fh.poolmgr.TapService(serviceUrl)
 }
 
 func (fh *functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
For every function call, the router has to make a tap-service request to poolmgr.
We can aggregate the requests in a interval (5 seconds).