### PR TITLE
Add package command

### DIFF
--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -78,12 +78,15 @@ func downloadUrl(url string, localPath string) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	w, err := os.Create(localPath)
 	if err != nil {
 		return err
 	}
-
-	err = ioutil.WriteFile(localPath, body, 0600)
+	_, err = io.Copy(w, resp.Body)
+	if err != nil {
+		return err
+	}
+	err = os.Chmod(localPath, 0600)
 	if err != nil {
 		return err
 	}

--- a/fission/common.go
+++ b/fission/common.go
@@ -160,9 +160,6 @@ func createPackage(client *client.Client, envName, srcArchiveName, deployArchive
 
 	if len(deployArchiveName) > 0 {
 		pkgSpec.Deployment = *createArchive(client, deployArchiveName)
-		if len(srcArchiveName) > 0 {
-			fmt.Println("Deployment may be overwritten by builder manager after source package compilation")
-		}
 	}
 	if len(srcArchiveName) > 0 {
 		pkgSpec.Source = *createArchive(client, srcArchiveName)

--- a/fission/common.go
+++ b/fission/common.go
@@ -110,7 +110,7 @@ func createArchive(client *client.Client, fileName string) *fission.Archive {
 
 	// fetch archive from arbitrary url if fileName is a url
 	if strings.HasPrefix(fileName, "http://") || strings.HasPrefix(fileName, "https://") {
-		fileName = fetchArchiveFromArbitraryURL(fileName)
+		fileName = downloadToTempFile(fileName)
 	}
 
 	if fileSize(fileName) < fission.ArchiveLiteralSizeLimit {
@@ -223,9 +223,9 @@ func writeArchiveToFile(fileName string, body []byte) error {
 	return nil
 }
 
-// fetchArchiveFromArbitraryURL fetches archive file from arbitrary url
+// downloadToTempFile fetches archive file from arbitrary url
 // and write it to temp file for further usage
-func fetchArchiveFromArbitraryURL(fileUrl string) string {
+func downloadToTempFile(fileUrl string) string {
 	body, err := downloadURL(fileUrl)
 	checkErr(err, fmt.Sprintf("download from url: %v", fileUrl))
 

--- a/fission/common.go
+++ b/fission/common.go
@@ -149,13 +149,12 @@ func createArchive(client *client.Client, fileName string) *fission.Archive {
 	return &archive
 }
 
-func createPackage(client *client.Client, envName, srcArchiveName, deployArchiveName, buildcmd, description string) *metav1.ObjectMeta {
+func createPackage(client *client.Client, envName, srcArchiveName, deployArchiveName, buildcmd string) *metav1.ObjectMeta {
 	pkgSpec := fission.PackageSpec{
 		Environment: fission.EnvironmentReference{
 			Namespace: metav1.NamespaceDefault,
 			Name:      envName,
 		},
-		Description: description,
 	}
 	var pkgStatus fission.BuildStatus = fission.BuildStatusSucceeded
 

--- a/fission/function.go
+++ b/fission/function.go
@@ -118,7 +118,7 @@ func fnCreate(c *cli.Context) error {
 		envName = pkg.Spec.Environment.Name
 	} else if len(srcArchiveName) != 0 || len(deployArchiveName) != 0 {
 		// create new package
-		pkgMetadata = createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, "(empty)")
+		pkgMetadata = createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, "")
 	} else {
 		fatal("Need --env or --code or --deploy or --src or --pkg argument.")
 	}

--- a/fission/function.go
+++ b/fission/function.go
@@ -92,6 +92,16 @@ func fnCreate(c *cli.Context) error {
 	entrypoint := c.String("entrypoint")
 	buildcmd := c.String("buildcmd")
 
+	fnList, err := client.FunctionList()
+	checkErr(err, "get function list")
+	// check function existence before creating package
+	for _, fn := range fnList {
+		if fn.Metadata.Name == fnName {
+			fatal("Function with the same name already exists.")
+			break
+		}
+	}
+
 	var pkgMetadata *metav1.ObjectMeta
 
 	if len(pkgName) > 0 {
@@ -134,7 +144,7 @@ func fnCreate(c *cli.Context) error {
 		},
 	}
 
-	_, err := client.FunctionCreate(function)
+	_, err = client.FunctionCreate(function)
 	checkErr(err, "create function")
 
 	fmt.Printf("function '%v' created\n", fnName)

--- a/fission/function.go
+++ b/fission/function.go
@@ -119,7 +119,7 @@ func fnCreate(c *cli.Context) error {
 		buildcmd := c.String("buildcmd")
 
 		// create new package
-		pkgMetadata = createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, "")
+		pkgMetadata = createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd)
 	}
 
 	function := &crd.Function{
@@ -296,7 +296,7 @@ func fnUpdate(c *cli.Context) error {
 		if len(deployArchiveName) > 0 || len(srcArchiveName) > 0 {
 			// create a new package for function
 			pkgMetadata = createPackage(client,
-				function.Spec.Environment.Name, srcArchiveName, deployArchiveName, buildcmd, "")
+				function.Spec.Environment.Name, srcArchiveName, deployArchiveName, buildcmd)
 		}
 	}
 

--- a/fission/function.go
+++ b/fission/function.go
@@ -273,6 +273,10 @@ func fnUpdate(c *cli.Context) error {
 		function.Spec.Package.FunctionName = entrypoint
 	}
 
+	if len(pkgName) == 0 {
+		pkgName = function.Spec.Package.PackageRef.Name
+	}
+
 	pkg, err := client.PackageGet(&metav1.ObjectMeta{
 		Namespace: metav1.NamespaceDefault,
 		Name:      pkgName,
@@ -282,8 +286,9 @@ func fnUpdate(c *cli.Context) error {
 	pkgMetadata := &pkg.Metadata
 
 	if len(deployArchiveName) != 0 || len(srcArchiveName) != 0 || len(buildcmd) != 0 || len(envName) != 0 {
-		pkgMetadata, err = updatePackage(client, pkg, envName, srcArchiveName, deployArchiveName, buildcmd, force)
+		pkgMetadata = updatePackage(client, pkg, envName, srcArchiveName, deployArchiveName, buildcmd, force)
 		checkErr(err, fmt.Sprintf("update package '%v'", pkgName))
+		fmt.Printf("package '%v' updated\n", pkgMetadata.GetName())
 	}
 
 	// pkgMetadata is nil when a user updates envName or

--- a/fission/function.go
+++ b/fission/function.go
@@ -81,7 +81,7 @@ func fnCreate(c *cli.Context) error {
 	// check function existence before creating package
 	for _, fn := range fnList {
 		if fn.Metadata.Name == fnName {
-			fatal("Function with the same name already exists.")
+			fatal("A function with the same name already exists.")
 		}
 	}
 	entrypoint := c.String("entrypoint")
@@ -113,7 +113,7 @@ func fnCreate(c *cli.Context) error {
 		}
 		// fatal when both src & deploy archive are empty
 		if len(srcArchiveName) == 0 && len(deployArchiveName) == 0 {
-			fatal("Need --code or --deploy or --src argument.")
+			fatal("Need --deploy or --src argument.")
 		}
 
 		buildcmd := c.String("buildcmd")
@@ -261,7 +261,7 @@ func fnUpdate(c *cli.Context) error {
 
 	if len(envName) == 0 && len(deployArchiveName) == 0 && len(srcArchiveName) == 0 && len(pkgName) == 0 &&
 		len(entrypoint) == 0 && len(buildcmd) == 0 {
-		fatal("Need --env or --code or --deploy or --src or --pkg or --entrypoint or --buildcmd argument.")
+		fatal("Need --env or --deploy or --src or --pkg or --entrypoint or --buildcmd argument.")
 	} else if len(pkgName) > 0 && (len(deployArchiveName) != 0 || len(srcArchiveName) != 0 || len(buildcmd) != 0 || len(envName) != 0) {
 		fatal("Please use package command to update package's src/deploy archive, environment and build command.")
 	}

--- a/fission/main.go
+++ b/fission/main.go
@@ -134,7 +134,7 @@ func main() {
 
 	// packages
 	pkgNameFlag := cli.StringFlag{Name: "name", Usage: "Package name"}
-	pkgForceFlag := cli.BoolFlag{Name: "force, f", Usage: "Force to update/delete a package used by functions"}
+	pkgForceFlag := cli.BoolFlag{Name: "force, f", Usage: "Force update a package even if it is used by one or more functions"}
 	pkgEnvironmentFlag := cli.StringFlag{Name: "env", Usage: "Environment name"}
 	pkgSrcArchiveFlag := cli.StringFlag{Name: "sourcearchive, src", Usage: "Local path or URL for source archive"}
 	pkgDeployArchiveFlag := cli.StringFlag{Name: "deployarchive, deploy", Usage: "Local path or URL for binary archive"}

--- a/fission/main.go
+++ b/fission/main.go
@@ -53,12 +53,13 @@ func main() {
 	fnEntryPointFlag := cli.StringFlag{Name: "entrypoint", Usage: "entry point for environment v2 to load with"}
 	fnBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "build command for builder to run with"}
 	fnLogCountFlag := cli.StringFlag{Name: "recordcount", Usage: "the n most recent log records"}
+	fnForceFlag := cli.BoolFlag{Name: "force", Usage: "Force update a package even if it is used by one or more functions"}
 
 	fnSubcommands := []cli.Command{
 		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag, fnPkgNameFlag, htUrlFlag, htMethodFlag}, Action: fnCreate},
 		{Name: "get", Usage: "Get function source code", Flags: []cli.Flag{fnNameFlag}, Action: fnGet},
 		{Name: "getmeta", Usage: "Get function metadata", Flags: []cli.Flag{fnNameFlag}, Action: fnGetMeta},
-		{Name: "update", Usage: "Update function source code", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnPkgNameFlag, fnBuildCmdFlag}, Action: fnUpdate},
+		{Name: "update", Usage: "Update function", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnPkgNameFlag, fnBuildCmdFlag, fnForceFlag}, Action: fnUpdate},
 		{Name: "delete", Usage: "Delete function", Flags: []cli.Flag{fnNameFlag}, Action: fnDelete},
 		{Name: "list", Usage: "List all functions", Flags: []cli.Flag{}, Action: fnList},
 		{Name: "logs", Usage: "Display function logs", Flags: []cli.Flag{fnNameFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBTypeFlag, fnLogCountFlag}, Action: fnLogs},

--- a/fission/main.go
+++ b/fission/main.go
@@ -140,11 +140,12 @@ func main() {
 	pkgDeployArchiveFlag := cli.StringFlag{Name: "deployarchive, deploy", Usage: "Local path or URL for binary archive"}
 	pkgBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for builder to run with"}
 	pkgDescriptionFlag := cli.StringFlag{Name: "desc", Usage: "Description of package"}
+	pkgOutputFlag := cli.StringFlag{Name: "output, o", Usage: "Output filename to save archive content"}
 	pkgSubCommands := []cli.Command{
 		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgDescriptionFlag}, Action: pkgCreate},
 		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgDescriptionFlag, pkgForceFlag}, Action: pkgCreate},
-		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag}, Action: pkgSourceGet},
-		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag}, Action: pkgDeployGet},
+		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag, pkgOutputFlag}, Action: pkgSourceGet},
+		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag, pkgOutputFlag}, Action: pkgDeployGet},
 		{Name: "info", Usage: "Show package information", Flags: []cli.Flag{pkgNameFlag}, Action: pkgInfo},
 		{Name: "list", Usage: "List all packages", Flags: []cli.Flag{}, Action: pkgList},
 		{Name: "delete", Usage: "Delete package", Flags: []cli.Flag{pkgNameFlag, pkgForceFlag}, Action: pkgDelete},

--- a/fission/main.go
+++ b/fission/main.go
@@ -139,11 +139,10 @@ func main() {
 	pkgSrcArchiveFlag := cli.StringFlag{Name: "sourcearchive, src", Usage: "Local path or URL for source archive"}
 	pkgDeployArchiveFlag := cli.StringFlag{Name: "deployarchive, deploy", Usage: "Local path or URL for binary archive"}
 	pkgBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for builder to run with"}
-	pkgDescriptionFlag := cli.StringFlag{Name: "desc", Usage: "Description of package"}
 	pkgOutputFlag := cli.StringFlag{Name: "output, o", Usage: "Output filename to save archive content"}
 	pkgSubCommands := []cli.Command{
-		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgDescriptionFlag}, Action: pkgCreate},
-		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgDescriptionFlag, pkgForceFlag}, Action: pkgCreate},
+		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag}, Action: pkgCreate},
+		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgForceFlag}, Action: pkgCreate},
 		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag, pkgOutputFlag}, Action: pkgSourceGet},
 		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag, pkgOutputFlag}, Action: pkgDeployGet},
 		{Name: "info", Usage: "Show package information", Flags: []cli.Flag{pkgNameFlag}, Action: pkgInfo},

--- a/fission/main.go
+++ b/fission/main.go
@@ -43,6 +43,7 @@ func main() {
 	fnPackageFlag := cli.StringFlag{Name: "package", Usage: "(Deprecated) local path or URL for binary package"}
 	fnDeployArchiveFlag := cli.StringFlag{Name: "deployarchive, deploy", Usage: "local path or URL for deployment archive"}
 	fnSrcArchiveFlag := cli.StringFlag{Name: "sourcearchive, src", Usage: "local path or URL for source archive"}
+	fnPkgNameFlag := cli.StringFlag{Name: "pkgname, pkg", Usage: "Name of the existing package (--deploy and --src and --env will be ignored)"}
 	fnPodFlag := cli.StringFlag{Name: "pod", Usage: "function pod name, optional (use latest if unspecified)"}
 	fnFollowFlag := cli.BoolFlag{Name: "follow, f", Usage: "specify if the logs should be streamed"}
 	fnDetailFlag := cli.BoolFlag{Name: "detail, d", Usage: "display detailed information"}
@@ -54,10 +55,10 @@ func main() {
 	fnLogCountFlag := cli.StringFlag{Name: "recordcount", Usage: "the n most recent log records"}
 
 	fnSubcommands := []cli.Command{
-		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag, htUrlFlag, htMethodFlag}, Action: fnCreate},
+		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag, fnPkgNameFlag, htUrlFlag, htMethodFlag}, Action: fnCreate},
 		{Name: "get", Usage: "Get function source code", Flags: []cli.Flag{fnNameFlag}, Action: fnGet},
 		{Name: "getmeta", Usage: "Get function metadata", Flags: []cli.Flag{fnNameFlag}, Action: fnGetMeta},
-		{Name: "update", Usage: "Update function source code", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag}, Action: fnUpdate},
+		{Name: "update", Usage: "Update function source code", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnPkgNameFlag, fnBuildCmdFlag}, Action: fnUpdate},
 		{Name: "delete", Usage: "Delete function", Flags: []cli.Flag{fnNameFlag}, Action: fnDelete},
 		{Name: "list", Usage: "List all functions", Flags: []cli.Flag{}, Action: fnList},
 		{Name: "logs", Usage: "Display function logs", Flags: []cli.Flag{fnNameFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBTypeFlag, fnLogCountFlag}, Action: fnLogs},
@@ -131,6 +132,24 @@ func main() {
 		{Name: "list", Usage: "List all watches", Flags: []cli.Flag{}, Action: wList},
 	}
 
+	// packages
+	pkgNameFlag := cli.StringFlag{Name: "name", Usage: "Package name"}
+	pkgForceFlag := cli.BoolFlag{Name: "force, f", Usage: "Force to update/delete a package used by functions"}
+	pkgEnvironmentFlag := cli.StringFlag{Name: "env", Usage: "Environment name"}
+	pkgSrcArchiveFlag := cli.StringFlag{Name: "sourcearchive, src", Usage: "Local path or URL for source archive"}
+	pkgDeployArchiveFlag := cli.StringFlag{Name: "deployarchive, deploy", Usage: "Local path or URL for binary archive"}
+	pkgBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for builder to run with"}
+	pkgDescriptionFlag := cli.StringFlag{Name: "desc", Usage: "Description of package"}
+	pkgSubCommands := []cli.Command{
+		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgDescriptionFlag}, Action: pkgCreate},
+		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgDescriptionFlag, pkgForceFlag}, Action: pkgCreate},
+		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag}, Action: pkgSourceGet},
+		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag}, Action: pkgDeployGet},
+		{Name: "info", Usage: "Show package information", Flags: []cli.Flag{pkgNameFlag}, Action: pkgInfo},
+		{Name: "list", Usage: "List all packages", Flags: []cli.Flag{}, Action: pkgList},
+		{Name: "delete", Usage: "Delete package", Flags: []cli.Flag{pkgNameFlag, pkgForceFlag}, Action: pkgDelete},
+	}
+
 	upgradeFileFlag := cli.StringFlag{Name: "file", Usage: "JSON file containing all fission state"}
 	upgradeSubCommands := []cli.Command{
 		{Name: "dump", Usage: "Dump all state from a v0.1 fission installation", Flags: []cli.Flag{upgradeFileFlag}, Action: upgradeDumpState},
@@ -151,6 +170,7 @@ func main() {
 		{Name: "mqtrigger", Aliases: []string{"mqt", "messagequeue"}, Usage: "Manage message queue triggers for functions", Subcommands: mqtSubcommands},
 		{Name: "environment", Aliases: []string{"env"}, Usage: "Manage environments", Subcommands: envSubcommands},
 		{Name: "watch", Aliases: []string{"w"}, Usage: "Manage watches", Subcommands: wSubCommands},
+		{Name: "package", Aliases: []string{"pkg"}, Usage: "Manage packages", Subcommands: pkgSubCommands},
 		{Name: "upgrade", Aliases: []string{}, Usage: "Upgrade tool from fission v0.1", Subcommands: upgradeSubCommands},
 		{Name: "tpr2crd", Aliases: []string{}, Usage: "Migrate tool for TPR to CRD", Subcommands: migrateSubCommands},
 	}

--- a/fission/main.go
+++ b/fission/main.go
@@ -142,7 +142,7 @@ func main() {
 	pkgOutputFlag := cli.StringFlag{Name: "output, o", Usage: "Output filename to save archive content"}
 	pkgSubCommands := []cli.Command{
 		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag}, Action: pkgCreate},
-		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgForceFlag}, Action: pkgCreate},
+		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgNameFlag, pkgEnvironmentFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgForceFlag}, Action: pkgUpdate},
 		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag, pkgOutputFlag}, Action: pkgSourceGet},
 		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag, pkgOutputFlag}, Action: pkgDeployGet},
 		{Name: "info", Usage: "Show package information", Flags: []cli.Flag{pkgNameFlag}, Action: pkgInfo},

--- a/fission/package.go
+++ b/fission/package.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2017 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mholt/archiver"
+	"github.com/satori/go.uuid"
+	"github.com/urfave/cli"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission"
+	"github.com/fission/fission/controller/client"
+	"github.com/fission/fission/crd"
+)
+
+func getFunctionsByPackage(client *client.Client, pkgName string) ([]crd.Function, error) {
+	fnList, err := client.FunctionList()
+	if err != nil {
+		return nil, err
+	}
+	fns := []crd.Function{}
+	for _, fn := range fnList {
+		if fn.Spec.Package.PackageRef.Name == pkgName {
+			fns = append(fns, fn)
+		}
+	}
+	return fns, nil
+}
+
+func writeFile(fileName string, body []byte) error {
+	tmpDir := uuid.NewV4().String()
+	tmpPath := filepath.Join(os.TempDir(), tmpDir)
+	err := os.Mkdir(tmpPath, 0744)
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(tmpPath, fileName+".tmp")
+	err = ioutil.WriteFile(path, body, 0644)
+	if err != nil {
+		return err
+	}
+
+	if archiver.Zip.Match(path) {
+		fileName = fileName + ".zip"
+	}
+
+	err = os.Rename(path, fileName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func downloadUrl(client *client.Client, fileUrl string) ([]byte, error) {
+	u, err := url.ParseRequestURI(fileUrl)
+	if err != nil {
+		return nil, err
+	}
+	// replace in-cluster storage service host with controller server url
+	fileDownloadUrl := strings.TrimSuffix(client.Url, "/") + "/proxy/storage" + u.RequestURI()
+	resp, err := http.Get(fileDownloadUrl)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func pkgCreate(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	envName := c.String("env")
+	if len(envName) == 0 {
+		fatal("Need --env argument.")
+	}
+
+	description := c.String("desc")
+	srcArchiveName := c.String("src")
+	deployArchiveName := c.String("deploy")
+	buildcmd := c.String("buildcmd")
+
+	if len(srcArchiveName) == 0 && len(deployArchiveName) == 0 {
+		fatal("Need --src to specify source archive, or use --deploy to specify deployment archive.")
+	}
+
+	createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, description)
+
+	return nil
+}
+
+func pkgUpdate(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	pkgName := c.String("name")
+	if len(pkgName) == 0 {
+		fatal("Need --name argument.")
+	}
+
+	force := c.Bool("f")
+	envName := c.String("env")
+	description := c.String("desc")
+	srcArchiveName := c.String("src")
+	deployArchiveName := c.String("deploy")
+
+	if len(srcArchiveName) == 0 && len(deployArchiveName) == 0 &&
+		len(envName) == 0 && len(description) == 0 {
+		fatal("Need --env or --desc or --src or --deploy or --desc argument.")
+	}
+
+	pkg, err := client.PackageGet(&metav1.ObjectMeta{
+		Namespace: metav1.NamespaceDefault,
+		Name:      pkgName,
+	})
+	checkErr(err, "get package")
+
+	fnList, err := getFunctionsByPackage(client, pkgName)
+	checkErr(err, "get function list")
+
+	if !force && len(fnList) > 0 {
+		fatal("Package is used by multiple functions, use -f to force update")
+	}
+
+	var srcArchiveMetadata, deployArchiveMetadata *fission.Archive
+	needToBuild := false
+
+	if len(envName) > 0 {
+		pkg.Spec.Environment.Name = envName
+		needToBuild = true
+	}
+
+	if len(srcArchiveName) > 0 {
+		srcArchiveMetadata = createArchive(client, srcArchiveName)
+		pkg.Spec.Source = *srcArchiveMetadata
+		needToBuild = true
+	}
+
+	if len(deployArchiveName) > 0 {
+		deployArchiveMetadata = createArchive(client, deployArchiveName)
+		pkg.Spec.Deployment = *deployArchiveMetadata
+	}
+
+	if len(description) > 0 {
+		pkg.Spec.Description = description
+	}
+
+	if needToBuild {
+		// change into pending state to trigger package build
+		pkg.Status = fission.PackageStatus{
+			BuildStatus: fission.BuildStatusPending,
+		}
+	}
+
+	newPkgMeta, err := client.PackageUpdate(pkg)
+	checkErr(err, "update package")
+
+	// update resource version of package reference of functions that shared the same package
+	for _, fn := range fnList {
+		fn.Spec.Package.PackageRef.ResourceVersion = newPkgMeta.ResourceVersion
+		_, err := client.FunctionUpdate(&fn)
+		checkErr(err, "update function")
+	}
+
+	return err
+}
+
+func pkgSourceGet(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	pkgName := c.String("name")
+	if len(pkgName) == 0 {
+		fatal("Need name of package, use --name")
+	}
+
+	pkg, err := client.PackageGet(&metav1.ObjectMeta{
+		Namespace: metav1.NamespaceDefault,
+		Name:      pkgName,
+	})
+	if err != nil {
+		return err
+	}
+
+	var sourceVal []byte
+
+	if pkg.Spec.Source.Type == fission.ArchiveTypeLiteral {
+		sourceVal = pkg.Spec.Source.Literal
+	} else if pkg.Spec.Source.Type == fission.ArchiveTypeUrl {
+		sourceVal, err = downloadUrl(client, pkg.Spec.Source.URL)
+		if err != nil {
+			fatal(fmt.Sprintf("Error downloading source archive from storage service: %v", err))
+		}
+	}
+
+	os.Stdout.Write(sourceVal)
+	return nil
+}
+
+func pkgDeployGet(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	pkgName := c.String("name")
+	if len(pkgName) == 0 {
+		fatal("Need name of package, use --name")
+	}
+
+	pkg, err := client.PackageGet(&metav1.ObjectMeta{
+		Namespace: metav1.NamespaceDefault,
+		Name:      pkgName,
+	})
+	if err != nil {
+		return err
+	}
+
+	var deployVal []byte
+
+	if pkg.Spec.Deployment.Type == fission.ArchiveTypeLiteral {
+		deployVal = pkg.Spec.Deployment.Literal
+	} else if pkg.Spec.Deployment.Type == fission.ArchiveTypeUrl {
+		deployVal, err = downloadUrl(client, pkg.Spec.Deployment.URL)
+		if err != nil {
+			fatal(fmt.Sprintf("Error downloading source archive from storage service: %v", err))
+		}
+	}
+
+	os.Stdout.Write(deployVal)
+	return nil
+}
+
+func pkgInfo(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	pkgName := c.String("name")
+	if len(pkgName) == 0 {
+		fatal("Need name of package, use --name")
+	}
+
+	pkg, err := client.PackageGet(&metav1.ObjectMeta{
+		Namespace: metav1.NamespaceDefault,
+		Name:      pkgName,
+	})
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "%v\t%v\n", "Name:", pkg.Metadata.Name)
+	fmt.Fprintf(w, "%v\t%v\n", "Description:", pkg.Spec.Description)
+	fmt.Fprintf(w, "%v\t%v\n", "Environment:", pkg.Spec.Environment.Name)
+	fmt.Fprintf(w, "%v\t%v\n", "Status:", pkg.Status.BuildStatus)
+	fmt.Fprintf(w, "%v\n%v", "Build Logs:", pkg.Status.BuildLog)
+	w.Flush()
+
+	return nil
+}
+
+func pkgList(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	pkgList, err := client.PackageList()
+	if err != nil {
+		return err
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV", "DESCRIPTION")
+	for _, pkg := range pkgList {
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", pkg.Metadata.Name,
+			pkg.Status.BuildStatus, pkg.Spec.Environment.Name, pkg.Spec.Description)
+	}
+	w.Flush()
+
+	return nil
+}
+
+func pkgDelete(c *cli.Context) error {
+	client := getClient(c.GlobalString("server"))
+
+	pkgName := c.String("name")
+	if len(pkgName) == 0 {
+		fmt.Println("Need --name argument.")
+		return nil
+	}
+
+	force := c.Bool("f")
+
+	fnList, err := getFunctionsByPackage(client, pkgName)
+
+	if !force && len(fnList) > 0 {
+		fatal("Package is used by at least one function, use -f to force delete")
+	}
+
+	err = client.PackageDelete(&metav1.ObjectMeta{
+		Namespace: metav1.NamespaceDefault,
+		Name:      pkgName,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Package %v is deleted\n", pkgName)
+
+	return nil
+}

--- a/fission/package.go
+++ b/fission/package.go
@@ -313,6 +313,12 @@ func pkgDelete(c *cli.Context) error {
 
 	force := c.Bool("f")
 
+	_, err := client.PackageGet(&metav1.ObjectMeta{
+		Namespace: metav1.NamespaceDefault,
+		Name:      pkgName,
+	})
+	checkErr(err, "find package")
+
 	fnList, err := getFunctionsByPackage(client, pkgName)
 
 	if !force && len(fnList) > 0 {

--- a/fission/package.go
+++ b/fission/package.go
@@ -75,7 +75,8 @@ func pkgCreate(c *cli.Context) error {
 		fatal("Need --src to specify source archive, or use --deploy to specify deployment archive.")
 	}
 
-	createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, description)
+	meta := createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, description)
+	fmt.Printf("Package %v is created\n", meta.GetName())
 
 	return nil
 }
@@ -151,6 +152,8 @@ func pkgUpdate(c *cli.Context) error {
 		_, err := client.FunctionUpdate(&fn)
 		checkErr(err, "update function")
 	}
+
+	fmt.Printf("Package %v is updated\n", newPkgMeta.GetName())
 
 	return err
 }

--- a/fission/package.go
+++ b/fission/package.go
@@ -77,7 +77,7 @@ func pkgCreate(c *cli.Context) error {
 	}
 
 	meta := createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd)
-	fmt.Printf("Package %v is created\n", meta.GetName())
+	fmt.Printf("Package '%v' created\n", meta.GetName())
 
 	return nil
 }
@@ -107,19 +107,21 @@ func pkgUpdate(c *cli.Context) error {
 	})
 	checkErr(err, "get package")
 
-	_, err = updatePackage(client, pkg, envName,
+	newPkgMeta := updatePackage(client, pkg, envName,
 		srcArchiveName, deployArchiveName, buildcmd, force)
 
-	return err
+	fmt.Printf("Package '%v' updated\n", newPkgMeta.GetName())
+
+	return nil
 }
 
 func updatePackage(client *client.Client, pkg *crd.Package, envName,
-	srcArchiveName, deployArchiveName, buildcmd string, force bool) (*metav1.ObjectMeta, error) {
+	srcArchiveName, deployArchiveName, buildcmd string, force bool) *metav1.ObjectMeta {
 
 	fnList, err := getFunctionsByPackage(client, pkg.Metadata.Name)
 	checkErr(err, "get function list")
 
-	if !force && len(fnList) > 0 {
+	if !force && len(fnList) > 1 {
 		fatal("Package is used by multiple functions, use --force to force update")
 	}
 
@@ -166,9 +168,7 @@ func updatePackage(client *client.Client, pkg *crd.Package, envName,
 		checkErr(err, "update function")
 	}
 
-	fmt.Printf("Package %v is updated\n", newPkgMeta.GetName())
-
-	return nil, err
+	return newPkgMeta
 }
 
 func pkgSourceGet(c *cli.Context) error {
@@ -319,7 +319,7 @@ func pkgDelete(c *cli.Context) error {
 		return err
 	}
 
-	fmt.Printf("Package %v is deleted\n", pkgName)
+	fmt.Printf("Package '%v' deleted\n", pkgName)
 
 	return nil
 }

--- a/fission/package.go
+++ b/fission/package.go
@@ -94,10 +94,11 @@ func pkgUpdate(c *cli.Context) error {
 	envName := c.String("env")
 	srcArchiveName := c.String("src")
 	deployArchiveName := c.String("deploy")
+	buildcmd := c.String("buildcmd")
 
 	if len(srcArchiveName) == 0 && len(deployArchiveName) == 0 &&
-		len(envName) == 0 {
-		fatal("Need --env or --src or --deploy argument.")
+		len(envName) == 0 && len(buildcmd) == 0 {
+		fatal("Need --env or --src or --deploy or --buildcmd argument.")
 	}
 
 	pkg, err := client.PackageGet(&metav1.ObjectMeta{
@@ -118,6 +119,11 @@ func pkgUpdate(c *cli.Context) error {
 
 	if len(envName) > 0 {
 		pkg.Spec.Environment.Name = envName
+		needToBuild = true
+	}
+
+	if len(buildcmd) > 0 {
+		pkg.Spec.BuildCommand = buildcmd
 		needToBuild = true
 	}
 

--- a/fission/package.go
+++ b/fission/package.go
@@ -66,7 +66,6 @@ func pkgCreate(c *cli.Context) error {
 		fatal("Need --env argument.")
 	}
 
-	description := c.String("desc")
 	srcArchiveName := c.String("src")
 	deployArchiveName := c.String("deploy")
 	buildcmd := c.String("buildcmd")
@@ -75,7 +74,7 @@ func pkgCreate(c *cli.Context) error {
 		fatal("Need --src to specify source archive, or use --deploy to specify deployment archive.")
 	}
 
-	meta := createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd, description)
+	meta := createPackage(client, envName, srcArchiveName, deployArchiveName, buildcmd)
 	fmt.Printf("Package %v is created\n", meta.GetName())
 
 	return nil
@@ -91,13 +90,12 @@ func pkgUpdate(c *cli.Context) error {
 
 	force := c.Bool("f")
 	envName := c.String("env")
-	description := c.String("desc")
 	srcArchiveName := c.String("src")
 	deployArchiveName := c.String("deploy")
 
 	if len(srcArchiveName) == 0 && len(deployArchiveName) == 0 &&
-		len(envName) == 0 && len(description) == 0 {
-		fatal("Need --env or --desc or --src or --deploy or --desc argument.")
+		len(envName) == 0 {
+		fatal("Need --env or --src or --deploy argument.")
 	}
 
 	pkg, err := client.PackageGet(&metav1.ObjectMeta{
@@ -130,10 +128,6 @@ func pkgUpdate(c *cli.Context) error {
 	if len(deployArchiveName) > 0 {
 		deployArchiveMetadata = createArchive(client, deployArchiveName)
 		pkg.Spec.Deployment = *deployArchiveMetadata
-	}
-
-	if len(description) > 0 {
-		pkg.Spec.Description = description
 	}
 
 	if needToBuild {
@@ -246,7 +240,6 @@ func pkgInfo(c *cli.Context) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "%v\t%v\n", "Name:", pkg.Metadata.Name)
-	fmt.Fprintf(w, "%v\t%v\n", "Description:", pkg.Spec.Description)
 	fmt.Fprintf(w, "%v\t%v\n", "Environment:", pkg.Spec.Environment.Name)
 	fmt.Fprintf(w, "%v\t%v\n", "Status:", pkg.Status.BuildStatus)
 	fmt.Fprintf(w, "%v\n%v", "Build Logs:", pkg.Status.BuildLog)
@@ -264,10 +257,10 @@ func pkgList(c *cli.Context) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV", "DESCRIPTION")
+	fmt.Fprintf(w, "%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV")
 	for _, pkg := range pkgList {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", pkg.Metadata.Name,
-			pkg.Status.BuildStatus, pkg.Spec.Environment.Name, pkg.Spec.Description)
+		fmt.Fprintf(w, "%v\t%v\t%v\n", pkg.Metadata.Name,
+			pkg.Status.BuildStatus, pkg.Spec.Environment.Name)
 	}
 	w.Flush()
 

--- a/fission/package.go
+++ b/fission/package.go
@@ -107,11 +107,20 @@ func pkgUpdate(c *cli.Context) error {
 	})
 	checkErr(err, "get package")
 
-	fnList, err := getFunctionsByPackage(client, pkgName)
+	_, err = updatePackage(client, pkg, envName,
+		srcArchiveName, deployArchiveName, buildcmd, force)
+
+	return err
+}
+
+func updatePackage(client *client.Client, pkg *crd.Package, envName,
+	srcArchiveName, deployArchiveName, buildcmd string, force bool) (*metav1.ObjectMeta, error) {
+
+	fnList, err := getFunctionsByPackage(client, pkg.Metadata.Name)
 	checkErr(err, "get function list")
 
 	if !force && len(fnList) > 0 {
-		fatal("Package is used by multiple functions, use -f to force update")
+		fatal("Package is used by multiple functions, use --force to force update")
 	}
 
 	var srcArchiveMetadata, deployArchiveMetadata *fission.Archive
@@ -159,7 +168,7 @@ func pkgUpdate(c *cli.Context) error {
 
 	fmt.Printf("Package %v is updated\n", newPkgMeta.GetName())
 
-	return err
+	return nil, err
 }
 
 func pkgSourceGet(c *cli.Context) error {

--- a/fission/package.go
+++ b/fission/package.go
@@ -130,7 +130,9 @@ func pkgUpdate(c *cli.Context) error {
 		pkg.Spec.Deployment = *deployArchiveMetadata
 	}
 
-	if needToBuild {
+	// Set package as pending status only when there is no
+	// deploy archive.
+	if needToBuild && len(pkg.Spec.Deployment.Type) == 0 {
 		// change into pending state to trigger package build
 		pkg.Status = fission.PackageStatus{
 			BuildStatus: fission.BuildStatusPending,

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -237,10 +237,13 @@ dump_fission_crd() {
 }
 
 dump_fission_crds() {
-    dump_fission_crd function.fission.io    
-    dump_fission_crd package.fission.io    
-    dump_fission_crd httptrigger.fission.io    
-    dump_fission_crd environment.fission.io    
+    dump_fission_crd environments.fission.io
+    dump_fission_crd functions.fission.io
+    dump_fission_crd httptriggers.fission.io
+    dump_fission_crd kuberneteswatchtriggers.fission.io
+    dump_fission_crd messagequeuetriggers.fission.io
+    dump_fission_crd packages.fission.io
+    dump_fission_crd timetriggers.fission.io
 }
 
 dump_env_pods() {

--- a/test/tests/test_package_command.sh
+++ b/test/tests/test_package_command.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 # able to work.
 
 ROOT=$(dirname $0)/../..
-PYTHON_RUNTIME_IMAGE=gcr.io/fission-ci/python-env:test
-PYTHON_BUILDER_IMAGE=gcr.io/fission-ci/python-env-builder:test
+PYTHON_RUNTIME_IMAGE=gcr.io/fission-ci/python3-env:test
+PYTHON_BUILDER_IMAGE=gcr.io/fission-ci/python3-env-builder:test
 
 fn=python-srcbuild-$(date +%s)
 

--- a/test/tests/test_package_command.sh
+++ b/test/tests/test_package_command.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Use package command to create two packages one with source 
+# archive and the other with deploy archive. Also, create a 
+# function to test the packages created by package command are 
+# able to work.
+
+ROOT=$(dirname $0)/../..
+PYTHON_RUNTIME_IMAGE=gcr.io/fission-ci/python-env:test
+PYTHON_BUILDER_IMAGE=gcr.io/fission-ci/python-env-builder:test
+
+fn=python-srcbuild-$(date +%s)
+
+waitBuild() {
+    echo "Waiting for builder manager to finish the build"
+    
+    while true; do
+      kubectl --namespace default get packages $1 -o jsonpath='{.status.buildstatus}'|grep succeeded
+      if [[ $? -eq 0 ]]; then
+          break
+      fi
+    done
+}
+export -f waitBuild
+
+checkFunctionResponse() {
+    echo "Doing an HTTP GET on the function's route"
+    response=$(curl http://$FISSION_ROUTER/$1)
+
+    echo "Checking for valid response"
+    echo $response
+    echo $response | grep -i "$2"
+}
+
+echo "Pre-test cleanup"
+fission env delete --name python || true
+
+echo "Creating python env"
+fission env create --name python --image $PYTHON_RUNTIME_IMAGE --builder $PYTHON_BUILDER_IMAGE
+trap "fission env delete --name python" EXIT
+
+echo "Waiting for env builder to catch up"
+sleep 30
+
+echo "Creating pacakage with source archive"
+zip -jr demo-src-pkg.zip $ROOT/examples/python/sourcepkg/
+pkgName=$(fission package create --src demo-src-pkg.zip --env python --buildcmd "./build.sh"| cut -f2 -d' ')
+
+# wait for build to finish at most 60s
+timeout 60s bash -c "waitBuild $pkgName"
+
+echo "Creating function " $fn
+fission fn create --name $fn --pkg $pkgName --entrypoint "user.main"
+trap "fission fn delete --name $fn" EXIT
+
+echo "Creating route"
+fission route create --function $fn --url /$fn --method GET
+
+echo "Waiting for router to catch up"
+sleep 3
+  
+checkFunctionResponse $fn 'a: 1 b: {c: 3, d: 4}'
+
+echo "Creating package with deploy archive"
+mkdir testDir
+printf 'def main():\n    return "Hello, world!"' > testDir/hello.py
+zip -jr demo-deploy-pkg.zip testDir/
+pkgName=$(fission package create --deploy demo-deploy-pkg.zip --env python| cut -f2 -d' ')
+
+echo "Updating function " $fn
+fission fn update --name $fn --pkg $pkgName --entrypoint "hello.main"
+trap "fission fn delete --name $fn" EXIT
+
+echo "Waiting for router to update cache"
+sleep 3
+
+checkFunctionResponse $fn 'Hello, world!'
+
+# crappy cleanup, improve this later
+kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
+
+echo "All done."

--- a/test/tests/test_package_command.sh
+++ b/test/tests/test_package_command.sh
@@ -65,6 +65,7 @@ checkFunctionResponse $fn 'a: 1 b: {c: 3, d: 4}'
 
 echo "Creating package with deploy archive"
 mkdir testDir
+touch testDir/__init__.py
 printf 'def main():\n    return "Hello, world!"' > testDir/hello.py
 zip -jr demo-deploy-pkg.zip testDir/
 pkgName=$(fission package create --deploy demo-deploy-pkg.zip --env python| cut -f2 -d' '| tr -d \')

--- a/test/tests/test_package_command.sh
+++ b/test/tests/test_package_command.sh
@@ -46,7 +46,7 @@ sleep 30
 
 echo "Creating pacakage with source archive"
 zip -jr demo-src-pkg.zip $ROOT/examples/python/sourcepkg/
-pkgName=$(fission package create --src demo-src-pkg.zip --env python --buildcmd "./build.sh"| cut -f2 -d' ')
+pkgName=$(fission package create --src demo-src-pkg.zip --env python --buildcmd "./build.sh"| cut -f2 -d' '| tr -d \')
 
 # wait for build to finish at most 60s
 timeout 60s bash -c "waitBuild $pkgName"
@@ -67,7 +67,7 @@ echo "Creating package with deploy archive"
 mkdir testDir
 printf 'def main():\n    return "Hello, world!"' > testDir/hello.py
 zip -jr demo-deploy-pkg.zip testDir/
-pkgName=$(fission package create --deploy demo-deploy-pkg.zip --env python| cut -f2 -d' ')
+pkgName=$(fission package create --deploy demo-deploy-pkg.zip --env python| cut -f2 -d' '| tr -d \')
 
 echo "Updating function " $fn
 fission fn update --name $fn --pkg $pkgName --entrypoint "hello.main"

--- a/types.go
+++ b/types.go
@@ -73,6 +73,7 @@ type (
 		Source       Archive              `json:"source"`
 		Deployment   Archive              `json:"deployment"`
 		BuildCommand string               `json:"buildcmd"`
+		Description  string               `json:"description"`
 		// In the future, we can have a debug build here too
 	}
 	PackageStatus struct {

--- a/types.go
+++ b/types.go
@@ -73,7 +73,6 @@ type (
 		Source       Archive              `json:"source"`
 		Deployment   Archive              `json:"deployment"`
 		BuildCommand string               `json:"buildcmd"`
-		Description  string               `json:"description"`
 		// In the future, we can have a debug build here too
 	}
 	PackageStatus struct {


### PR DESCRIPTION
This PR adds `package` command to CLI. `package` provides some useful subcommands to use such as packages CURD and display package detail information. Also its able to reuse existing package at function creation.

```
NAME:
   fission package - Manage packages

USAGE:
   fission package command [command options] [arguments...]

COMMANDS:
     create     Create new package
     update     Update package
     getsrc     Get source archive content
     getdeploy  Get deployment archive content
     info       Show package information
     list       List all packages
     delete     Delete package

OPTIONS:
   --help, -h  show help
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/385)
<!-- Reviewable:end -->
