### PR TITLE
Fix python environment failed to launch

### DIFF
--- a/environments/python/server.py
+++ b/environments/python/server.py
@@ -95,4 +95,4 @@ def setup_logger(loglevel):
 #
 setup_logger(logging.DEBUG)
 app.logger.info("Starting server")
-app.run(host='0.0.0.0', port='8888')
+app.run(host='0.0.0.0', port=8888)

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -167,10 +167,10 @@ helm_install_fission() {
 
     helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always,analytics=false,logger.fluentdImage=$fluentdImage
 
-    timeout 30 helm_setup
+    timeout 30 bash -c "helm_setup"
 
     echo "Deleting old releases"
-    helm list -q|xargs helm_uninstall_fission
+    helm list -q|xargs -I@ bash -c "helm_uninstall_fission @"
 
     echo "Installing fission"
     helm install		\


### PR DESCRIPTION
This PR aims to fix python environment failed to launch problem.

```
2018-01-20 10:09:15,137 - INFO - Starting server
Traceback (most recent call last):
  File "server.py", line 98, in <module>
    app.run(host='0.0.0.0', port='8888')
  File "/usr/lib/python3.5/site-packages/flask/app.py", line 843, in run
    run_simple(host, port, self, **options)
  File "/usr/lib/python3.5/site-packages/werkzeug/serving.py", line 733, in run_simple
    raise TypeError('port must be an integer')
TypeError: port must be an integer
```
Also, fix `no such file or directory` when trying to execute `helm_setup` and helm_uninstall_fission` problems in test script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/451)
<!-- Reviewable:end -->
