### PR TITLE
Helm chart bugfixes + end to end test bugfixes

### DIFF
--- a/charts/fission-all/Chart.yaml
+++ b/charts/fission-all/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fission-all
-version: 0.1.0
+version: v0.2.0-20170822
 description: Fission is a fast serverless framework for Kubernetes.
 keywords:
 - fission

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -194,7 +194,7 @@ spec:
       - name: router
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         command: ["/fission-bundle"]
-        args: ["--routerPort", "8888"]
+        args: ["--routerPort", "8888", "--poolmgrUrl", "poolmgr.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -194,7 +194,7 @@ spec:
       - name: router
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         command: ["/fission-bundle"]
-        args: ["--routerPort", "8888", "--poolmgrUrl", "poolmgr.{{ .Release.Namespace }}"]
+        args: ["--routerPort", "8888", "--poolmgrUrl", "http://poolmgr.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -172,6 +172,7 @@ spec:
       containers:
       - name: controller
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
       serviceAccount: fission-svc
@@ -193,6 +194,7 @@ spec:
       containers:
       - name: router
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--poolmgrUrl", "http://poolmgr.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
@@ -230,6 +232,7 @@ spec:
       containers:
       - name: poolmgr
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--poolmgrPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}"]
         env:
@@ -254,6 +257,7 @@ spec:
       containers:
       - name: kubewatcher
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher"]
       serviceAccount: fission-svc
@@ -321,7 +325,7 @@ spec:
       containers:
         - name: logger
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.pullPolicy }}
           command: ["/fission-bundle"]
           args: ["--logger"]
           volumeMounts:
@@ -340,7 +344,7 @@ spec:
               protocol: TCP
         - name: fluentd
           image: {{ .Values.logger.fluentdImage }}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: {{ .Values.pullPolicy }}
           env:
             - name: INFLUXDB_ADDRESS
               value: influxdb
@@ -397,6 +401,7 @@ spec:
       containers:
       - name: timer
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer"]
       serviceAccount: fission-svc
@@ -468,6 +473,7 @@ spec:
       containers:
       - name: mqtrigger
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt"]
         env:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -10,16 +10,16 @@ serviceType: LoadBalancer
 image: fission/fission-bundle
 
 ## Image pull policy
-pullPolicy: ifNotPresent
+pullPolicy: IfNotPresent
 
 ## Fission image version
-imageTag: nightly20170705
+imageTag: v0.2.0-20170822
 
 ## Fission fetcher repository
 fetcherImage: fission/fetcher
 
 ## Fission fetcher image version
-fetcherImageTag: latest
+fetcherImageTag: v0.2.0-20170822
 
 ## Port at which Fission controller service should be exposed
 controllerPort: 31313

--- a/charts/fission-core/Chart.yaml
+++ b/charts/fission-core/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: fission-core
-version: 0.1.0
+version: v0.2.0-20170822
 description: Fission is a fast serverless framework for Kubernetes.
 keywords:
 - fission

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -194,7 +194,7 @@ spec:
       - name: router
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         command: ["/fission-bundle"]
-        args: ["--routerPort", "8888"]
+        args: ["--routerPort", "8888", "--poolmgrUrl", "poolmgr.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -194,7 +194,7 @@ spec:
       - name: router
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         command: ["/fission-bundle"]
-        args: ["--routerPort", "8888", "--poolmgrUrl", "poolmgr.{{ .Release.Namespace }}"]
+        args: ["--routerPort", "8888", "--poolmgrUrl", "http://poolmgr.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -172,6 +172,7 @@ spec:
       containers:
       - name: controller
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
       serviceAccount: fission-svc
@@ -193,6 +194,7 @@ spec:
       containers:
       - name: router
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--poolmgrUrl", "http://poolmgr.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
@@ -230,6 +232,7 @@ spec:
       containers:
       - name: poolmgr
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--poolmgrPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}"]
         env:
@@ -254,6 +257,7 @@ spec:
       containers:
       - name: kubewatcher
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher"]
       serviceAccount: fission-svc
@@ -275,6 +279,7 @@ spec:
       containers:
       - name: timer
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+        imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer"]
       serviceAccount: fission-svc

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -10,13 +10,16 @@ serviceType: LoadBalancer
 image: fission/fission-bundle
 
 ## Fission image version
-imageTag: alpha20170124
+imageTag: v0.2.0-20170822
+
+## Image pull policy
+pullPolicy: ifNotPresent
 
 ## Fission fetcher repository
 fetcherImage: fission/fetcher
 
 ## Fission fetcher image version
-fetcherImageTag: latest
+fetcherImageTag: v0.2.0-20170822
 
 ## Port at which Fission controller service should be exposed
 controllerPort: 31313

--- a/hack/runtests.sh
+++ b/hack/runtests.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
-# The poolmgr unit test only works with NodePort-type services for
-# now. So disable it for our travis ci tests.
 
 if [ ! -f ${KUBECONFIG} ]
 then
     unset KUBECONFIG
+else
+    K=kubectl --kubeconfig $KUBECONFIG
+    if $K get configmap ok-to-destroy
+    then
+	$K get function.fission.io -o name | cut -f2 -d'/' | xargs $K delete function.fission.io
+	$K get environment.fission.io -o name | cut -f2 -d'/' | xargs $K delete environment.fission.io
+	$K get httptrigger.fission.io -o name | cut -f2 -d'/' | xargs $K delete httptrigger.fission.io
+    fi
 fi
 
 go test -v -i $(go list ./... | grep -v '/vendor/' | grep -v 'examples/go')
+
+# The poolmgr unit test only works with NodePort-type services for
+# now. So disable it for our travis ci tests.
 go test -v $(go list ./... | grep -v '/vendor/' | grep -v 'examples/go' | grep -v poolmgr)

--- a/hack/runtests.sh
+++ b/hack/runtests.sh
@@ -5,7 +5,7 @@ if [ ! -f ${KUBECONFIG} ]
 then
     unset KUBECONFIG
 else
-    K=kubectl --kubeconfig $KUBECONFIG
+    K="kubectl --kubeconfig $KUBECONFIG"
     if $K get configmap ok-to-destroy
     then
 	$K get function.fission.io -o name | cut -f2 -d'/' | xargs $K delete function.fission.io

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -11,10 +11,13 @@ fi
 source $(dirname $0)/test_utils.sh
 
 IMAGE=gcr.io/fission-ci/fission-bundle
+FETCHER_IMAGE=gcr.io/fission-ci/fetcher
 TAG=test
 
 build_and_push_fission_bundle $IMAGE:$TAG
 
+build_and_push_fetcher $FETCHER_IMAGE:$TAG
+
 build_fission_cli
 
-install_and_test $IMAGE $TAG
+install_and_test $IMAGE $TAG $FETCHER_IMAGE $TAG

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -73,7 +73,7 @@ helm_install_fission() {
     ns=f-$id
     fns=f-func-$id
 
-    helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=alwaysPull
+    helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always
 
     helm_setup
     

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -182,7 +182,12 @@ install_and_test() {
     wait_for_services $id
     set_environment $id
 
-    success=run_all_tests $id
+    if run_all_tests $id
+    then
+	success=0
+    else
+	success=1
+    fi
 
     dump_logs $id
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -139,7 +139,7 @@ dump_function_pod_logs() {
     for p in $functionPods
     do
 	echo "--- function pod logs $p ---"
-	containers=$(kubectl -n $fns get pod $p -o jsonpath={.spec.containers[*].name})
+	containers=$(kubectl -n $fns get $p -o jsonpath={.spec.containers[*].name})
 	for c in $containers
 	do
 	    echo "--- function pod logs $p: container $c ---"

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -171,13 +171,14 @@ dump_logs() {
     dump_fission_resources
 }
 
+export FAILURES=0
+
 run_all_tests() {
     id=$1
 
     export FISSION_NAMESPACE=f-$id
     export FUNCTION_NAMESPACE=f-func-$id
         
-    failures=0
     for file in $ROOT/test/tests/test_*.sh
     do
 	echo ------- Running $file -------
@@ -186,14 +187,9 @@ run_all_tests() {
 	    echo SUCCESS: $file
 	else
 	    echo FAILED: $file
-	    failures=$(($failures+1))
+	    export FAILURES=$(($FAILURES+1))
 	fi
     done
-
-    if [ $failures -ne 0 ]
-    then
-	exit 1
-    fi
 }
 
 install_and_test() {
@@ -210,16 +206,11 @@ install_and_test() {
     wait_for_services $id
     set_environment $id
 
-    if run_all_tests $id
-    then
-	success=0
-    else
-	success=1
-    fi
+    run_all_tests $id
 
     dump_logs $id
 
-    if [ ! $success ]
+    if [ $FAILURES -ne 0 ]
     then
 	exit 1
     fi

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -154,8 +154,7 @@ run_all_tests() {
     for file in $ROOT/test/tests/test_*.sh
     do
 	echo ------- Running $file -------
-	e=$file
-	if [ ! $e ]
+	if [ ! $file ]
 	then
 	    echo FAILED: $file
 	    failures=$(($failures+1))

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -30,4 +30,7 @@ response=$(curl http://$FISSION_ROUTER/$fn)
 echo "Checking for valid response"
 echo $response | grep -i hello
 
+# crappy cleanup, improve this later
+kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
+
 echo "All done."

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(dirname $0)/../..
+
+# Create a hello world function in nodejs, test it with an http trigger
+
+echo "Test test, please ignore."
+
+fission env create --name nodejs --image fission/node-env
+trap "fission env delete --name nodejs" EXIT
+
+fission fn create --name hello --env nodejs --code $ROOT/examples/nodejs/hello.js
+trap "fission fn delete --name hello" EXIT
+
+fission route create --function hello --url /hello --method GET
+
+sleep 3
+
+time curl http://$FISSION_ROUTER/hello
+
+time curl http://$FISSION_ROUTER/hello

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -7,18 +7,27 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-hello-$(date +%N)
 
 # Create a hello world function in nodejs, test it with an http trigger
+echo "Pre-test cleanup"
+fission env delete --name nodejs || true
 
-echo "Test test, please ignore."
-
+echo "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
+echo "Creating function"
 fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js
 trap "fission fn delete --name $fn" EXIT
 
+echo "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
+echo "Waiting for router to catch up"
 sleep 3
 
+echo "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
+
+echo "Checking for valid response"
 echo $response | grep -i hello
+
+echo "All done."

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -14,7 +14,7 @@ fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
 fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js
-trap "fission fn delete --name hello" EXIT
+trap "fission fn delete --name $fn" EXIT
 
 fission route create --function $fn --url /$fn --method GET
 

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 ROOT=$(dirname $0)/../..
 
+fn=nodejs-hello-$(date +%N)
+
 # Create a hello world function in nodejs, test it with an http trigger
 
 echo "Test test, please ignore."
@@ -11,13 +13,12 @@ echo "Test test, please ignore."
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-fission fn create --name hello --env nodejs --code $ROOT/examples/nodejs/hello.js
+fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js
 trap "fission fn delete --name hello" EXIT
 
-fission route create --function hello --url /hello --method GET
+fission route create --function $fn --url /$fn --method GET
 
 sleep 3
 
-time curl http://$FISSION_ROUTER/hello
-
-time curl http://$FISSION_ROUTER/hello
+response=$(curl http://$FISSION_ROUTER/$fn)
+echo $response | grep -i hello

--- a/tpr/tpr_test.go
+++ b/tpr/tpr_test.go
@@ -177,7 +177,7 @@ func environmentTests(tprClient *rest.RESTClient) {
 	el, err := ei.List(api.ListOptions{})
 	panicIf(err)
 	if len(el.Items) != 1 {
-		log.Panicf("wrong count from list: %v", el)
+		log.Panicf("wrong count from list: %v", len(el.Items))
 	}
 	if el.Items[0].Spec.Runtime.Image != environment.Spec.Runtime.Image {
 		log.Panicf("bad object from list: %v", el.Items[0])


### PR DESCRIPTION
End to end tests on a Kubernetes cluster. Travis CI builds now build fission-bundle, cli, fetcher; deploy the helm chart on a k8s cluster; and run a simple hello world test against this setup.

This PR includes a bunch of little bugfixes to the helm charts as well, which I found while getting this test to work.

