### PR TITLE
Fluentd image tag issue in tests - an additional tag was appended

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -309,7 +309,7 @@ spec:
     spec:
       containers:
         - name: fluentd
-          image: "{{ .Values.logger.fluentdImage }}:{{ .Values.imageTag }}"
+          image: "{{ .Values.logger.fluentdImage }}:{{ .Values.logger.fluentdImageTag }}"
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
             - name: INFLUXDB_ADDRESS

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -42,6 +42,7 @@ builderNamespace: fission-builder
 logger:
   influxdbAdmin: "admin"
   fluentdImage: fission/fluentd
+  fluentdImageTag: 0.4.1
 
 ## Message queue trigger config
 ### NATS Streaming

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -161,11 +161,12 @@ helm_install_fission() {
     controllerNodeport=$6
     routerNodeport=$7
     fluentdImage=$8
+    fluentdImageTag=$9
 
     ns=f-$id
     fns=f-func-$id
 
-    helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always,analytics=false,logger.fluentdImage=$fluentdImage
+    helmVars=image=$image,imageTag=$imageTag,fetcherImage=$fetcherImage,fetcherImageTag=$fetcherImageTag,functionNamespace=$fns,controllerPort=$controllerNodeport,routerPort=$routerNodeport,pullPolicy=Always,analytics=false,logger.fluentdImage=$fluentdImage,logger.fluentdImageTag=$fluentdImageTag
 
     timeout 30 bash -c "helm_setup"
 
@@ -376,7 +377,7 @@ install_and_test() {
 
     id=$(generate_test_id)
     trap "helm_uninstall_fission $id" EXIT
-    if ! helm_install_fission $id $image $imageTag $fetcherImage $fetcherImageTag $controllerPort $routerPort $fluentdImage:$fluentdImageTag
+    if ! helm_install_fission $id $image $imageTag $fetcherImage $fetcherImageTag $controllerPort $routerPort $fluentdImage $fluentdImageTag
     then
 	dump_logs $id
 	exit 1


### PR DESCRIPTION
The test code was combining the fluentd image name and tag into a single argument when passing to `helm_install_fission" procedure like this: `$fluentdImage:$fluentdImageTag`

This worked fine until #462, after which resulting fluentd image url during tests looked like:
`gcr.io/fission-ci/fluentd:test:test` causing test failures for PRs. Helm logs show that logger could not start:

```
[kube] 2018/01/31 08:30:25 Pod is not ready: f-1ef641/logger-92lgf
[kube] 2018/01/31 08:30:29 Pod is not ready: f-1ef641/logger-92lgf
[tiller] 2018/01/31 08:30:29 warning: Release "1ef641" failed: timed out waiting for the condition
[storage] 2018/01/31 08:30:29 updating release "1ef641.v1"
[tiller] 2018/01/31 08:30:29 failed install perform step: release 1ef641 failed: timed out waiting for the condition
```

So to fix this, made usage of Fluentd image and tag inline with other image and tag usage - which changes tests and a small change in deployment & values yaml files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/469)
<!-- Reviewable:end -->
