### PR TITLE
Removed limit on max number of channels in NATS Streaming deployment

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -460,7 +460,11 @@ spec:
       containers:
       - name: nats-streaming
         image: nats-streaming
-        args: ["--cluster_id", "{{ .Values.nats.clusterID }}", "--auth", "{{ .Values.nats.authToken }}"]
+        args: [
+          "--cluster_id", "{{ .Values.nats.clusterID }}",
+          "--auth", "{{ .Values.nats.authToken }}",
+          "--max_channels", "0"
+        ]
         ports:
         - containerPort: 4222
           hostPort: 4222


### PR DESCRIPTION
This change removes the artificial limit in place for the number channels that NATS streaming defaults to. We need this because we use this deployment of NATS streaming for Fission Workflows - creating channels to group events of workflow invocations together. Unfortunately, channels are not yet deletable in NATS Streaming (though they are working on it), which causes us to hit this limit eventually. Performance-wise there does not seem to be a performance impact going beyond this default limit.

For details on the arguments see https://hub.docker.com/_/nats-streaming/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/482)
<!-- Reviewable:end -->
