### PR TITLE
Use latest function metadata to check cached function service.

### DIFF
--- a/poolmgr/api.go
+++ b/poolmgr/api.go
@@ -179,21 +179,6 @@ func (poolMgr *Poolmgr) getFunctionEnv(m *api.ObjectMeta) (*tpr.Environment, err
 }
 
 func (poolMgr *Poolmgr) getServiceForFunction(m *api.ObjectMeta) (string, error) {
-	// Pool manager uses function metadata to generate a key
-	// for cache index. However the function metadata passed
-	// from router may be out-of-date (e.g. resourceVersion).
-	// We should always use the latest function metadata grab
-	// from TPR for the following operation.
-	fn, err := poolMgr.fissionClient.Functions(m.Namespace).Get(m.Name)
-	if err != nil {
-		e := fmt.Sprintf("Error getting TPR resource info for function %v: %v", m.Name, err)
-		log.Println(e)
-		return "", err
-	}
-
-	// update function metadata
-	m = &fn.Metadata
-
 	// Check function -> svc cache
 	log.Printf("[%v] Checking for cached function service", m.Name)
 	fsvc, err := poolMgr.fsCache.GetByFunction(m)

--- a/poolmgr/api.go
+++ b/poolmgr/api.go
@@ -143,6 +143,7 @@ func (poolMgr *Poolmgr) getServiceForFunctionApi(w http.ResponseWriter, r *http.
 		code, msg := fission.GetHTTPError(err)
 		log.Printf("Error: %v: %v", code, msg)
 		http.Error(w, msg, code)
+		return
 	}
 
 	w.Write([]byte(serviceName))
@@ -178,6 +179,21 @@ func (poolMgr *Poolmgr) getFunctionEnv(m *api.ObjectMeta) (*tpr.Environment, err
 }
 
 func (poolMgr *Poolmgr) getServiceForFunction(m *api.ObjectMeta) (string, error) {
+	// Pool manager uses function metadata to generate a key
+	// for cache index. However the function metadata passed
+	// from router may be out-of-date (e.g. resourceVersion).
+	// We should always use the latest function metadata grab
+	// from TPR for the following operation.
+	fn, err := poolMgr.fissionClient.Functions(m.Namespace).Get(m.Name)
+	if err != nil {
+		e := fmt.Sprintf("Error getting TPR resource info for function %v: %v", m.Name, err)
+		log.Println(e)
+		return "", err
+	}
+
+	// update function metadata
+	m = &fn.Metadata
+
 	// Check function -> svc cache
 	log.Printf("[%v] Checking for cached function service", m.Name)
 	fsvc, err := poolMgr.fsCache.GetByFunction(m)

--- a/router/functionReferenceResolver.go
+++ b/router/functionReferenceResolver.go
@@ -116,3 +116,21 @@ func (frr *functionReferenceResolver) resolveByName(namespace, name string) (*re
 	}
 	return &rr, nil
 }
+
+func (frr *functionReferenceResolver) delete(namespace string, fr *fission.FunctionReference) error {
+	nfr := namespacedFunctionReference{
+		namespace:         namespace,
+		functionReference: *fr,
+	}
+	return frr.refCache.Delete(nfr)
+}
+
+func (frr *functionReferenceResolver) copy() map[namespacedFunctionReference]resolveResult {
+	cache := make(map[namespacedFunctionReference]resolveResult)
+	for k, v := range frr.refCache.Copy() {
+		key := k.(namespacedFunctionReference)
+		val := v.(resolveResult)
+		cache[key] = val
+	}
+	return cache
+}

--- a/router/functionServiceMap.go
+++ b/router/functionServiceMap.go
@@ -75,3 +75,17 @@ func (fmap *functionServiceMap) assign(f *api.ObjectMeta, serviceUrl *url.URL) {
 		// ignore error
 	}
 }
+
+func (fmap *functionServiceMap) copy() map[metadataKey]*url.URL {
+	svcCache := make(map[metadataKey]*url.URL)
+	for k, v := range fmap.cache.Copy() {
+		key := k.(metadataKey)
+		val := v.(*url.URL)
+		svcCache[key] = val
+	}
+	return svcCache
+}
+
+func (fmap *functionServiceMap) delete(key metadataKey) error {
+	return fmap.cache.Delete(key)
+}

--- a/router/functionServiceMap.go
+++ b/router/functionServiceMap.go
@@ -75,17 +75,3 @@ func (fmap *functionServiceMap) assign(f *api.ObjectMeta, serviceUrl *url.URL) {
 		// ignore error
 	}
 }
-
-func (fmap *functionServiceMap) copy() map[metadataKey]*url.URL {
-	svcCache := make(map[metadataKey]*url.URL)
-	for k, v := range fmap.cache.Copy() {
-		key := k.(metadataKey)
-		val := v.(*url.URL)
-		svcCache[key] = val
-	}
-	return svcCache
-}
-
-func (fmap *functionServiceMap) delete(key metadataKey) error {
-	return fmap.cache.Delete(key)
-}

--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -188,19 +188,6 @@ func (ts *HTTPTriggerSet) watchFunctions() {
 			fn := ev.Object.(*tpr.Function)
 			rv = fn.Metadata.ResourceVersion
 
-			// update service map cache
-			for key := range ts.functionServiceMap.copy() {
-				if key.Name == fn.Metadata.Name &&
-					key.ResourceVersion != fn.Metadata.ResourceVersion {
-					err := ts.functionServiceMap.delete(key)
-					if err != nil {
-						log.Printf("Error deleting functionServiceMap cache: %v", err)
-					}
-					break
-				}
-
-			}
-
 			// update resolver function reference cache
 			for key, rr := range ts.resolver.copy() {
 				if key.functionReference.Name == fn.Metadata.Name &&

--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -61,6 +61,7 @@ func (ts *HTTPTriggerSet) subscribeRouter(mr *mutableRouter) {
 		return
 	}
 	go ts.watchTriggers()
+	go ts.watchFunctions()
 }
 
 func defaultHomeHandler(w http.ResponseWriter, r *http.Request) {
@@ -157,6 +158,61 @@ func (ts *HTTPTriggerSet) watchTriggers() {
 			}
 			ht := ev.Object.(*tpr.Httptrigger)
 			rv = ht.Metadata.ResourceVersion
+			ts.syncTriggers()
+		}
+	}
+}
+
+func (ts *HTTPTriggerSet) watchFunctions() {
+	rv := ""
+	for {
+		wi, err := ts.fissionClient.Functions(api.NamespaceAll).Watch(api.ListOptions{
+			ResourceVersion: rv,
+		})
+		if err != nil {
+			log.Fatalf("Failed to watch function list: %v", err)
+		}
+
+		for {
+			ev, more := <-wi.ResultChan()
+			if !more {
+				// restart watch from last rv
+				break
+			}
+			if ev.Type == watch.Error {
+				// restart watch from the start
+				rv = ""
+				time.Sleep(time.Second)
+				break
+			}
+			fn := ev.Object.(*tpr.Function)
+			rv = fn.Metadata.ResourceVersion
+
+			// update service map cache
+			for key := range ts.functionServiceMap.copy() {
+				if key.Name == fn.Metadata.Name &&
+					key.ResourceVersion != fn.Metadata.ResourceVersion {
+					err := ts.functionServiceMap.delete(key)
+					if err != nil {
+						log.Printf("Error deleting functionServiceMap cache: %v", err)
+					}
+					break
+				}
+
+			}
+
+			// update resolver function reference cache
+			for key, rr := range ts.resolver.copy() {
+				if key.functionReference.Name == fn.Metadata.Name &&
+					rr.functionMetadata.ResourceVersion != fn.Metadata.ResourceVersion {
+					err := ts.resolver.delete(key.namespace, &key.functionReference)
+					if err != nil {
+						log.Printf("Error deleting functionReferenceResolver cache: %v", err)
+					}
+					break
+				}
+			}
+
 			ts.syncTriggers()
 		}
 	}

--- a/test/tests/test_function_update.sh
+++ b/test/tests/test_function_update.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT=$(dirname $0)/../..
+
+fn=nodejs-hello-$(date +%s)
+
+# Create a function in nodejs, test it with an HTTP trigger.
+# Update it and check it's output, the output should be 
+# different from the previous one.
+
+echo "Pre-test cleanup"
+fission env delete --name nodejs || true
+
+echo "Creating nodejs env"
+fission env create --name nodejs --image fission/node-env
+trap "fission env delete --name nodejs" EXIT
+
+echo "Creating function"
+echo 'module.exports = function(context, callback) { callback(200, "foo!\n"); }' > foo.js
+fission fn create --name $fn --env nodejs --code foo.js
+trap "fission fn delete --name $fn" EXIT
+
+echo "Creating route"
+fission route create --function $fn --url /$fn --method GET
+
+echo "Waiting for router to catch up"
+sleep 10
+
+echo "Doing an HTTP GET on the function's route"
+response=$(curl http://$FISSION_ROUTER/$fn)
+
+echo "Checking for valid response"
+echo $response | grep -i foo
+
+# Running a background process to keep access the
+# function to emulate real online traffic. The router
+# should be able to update cache under this situation.
+( watch -n1 curl http://$FISSION_ROUTER/$fn ) > /dev/null 2>&1 &
+pid=$!
+
+echo "Updating function"
+echo 'module.exports = function(context, callback) { callback(200, "bar!\n"); }' > bar.js
+fission fn update --name $fn --code bar.js
+trap "fission fn delete --name $fn" EXIT
+
+echo "Waiting for router to update cache"
+sleep 10
+
+echo "Doing an HTTP GET on the function's route"
+response=$(curl http://$FISSION_ROUTER/$fn)
+
+echo "Checking for valid response again"
+echo $response | grep -i bar
+
+kill -15 $pid
+
+# crappy cleanup, improve this later
+kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
+
+echo "All done."


### PR DESCRIPTION
This PR aims to solve https://github.com/fission/fission/issues/287.

When an HTTP request comes to the router, it will send a tap request to pool manager with function metadata. The metadata within payload may be out-of-date, so pool manager always returns the IP address of old function pod to the router. In this situation, a user received wrong function response until the pod is killed by the pool manager.

With this PR, when a `getServiceForFunction` request comes to pool manager, pool manager will fetch the latest function metadata from TPR and use this metadata to find correspond service cache. If cache missed, then a new function pod will be created to serve the user request.