### PR TITLE
Prepare Fission for IPv6 uses

### DIFF
--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -309,15 +309,15 @@ func (gp *GenericPool) getSpecializeUrl(podIP string, version int) string {
 	}
 	t := IsIPv6(podIP)
 	if t == false {
-		if version == 1 {
-			return fmt.Sprintf("http://%v:8888/specialize", podIP)
-		}
-		return fmt.Sprintf("http://%v:8888/v%v/specialize", podIP, version)
-	} else if t == true {
-		if version == 1 {
-			return fmt.Sprintf("http://[%v]:8888/specialize", podIP)
-		}
-		return fmt.Sprintf("http://[%v]:8888/v%v/specialize", podIP, version)
+		r := fmt.Sprintf("http://%v:8888", podIP)
+	} else if t == true { //Use bracket if IP == IPv6
+		r := fmt.Sprintf("http://[%v]:8888", podIP)
+	}
+
+	if version == 1 {
+	 	return fmt.Sprintf("%v/specialize", r)
+	} else {
+	 	return fmt.Sprintf("%v/v%v/specialize", r, version)
 	}
 }
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -285,6 +285,12 @@ func (gp *GenericPool) scheduleDeletePod(name string) {
 	}()
 }
 
+func IsIPv6(podIP string) bool {
+	ip := net.ParseIP(podIP)
+	return ip != nil && strings.Contains(podIP, ":")
+}
+
+
 func (gp *GenericPool) getFetcherUrl(podIP string) string {
 	testUrl := os.Getenv("TEST_FETCHER_URL")
 	if len(testUrl) != 0 {
@@ -294,12 +300,13 @@ func (gp *GenericPool) getFetcherUrl(podIP string) string {
 		time.Sleep(5 * time.Second)
 		return testUrl
 	}
-	return fmt.Sprintf("http://%v:8000/", podIP)
-}
+	isv6 := IsIPv6(podIP)
+	if isv6 == false {
+		return fmt.Sprintf("http://%v:8000/", podIP)
+	} else if isv6 == true { // We use bracket if the IP is in IPv6.
+		return fmt.Sprintf("http://[%v]:8000/", podIP)
+	}
 
-func IsIPv6(podIP string) bool {
-	ip := net.ParseIP(podIP)
-	return ip != nil && strings.Contains(podIP, ":")
 }
 
 func (gp *GenericPool) getSpecializeUrl(podIP string, version int) string {

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -297,15 +297,28 @@ func (gp *GenericPool) getFetcherUrl(podIP string) string {
 	return fmt.Sprintf("http://%v:8000/", podIP)
 }
 
+func IsIPv6(podIP string) bool {
+	ip := net.ParseIP(podIP)
+	return ip != nil && strings.Contains(podIP, ":")
+}
+
 func (gp *GenericPool) getSpecializeUrl(podIP string, version int) string {
 	u := os.Getenv("TEST_SPECIALIZE_URL")
 	if len(u) != 0 {
 		return u
 	}
-	if version == 1 {
-		return fmt.Sprintf("http://%v:8888/specialize", podIP)
+	t := IsIPv6(podIP)
+	if t == false {
+		if version == 1 {
+			return fmt.Sprintf("http://%v:8888/specialize", podIP)
+		}
+		return fmt.Sprintf("http://%v:8888/v%v/specialize", podIP, version)
+	} else if t == true {
+		if version == 1 {
+			return fmt.Sprintf("http://[%v]:8888/specialize", podIP)
+		}
+		return fmt.Sprintf("http://[%v]:8888/v%v/specialize", podIP, version)
 	}
-	return fmt.Sprintf("http://%v:8888/v%v/specialize", podIP, version)
 }
 
 // specializePod chooses a pod, copies the required user-defined function to that pod

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -300,11 +300,13 @@ func (gp *GenericPool) getFetcherUrl(podIP string) string {
 		return testUrl
 	}
 	isv6 := IsIPv6(podIP)
+	var baseUrl string
 	if isv6 == false {
-		return fmt.Sprintf("http://%v:8000/", podIP)
+		baseUrl = fmt.Sprintf("http://%v:8000/", podIP)
 	} else if isv6 == true { // We use bracket if the IP is in IPv6.
-		return fmt.Sprintf("http://[%v]:8000/", podIP)
+		baseUrl = fmt.Sprintf("http://[%v]:8000/", podIP)
 	}
+	return baseUrl
 
 }
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -304,20 +304,21 @@ func IsIPv6(podIP string) bool {
 
 func (gp *GenericPool) getSpecializeUrl(podIP string, version int) string {
 	u := os.Getenv("TEST_SPECIALIZE_URL")
+	isv6 := IsIPv6(podIP)
+	var baseUrl string
 	if len(u) != 0 {
 		return u
 	}
-	t := IsIPv6(podIP)
-	if t == false {
-		r := fmt.Sprintf("http://%v:8888", podIP)
-	} else if t == true { //Use bracket if IP == IPv6
-		r := fmt.Sprintf("http://[%v]:8888", podIP)
+	if isv6 == false {
+		baseUrl := fmt.Sprintf("http://%v:8888", podIP)
+	} else if isv6 == true { //Use bracket if IP == IPv6
+		baseUrl := fmt.Sprintf("http://[%v]:8888", podIP)
 	}
 
 	if version == 1 {
-	 	return fmt.Sprintf("%v/specialize", r)
+	 	return fmt.Sprintf("%v/specialize", baseUrl)
 	} else {
-	 	return fmt.Sprintf("%v/v%v/specialize", r, version)
+	 	return fmt.Sprintf("%v/v%v/specialize", baseUrl, version)
 	}
 }
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -310,9 +310,9 @@ func (gp *GenericPool) getSpecializeUrl(podIP string, version int) string {
 		return u
 	}
 	if isv6 == false {
-		baseUrl := fmt.Sprintf("http://%v:8888", podIP)
-	} else if isv6 == true { //Use bracket if IP == IPv6
-		baseUrl := fmt.Sprintf("http://[%v]:8888", podIP)
+		baseUrl = fmt.Sprintf("http://%v:8888", podIP)
+	} else if isv6 == true { 		// We use bracket if the IP is in IPv6.
+		baseUrl = fmt.Sprintf("http://[%v]:8888", podIP)
 	}
 
 	if version == 1 {

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -311,14 +311,14 @@ func (gp *GenericPool) getSpecializeUrl(podIP string, version int) string {
 	}
 	if isv6 == false {
 		baseUrl = fmt.Sprintf("http://%v:8888", podIP)
-	} else if isv6 == true { 		// We use bracket if the IP is in IPv6.
+	} else if isv6 == true { // We use bracket if the IP is in IPv6.
 		baseUrl = fmt.Sprintf("http://[%v]:8888", podIP)
 	}
 
 	if version == 1 {
-	 	return fmt.Sprintf("%v/specialize", baseUrl)
+		return fmt.Sprintf("%v/specialize", baseUrl)
 	} else {
-	 	return fmt.Sprintf("%v/v%v/specialize", baseUrl, version)
+		return fmt.Sprintf("%v/v%v/specialize", baseUrl, version)
 	}
 }
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -290,7 +290,6 @@ func IsIPv6(podIP string) bool {
 	return ip != nil && strings.Contains(podIP, ":")
 }
 
-
 func (gp *GenericPool) getFetcherUrl(podIP string) string {
 	testUrl := os.Getenv("TEST_FETCHER_URL")
 	if len(testUrl) != 0 {


### PR DESCRIPTION
Hi,

Here is a small contribution to allow Fission to talk to IPv6 function pods. 

I'm able to make all work except to communications to IPv6 function pod : 

poolmgr logs : 
```
 Error: 500: Post http://1404:f600:f::0:e:16:d0bb:8000/: invalid URL port "404:f600:f::0:e:16:d0bb"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/408)
<!-- Reviewable:end -->
