### PR TITLE
Use shorter resync period to flush out-of-dated cache

### DIFF
--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -151,7 +151,7 @@ func (ts *HTTPTriggerSet) watchTriggers() {
 			return watchlist.Watch(options)
 		},
 	}
-	resyncPeriod := 30 * time.Second
+	resyncPeriod := 5 * time.Second
 	_, controller := k8sCache.NewInformer(listWatch, &tpr.Httptrigger{}, resyncPeriod,
 		k8sCache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -183,7 +183,7 @@ func (ts *HTTPTriggerSet) watchFunctions() {
 			return watchlist.Watch(options)
 		},
 	}
-	resyncPeriod := 30 * time.Second
+	resyncPeriod := 5 * time.Second
 	_, controller := k8sCache.NewInformer(listWatch, &tpr.Function{}, resyncPeriod,
 		k8sCache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {


### PR DESCRIPTION
This small PR aims to fix the test failure during CI test due to long `resyncPeriod`.

Informer resync watch resources from k8s api server.  If `resyncPeriod` is too long, router may not be able to update with the latest resources cache and caused test failure.

It should fix the PRs (PR382, 381, 367) that failed at test case `test_node_hello_http.sh`. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/388)
<!-- Reviewable:end -->
