### PR TITLE
Add 'function invoke' subcommand

### DIFF
--- a/fission/common.go
+++ b/fission/common.go
@@ -29,6 +29,10 @@ func fatal(msg string) {
 	os.Exit(1)
 }
 
+func warn(msg string) {
+	os.Stderr.WriteString(msg + "\n")
+}
+
 func getClient(serverUrl string) *client.Client {
 
 	if len(serverUrl) == 0 {

--- a/fission/function.go
+++ b/fission/function.go
@@ -405,7 +405,7 @@ func fnInvoke(c *cli.Context) error {
 	// Temporary, switch once internal function routes are extracted to separate internal router.
 	routerUrl := os.Getenv("FISSION_ROUTER")
 	if len(routerUrl) == 0 {
-		fatal("Need FISSION_ROUTER set to your fission router.")
+		fatal("Need FISSION_ROUTER set to your Fission router.")
 	}
 
 	fnName := c.String("name")
@@ -421,9 +421,13 @@ func fnInvoke(c *cli.Context) error {
 		fatal(fmt.Sprintf("Invalid HTTP method '%s'.", httpMethod))
 	}
 
+	url := fmt.Sprintf("%s/fission-function/%s", routerUrl, fnName)
+	if !strings.HasPrefix(url, "http") {
+		url = fmt.Sprintf("http://%s", url)
+	}
+
 	input := c.String("body")
 	headers := c.StringSlice("header")
-	url := fmt.Sprintf("http://%s/fission-function/%s", routerUrl, fnName)
 
 	req, err := http.NewRequest(httpMethod, url, strings.NewReader(input))
 	if err != nil {
@@ -434,7 +438,7 @@ func fnInvoke(c *cli.Context) error {
 	for _, header := range headers {
 		headerKeyValue := strings.SplitN(header, ":", 2)
 		if len(headerKeyValue) != 2 {
-			warn(fmt.Sprintf("Invalid header '%s'. Skipping...", headerKeyValue));
+			warn(fmt.Sprintf("Invalid header '%s'. Skipping...", headerKeyValue))
 			continue
 		}
 		req.Header.Set(headerKeyValue[0], headerKeyValue[1])

--- a/fission/function.go
+++ b/fission/function.go
@@ -400,3 +400,55 @@ func fnPods(c *cli.Context) error {
 
 	return err
 }
+
+func fnInvoke(c *cli.Context) error {
+	// Temporary, switch once internal function routes are extracted to separate internal router.
+	routerUrl := os.Getenv("FISSION_ROUTER")
+	if len(routerUrl) == 0 {
+		fatal("Need FISSION_ROUTER set to your fission router.")
+	}
+
+	fnName := c.String("name")
+	if len(fnName) == 0 {
+		fatal("Need name of function, use --name")
+	}
+
+	httpMethod := c.String("method")
+	if httpMethod != http.MethodGet &&
+		httpMethod != http.MethodDelete &&
+		httpMethod != http.MethodPost &&
+		httpMethod != http.MethodPut {
+		fatal(fmt.Sprintf("Invalid HTTP method '%s'.", httpMethod))
+	}
+
+	input := c.String("body")
+	headers := c.StringSlice("header")
+	url := fmt.Sprintf("http://%s/fission-function/%s", routerUrl, fnName)
+
+	req, err := http.NewRequest(httpMethod, url, strings.NewReader(input))
+	if err != nil {
+		panic(err)
+		fatal("Failed to create request.")
+	}
+
+	for _, header := range headers {
+		headerKeyValue := strings.SplitN(header, ":", 2)
+		if len(headerKeyValue) != 2 {
+			warn(fmt.Sprintf("Invalid header '%s'. Skipping...", headerKeyValue));
+			continue
+		}
+		req.Header.Set(headerKeyValue[0], headerKeyValue[1])
+	}
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fatal("Request failed.")
+	}
+	defer resp.Body.Close()
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	fmt.Print(string(body))
+
+	return nil
+}

--- a/fission/main.go
+++ b/fission/main.go
@@ -45,6 +45,9 @@ func main() {
 	fnFollowFlag := cli.BoolFlag{Name: "follow, f", Usage: "specify if the logs should be streamed"}
 	fnDetailFlag := cli.BoolFlag{Name: "detail, d", Usage: "display detailed information"}
 	fnLogDBTypeFlag := cli.StringFlag{Name: "dbtype", Usage: "log database type, e.g. influxdb (currently only influxdb is supported)"}
+	fnMethodFlag := cli.StringFlag{Name: "method, m", Usage: "HTTP method (GET|POST|PUT|DELETE)", Value: "GET"}
+	fnBodyFlag := cli.StringFlag{Name: "body, b", Usage: "request body"}
+	fnHeaderFlag := cli.StringSliceFlag{Name: "header, H", Usage: "request headers"}
 	fnSubcommands := []cli.Command{
 		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, htUrlFlag, htMethodFlag}, Action: fnCreate},
 		{Name: "get", Usage: "Get function source code", Flags: []cli.Flag{fnNameFlag, fnUidFlag}, Action: fnGet},
@@ -55,6 +58,7 @@ func main() {
 		{Name: "list", Usage: "List all functions", Flags: []cli.Flag{}, Action: fnList},
 		{Name: "logs", Usage: "Display function logs", Flags: []cli.Flag{fnNameFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBTypeFlag}, Action: fnLogs},
 		{Name: "pods", Usage: "Display function pods", Flags: []cli.Flag{fnNameFlag, fnLogDBTypeFlag}, Action: fnPods},
+		{Name: "invoke", Usage: "Invoke a function", Flags: []cli.Flag{fnNameFlag, fnMethodFlag, fnBodyFlag, fnHeaderFlag}, Action: fnInvoke},
 	}
 
 	// httptriggers


### PR DESCRIPTION
This PR adds an initial "function invoke" subcommand to the CLI. 

Currently a downside is that it requires the FISSION_ROUTER to be present. This should be just temporary issue. As discussed #257 at some point the internal routes will be extracted and placed in an internal router, which will allow the CLI connect to the cluster API server and get proxied to the internal router. Until then this seems like a useful addition to the current CLI.