### PR TITLE
Post-install hook to poke analytics function

### DIFF
--- a/charts/fission-all/templates/post-install-job.yaml
+++ b/charts/fission-all/templates/post-install-job.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.analytics }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    # The "release" convention makes it easy to tie a release to all of the
+    # Kubernetes resources that were created as part of that release.
+    release: {{ .Release.Name }}
+    # This makes it easy to audit chart usage.
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "name" . }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+spec:
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        release: {{ .Release.Name }}
+        app: {{ template "name" . }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: post-install-job
+          image: "fission/alpinecurl"
+          command: ["/usr/bin/curl", "-H", "Content-Type: application/json", "-X", "POST", "-d", "{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}", "https://g.fission.io/analytics"]
+{{ end }}

--- a/charts/fission-all/templates/post-install-job.yaml
+++ b/charts/fission-all/templates/post-install-job.yaml
@@ -26,5 +26,5 @@ spec:
       containers:
         - name: post-install-job
           image: "fission/alpinecurl"
-          command: ["sh", "-c", "/usr/bin/curl -H \"Content-Type: application/json\" -X POST -d '{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}' https://g.fission.io/analytics || true"]
+          command: ["sh", "-c", "/usr/bin/curl -H \"Content-Type: application/json\" -X POST -d '{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}' https://g.fission.sh/analytics || true"]
 {{ end }}

--- a/charts/fission-all/templates/post-install-job.yaml
+++ b/charts/fission-all/templates/post-install-job.yaml
@@ -26,5 +26,5 @@ spec:
       containers:
         - name: post-install-job
           image: "fission/alpinecurl"
-          command: ["/usr/bin/curl", "-H", "Content-Type: application/json", "-X", "POST", "-d", "{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}", "https://g.fission.io/analytics"]
+          command: ["sh", "-c", "/usr/bin/curl -H \"Content-Type: application/json\" -X POST -d '{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}' https://g.fission.io/analytics || true"]
 {{ end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -58,3 +58,7 @@ persistence:
   # storageClass:
   accessMode: ReadWriteOnce
   size: 8Gi
+
+## Analytics let us count how many people installed fission. Set to
+## false to disable analytics.
+analytics: true

--- a/charts/fission-core/templates/post-install-job.yaml
+++ b/charts/fission-core/templates/post-install-job.yaml
@@ -26,5 +26,5 @@ spec:
       containers:
         - name: post-install-job
           image: "fission/alpinecurl"
-          command: ["sh", "-c", "/usr/bin/curl -H \"Content-Type: application/json\" -X POST -d '{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}' https://g.fission.io/analytics || true"]
+          command: ["sh", "-c", "/usr/bin/curl -H \"Content-Type: application/json\" -X POST -d '{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}' https://g.fission.sh/analytics || true"]
 {{ end }}

--- a/charts/fission-core/templates/post-install-job.yaml
+++ b/charts/fission-core/templates/post-install-job.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.analytics }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "fullname" . }}
+  labels:
+    # The "release" convention makes it easy to tie a release to all of the
+    # Kubernetes resources that were created as part of that release.
+    release: {{ .Release.Name }}
+    # This makes it easy to audit chart usage.
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app: {{ template "name" . }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+spec:
+  template:
+    metadata:
+      name: {{ template "fullname" . }}
+      labels:
+        release: {{ .Release.Name }}
+        app: {{ template "name" . }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: post-install-job
+          image: "fission/alpinecurl"
+          command: ["sh", "-c", "/usr/bin/curl -H \"Content-Type: application/json\" -X POST -d '{\"type\": \"helm-post-install\", \"chartName\": \"{{ .Chart.Name }}\", \"chartName\": \"{{ .Chart.Version }}\"}' https://g.fission.io/analytics || true"]
+{{ end }}

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -43,3 +43,7 @@ persistence:
   # storageClass:
   accessMode: ReadWriteOnce
   size: 8Gi
+
+## Analytics let us count how many people installed fission. Set to
+## false to disable analytics.
+analytics: true

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -73,7 +73,7 @@ helm_install_fission() {
     ns=f-$id
     fns=f-func-$id
 
-    helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always
+    helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always,analytics=false
 
     helm_setup
     


### PR DESCRIPTION
This lets us count how many people install fission.

It can be disabled with `helm install --set analytics=false ...` 