### PR TITLE
Istio integration

### DIFF
--- a/Documentation/docs-site/content/tutorial/enabling-istio-on-fission.md
+++ b/Documentation/docs-site/content/tutorial/enabling-istio-on-fission.md
@@ -1,5 +1,5 @@
 ---
-title: "Enable Istio feature"
+title: "Enabling Istio on Fission"
 draft: false
 weight: 42
 ---
@@ -116,10 +116,10 @@ $ kubectl config set-context $(kubectl config current-context) --namespace=$FISS
 Follow the [installation guide](../../installation/) to install fission with flag `enableIstio` true.
 
 ``` bash
-$ helm install --debug --namespace $FISSION_NAMESPACE --set enableIstio=true --name istio-demo <chart-fission-all-url>
+$ helm install --namespace $FISSION_NAMESPACE --set enableIstio=true --name istio-demo <chart-fission-all-url>
 ```
 
-### Create a custom function
+### Create a function
 
 Set environment
 

--- a/Documentation/docs-site/content/tutorial/istio-integration.md
+++ b/Documentation/docs-site/content/tutorial/istio-integration.md
@@ -1,0 +1,203 @@
+---
+title: "Enable Istio feature"
+draft: false
+weight: 42
+---
+
+This is the very first step for fission to integrate with [Istio](https://istio.io/). For those interested in trying to integrate fission with istio, following is the set up tutorial.
+
+## Test Environment
+* Google Kubernetes Engine: 1.9.2-gke.1
+
+## Set Up
+### Create Kubernetes v1.9+ cluster
+
+Enable both RBAC & initializer features on kubernetes cluster.
+
+``` bash
+$ export ZONE=<zone name>
+$ gcloud container clusters create istio-demo-1 \
+    --machine-type=n1-standard-2 \
+    --num-nodes=1 \
+    --no-enable-legacy-authorization \
+    --zone=$ZONE \
+    --cluster-version=1.9.2-gke.1
+```
+
+### Grant cluster admin permissions
+
+Grant admin permission for `system:serviceaccount:kube-system:default` and current user.
+
+``` bash
+# for system:serviceaccount:kube-system:default
+$ kubectl create clusterrolebinding --user system:serviceaccount:kube-system:default kube-system-cluster-admin --clusterrole cluster-admin
+
+# for current user
+$ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud config get-value core/account)
+```
+
+### Set up Istio environment
+
+For Istio 0.5.1 you can follow the installation tutorial below. Also, you can follow the latest installation guides on Istio official site: [Quick Start](https://istio.io/docs/setup/kubernetes/quick-start.html) and [Sidecar Injection](https://istio.io/docs/setup/kubernetes/sidecar-injection.html).
+
+
+Download Istio 0.5.1
+
+``` bash
+$ export ISTIO_VERSION=0.5.1
+$ curl -L https://git.io/getLatestIstio | sh -
+$ cd istio-0.5.1
+```
+
+Apply istio related YAML files
+
+``` bash
+$ kubectl apply -f install/kubernetes/istio.yaml
+```
+
+Automatic sidecar injection
+
+``` bash
+$ kubectl api-versions | grep admissionregistration
+admissionregistration.k8s.io/v1beta1
+```
+
+Installing the webhook
+
+Download the missing files in istio release 0.5.1
+
+``` bash
+$ wget https://raw.githubusercontent.com/istio/istio/master/install/kubernetes/webhook-create-signed-cert.sh -P install/kubernetes/
+$ wget https://raw.githubusercontent.com/istio/istio/master/install/kubernetes/webhook-patch-ca-bundle.sh -P install/kubernetes/
+$ chmod +x install/kubernetes/webhook-create-signed-cert.sh install/kubernetes/webhook-patch-ca-bundle.sh
+```
+
+Install the sidecar injection configmap.
+
+``` bash
+$ ./install/kubernetes/webhook-create-signed-cert.sh \
+    --service istio-sidecar-injector \
+    --namespace istio-system \
+    --secret sidecar-injector-certs
+
+$ kubectl apply -f install/kubernetes/istio-sidecar-injector-configmap-release.yaml
+```
+
+Install the sidecar injector
+
+``` bash
+$ cat install/kubernetes/istio-sidecar-injector.yaml | \
+     ./install/kubernetes/webhook-patch-ca-bundle.sh > \
+     install/kubernetes/istio-sidecar-injector-with-ca-bundle.yaml
+
+$ kubectl apply -f install/kubernetes/istio-sidecar-injector-with-ca-bundle.yaml
+
+# Check sidecar injector status
+$ kubectl -n istio-system get deployment -listio=sidecar-injector
+NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+istio-sidecar-injector   1         1         1            1           26s
+```
+
+### Install fission
+
+Set default namespace for helm installation, here we use `fission` as example namespace.
+``` bash
+$ export FISSION_NAMESPACE=fission
+```
+
+Create namespace & add label for Istio sidecar injection.
+
+``` bash
+$ kubectl create namespace $FISSION_NAMESPACE
+$ kubectl label namespace $FISSION_NAMESPACE istio-injection=enabled
+$ kubectl config set-context $(kubectl config current-context) --namespace=$FISSION_NAMESPACE
+```
+
+Follow the [installation guide](../../installation/) to install fission with flag `enableIstio` true.
+
+``` bash
+$ helm install --debug --namespace $FISSION_NAMESPACE --set enableIstio=true --name istio-demo <chart-fission-all-url>
+```
+
+### Create a custom function
+
+Set environment
+
+``` bash
+$ export FISSION_URL=http://$(kubectl --namespace fission get svc controller -o=jsonpath='{..ip}')
+$ export FISSION_ROUTER=$(kubectl --namespace fission get svc router -o=jsonpath='{..ip}')
+```
+
+Let's create a simple function with Node.js.
+
+``` js
+# hello.js
+module.exports = async function(context) {
+    console.log(context.request.headers);
+    return {
+        status: 200,
+        body: "Hello, World!\n"
+    };
+}
+```
+
+Create environment
+
+``` bash
+$ fission env create --name nodejs --image fission/node-env:latest
+```
+
+Create function
+
+``` bash
+$ fission fn create --name h1 --env nodejs --code hello.js --method GET
+```
+
+Create route
+
+``` bash
+$ fission route create --method GET --url /h1 --function h1
+```
+
+Access function
+
+``` bash
+$ curl http://$FISSION_ROUTER/h1
+Hello, World!
+```
+
+
+### Install Istio Add-ons
+
+* Prometheus
+
+``` bash
+$ kubectl apply -f istio-0.5.1/install/kubernetes/addons/prometheus.yaml
+$ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=prometheus -o jsonpath='{.items[0].metadata.name}') 9090:9090
+```
+
+Web Link: [http://127.0.0.1:9090/graph](http://127.0.0.1:9090/graph)
+
+* Grafana
+
+Please install Prometheus first.
+
+![grafana min](https://user-images.githubusercontent.com/202578/33528556-639493e2-d89d-11e7-9768-976fb9208646.png)
+
+``` bash
+$ kubectl apply -f istio-0.5.1/install/kubernetes/addons/grafana.yaml
+$ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=grafana -o jsonpath='{.items[0].metadata.name}') 3000:3000
+```
+
+Web Link: [http://127.0.0.1:3000/dashboard/db/istio-dashboard](http://127.0.0.1:3000/dashboard/db/istio-dashboard)
+
+* Jaegar
+
+![jaeger min](https://user-images.githubusercontent.com/202578/33528554-572c4f28-d89d-11e7-8a01-1543fc2aa064.png)
+
+``` bash
+$ kubectl apply -n istio-system -f https://raw.githubusercontent.com/jaegertracing/jaeger-kubernetes/master/all-in-one/jaeger-all-in-one-template.yml
+$ kubectl port-forward -n istio-system $(kubectl get pod -n istio-system -l app=jaeger -o jsonpath='{.items[0].metadata.name}') 16686:16686
+```
+
+Web Link: [http://localhost:16686](http://localhost:16686)

--- a/builder/client/client.go
+++ b/builder/client/client.go
@@ -21,8 +21,11 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/fission/fission"
 	builder "github.com/fission/fission/builder"
@@ -30,13 +33,15 @@ import (
 
 type (
 	Client struct {
-		url string
+		url      string
+		useIstio bool
 	}
 )
 
-func MakeClient(builderUrl string) *Client {
+func MakeClient(builderUrl string, useIstio bool) *Client {
 	return &Client{
-		url: strings.TrimSuffix(builderUrl, "/"),
+		url:      strings.TrimSuffix(builderUrl, "/"),
+		useIstio: useIstio,
 	}
 }
 
@@ -45,10 +50,50 @@ func (c *Client) Build(req *builder.PackageBuildRequest) (*builder.PackageBuildR
 	if err != nil {
 		return nil, err
 	}
-	resp, err := http.Post(c.url, "application/json", bytes.NewReader(body))
-	if err != nil {
+
+	maxRetries := 20
+	var resp *http.Response
+
+	for i := 0; i < maxRetries; i++ {
+		resp, err = http.Post(c.url, "application/json", bytes.NewReader(body))
+
+		if err == nil && resp.StatusCode == 200 {
+			break
+		}
+
+		retry := false
+
+		// Only retry for the specific case of a connection error.
+		if urlErr, ok := err.(*url.Error); ok {
+			if netErr, ok := urlErr.Err.(*net.OpError); ok {
+				if netErr.Op == "dial" {
+					if i < maxRetries-1 {
+						retry = true
+					}
+				}
+			}
+		}
+
+		if err == nil {
+			err = fission.MakeErrorFromHTTP(resp)
+		}
+
+		// https://istio.io/docs/concepts/traffic-management/pilot.html
+		// Istio Pilot convert routing rules to Envoy-specific configurations,
+		// then propagates them to Envoy(istio-proxy) sidecars.
+		// Requests to the endpoints that are not ready to serve traffic will
+		// be rejected by Envoy before the requests go out of the pod. So retry
+		// here until Pilot updates its service discovery cache and new configs
+		// are propagated.
+		if retry || c.useIstio {
+			time.Sleep(50 * time.Duration(2*i) * time.Millisecond)
+			log.Printf("Error building package (%v), retrying", err)
+			continue
+		}
+
 		return nil, err
 	}
+
 	defer resp.Body.Close()
 
 	rBody, err := ioutil.ReadAll(resp.Body)

--- a/builder/client/client.go
+++ b/builder/client/client.go
@@ -85,7 +85,7 @@ func (c *Client) Build(req *builder.PackageBuildRequest) (*builder.PackageBuildR
 		// be rejected by Envoy before the requests go out of the pod. So retry
 		// here until Pilot updates its service discovery cache and new configs
 		// are propagated.
-		if retry || c.useIstio {
+		if (retry || c.useIstio) && i < maxRetries-1 {
 			time.Sleep(50 * time.Duration(2*i) * time.Millisecond)
 			log.Printf("Error building package (%v), retrying", err)
 			continue

--- a/buildermgr/buildermgr.go
+++ b/buildermgr/buildermgr.go
@@ -28,10 +28,11 @@ import (
 func Start(storageSvcUrl string, envBuilderNamespace string) error {
 
 	useIstio := false
-	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
-		istio, err := strconv.ParseBool(os.Getenv("ENABLE_ISTIO"))
+	enableIstio := os.Getenv("ENABLE_ISTIO")
+	if len(enableIstio) > 0 {
+		istio, err := strconv.ParseBool(enableIstio)
 		if err != nil {
-			log.Println("Failed to parse ENABLE_ISTIO")
+			log.Println("Failed to parse ENABLE_ISTIO, defaults to false")
 		}
 		useIstio = istio
 	}

--- a/buildermgr/buildermgr.go
+++ b/buildermgr/buildermgr.go
@@ -43,7 +43,7 @@ func Start(storageSvcUrl string, envBuilderNamespace string) error {
 		return err
 	}
 
-	envWatcher := makeEnvironmentWatcher(fissionClient, kubernetesClient, envBuilderNamespace)
+	envWatcher := makeEnvironmentWatcher(fissionClient, kubernetesClient, envBuilderNamespace, useIstio)
 	go envWatcher.watchEnvironments()
 
 	pkgWatcher := makePackageWatcher(fissionClient, kubernetesClient.CoreV1().RESTClient(),

--- a/buildermgr/buildermgr.go
+++ b/buildermgr/buildermgr.go
@@ -18,8 +18,6 @@ package buildermgr
 
 import (
 	"log"
-	"os"
-	"strconv"
 
 	"github.com/fission/fission/crd"
 )
@@ -27,27 +25,17 @@ import (
 // Start the buildermgr service.
 func Start(storageSvcUrl string, envBuilderNamespace string) error {
 
-	useIstio := false
-	enableIstio := os.Getenv("ENABLE_ISTIO")
-	if len(enableIstio) > 0 {
-		istio, err := strconv.ParseBool(enableIstio)
-		if err != nil {
-			log.Println("Failed to parse ENABLE_ISTIO, defaults to false")
-		}
-		useIstio = istio
-	}
-
 	fissionClient, kubernetesClient, _, err := crd.MakeFissionClient()
 	if err != nil {
 		log.Printf("Failed to get kubernetes client: %v", err)
 		return err
 	}
 
-	envWatcher := makeEnvironmentWatcher(fissionClient, kubernetesClient, envBuilderNamespace, useIstio)
+	envWatcher := makeEnvironmentWatcher(fissionClient, kubernetesClient, envBuilderNamespace)
 	go envWatcher.watchEnvironments()
 
-	pkgWatcher := makePackageWatcher(fissionClient, kubernetesClient.CoreV1().RESTClient(),
-		envBuilderNamespace, storageSvcUrl, useIstio)
+	pkgWatcher := makePackageWatcher(fissionClient,
+		kubernetesClient.CoreV1().RESTClient(), envBuilderNamespace, storageSvcUrl)
 	go pkgWatcher.watchPackages()
 
 	select {}

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -41,7 +41,7 @@ import (
 // 4. Return upload response and build logs.
 // *. Return build logs and error if any one of steps above failed.
 func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
-	storageSvcUrl string, pkg *crd.Package) (uploadResp *fetcher.UploadResponse, buildLogs string, err error) {
+	storageSvcUrl string, pkg *crd.Package, useIstio bool) (uploadResp *fetcher.UploadResponse, buildLogs string, err error) {
 
 	env, err := fissionClient.Environments(metav1.NamespaceDefault).Get(pkg.Spec.Environment.Name)
 	if err != nil {
@@ -52,7 +52,7 @@ func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
 
 	svcName := fmt.Sprintf("%v-%v.%v", env.Metadata.Name, env.Metadata.ResourceVersion, builderNamespace)
 	srcPkgFilename := fmt.Sprintf("%v-%v", pkg.Metadata.Name, strings.ToLower(uniuri.NewLen(6)))
-	fetcherC := fetcherClient.MakeClient(fmt.Sprintf("http://%v:8000", svcName))
+	fetcherC := fetcherClient.MakeClient(fmt.Sprintf("http://%v:8000", svcName), useIstio)
 	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName))
 
 	fetchReq := &fetcher.FetchRequest{

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -53,7 +53,7 @@ func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
 	svcName := fmt.Sprintf("%v-%v.%v", env.Metadata.Name, env.Metadata.ResourceVersion, builderNamespace)
 	srcPkgFilename := fmt.Sprintf("%v-%v", pkg.Metadata.Name, strings.ToLower(uniuri.NewLen(6)))
 	fetcherC := fetcherClient.MakeClient(fmt.Sprintf("http://%v:8000", svcName), useIstio)
-	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName))
+	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName), useIstio)
 
 	fetchReq := &fetcher.FetchRequest{
 		FetchType: fetcher.FETCH_SOURCE,

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -90,7 +90,7 @@ func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
 			buildLogs = buildResp.BuildLogs
 		}
 		buildLogs += fmt.Sprintf("%v\n", e)
-		return nil, buildResp.BuildLogs, fission.MakeError(http.StatusInternalServerError, e)
+		return nil, buildLogs, fission.MakeError(http.StatusInternalServerError, e)
 	}
 
 	log.Printf("Build succeed, source package: %v, deployment package: %v", srcPkgFilename, buildResp.ArtifactFilename)

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -41,7 +41,7 @@ import (
 // 4. Return upload response and build logs.
 // *. Return build logs and error if any one of steps above failed.
 func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
-	storageSvcUrl string, pkg *crd.Package, useIstio bool) (uploadResp *fetcher.UploadResponse, buildLogs string, err error) {
+	storageSvcUrl string, pkg *crd.Package) (uploadResp *fetcher.UploadResponse, buildLogs string, err error) {
 
 	env, err := fissionClient.Environments(metav1.NamespaceDefault).Get(pkg.Spec.Environment.Name)
 	if err != nil {
@@ -52,8 +52,8 @@ func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
 
 	svcName := fmt.Sprintf("%v-%v.%v", env.Metadata.Name, env.Metadata.ResourceVersion, builderNamespace)
 	srcPkgFilename := fmt.Sprintf("%v-%v", pkg.Metadata.Name, strings.ToLower(uniuri.NewLen(6)))
-	fetcherC := fetcherClient.MakeClient(fmt.Sprintf("http://%v:8000", svcName), useIstio)
-	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName), useIstio)
+	fetcherC := fetcherClient.MakeClient(fmt.Sprintf("http://%v:8000", svcName))
+	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName))
 
 	fetchReq := &fetcher.FetchRequest{
 		FetchType: fetcher.FETCH_SOURCE,

--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -131,7 +131,7 @@ func (envw *environmentWatcher) watchEnvironments() {
 		})
 		if err != nil {
 			if fission.IsNetworkError(err) {
-				log.Printf("Encounter network error, retry again later: %v", err)
+				log.Printf("Encounter network error, retrying later: %v", err)
 				time.Sleep(5 * time.Second)
 				continue
 			}

--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -440,6 +441,11 @@ func (envw *environmentWatcher) createBuilderDeployment(env *crd.Environment) (*
 	name := envw.getCacheKey(env.Metadata.Name, env.Metadata.ResourceVersion)
 	sel := envw.getLabels(env.Metadata.Name, env.Metadata.ResourceVersion)
 	var replicas int32 = 1
+
+	podAnnotation := map[string]string{
+		"sidecar.istio.io/inject": strconv.FormatBool(env.Spec.AllowedAccessExternalNetwork),
+	}
+
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: envw.builderNamespace,
@@ -453,7 +459,8 @@ func (envw *environmentWatcher) createBuilderDeployment(env *crd.Environment) (*
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: sel,
+					Labels:      sel,
+					Annotations: podAnnotation,
 				},
 				Spec: apiv1.PodSpec{
 					Volumes: []apiv1.Volume{

--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -444,7 +444,7 @@ func (envw *environmentWatcher) createBuilderDeployment(env *crd.Environment) (*
 	var replicas int32 = 1
 
 	podAnnotation := make(map[string]string)
-	if envw.useIstio && env.Spec.AllowedAccessExternalNetwork {
+	if envw.useIstio && env.Spec.AllowAccessToExternalNetwork {
 		podAnnotation["sidecar.istio.io/inject"] = "false"
 	}
 

--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -76,7 +77,17 @@ type (
 )
 
 func makeEnvironmentWatcher(fissionClient *crd.FissionClient,
-	kubernetesClient *kubernetes.Clientset, builderNamespace string, useIstio bool) *environmentWatcher {
+	kubernetesClient *kubernetes.Clientset, builderNamespace string) *environmentWatcher {
+
+	useIstio := false
+	enableIstio := os.Getenv("ENABLE_ISTIO")
+	if len(enableIstio) > 0 {
+		istio, err := strconv.ParseBool(enableIstio)
+		if err != nil {
+			log.Println("Failed to parse ENABLE_ISTIO, defaults to false")
+		}
+		useIstio = istio
+	}
 
 	fetcherImage := os.Getenv("FETCHER_IMAGE")
 	if len(fetcherImage) == 0 {

--- a/buildermgr/pkgwatcher.go
+++ b/buildermgr/pkgwatcher.go
@@ -38,12 +38,11 @@ type (
 		podStore         k8sCache.Store
 		builderNamespace string
 		storageSvcUrl    string
-		useIstio         bool
 	}
 )
 
 func makePackageWatcher(fissionClient *crd.FissionClient, getter k8sCache.Getter,
-	builderNamespace string, storageSvcUrl string, useIstio bool) *packageWatcher {
+	builderNamespace string, storageSvcUrl string) *packageWatcher {
 
 	lw := k8sCache.NewListWatchFromClient(getter, "pods", builderNamespace, fields.Everything())
 	store, controller := k8sCache.NewInformer(lw, &apiv1.Pod{}, 30*time.Second, k8sCache.ResourceEventHandlerFuncs{})
@@ -54,7 +53,6 @@ func makePackageWatcher(fissionClient *crd.FissionClient, getter k8sCache.Getter
 		podStore:         store,
 		builderNamespace: builderNamespace,
 		storageSvcUrl:    storageSvcUrl,
-		useIstio:         useIstio,
 	}
 	return pkgw
 }
@@ -141,7 +139,7 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, pkg *crd.Package) {
 			}
 
 			uploadResp, buildLogs, err := buildPackage(pkgw.fissionClient,
-				pkgw.builderNamespace, pkgw.storageSvcUrl, pkg, pkgw.useIstio)
+				pkgw.builderNamespace, pkgw.storageSvcUrl, pkg)
 			if err != nil {
 				log.Printf("Error building package %v: %v", pkg.Metadata.Name, err)
 				updatePackage(pkgw.fissionClient, pkg, fission.BuildStatusFailed, buildLogs, nil)

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -130,6 +130,11 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
+        env:
+          - name: FISSION_FUNCTION_NAMESPACE
+            value: "{{ .Values.functionNamespace }}"
+          - name: ENABLE_ISTIO
+            value: "{{ .Values.enableIstio }}"
         readinessProbe:
           httpGet:
             path: "/healthz"
@@ -223,6 +228,8 @@ spec:
           value: "{{ .Values.pullPolicy }}"
         - name: RUNTIME_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        - name: ENABLE_ISTIO
+          value: "{{ .Values.enableIstio }}"
         readinessProbe:
           httpGet:
             path: "/healthz"

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     name: fission-function
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- if .Values.enableIstio }}
+    istio-injection: enabled
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -15,6 +18,9 @@ metadata:
   labels:
     name: fission-builder
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- if .Values.enableIstio }}
+    istio-injection: enabled
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -270,6 +276,8 @@ spec:
           value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        - name: ENABLE_ISTIO
+          value: "{{ .Values.enableIstio }}"
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-all/templates/post-install-job.yaml
+++ b/charts/fission-all/templates/post-install-job.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         release: {{ .Release.Name }}
         app: {{ template "name" . }}
+      annotations:
+        {{- if .Values.enableIstio }}
+        "sidecar.istio.io/inject": "false"
+        {{- end }}
     spec:
       restartPolicy: Never
       containers:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -41,6 +41,9 @@ functionNamespace: fission-function
 ## the release namespace)
 builderNamespace: fission-builder
 
+## Enable istio integration
+enableIstio: false
+
 ## Logger config
 logger:
   influxdbAdmin: "admin"

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     name: fission-function
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- if .Values.enableIstio }}
+    istio-injection: enabled
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -15,6 +18,9 @@ metadata:
   labels:
     name: fission-builder
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- if .Values.enableIstio }}
+    istio-injection: enabled
+    {{- end }}
 
 ---
 apiVersion: v1
@@ -268,6 +274,8 @@ spec:
           value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        - name: ENABLE_ISTIO
+          value: "{{ .Values.enableIstio }}"
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -130,6 +130,11 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
+        env:
+          - name: FISSION_FUNCTION_NAMESPACE
+            value: "{{ .Values.functionNamespace }}"
+          - name: ENABLE_ISTIO
+            value: "{{ .Values.enableIstio }}"
         readinessProbe:
           httpGet:
             path: "/healthz"
@@ -221,6 +226,8 @@ spec:
           value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        - name: ENABLE_ISTIO
+          value: "{{ .Values.enableIstio }}"
         readinessProbe:
           httpGet:
             path: "/healthz"

--- a/charts/fission-core/templates/post-install-job.yaml
+++ b/charts/fission-core/templates/post-install-job.yaml
@@ -22,6 +22,10 @@ spec:
       labels:
         release: {{ .Release.Name }}
         app: {{ template "name" . }}
+      annotations:
+        {{- if .Values.enableIstio }}
+        "sidecar.istio.io/inject": "false"
+        {{- end }}
     spec:
       restartPolicy: Never
       containers:

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -38,6 +38,9 @@ functionNamespace: fission-function
 ## the release namespace)
 builderNamespace: fission-builder
 
+## Enable istio integration
+enableIstio: false
+
 ## Persist data to a persistent volume.
 persistence:
   enabled: true

--- a/common.go
+++ b/common.go
@@ -18,7 +18,6 @@ package fission
 
 import (
 	"fmt"
-	"io"
 	"net"
 	"os"
 	"os/signal"
@@ -43,10 +42,8 @@ func SetupStackTraceHandler() {
 	}()
 }
 
+// IsNetworkError returns true if an error is a network error, and false otherwise.
 func IsNetworkError(err error) bool {
-	if err == io.EOF {
-		return true
-	}
 	_, ok := err.(net.Error)
 	return ok
 }

--- a/common.go
+++ b/common.go
@@ -18,6 +18,8 @@ package fission
 
 import (
 	"fmt"
+	"io"
+	"net"
 	"os"
 	"os/signal"
 	"runtime/debug"
@@ -39,4 +41,12 @@ func SetupStackTraceHandler() {
 		debug.PrintStack()
 		os.Exit(1)
 	}()
+}
+
+func IsNetworkError(err error) bool {
+	if err == io.EOF {
+		return true
+	}
+	_, ok := err.(net.Error)
+	return ok
 }

--- a/common.go
+++ b/common.go
@@ -47,3 +47,8 @@ func IsNetworkError(err error) bool {
 	_, ok := err.(net.Error)
 	return ok
 }
+
+// GetFunctionIstioServiceName return service name of function for istio feature
+func GetFunctionIstioServiceName(fnName, fnNamespace string) string {
+	return fmt.Sprintf("istio-%v-%v", fnName, fnNamespace)
+}

--- a/controller/api.go
+++ b/controller/api.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/handlers"
@@ -41,6 +42,8 @@ type (
 		storageServiceUrl string
 		builderManagerUrl string
 		workflowApiUrl    string
+		functionNamespace string
+		useIstio          bool
 	}
 
 	logDBConfig struct {
@@ -72,6 +75,21 @@ func MakeAPI() (*API, error) {
 		api.workflowApiUrl = strings.TrimSuffix(wfEnv, "/")
 	} else {
 		api.workflowApiUrl = "http://workflows-apiserver"
+	}
+
+	fnNs := os.Getenv("FISSION_FUNCTION_NAMESPACE")
+	if len(fnNs) > 0 {
+		api.functionNamespace = fnNs
+	} else {
+		api.functionNamespace = "fission-function"
+	}
+
+	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
+		istio, err := strconv.ParseBool(os.Getenv("ENABLE_ISTIO"))
+		if err != nil {
+			log.Println("Failed to parse ENABLE_ISTIO")
+		}
+		api.useIstio = istio
 	}
 
 	return api, err

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -106,7 +106,7 @@ func (a *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
 		// service for accepting user traffic
 		svc := apiv1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "fission-function",
+				Namespace: a.functionNamespace,
 				Name:      fmt.Sprintf("istio-%v", f.Metadata.Name),
 				Labels:    a.getIstioServiceLabels(f.Metadata.Name),
 			},
@@ -127,7 +127,6 @@ func (a *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
 					},
 				},
 				Selector: sel,
-				//ClusterIP: apiv1.ClusterIPNone,
 			},
 		}
 		_, err = a.kubernetesClient.CoreV1().Services(a.functionNamespace).Create(&svc)

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -119,16 +119,21 @@ func (a *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
 			Spec: apiv1.ServiceSpec{
 				Type: apiv1.ServiceTypeClusterIP,
 				Ports: []apiv1.ServicePort{
-					// Service port name must follow the rules list in
-					// https://istio.io/docs/setup/kubernetes/sidecar-injection.html
+					// Service port name should begin with a recognized prefix, or the traffic will be
+					// treated as TCP traffic. (https://istio.io/docs/setup/kubernetes/sidecar-injection.html)
+					// Originally the ports' name are similar to "http-fetch" and "http-specialize".
+					// But for istio 0.5.1, istio-proxy return unexpected 431 error with such naming.
+					// https://github.com/istio/istio/issues/928
+					// Workaround: remove prefix
+					// TODO: prepend prefix once the bug fixed
 					{
-						Name:       "http-fetch",
+						Name:       "fetch",
 						Protocol:   apiv1.ProtocolTCP,
 						Port:       8000,
 						TargetPort: intstr.FromInt(8000),
 					},
 					{
-						Name:       "http-specialize",
+						Name:       "specialize",
 						Protocol:   apiv1.ProtocolTCP,
 						Port:       8888,
 						TargetPort: intstr.FromInt(8888),

--- a/crd/crd.go
+++ b/crd/crd.go
@@ -38,6 +38,7 @@ func ensureCRD(clientset *apiextensionsclient.Clientset, crd *apiextensionsv1bet
 	maxRetries := 5
 	for i := 0; i < maxRetries; i++ {
 		_, err := clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.ObjectMeta.Name, metav1.GetOptions{})
+
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// crd resource not found error
@@ -52,10 +53,10 @@ func ensureCRD(clientset *apiextensionsclient.Clientset, crd *apiextensionsv1bet
 				time.Sleep(500 * time.Duration(2*i) * time.Millisecond)
 				continue
 			}
-		} else {
-			// resource is existed already
-			break
 		}
+
+		// resource already exists
+		break
 	}
 	return nil
 }

--- a/environments/fetcher/client/client.go
+++ b/environments/fetcher/client/client.go
@@ -43,6 +43,12 @@ func (c *Client) Fetch(fr *fetcher.FetchRequest) error {
 			return nil
 		}
 
+		if err == nil && resp.StatusCode != 200 {
+			resp.Body.Close()
+			time.Sleep(50 * time.Duration(2*i) * time.Millisecond)
+			continue
+		}
+
 		// Only retry for the specific case of a connection error.
 		if urlErr, ok := err.(*url.Error); ok {
 			if netErr, ok := urlErr.Err.(*net.OpError); ok {

--- a/environments/fetcher/client/client.go
+++ b/environments/fetcher/client/client.go
@@ -69,7 +69,7 @@ func (c *Client) Fetch(fr *fetcher.FetchRequest) error {
 		// be rejected by Envoy before the requests go out of the pod. So retry
 		// here until Pilot updates its service discovery cache and new configs
 		// are propagated.
-		if retry || c.useIstio {
+		if (retry || c.useIstio) && i < maxRetries-1 {
 			time.Sleep(50 * time.Duration(2*i) * time.Millisecond)
 			log.Printf("Error fetching package (%v), retrying", err)
 			continue

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -128,15 +128,6 @@ func specializePod(f *fetcher.Fetcher, fetchPayload *string, loadPayload *string
 		if err == nil && resp.StatusCode < 300 {
 			// Success
 			resp.Body.Close()
-			//On Success creates a file which is used as a readiness probe by Kubernetes for this container/pod
-			file, err := os.OpenFile("/tmp/ready", os.O_RDONLY|os.O_CREATE, 0666)
-			if err != nil {
-				log.Fatalf("Error creating readiness file: %v", err)
-			}
-			err = file.Close()
-			if err != nil {
-				log.Fatalf("Error closing readiness file: %v", err)
-			}
 			break
 		}
 

--- a/executor/fscache/functionServiceCache.go
+++ b/executor/fscache/functionServiceCache.go
@@ -163,7 +163,9 @@ func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 				err = nil
 			}
 		}
-		log.Printf("error caching fsvc: %v", err)
+		if err != nil {
+			log.Printf("error caching fsvc: %v", err)
+		}
 		return nil, err
 	}
 	return nil, nil

--- a/executor/fscache/functionServiceCache.go
+++ b/executor/fscache/functionServiceCache.go
@@ -162,8 +162,7 @@ func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 			if fe.Code == fission.ErrorNameExists {
 				err = nil
 			}
-		}
-		if err != nil {
+		} else {
 			log.Printf("error caching fsvc: %v", err)
 		}
 		return nil, err

--- a/executor/fscache/functionServiceCache.go
+++ b/executor/fscache/functionServiceCache.go
@@ -162,7 +162,8 @@ func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 			if fe.Code == fission.ErrorNameExists {
 				err = nil
 			}
-		} else {
+		}
+		if err != nil {
 			log.Printf("error caching fsvc: %v", err)
 		}
 		return nil, err

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -56,8 +56,6 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 	}
 	targetFilename := "user"
 	userfunc := "userfunc"
-	secrets := "secrets"
-	config := "config"
 	var gracePeriodSeconds int64 = 6 * 60
 
 	existingDepl, err := deploy.kubernetesClient.ExtensionsV1beta1().Deployments(deploy.namespace).Get(deployName, metav1.GetOptions{})
@@ -127,18 +125,6 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 									EmptyDir: &apiv1.EmptyDirVolumeSource{},
 								},
 							},
-							{
-								Name: secrets,
-								VolumeSource: apiv1.VolumeSource{
-									EmptyDir: &apiv1.EmptyDirVolumeSource{},
-								},
-							},
-							{
-								Name: config,
-								VolumeSource: apiv1.VolumeSource{
-									EmptyDir: &apiv1.EmptyDirVolumeSource{},
-								},
-							},
 						},
 						Containers: []apiv1.Container{
 							{
@@ -150,14 +136,6 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 									{
 										Name:      userfunc,
 										MountPath: deploy.sharedMountPath,
-									},
-									{
-										Name:      secrets,
-										MountPath: deploy.sharedSecretPath,
-									},
-									{
-										Name:      config,
-										MountPath: deploy.sharedCfgMapPath,
 									},
 								},
 								Resources: env.Spec.Resources,
@@ -181,14 +159,6 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 									{
 										Name:      userfunc,
 										MountPath: deploy.sharedMountPath,
-									},
-									{
-										Name:      secrets,
-										MountPath: deploy.sharedSecretPath,
-									},
-									{
-										Name:      config,
-										MountPath: deploy.sharedCfgMapPath,
 									},
 								},
 								Command: []string{"/fetcher", "-specialize-on-startup",

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -98,7 +98,7 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 		}
 
 		podAnnotation := make(map[string]string)
-		if deploy.useIstio && env.Spec.AllowedAccessExternalNetwork {
+		if deploy.useIstio && env.Spec.AllowAccessToExternalNetwork {
 			podAnnotation["sidecar.istio.io/inject"] = "false"
 		}
 

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -99,8 +99,9 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 			return nil, err
 		}
 
-		podAnnotation := map[string]string{
-			"sidecar.istio.io/inject": strconv.FormatBool(env.Spec.AllowedAccessExternalNetwork),
+		podAnnotation := make(map[string]string)
+		if deploy.useIstio && env.Spec.AllowedAccessExternalNetwork {
+			podAnnotation["sidecar.istio.io/inject"] = "false"
 		}
 
 		deployment := &v1beta1.Deployment{

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -216,13 +216,18 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 								// TBD Use smaller default resources, for now needed to make HPA work
 								Resources: fetcherResources,
 								ReadinessProbe: &apiv1.Probe{
-									Handler: apiv1.Handler{
-										Exec: &apiv1.ExecAction{
-											Command: []string{"cat", "/tmp/ready"},
-										},
-									},
 									InitialDelaySeconds: 1,
 									PeriodSeconds:       1,
+									FailureThreshold:    30,
+									Handler: apiv1.Handler{
+										HTTPGet: &apiv1.HTTPGetAction{
+											Path: "/healthz",
+											Port: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 8000,
+											},
+										},
+									},
 								},
 								LivenessProbe: &apiv1.Probe{
 									InitialDelaySeconds: 35,

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -127,6 +127,18 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 									EmptyDir: &apiv1.EmptyDirVolumeSource{},
 								},
 							},
+							{
+								Name: secrets,
+								VolumeSource: apiv1.VolumeSource{
+									EmptyDir: &apiv1.EmptyDirVolumeSource{},
+								},
+							},
+							{
+								Name: config,
+								VolumeSource: apiv1.VolumeSource{
+									EmptyDir: &apiv1.EmptyDirVolumeSource{},
+								},
+							},
 						},
 						Containers: []apiv1.Container{
 							{
@@ -143,7 +155,6 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *crd.Function, env *crd.Enviro
 										Name:      secrets,
 										MountPath: deploy.sharedSecretPath,
 									},
-
 									{
 										Name:      config,
 										MountPath: deploy.sharedCfgMapPath,

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/fission/fission"
@@ -50,6 +51,7 @@ type (
 		sharedMountPath        string
 		sharedSecretPath       string
 		sharedCfgMapPath       string
+		useIstio               bool
 
 		fsCache        *fscache.FunctionServiceCache // cache funcSvc's by function, address and podname
 		requestChannel chan *fnRequest
@@ -97,6 +99,15 @@ func MakeNewDeploy(
 		fetcherImagePullPolicy = "IfNotPresent"
 	}
 
+	enableIstio := false
+	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
+		istio, err := strconv.ParseBool(os.Getenv("ENABLE_ISTIO"))
+		if err != nil {
+			log.Println("Failed to parse ENABLE_ISTIO")
+		}
+		enableIstio = istio
+	}
+
 	nd := &NewDeploy{
 		fissionClient:    fissionClient,
 		kubernetesClient: kubernetesClient,
@@ -111,6 +122,7 @@ func MakeNewDeploy(
 		sharedMountPath:        "/userfunc",
 		sharedSecretPath:       "/secrets",
 		sharedCfgMapPath:       "/configs",
+		useIstio:               enableIstio,
 
 		requestChannel: make(chan *fnRequest),
 	}

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -421,29 +421,34 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 			specializeUrl := gp.getSpecializeUrl(podIP, 1)
 			resp2, err = http.Post(specializeUrl, "text/plain", bytes.NewReader([]byte{}))
 		}
-		if err == nil && resp2.StatusCode < 300 {
-			// Success
-			resp2.Body.Close()
-			return nil
-		}
 
-		// Only retry for the specific case of a connection error.
-		if urlErr, ok := err.(*url.Error); ok {
-			if netErr, ok := urlErr.Err.(*net.OpError); ok {
-				if netErr.Op == "dial" {
-					if i < maxRetries-1 {
-						time.Sleep(500 * time.Duration(2*i) * time.Millisecond)
-						log.Printf("Error connecting to pod (%v), retrying", netErr)
-						continue
+		if err != nil {
+			// Only retry for the specific case of a connection error.
+			if urlErr, ok := err.(*url.Error); ok {
+				if netErr, ok := urlErr.Err.(*net.OpError); ok {
+					if netErr.Op == "dial" {
+						if i < maxRetries-1 {
+							time.Sleep(500 * time.Duration(2*i) * time.Millisecond)
+							log.Printf("Error connecting to pod (%v), retrying", netErr)
+							continue
+						}
 					}
 				}
+			} else {
+				break
 			}
 		}
 
+		// get error when received http code other than 200
+		err = fission.MakeErrorFromHTTP(resp2)
+
 		if err == nil {
-			err = fission.MakeErrorFromHTTP(resp2)
+			// Success
+			return nil
 		}
+
 		log.Printf("Failed to specialize pod: %v", err)
+
 		return err
 	}
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -482,7 +482,7 @@ func (gp *GenericPool) createPool() error {
 
 	podAnnotation := make(map[string]string)
 
-	if gp.useIstio && gp.env.Spec.AllowedAccessExternalNetwork {
+	if gp.useIstio && gp.env.Spec.AllowAccessToExternalNetwork {
 		podAnnotation["sidecar.istio.io/inject"] = "false"
 	}
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -358,7 +358,8 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 	}
 	// specialize pod with service
 	if gp.useIstio {
-		podIP = fmt.Sprintf("istio-%v.%v", metadata.Name, gp.namespace)
+		svc := fission.GetFunctionIstioServiceName(metadata.Name, metadata.Namespace)
+		podIP = fmt.Sprintf("%v.%v", svc, gp.namespace)
 	}
 
 	// tell fetcher to get the function.
@@ -766,7 +767,8 @@ func (gp *GenericPool) GetFuncSvc(m *metav1.ObjectMeta) (*fscache.FuncSvc, error
 		// namespace-qualified hostname
 		svcHost = fmt.Sprintf("%v.%v", svcName, gp.namespace)
 	} else if gp.useIstio {
-		svcHost = fmt.Sprintf("istio-%v.%v:8888", m.Name, gp.namespace)
+		svc := fission.GetFunctionIstioServiceName(m.Name, m.Namespace)
+		svcHost = fmt.Sprintf("%v.%v:8888", svc, gp.namespace)
 	} else {
 		log.Printf("Using pod IP for specialized pod")
 		svcHost = fmt.Sprintf("%v:8888", pod.Status.PodIP)

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -122,7 +122,7 @@ func MakeGenericPool(
 		runtimeImagePullPolicy = "IfNotPresent"
 	}
 
-	var enableIstio bool
+	enableIstio := false
 
 	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
 		istio, err := strconv.ParseBool(os.Getenv("ENABLE_ISTIO"))
@@ -147,8 +147,8 @@ func MakeGenericPool(
 		poolInstanceId:   uniuri.NewLen(8),
 		instanceId:       instanceId,
 		fetcherImage:     fetcherImage,
-		useSvc:           false, // defaults off -- svc takes a second or more to become routable, slowing cold start
-		useIstio:         enableIstio,
+		useSvc:           false,       // defaults off -- svc takes a second or more to become routable, slowing cold start
+		useIstio:         enableIstio, // defaults off -- istio integration requires pod relabeling and it takes a second or more to become routable, slowing cold start
 		sharedMountPath:  "/userfunc", // change this may break v1 compatibility, since most of the v1 environments have hard-coded "/userfunc" in loading path
 		sharedSecretPath: "/secrets",
 		sharedCfgMapPath: "/configs",

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -381,7 +381,7 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 		targetFilename = string(fn.Metadata.UID)
 	}
 
-	err = fetcherClient.MakeClient(fetcherUrl, gp.useIstio).Fetch(&fetcher.FetchRequest{
+	err = fetcherClient.MakeClient(fetcherUrl).Fetch(&fetcher.FetchRequest{
 		FetchType: fetcher.FETCH_DEPLOYMENT,
 		Package: metav1.ObjectMeta{
 			Namespace: fn.Spec.Package.PackageRef.Namespace,

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -480,6 +480,10 @@ func (gp *GenericPool) createPool() error {
 	// pod still runs user functions.
 	var gracePeriodSeconds int64 = 6 * 60
 
+	podAnnotation := map[string]string{
+		"sidecar.istio.io/inject": strconv.FormatBool(gp.env.Spec.AllowedAccessExternalNetwork),
+	}
+
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   poolDeploymentName,
@@ -492,7 +496,8 @@ func (gp *GenericPool) createPool() error {
 			},
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: gp.labelsForPool,
+					Labels:      gp.labelsForPool,
+					Annotations: podAnnotation,
 				},
 				Spec: apiv1.PodSpec{
 					Volumes: []apiv1.Volume{
@@ -531,13 +536,12 @@ func (gp *GenericPool) createPool() error {
 									Name:      "secrets",
 									MountPath: gp.sharedSecretPath,
 								},
-
 								{
 									Name:      "config",
 									MountPath: gp.sharedCfgMapPath,
 								},
 							},
-							Resources: fetcherResources,
+							Resources: gp.env.Spec.Resources,
 							// Pod is removed from endpoints list for service when it's
 							// state became "Termination". We used preStop hook as the
 							// workaround for connection draining since pod maybe shutdown
@@ -565,12 +569,10 @@ func (gp *GenericPool) createPool() error {
 									Name:      "userfunc",
 									MountPath: gp.sharedMountPath,
 								},
-
 								{
 									Name:      "secrets",
 									MountPath: gp.sharedSecretPath,
 								},
-
 								{
 									Name:      "config",
 									MountPath: gp.sharedCfgMapPath,

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -480,8 +480,10 @@ func (gp *GenericPool) createPool() error {
 	// pod still runs user functions.
 	var gracePeriodSeconds int64 = 6 * 60
 
-	podAnnotation := map[string]string{
-		"sidecar.istio.io/inject": strconv.FormatBool(gp.env.Spec.AllowedAccessExternalNetwork),
+	podAnnotation := make(map[string]string)
+
+	if gp.useIstio && gp.env.Spec.AllowedAccessExternalNetwork {
+		podAnnotation["sidecar.istio.io/inject"] = "false"
 	}
 
 	deployment := &v1beta1.Deployment{

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -515,7 +515,6 @@ func (gp *GenericPool) createPool() error {
 								EmptyDir: &apiv1.EmptyDirVolumeSource{},
 							},
 						},
-
 						{
 							Name: "config",
 							VolumeSource: apiv1.VolumeSource{

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -480,7 +480,7 @@ func (gp *GenericPool) createPool() error {
 	if gp.useIstio {
 		// Use long terminationGracePeriodSeconds for connection draining in case that
 		// pod still runs user functions.
-		var gracePeriod int64 = 6 * 60
+		var gracePeriodSeconds int64 = 6 * 60
 
 		deployment = &v1beta1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -553,7 +553,7 @@ func (gp *GenericPool) createPool() error {
 										Exec: &apiv1.ExecAction{
 											Command: []string{
 												"sleep",
-												"360",
+												fmt.Sprintf("%v", gracePeriodSeconds),
 											},
 										},
 									},
@@ -616,7 +616,7 @@ func (gp *GenericPool) createPool() error {
 						// TerminationGracePeriodSeconds should be equal to the
 						// sleep time of preStop to make sure that SIGTERM is sent
 						// to pod after 6 mins.
-						TerminationGracePeriodSeconds: &gracePeriod,
+						TerminationGracePeriodSeconds: &gracePeriodSeconds,
 					},
 				},
 			},

--- a/executor/poolmgr/gpm.go
+++ b/executor/poolmgr/gpm.go
@@ -155,7 +155,7 @@ func (gpm *GenericPoolManager) eagerPoolCreator() {
 		envs, err := gpm.fissionClient.Environments(metav1.NamespaceAll).List(metav1.ListOptions{})
 		if err != nil {
 			if fission.IsNetworkError(err) {
-				log.Printf("Encounter network error, retry again: %v", err)
+				log.Printf("Encountered network error, retrying: %v", err)
 				time.Sleep(5 * time.Second)
 				continue
 			}

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -163,9 +163,7 @@ func envUpdate(c *cli.Context) error {
 		env.Spec.Poolsize = c.Int("poolsize")
 	}
 
-	if envExternalNetwork {
-		env.Spec.AllowedAccessExternalNetwork = envExternalNetwork
-	}
+	env.Spec.AllowedAccessExternalNetwork = envExternalNetwork
 
 	_, err = client.EnvironmentUpdate(env)
 	checkErr(err, "update environment")

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -54,6 +54,7 @@ func envCreate(c *cli.Context) error {
 	envVersion := c.Int("version")
 	envBuilderImg := c.String("builder")
 	envBuildCmd := c.String("buildcmd")
+	envExternalNetwork := c.Bool("externalnetwork")
 
 	if len(envBuilderImg) > 0 {
 		envVersion = 2
@@ -84,8 +85,9 @@ func envCreate(c *cli.Context) error {
 				Image:   envBuilderImg,
 				Command: envBuildCmd,
 			},
-			Poolsize:  poolsize,
-			Resources: resourceReq,
+			Poolsize:                     poolsize,
+			Resources:                    resourceReq,
+			AllowedAccessExternalNetwork: envExternalNetwork,
 		},
 	}
 
@@ -130,6 +132,7 @@ func envUpdate(c *cli.Context) error {
 	envImg := c.String("image")
 	envBuilderImg := c.String("builder")
 	envBuildCmd := c.String("buildcmd")
+	envExternalNetwork := c.Bool("externalnetwork")
 
 	if len(envImg) == 0 && len(envBuilderImg) == 0 && len(envBuildCmd) == 0 {
 		fatal("Need --image to specify env image, or use --builder to specify env builder, or use --buildcmd to specify new build command.")
@@ -158,6 +161,10 @@ func envUpdate(c *cli.Context) error {
 
 	if c.IsSet("poolsize") {
 		env.Spec.Poolsize = c.Int("poolsize")
+	}
+
+	if envExternalNetwork {
+		env.Spec.AllowedAccessExternalNetwork = envExternalNetwork
 	}
 
 	_, err = client.EnvironmentUpdate(env)

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -87,7 +87,7 @@ func envCreate(c *cli.Context) error {
 			},
 			Poolsize:                     poolsize,
 			Resources:                    resourceReq,
-			AllowedAccessExternalNetwork: envExternalNetwork,
+			AllowAccessToExternalNetwork: envExternalNetwork,
 		},
 	}
 
@@ -163,7 +163,7 @@ func envUpdate(c *cli.Context) error {
 		env.Spec.Poolsize = c.Int("poolsize")
 	}
 
-	env.Spec.AllowedAccessExternalNetwork = envExternalNetwork
+	env.Spec.AllowAccessToExternalNetwork = envExternalNetwork
 
 	_, err = client.EnvironmentUpdate(env)
 	checkErr(err, "update environment")

--- a/fission/main.go
+++ b/fission/main.go
@@ -142,12 +142,13 @@ func main() {
 	envImageFlag := cli.StringFlag{Name: "image", Usage: "Environment image URL"}
 	envBuilderImageFlag := cli.StringFlag{Name: "builder", Usage: "Environment builder image URL (optional)"}
 	envBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for environment builder to build source package (optional)"}
+	envExternalNetworkFlag := cli.BoolFlag{Name: "externalnetwork", Usage: "Allow environment access external network when istio feature enabled (optional, defaults to false)"}
 
 	envVersionFlag := cli.IntFlag{Name: "version", Usage: "Environment API version: defaults to 1 (means v1 interface)"}
 	envSubcommands := []cli.Command{
-		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag}, Action: envCreate},
+		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag, envExternalNetworkFlag}, Action: envCreate},
 		{Name: "get", Usage: "Get environment details", Flags: []cli.Flag{envNameFlag}, Action: envGet},
-		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, minCpu, maxCpu, minMem, maxMem}, Action: envUpdate},
+		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, minCpu, maxCpu, minMem, maxMem, envExternalNetworkFlag}, Action: envUpdate},
 		{Name: "delete", Usage: "Delete environment", Flags: []cli.Flag{envNameFlag}, Action: envDelete},
 		{Name: "list", Usage: "List all environments", Flags: []cli.Flag{}, Action: envList},
 	}

--- a/mqtrigger/messageQueue/messageQueue.go
+++ b/mqtrigger/messageQueue/messageQueue.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
@@ -169,6 +170,11 @@ func (mqt *MessageQueueTriggerManager) syncTriggers() {
 		// get new set of triggers
 		newTriggers, err := mqt.fissionClient.MessageQueueTriggers(metav1.NamespaceAll).List(metav1.ListOptions{})
 		if err != nil {
+			if fission.IsNetworkError(err) {
+				log.Printf("Encounter network error, retry again: %v", err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			log.Fatalf("Failed to read message queue trigger list: %v", err)
 		}
 		newTriggerMap := make(map[string]*crd.MessageQueueTrigger)

--- a/router/mutablemux.go
+++ b/router/mutablemux.go
@@ -17,10 +17,11 @@ limitations under the License.
 package router
 
 import (
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"sync/atomic"
+
+	"github.com/gorilla/mux"
 )
 
 //

--- a/timer/timerSync.go
+++ b/timer/timerSync.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
@@ -45,6 +46,11 @@ func (ws *TimerSync) syncSvc() {
 	for {
 		triggers, err := ws.fissionClient.TimeTriggers(metav1.NamespaceAll).List(metav1.ListOptions{})
 		if err != nil {
+			if fission.IsNetworkError(err) {
+				log.Printf("Encounter network error, retry again: %v", err)
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			log.Fatalf("Failed get time trigger list: %v", err)
 		}
 		ws.timer.Sync(triggers.Items)

--- a/types.go
+++ b/types.go
@@ -233,6 +233,9 @@ type (
 		// Optional, defaults to 'AllowedFunctionsPerContainerSingle'
 		AllowedFunctionsPerContainer AllowedFunctionsPerContainer `json:"allowedFunctionsPerContainer,omitempty"`
 
+		// Optional, defaults to 'false'
+		AllowedAccessExternalNetwork bool `json:"allowedAccessExternalNetwork,omitempty"`
+
 		// Request and limit resources for the environment
 		Resources v1.ResourceRequirements `json:"resources"`
 

--- a/types.go
+++ b/types.go
@@ -234,7 +234,7 @@ type (
 		AllowedFunctionsPerContainer AllowedFunctionsPerContainer `json:"allowedFunctionsPerContainer,omitempty"`
 
 		// Optional, defaults to 'false'
-		AllowedAccessExternalNetwork bool `json:"allowedAccessExternalNetwork,omitempty"`
+		AllowAccessToExternalNetwork bool `json:"allowAccessToExternalNetwork,omitempty"`
 
 		// Request and limit resources for the environment
 		Resources v1.ResourceRequirements `json:"resources"`


### PR DESCRIPTION
This is the very first step for fission to integrate with Istio and there are still couple problems need to be solved. For those  interested in trying integrate fission with istio, following is the set up tutorial (Tutorial also post on [here](https://tachingchen.com/blog/fission-and-istio-integration/)). (https://github.com/fission/fission/issues/278, https://github.com/fission/fission/issues/344) 
## Test Environment
* Google Kubernetes Engine: 1.8.4-gke.0

## Set Up
### Create Kubernetes v1.8+ alpha cluster

Enable both RBAC & initializer features on kubernetes cluster.

** NOTICE ** `kubectl logs -f` is [not working correctly](https://github.com/kubernetes/kubernetes/issues/54205#issuecomment-340111607) on GKE alpha cluster right now.

```
$ gcloud container clusters create istio-demo \
	--enable-kubernetes-alpha \
    --machine-type=n1-standard-2 \
    --num-nodes=1 \
    --no-enable-legacy-authorization \
    --zone=<ZONE> \
    --cluster-version=1.8.4-gke.0
```

### Grant cluster admin permissions

Grant admin permission for `system:serviceaccount:kube-system:default` and current user.

```
# for system:serviceaccount:kube-system:default
$ kubectl create clusterrolebinding --user system:serviceaccount:kube-system:default kube-system-cluster-admin --clusterrole cluster-admin

# for current user
$ kubectl create clusterrolebinding cluster-admin-binding --clusterrole=cluster-admin --user=$(gcloud config get-value core/account)
```

### Set up Istio environment

Download Istio 0.2.12

```
curl -L https://git.io/getLatestIstio | sh -
```

Apply istio related YAML files

```
$ kubectl apply -f istio-0.2.12/install/kubernetes/istio.yaml
$ kubectl apply -f istio-0.2.12/install/kubernetes/istio-initializer.yaml
```

Since helm uses jobs to install charts, we have to remove `jobs` from `initializers.rules.resources` due to a known [bug](https://github.com/istio/issues/issues/93) in istio pilot as a workaround.

```
$ kubectl edit initializerconfigurations
```

```
apiVersion: admissionregistration.k8s.io/v1alpha1
initializers:
- name: sidecar.initializer.istio.io
  rules:
  - apiGroups:
    - '*'
    apiVersions:
    - '*'
    resources:
    - deployments
    - statefulsets
    # As a workaround right now, remove jobs here 
    # due to a known bug (https://github.com/istio/issues/issues/93) 
    - jobs 
    - daemonsets
```

Set default namespace to `fission`

```
$ kubectl config set-context $(kubectl config current-context) --namespace=fission
```

### Install fission

```
$ git clone https://github.com/fission/fission.git
$ cd fission/charts && git checkout istio-integration
```

fission-bundle docker image for demo: `life1347/fission-istio-integration:1.0.0`

```
$ helm init
$ helm install --debug --namespace fission --set enableIstio=true,image=life1347/fission-istio-integration,imageTag=latest,pullPolicy=Always --name istio-demo fission-all
```

### Create custom function


Set environment

```
$ export FISSION_URL=http://$(kubectl --namespace fission get svc controller -o=jsonpath='{..ip}')
$ export FISSION_ROUTER=$(kubectl --namespace fission get svc router -o=jsonpath='{..ip}')
```

demo function: hello.js

```
module.exports = async function(context) {
    console.log(context.request.headers);
    return {
        status: 200,
        body: "Hello, World!\n"
    };
}
```

Create environment

```
$ fission env create --name nodejs --image fission/node-env
```

Create function

```
$ fission fn create --name h1 --env nodejs --code hello.js --method GET
```

Create route

```
$ fission route create --method GET --url /h1 --function h1
```

Access function

```
$ curl http://$FISSION_ROUTER/h1
Hello, World!
```


### Install Add-ons

* Prometheus

```
$ kubectl apply -f istio-0.2.12/install/kubernetes/addons/prometheus.yaml
$ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=prometheus -o jsonpath='{.items[0].metadata.name}') 9090:9090
```

Web Link: [http://127.0.0.1:9090/graph](http://127.0.0.1:9090/graph)

* Grafana

Please install Prometheus first.

![grafana min](https://user-images.githubusercontent.com/202578/33528556-639493e2-d89d-11e7-9768-976fb9208646.png)

```
$ kubectl apply -f istio-0.2.12/install/kubernetes/addons/grafana.yaml
$ kubectl -n istio-system port-forward $(kubectl -n istio-system get pod -l app=grafana -o jsonpath='{.items[0].metadata.name}') 3000:3000
```

Web Link: [http://127.0.0.1:3000/dashboard/db/istio-dashboard](http://127.0.0.1:3000/dashboard/db/istio-dashboard)

* Jaegar

![jaeger min](https://user-images.githubusercontent.com/202578/33528554-572c4f28-d89d-11e7-8a01-1543fc2aa064.png)

```
$ kubectl apply -n istio-system -f https://raw.githubusercontent.com/jaegertracing/jaeger-kubernetes/master/all-in-one/jaeger-all-in-one-template.yml
$ kubectl port-forward -n istio-system $(kubectl get pod -n istio-system -l app=jaeger -o jsonpath='{.items[0].metadata.name}') 16686:16686
```

Web Link: [http://localhost:16686](http://localhost:16686)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/421)
<!-- Reviewable:end -->
