### PR TITLE
Fix functionReferenceResolver return out-of-date function metadata

### DIFF
--- a/router/functionReferenceResolver.go
+++ b/router/functionReferenceResolver.go
@@ -36,8 +36,6 @@ type (
 	// functionReferenceResolver provides a resolver to turn a function
 	// reference into a resolveResult
 	functionReferenceResolver struct {
-		fissionClient *crd.FissionClient
-
 		// FunctionReference -> function metadata
 		refCache *cache.Cache
 
@@ -68,26 +66,12 @@ const (
 	resolveResultSingleFunction = iota
 )
 
-func makeFunctionReferenceResolver(fissionClient *crd.FissionClient) *functionReferenceResolver {
+func makeFunctionReferenceResolver(store k8sCache.Store) *functionReferenceResolver {
 	frr := &functionReferenceResolver{
-		fissionClient: fissionClient,
-		refCache:      cache.MakeCache(time.Minute, 0),
+		refCache: cache.MakeCache(time.Minute, 0),
+		store:    store,
 	}
 	return frr
-}
-
-// Sync starts syncing crd function resources from k8s api server
-func (frr *functionReferenceResolver) Sync(crdClient *rest.RESTClient) {
-	stopCh := make(chan struct{})
-	store, controller := makeK8SCache(crdClient)
-	frr.stopCh = stopCh
-	frr.store = store
-	go controller.Run(stopCh)
-}
-
-// Stop stops crd resources syncing
-func (frr *functionReferenceResolver) Stop() {
-	frr.stopCh <- struct{}{}
 }
 
 func makeK8SCache(crdClient *rest.RESTClient) (k8sCache.Store, k8sCache.Controller) {

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -58,7 +58,7 @@ func TestRouter(t *testing.T) {
 	frr.refCache.Set(nfr, rr)
 
 	// HTTP trigger set with a trigger for this function
-	triggers := makeHTTPTriggerSet(fmap, nil, nil, frr, nil)
+	triggers, _, _ := makeHTTPTriggerSet(fmap, nil, nil, nil)
 	triggerUrl := "/foo"
 	triggers.triggers = append(triggers.triggers,
 		crd.HTTPTrigger{
@@ -75,7 +75,7 @@ func TestRouter(t *testing.T) {
 
 	// run the router
 	port := 4242
-	go serve(port, triggers)
+	go serve(port, triggers, frr)
 	time.Sleep(100 * time.Millisecond)
 
 	// hit the router

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package router
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -75,7 +76,9 @@ func TestRouter(t *testing.T) {
 
 	// run the router
 	port := 4242
-	go serve(port, triggers, frr)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go serve(ctx, port, triggers, frr)
 	time.Sleep(100 * time.Millisecond)
 
 	// hit the router


### PR DESCRIPTION
In router we launch two watcher to watch function changes. One for HTTPTriggerSet, another for functionReferenceResolver. 

In some situation, two watchers may not receive change events at the same time.  So functionReferenceResolver return out-of-date function metadata  back to httpTrigger. In this case, router proxies request to the old pod and caused test failure.

This PR aims to solve this problem by sharing http trigger resource store with functionReferenceResolver to prevent data consistency problem.

Following is the interaction diagram for this problem.

![router-informer-store-bug](https://user-images.githubusercontent.com/202578/32565172-e801aa92-c47b-11e7-944e-9c38e7c1be26.jpg)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/390)
<!-- Reviewable:end -->
