### PR TITLE
Fix possible context leak problem

### DIFF
--- a/fission/spec.go
+++ b/fission/spec.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -33,8 +34,6 @@ import (
 	"github.com/satori/go.uuid"
 	"github.com/urfave/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"io/ioutil"
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/controller/client"

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -420,7 +420,7 @@ func specApply(c *cli.Context) error {
 		checkErr(err, "read specs")
 
 		// make changes to the cluster based on the specs
-		pkgMetas, as, err := apply(fclient, specDir, fr, deleteResources)
+		pkgMetas, as, err := applyResources(fclient, specDir, fr, deleteResources)
 		checkErr(err, "apply specs")
 		printApplyStatus(as)
 
@@ -534,7 +534,7 @@ func specDestroy(c *cli.Context) error {
 	emptyFr.deploymentConfig = fr.deploymentConfig
 
 	// "apply" the empty state
-	_, _, err = apply(fclient, specDir, &emptyFr, true)
+	_, _, err = applyResources(fclient, specDir, &emptyFr, true)
 	checkErr(err, "delete resources")
 
 	return nil
@@ -609,8 +609,8 @@ func applyArchives(fclient *client.Client, specDir string, fr *FissionResources)
 	return nil
 }
 
-// apply applies the given set of fission resources.
-func apply(fclient *client.Client, specDir string, fr *FissionResources, delete bool) (map[string]metav1.ObjectMeta, map[string]resourceApplyStatus, error) {
+// applyResources applies the given set of fission resources.
+func applyResources(fclient *client.Client, specDir string, fr *FissionResources, delete bool) (map[string]metav1.ObjectMeta, map[string]resourceApplyStatus, error) {
 
 	applyStatus := make(map[string]resourceApplyStatus)
 

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -420,7 +420,7 @@ func specApply(c *cli.Context) error {
 		checkErr(err, "read specs")
 
 		// make changes to the cluster based on the specs
-		pkgMeta, as, err := apply(fclient, specDir, fr, deleteResources)
+		pkgMetas, as, err := apply(fclient, specDir, fr, deleteResources)
 		checkErr(err, "apply specs")
 		printApplyStatus(as)
 
@@ -429,7 +429,7 @@ func specApply(c *cli.Context) error {
 		if watchResources || waitForBuild {
 			// watch package builds
 			ctx, pkgWatchCancel = context.WithCancel(context.Background())
-			pbw.addPackages(pkgMeta)
+			pbw.addPackages(pkgMetas)
 		}
 
 		if watchResources {

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -34,10 +34,11 @@ import (
 	"github.com/urfave/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"io/ioutil"
+
 	"github.com/fission/fission"
 	"github.com/fission/fission/controller/client"
 	"github.com/fission/fission/crd"
-	"io/ioutil"
 )
 
 const SPEC_API_VERSION = "fission.io/v1"
@@ -441,6 +442,7 @@ func specApply(c *cli.Context) error {
 		}
 
 		if !watchResources {
+			pkgWatchCancel()
 			break
 		}
 


### PR DESCRIPTION
Go vet logs
```
$ ./hack/verify-govet.sh
./fission/spec.go:431: the pkgWatchCancel function is not used on all paths (possible context leak)
./fission/spec.go:473: this return statement may be reached without using the pkgWatchCancel var defined on line 431
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/483)
<!-- Reviewable:end -->
