### PR TITLE
Overwrite request host with internal host to prevent request rejection

### DIFF
--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -141,6 +141,11 @@ func (fh *functionHandler) handler(responseWriter http.ResponseWriter, request *
 		// function metadata here.
 		req.URL.Path = "/"
 
+		// Overwrite request host with internal host,
+		// or request will be blocked in some situations
+		// (e.g. istio-proxy)
+		req.Host = serviceUrl.Host
+
 		// leave the query string intact (req.URL.RawQuery)
 
 		if _, ok := req.Header["User-Agent"]; !ok {


### PR DESCRIPTION
In `http.Request` contains a `Host` field that holds the hostname the HTTP request targeting. When a request comes to the router, the router will proxy the request to one of backend function pods. 

Normally, it will be fine not changing the Host field of the request. But after some experiment for istio integration, the request with mismatched Host and Url was rejected by istio-proxy automatically. And the solution is to replace Host with right hostname the request targeting.

Since it's not really related to istio, so I separated it into an independent PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/419)
<!-- Reviewable:end -->
