### PR TITLE
Set fetcher image through poolmgr env

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -42,6 +42,8 @@ The following table lists the configurable parameters of the Fission chart and t
 | `serviceType`       | Type of service to use                     | `LoadBalancer`.          |
 | `image`             | Fission image                              | `fission/fission-bundle` |
 | `imageTag`          | Fission image tag                          | `alpha20170124`          |
+| `fetcherImage`      | Fission fetcher image                      | `fission/fetcher`        |
+| `fetcherImageTag`   | Fission fetcher image tag                  | `latest`                 |
 | `controllerPort`    | Fission Controller Service Port            | `31313`                  |
 | `routerPort`        | Fission Router Service Port                | `31314`                  |
 | `functionNamespace` | Namespace for Fission functions            | `fission-function`       |

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -211,6 +211,9 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         command: ["/fission-bundle"]
         args: ["--poolmgrPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}"]
+        env:
+        - name: FETCHER_IMAGE
+          value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -6,7 +6,7 @@
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer.
 serviceType: LoadBalancer
 
-## Fission image repostiroy
+## Fission image repository
 image: fission/fission-bundle
 
 ## Image pull policy
@@ -15,7 +15,7 @@ pullPolicy: ifNotPresent
 ## Fission image version
 imageTag: nightly20170705
 
-## Fission fetcher repostiroy
+## Fission fetcher repository
 fetcherImage: fission/fetcher
 
 ## Fission fetcher image version

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -15,6 +15,12 @@ pullPolicy: ifNotPresent
 ## Fission image version
 imageTag: nightly20170705
 
+## Fission fetcher repostiroy
+fetcherImage: fission/fetcher
+
+## Fission fetcher image version
+fetcherImageTag: latest
+
 ## Port at which Fission controller service should be exposed
 controllerPort: 31313
 

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -211,6 +211,9 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         command: ["/fission-bundle"]
         args: ["--poolmgrPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}"]
+        env:
+        - name: FETCHER_IMAGE
+          value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -12,6 +12,12 @@ image: fission/fission-bundle
 ## Fission image version
 imageTag: alpha20170124
 
+## Fission fetcher repostiroy
+fetcherImage: fission/fetcher
+
+## Fission fetcher image version
+fetcherImageTag: latest
+
 ## Port at which Fission controller service should be exposed
 controllerPort: 31313
 

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -6,13 +6,13 @@
 ## For minikube, set this to NodePort, elsewhere use LoadBalancer.
 serviceType: LoadBalancer
 
-## Fission image repostiroy
+## Fission image repository
 image: fission/fission-bundle
 
 ## Fission image version
 imageTag: alpha20170124
 
-## Fission fetcher repostiroy
+## Fission fetcher repository
 fetcherImage: fission/fetcher
 
 ## Fission fetcher image version


### PR DESCRIPTION
This PR aims to update helm charts, so that a user can change fetcher image with poolmgr env (https://github.com/fission/fission/blob/master/poolmgr/gp.go#L90).