### PR TITLE
Upgrade tool for 0.1 -> 0.2.1

### DIFF
--- a/Documentation/docs-site/content/install.md
+++ b/Documentation/docs-site/content/install.md
@@ -109,7 +109,7 @@ $ helm install --namespace fission https://github.com/fission/fission/releases/d
 
 ### Install the Fission CLI
 
-#### Mac OS
+#### OS X
 
 Get the CLI binary for Mac:
 

--- a/Documentation/docs-site/content/upgrade-from-v0.1.md
+++ b/Documentation/docs-site/content/upgrade-from-v0.1.md
@@ -34,47 +34,73 @@ rigorous about it from the beta release onwards.
 
 ## How to Upgrade
 
-1. Get the v0.2 CLI
-1. Get your Fission state from your old install
-1. Install v0.2.1
-1. Restore your Fission state
+1. Get the v0.2.1 CLI
+1. Get the Fission state from your old install
+1. Install Fission v0.2.1
+1. Restore Fission state into your new install
 1. Destroy your old install
 
 ### Get the new CLI
 
+#### OS X
+
 ```
-curl -Lo fission https://...
+$ curl -Lo fission https://github.com/fission/fission/releases/download/v0.2.1-rc/fission-cli-osx && chmod +x fission && sudo mv fission /usr/local/bin/
 ```
+
+#### Linux
+
+```
+$ curl -Lo fission https://github.com/fission/fission/releases/download/v0.2.1-rc/fission-cli-linux && chmod +x fission && sudo mv fission /usr/local/bin/
+```
+
+#### Windows
+
+For Windows, you can use the linux binary on WSL. Or you can download
+this windows executable: [fission.exe](https://github.com/fission/fission/releases/download/v0.2.1-rc/fission-cli-windows.exe)
 
 ### Get Fission state from v0.1 install
 
 ```
-fission upgrade dump
+fission --server <your V1 server> upgrade dump --file state.json
 ```
 
-This will create a JSON file with all your fission state in the current directory.
+You can skip the --server argument if you have the environment
+variable `$FISSION_URL` set to point at a v0.1 Fission server.
+
+This will create a JSON file with all your fission state in the
+current directory.
 
 ### Install the new version
 
-Follow the [install guide](../install), but you will need to ensure your two installs don't
-conflict. To do that, use separate namespaces and ensure nodeports don't conflict.  Install with a
-command similar to this:
+Read the [install guide](../install).  You can follow all of it, except that you will need to
+ensure your two installs don't conflict.  To do that, use separate namespaces and ensure nodeports
+don't conflict.  Install with a command similar to this:
 
 ```
 helm install fission-all --namespace fission2 --set controllerPort=31303,routerPort=31304,natsStreamingPort=31305,functionNamespace=fission2-function
 ```
 
+This installs fission in the `fission2` namespace and runs functions
+in the `fission2-function` namespace.
+
 ### Restore your Fission state into Fission v0.2.1
 
 ```
-fission upgrade restore
+fission upgrade restore --file state.json
 ```
 
-This uses the file created in the first step.
+This commands needs $FISSION_URL set to point to new fission installation.
+
+It uses the file created in the first step.  It doesn't modify state.json.
+
+(Note that you can run this restore on any cluster; it doesn't have the be the same kubernetes
+cluster as your old install.)
 
 ### Verify
 
-How exactly you do this is up to you! But, verify that your new install is working.
+How exactly you do this is up to you! But, at a minimum, run `fission
+fn list` to check that all the functions you expect are there.
 
 ### Switch over
 
@@ -82,7 +108,8 @@ If you had exposed fission's router to the outside world, switch over to using t
    
 ### Destroy your old install
 
-Once you're no longer using the old install, you can destroy it with:
+Once you're no longer using the old install, you can destroy it by
+deleting the namespaces that was installed in.
 
 ```
 kubectl delete namespace fission fission-function

--- a/fission/main.go
+++ b/fission/main.go
@@ -122,6 +122,10 @@ func main() {
 		{Name: "list", Usage: "List all watches", Flags: []cli.Flag{}, Action: wList},
 	}
 
+	upgradeSubCommands := []cli.Command{
+		{Name: "dump", Usage: "Dump all state from a v0.1 fission installation", Flags: nil, Action: upgradeDumpState},
+		{Name: "restore", Usage: "Restore state dumped from a v0.1 install into a v0.2 install", Flags: nil, Action: upgradeRestoreState},
+	}
 	app.Commands = []cli.Command{
 		{Name: "function", Aliases: []string{"fn"}, Usage: "Create, update and manage functions", Subcommands: fnSubcommands},
 		{Name: "httptrigger", Aliases: []string{"ht", "route"}, Usage: "Manage HTTP triggers (routes) for functions", Subcommands: htSubcommands},
@@ -129,6 +133,7 @@ func main() {
 		{Name: "mqtrigger", Aliases: []string{"mqt", "messagequeue"}, Usage: "Manage message queue triggers for functions", Subcommands: mqtSubcommands},
 		{Name: "environment", Aliases: []string{"env"}, Usage: "Manage environments", Subcommands: envSubcommands},
 		{Name: "watch", Aliases: []string{"w"}, Usage: "Manage watches", Subcommands: wSubCommands},
+		{Name: "upgrade", Aliases: []string{}, Usage: "Upgrade tool from fission v0.1", Subcommands: upgradeSubCommands},
 	}
 
 	app.Run(os.Args)

--- a/fission/main.go
+++ b/fission/main.go
@@ -122,9 +122,10 @@ func main() {
 		{Name: "list", Usage: "List all watches", Flags: []cli.Flag{}, Action: wList},
 	}
 
+	upgradeFileFlag := cli.StringFlag{Name: "file", Usage: "JSON file containing all fission state"}
 	upgradeSubCommands := []cli.Command{
-		{Name: "dump", Usage: "Dump all state from a v0.1 fission installation", Flags: nil, Action: upgradeDumpState},
-		{Name: "restore", Usage: "Restore state dumped from a v0.1 install into a v0.2 install", Flags: nil, Action: upgradeRestoreState},
+		{Name: "dump", Usage: "Dump all state from a v0.1 fission installation", Flags: []cli.Flag{upgradeFileFlag}, Action: upgradeDumpState},
+		{Name: "restore", Usage: "Restore state dumped from a v0.1 install into a v0.2 install", Flags: []cli.Flag{upgradeFileFlag}, Action: upgradeRestoreState},
 	}
 	app.Commands = []cli.Command{
 		{Name: "function", Aliases: []string{"fn"}, Usage: "Create, update and manage functions", Subcommands: fnSubcommands},

--- a/fission/upgrade.go
+++ b/fission/upgrade.go
@@ -187,7 +187,7 @@ func upgradeDumpV1State(v1url string, filename string) {
 	fmt.Println("Getting functions")
 	// get each function
 	funcs := make(map[v1.Metadata]v1.Function)
-	for m, _ := range funcMetaSet {
+	for m := range funcMetaSet {
 		if len(m.Uid) != 0 {
 			resp = get(fmt.Sprintf("%v/functions/%v?uid=%v", v1url, m.Name, m.Uid))
 		} else {

--- a/fission/upgrade.go
+++ b/fission/upgrade.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/urfave/cli"
+	"k8s.io/client-go/1.5/pkg/api"
+
+	"github.com/fission/fission"
+	"github.com/fission/fission/tpr"
+	"github.com/fission/fission/v1"
+)
+
+type (
+	V1FissionState struct {
+		functions    []v1.Function            `json:"functions"`
+		environments []v1.Environment         `json:"environments"`
+		httptriggers []v1.HTTPTrigger         `json:"httptriggers"`
+		mqtriggers   []v1.MessageQueueTrigger `json:"mqtriggers"`
+		timetriggers []v1.TimeTrigger         `json:"timetriggers"`
+		watches      []v1.Watch               `json:"watches"`
+	}
+)
+
+func getV1URL(serverUrl string) string {
+	if len(serverUrl) == 0 {
+		fatal("Need --server or FISSION_URL set to your fission server.")
+	}
+	isHTTPS := strings.Index(serverUrl, "https://") == 0
+	isHTTP := strings.Index(serverUrl, "http://") == 0
+	if !(isHTTP || isHTTPS) {
+		serverUrl = "http://" + serverUrl
+	}
+	v1url := strings.TrimSuffix(serverUrl, "/") + "/v1"
+	return v1url
+}
+
+func get(url string) []byte {
+	resp, err := http.Get(url)
+	checkErr(err, "get fission v0.1 state")
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	checkErr(err, "reading server response")
+
+	if resp.StatusCode != 200 {
+		fatal(fmt.Sprintf("Failed to fetch fission v0.1 state: %v", string(body)))
+	}
+	return body
+}
+
+func upgradeDumpV1State(v1url string) {
+	var v1state V1FissionState
+
+	resp := get(v1url + "/environments")
+	err := json.Unmarshal(resp, &v1state.environments)
+	checkErr(err, "parse server response")
+
+	resp = get(v1url + "/watches")
+	err = json.Unmarshal(resp, &v1state.watches)
+	checkErr(err, "parse server response")
+
+	resp = get(v1url + "/triggers/http")
+	err = json.Unmarshal(resp, &v1state.httptriggers)
+	checkErr(err, "parse server response")
+
+	resp = get(v1url + "/triggers/messagequeue")
+	err = json.Unmarshal(resp, &v1state.mqtriggers)
+	checkErr(err, "parse server response")
+
+	resp = get(v1url + "/triggers/time")
+	err = json.Unmarshal(resp, &v1state.timetriggers)
+	checkErr(err, "parse server response")
+
+	resp = get(v1url + "/functions")
+	err = json.Unmarshal(resp, &v1state.functions)
+	checkErr(err, "parse server response")
+
+	funcMetaSet := make(map[v1.Metadata]bool)
+	for _, f := range v1state.functions {
+		funcMetaSet[f.Metadata] = true
+	}
+	for _, t := range v1state.httptriggers {
+		funcMetaSet[t.Function] = true
+	}
+	for _, t := range v1state.mqtriggers {
+		funcMetaSet[t.Function] = true
+	}
+	for _, t := range v1state.watches {
+		funcMetaSet[t.Function] = true
+	}
+	for _, t := range v1state.timetriggers {
+		funcMetaSet[t.Function] = true
+	}
+
+	// get each function
+	v1state.functions = nil
+	for m, _ := range funcMetaSet {
+		resp = get(fmt.Sprintf("%v/functions/%v", v1url, m.Name))
+		var f v1.Function
+		// unmarshal
+		err = json.Unmarshal(resp, &f)
+		checkErr(err, "parse server response")
+		// add to v1state list
+		v1state.functions = append(v1state.functions, f)
+	}
+
+	// serialize v1state
+	out, err := json.Marshal(v1state)
+	checkErr(err, "serializing v0.1 state")
+
+	// dump to file fission-v01-state.json
+	err = ioutil.WriteFile("fission-v01-state.json", out, 0644)
+	checkErr(err, "writing file")
+}
+
+func upgradeDumpState(c *cli.Context) error {
+	u := getV1URL(c.GlobalString("server"))
+	upgradeDumpV1State(u)
+	return nil
+}
+
+func upgradeRestoreState(c *cli.Context) error {
+	filename := "fission-v01-state.json"
+	contents, err := ioutil.ReadFile(filename)
+	checkErr(err, fmt.Sprintf("open file %v", filename))
+
+	var v1state V1FissionState
+	err = json.Unmarshal(contents, &v1state)
+	checkErr(err, "parse dumped v1 state")
+
+	// create a regular v2 client
+	client := getClient(c.GlobalString("server"))
+
+	// create envs
+	for _, e := range v1state.environments {
+		_, err = client.EnvironmentCreate(&tpr.Environment{
+			Metadata: api.ObjectMeta{
+				Name:      e.Metadata.Name,
+				Namespace: api.NamespaceDefault,
+			},
+			Spec: fission.EnvironmentSpec{
+				Version: 1,
+				Runtime: fission.Runtime{
+					Image: e.RunContainerImageUrl,
+				},
+			},
+		})
+		checkErr(err, fmt.Sprintf("create environment %v", e.Metadata))
+	}
+
+	// create httptriggers
+	// create mqtriggers
+	// create time triggers
+	// create watches
+	// create functions
+
+	return nil
+}

--- a/v1/types.go
+++ b/v1/types.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+//
+// These are types from the v1 API, and are only preserved for
+// compatibility.  They should never be changed.
+//
+
+type (
+	// Metadata is used as the general identifier for all kinds of
+	// resources managed by the controller.
+	Metadata struct {
+		Name string `json:"name"`
+		Uid  string `json:"uid,omitempty"`
+	}
+
+	// Function is a unit of executable code.  Though it's called
+	// a function, the code may have more than one function; it's
+	// usually some sort of module or package.
+	Function struct {
+		Metadata    `json:"metadata"`
+		Environment Metadata `json:"environment"`
+		Code        string   `json:"code"`
+	}
+
+	// Environment identifies the language and OS specific
+	// resources that a function depends on.  For now this
+	// includes only the function run container image.  Later,
+	// this will also include build containers, as well as support
+	// tools like debuggers, profilers, etc.
+	Environment struct {
+		Metadata             `json:"metadata"`
+		RunContainerImageUrl string `json:"runContainerImageUrl"`
+	}
+
+	// HTTPTrigger maps URL patterns to functions.  Function.UID
+	// is optional; if absent, the latest version of the function
+	// will automatically be selected.
+	HTTPTrigger struct {
+		Metadata   `json:"metadata"`
+		UrlPattern string   `json:"urlpattern"`
+		Method     string   `json:"method"`
+		Function   Metadata `json:"function"`
+	}
+
+	MessageQueueTrigger struct {
+		Metadata         `json:"metadata"`
+		Function         Metadata `json:"function"`
+		MessageQueueType string   `json:"messageQueueType"`
+		Topic            string   `json:"topic"`
+		ResponseTopic    string   `json:"respTopic,omitempty"`
+	}
+
+	// Watch is a specification of Kubernetes watch along with a URL to post events to.
+	Watch struct {
+		Metadata `json:"metadata"`
+
+		Namespace     string `json:"namespace"`
+		ObjType       string `json:"objtype"`
+		LabelSelector string `json:"labelselector"`
+		FieldSelector string `json:"fieldselector"`
+
+		Function Metadata `json:"function"`
+
+		Target string `json:"target"` // Watch publish target (URL, NATS stream, etc)
+	}
+
+	// TimeTrigger invokes the specific function at a time or
+	// times specified by a cron string.
+	TimeTrigger struct {
+		Metadata `json:"metadata"`
+
+		Cron string `json:"cron"`
+
+		Function Metadata `json:"function"`
+	}
+
+	// Errors returned by the Fission API.
+	Error struct {
+		Code    errorCode `json:"code"`
+		Message string    `json:"message"`
+	}
+
+	errorCode int
+)
+
+const (
+	ErrorInternal = iota
+
+	ErrorNotAuthorized
+	ErrorNotFound
+	ErrorNameExists
+	ErrorInvalidArgument
+	ErrorNoSpace
+	ErrorNotImplmented
+)
+
+// must match order and len of the above const
+var errorDescriptions = []string{
+	"Internal error",
+	"Not authorized",
+	"Resource not found",
+	"Resource exists",
+	"Invalid argument",
+	"No space",
+	"Not implemented",
+}


### PR DESCRIPTION
This allows people to upgrade to 0.2.1 without losing their state or having to manually migrate it. 

Upgrade guide will be at: http://fission.io/docs/v0.2.1/upgrade-from-v0.1/

Tested on platform9-ops internal cluster.

closes #303 