### PR TITLE
Added instructions for deploying Fission on  docker for mac/windows

### DIFF
--- a/Documentation/docs-site/content/install.md
+++ b/Documentation/docs-site/content/install.md
@@ -72,7 +72,7 @@ $ helm init
 
 ### Install Fission
 
-#### Minikube
+#### Minikube, Docker for Mac/Windows
 
 ```
 $ helm install --namespace fission --set serviceType=NodePort https://github.com/fission/fission/releases/download/0.4.0/fission-all-0.4.0.tgz
@@ -133,6 +133,16 @@ If you're using minikube, use these commands:
   $ export FISSION_URL=http://$(minikube ip):31313
   $ export FISSION_ROUTER=$(minikube ip):31314
 ```
+
+#### Docker for Mac/Windows
+
+If you're using Docker for Mac or Windows, use the following commands:
+
+```
+  $ export FISSION_URL=http://localhost:31313
+  $ export FISSION_ROUTER=localhost:31314
+```
+
 #### Cloud setups
 
 Save the external IP addresses of controller and router services in

--- a/Documentation/docs-site/content/kubernetessetup.md
+++ b/Documentation/docs-site/content/kubernetessetup.md
@@ -34,6 +34,16 @@ $ curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.16.0/min
 $ minikube start
 ```
 
+## Docker for Mac/Windows
+
+Docker 17.12.0 and up ship with a [full Kubernetes cluster built-in](https://www.docker.com/kubernetes).
+After enabling the Kubernetes cluster in Docker for Mac or Docker for Windows, ensure that you switch to the right context:
+
+```
+kubectl config use-context docker-for-desktop
+```
+
+
 ## Google Container Engine
 
 Alternatively, you can use [Google Container Engine's](https://cloud.google.com/container-engine/) free trial to


### PR DESCRIPTION
Playing around with the Kubernetes support in Docker for Mac today, one of the first things to check is of course how this affects Fission. So I documented my experiences

So far I haven't run into any issues with Fission. Docker for Mac automatically ensures that the single node cluster is exposed on localhost. Seems like a really promising alternative to Minikube.

There is a small gotcha, at least when you have been using Minikube on the same machine. To get it working you need to switch the config context to `docker-for-mac`.

It would be great if someone could try this out (both on Windows and Mac) to verify that there aren't any other issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/442)
<!-- Reviewable:end -->

  