### PR TITLE
Minor documentation fix for the Go example

### DIFF
--- a/examples/go/README.md
+++ b/examples/go/README.md
@@ -29,7 +29,7 @@ $ chmod +x go-function-build
 $ go-function-build hello.go
 
 # Upload the function to fission
-$ fission function create --name hello --env go-runtime --package function.so
+$ fission function create --name hello --env go-env --package function.so
 
 # Map /hello to the hello function
 $ fission route create --method GET --url /hello --function hello


### PR DESCRIPTION
Really minor documentation fix that might trip people up otherwise. Changes the `--env` referenced in the create command to match the env that is created earlier in the example.