### PR TITLE
Fix broken redirect in python example

### DIFF
--- a/examples/python/guestbook/add.py
+++ b/examples/python/guestbook/add.py
@@ -13,4 +13,6 @@ def main():
     # back to the list
     item = request.form['text']
     redisConnection.rpush('guestbook', item)
-    return redirect('/guestbook', code=303)
+    r = redirect('/guestbook', code=303)
+    r.autocorrect_location_header = False
+    return r


### PR DESCRIPTION
By default, flask turns redirects into absolute URLs. This is
undesired behaviour on Kubernetes, because the Pod's own IP address is
not really useful to any client that's not in the cluster (and even
within the cluster most clients will want to use the address of a
Service, not a Pod).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/467)
<!-- Reviewable:end -->
