### PR TITLE
Fix creating redundant pods on heavyload coldstart

### DIFF
--- a/poolmgr/gp.go
+++ b/poolmgr/gp.go
@@ -438,7 +438,7 @@ func (gp *GenericPool) GetFuncSvc(m *fission.Metadata) (*funcSvc, error) {
 	if gp.useSvc {
 		svcName := fmt.Sprintf("svc-%v", m.Name)
 		if len(m.Uid) > 0 {
-			svcName += ("-" + m.Uid)
+			svcName += "-" + m.Uid
 		}
 
 		labels := gp.labelsForFunction(m)
@@ -472,8 +472,7 @@ func (gp *GenericPool) GetFuncSvc(m *fission.Metadata) (*funcSvc, error) {
 	err, existingFsvc := gp.fsCache.Add(*fsvc)
 	if err != nil {
 		// Some other thread beat us to it -- return the other thread's fsvc and clean up
-		// our own.  TODO: this is grossly inefficient, improve it with some sort of state
-		// machine
+		// our own.
 		log.Printf("func svc already exists: %v", existingFsvc.podName)
 		go func() {
 			gp.kubernetesClient.Core().Pods(gp.namespace).Delete(fsvc.podName, nil)

--- a/router/functionServiceMap.go
+++ b/router/functionServiceMap.go
@@ -45,9 +45,12 @@ func (fmap *functionServiceMap) lookup(f *fission.Metadata) (*url.URL, error) {
 }
 
 func (fmap *functionServiceMap) assign(f *fission.Metadata, serviceUrl *url.URL) {
-	err, _ := fmap.cache.Set(*f, serviceUrl)
+	err, old := fmap.cache.Set(*f, serviceUrl)
 	if err != nil {
-		log.Printf("error caching service url for function: %v", err)
+		if *serviceUrl == *(old.(*url.URL)) {
+			return
+		}
+		log.Printf("error caching service url for function with a different value: %v", err)
 		// ignore error
 	}
 }


### PR DESCRIPTION
This is a proposal for fixing creating redundant pods on heavy load cold start.

When there are many requests on a cold function and the func service is not ready, each of the request will trigger poolmgr to specialize a pod. If the env pool size is smaller than the incoming concurrent requests, the request is hung up until a pod is available in the env pool. Then a pod is specialized and deleted if a func service already exists (beated by other requests). In `poormgr.go`, there is a already TODO showing we need a fix for this.

In this commit, the first request will create the func service as usual and create a channel for other requests to block on. Once the func service is ready, it will notify all the wait requests to fetch the func request from the cache again. There is no lock to visit the func service waiting channel, so there is a tiny chance that multi goroutines step into creating the same func service.

I use `ab -n 10 -c 10` to test the commit on a two vCPU, single node GKE. Time per request is 1842.712 ms (current master) vs 174.420 ms (this commit).