### PR TITLE
Fscache support for multiple kubernetes objects

### DIFF
--- a/executor/fscache/functionServiceCache_test.go
+++ b/executor/fscache/functionServiceCache_test.go
@@ -21,6 +21,21 @@ func TestFunctionServiceCache(t *testing.T) {
 	var fsvc *FuncSvc
 	now := time.Now()
 
+	objects := []api.ObjectReference{
+		{
+			Kind:       "pod",
+			Name:       "xxx",
+			APIVersion: "v1",
+			Namespace:  "fission-function",
+		},
+		{
+			Kind:       "pod",
+			Name:       "xxx2",
+			APIVersion: "v1",
+			Namespace:  "fission-function",
+		},
+	}
+
 	fsvc = &FuncSvc{
 		Function: &metav1.ObjectMeta{
 			Name: "foo",
@@ -39,15 +54,10 @@ func TestFunctionServiceCache(t *testing.T) {
 				Builder: fission.Builder{},
 			},
 		},
-		Address: "xxx",
-		KubernetesObject: api.ObjectReference{
-			Kind:       "pod",
-			Name:       "xxx",
-			APIVersion: "v1",
-			Namespace:  "fission-function",
-		},
-		Ctime: now,
-		Atime: now,
+		Address:           "xxx",
+		KubernetesObjects: objects,
+		Ctime:             now,
+		Atime:             now,
 	}
 	err, _ := fsc.Add(*fsvc)
 	if err != nil {
@@ -62,7 +72,7 @@ func TestFunctionServiceCache(t *testing.T) {
 	}
 	fsvc.Atime = f.Atime
 	fsvc.Ctime = f.Ctime
-	if *f != *fsvc {
+	if f.Address != fsvc.Address {
 		fsc.Log()
 		log.Panicf("Incorrect fsvc \n(expected: %#v)\n (found: %#v)", fsvc, f)
 	}
@@ -73,7 +83,7 @@ func TestFunctionServiceCache(t *testing.T) {
 		log.Panicf("Failed to touch fsvc: %v", err)
 	}
 
-	deleted, err := fsc.DeleteByKubeObject(fsvc.KubernetesObject, 0)
+	deleted, err := fsc.DeleteOld(fsvc, 0)
 	if err != nil {
 		fsc.Log()
 		log.Panicf("Failed to delete fsvc: %v", err)

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -580,23 +580,25 @@ func (gp *GenericPool) GetFuncSvc(m *metav1.ObjectMeta) (*fscache.FuncSvc, error
 		svcHost = fmt.Sprintf("%v:8888", pod.Status.PodIP)
 	}
 
-	kubeObjRef := api.ObjectReference{
-		Kind:            pod.TypeMeta.Kind,
-		Name:            pod.ObjectMeta.Name,
-		APIVersion:      pod.TypeMeta.APIVersion,
-		Namespace:       pod.ObjectMeta.Namespace,
-		ResourceVersion: pod.ObjectMeta.ResourceVersion,
-		UID:             pod.ObjectMeta.UID,
+	kubeObjRef := []api.ObjectReference{
+		{
+			Kind:            pod.TypeMeta.Kind,
+			Name:            pod.ObjectMeta.Name,
+			APIVersion:      pod.TypeMeta.APIVersion,
+			Namespace:       pod.ObjectMeta.Namespace,
+			ResourceVersion: pod.ObjectMeta.ResourceVersion,
+			UID:             pod.ObjectMeta.UID,
+		},
 	}
 
 	fsvc := &fscache.FuncSvc{
-		Function:         m,
-		Environment:      gp.env,
-		Address:          svcHost,
-		KubernetesObject: kubeObjRef,
-		Backend:          fscache.POOLMGR,
-		Ctime:            time.Now(),
-		Atime:            time.Now(),
+		Function:          m,
+		Environment:       gp.env,
+		Address:           svcHost,
+		KubernetesObjects: kubeObjRef,
+		Backend:           fscache.POOLMGR,
+		Ctime:             time.Now(),
+		Atime:             time.Now(),
 	}
 
 	err, _ = gp.fsCache.Add(*fsvc)
@@ -606,39 +608,43 @@ func (gp *GenericPool) GetFuncSvc(m *metav1.ObjectMeta) (*fscache.FuncSvc, error
 	return fsvc, nil
 }
 
-func (gp *GenericPool) CleanupFunctionService(obj api.ObjectReference) error {
+func (gp *GenericPool) CleanupFunctionService(obj *fscache.FuncSvc) error {
 	// remove ourselves from fsCache (only if we're still old)
-	deleted, err := gp.fsCache.DeleteByKubeObject(obj, gp.idlePodReapTime)
+	deleted, err := gp.fsCache.DeleteOld(obj, gp.idlePodReapTime)
 	if err != nil {
 		return err
 	}
 
 	if !deleted {
-		log.Printf("Not deleting %v, in use", obj.Name)
+		log.Printf("Not deleting %v, in use", obj.Function)
 		return nil
 	}
 
-	pod, err := gp.kubernetesClient.CoreV1().Pods(gp.namespace).Get(obj.Name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
+	var pod *apiv1.Pod
 
-	loggerUrl := fmt.Sprintf("http://%s:1234/v1/log/%s", pod.Spec.NodeName, pod.Name)
-	req, err := http.NewRequest("DELETE", loggerUrl, nil)
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		log.Printf("Error from %s daemonset logger: %v", pod.Spec.NodeName, err)
-	} else {
-		if resp.StatusCode != 200 {
-			log.Printf("Received not http 200(OK) status from %s daemonset logger: %s", pod.Spec.NodeName, resp.Status)
+	for _, kubeobj := range obj.KubernetesObjects {
+		pod, err = gp.kubernetesClient.CoreV1().Pods(gp.namespace).Get(kubeobj.Name, metav1.GetOptions{})
+
+		loggerUrl := fmt.Sprintf("http://%s:1234/v1/log/%s", pod.Spec.NodeName, pod.Name)
+		req, err := http.NewRequest("DELETE", loggerUrl, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			log.Printf("Error from %s daemonset logger: %v", pod.Spec.NodeName, err)
+		} else {
+			if resp.StatusCode != 200 {
+				log.Printf("Received not http 200(OK) status from %s daemonset logger: %s", pod.Spec.NodeName, resp.Status)
+			}
+			resp.Body.Close()
 		}
-		resp.Body.Close()
-	}
 
-	// delete pod
-	err = gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(obj.Name, nil)
-	if err != nil {
-		return err
+		// delete pod
+		err = gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(kubeobj.Name, nil)
+		if err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -653,10 +659,9 @@ func (gp *GenericPool) idlePodReaper() {
 			continue
 		}
 		for _, obj := range objects {
-			log.Printf("Reaping idle pod '%v'", obj.Name)
 			err := gp.CleanupFunctionService(obj)
 			if err != nil {
-				log.Printf("Error deleting idle pod '%v': %v", obj.Name, err)
+				log.Printf("Error deleting Kube objects for fsvc '%v': %v", obj, err)
 			}
 		}
 	}

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -580,7 +580,7 @@ func (gp *GenericPool) GetFuncSvc(m *metav1.ObjectMeta) (*fscache.FuncSvc, error
 		svcHost = fmt.Sprintf("%v:8888", pod.Status.PodIP)
 	}
 
-	kubeObjRef := []api.ObjectReference{
+	kubeObjRefs := []api.ObjectReference{
 		{
 			Kind:            pod.TypeMeta.Kind,
 			Name:            pod.ObjectMeta.Name,
@@ -595,7 +595,7 @@ func (gp *GenericPool) GetFuncSvc(m *metav1.ObjectMeta) (*fscache.FuncSvc, error
 		Function:          m,
 		Environment:       gp.env,
 		Address:           svcHost,
-		KubernetesObjects: kubeObjRef,
+		KubernetesObjects: kubeObjRefs,
 		Backend:           fscache.POOLMGR,
 		Ctime:             time.Now(),
 		Atime:             time.Now(),
@@ -620,10 +620,8 @@ func (gp *GenericPool) CleanupFunctionService(obj *fscache.FuncSvc) error {
 		return nil
 	}
 
-	var pod *apiv1.Pod
-
 	for _, kubeobj := range obj.KubernetesObjects {
-		pod, err = gp.kubernetesClient.CoreV1().Pods(gp.namespace).Get(kubeobj.Name, metav1.GetOptions{})
+		pod, err := gp.kubernetesClient.CoreV1().Pods(gp.namespace).Get(kubeobj.Name, metav1.GetOptions{})
 
 		loggerUrl := fmt.Sprintf("http://%s:1234/v1/log/%s", pod.Spec.NodeName, pod.Name)
 		req, err := http.NewRequest("DELETE", loggerUrl, nil)
@@ -653,15 +651,19 @@ func (gp *GenericPool) CleanupFunctionService(obj *fscache.FuncSvc) error {
 func (gp *GenericPool) idlePodReaper() {
 	for {
 		time.Sleep(time.Minute)
-		objects, err := gp.fsCache.ListOld(&gp.env.Metadata, gp.idlePodReapTime)
+		funcSvcs, err := gp.fsCache.ListOld(&gp.env.Metadata, gp.idlePodReapTime)
 		if err != nil {
 			log.Printf("Error reaping idle pods: %v", err)
 			continue
 		}
-		for _, obj := range objects {
+		for _, obj := range funcSvcs {
 			err := gp.CleanupFunctionService(obj)
 			if err != nil {
-				log.Printf("Error deleting Kube objects for fsvc '%v': %v", obj, err)
+				log.Printf("Error deleting Kubernetes objects for fsvc '%v': %v", obj, err)
+				log.Printf("Object Name| Object Kind | Object Space")
+				for _, kubeobj := range obj.KubernetesObjects{
+					log.Printf("%v | %v | %v", kubeobj.Name, kubeobj.Kind, kubeobj.Namespace)
+				}
 			}
 		}
 	}

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -661,7 +661,7 @@ func (gp *GenericPool) idlePodReaper() {
 			if err != nil {
 				log.Printf("Error deleting Kubernetes objects for fsvc '%v': %v", obj, err)
 				log.Printf("Object Name| Object Kind | Object Space")
-				for _, kubeobj := range obj.KubernetesObjects{
+				for _, kubeobj := range obj.KubernetesObjects {
 					log.Printf("%v | %v | %v", kubeobj.Name, kubeobj.Kind, kubeobj.Namespace)
 				}
 			}


### PR DESCRIPTION
Addresses #415

In poolmgr backend fsvc could store only one Kubernetes object, but newdeploy backend created three objects for a function (Deployment, Service, HPA). This PR adds support for storing multiple Kube objects in FuncSvc. As a side effect, the DeleteByKubeObject does not work very well so this PR also adds a new DeleteOld implementation and changes the ListOld implementation a bit. Finally all these changes impact the generic pools idlePodRepaer hence that has been changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/435)
<!-- Reviewable:end -->
