### PR TITLE
Parse metadata.Name before creating tpr resource

### DIFF
--- a/controller/environmentApi.go
+++ b/controller/environmentApi.go
@@ -60,6 +60,12 @@ func (a *API) EnvironmentApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = validateResourceName(env.Metadata.Name)
+	if err != nil {
+		a.respondWithError(w, err)
+		return
+	}
+
 	enew, err := a.fissionClient.Environments(env.Metadata.Namespace).Create(&env)
 	if err != nil {
 		a.respondWithError(w, err)

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -61,6 +61,12 @@ func (a *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = validateResourceName(f.Metadata.Name)
+	if err != nil {
+		a.respondWithError(w, err)
+		return
+	}
+
 	// Ensure size limits
 	if len(f.Spec.Source.Literal) > 256*1024 {
 		err := fission.MakeError(fission.ErrorInvalidArgument, "Source package literal larger than 256K")

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -74,6 +74,12 @@ func (a *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = validateResourceName(t.Metadata.Name)
+	if err != nil {
+		a.respondWithError(w, err)
+		return
+	}
+
 	// Ensure we don't have a duplicate HTTP route defined (same URL and method)
 	err = a.checkHttpTriggerDuplicates(&t)
 	if err != nil {

--- a/controller/mqTriggerApi.go
+++ b/controller/mqTriggerApi.go
@@ -57,6 +57,12 @@ func (a *API) MessageQueueTriggerApiCreate(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	err = validateResourceName(mqTrigger.Metadata.Name)
+	if err != nil {
+		a.respondWithError(w, err)
+		return
+	}
+
 	tnew, err := a.fissionClient.Messagequeuetriggers(mqTrigger.Metadata.Namespace).Create(&mqTrigger)
 	if err != nil {
 		a.respondWithError(w, err)

--- a/controller/timeTriggerApi.go
+++ b/controller/timeTriggerApi.go
@@ -59,6 +59,12 @@ func (a *API) TimeTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = validateResourceName(t.Metadata.Name)
+	if err != nil {
+		a.respondWithError(w, err)
+		return
+	}
+
 	// validate
 	_, err = cron.Parse(t.Spec.Cron)
 	if err != nil {

--- a/controller/tpr.go
+++ b/controller/tpr.go
@@ -17,6 +17,9 @@ limitations under the License.
 package controller
 
 import (
+	"errors"
+	"regexp"
+
 	"github.com/fission/fission/tpr"
 )
 
@@ -26,4 +29,12 @@ func makeTPRBackedAPI() (*API, error) {
 		return nil, err
 	}
 	return &API{fissionClient: fissionClient}, nil
+}
+
+func validateResourceName(name string) error {
+	re := regexp.MustCompile(`[a-z0-9]([-a-z0-9]*[a-z0-9])?`)
+	if len(re.FindString(name)) != len(name) {
+		return errors.New("Name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'")
+	}
+	return nil
 }

--- a/controller/watchApi.go
+++ b/controller/watchApi.go
@@ -58,6 +58,12 @@ func (a *API) WatchApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	err = validateResourceName(watch.Metadata.Name)
+	if err != nil {
+		a.respondWithError(w, err)
+		return
+	}
+
 	// TODO check for duplicate watches
 
 	wnew, err := a.fissionClient.Kuberneteswatchtriggers(watch.Metadata.Namespace).Create(&watch)


### PR DESCRIPTION
This small PR aims to improve the usability of fission CLI when a user tries to create a resource with an invalid name. (https://github.com/fission/fission/issues/269)