### PR TITLE
Add bodyparser for text/plain to node-env

### DIFF
--- a/environments/nodejs/server.js
+++ b/environments/nodejs/server.js
@@ -66,6 +66,7 @@ app.use(morgan('combined'))
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 app.use(bodyParser.raw());
+app.use(bodyParser.text({ type : "text/*" }));
 
 app.post('/specialize', specialize);
 


### PR DESCRIPTION
Currently, the node-env only uses the 'json' and 'raw' bodyparser. These only handle bodies with content-types `application/octet-stream` and `application/json`. Bodies of other formats are ignored by the `request.body` (and would need to be fetched with the bit awkward parsing).

Adding `app.use(bodyParser.text({ type : "*/*" }));` will parse any other content-types (other than json and raw which take precedence) to plain text to `request.body`. This should avoid most issues with missing bodies.

The `*/*` could definitely be left out. But I propose it to avoid also missing bodies for 'related' content types like text/html.