### PR TITLE
Multiple Trigger Definitions Fix

### DIFF
--- a/mqtrigger/messageQueue/messageQueue.go
+++ b/mqtrigger/messageQueue/messageQueue.go
@@ -165,8 +165,9 @@ func (mqt *MessageQueueTriggerManager) syncTriggers() {
 			log.Fatalf("Failed to read message queue trigger list: %v", err)
 		}
 		newTriggerMap := make(map[string]*tpr.Messagequeuetrigger)
-		for _, trigger := range newTriggers.Items {
-			newTriggerMap[tpr.CacheKey(&trigger.Metadata)] = &trigger
+		for index := range newTriggers.Items {
+			newTrigger := &newTriggers.Items[index]
+			newTriggerMap[tpr.CacheKey(&newTrigger.Metadata)] = newTrigger
 		}
 
 		// get current set of triggers


### PR DESCRIPTION
Fix for #340 

The issue was that `range` allocates the `trigger` value once which causes the newTriggerMap to have reference to last instance trigger.

To fix the issue, create a new trigger by pulling it off the original map.