### PR TITLE
Allow namespaces to be used in dotnet functions for better local dev exp

### DIFF
--- a/environments/dotnet/FissionCompiler.cs
+++ b/environments/dotnet/FissionCompiler.cs
@@ -64,7 +64,7 @@ namespace Fission.DotNetCore.Compiler
                     ms.Seek(0, SeekOrigin.Begin);
 
                     Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(ms);
-                    var type = assembly.GetType("FissionFunction");
+                    var type = assembly.GetTypes().FirstOrDefault(x => x.Name.Equals("FissionFunction"));
                     var info = type.GetMember("Execute").First() as MethodInfo;
                     return new Function(assembly, type, info);
                 }

--- a/environments/dotnet20/FissionCompiler.cs
+++ b/environments/dotnet20/FissionCompiler.cs
@@ -64,7 +64,7 @@ namespace Fission.DotNetCore.Compiler
                     ms.Seek(0, SeekOrigin.Begin);
 
                     Assembly assembly = AssemblyLoadContext.Default.LoadFromStream(ms);
-                    var type = assembly.GetType("FissionFunction");
+                    var type = assembly.GetTypes().FirstOrDefault(x => x.Name.Equals("FissionFunction"));
                     var info = type.GetMember("Execute").First() as MethodInfo;
                     return new Function(assembly, type, info);
                 }


### PR DESCRIPTION
Issue: For a local development environment we create small projects with a series of functions in them, also with unit tests as well for testing them locally. Currently fission requires the class to be at the root name space, which means working locally i cannot have more than on FissionFunction in my project.

example working
```csharp
using System;
using Fission.DotNetCore.Api;

    public class FissionFunction
    {
        public string Execute(FissionContext context)
        {
            return "Hello World!";
        }
    }
```
example not working
```csharp
//func1.cs
using System;
using Fission.DotNetCore.Api;

namespace dotnet.HelloWorld
{
    public class FissionFunction
    {
        public string Execute(FissionContext context)
        {
            return "Hello World!";
        }
    }
}
```

```csharp
//func2.cs
using System;
using Fission.DotNetCore.Api;
namespace dotnet.HelloWorld2
{
    public class FissionFunction
    {
        public string Execute(FissionContext context)
        {
            return "Hello World Number 2!";
        }
    }
}
```

This change will allow the class to be placed inside a namespace. This means in cases like ours where we are building small project with a series of functions in them that we want to test and deploy together we can place them in separate namespaces and test and compile them locally together.