### PR TITLE
Add fission/builder image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ cache:
     - $HOME/google-cloud-sdk/
     - $HOME/k8scli
 
+services:
+  - docker
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+
 install:
   - go get github.com/Masterminds/glide
   - hack/travis-kube-setup.sh

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -181,14 +181,16 @@ func (builder *Builder) build(command string, srcPkgPath string, deployPkgPath s
 	}
 
 	if err := scanner.Err(); err != nil {
-		fmt.Println(err)
-		return "", errors.New(fmt.Sprintf("Error reading cmd output: %v", err.Error()))
+		scanErr := errors.New(fmt.Sprintf("Error reading cmd output: %v", err.Error()))
+		fmt.Println(scanErr)
+		return "", scanErr
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		fmt.Println(err)
-		return "", errors.New(fmt.Sprintf("Error waiting for cmd '%v': %v", command, err.Error()))
+		cmdErr := errors.New(fmt.Sprintf("Error waiting for cmd '%v': %v", command, err.Error()))
+		fmt.Println(cmdErr)
+		return "", cmdErr
 	}
 	fmt.Println("==================\n")
 

--- a/builder/cmd/Dockerfile
+++ b/builder/cmd/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.5
 
 RUN apk update
+# Install some utility libraries for builders extending image
 RUN apk add coreutils binutils findutils grep
 
 ADD builder /builder

--- a/builder/cmd/Dockerfile
+++ b/builder/cmd/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:3.5
+
+RUN apk update
+RUN apk add coreutils binutils findutils grep
+
+ADD builder /builder
+
+EXPOSE 8001

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -46,8 +46,9 @@ import (
 func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes.Clientset,
 	builderNamespace string, storageSvcUrl string, buildReq BuildRequest) (buildLogs string, err error) {
 
-	pkg, err := fissionClient.Packages(
-		buildReq.Package.Namespace).Get(buildReq.Package.Name)
+	pkg, err := fissionClient.
+		Packages(buildReq.Package.Namespace).
+		Get(buildReq.Package.Name)
 	if err != nil {
 		e := fmt.Sprintf("Error getting function CRD info: %v", err)
 		log.Println(e)
@@ -107,9 +108,14 @@ func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes
 		return e, fission.MakeError(500, e)
 	}
 
+	buildCmd := pkg.Spec.BuildCommand
+	if len(buildCmd) == 0 {
+		buildCmd = env.Spec.Builder.Command
+	}
+
 	pkgBuildReq := &builder.PackageBuildRequest{
 		SrcPkgFilename: srcPkgFilename,
-		BuildCommand:   pkg.Spec.BuildCommand,
+		BuildCommand:   buildCmd,
 	}
 
 	log.Printf("Start building with source package: %v", srcPkgFilename)

--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -449,7 +449,7 @@ func (envw *environmentWatcher) createBuilderDeployment(env *crd.Environment) (*
 						{
 							Name:                   "builder",
 							Image:                  env.Spec.Builder.Image,
-							ImagePullPolicy:        apiv1.PullIfNotPresent,
+							ImagePullPolicy:        apiv1.PullAlways,
 							TerminationMessagePath: "/dev/termination-log",
 							VolumeMounts: []apiv1.VolumeMount{
 								{

--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -449,7 +449,7 @@ func (envw *environmentWatcher) createBuilderDeployment(env *crd.Environment) (*
 						{
 							Name:                   "builder",
 							Image:                  env.Spec.Builder.Image,
-							ImagePullPolicy:        apiv1.PullAlways,
+							ImagePullPolicy:        apiv1.PullIfNotPresent,
 							TerminationMessagePath: "/dev/termination-log",
 							VolumeMounts: []apiv1.VolumeMount{
 								{

--- a/environments/python/builder/Dockerfile
+++ b/environments/python/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM fission/builder
 
 RUN apk update
 RUN apk add --no-cache python3 python3-dev build-base
@@ -6,6 +6,5 @@ RUN pip3 install --upgrade pip
 RUN rm -r /root/.cache
 
 ADD defaultBuildCmd /usr/local/bin/build
-ADD builder /builder
 
 EXPOSE 8001

--- a/environments/python/builder/Dockerfile
+++ b/environments/python/builder/Dockerfile
@@ -1,4 +1,5 @@
-FROM fission/builder
+ARG BUILDER_IMAGE=fission/builder:latest
+FROM ${BUILDER_IMAGE}
 
 RUN apk update
 RUN apk add --no-cache python3 python3-dev build-base

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -93,6 +93,24 @@ push_fetcher_image() {
     docker push $tag
 }
 
+build_builder_image() {
+    version=$1
+    tag=fission/builder:$version
+
+    pushd $DIR/builder/cmd
+
+    ./build.sh
+    docker build -t $tag .
+
+    popd
+}
+
+push_builder_image() {
+    version=$1
+    tag=fission/builder:$version
+    docker push $tag
+}
+
 build_and_push_env_image() {
     version=$1
     envdir=$2
@@ -172,13 +190,15 @@ build_all() {
     
     build_fission_bundle_image $version
     build_fetcher_image $version
+    build_builder_image $version
     build_all_cli
     build_charts $version
 }
 
 push_all() {
     push_fission_bundle_image $version
-    push_fetcher_image $version    
+    push_fetcher_image $version
+    push_builder_image $version
 }
 
 tag_and_release() {

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -14,19 +14,22 @@ REPO=gcr.io/fission-ci
 IMAGE=$REPO/fission-bundle
 FETCHER_IMAGE=$REPO/fetcher
 FLUENTD_IMAGE=gcr.io/fission-ci/fluentd
+BUILDER_IMAGE=$REPO/builder
 TAG=test
+
+dump_system_info
 
 build_and_push_fission_bundle $IMAGE:$TAG
 
 build_and_push_fetcher $FETCHER_IMAGE:$TAG
 
-build_builder
+build_and_push_builder $BUILDER_IMAGE:$TAG
 
 ENV='python'
 
 build_and_push_env_runtime $ENV $REPO/$ENV-env:$TAG
 
-build_and_push_env_builder $ENV $REPO/$ENV-env-builder:$TAG
+build_and_push_env_builder $ENV $REPO/$ENV-env-builder:$TAG $BUILDER_IMAGE:$TAG
 
 build_and_push_fluentd $FLUENTD_IMAGE:$TAG
 

--- a/types.go
+++ b/types.go
@@ -152,7 +152,7 @@ type (
 	}
 	Builder struct {
 		// Image for containing the language runtime.
-		Image   string `json:"image"`
+		Image string `json:"image"`
 
 		// (Optional) Default build command to run for this build environment.
 		Command string `json:"command"`

--- a/types.go
+++ b/types.go
@@ -151,7 +151,10 @@ type (
 		FunctionEndpointPort int32 `json:"functionendpointport"`
 	}
 	Builder struct {
+		// Image for containing the language runtime.
 		Image   string `json:"image"`
+
+		// (Optional) Default build command to run for this build environment.
 		Command string `json:"command"`
 	}
 	EnvironmentSpec struct {


### PR DESCRIPTION
This PR tackles a couple of issues with builder(mgr)

It...:
- ...fixes the issue where the environment-scoped buildcmd was not used.
- ...allows files to be passed to the builder
- ...adds a `fission/builder` docker image avoiding the need to compile fission to get the binary.
- ...fixes the issue where the builder did not log the stderr

~~As a flyby, I updated the deploy script to correspond with the one in fission workflows~~

cc @life1347

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/397)
<!-- Reviewable:end -->
