### PR TITLE
Fix potential nil pointer problem

### DIFF
--- a/fission/spec.go
+++ b/fission/spec.go
@@ -424,13 +424,12 @@ func specApply(c *cli.Context) error {
 		checkErr(err, "apply specs")
 		printApplyStatus(as)
 
-		var ctx context.Context
-		var pkgWatchCancel context.CancelFunc
 		if watchResources || waitForBuild {
 			// watch package builds
-			ctx, pkgWatchCancel = context.WithCancel(context.Background())
 			pbw.addPackages(pkgMetas)
 		}
+
+		ctx, pkgWatchCancel := context.WithCancel(context.Background())
 
 		if watchResources {
 			// if we're watching for files, we don't need to wait for builds to complete


### PR DESCRIPTION
Fix potential nil pointer problem when both watchResources and waitForBuild are equal to false.
I moved L431 out of if condition, it's more clean and easy to understand.

https://github.com/fission/fission/blob/fe9453a92eec70ff63dd38166da84e7d85c7381e/fission/spec.go#L427-L433

https://github.com/fission/fission/blob/fe9453a92eec70ff63dd38166da84e7d85c7381e/fission/spec.go#L443-L446

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/485)
<!-- Reviewable:end -->
