### PR TITLE
Update a dependency in the package.json

### DIFF
--- a/environments/nodejs/package.json
+++ b/environments/nodejs/package.json
@@ -13,12 +13,12 @@
     "node": ">=7.6.0"
   },
   "dependencies": {
-    "body-parser": "",
+    "body-parser": "*",
     "co": "~4.6.0",
-    "express": "",
-    "minimist": "",
-    "morgan": "",
-    "mz": "~2.1.0",
+    "express": "*",
+    "minimist": "*",
+    "morgan": "*",
+    "mz": "~2.7.0",
     "request": "^2.81.0",
     "request-promise-native": "^1.0.3",
     "underscore": ">=1.8.3"


### PR DESCRIPTION
Since `mz` has already bumped for several times without
breaking change, it's better to follow the updates.

```console
$ npm outdated
Package  Current  Wanted  Latest  Location
mz         2.1.0   2.1.0   2.7.0  fission-nodejs-runtime
```

Fixes: https://github.com/fission/fission/issues/167