### PR TITLE
Add glide flag to strip nested vendor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 
 script:
   - cd ${TRAVIS_BUILD_DIR}
-  - glide install
+  - glide install -v
   - ./fission-bundle/build.sh
   - hack/verify-gofmt.sh
   - hack/verify-govet.sh


### PR DESCRIPTION
Fission-bundle is not able to build once the dependencies version of `k8s.io/apiextensions-apiserver` and `k8s.io/apimachinery` in glide.lock are upgraded.

Build logs:

```
$ go build
# github.com/fission/fission/crd
../crd/client.go:70:58: cannot use config (type *"github.com/fission/fission/vendor/k8s.io/client-go/rest".Config) as type *"github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/client-go/rest".Config in argument to clientset.NewForConfig
../crd/crd.go:35:115: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".GetOptions literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".GetOptions) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".GetOptions in argument to clientset.ApiextensionsV1beta1().CustomResourceDefinitions().Get
../crd/crd.go:52:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
../crd/crd.go:68:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
../crd/crd.go:84:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
../crd/crd.go:100:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
../crd/crd.go:116:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
../crd/crd.go:132:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
../crd/crd.go:148:14: cannot use "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta literal (type "github.com/fission/fission/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta) as type "github.com/fission/fission/vendor/k8s.io/apiextensions-apiserver/vendor/k8s.io/apimachinery/pkg/apis/meta/v1".ObjectMeta in field value
```

This PR adds `--strip-vendor (-v)` to travis.yml when installing dependencies. 
For more information about the flag, please check [Dependency Flattening](https://glide.readthedocs.io/en/stable/getting-started/)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/480)
<!-- Reviewable:end -->
