### PR TITLE
Delete failed helm releases to prevent test case failure

### DIFF
--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -117,6 +117,9 @@ helm_install_fission() {
     helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always,analytics=false
 
     helm_setup
+
+    echo "Deleting failed releases"
+    helm list --failed -q|xargs -I@ bash -c "helm delete @"
     
     echo "Installing fission"
     helm install		\
@@ -127,6 +130,8 @@ helm_install_fission() {
 	 --namespace $ns        \
 	 --debug                \
 	 $ROOT/charts/fission-all
+    
+    helm list
 }
 
 wait_for_service() {


### PR DESCRIPTION
Some failed helm releases were not deleted after the testing and caused helm failed to deploy new release to test k8s cluster. This PR add cleanup step to remove failed releases before deploying new helm release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/393)
<!-- Reviewable:end -->
