### PR TITLE
Upgrade Node Environment to 8.x

### DIFF
--- a/environments/nodejs/Dockerfile
+++ b/environments/nodejs/Dockerfile
@@ -1,6 +1,6 @@
 # A docker image for the func container.
 
-FROM node:7-onbuild
+FROM node:8-onbuild
 
 ADD server.js /usr/src/app/server.js
 


### PR DESCRIPTION
7.x has not been maintained since April. 8.x is going into LTS
during October and will receive another 30 months of support.

This update should simply work out of the box. Let me know if
I can help with anything