### PR TITLE
Removed openshift specifics as they are no longer necessary

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -48,7 +48,6 @@ The following table lists the configurable parameters of the Fission chart and t
 | `routerPort`        | Fission Router Service Port                | `31314`                  |
 | `functionNamespace` | Namespace for Fission functions            | `fission-function`       |
 | `builderNamespace`  | Namespace for Fission environment builders | `fission-builder`        |
-| `openshift`         | RBAC for openshift                         | `false`                  |
 
 
 * Extra configuration for `fission-all`

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -1,77 +1,3 @@
-{{ if .Values.openshift }}
-
-# For openshift
-
----
-apiVersion: v1
-kind: ProjectRequest
-metadata:
-  name: fission
-  labels:
-    name: fission
-
----
-apiVersion: v1
-kind: ProjectRequest
-metadata:
-  name: {{ .Values.functionNamespace }}
-  labels:
-    name: fission-function
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: fission-admin
-  namespace: {{ .Release.Namespace }}
-
----
-apiVersion: v1
-kind: ClusterRole
-metadata:
-  name: fission:fission-admin
-rules:
-- apiGroups:
-  - extensions
-  attributeRestrictions: null
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  attributeRestrictions: null
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - update
-
----
-apiVersion: v1
-groupNames: null
-kind: RoleBinding
-metadata:
-  name: fission:fission-admin
-  namespace: {{ .Values.functionNamespace }}
-roleRef:
-  name: fission:fission-admin
-subjects:
-- kind: ServiceAccount
-  name: fission-admin
-  namespace: {{ .Release.Namespace }}
-userNames:
-- system:serviceaccount:fission:fission-admin
-
-{{ else }}
-
-# For all environments except openshift
-
 ---
 apiVersion: v1
 kind: Namespace
@@ -182,8 +108,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
-
-{{ end }}
 
 ---
 apiVersion: extensions/v1beta1

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -38,9 +38,6 @@ functionNamespace: fission-function
 ## the release namespace)
 builderNamespace: fission-builder
 
-## Set up openshift RBAC rule
-openshift: false
-
 ## Logger config
 logger:
   influxdbAdmin: "admin"

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -1,77 +1,3 @@
-{{ if .Values.openshift }}
-
-# For openshift
-
----
-apiVersion: v1
-kind: ProjectRequest
-metadata:
-  name: fission
-  labels:
-    name: fission
-
----
-apiVersion: v1
-kind: ProjectRequest
-metadata:
-  name: {{ .Values.functionNamespace }}
-  labels:
-    name: fission-function
-
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: fission-admin
-  namespace: {{ .Release.Namespace }}
-
----
-apiVersion: v1
-kind: ClusterRole
-metadata:
-  name: fission:fission-admin
-rules:
-- apiGroups:
-  - extensions
-  attributeRestrictions: null
-  resources:
-  - deployments
-  verbs:
-  - create
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  attributeRestrictions: null
-  resources:
-  - pods
-  verbs:
-  - get
-  - list
-  - update
-
----
-apiVersion: v1
-groupNames: null
-kind: RoleBinding
-metadata:
-  name: fission:fission-admin
-  namespace: {{ .Values.functionNamespace }}
-roleRef:
-  name: fission:fission-admin
-subjects:
-- kind: ServiceAccount
-  name: fission-admin
-  namespace: {{ .Release.Namespace }}
-userNames:
-- system:serviceaccount:fission:fission-admin
-
-{{ else }}
-
-# For all environments except openshift
-
 ---
 apiVersion: v1
 kind: Namespace
@@ -182,8 +108,6 @@ roleRef:
   kind: ClusterRole
   name: cluster-admin
   apiGroup: rbac.authorization.k8s.io
-
-{{ end }}
 
 ---
 apiVersion: extensions/v1beta1

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -35,9 +35,6 @@ functionNamespace: fission-function
 ## the release namespace)
 builderNamespace: fission-builder
 
-## Set up openshift RBAC rule
-openshift: false
-  
 ## Persist data to a persistent volume.
 persistence:
   enabled: true


### PR DESCRIPTION
tested fission on openshift 3.7.0 and installed fine, without having to use openshift variables
those variables were used prior to switching to custom resource definitions, and as such are obsolete

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/424)
<!-- Reviewable:end -->
