### PR TITLE
Set message content-type based on the trigger.Spec.ContentType

### DIFF
--- a/fission/main.go
+++ b/fission/main.go
@@ -84,10 +84,11 @@ func main() {
 	mqtMQTypeFlag := cli.StringFlag{Name: "mqtype", Usage: "Message queue type, e.g. nats-streaming  (optional; uses \"nats-streaming\" if unspecified)"}
 	mqtTopicFlag := cli.StringFlag{Name: "topic", Usage: "Message queue Topic the trigger listens on"}
 	mqtRespTopicFlag := cli.StringFlag{Name: "resptopic", Usage: "Topic that the function response is sent on (optional; response discarded if unspecified)"}
+	mqtMsgContentType := cli.StringFlag{Name: "contenttype, c", Usage: "Content type of messages that publish to the topic (optional; uses \"application/json\" if unspecified)"}
 	mqtSubcommands := []cli.Command{
-		{Name: "create", Aliases: []string{"add"}, Usage: "Create Message queue trigger", Flags: []cli.Flag{mqtNameFlag, mqtFnNameFlag, mqtMQTypeFlag, mqtTopicFlag, mqtRespTopicFlag}, Action: mqtCreate},
+		{Name: "create", Aliases: []string{"add"}, Usage: "Create Message queue trigger", Flags: []cli.Flag{mqtNameFlag, mqtFnNameFlag, mqtMQTypeFlag, mqtTopicFlag, mqtRespTopicFlag, mqtMsgContentType}, Action: mqtCreate},
 		{Name: "get", Usage: "Get message queue trigger", Flags: []cli.Flag{}, Action: mqtGet},
-		{Name: "update", Usage: "Update message queue trigger", Flags: []cli.Flag{mqtNameFlag, mqtTopicFlag, mqtRespTopicFlag, mqtFnNameFlag}, Action: mqtUpdate},
+		{Name: "update", Usage: "Update message queue trigger", Flags: []cli.Flag{mqtNameFlag, mqtTopicFlag, mqtRespTopicFlag, mqtFnNameFlag, mqtMsgContentType}, Action: mqtUpdate},
 		{Name: "delete", Usage: "Delete message queue trigger", Flags: []cli.Flag{mqtNameFlag}, Action: mqtDelete},
 		{Name: "list", Usage: "List message queue triggers", Flags: []cli.Flag{mqtMQTypeFlag}, Action: mqtList},
 	}

--- a/fission/mqtrigger.go
+++ b/fission/mqtrigger.go
@@ -65,6 +65,11 @@ func mqtCreate(c *cli.Context) error {
 		fatal("Listen topic should not equal to response topic")
 	}
 
+	contentType := c.String("contenttype")
+	if len(contentType) == 0 {
+		contentType = "application/json"
+	}
+
 	checkMQTopicAvailability(mqType, topic, respTopic)
 
 	mqt := tpr.Messagequeuetrigger{
@@ -80,6 +85,7 @@ func mqtCreate(c *cli.Context) error {
 			MessageQueueType: mqType,
 			Topic:            topic,
 			ResponseTopic:    respTopic,
+			ContentType:      contentType,
 		},
 	}
 
@@ -103,6 +109,7 @@ func mqtUpdate(c *cli.Context) error {
 	topic := c.String("topic")
 	respTopic := c.String("resptopic")
 	fnName := c.String("function")
+	contentType := c.String("contenttype")
 
 	mqt, err := client.MessageQueueTriggerGet(&api.ObjectMeta{
 		Name:      mqtName,
@@ -123,6 +130,10 @@ func mqtUpdate(c *cli.Context) error {
 	}
 	if len(fnName) > 0 {
 		mqt.Spec.FunctionReference.Name = fnName
+		updated = true
+	}
+	if len(contentType) > 0 {
+		mqt.Spec.ContentType = contentType
 		updated = true
 	}
 
@@ -162,11 +173,11 @@ func mqtList(c *cli.Context) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
-		"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n",
+		"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "PUB_MSG_CONTENT_TYPE")
 	for _, mqt := range mqts {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
-			mqt.Metadata.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n",
+			mqt.Metadata.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ContentType)
 	}
 	w.Flush()
 

--- a/mqtrigger/messageQueue/nats.go
+++ b/mqtrigger/messageQueue/nats.go
@@ -106,6 +106,7 @@ func msgHandler(nats *Nats, trigger *tpr.Messagequeuetrigger) func(*ns.Msg) {
 		headers := map[string]string{
 			"X-Fission-MQTrigger-Topic":     trigger.Spec.Topic,
 			"X-Fission-MQTrigger-RespTopic": trigger.Spec.ResponseTopic,
+			"Content-Type":                  trigger.Spec.ContentType,
 		}
 
 		// Create request

--- a/types.go
+++ b/types.go
@@ -159,6 +159,7 @@ type (
 		MessageQueueType  string            `json:"messageQueueType"`
 		Topic             string            `json:"topic"`
 		ResponseTopic     string            `json:"respTopic,omitempty"`
+		ContentType       string            `json:"contentType"`
 	}
 
 	// TimeTrigger invokes the specific function at a time or


### PR DESCRIPTION
This PR aims to add content-type to http header when mqtrigger tries to post message to the function. (https://github.com/fission/fission/issues/275)

The user can specify content-type of messages when creating the mqtrigger, and update it later.

```
$ fission mqtrigger create --name h1 --function hello1 --mqtype "nats-streaming" --topic "foo.bar" --resptopic "foo.foo" --contenttype "application/xml"
$ fission mqtrigger update --name h1 -c application/json
```

Also, `mqtrigger list` shows the message content type now.

```
$ fission mqtrigger list
NAME FUNCTION_NAME MESSAGE_QUEUE_TYPE TOPIC   RESPONSE_TOPIC PUB_MSG_CONTENT_TYPE
h1   hello1        nats-streaming     foo.bar foo.foo        application/json
```