### PR TITLE
Different Minishift example

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -122,8 +122,8 @@ $ oc create -f https://github.com/fission/fission/releases/download/nightly20170
 Identically as with Kubernetes, you need to set the FISSION_URL and FISSION_ROUTER environment variables. If you're using minishift, use these commands:
 
 ```
-  $ export FISSION_URL=http://$(oc export route/controller -o json | jq -r '.spec.host')¬
-  $ export FISSION_ROUTER=$(oc export route/router -o json | jq -r '.spec.host')¬
+  $ export FISSION_URL=http://$(oc get route/controller -o=jsonpath='{.spec.host}')¬
+  $ export FISSION_ROUTER=$(oc get route/router -o=jsonpath='{.spec.host}')¬
 ```
 After these steps, you should be able to run fission client as with kubernetes.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -94,18 +94,14 @@ permissions (like `system:admin`), as it needs to create a
 `ClusterRole` for deploying function containers from the `fission`
 namespace/project.
 
-Identically as with Kubernetes, you need to set the FISSION_URL and FISSION_ROUTER environment variables. If you're using minishift, use these commands:
-
-```
-  $ export FISSION_URL=http://$(minishift ip):31313¬
-  $ export FISSION_ROUTER=$(minishift ip):31314¬
-```
 #### Using Minishift or Local Cluster
 
 If you're using minishift or no cloud provider, use these commands to set up services with NodePort. This exposes fission on ports 31313 and 31314.
 
 ```
   $ oc login -u system:admin
+  $ oc adm policy add-cluster-role-to-user cluster-admin developer
+  $ oc login -u developer
   $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-openshift.yaml
   $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-nodeport.yaml
 ```
@@ -118,6 +114,15 @@ If you're using any cloud provider that supports the LoadBalancer service type, 
 $ oc login -u system:admin
 $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-openshift.yaml
 $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-cloud.yaml
+$ oc expose service router --port 8888
+$ oc expose service controller --port 8888
+```
+
+Identically as with Kubernetes, you need to set the FISSION_URL and FISSION_ROUTER environment variables. If you're using minishift, use these commands:
+
+```
+  $ export FISSION_URL=http://$(oc export route/controller -o json | jq -r '.spec.host')¬
+  $ export FISSION_ROUTER=$(oc export route/router -o json | jq -r '.spec.host')¬
 ```
 After these steps, you should be able to run fission client as with kubernetes.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -103,7 +103,10 @@ If you're using minishift or no cloud provider, use these commands to set up ser
   $ oc adm policy add-cluster-role-to-user cluster-admin developer
   $ oc login -u developer
   $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-openshift.yaml
-  $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-nodeport.yaml
+  $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-cloud.yaml
+  $ oc project fission
+  $ oc expose service router --port 8888
+  $ oc expose service controller --port 8888
 ```
 
 #### Using other clouds
@@ -114,8 +117,6 @@ If you're using any cloud provider that supports the LoadBalancer service type, 
 $ oc login -u system:admin
 $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-openshift.yaml
 $ oc create -f https://github.com/fission/fission/releases/download/nightly20170705/fission-cloud.yaml
-$ oc expose service router --port 8888
-$ oc expose service controller --port 8888
 ```
 
 Identically as with Kubernetes, you need to set the FISSION_URL and FISSION_ROUTER environment variables. If you're using minishift, use these commands:


### PR DESCRIPTION
adds the cluster-admin policy to developer, then uses the developer role
exposes the router and service using the nip.io (or alternative) proxy that comes with minishift (on my mac, at least)

I use jq to parse the json output from oc export to get the FISSION_URL and FISSION_ROUTER. There may be a way to do it without jq.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/274)
<!-- Reviewable:end -->
