### PR TITLE
Reduce function resolving time

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: b73c8c15207c8906bdc2c2713da03353d7c7ab78649f222b067e805b6f4c03dd
-updated: 2017-09-29T00:30:00.245121189+08:00
+hash: 285f5f29e18f61b5b834a48ce815fd40e023aa55d51acbc2ac8033cd8267635d
+updated: 2017-10-14T14:54:26.384349074+08:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -87,6 +87,10 @@ imports:
   version: da285caa6daa337ae04a9ac603dbaf9009ffe687
   subpackages:
   - local
+- name: github.com/hashicorp/golang-lru
+  version: a0d98a5f288019575c6d1f4bb1573fef2d1fcdc4
+  subpackages:
+  - simplelru
 - name: github.com/howeyc/gopass
   version: bf9dde6d0d2c004a008c27aaee91170c786f6db8
 - name: github.com/imdario/mergo
@@ -207,6 +211,10 @@ imports:
   version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 53feefa2559fb8dfa8d81baad31be332c97d6c77
+- name: k8s.io/api
+  version: 4b8fc5be9b77d91bbb6525d18591c43699a2b4e5
+  subpackages:
+  - core/v1
 - name: k8s.io/apimachinery
   version: 1fd2e63a9a370677308a42f24fd40c86438afddf
   subpackages:
@@ -236,6 +244,7 @@ imports:
   - pkg/runtime/serializer/versioning
   - pkg/selection
   - pkg/types
+  - pkg/util/cache
   - pkg/util/clock
   - pkg/util/diff
   - pkg/util/errors
@@ -327,6 +336,7 @@ imports:
   - rest/watch
   - third_party/forked/golang/template
   - tools/auth
+  - tools/cache
   - tools/clientcmd
   - tools/clientcmd/api
   - tools/clientcmd/api/latest

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,6 +29,10 @@ import:
   - pkg/labels
   - pkg/util/intstr
   - rest
+- package: k8s.io/api
+  version: 4b8fc5be9b77d91bbb6525d18591c43699a2b4e5
+- package: k8s.io/apimachinery
+  version: 1fd2e63a9a370677308a42f24fd40c86438afddf
 - package: github.com/influxdata/influxdb
   version: v1.2.0
   subpackages:

--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -23,7 +23,11 @@ import (
 
 	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/rest"
+	k8sCache "k8s.io/client-go/tools/cache"
 
 	"github.com/fission/fission"
 	poolmgrClient "github.com/fission/fission/poolmgr/client"
@@ -38,9 +42,11 @@ type HTTPTriggerSet struct {
 	resolver      *functionReferenceResolver
 	triggers      []tpr.Httptrigger
 	functions     []tpr.Function
+	tprClient     *rest.RESTClient
 }
 
-func makeHTTPTriggerSet(fmap *functionServiceMap, fissionClient *tpr.FissionClient, poolmgr *poolmgrClient.Client, resolver *functionReferenceResolver) *HTTPTriggerSet {
+func makeHTTPTriggerSet(fmap *functionServiceMap, fissionClient *tpr.FissionClient,
+	poolmgr *poolmgrClient.Client, resolver *functionReferenceResolver, tprClient *rest.RESTClient) *HTTPTriggerSet {
 	triggers := make([]tpr.Httptrigger, 1)
 	return &HTTPTriggerSet{
 		functionServiceMap: fmap,
@@ -48,6 +54,7 @@ func makeHTTPTriggerSet(fmap *functionServiceMap, fissionClient *tpr.FissionClie
 		fissionClient:      fissionClient,
 		poolmgr:            poolmgr,
 		resolver:           resolver,
+		tprClient:          tprClient,
 	}
 }
 
@@ -135,75 +142,77 @@ func (ts *HTTPTriggerSet) watchTriggers() {
 	// sync all http triggers
 	ts.syncTriggers()
 
-	// Watch controller for updates to triggers and update the router accordingly.
-	rv := ""
-	for {
-		wi, err := ts.fissionClient.Httptriggers(metav1.NamespaceAll).Watch(metav1.ListOptions{
-			ResourceVersion: rv,
-		})
-		if err != nil {
-			log.Fatalf("Failed to watch http trigger list: %v", err)
-		}
-
-		for {
-			ev, more := <-wi.ResultChan()
-			if !more {
-				// restart watch from last rv
-				break
-			}
-			if ev.Type == watch.Error {
-				// restart watch from the start
-				rv = ""
-				time.Sleep(time.Second)
-				break
-			}
-			ht := ev.Object.(*tpr.Httptrigger)
-			rv = ht.Metadata.ResourceVersion
-			ts.syncTriggers()
-		}
+	watchlist := k8sCache.NewListWatchFromClient(ts.tprClient, "httptriggers", metav1.NamespaceDefault, fields.Everything())
+	listWatch := &k8sCache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return watchlist.List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return watchlist.Watch(options)
+		},
 	}
+	resyncPeriod := 30 * time.Second
+	_, controller := k8sCache.NewInformer(listWatch, &tpr.Httptrigger{}, resyncPeriod,
+		k8sCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				ts.syncTriggers()
+			},
+			DeleteFunc: func(obj interface{}) {
+				ts.syncTriggers()
+			},
+			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+				ts.syncTriggers()
+			},
+		})
+	stop := make(chan struct{})
+	defer func() {
+		stop <- struct{}{}
+	}()
+	controller.Run(stop)
 }
 
 func (ts *HTTPTriggerSet) watchFunctions() {
-	rv := ""
-	for {
-		wi, err := ts.fissionClient.Functions(metav1.NamespaceAll).Watch(metav1.ListOptions{
-			ResourceVersion: rv,
-		})
-		if err != nil {
-			log.Fatalf("Failed to watch function list: %v", err)
-		}
+	ts.syncTriggers()
 
-		for {
-			ev, more := <-wi.ResultChan()
-			if !more {
-				// restart watch from last rv
-				break
-			}
-			if ev.Type == watch.Error {
-				// restart watch from the start
-				rv = ""
-				time.Sleep(time.Second)
-				break
-			}
-			fn := ev.Object.(*tpr.Function)
-			rv = fn.Metadata.ResourceVersion
-
-			// update resolver function reference cache
-			for key, rr := range ts.resolver.copy() {
-				if key.functionReference.Name == fn.Metadata.Name &&
-					rr.functionMetadata.ResourceVersion != fn.Metadata.ResourceVersion {
-					err := ts.resolver.delete(key.namespace, &key.functionReference)
-					if err != nil {
-						log.Printf("Error deleting functionReferenceResolver cache: %v", err)
-					}
-					break
-				}
-			}
-
-			ts.syncTriggers()
-		}
+	watchlist := k8sCache.NewListWatchFromClient(ts.tprClient, "functions", metav1.NamespaceDefault, fields.Everything())
+	listWatch := &k8sCache.ListWatch{
+		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+			return watchlist.List(options)
+		},
+		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+			return watchlist.Watch(options)
+		},
 	}
+	resyncPeriod := 30 * time.Second
+	_, controller := k8sCache.NewInformer(listWatch, &tpr.Function{}, resyncPeriod,
+		k8sCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				ts.syncTriggers()
+			},
+			DeleteFunc: func(obj interface{}) {
+				ts.syncTriggers()
+			},
+			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+				fn := newObj.(*tpr.Function)
+				// update resolver function reference cache
+				for key, rr := range ts.resolver.copy() {
+					if key.functionReference.Name == fn.Metadata.Name &&
+						rr.functionMetadata.ResourceVersion != fn.Metadata.ResourceVersion {
+						err := ts.resolver.delete(key.namespace, &key.functionReference)
+						if err != nil {
+							log.Printf("Error deleting functionReferenceResolver cache: %v", err)
+						}
+						break
+					}
+				}
+				ts.syncTriggers()
+			},
+		})
+	stop := make(chan struct{})
+	defer func() {
+		stop <- struct{}{}
+	}()
+	controller.Run(stop)
 }
 
 func (ts *HTTPTriggerSet) syncTriggers() {

--- a/router/router.go
+++ b/router/router.go
@@ -77,12 +77,13 @@ func Start(port int, poolmgrUrl string) {
 	if err != nil {
 		log.Fatalf("Error connecting to kubernetes API: %v", err)
 	}
+	restClient := fissionClient.GetTprClient()
 	poolmgr := poolmgrClient.MakeClient(poolmgrUrl)
-	resolver := makeFunctionReferenceResolver(fissionClient, fissionClient.GetTprClient())
+	resolver := makeFunctionReferenceResolver(fissionClient, restClient)
 	defer func() {
 		resolver.Stop()
 	}()
-	triggers := makeHTTPTriggerSet(fmap, fissionClient, poolmgr, resolver)
+	triggers := makeHTTPTriggerSet(fmap, fissionClient, poolmgr, resolver, restClient)
 	log.Printf("Starting router at port %v\n", port)
 	serve(port, triggers)
 }

--- a/router/router.go
+++ b/router/router.go
@@ -78,7 +78,10 @@ func Start(port int, poolmgrUrl string) {
 		log.Fatalf("Error connecting to kubernetes API: %v", err)
 	}
 	poolmgr := poolmgrClient.MakeClient(poolmgrUrl)
-	resolver := makeFunctionReferenceResolver(fissionClient)
+	resolver := makeFunctionReferenceResolver(fissionClient, fissionClient.GetTprClient())
+	defer func() {
+		resolver.Stop()
+	}()
 	triggers := makeHTTPTriggerSet(fmap, fissionClient, poolmgr, resolver)
 	log.Printf("Starting router at port %v\n", port)
 	serve(port, triggers)

--- a/router/router.go
+++ b/router/router.go
@@ -79,7 +79,8 @@ func Start(port int, poolmgrUrl string) {
 	}
 	restClient := fissionClient.GetTprClient()
 	poolmgr := poolmgrClient.MakeClient(poolmgrUrl)
-	resolver := makeFunctionReferenceResolver(fissionClient, restClient)
+	resolver := makeFunctionReferenceResolver(fissionClient)
+	resolver.Sync(restClient)
 	defer func() {
 		resolver.Stop()
 	}()

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -58,7 +58,7 @@ func TestRouter(t *testing.T) {
 	frr.refCache.Set(nfr, rr)
 
 	// HTTP trigger set with a trigger for this function
-	triggers := makeHTTPTriggerSet(fmap, nil, nil, frr)
+	triggers := makeHTTPTriggerSet(fmap, nil, nil, frr, nil)
 	triggerUrl := "/foo"
 	triggers.triggers = append(triggers.triggers,
 		tpr.Httptrigger{

--- a/tpr/client.go
+++ b/tpr/client.go
@@ -209,3 +209,6 @@ func (fc *FissionClient) Packages(ns string) PackageInterface {
 func (fc *FissionClient) WaitForTPRs() {
 	waitForTPRs(fc.tprClient)
 }
+func (fc *FissionClient) GetTprClient() *rest.RESTClient {
+	return fc.tprClient
+}


### PR DESCRIPTION
Before this PR, resolver takes long time to resolve function because of `kube-api-qps` of api server.
In this PR, resolver uses informer cache to resolve function instead of making http call every time to avoid hitting the qps of api server. And now the resolve time is down to average 5µs (original ~400ms) each time. (solve issue https://github.com/fission/fission/issues/366)