### PR TITLE
fission function logs returns logs in correct order now

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -444,9 +444,9 @@ func fnLogs(c *cli.Context) error {
 		Namespace: metav1.NamespaceDefault,
 	}
 
-	recordLimit := c.String("recordcount")
-	if len(recordLimit) == 0 {
-		recordLimit = "1000"
+	recordLimit := c.Int("recordcount")
+	if recordLimit <= 0 {
+		recordLimit = 1000
 	}
 
 	f, err := client.FunctionGet(m)

--- a/fission/function.go
+++ b/fission/function.go
@@ -433,6 +433,7 @@ func fnLogs(c *cli.Context) error {
 		fatal("Need name of function, use --name")
 	}
 
+
 	dbType := c.String("dbtype")
 	if len(dbType) == 0 {
 		dbType = logdb.INFLUXDB
@@ -442,6 +443,11 @@ func fnLogs(c *cli.Context) error {
 	m := &metav1.ObjectMeta{
 		Name:      fnName,
 		Namespace: metav1.NamespaceDefault,
+	}
+
+	recordLimit := c.String("recordcount")
+	if len(recordLimit) == 0 {
+		recordLimit = "1000"
 	}
 
 	f, err := client.FunctionGet(m)
@@ -467,6 +473,7 @@ func fnLogs(c *cli.Context) error {
 					Function: f.Metadata.Name,
 					FuncUid:  string(f.Metadata.UID),
 					Since:    t,
+					RecordLimit: recordLimit,
 				}
 				logEntries, err := logDB.GetLogs(logFilter)
 				if err != nil {
@@ -477,7 +484,7 @@ func fnLogs(c *cli.Context) error {
 						fmt.Printf("Timestamp: %s\nNamespace: %s\nFunction Name: %s\nFunction ID: %s\nPod: %s\nContainer: %s\nStream: %s\nLog: %s\n---\n",
 							logEntry.Timestamp, logEntry.Namespace, logEntry.FuncName, logEntry.FuncUid, logEntry.Pod, logEntry.Container, logEntry.Stream, logEntry.Message)
 					} else {
-						fmt.Printf("[%s] #%v %s\n", logEntry.Timestamp, logEntry.Sequence, logEntry.Message)
+						fmt.Printf("[%s] %s\n", logEntry.Timestamp, logEntry.Message)
 					}
 					t = logEntry.Timestamp
 				}

--- a/fission/function.go
+++ b/fission/function.go
@@ -433,7 +433,6 @@ func fnLogs(c *cli.Context) error {
 		fatal("Need name of function, use --name")
 	}
 
-
 	dbType := c.String("dbtype")
 	if len(dbType) == 0 {
 		dbType = logdb.INFLUXDB
@@ -469,10 +468,10 @@ func fnLogs(c *cli.Context) error {
 			select {
 			case <-requestChan:
 				logFilter := logdb.LogFilter{
-					Pod:      fnPod,
-					Function: f.Metadata.Name,
-					FuncUid:  string(f.Metadata.UID),
-					Since:    t,
+					Pod:         fnPod,
+					Function:    f.Metadata.Name,
+					FuncUid:     string(f.Metadata.UID),
+					Since:       t,
 					RecordLimit: recordLimit,
 				}
 				logEntries, err := logDB.GetLogs(logFilter)

--- a/fission/function.go
+++ b/fission/function.go
@@ -477,7 +477,7 @@ func fnLogs(c *cli.Context) error {
 						fmt.Printf("Timestamp: %s\nNamespace: %s\nFunction Name: %s\nFunction ID: %s\nPod: %s\nContainer: %s\nStream: %s\nLog: %s\n---\n",
 							logEntry.Timestamp, logEntry.Namespace, logEntry.FuncName, logEntry.FuncUid, logEntry.Pod, logEntry.Container, logEntry.Stream, logEntry.Message)
 					} else {
-						fmt.Printf("[%s] %s\n", logEntry.Timestamp, logEntry.Message)
+						fmt.Printf("[%s] #%v %s\n", logEntry.Timestamp, logEntry.Sequence, logEntry.Message)
 					}
 					t = logEntry.Timestamp
 				}

--- a/fission/logdb/influxdb.go
+++ b/fission/logdb/influxdb.go
@@ -19,12 +19,12 @@ package logdb
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"log"
 	"net/http"
 	"net/url"
-	"strings"
+	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	influxdbClient "github.com/influxdata/influxdb/client/v2"
@@ -81,7 +81,7 @@ func (influx InfluxDB) GetLogs(filter LogFilter) ([]LogEntry, error) {
 		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid AND \"pod\" = $pod AND \"time\" > $time ORDER BY time ASC"
 		parameters["pod"] = filter.Pod
 	} else {
-		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid" 
+		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid"
 	}
 
 	query := influxdbClient.NewQueryWithParameters(queryCmd, INFLUXDB_DATABASE, "", parameters)
@@ -97,7 +97,7 @@ func (influx InfluxDB) GetLogs(filter LogFilter) ([]LogEntry, error) {
 				if err != nil {
 					log.Fatal(err)
 				}
-				seqNum, err := strconv.Atoi(row[1].(string)) 
+				seqNum, err := strconv.Atoi(row[1].(string))
 				if err != nil {
 					return logEntries, err
 				}
@@ -111,16 +111,16 @@ func (influx InfluxDB) GetLogs(filter LogFilter) ([]LogEntry, error) {
 					Namespace: row[14].(string),                           //kubernetes_namespace_name
 					Pod:       row[15].(string),                           //kubernetes_pod_name
 					Stream:    row[18].(string),                           //stream
-					Sequence:  seqNum,							           //sequence tag
+					Sequence:  seqNum,                                     //sequence tag
 				})
 			}
 		}
-	}	
+	}
 	sort.Slice(logEntries, func(i, j int) bool {
 
 		if logEntries[i].Timestamp.Before(logEntries[j].Timestamp) {
 			return true
-		} 
+		}
 		if logEntries[j].Timestamp.Before(logEntries[i].Timestamp) {
 			return false
 		}

--- a/fission/logdb/influxdb.go
+++ b/fission/logdb/influxdb.go
@@ -79,10 +79,10 @@ func (influx InfluxDB) GetLogs(filter LogFilter) ([]LogEntry, error) {
 	//the parameters above are only for the where clause and do not work with LIMIT
 
 	if filter.Pod != "" {
-		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid AND \"pod\" = $pod AND \"time\" > $time LIMIT " + filter.RecordLimit
+		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid AND \"pod\" = $pod AND \"time\" > $time LIMIT " + strconv.Itoa(filter.RecordLimit)
 		parameters["pod"] = filter.Pod
 	} else {
-		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid AND \"time\" > $time LIMIT " + filter.RecordLimit
+		queryCmd = "select * from \"log\" where \"funcuid\" = $funcuid AND \"time\" > $time LIMIT " + strconv.Itoa(filter.RecordLimit)
 	}
 
 	query := influxdbClient.NewQueryWithParameters(queryCmd, INFLUXDB_DATABASE, "", parameters)

--- a/fission/logdb/logdb.go
+++ b/fission/logdb/logdb.go
@@ -32,10 +32,10 @@ type LogDatabase interface {
 }
 
 type LogFilter struct {
-	Pod      string
-	Function string
-	FuncUid  string
-	Since    time.Time
+	Pod         string
+	Function    string
+	FuncUid     string
+	Since       time.Time
 	RecordLimit string
 }
 

--- a/fission/logdb/logdb.go
+++ b/fission/logdb/logdb.go
@@ -36,6 +36,7 @@ type LogFilter struct {
 	Function string
 	FuncUid  string
 	Since    time.Time
+	RecordLimit string
 }
 
 type LogEntry struct {

--- a/fission/logdb/logdb.go
+++ b/fission/logdb/logdb.go
@@ -42,6 +42,7 @@ type LogEntry struct {
 	Timestamp time.Time
 	Message   string
 	Stream    string
+	Sequence  int
 	Container string
 	Namespace string
 	FuncName  string

--- a/fission/logdb/logdb.go
+++ b/fission/logdb/logdb.go
@@ -36,7 +36,7 @@ type LogFilter struct {
 	Function    string
 	FuncUid     string
 	Since       time.Time
-	RecordLimit string
+	RecordLimit int
 }
 
 type LogEntry struct {

--- a/fission/main.go
+++ b/fission/main.go
@@ -51,6 +51,7 @@ func main() {
 	fnHeaderFlag := cli.StringSliceFlag{Name: "header, H", Usage: "request headers"}
 	fnEntryPointFlag := cli.StringFlag{Name: "entrypoint", Usage: "entry point for environment v2 to load with"}
 	fnBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "build command for builder to run with"}
+	fnLogCountFlag := cli.StringFlag{Name: "recordcount", Usage: "the n most recent log records"}
 
 	fnSubcommands := []cli.Command{
 		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag, htUrlFlag, htMethodFlag}, Action: fnCreate},
@@ -59,7 +60,7 @@ func main() {
 		{Name: "update", Usage: "Update function source code", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag}, Action: fnUpdate},
 		{Name: "delete", Usage: "Delete function", Flags: []cli.Flag{fnNameFlag}, Action: fnDelete},
 		{Name: "list", Usage: "List all functions", Flags: []cli.Flag{}, Action: fnList},
-		{Name: "logs", Usage: "Display function logs", Flags: []cli.Flag{fnNameFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBTypeFlag}, Action: fnLogs},
+		{Name: "logs", Usage: "Display function logs", Flags: []cli.Flag{fnNameFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBTypeFlag, fnLogCountFlag}, Action: fnLogs},
 		{Name: "pods", Usage: "Display function pods", Flags: []cli.Flag{fnNameFlag, fnLogDBTypeFlag}, Action: fnPods},
 		{Name: "test", Usage: "Test a function", Flags: []cli.Flag{fnNameFlag, fnEnvNameFlag, fnCodeFlag, fnPackageFlag, fnSrcArchiveFlag, htMethodFlag, fnBodyFlag, fnHeaderFlag}, Action: fnTest},
 	}


### PR DESCRIPTION
This PR solves an issue with fission function logs where the log records were displayed to the console in an erroneous order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/405)
<!-- Reviewable:end -->
