### PR TITLE
Use horizontal autoscaler to autoscale

### DIFF
--- a/controller/functionStore.go
+++ b/controller/functionStore.go
@@ -83,6 +83,8 @@ func (fs *FunctionStore) Update(f *fission.Function) (string, error) {
 
 	fnew.Metadata.Uid = uid
 	fnew.Environment = f.Environment
+	fnew.CpuTarget = f.CpuTarget
+	fnew.MaxInstance = f.MaxInstance
 
 	err = fs.ResourceStore.update(fnew)
 	if err != nil {

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -164,17 +164,18 @@ func main() {
 	fetcher := MakeFetcher(dir)
 
 	// if we have a request via an env var, run that first
-	envRequest := os.Getenv("FETCH_REQUEST")
+	envRequest := os.Getenv("FETCHER_REQUEST")
+	fmt.Println("req x", envRequest)
 	if len(envRequest) > 0 {
 		var req FetchRequest
 		err := json.Unmarshal([]byte(envRequest), &req)
 		if err != nil {
-			log.Fatalf("Error parsing FETCH_REQUEST env var: %v", err)
+			log.Fatalf("Error parsing FETCHER_REQUEST env var: %v", err)
 		}
 
 		err = fetcher.handleFetchRequest(&req)
 		if err != nil {
-			log.Fatalf("Error handling fetch request: %v", err)
+			log.Fatalf("Error handling fetcher request: %v", err)
 		}
 
 		// this pod is being started up without the help of

--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -48,8 +48,8 @@ func runKubeWatcher(controllerUrl, routerUrl string) {
 	}
 }
 
-func runLogger() {
-	logger.Start()
+func runLogger(namespace string) {
+	logger.Start(namespace)
 	log.Fatalf("Error: Logger exited.")
 }
 
@@ -132,7 +132,7 @@ Options:
 	}
 
 	if arguments["--logger"] == true {
-		runLogger()
+		runLogger(namespace)
 	}
 
 	select {}

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -18,12 +18,13 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"text/tabwriter"
 
 	"github.com/urfave/cli"
 
 	"github.com/fission/fission"
-	"os"
+	"github.com/fission/fission/poolmgr"
 )
 
 func envCreate(c *cli.Context) error {
@@ -39,11 +40,32 @@ func envCreate(c *cli.Context) error {
 		fatal("Need an image, use --image.")
 	}
 
+	envCpuLimit := c.String("cpulimit")
+	if len(envCpuLimit) == 0 {
+		envCpuLimit = poolmgr.DEFAULT_CPU_LIMIT.String()
+	}
+	envMemLimit := c.String("memlimit")
+	if len(envMemLimit) == 0 {
+		envMemLimit = poolmgr.DEFAULT_MEM_LIMIT.String()
+	}
+	envCpuRequest := c.String("cpurequest")
+	if len(envCpuRequest) == 0 {
+		envCpuRequest = poolmgr.DEFAULT_CPU_REQUEST.String()
+	}
+	envMemRequest := c.String("memrequest")
+	if len(envMemRequest) == 0 {
+		envMemRequest = poolmgr.DEFAULT_MEM_REQUEST.String()
+	}
+
 	env := &fission.Environment{
 		Metadata: fission.Metadata{
 			Name: envName,
 		},
 		RunContainerImageUrl: envImg,
+		CpuLimit:             envCpuLimit,
+		MemLimit:             envMemLimit,
+		CpuRequest:           envCpuRequest,
+		MemRequest:           envMemRequest,
 	}
 
 	_, err := client.EnvironmentCreate(env)
@@ -66,9 +88,10 @@ func envGet(c *cli.Context) error {
 	checkErr(err, "get environment")
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\n", "NAME", "UID", "IMAGE")
-	fmt.Fprintf(w, "%v\t%v\t%v\n",
-		env.Metadata.Name, env.Metadata.Uid, env.RunContainerImageUrl)
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "UID", "IMAGE", "CPU_LIMIT", "CPU_REQUEST", "MEM_LIMIT", "MEM_REQUEST")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+		env.Metadata.Name, env.Metadata.Uid, env.RunContainerImageUrl,
+		env.CpuLimit, env.CpuRequest, env.MemLimit, env.MemRequest)
 	w.Flush()
 	return nil
 }
@@ -86,11 +109,32 @@ func envUpdate(c *cli.Context) error {
 		fatal("Need an image, use --image.")
 	}
 
+	envCpuLimit := c.String("cpulimit")
+	if len(envCpuLimit) == 0 {
+		envCpuLimit = poolmgr.DEFAULT_CPU_LIMIT.String()
+	}
+	envMemLimit := c.String("memlimit")
+	if len(envMemLimit) == 0 {
+		envMemLimit = poolmgr.DEFAULT_MEM_LIMIT.String()
+	}
+	envCpuRequest := c.String("cpurequest")
+	if len(envCpuRequest) == 0 {
+		envCpuRequest = poolmgr.DEFAULT_CPU_REQUEST.String()
+	}
+	envMemRequest := c.String("memrequest")
+	if len(envMemRequest) == 0 {
+		envMemRequest = poolmgr.DEFAULT_MEM_REQUEST.String()
+	}
+
 	env := &fission.Environment{
 		Metadata: fission.Metadata{
 			Name: envName,
 		},
 		RunContainerImageUrl: envImg,
+		CpuLimit:             envCpuLimit,
+		MemLimit:             envMemLimit,
+		CpuRequest:           envCpuRequest,
+		MemRequest:           envMemRequest,
 	}
 
 	_, err := client.EnvironmentUpdate(env)
@@ -123,10 +167,11 @@ func envList(c *cli.Context) error {
 	checkErr(err, "list environments")
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\n", "NAME", "UID", "IMAGE")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "UID", "IMAGE", "CPU_LIMIT", "CPU_REQUEST", "MEM_LIMIT", "MEM_REQUEST")
 	for _, env := range envs {
-		fmt.Fprintf(w, "%v\t%v\t%v\n",
-			env.Metadata.Name, env.Metadata.Uid, env.RunContainerImageUrl)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+			env.Metadata.Name, env.Metadata.Uid, env.RunContainerImageUrl,
+			env.CpuLimit, env.CpuRequest, env.MemLimit, env.MemRequest)
 	}
 	w.Flush()
 

--- a/fission/main.go
+++ b/fission/main.go
@@ -48,12 +48,14 @@ func main() {
 	fnLogDBTypeFlag := cli.StringFlag{Name: "dbtype", Usage: "log database type, e.g. influxdb (currently only influxdb is supported)"}
 	fnUserNameFlag := cli.StringFlag{Name: "username, u", Usage: "username for connecting log database"}
 	fnPasswordFlag := cli.StringFlag{Name: "password, p", Usage: "password for connecting log database"}
+	fnCpuTargetFlag := cli.StringFlag{Name: "cputarget", Usage: "target cpu usage in percentage for hpa to scale"}
+	fnMaxInstanceFlag := cli.StringFlag{Name: "maxinstance", Usage: "max instance number the function can scale"}
 	fnSubcommands := []cli.Command{
-		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, htUrlFlag, htMethodFlag}, Action: fnCreate},
+		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, htUrlFlag, htMethodFlag, fnCpuTargetFlag, fnMaxInstanceFlag}, Action: fnCreate},
 		{Name: "get", Usage: "Get function source code", Flags: []cli.Flag{fnNameFlag, fnUidFlag}, Action: fnGet},
 		{Name: "edit", Usage: "Edit function source code in $EDITOR", Flags: []cli.Flag{fnNameFlag, fnUidFlag}, Action: fnEdit},
 		{Name: "getmeta", Usage: "Get function metadata", Flags: []cli.Flag{fnNameFlag, fnUidFlag}, Action: fnGetMeta},
-		{Name: "update", Usage: "Update function source code", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag}, Action: fnUpdate},
+		{Name: "update", Usage: "Update function source code", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnCpuTargetFlag, fnMaxInstanceFlag}, Action: fnUpdate},
 		{Name: "delete", Usage: "Delete function", Flags: []cli.Flag{fnNameFlag, fnUidFlag}, Action: fnDelete},
 		{Name: "list", Usage: "List all functions", Flags: []cli.Flag{}, Action: fnList},
 		{Name: "logs", Usage: "Display funtion logs", Flags: []cli.Flag{fnNameFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBHostFlag, fnLogDBTypeFlag, fnUserNameFlag, fnPasswordFlag}, Action: fnLogs},
@@ -75,10 +77,14 @@ func main() {
 	// environments
 	envNameFlag := cli.StringFlag{Name: "name", Usage: "Environment name"}
 	envImageFlag := cli.StringFlag{Name: "image", Usage: "Environment image URL"}
+	envCpuLimitFlag := cli.StringFlag{Name: "cpulimit", Usage: "Environment cpu limit"}
+	envMemLimitFlag := cli.StringFlag{Name: "memlimit", Usage: "Environment mem limit"}
+	envCpuRequestFlag := cli.StringFlag{Name: "cpurequest", Usage: "Environment mem request"}
+	envMemRequestFlag := cli.StringFlag{Name: "memrequest", Usage: "Environment mem request"}
 	envSubcommands := []cli.Command{
-		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envImageFlag}, Action: envCreate},
+		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envImageFlag, envCpuLimitFlag, envMemLimitFlag, envCpuRequestFlag, envMemRequestFlag}, Action: envCreate},
 		{Name: "get", Usage: "Get environment details", Flags: []cli.Flag{envNameFlag}, Action: envGet},
-		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envImageFlag}, Action: envUpdate},
+		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envImageFlag, envCpuLimitFlag, envMemLimitFlag, envCpuRequestFlag, envMemRequestFlag}, Action: envUpdate},
 		{Name: "delete", Usage: "Delete environment", Flags: []cli.Flag{envNameFlag}, Action: envDelete},
 		{Name: "list", Usage: "List all environments", Flags: []cli.Flag{}, Action: envList},
 	}

--- a/poolmgr/autoscale.go
+++ b/poolmgr/autoscale.go
@@ -1,0 +1,87 @@
+package poolmgr
+
+import (
+	"k8s.io/client-go/1.5/pkg/api/resource"
+
+	"github.com/fission/fission"
+)
+
+type EnvResources struct {
+	cpuLimit   resource.Quantity
+	memLimit   resource.Quantity
+	cpuRequest resource.Quantity
+	memRequest resource.Quantity
+}
+
+var (
+	FETCHER_MEM_LIMIT, _   = resource.ParseQuantity("64Mi")
+	FETCHER_CPU_LIMIT, _   = resource.ParseQuantity("50m")
+	FETCHER_MEM_REQUEST, _ = resource.ParseQuantity("64Mi")
+	FETCHER_CPU_REQUEST, _ = resource.ParseQuantity("10m")
+	DEFAULT_MEM_LIMIT, _   = resource.ParseQuantity("256Mi")
+	DEFAULT_CPU_LIMIT, _   = resource.ParseQuantity("100m")
+	DEFAULT_MEM_REQUEST, _ = resource.ParseQuantity("128Mi")
+	DEFAULT_CPU_REQUEST, _ = resource.ParseQuantity("50m")
+	DEFAULT_MEM_UPPER, _   = resource.ParseQuantity("1024Mi")
+	DEFAULT_CPU_UPPER, _   = resource.ParseQuantity("1000m")
+	DEFAULT_MEM_LOWER, _   = resource.ParseQuantity("8Mi")
+	DEFAULT_CPU_LOWER, _   = resource.ParseQuantity("1m")
+)
+
+func EnsureCpuQuantityInRange(quantity resource.Quantity) resource.Quantity {
+	if quantity.Cmp(DEFAULT_CPU_LOWER) == -1 {
+		return DEFAULT_CPU_LOWER
+	}
+	if quantity.Cmp(DEFAULT_CPU_UPPER) == 1 {
+		return DEFAULT_CPU_UPPER
+	}
+	return quantity
+}
+
+func EnsureMemQuantityInRange(quantity resource.Quantity) resource.Quantity {
+	if quantity.Cmp(DEFAULT_MEM_LOWER) == -1 {
+		return DEFAULT_MEM_LOWER
+	}
+	if quantity.Cmp(DEFAULT_MEM_UPPER) == 1 {
+		return DEFAULT_MEM_UPPER
+	}
+	return quantity
+}
+
+func GetResourceQuantity(env *fission.Environment) *EnvResources {
+	res := EnvResources{}
+	var err error
+	res.cpuLimit, err = resource.ParseQuantity(env.CpuLimit)
+	if err != nil {
+		res.cpuLimit = DEFAULT_CPU_LIMIT
+	} else {
+		res.cpuLimit = EnsureCpuQuantityInRange(res.cpuLimit)
+	}
+	res.memLimit, err = resource.ParseQuantity(env.MemLimit)
+	if err != nil {
+		res.memLimit = DEFAULT_MEM_LIMIT
+	} else {
+		res.memLimit = EnsureMemQuantityInRange(res.memLimit)
+	}
+	res.cpuRequest, err = resource.ParseQuantity(env.CpuRequest)
+	if err != nil {
+		res.cpuRequest = DEFAULT_CPU_REQUEST
+	} else {
+		res.cpuRequest = EnsureCpuQuantityInRange(res.cpuRequest)
+	}
+	res.memRequest, err = resource.ParseQuantity(env.MemRequest)
+	if err != nil {
+		res.memRequest = DEFAULT_MEM_REQUEST
+	} else {
+		res.memRequest = EnsureMemQuantityInRange(res.memRequest)
+	}
+
+	if res.cpuLimit.Cmp(res.cpuRequest) == -1 {
+		res.cpuLimit = res.cpuRequest
+	}
+	if res.memLimit.Cmp(res.memRequest) == -1 {
+		res.memLimit = res.memRequest
+	}
+
+	return &res
+}

--- a/poolmgr/functionServiceCache_test.go
+++ b/poolmgr/functionServiceCache_test.go
@@ -29,10 +29,11 @@ func TestFunctionServiceCache(t *testing.T) {
 			},
 			RunContainerImageUrl: "fission/foo-env",
 		},
-		address: "xxx",
-		podName: "yyy",
-		ctime:   now,
-		atime:   now,
+		podAddress: "xxx",
+		svcAddress: "zzz",
+		podName:    "yyy",
+		ctime:      now,
+		atime:      now,
 	}
 	err, _ := fsc.Add(*fsvc)
 	if err != nil {
@@ -52,7 +53,7 @@ func TestFunctionServiceCache(t *testing.T) {
 		log.Panicf("Incorrect fsvc \n(expected: %#v)\n (found: %#v)", fsvc, f)
 	}
 
-	err = fsc.TouchByAddress(fsvc.address)
+	err = fsc.TouchByAddress(fsvc.svcAddress)
 	if err != nil {
 		fsc.Log()
 		log.Panicf("Failed to touch fsvc: %v", err)

--- a/types.go
+++ b/types.go
@@ -31,6 +31,8 @@ type (
 		Metadata    `json:"metadata"`
 		Environment Metadata `json:"environment"`
 		Code        string   `json:"code"`
+		CpuTarget   int      `json:"cputarget,omitempty"`
+		MaxInstance int      `json:"maxinstance,omitempty"`
 	}
 
 	// Environment identifies the language and OS specific
@@ -41,6 +43,10 @@ type (
 	Environment struct {
 		Metadata             `json:"metadata"`
 		RunContainerImageUrl string `json:"runContainerImageUrl"`
+		CpuRequest           string `json:"cpurequest,omitempty"`
+		CpuLimit             string `json:"cpulimit,omitempty"`
+		MemRequest           string `json:"memrequest,omitempty"`
+		MemLimit             string `json:"memlimit,omitempty"`
 	}
 
 	// HTTPTrigger maps URL patterns to functions.  Function.UID


### PR DESCRIPTION
These two commits are based on @soamvasani previous commits.
- Use horizontal autoscaler to scale the function instance, currently deployment cpu usage is the only metric
- Make hpa related params adjustable
- Logger watch k8s pod events to setup/unset logging for function automatically

I use the function below to generate loads, on a two core k8s in GCP
```
module.exports = function(context, callback) {
    for (i=0; i<1000;i++) {
        x = Math.random();
    }
    callback(200, "Hello, world!\n");
}
```