### PR TITLE
[Issue 423] build logs not saved on build error

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -183,14 +183,14 @@ func (builder *Builder) build(command string, srcPkgPath string, deployPkgPath s
 	if err := scanner.Err(); err != nil {
 		scanErr := errors.New(fmt.Sprintf("Error reading cmd output: %v", err.Error()))
 		fmt.Println(scanErr)
-		return "", scanErr
+		return buildLogs, scanErr
 	}
 
 	err = cmd.Wait()
 	if err != nil {
 		cmdErr := errors.New(fmt.Sprintf("Error waiting for cmd '%v': %v", command, err.Error()))
 		fmt.Println(cmdErr)
-		return "", cmdErr
+		return buildLogs, cmdErr
 	}
 	fmt.Println("==================\n")
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -21,18 +21,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/dchest/uniuri"
-	"io"
-	"path"
 )
 
 const (
@@ -70,7 +70,9 @@ func MakeBuilder(sharedVolumePath string) *Builder {
 
 func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
-		http.Error(w, "", 405)
+		e := fmt.Sprintf("Method not allowed: %v", r.Method)
+		log.Println(e)
+		builder.reply(w, "", e, http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -83,15 +85,17 @@ func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
 	// parse request
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		log.Printf("Error reading request body")
-		http.Error(w, err.Error(), 500)
+		e := errors.New(fmt.Sprintf("Error reading request body: %v", err))
+		log.Println(e.Error())
+		builder.reply(w, "", e.Error(), http.StatusInternalServerError)
 		return
 	}
 	var req PackageBuildRequest
 	err = json.Unmarshal(body, &req)
 	if err != nil {
-		log.Printf("Error parsing json body: %v", err)
-		http.Error(w, err.Error(), 400)
+		e := errors.New(fmt.Sprintf("Error parsing json body: %v", err))
+		log.Println(e.Error())
+		builder.reply(w, "", e.Error(), http.StatusBadRequest)
 		return
 	}
 	log.Printf("Builder received request: %v", req)
@@ -108,25 +112,34 @@ func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
 	buildLogs, err := builder.build(buildCmd, srcPkgPath, deployPkgPath)
 	if err != nil {
 		e := errors.New(fmt.Sprintf("Error building source package: %v", err))
-		http.Error(w, e.Error(), 500)
+		log.Println(e.Error())
+		// append error at the end of build logs
+		buildLogs += fmt.Sprintf("%v\n", e.Error())
+		builder.reply(w, deployPkgFilename, buildLogs, http.StatusInternalServerError)
 		return
 	}
 
+	builder.reply(w, deployPkgFilename, buildLogs, http.StatusOK)
+}
+
+func (builder *Builder) reply(w http.ResponseWriter, pkgFilename string, buildLogs string, statusCode int) {
 	resp := PackageBuildResponse{
-		ArtifactFilename: deployPkgFilename,
+		ArtifactFilename: pkgFilename,
 		BuildLogs:        buildLogs,
 	}
 
 	rBody, err := json.Marshal(resp)
 	if err != nil {
 		e := errors.New(fmt.Sprintf("Error encoding response body: %v", err))
-		http.Error(w, e.Error(), 500)
-		return
+		rBody = []byte(fmt.Sprintf(`{"buildLogs": "%v"}`, e.Error()))
+		statusCode = http.StatusInternalServerError
 	}
 
 	w.Header().Add("Content-Type", "application/json")
+	// should write header before body or client
+	// will receive http 200 regardless the real statusCode
+	w.WriteHeader(statusCode)
 	w.Write(rBody)
-	w.WriteHeader(http.StatusOK)
 }
 
 func (builder *Builder) build(command string, srcPkgPath string, deployPkgPath string) (string, error) {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -136,8 +136,8 @@ func (builder *Builder) reply(w http.ResponseWriter, pkgFilename string, buildLo
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	// should write header before body or client
-	// will receive http 200 regardless the real statusCode
+	// should write header before writing the body,
+	// or client will receive HTTP 200 regardless the real status code
 	w.WriteHeader(statusCode)
 	w.Write(rBody)
 }

--- a/builder/client/client.go
+++ b/builder/client/client.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"strings"
 
@@ -50,20 +51,18 @@ func (c *Client) Build(req *builder.PackageBuildRequest) (*builder.PackageBuildR
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != 200 {
-		return nil, fission.MakeErrorFromHTTP(resp)
-	}
-
 	rBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
+		log.Printf("Error reading resp body: %v", err)
 		return nil, err
 	}
 
 	pkgBuildResp := builder.PackageBuildResponse{}
 	err = json.Unmarshal([]byte(rBody), &pkgBuildResp)
 	if err != nil {
+		log.Printf("Error parsing resp body: %v", err)
 		return nil, err
 	}
 
-	return &pkgBuildResp, nil
+	return &pkgBuildResp, fission.MakeErrorFromHTTP(resp)
 }

--- a/buildermgr/api.go
+++ b/buildermgr/api.go
@@ -82,8 +82,18 @@ func (builderMgr *BuilderMgr) build(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	pkg, err := builderMgr.fissionClient.
+		Packages(buildReq.Package.Namespace).
+		Get(buildReq.Package.Name)
+	if err != nil {
+		e := fmt.Sprintf("Error getting package CRD info: %v", err)
+		log.Println(e)
+		http.Error(w, e, 500)
+		return
+	}
+
 	buildLogs, err := buildPackage(builderMgr.fissionClient, builderMgr.kubernetesClient,
-		builderMgr.namespace, builderMgr.storageSvcUrl, buildReq)
+		builderMgr.namespace, builderMgr.storageSvcUrl, pkg)
 	if err != nil {
 		code, e := fission.GetHTTPError(err)
 		http.Error(w, e, code)

--- a/buildermgr/api.go
+++ b/buildermgr/api.go
@@ -39,9 +39,9 @@ type (
 	}
 
 	BuilderMgr struct {
-		fissionClient    *crd.FissionClient
-		storageSvcUrl    string
-		namespace        string
+		fissionClient *crd.FissionClient
+		storageSvcUrl string
+		namespace     string
 	}
 )
 
@@ -56,9 +56,9 @@ func MakeBuilderMgr(fissionClient *crd.FissionClient,
 	go pkgWatcher.watchPackages()
 
 	return &BuilderMgr{
-		fissionClient:    fissionClient,
-		storageSvcUrl:    storageSvcUrl,
-		namespace:        envBuilderNamespace,
+		fissionClient: fissionClient,
+		storageSvcUrl: storageSvcUrl,
+		namespace:     envBuilderNamespace,
 	}
 }
 

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -44,17 +44,7 @@ import (
 // 7. Update package resource in package ref of functions that share the same package
 // *. Update package status to failed state,if any one of steps above failed
 func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes.Clientset,
-	builderNamespace string, storageSvcUrl string, buildReq BuildRequest) (buildLogs string, err error) {
-
-	pkg, err := fissionClient.
-		Packages(buildReq.Package.Namespace).
-		Get(buildReq.Package.Name)
-	if err != nil {
-		e := fmt.Sprintf("Error getting function CRD info: %v", err)
-		log.Println(e)
-		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, e, nil)
-		return e, fission.MakeError(500, e)
-	}
+	builderNamespace string, storageSvcUrl string, pkg *crd.Package) (buildLogs string, err error) {
 
 	// Only do build for pending packages
 	if pkg.Status.BuildStatus != fission.BuildStatusPending {

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -124,7 +124,12 @@ func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes
 	if err != nil {
 		e := fmt.Sprintf("Error building deployment package: %v", err)
 		log.Println(e)
-		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, e, nil)
+		var buildLogs string
+		if buildResp != nil {
+			buildLogs = buildResp.BuildLogs
+		}
+		buildLogs += fmt.Sprintf("%v\n", e)
+		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, buildLogs, nil)
 		return e, fission.MakeError(500, e)
 	}
 
@@ -141,7 +146,8 @@ func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes
 	if err != nil {
 		e := fmt.Sprintf("Error uploading deployment package: %v", err)
 		log.Println(e)
-		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, e, nil)
+		buildResp.BuildLogs += fmt.Sprintf("%v\n", e)
+		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, buildResp.BuildLogs, nil)
 		return e, fission.MakeError(500, e)
 	}
 
@@ -153,7 +159,8 @@ func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes
 	if err != nil {
 		e := fmt.Sprintf("Error creating deployment package CRD resource: %v", err)
 		log.Println(e)
-		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, e, nil)
+		buildResp.BuildLogs += fmt.Sprintf("%v\n", e)
+		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, buildResp.BuildLogs, nil)
 		return e, fission.MakeError(500, e)
 	}
 
@@ -162,7 +169,8 @@ func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes
 	if err != nil {
 		e := fmt.Sprintf("Error getting function list: %v", err)
 		log.Println(e)
-		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, e, nil)
+		buildResp.BuildLogs += fmt.Sprintf("%v\n", e)
+		updatePackage(fissionClient, pkg, fission.BuildStatusFailed, buildResp.BuildLogs, nil)
 		return e, fission.MakeError(500, e)
 	}
 
@@ -178,7 +186,8 @@ func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes
 			if err != nil {
 				e := fmt.Sprintf("Error updating function package resource version: %v", err)
 				log.Println(e)
-				updatePackage(fissionClient, pkg, fission.BuildStatusFailed, e, nil)
+				buildResp.BuildLogs += fmt.Sprintf("%v\n", e)
+				updatePackage(fissionClient, pkg, fission.BuildStatusFailed, buildResp.BuildLogs, nil)
 				return e, fission.MakeError(500, e)
 			}
 		}

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/dchest/uniuri"
 	"github.com/fission/fission"
@@ -44,8 +43,8 @@ import (
 // 6. Update package status to succeed state
 // 7. Update package resource in package ref of functions that share the same package
 // *. Update package status to failed state,if any one of steps above failed
-func buildPackage(fissionClient *crd.FissionClient, kubernetesClient *kubernetes.Clientset,
-	builderNamespace string, storageSvcUrl string, pkg *crd.Package) (buildLogs string, err error) {
+func buildPackage(fissionClient *crd.FissionClient, builderNamespace string,
+	storageSvcUrl string, pkg *crd.Package) (buildLogs string, err error) {
 
 	// Only do build for pending packages
 	if pkg.Status.BuildStatus != fission.BuildStatusPending {

--- a/buildermgr/pkgwatcher.go
+++ b/buildermgr/pkgwatcher.go
@@ -48,14 +48,11 @@ func makePackageWatcher(fissionClient *crd.FissionClient,
 	return pkgw
 }
 
-func (pkgw *packageWatcher) build(pkgMetadata metav1.ObjectMeta) {
-	buildReq := BuildRequest{
-		Package: pkgMetadata,
-	}
+func (pkgw *packageWatcher) build(pkg *crd.Package) {
 	_, err := buildPackage(pkgw.fissionClient,
-		pkgw.kubernetesClient, pkgw.builderNamespace, pkgw.storageSvcUrl, buildReq)
+		pkgw.kubernetesClient, pkgw.builderNamespace, pkgw.storageSvcUrl, pkg)
 	if err != nil {
-		log.Printf("Error building package %v: %v", buildReq.Package.Name, err)
+		log.Printf("Error building package %v: %v", pkg.Metadata.Name, err)
 	}
 }
 
@@ -84,7 +81,7 @@ func (pkgw *packageWatcher) watchPackages() {
 
 			// only do build for packages in pending state
 			if pkg.Status.BuildStatus == fission.BuildStatusPending {
-				go pkgw.build(pkg.Metadata)
+				go pkgw.build(pkg)
 			}
 		}
 	}

--- a/buildermgr/pkgwatcher.go
+++ b/buildermgr/pkgwatcher.go
@@ -22,7 +22,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
@@ -31,17 +30,15 @@ import (
 type (
 	packageWatcher struct {
 		fissionClient    *crd.FissionClient
-		kubernetesClient *kubernetes.Clientset
 		builderNamespace string
 		storageSvcUrl    string
 	}
 )
 
 func makePackageWatcher(fissionClient *crd.FissionClient,
-	kubernetesClient *kubernetes.Clientset, builderNamespace string, storageSvcUrl string) *packageWatcher {
+	builderNamespace string, storageSvcUrl string) *packageWatcher {
 	pkgw := &packageWatcher{
 		fissionClient:    fissionClient,
-		kubernetesClient: kubernetesClient,
 		builderNamespace: builderNamespace,
 		storageSvcUrl:    storageSvcUrl,
 	}
@@ -49,8 +46,7 @@ func makePackageWatcher(fissionClient *crd.FissionClient,
 }
 
 func (pkgw *packageWatcher) build(pkg *crd.Package) {
-	_, err := buildPackage(pkgw.fissionClient,
-		pkgw.kubernetesClient, pkgw.builderNamespace, pkgw.storageSvcUrl, pkg)
+	_, err := buildPackage(pkgw.fissionClient, pkgw.builderNamespace, pkgw.storageSvcUrl, pkg)
 	if err != nil {
 		log.Printf("Error building package %v: %v", pkg.Metadata.Name, err)
 	}


### PR DESCRIPTION
This PR tends to fix the bug ~introduced in PR #397~ that builder manager updates package with empty build logs when build script exited with non-zero code. Also fix a potential nil pointer issue. (issue #423)

(Update: 2017/12/05 )
Looks like this bug existed at the beginning

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/426)
<!-- Reviewable:end -->
