### PR TITLE
Fission update must require at least one change to function

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -179,9 +179,16 @@ func fnUpdate(c *cli.Context) error {
 	}
 
 	fileName := c.String("code")
+	if len(fileName) == 0 {
+		fileName = c.String("package")
+	}
+
+	if len(envName) == 0 && len(fileName) == 0 {
+		fatal("Need --env or --code or --package argument.")
+	}
+
 	if len(fileName) > 0 {
 		code := fnFetchCode(fileName)
-
 		function.Code = string(code)
 	}
 


### PR DESCRIPTION
This PR aims to improve the usability of fission CLI mentioned in https://github.com/fission/fission/issues/237. Also, fix the argument `--package` is not working in `fission fn update`. 
Now, at least one argument (`--env`, `--code`, `--package`) needs to specify when a user tries to update a function.