### PR TITLE
Fix pool manager crash problem if failed at http call

### DIFF
--- a/environments/fetcher/client/client.go
+++ b/environments/fetcher/client/client.go
@@ -36,7 +36,7 @@ func (c *Client) Fetch(fr *fetcher.FetchRequest) error {
 	var resp *http.Response
 
 	for i := 0; i < maxRetries; i++ {
-		resp, err := http.Post(c.url, "application/json", bytes.NewReader(body))
+		resp, err = http.Post(c.url, "application/json", bytes.NewReader(body))
 
 		if err == nil && resp.StatusCode == 200 {
 			defer resp.Body.Close()


### PR DESCRIPTION
Pool manager crashed due to nil pointer problem when it failed at calling fetcher to fetch code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/418)
<!-- Reviewable:end -->
