### PR TITLE
Move builds to package level

### DIFF
--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -81,8 +81,10 @@ func TestFunctionApi(t *testing.T) {
 			Namespace: api.NamespaceDefault,
 		},
 		Spec: fission.FunctionSpec{
-			EnvironmentName: "nodejs",
-			Deployment: fission.FunctionPackageRef{
+			Environment: fission.EnvironmentReference{
+				Name: "nodejs",
+			},
+			Package: fission.FunctionPackageRef{
 				FunctionName: "xxx",
 			},
 		},
@@ -99,7 +101,7 @@ func TestFunctionApi(t *testing.T) {
 	_, err = g.client.FunctionCreate(testFunc)
 	assertNameReuseFailure(err, "function")
 
-	testFunc.Spec.Deployment.FunctionName = "yyy"
+	testFunc.Spec.Package.FunctionName = "yyy"
 	_, err = g.client.FunctionUpdate(testFunc)
 	panicIf(err)
 

--- a/controller/packageApi.go
+++ b/controller/packageApi.go
@@ -65,7 +65,12 @@ func (a *API) PackageApiCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure size limits
-	if len(f.Spec.Literal) > 256*1024 {
+	if len(f.Spec.Source.Literal) > 256*1024 {
+		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")
+		a.respondWithError(w, err)
+		return
+	}
+	if len(f.Spec.Deployment.Literal) > 256*1024 {
 		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")
 		a.respondWithError(w, err)
 		return
@@ -104,7 +109,7 @@ func (a *API) PackageApiGet(w http.ResponseWriter, r *http.Request) {
 
 	var resp []byte
 	if raw != "" {
-		resp = []byte(f.Spec.Literal)
+		resp = []byte(f.Spec.Deployment.Literal)
 	} else {
 		resp, err = json.Marshal(f)
 		if err != nil {

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -155,11 +155,7 @@ func (fetcher *Fetcher) Handler(w http.ResponseWriter, r *http.Request) {
 
 		// get pkg
 		var pkg *tpr.Package
-		if req.FetchType == FETCH_SOURCE {
-			pkg, err = fetcher.fissionClient.Packages(fn.Spec.Source.PackageRef.Namespace).Get(fn.Spec.Source.PackageRef.Name)
-		} else if req.FetchType == FETCH_DEPLOYMENT {
-			pkg, err = fetcher.fissionClient.Packages(fn.Spec.Deployment.PackageRef.Namespace).Get(fn.Spec.Deployment.PackageRef.Name)
-		}
+		pkg, err = fetcher.fissionClient.Packages(fn.Spec.Package.Namespace).Get(fn.Spec.Package.Name)
 		if err != nil {
 			e := fmt.Sprintf("Failed to get package: %v", err)
 			log.Printf(e)
@@ -167,8 +163,15 @@ func (fetcher *Fetcher) Handler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		var archive *fission.Archive
+		if req.FetchType == FETCH_SOURCE {
+			archive = &pkg.Source
+		} else if req.FetchType == FETCH_DEPLOYMENT {
+			archive = &pkg.Deployment
+		}
+
 		// get package data as literal or by url
-		if len(pkg.Spec.Literal) > 0 {
+		if len(archive.Literal) > 0 {
 			// write pkg.Literal into tmpPath
 			err = ioutil.WriteFile(tmpPath, pkg.Spec.Literal, 0600)
 			if err != nil {

--- a/poolmgr/api.go
+++ b/poolmgr/api.go
@@ -167,7 +167,7 @@ func (poolMgr *Poolmgr) getFunctionEnv(m *api.ObjectMeta) (*tpr.Environment, err
 
 	// Get env from metadata
 	log.Printf("[%v] getting env", m)
-	env, err = poolMgr.fissionClient.Environments(f.Metadata.Namespace).Get(f.Spec.EnvironmentName)
+	env, err = poolMgr.fissionClient.Environments(f.Spec.Environment.Namespace).Get(f.Spec.Environment.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/tpr/tpr_test.go
+++ b/tpr/tpr_test.go
@@ -46,15 +46,16 @@ func functionTests(tprClient *rest.RESTClient) {
 			Name: "hello",
 		},
 		Spec: fission.FunctionSpec{
-			Source: fission.FunctionPackageRef{},
-			Deployment: fission.FunctionPackageRef{
+			Package: fission.FunctionPackageRef{
 				PackageRef: fission.PackageRef{
 					Name:      "foo",
 					Namespace: "bar",
 				},
 				FunctionName: "hello",
 			},
-			EnvironmentName: "xxx",
+			Environment: fission.EnvironmentReference{
+				Name: "xxx",
+			},
 		},
 	}
 
@@ -74,14 +75,14 @@ func functionTests(tprClient *rest.RESTClient) {
 	// read
 	f, err = fi.Get(function.Metadata.Name)
 	panicIf(err)
-	if f.Spec.Deployment.FunctionName != function.Spec.Deployment.FunctionName {
+	if f.Spec.Environment.Name != function.Spec.Environment.Name {
 		log.Panicf("Bad result from Get: %v", f)
 	}
 
 	log.Printf("f.Metadata = %#v", f.Metadata)
 
 	// update
-	function.Spec.EnvironmentName = "yyy"
+	function.Spec.Environment.Name = "yyy"
 	f, err = fi.Update(function)
 	panicIf(err)
 
@@ -93,7 +94,7 @@ func functionTests(tprClient *rest.RESTClient) {
 	if len(fl.Items) != 1 {
 		log.Panicf("wrong count from list: %v", fl)
 	}
-	if fl.Items[0].Spec.EnvironmentName != function.Spec.EnvironmentName {
+	if fl.Items[0].Spec.Environment.Name != function.Spec.Environment.Name {
 		log.Panicf("bad object from list: %v", fl.Items[0])
 	}
 
@@ -122,7 +123,7 @@ func functionTests(tprClient *rest.RESTClient) {
 		if !ok {
 			log.Panicf("Can't cast to Function")
 		}
-		if wf.Spec.EnvironmentName != function.Spec.EnvironmentName {
+		if wf.Spec.Environment.Name != function.Spec.Environment.Name {
 			log.Panicf("Bad object from watch: %#v", wf)
 		}
 		log.Printf("watch event took %v", time.Now().Sub(start))

--- a/types.go
+++ b/types.go
@@ -34,16 +34,16 @@ type (
 		Sum  string       `json:"sum"`
 	}
 
-	// PackageType is either literal or URL, indicating whether
-	// the package is specified in the Package struct or
+	// ArchiveType is either literal or URL, indicating whether
+	// the package is specified in the Archive struct or
 	// externally.
-	PackageType string
+	ArchiveType string
 
 	// Package contains or references a collection of source or
 	// binary files.
-	PackageSpec struct {
+	Archive struct {
 		// Type defines how the package is specified: literal or URL.
-		Type PackageType `json:"type"`
+		Type ArchiveType `json:"type"`
 
 		// Literal contents of the package. Can be used for
 		// encoding packages below TODO (256KB?) size.
@@ -55,6 +55,15 @@ type (
 		// Checksum ensures the integrity of packages
 		// refereced by URL. Ignored for literals.
 		Checksum Checksum `json:"checksum"`
+	}
+
+	PackageSpec struct {
+		Source     Archive
+		Deployment Archive
+	}
+	PackageStatus struct {
+		BuildStatus BuildStatus // success/in-progress/failure
+		BuildLog    string      // output of build
 	}
 
 	PackageRef struct {
@@ -82,13 +91,8 @@ type (
 		// be invoked.
 		EnvironmentName string `json:"environmentName"`
 
-		// Source is an source package for this function; it's used for the build step if
-		// the environment defines a build container.
-		Source FunctionPackageRef `json:"source"`
-
-		// Deployment is a deployable package for this function. This is the package that's
-		// loaded into the environment's runtime container.
-		Deployment FunctionPackageRef `json:"deployment"`
+		// Reference to a package containing deployment and optionally the source
+		Packages FunctionPackageRef
 	}
 
 	FunctionReferenceType string

--- a/types.go
+++ b/types.go
@@ -57,13 +57,14 @@ type (
 		Checksum Checksum `json:"checksum"`
 	}
 
+	BuildStatus string
 	PackageSpec struct {
 		Source     Archive
 		Deployment Archive
 	}
 	PackageStatus struct {
-		BuildStatus BuildStatus // success/in-progress/failure
-		BuildLog    string      // output of build
+		BuildStatus BuildStatus
+		BuildLog    string // output of the build (errors etc)
 	}
 
 	PackageRef struct {
@@ -92,7 +93,7 @@ type (
 		EnvironmentName string `json:"environmentName"`
 
 		// Reference to a package containing deployment and optionally the source
-		Packages FunctionPackageRef
+		Package FunctionPackageRef
 	}
 
 	FunctionReferenceType string
@@ -224,12 +225,19 @@ const (
 )
 
 const (
-	// PackageTypeLiteral means the package contents are specified in the Literal field of
+	// ArchiveTypeLiteral means the package contents are specified in the Literal field of
 	// resource itself.
-	PackageTypeLiteral PackageType = "literal"
+	ArchiveTypeLiteral ArchiveType = "literal"
 
-	// PackageTypeUrl means the package contents are at the specified URL.
-	PackageTypeUrl PackageType = "url"
+	// ArchiveTypeUrl means the package contents are at the specified URL.
+	ArchiveTypeUrl ArchiveType = "url"
+)
+
+const (
+	BuildStatusPending   = "pending"
+	BuildStatusRunning   = "running"
+	BuildStatusSucceeded = "succeeded"
+	BuildStatusFailed    = "failed"
 )
 
 const (

--- a/types.go
+++ b/types.go
@@ -57,22 +57,30 @@ type (
 		Checksum Checksum `json:"checksum"`
 	}
 
+	EnvironmentReference struct {
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
+	}
+
 	BuildStatus string
+
 	PackageSpec struct {
-		Source     Archive
-		Deployment Archive
+		Environment EnvironmentReference `json:"environment"`
+		Source      Archive              `json:"source"`
+		Deployment  Archive              `json:"deployment"`
+		// In the future, we can have a debug build here too
 	}
 	PackageStatus struct {
-		BuildStatus BuildStatus
-		BuildLog    string // output of the build (errors etc)
+		BuildStatus BuildStatus `json:"buildstatus"`
+		BuildLog    string      `json:"buildlog"` // output of the build (errors etc)
 	}
 
 	PackageRef struct {
-		Name      string
-		Namespace string
+		Namespace string `json:"namespace"`
+		Name      string `json:"name"`
 	}
 	FunctionPackageRef struct {
-		PackageRef PackageRef
+		PackageRef PackageRef `json:"packageref"`
 
 		// FunctionName specifies a specific function within the package. This allows
 		// functions to share packages, by having different functions within the same
@@ -87,13 +95,13 @@ type (
 
 	// FunctionSpec describes the contents of the function.
 	FunctionSpec struct {
-		// EnvironmentName is the name of the environment that this function is associated
-		// with. An Environment with this name should exist, otherwise the function cannot
-		// be invoked.
-		EnvironmentName string `json:"environmentName"`
+		// Environment is the build and runtime environment that this function is
+		// associated with. An Environment with this name should exist, otherwise the
+		// function cannot be invoked.
+		Environment EnvironmentReference `json:"environment"`
 
 		// Reference to a package containing deployment and optionally the source
-		Package FunctionPackageRef
+		Package FunctionPackageRef `json:"package"`
 	}
 
 	FunctionReferenceType string

--- a/types.go
+++ b/types.go
@@ -78,6 +78,10 @@ type (
 	PackageRef struct {
 		Namespace string `json:"namespace"`
 		Name      string `json:"name"`
+
+		// Including resource version in the reference forces the function to be updated on
+		// package update, making it possible to cache the function based on its metadata.
+		ResourceVersion string `json:"resourceversion"`
 	}
 	FunctionPackageRef struct {
 		PackageRef PackageRef `json:"packageref"`
@@ -286,5 +290,5 @@ var errorDescriptions = []string{
 }
 
 const (
-	PackageLiteralSizeLimit int64 = 256 * 1024
+	ArchiveLiteralSizeLimit int64 = 256 * 1024
 )


### PR DESCRIPTION
Rename the old "packages" to "archives".

"Packages" are now a pair of source and deployment archives.

Functions now have a single FunctionPackageRef into a single Package,
instead of two separate references.

The Package type will also have a PackageStatus, which will contain
build information.