### PR TITLE
Add go vet check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ script:
   - glide install
   - ./fission-bundle/build.sh
   - hack/verify-gofmt.sh
+  - hack/verify-govet.sh
   - hack/runtests.sh
   - test/build_and_test.sh
 

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -173,7 +173,7 @@ func (builder *Builder) build(command string, srcPkgPath string, deployPkgPath s
 
 	var buildLogs string
 
-	fmt.Println("\n=== Build Logs ===")
+	fmt.Printf("\n=== Build Logs ===")
 	// Init logs
 	fmt.Printf("command=%v\n", command)
 	fmt.Printf("env=%v\n", cmd.Env)
@@ -205,7 +205,7 @@ func (builder *Builder) build(command string, srcPkgPath string, deployPkgPath s
 		fmt.Println(cmdErr)
 		return buildLogs, cmdErr
 	}
-	fmt.Println("==================\n")
+	fmt.Printf("==================\n")
 
 	return buildLogs, nil
 }

--- a/fission/timetrigger.go
+++ b/fission/timetrigger.go
@@ -133,7 +133,7 @@ func ttList(c *cli.Context) error {
 
 	fmt.Fprintf(w, "%v\t%v\t%v\n", "NAME", "CRON", "FUNCTION_NAME")
 	for _, tt := range tts {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n",
+		fmt.Fprintf(w, "%v\t%v\t%v\n",
 			tt.Metadata.Name, tt.Spec.Cron, tt.Spec.FunctionReference.Name)
 	}
 	w.Flush()

--- a/fission/watch.go
+++ b/fission/watch.go
@@ -125,7 +125,7 @@ func wList(c *cli.Context) error {
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
 		"NAME", "NAMESPACE", "OBJTYPE", "LABELS", "FUNCTION_NAME")
 	for _, wa := range ws {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\n",
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
 			wa.Metadata.Name, wa.Spec.Namespace, wa.Spec.Type, wa.Spec.LabelSelector, wa.Spec.FunctionReference.Name)
 	}
 	w.Flush()

--- a/hack/verify-govet.sh
+++ b/hack/verify-govet.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+find_files() {
+  find . -not \( \
+      \( \
+        -wholename '*/vendor/*' \
+      \) -prune \
+    \) -name '*.go'
+}
+
+find_files | grep -v '.glide/cache' | xargs -I@ bash -c "go vet @"

--- a/kubewatcher/kubewatcher.go
+++ b/kubewatcher/kubewatcher.go
@@ -288,7 +288,7 @@ func (ws *watchSubscription) eventDispatchLoop() {
 
 		if ev.Type == watch.Error {
 			e := errors.FromObject(ev.Object)
-			log.Println("Watch error, retrying in a second: %v", e)
+			log.Printf("Watch error, retrying in a second: %v", e)
 			// Start from the beginning to get around "too old resource version"
 			ws.lastResourceVersion = ""
 			time.Sleep(time.Second)


### PR DESCRIPTION
This PR add `go vet` check during travi build and fix some existing issues in current codebase. Though `go vet` is adopted, the bug fixed in #418 still not able to detect by `go vet` and need to be checked manually.