### PR TITLE
CI modifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ services:
 before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
 
 install:
   - go get github.com/Masterminds/glide

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 
 dist: trusty
 
+branches:
+  only:
+  - master
+
 language: go
 
 go:
@@ -14,10 +18,6 @@ cache:
 
 services:
   - docker
-
-#branches:
-#  only:
-#  - master
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,10 @@ cache:
 services:
   - docker
 
+#branches:
+#  only:
+#  - master
+
 before_install:
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -169,7 +169,7 @@ spec:
             port: "8888"
           initialDelaySeconds: 5
           periodSeconds: 2
-         livenessProbe:
+        livenessProbe:
           httpGet:
             path: "/router-healthz"
             port: "8888"
@@ -226,7 +226,7 @@ spec:
             port: "8888"
           initialDelaySeconds: 5
           periodSeconds: 2
-         livenessProbe:
+        livenessProbe:
           httpGet:
             path: "/healthz"
             port: "8888"

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -129,6 +129,18 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
+        readinessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
 
 ---
@@ -151,6 +163,18 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}"]
+        readinessProbe:
+          httpGet:
+            path: "/router-healthz"
+            port: "8888"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+         livenessProbe:
+          httpGet:
+            path: "/router-healthz"
+            port: "8888"
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
 
 ---
@@ -196,6 +220,18 @@ spec:
           value: "{{ .Values.pullPolicy }}"
         - name: RUNTIME_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        readinessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+         livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -132,13 +132,13 @@ spec:
         readinessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 5
           periodSeconds: 2
         livenessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 16
           periodSeconds: 5
       serviceAccount: fission-svc
@@ -166,13 +166,13 @@ spec:
         readinessProbe:
           httpGet:
             path: "/router-healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 5
           periodSeconds: 2
         livenessProbe:
           httpGet:
             path: "/router-healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 16
           periodSeconds: 5
       serviceAccount: fission-svc
@@ -223,13 +223,13 @@ spec:
         readinessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 5
           periodSeconds: 2
         livenessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 16
           periodSeconds: 5
       serviceAccount: fission-svc

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -133,13 +133,14 @@ spec:
           httpGet:
             path: "/healthz"
             port: 8888
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
             port: 8888
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
 
@@ -167,13 +168,14 @@ spec:
           httpGet:
             path: "/router-healthz"
             port: 8888
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/router-healthz"
             port: 8888
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
 
@@ -224,13 +226,14 @@ spec:
           httpGet:
             path: "/healthz"
             port: 8888
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
             port: 8888
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
 
@@ -563,13 +566,14 @@ spec:
           httpGet:
             path: "/healthz"
             port: 8000
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
             port: 8000
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
       volumes:

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -559,6 +559,18 @@ spec:
         volumeMounts:
         - name: fission-storage
           mountPath: /fission
+        readinessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 8000
+          initialDelaySeconds: 5
+          periodSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 8000
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
       volumes:
       - name: fission-storage

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -129,6 +129,18 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
+        readinessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
 
 ---
@@ -151,6 +163,18 @@ spec:
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}"]
+        readinessProbe:
+          httpGet:
+            path: "/router-healthz"
+            port: "8888"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: "/router-healthz"
+            port: "8888"
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
 
 ---
@@ -194,6 +218,18 @@ spec:
           value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        readinessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 5
+          periodSeconds: 2
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: "8888"
+          initialDelaySeconds: 16
+          periodSeconds: 5
       serviceAccount: fission-svc
 
 ---

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -133,13 +133,14 @@ spec:
           httpGet:
             path: "/healthz"
             port: "8888"
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
             port: "8888"
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
 
@@ -167,13 +168,14 @@ spec:
           httpGet:
             path: "/router-healthz"
             port: "8888"
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/router-healthz"
             port: "8888"
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
 
@@ -222,13 +224,14 @@ spec:
           httpGet:
             path: "/healthz"
             port: "8888"
-          initialDelaySeconds: 5
-          periodSeconds: 2
+          initialDelaySeconds: 1
+          periodSeconds: 1
+          failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
             port: "8888"
-          initialDelaySeconds: 16
+          initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
 

--- a/common.go
+++ b/common.go
@@ -18,9 +18,25 @@ package fission
 
 import (
 	"fmt"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"syscall"
 )
 
 func UrlForFunction(name string) string {
 	prefix := "/fission-function"
 	return fmt.Sprintf("%v/%v", prefix, name)
+}
+
+func SetupStackTraceHandler() {
+	// register signal handler for dumping stack trace.
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGTERM)
+	go func() {
+		<-c
+		fmt.Println("Received SIGTERM : Dumping stack trace")
+		debug.PrintStack()
+		os.Exit(1)
+	}()
 }

--- a/controller/api.go
+++ b/controller/api.go
@@ -128,7 +128,7 @@ func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request
 	api.respondWithError(w, err)
 }
 
-func (api *API) HealthHandler (w http.ResponseWriter, r *http.Request) {
+func (api *API) HealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/controller/api.go
+++ b/controller/api.go
@@ -128,8 +128,13 @@ func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request
 	api.respondWithError(w, err)
 }
 
+func (api *API) HealthHandler (w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 func (api *API) Serve(port int) {
 	r := mux.NewRouter()
+	r.HandleFunc("/healthz", api.HealthHandler).Methods("GET")
 	// Give a useful error message if an older CLI attempts to make a request
 	r.HandleFunc(`/v1/{rest:[a-zA-Z0-9=\-\/]+}`, api.ApiVersionMismatchHandler)
 	r.HandleFunc("/", api.HomeHandler)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -18,11 +18,28 @@ package controller
 
 import (
 	"log"
+	"os/signal"
+	"syscall"
+	"os"
+	"runtime/debug"
 
 	"github.com/fission/fission/crd"
 )
 
+func dumpStackTrace() {
+	debug.PrintStack()
+}
+
 func Start(port int) {
+	// register signal handler for dumping stack trace.
+	c := make(chan os.Signal, 1)
+    	signal.Notify(c, syscall.SIGTERM)
+    	go func() {
+		<-c
+		dumpStackTrace()
+		os.Exit(1)
+    	}()
+
 	fc, _, apiExtClient, err := crd.MakeFissionClient()
 	if err != nil {
 		log.Fatalf("Failed to connect to K8s API: %v", err)

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -36,6 +36,7 @@ func Start(port int) {
     	signal.Notify(c, syscall.SIGTERM)
     	go func() {
 		<-c
+		log.Println("Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
     	}()

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -18,28 +18,14 @@ package controller
 
 import (
 	"log"
-	"os"
-	"os/signal"
-	"runtime/debug"
-	"syscall"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
-func dumpStackTrace() {
-	debug.PrintStack()
-}
-
 func Start(port int) {
-	// register signal handler for dumping stack trace.
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGTERM)
-	go func() {
-		<-c
-		log.Println("Received SIGTERM : Dumping stack trace")
-		dumpStackTrace()
-		os.Exit(1)
-	}()
+	// setup a signal handler for SIGTERM
+	fission.SetupStackTraceHandler()
 
 	fc, _, apiExtClient, err := crd.MakeFissionClient()
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -36,7 +36,7 @@ func Start(port int) {
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Println("Recived SIGTERM : Dumping stack trace")
+		log.Println("Received SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -18,10 +18,10 @@ package controller
 
 import (
 	"log"
-	"os/signal"
-	"syscall"
 	"os"
+	"os/signal"
 	"runtime/debug"
+	"syscall"
 
 	"github.com/fission/fission/crd"
 )
@@ -33,13 +33,13 @@ func dumpStackTrace() {
 func Start(port int) {
 	// register signal handler for dumping stack trace.
 	c := make(chan os.Signal, 1)
-    	signal.Notify(c, syscall.SIGTERM)
-    	go func() {
+	signal.Notify(c, syscall.SIGTERM)
+	go func() {
 		<-c
 		log.Println("Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
-    	}()
+	}()
 
 	fc, _, apiExtClient, err := crd.MakeFissionClient()
 	if err != nil {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -36,7 +36,7 @@ func Start(port int) {
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Println("Dumping stack trace")
+		log.Println("Recived SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -12,13 +12,29 @@ import (
 	"os"
 	"strconv"
 	"time"
+	"os/signal"
+	"syscall"
+	"runtime/debug"
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/environments/fetcher"
 )
 
+func dumpStackTrace() {
+	debug.PrintStack()
+}
+
 // Usage: fetcher <shared volume path>
 func main() {
+	// register signal handler for dumping stack trace.
+	c := make(chan os.Signal, 1)
+    	signal.Notify(c, syscall.SIGTERM)
+    	go func() {
+		<-c
+		dumpStackTrace()
+		os.Exit(1)
+    	}()
+
 	flag.Usage = fetcherUsage
 	specializeOnStart := flag.Bool("specialize-on-startup", false, "Flag to activate specialize process at pod starup")
 	fetchPayload := flag.String("fetch-request", "", "JSON Payload for fetch request")

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -10,11 +10,11 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
-	"time"
 	"os/signal"
-	"syscall"
 	"runtime/debug"
+	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/environments/fetcher"
@@ -28,12 +28,12 @@ func dumpStackTrace() {
 func main() {
 	// register signal handler for dumping stack trace.
 	c := make(chan os.Signal, 1)
-    	signal.Notify(c, syscall.SIGTERM)
-    	go func() {
+	signal.Notify(c, syscall.SIGTERM)
+	go func() {
 		<-c
 		dumpStackTrace()
 		os.Exit(1)
-    	}()
+	}()
 
 	flag.Usage = fetcherUsage
 	specializeOnStart := flag.Bool("specialize-on-startup", false, "Flag to activate specialize process at pod starup")

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -31,7 +31,7 @@ func main() {
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Println("Recived SIGTERM : Dumping stack trace")
+		log.Println("Received SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -42,7 +42,10 @@ func main() {
 		}
 	}
 
-	fetcher := fetcher.MakeFetcher(dir, *secretDir, *configDir)
+	fetcher, err := fetcher.MakeFetcher(dir, *secretDir, *configDir)
+	if err != nil {
+		log.Fatalf("Error making fetcher: %v", err)
+	}
 
 	if *specializeOnStart {
 		specializePod(fetcher, fetchPayload, loadPayload)
@@ -54,6 +57,8 @@ func main() {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
+
+	log.Println("Fetcher ready to receive requests")
 	http.ListenAndServe(":8000", mux)
 }
 

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -31,6 +31,7 @@ func main() {
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
+		log.Println("Recived SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -74,14 +74,14 @@ func makeVolumeDir(dirPath string) {
 	}
 }
 
-func MakeFetcher(sharedVolumePath string, sharedSecretPath string, sharedConfigPath string) *Fetcher {
+func MakeFetcher(sharedVolumePath string, sharedSecretPath string, sharedConfigPath string) (*Fetcher, error) {
 	makeVolumeDir(sharedVolumePath)
 	makeVolumeDir(sharedSecretPath)
 	makeVolumeDir(sharedConfigPath)
 
 	fissionClient, kubeClient, _, err := crd.MakeFissionClient()
 	if err != nil {
-		return nil
+		return nil, err
 	}
 	return &Fetcher{
 		sharedVolumePath: sharedVolumePath,
@@ -89,7 +89,7 @@ func MakeFetcher(sharedVolumePath string, sharedSecretPath string, sharedConfigP
 		sharedConfigPath: sharedConfigPath,
 		fissionClient:    fissionClient,
 		kubeClient:       kubeClient,
-	}
+	}, nil
 }
 
 func downloadUrl(url string, localPath string) error {

--- a/executor/api.go
+++ b/executor/api.go
@@ -99,10 +99,15 @@ func (executor *Executor) tapService(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func (executor *Executor) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 func (executor *Executor) Serve(port int) {
 	r := mux.NewRouter()
 	r.HandleFunc("/v2/getServiceForFunction", executor.getServiceForFunctionApi).Methods("POST")
 	r.HandleFunc("/v2/tapService", executor.tapService).Methods("POST")
+	r.HandleFunc("/healthz", executor.healthHandler).Methods("GET")
 	address := fmt.Sprintf(":%v", port)
 	log.Printf("starting executor at port %v", port)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -18,12 +18,9 @@ package executor
 
 import (
 	"log"
-	"os"
-	"os/signal"
 	"runtime/debug"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/dchest/uniuri"
@@ -192,15 +189,8 @@ func dumpStackTrace() {
 // StartExecutor Starts executor and the executor components such as Poolmgr,
 // deploymgr and potential future executor types
 func StartExecutor(fissionNamespace string, functionNamespace string, port int) error {
-	// register signal handler for dumping stack trace.
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGTERM)
-	go func() {
-		<-c
-		log.Println("Received SIGTERM : Dumping stack trace")
-		dumpStackTrace()
-		os.Exit(1)
-	}()
+	// setup a signal handler for SIGTERM
+	fission.SetupStackTraceHandler()
 
 	fissionClient, kubernetesClient, _, err := crd.MakeFissionClient()
 	restClient := fissionClient.GetCrdClient()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -197,7 +197,7 @@ func StartExecutor(fissionNamespace string, functionNamespace string, port int) 
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Println("Recived SIGTERM : Dumping stack trace")
+		log.Println("Received SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -18,13 +18,13 @@ package executor
 
 import (
 	"log"
-	"strings"
-	"sync"
-	"time"
 	"os"
 	"os/signal"
-	"syscall"
 	"runtime/debug"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
 
 	"github.com/dchest/uniuri"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,12 +194,12 @@ func dumpStackTrace() {
 func StartExecutor(fissionNamespace string, functionNamespace string, port int) error {
 	// register signal handler for dumping stack trace.
 	c := make(chan os.Signal, 1)
-    	signal.Notify(c, syscall.SIGTERM)
-    	go func() {
+	signal.Notify(c, syscall.SIGTERM)
+	go func() {
 		<-c
 		dumpStackTrace()
 		os.Exit(1)
-    	}()
+	}()
 
 	fissionClient, kubernetesClient, _, err := crd.MakeFissionClient()
 	restClient := fissionClient.GetCrdClient()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -197,6 +197,7 @@ func StartExecutor(fissionNamespace string, functionNamespace string, port int) 
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
+		log.Println("Recived SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -519,7 +519,7 @@ func (gp *GenericPool) createPool() error {
 								"-secret-dir", gp.sharedSecretPath,
 								"-cfgmap-dir", gp.sharedCfgMapPath,
 								gp.sharedMountPath},
-							ReadinessProbe: &apiv1.Probe {
+							ReadinessProbe: &apiv1.Probe{
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       2,
 								Handler: apiv1.Handler{
@@ -532,7 +532,7 @@ func (gp *GenericPool) createPool() error {
 									},
 								},
 							},
-							LivenessProbe: &apiv1.Probe {
+							LivenessProbe: &apiv1.Probe{
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       5,
 								Handler: apiv1.Handler{

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -519,6 +519,32 @@ func (gp *GenericPool) createPool() error {
 								"-secret-dir", gp.sharedSecretPath,
 								"-cfgmap-dir", gp.sharedCfgMapPath,
 								gp.sharedMountPath},
+							ReadinessProbe: &apiv1.Probe {
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       2,
+								Handler: apiv1.Handler{
+									HTTPGet: &apiv1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 8000, // TODO : Find out the correct port.
+										},
+									},
+								},
+							},
+							LivenessProbe: &apiv1.Probe {
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       5,
+								Handler: apiv1.Handler{
+									HTTPGet: &apiv1.HTTPGetAction{
+										Path: "/healthz",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: 8000, // TODO : Find out the correct port.
+										},
+									},
+								},
+							},
 						},
 					},
 					ServiceAccountName: "fission-fetcher",

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -520,27 +520,28 @@ func (gp *GenericPool) createPool() error {
 								"-cfgmap-dir", gp.sharedCfgMapPath,
 								gp.sharedMountPath},
 							ReadinessProbe: &apiv1.Probe{
-								InitialDelaySeconds: 5,
-								PeriodSeconds:       2,
+								InitialDelaySeconds: 1,
+								PeriodSeconds:       1,
+								FailureThreshold:    30,
 								Handler: apiv1.Handler{
 									HTTPGet: &apiv1.HTTPGetAction{
 										Path: "/healthz",
 										Port: intstr.IntOrString{
 											Type:   intstr.Int,
-											IntVal: 8000, // TODO : Find out the correct port.
+											IntVal: 8000,
 										},
 									},
 								},
 							},
 							LivenessProbe: &apiv1.Probe{
-								InitialDelaySeconds: 5,
+								InitialDelaySeconds: 35,
 								PeriodSeconds:       5,
 								Handler: apiv1.Handler{
 									HTTPGet: &apiv1.HTTPGetAction{
 										Path: "/healthz",
 										Port: intstr.IntOrString{
 											Type:   intstr.Int,
-											IntVal: 8000, // TODO : Find out the correct port.
+											IntVal: 8000,
 										},
 									},
 								},
@@ -554,6 +555,7 @@ func (gp *GenericPool) createPool() error {
 	}
 	depl, err := gp.kubernetesClient.ExtensionsV1beta1().Deployments(gp.namespace).Create(deployment)
 	if err != nil {
+		log.Printf("Error creating deployment for %s in kubernetes, err: %v", deployment.Name, err)
 		return err
 	}
 	gp.deployment = depl

--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -89,6 +89,10 @@ func defaultHomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+func routerHealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 func (ts *HTTPTriggerSet) getRouter() *mux.Router {
 	muxRouter := mux.NewRouter()
 
@@ -149,6 +153,9 @@ func (ts *HTTPTriggerSet) getRouter() *mux.Router {
 		}
 		muxRouter.HandleFunc(fission.UrlForFunction(function.Metadata.Name), fh.handler)
 	}
+
+	// Healthz endpoint for the router.
+	muxRouter.HandleFunc("/router-healthz", routerHealthHandler).Methods("GET")
 
 	return muxRouter
 }

--- a/router/router.go
+++ b/router/router.go
@@ -84,7 +84,7 @@ func Start(port int, executorUrl string) {
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Println("Recived SIGTERM : Dumping stack trace")
+		log.Println("Received SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/router/router.go
+++ b/router/router.go
@@ -84,6 +84,7 @@ func Start(port int, executorUrl string) {
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
+		log.Println("Recived SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/router/router.go
+++ b/router/router.go
@@ -45,10 +45,10 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"time"
 	"os/signal"
-	"syscall"
 	"runtime/debug"
+	"syscall"
+	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -81,12 +81,12 @@ func dumpStackTrace() {
 func Start(port int, executorUrl string) {
 	// register signal handler for dumping stack trace.
 	c := make(chan os.Signal, 1)
-    	signal.Notify(c, syscall.SIGTERM)
-    	go func() {
+	signal.Notify(c, syscall.SIGTERM)
+	go func() {
 		<-c
 		dumpStackTrace()
 		os.Exit(1)
-    	}()
+	}()
 
 	fmap := makeFunctionServiceMap(time.Minute)
 

--- a/router/router.go
+++ b/router/router.go
@@ -45,14 +45,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"os/signal"
-	"runtime/debug"
-	"syscall"
 	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 	executorClient "github.com/fission/fission/executor/client"
 )
@@ -74,20 +72,9 @@ func serve(ctx context.Context, port int, httpTriggerSet *HTTPTriggerSet, resolv
 	http.ListenAndServe(url, handlers.LoggingHandler(os.Stdout, mr))
 }
 
-func dumpStackTrace() {
-	debug.PrintStack()
-}
-
 func Start(port int, executorUrl string) {
-	// register signal handler for dumping stack trace.
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGTERM)
-	go func() {
-		<-c
-		log.Println("Received SIGTERM : Dumping stack trace")
-		dumpStackTrace()
-		os.Exit(1)
-	}()
+	// setup a signal handler for SIGTERM
+	fission.SetupStackTraceHandler()
 
 	fmap := makeFunctionServiceMap(time.Minute)
 

--- a/storagesvc/storagesvc.go
+++ b/storagesvc/storagesvc.go
@@ -149,6 +149,10 @@ func (ss *StorageService) downloadHandler(w http.ResponseWriter, r *http.Request
 	}
 }
 
+func (ss *StorageService) healthHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+
 func MakeStorageService(storageClient *StowClient, port int) *StorageService {
 	return &StorageService{
 		storageClient: storageClient,
@@ -161,6 +165,7 @@ func (ss *StorageService) Start(port int) {
 	r.HandleFunc("/v1/archive", ss.uploadHandler).Methods("POST")
 	r.HandleFunc("/v1/archive", ss.downloadHandler).Methods("GET")
 	r.HandleFunc("/v1/archive", ss.deleteHandler).Methods("DELETE")
+	r.HandleFunc("/healthz", ss.healthHandler).Methods("GET")
 
 	address := fmt.Sprintf(":%v", port)
 	log.Fatal(http.ListenAndServe(address, handlers.LoggingHandler(os.Stdout, r)))

--- a/storagesvc/storagesvc.go
+++ b/storagesvc/storagesvc.go
@@ -22,12 +22,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/signal"
-	"runtime/debug"
 	"strconv"
-	"syscall"
 	"time"
 
+	"github.com/fission/fission"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	_ "github.com/graymeta/stow/local"
@@ -174,20 +172,9 @@ func (ss *StorageService) Start(port int) {
 	log.Fatal(http.ListenAndServe(address, handlers.LoggingHandler(os.Stdout, r)))
 }
 
-func dumpStackTrace() {
-	debug.PrintStack()
-}
-
 func RunStorageService(storageType StorageType, storagePath string, containerName string, port int, enablePruner bool) *StorageService {
-	// register signal handler for dumping stack trace.
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGTERM)
-	go func() {
-		<-c
-		log.Println("Received SIGTERM : Dumping stack trace")
-		dumpStackTrace()
-		os.Exit(1)
-	}()
+	// setup a signal handler for SIGTERM
+	fission.SetupStackTraceHandler()
 
 	// initialize logger
 	log.SetLevel(log.InfoLevel)

--- a/storagesvc/storagesvc.go
+++ b/storagesvc/storagesvc.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"strconv"
-	"time"
 	"os/signal"
-	"syscall"
 	"runtime/debug"
+	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -181,12 +181,12 @@ func dumpStackTrace() {
 func RunStorageService(storageType StorageType, storagePath string, containerName string, port int, enablePruner bool) *StorageService {
 	// register signal handler for dumping stack trace.
 	c := make(chan os.Signal, 1)
-    	signal.Notify(c, syscall.SIGTERM)
-    	go func() {
+	signal.Notify(c, syscall.SIGTERM)
+	go func() {
 		<-c
 		dumpStackTrace()
 		os.Exit(1)
-    	}()
+	}()
 
 	// initialize logger
 	log.SetLevel(log.InfoLevel)

--- a/storagesvc/storagesvc.go
+++ b/storagesvc/storagesvc.go
@@ -184,6 +184,7 @@ func RunStorageService(storageType StorageType, storagePath string, containerNam
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
+		log.Println("Recived SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/storagesvc/storagesvc.go
+++ b/storagesvc/storagesvc.go
@@ -184,7 +184,7 @@ func RunStorageService(storageType StorageType, storagePath string, containerNam
 	signal.Notify(c, syscall.SIGTERM)
 	go func() {
 		<-c
-		log.Println("Recived SIGTERM : Dumping stack trace")
+		log.Println("Received SIGTERM : Dumping stack trace")
 		dumpStackTrace()
 		os.Exit(1)
 	}()

--- a/storagesvc/stowClient.go
+++ b/storagesvc/stowClient.go
@@ -60,6 +60,7 @@ var (
 )
 
 func MakeStowClient(storageType StorageType, storagePath string, containerName string) (*StowClient, error) {
+	log.Infof("start : MakeStowClient")
 	if storageType != StorageTypeLocal {
 		return nil, errors.New("Storage types other than 'local' are not implemented")
 	}
@@ -104,6 +105,7 @@ func MakeStowClient(storageType StorageType, storagePath string, containerName s
 	}
 	stowClient.container = con
 
+	log.Infof("end : MakeStowClient")
 	return stowClient, nil
 }
 

--- a/storagesvc/stowClient.go
+++ b/storagesvc/stowClient.go
@@ -60,7 +60,6 @@ var (
 )
 
 func MakeStowClient(storageType StorageType, storagePath string, containerName string) (*StowClient, error) {
-	log.Infof("start : MakeStowClient")
 	if storageType != StorageTypeLocal {
 		return nil, errors.New("Storage types other than 'local' are not implemented")
 	}
@@ -105,7 +104,6 @@ func MakeStowClient(storageType StorageType, storagePath string, containerName s
 	}
 	stowClient.container = con
 
-	log.Infof("end : MakeStowClient")
 	return stowClient, nil
 }
 

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -20,19 +20,19 @@ PRUNE_INTERVAL=1 # this variable controls the interval to run archivePruner. The
 
 dump_system_info
 
-#build_and_push_fission_bundle $IMAGE:$TAG
-#
-#build_and_push_fetcher $FETCHER_IMAGE:$TAG
-#
-#build_and_push_builder $BUILDER_IMAGE:$TAG
-#
-#ENV='python'
-#
-#build_and_push_env_runtime $ENV $REPO/$ENV-env:$TAG
-#
-#build_and_push_env_builder $ENV $REPO/$ENV-env-builder:$TAG $BUILDER_IMAGE:$TAG
-#
-#build_and_push_fluentd $FLUENTD_IMAGE:$TAG
+build_and_push_fission_bundle $IMAGE:$TAG
+
+build_and_push_fetcher $FETCHER_IMAGE:$TAG
+
+build_and_push_builder $BUILDER_IMAGE:$TAG
+
+ENV='python'
+
+build_and_push_env_runtime $ENV $REPO/$ENV-env:$TAG
+
+build_and_push_env_builder $ENV $REPO/$ENV-env-builder:$TAG $BUILDER_IMAGE:$TAG
+
+build_and_push_fluentd $FLUENTD_IMAGE:$TAG
 
 build_fission_cli
 

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -20,19 +20,19 @@ PRUNE_INTERVAL=1 # this variable controls the interval to run archivePruner. The
 
 dump_system_info
 
-build_and_push_fission_bundle $IMAGE:$TAG
-
-build_and_push_fetcher $FETCHER_IMAGE:$TAG
-
-build_and_push_builder $BUILDER_IMAGE:$TAG
-
-ENV='python'
-
-build_and_push_env_runtime $ENV $REPO/$ENV-env:$TAG
-
-build_and_push_env_builder $ENV $REPO/$ENV-env-builder:$TAG $BUILDER_IMAGE:$TAG
-
-build_and_push_fluentd $FLUENTD_IMAGE:$TAG
+#build_and_push_fission_bundle $IMAGE:$TAG
+#
+#build_and_push_fetcher $FETCHER_IMAGE:$TAG
+#
+#build_and_push_builder $BUILDER_IMAGE:$TAG
+#
+#ENV='python'
+#
+#build_and_push_env_runtime $ENV $REPO/$ENV-env:$TAG
+#
+#build_and_push_env_builder $ENV $REPO/$ENV-env-builder:$TAG $BUILDER_IMAGE:$TAG
+#
+#build_and_push_fluentd $FLUENTD_IMAGE:$TAG
 
 build_fission_cli
 

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -36,4 +36,4 @@ build_and_push_fluentd $FLUENTD_IMAGE:$TAG
 
 build_fission_cli
 
-install_and_test $IMAGE $TAG $FETCHER_IMAGE $TAG $FLUENTD_IMAGE $TAG $PRUNE_INTERVAL | while read line; do echo -e "$(tstamp)\t$line"; done
+install_and_test $IMAGE $TAG $FETCHER_IMAGE $TAG $FLUENTD_IMAGE $TAG $PRUNE_INTERVAL

--- a/test/build_and_test.sh
+++ b/test/build_and_test.sh
@@ -36,4 +36,4 @@ build_and_push_fluentd $FLUENTD_IMAGE:$TAG
 
 build_fission_cli
 
-install_and_test $IMAGE $TAG $FETCHER_IMAGE $TAG $FLUENTD_IMAGE $TAG $PRUNE_INTERVAL
+install_and_test $IMAGE $TAG $FETCHER_IMAGE $TAG $FLUENTD_IMAGE $TAG $PRUNE_INTERVAL | while read line; do echo -e "$(tstamp)\t$line"; done

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -255,12 +255,13 @@ helm_uninstall_fission() {(set +e
 	echo "Fission uninstallation skipped"
 	return
     fi
-    echo "Uninstalling fission"
-    helm delete --purge $id
 
-    kubectl delete ns f-$id
     dump_kubernetes_events $id
     dump_tiller_logs
+
+    echo "Uninstalling fission"
+    helm delete --purge $id
+    kubectl delete ns f-$id
 )}
 export -f helm_uninstall_fission
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -243,7 +243,7 @@ dump_kubernetes_events() {
 dump_tiller_logs() {
     echo "--- tiller logs ---"
     tiller_pod=`kubectl get pods -n kube-system | grep tiller| tr -s " "| cut -d" " -f1`
-    kubectl logs $tiller_pod -n kube-system
+    kubectl logs $tiller_pod --since=30m -n kube-system
     echo "--- end tiller logs ---"
 }
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -435,7 +435,7 @@ install_and_test() {
     clean_tpr_crd_resources
 
     id=$(generate_test_id)
-    trap "helm_uninstall_fission $id" EXIT
+    #trap "helm_uninstall_fission $id" EXIT
     if ! helm_install_fission $id $image $imageTag $fetcherImage $fetcherImageTag $controllerPort $routerPort $fluentdImage $fluentdImageTag $pruneInterval
     then
 	dump_logs $id

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -206,7 +206,7 @@ wait_for_service() {
         if [ -z $ip ]; then
             continue
         fi
-        echo "IP for $svc : $ip"
+        echo "IP for $svc : $ip, healthendpoint : $health_endpoint"
         http_status=`curl -sw "%{http_code}" "http://$ip/$health_endpoint"`
         echo "http_status for svc $svc : $http_status"
         if [ "$http_status" -ne "200" ]; then
@@ -258,9 +258,6 @@ helm_uninstall_fission() {(set +e
 	echo "Fission uninstallation skipped"
 	return
     fi
-
-    dump_kubernetes_events $id
-    dump_tiller_logs
 
     echo "Uninstalling fission"
     helm delete --purge $id
@@ -442,6 +439,8 @@ install_and_test() {
     if ! helm_install_fission $id $image $imageTag $fetcherImage $fetcherImageTag $controllerPort $routerPort $fluentdImage $fluentdImageTag $pruneInterval
     then
 	dump_logs $id
+	dump_kubernetes_events $id
+    dump_tiller_logs
 	exit 1
     fi
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -239,6 +239,7 @@ dump_kubernetes_events() {
     kubectl get events -n $ns
     echo "--- end kubectl events $ns ---"
 }
+export -f dump_kubernetes_events
 
 dump_tiller_logs() {
     echo "--- tiller logs ---"
@@ -246,6 +247,8 @@ dump_tiller_logs() {
     kubectl logs $tiller_pod --since=30m -n kube-system
     echo "--- end tiller logs ---"
 }
+export -f dump_tiller_logs
+
 
 helm_uninstall_fission() {(set +e
     id=$1

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -177,7 +177,7 @@ helm_install_fission() {
     echo "Installing fission"
     helm install		\
 	 --wait			\
-	 --timeout 600	        \
+	 --timeout 540	        \
 	 --name $id		\
 	 --set $helmVars	\
 	 --namespace $ns        \
@@ -190,28 +190,61 @@ helm_install_fission() {
 wait_for_service() {
     id=$1
     svc=$2
+    health_endpoint=$3
 
     ns=f-$id
+    retry=0
+    max_retries=5
     while true
     do
-	ip=$(kubectl -n $ns get svc $svc -o jsonpath='{...ip}')
-	if [ ! -z $ip ]
-	then
-	    break
-	fi
-	echo Waiting for service $svc...
-	sleep 1
+        retry=$((retry+1))
+        if ((retry == max_retries)); then
+            echo "Waiting for $svc to be routable exceeded max retries. Quitting.."
+            exit 1
+        fi
+        ip=$(kubectl -n $ns get svc $svc -o jsonpath='{...ip}')
+        if [ -z $ip ]; then
+            continue
+        fi
+        echo "IP for $svc : $ip"
+        http_status=`curl -sw "%{http_code}" "http://$ip/$health_endpoint"`
+        echo "http_status for svc $svc : $http_status"
+        if [ "$http_status" -ne "200" ]; then
+            echo "Service $svc returned response other than 200. waiting for 200 after backing off for 1 second"
+            sleep 1
+        else
+            break
+        fi
     done
 }
 
 wait_for_services() {
     id=$1
 
-    wait_for_service $id controller
-    wait_for_service $id router
+    wait_for_service $id controller "healthz"
+    wait_for_service $id router "router-healthz"
 
-    echo Waiting for service is routable...
-    sleep 10
+    echo "Controller and router services are routable"
+}
+
+dump_kubernetes_events() {
+    id=$1
+    ns=f-$id
+    fns=f-func-$id
+    echo "--- kubectl events $fns ---"
+    kubectl get events -n $fns
+    echo "--- end kubectl events $fns ---"
+
+    echo "--- kubectl events $ns ---"
+    kubectl get events -n $ns
+    echo "--- end kubectl events $ns ---"
+}
+
+dump_tiller_logs() {
+    echo "--- tiller logs ---"
+    tiller_pod=`kubectl get pods -n kube-system | grep tiller| tr -s " "| cut -d" " -f1`
+    kubectl logs $tiller_pod -n kube-system
+    echo "--- end tiller logs ---"
 }
 
 helm_uninstall_fission() {(set +e
@@ -226,6 +259,8 @@ helm_uninstall_fission() {(set +e
     helm delete --purge $id
 
     kubectl delete ns f-$id
+    dump_kubernetes_events $id
+    dump_tiller_logs
 )}
 export -f helm_uninstall_fission
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -379,7 +379,7 @@ dump_logs() {
     dump_fission_logs $ns $fns router
     dump_fission_logs $ns $fns buildermgr
     dump_fission_logs $ns $fns executor
-    dump_fission_logs $ns $fns storagsvc
+    dump_fission_logs $ns $fns storagesvc
     dump_function_pod_logs $ns $fns
     dump_builder_pod_logs $bns
     dump_fission_crds

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -174,6 +174,9 @@ helm_install_fission() {
     echo "Deleting old releases"
     helm list -q|xargs -I@ bash -c "helm_uninstall_fission @"
 
+    # deleting ns does take a while after command is issued.
+    sleep 45
+
     echo "Installing fission"
     helm install		\
 	 --wait			\
@@ -261,7 +264,9 @@ helm_uninstall_fission() {(set +e
 
     echo "Uninstalling fission"
     helm delete --purge $id
-    kubectl delete ns f-$id
+    kubectl delete ns f-$id || true
+    kubectl delete ns f-func-$id || true
+    kubectl delete ns fission-builder || true
 )}
 export -f helm_uninstall_fission
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -264,9 +264,9 @@ helm_uninstall_fission() {(set +e
 
     echo "Uninstalling fission"
     helm delete --purge $id
-    kubectl delete ns f-$id || true
-    kubectl delete ns f-func-$id || true
-    kubectl delete ns fission-builder || true
+#    kubectl delete ns f-$id || true
+#    kubectl delete ns f-func-$id || true
+#    kubectl delete ns fission-builder || true
 )}
 export -f helm_uninstall_fission
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -171,8 +171,8 @@ helm_install_fission() {
 
     timeout 30 bash -c "helm_setup"
 
-#    echo "Deleting old releases"
-#    helm list -q|xargs -I@ bash -c "helm_uninstall_fission @"
+    echo "Deleting old releases"
+    helm list -q|xargs -I@ bash -c "helm_uninstall_fission @"
 
     echo "Installing fission"
     helm install		\

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -171,8 +171,8 @@ helm_install_fission() {
 
     timeout 30 bash -c "helm_setup"
 
-    echo "Deleting old releases"
-    helm list -q|xargs -I@ bash -c "helm_uninstall_fission @"
+#    echo "Deleting old releases"
+#    helm list -q|xargs -I@ bash -c "helm_uninstall_fission @"
 
     echo "Installing fission"
     helm install		\
@@ -379,7 +379,7 @@ dump_logs() {
     dump_fission_logs $ns $fns router
     dump_fission_logs $ns $fns buildermgr
     dump_fission_logs $ns $fns executor
-    dump_fission_logs $ns $fn storagsvc
+    dump_fission_logs $ns $fns storagsvc
     dump_function_pod_logs $ns $fns
     dump_builder_pod_logs $bns
     dump_fission_crds

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -379,6 +379,7 @@ dump_logs() {
     dump_fission_logs $ns $fns router
     dump_fission_logs $ns $fns buildermgr
     dump_fission_logs $ns $fns executor
+    dump_fission_logs $ns $fn storagsvc
     dump_function_pod_logs $ns $fns
     dump_builder_pod_logs $bns
     dump_fission_crds

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -264,9 +264,7 @@ helm_uninstall_fission() {(set +e
 
     echo "Uninstalling fission"
     helm delete --purge $id
-#    kubectl delete ns f-$id || true
-#    kubectl delete ns f-func-$id || true
-#    kubectl delete ns fission-builder || true
+    kubectl delete ns f-$id || true
 )}
 export -f helm_uninstall_fission
 
@@ -284,7 +282,7 @@ set_environment() {
 dump_builder_pod_logs() {
     bns=$1
     builderPods=$(kubectl -n $bns get pod -o name)
-    
+
     for p in $builderPods
     do
     echo "--- builder pod logs $p ---"
@@ -359,6 +357,7 @@ dump_all_fission_resources() {
 
     echo "--- All objects in the fission namespace $ns ---"
     kubectl -n $ns get all
+    kubectl -n $ns get pods -o wide
     echo "--- End objects in the fission namespace $ns ---"
 }
 

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -352,6 +352,23 @@ dump_env_pods() {
     echo --- End environment pods ---
 }
 
+describe_pods_ns() {
+    echo "--- describe pods $1---"
+    kubect describe pods -n $1
+    echo "--- End describe pods $1 ---"
+}
+
+describe_all_pods() {
+    id=$1
+    ns=f-$id
+    fns=f-func-$id
+    bns=fission-builder
+
+    describe_pods_ns $ns
+    describe_pods_ns $fns
+    describe_pods_ns $bns
+}
+
 dump_all_fission_resources() {
     ns=$1
 
@@ -387,6 +404,11 @@ dump_logs() {
     dump_function_pod_logs $ns $fns
     dump_builder_pod_logs $bns
     dump_fission_crds
+}
+
+DATE='date +%Y/%m/%d:%H:%M:%S'
+echo_log() {
+    echo `$DATE`" $1"
 }
 
 export FAILURES=0
@@ -460,6 +482,8 @@ install_and_test() {
 
     if [ $FAILURES -ne 0 ]
     then
+    # describe each pod in fission ns and function namespace
+
 	exit 1
     fi
 }

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -59,7 +59,7 @@ build_and_push_fission_bundle() {
 
     pushd $ROOT/fission-bundle
     ./build.sh
-    docker build -t $image_tag .
+    docker build -q -t $image_tag .
 
     gcloud_login
 
@@ -72,7 +72,7 @@ build_and_push_fetcher() {
 
     pushd $ROOT/environments/fetcher/cmd
     ./build.sh
-    docker build -t $image_tag .
+    docker build -q -t $image_tag .
 
     gcloud_login
 
@@ -86,7 +86,7 @@ build_and_push_builder() {
 
     pushd $ROOT/builder/cmd
     ./build.sh
-    docker build -t $image_tag .
+    docker build -q -t $image_tag .
 
     gcloud_login
 
@@ -98,7 +98,7 @@ build_and_push_fluentd(){
     image_tag=$1
 
     pushd $ROOT/logger/fluentd
-    docker build -t $image_tag .
+    docker build -q -t $image_tag .
 
     gcloud_login
 
@@ -112,7 +112,7 @@ build_and_push_env_runtime() {
     image_tag=$2
 
     pushd $ROOT/environments/$env/
-    docker build -t $image_tag .
+    docker build -q -t $image_tag .
 
     gcloud_login
 
@@ -127,7 +127,7 @@ build_and_push_env_builder() {
 
     pushd $ROOT/environments/$env/builder
 
-    docker build -t $image_tag --build-arg BUILDER_IMAGE=${builder_image} .
+    docker build -q -t $image_tag --build-arg BUILDER_IMAGE=${builder_image} .
 
     gcloud_login
 
@@ -461,7 +461,7 @@ install_and_test() {
     clean_tpr_crd_resources
 
     id=$(generate_test_id)
-    #trap "helm_uninstall_fission $id" EXIT
+    trap "helm_uninstall_fission $id" EXIT
     if ! helm_install_fission $id $image $imageTag $fetcherImage $fetcherImageTag $controllerPort $routerPort $fluentdImage $fluentdImageTag $pruneInterval
     then
 	describe_all_pods $id

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -208,7 +208,6 @@ wait_for_service() {
         if [ -z $ip ]; then
             continue
         fi
-        echo "IP for $svc : $ip, healthendpoint : $health_endpoint"
         http_status=`curl -sw "%{http_code}" "http://$ip/$health_endpoint"`
         echo "http_status for svc $svc : $http_status"
         if [ "$http_status" -ne "200" ]; then
@@ -223,10 +222,10 @@ wait_for_service() {
 wait_for_services() {
     id=$1
 
+    echo "\n--- wait for controller and router services to be routable ---"
     wait_for_service $id controller "healthz"
     wait_for_service $id router "router-healthz"
-
-    echo "Controller and router services are routable"
+    echo "\n--- end wait for controller and router services to be routable ---"
 }
 
 dump_kubernetes_events() {
@@ -373,6 +372,7 @@ dump_all_fission_resources() {
 
     echo "--- All objects in the fission namespace $ns ---"
     kubectl -n $ns get pods -o wide
+    echo ""
     kubectl -n $ns get svc
     echo "--- End objects in the fission namespace $ns ---"
 }

--- a/test/tests/test_archive_pruner.sh
+++ b/test/tests/test_archive_pruner.sh
@@ -16,7 +16,7 @@ cleanup() {
 }
 
 create_archive() {
-    echo "Creating an archive"
+    echo_log "Creating an archive"
     mkdir test_dir
     dd if=/dev/urandom of=test_dir/dynamically_generated_file bs=256k count=1
     printf 'def main():\n    return "Hello, world!"' > test_dir/hello.py
@@ -24,17 +24,17 @@ create_archive() {
 }
 
 create_package() {
-    echo "Creating package"
+    echo_log "Creating package"
     pkg=$(fission package create --deploy "test-deploy-pkg.zip" --env python| cut -f2 -d' '| tr -d \')
 }
 
 delete_package() {
-    echo "Deleting package: $1"
+    echo_log "Deleting package: $1"
     fission package delete --name $1
 }
 
 get_archive_url_from_package() {
-    echo "Getting archive URL from package: $1"
+    echo_log "Getting archive URL from package: $1"
     url=`kubectl get package $1 -ojsonpath='{.spec.deployment.url}'`
 }
 
@@ -42,76 +42,76 @@ get_archive_from_storage() {
     http_status=`curl -sw "%{http_code}" $1 -o /tmp/file`
 }
 
-#1. declare trap to cleanup for all the required signals
-#2. create an archives with large files such that total size of archive is > 256KB
+#1. declare trap to cleanup for EXIT
+#2. create an archive with large files such that total size of archive is > 256KB
 #3. create 2 pkgs referencing those archives
 #4. delete both the packages
 #5. verify archives are not recycled . this handles the case where archives are just created but not referenced by pkgs yet.
 #6. sleep for two minutes
-#7. now verify that both get deleted.
+#7. now verify that both got deleted.
 main() {
     # trap
     trap cleanup EXIT
 
     # create a huge archive
     create_archive
-    echo "created archive test-deploy-pkg.zip"
+    echo_log "created archive test-deploy-pkg.zip"
 
     # create packages with the huge archive
     create_package
     pkg_1=$pkg
     get_archive_url_from_package $pkg_1
     url_1=$url
-    echo "pkg: $pkg_1, archive_url : $url_1"
+    echo_log "pkg: $pkg_1, archive_url : $url_1"
 
     create_package
     pkg_2=$pkg
     get_archive_url_from_package $pkg_2
     url_2=$url
-    echo "pkg: $pkg_2, archive_url : $url_2"
+    echo_log "pkg: $pkg_2, archive_url : $url_2"
 
     # delete packages
     delete_package $pkg_1
     delete_package $pkg_2
-    echo "deleted packages : $pkg_1 $pkg_2"
+    echo_log "deleted packages : $pkg_1 $pkg_2"
 
     # curl on the archive url
     get_archive_from_storage $url_1
-    echo "http_status for $url_1 : $http_status"
+    echo_log "http_status for $url_1 : $http_status"
     if [ "$http_status" -ne "200" ]; then
-        echo "Archive $url_1 absent on storage, while expected to be present"
+        echo_log "Archive $url_1 absent on storage, while expected to be present"
         exit 1
     fi
 
     # curl on the archive url
     get_archive_from_storage $url_2
-    echo "http_status for $url_2 : $http_status"
+    echo_log "http_status for $url_2 : $http_status"
     if [ "$http_status" -ne "200" ]; then
-        echo "Archive $url_2 absent on storage, while expected to be present"
+        echo_log "Archive $url_2 absent on storage, while expected to be present"
         exit 1
     fi
 
     # archivePruner is set to run every minute for test. In production, its set to run every hour.
-    echo "waiting for packages to get recycled"
+    echo_log "waiting for packages to get recycled"
     sleep 120
 
     # curl on the archive url
     get_archive_from_storage $url_1
-    echo "http_status for $url_1 : $http_status"
+    echo_log "http_status for $url_1 : $http_status"
     if [ "$http_status" -ne "404" ]; then
-        echo "Archive $url_1 should have been recycled, but curl returned $http_status, while expected status is 404."
+        echo_log "Archive $url_1 should have been recycled, but curl returned $http_status, while expected status is 404."
         exit 1
     fi
 
     # curl on the archive url
     get_archive_from_storage $url_2
-    echo "http_status for $url_2 : $http_status"
+    echo_log "http_status for $url_2 : $http_status"
     if [ "$http_status" -ne "404" ]; then
-        echo "Archive $url_2 should have been recycled, but curl returned $http_status, while expected status is 404."
+        echo_log "Archive $url_2 should have been recycled, but curl returned $http_status, while expected status is 404."
         exit 1
     fi
 
-    echo "Test archive pruner PASSED"
+    echo_log "Test archive pruner PASSED"
 }
 
 main

--- a/test/tests/test_backend_newdeploy.sh
+++ b/test/tests/test_backend_newdeploy.sh
@@ -5,51 +5,51 @@ set -euo pipefail
 ROOT=$(dirname $0)/../.. 
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo "NewDeploy ExecutorType: Pre-test cleanup"
+echo_log "NewDeploy ExecutorType: Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo "Creating nodejs env"
+echo_log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
 trap "fission env delete --name nodejs" EXIT
 
 # TODO Imporve test code by reusing common blocks
 
-echo "Creating function, testing for cold start with MinScale 0"
+echo_log "Creating function, testing for cold start with MinScale 0"
 fn0=nodejs-hello-$(date +%N)
 fission fn create --name $fn0 --env nodejs --code $ROOT/examples/nodejs/hello.js --minscale 0 --maxscale 4 --executortype newdeploy
 trap "fission fn delete --name $fn0" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn0 --url /$fn0 --method GET
 
-echo "Waiting for router & newdeploy deployment creation"
+echo_log "Waiting for router & newdeploy deployment creation"
 sleep 5
 
-echo "Doing an HTTP GET on the function's route"
+echo_log "Doing an HTTP GET on the function's route"
 response0=$(curl http://$FISSION_ROUTER/$fn0)
 
-echo "Checking for valid response"
+echo_log "Checking for valid response"
 echo $response0 | grep -i hello
 
 
-echo "Creating function, testing for warm start with MinScale 1"
+echo_log "Creating function, testing for warm start with MinScale 1"
 fn1=nodejs-hello-$(date +%N)
 fission fn create --name $fn1 --env nodejs --code $ROOT/examples/nodejs/hello.js --minscale 1 --maxscale 4 --executortype newdeploy
 trap "fission fn delete --name $fn1" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn1 --url /$fn1 --method GET
 
-echo "Waiting for router & newdeploy deployment creation"
+echo_log "Waiting for router & newdeploy deployment creation"
 sleep 5
 
-echo "Doing an HTTP GET on the function's route"
+echo_log "Doing an HTTP GET on the function's route"
 response1=$(curl http://$FISSION_ROUTER/$fn0)
 
-echo "Checking for valid response"
+echo_log "Checking for valid response"
 echo $response1 | grep -i hello
 
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo "NewDeploy ExecutorType: All done."
+echo_log "NewDeploy ExecutorType: All done."

--- a/test/tests/test_backend_newdeploy.sh
+++ b/test/tests/test_backend_newdeploy.sh
@@ -5,51 +5,51 @@ set -euo pipefail
 ROOT=$(dirname $0)/../.. 
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo_log "NewDeploy ExecutorType: Pre-test cleanup"
+log "NewDeploy ExecutorType: Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo_log "Creating nodejs env"
+log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
 trap "fission env delete --name nodejs" EXIT
 
 # TODO Imporve test code by reusing common blocks
 
-echo_log "Creating function, testing for cold start with MinScale 0"
+log "Creating function, testing for cold start with MinScale 0"
 fn0=nodejs-hello-$(date +%N)
 fission fn create --name $fn0 --env nodejs --code $ROOT/examples/nodejs/hello.js --minscale 0 --maxscale 4 --executortype newdeploy
 trap "fission fn delete --name $fn0" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn0 --url /$fn0 --method GET
 
-echo_log "Waiting for router & newdeploy deployment creation"
+log "Waiting for router & newdeploy deployment creation"
 sleep 5
 
-echo_log "Doing an HTTP GET on the function's route"
+log "Doing an HTTP GET on the function's route"
 response0=$(curl http://$FISSION_ROUTER/$fn0)
 
-echo_log "Checking for valid response"
+log "Checking for valid response"
 echo $response0 | grep -i hello
 
 
-echo_log "Creating function, testing for warm start with MinScale 1"
+log "Creating function, testing for warm start with MinScale 1"
 fn1=nodejs-hello-$(date +%N)
 fission fn create --name $fn1 --env nodejs --code $ROOT/examples/nodejs/hello.js --minscale 1 --maxscale 4 --executortype newdeploy
 trap "fission fn delete --name $fn1" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn1 --url /$fn1 --method GET
 
-echo_log "Waiting for router & newdeploy deployment creation"
+log "Waiting for router & newdeploy deployment creation"
 sleep 5
 
-echo_log "Doing an HTTP GET on the function's route"
+log "Doing an HTTP GET on the function's route"
 response1=$(curl http://$FISSION_ROUTER/$fn0)
 
-echo_log "Checking for valid response"
+log "Checking for valid response"
 echo $response1 | grep -i hello
 
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo_log "NewDeploy ExecutorType: All done."
+log "NewDeploy ExecutorType: All done."

--- a/test/tests/test_backend_poolmgr.sh
+++ b/test/tests/test_backend_poolmgr.sh
@@ -7,30 +7,30 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-hello-$(date +%N)
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo "Poolmgr ExecutorType: Pre-test cleanup"
+echo_log "Poolmgr ExecutorType: Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo "Creating nodejs env"
+echo_log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
 trap "fission env delete --name nodejs" EXIT
 
-echo "Creating function"
+echo_log "Creating function"
 fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js --executortype poolmgr
 trap "fission fn delete --name $fn" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo "Waiting for router to catch up"
+echo_log "Waiting for router to catch up"
 sleep 5
 
-echo "Doing an HTTP GET on the function's route"
+echo_log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo "Checking for valid response"
+echo_log "Checking for valid response"
 echo $response | grep -i hello
 
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo "Poolmgr ExecutorType: All done."
+echo_log "Poolmgr ExecutorType: All done."

--- a/test/tests/test_backend_poolmgr.sh
+++ b/test/tests/test_backend_poolmgr.sh
@@ -7,30 +7,30 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-hello-$(date +%N)
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo_log "Poolmgr ExecutorType: Pre-test cleanup"
+log "Poolmgr ExecutorType: Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo_log "Creating nodejs env"
+log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
 trap "fission env delete --name nodejs" EXIT
 
-echo_log "Creating function"
+log "Creating function"
 fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js --executortype poolmgr
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 5
 
-echo_log "Doing an HTTP GET on the function's route"
+log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo_log "Checking for valid response"
+log "Checking for valid response"
 echo $response | grep -i hello
 
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo_log "Poolmgr ExecutorType: All done."
+log "Poolmgr ExecutorType: All done."

--- a/test/tests/test_buildermgr.sh
+++ b/test/tests/test_buildermgr.sh
@@ -15,16 +15,16 @@ PYTHON_BUILDER_IMAGE=gcr.io/fission-ci/python-env-builder:test
 fn=python-srcbuild-$(date +%s)
 
 checkFunctionResponse() {
-    echo "Doing an HTTP GET on the function's route"
+    echo_log "Doing an HTTP GET on the function's route"
     response=$(curl http://$FISSION_ROUTER/$1)
 
-    echo "Checking for valid response"
-    echo $response
+    echo_log "Checking for valid response"
+    echo_log $response
     echo $response | grep -i "a: 1 b: {c: 3, d: 4}"
 }
 
 waitBuild() {
-    echo "Waiting for builder manager to finish the build"
+    echo_log "Waiting for builder manager to finish the build"
     
     while true; do
       kubectl --namespace default get packages $1 -o jsonpath='{.status.buildstatus}'|grep succeeded
@@ -39,7 +39,7 @@ waitEnvBuilder() {
     env=$1
     envRV=$(kubectl -n default get environments ${env} -o jsonpath='{.metadata.resourceVersion}')
 
-    echo "Waiting for env builder to catch up"
+    echo_log "Waiting for env builder to catch up"
 
     while true; do
       kubectl -n fission-builder get pod -l envName=${env},envResourceVersion=${envRV} \
@@ -51,27 +51,27 @@ waitEnvBuilder() {
 }
 export -f waitEnvBuilder
 
-echo "Pre-test cleanup"
+echo_log "Pre-test cleanup"
 fission env delete --name python || true
 kubectl --namespace default get packages|grep -v NAME|awk '{print $1}'|xargs -I@ bash -c 'kubectl --namespace default delete packages @' || true
 
-echo "Creating python env"
+echo_log "Creating python env"
 fission env create --name python --image $PYTHON_RUNTIME_IMAGE --builder $PYTHON_BUILDER_IMAGE
 trap "fission env delete --name python" EXIT
 
 timeout 180s bash -c "waitEnvBuilder python"
 
-echo "Creating source pacakage"
+echo_log "Creating source pacakage"
 zip -jr demo-src-pkg.zip $ROOT/examples/python/sourcepkg/
 
-echo "Creating function " $fn
+echo_log "Creating function " $fn
 fission fn create --name $fn --env python --src demo-src-pkg.zip --entrypoint "user.main" --buildcmd "./build.sh"
 trap "fission fn delete --name $fn" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo "Waiting for router to catch up"
+echo_log "Waiting for router to catch up"
 sleep 3
 
 pkg=$(kubectl --namespace default get functions $fn -o jsonpath='{.spec.package.packageref.name}')
@@ -81,7 +81,7 @@ timeout 60s bash -c "waitBuild $pkg"
 
 checkFunctionResponse $fn
 
-echo "Updating function " $fn
+echo_log "Updating function " $fn
 fission fn update --name $fn --src demo-src-pkg.zip
 trap "fission fn delete --name $fn" EXIT
 
@@ -95,4 +95,4 @@ checkFunctionResponse $fn
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo "All done."
+echo_log "All done."

--- a/test/tests/test_function_update.sh
+++ b/test/tests/test_function_update.sh
@@ -10,28 +10,28 @@ fn=nodejs-hello-$(date +%s)
 # Update it and check it's output, the output should be 
 # different from the previous one.
 
-echo "Pre-test cleanup"
+echo_log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo "Creating nodejs env"
+echo_log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo "Creating function"
+echo_log "Creating function"
 echo 'module.exports = function(context, callback) { callback(200, "foo!\n"); }' > foo.js
 fission fn create --name $fn --env nodejs --code foo.js
 trap "fission fn delete --name $fn" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo "Waiting for router to catch up"
+echo_log "Waiting for router to catch up"
 sleep 10
 
-echo "Doing an HTTP GET on the function's route"
+echo_log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo "Checking for valid response"
+echo_log "Checking for valid response"
 echo $response | grep -i foo
 
 # Running a background process to keep access the
@@ -40,18 +40,18 @@ echo $response | grep -i foo
 ( watch -n1 curl http://$FISSION_ROUTER/$fn ) > /dev/null 2>&1 &
 pid=$!
 
-echo "Updating function"
+echo_log "Updating function"
 echo 'module.exports = function(context, callback) { callback(200, "bar!\n"); }' > bar.js
 fission fn update --name $fn --code bar.js
 trap "fission fn delete --name $fn" EXIT
 
-echo "Waiting for router to update cache"
+echo_log "Waiting for router to update cache"
 sleep 10
 
-echo "Doing an HTTP GET on the function's route"
+echo_log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo "Checking for valid response again"
+echo_log "Checking for valid response again"
 echo $response | grep -i bar
 
 kill -15 $pid
@@ -59,4 +59,4 @@ kill -15 $pid
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo "All done."
+echo_log "All done."

--- a/test/tests/test_function_update.sh
+++ b/test/tests/test_function_update.sh
@@ -10,28 +10,28 @@ fn=nodejs-hello-$(date +%s)
 # Update it and check it's output, the output should be 
 # different from the previous one.
 
-echo_log "Pre-test cleanup"
+log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo_log "Creating nodejs env"
+log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo_log "Creating function"
+log "Creating function"
 echo 'module.exports = function(context, callback) { callback(200, "foo!\n"); }' > foo.js
 fission fn create --name $fn --env nodejs --code foo.js
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 10
 
-echo_log "Doing an HTTP GET on the function's route"
+log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo_log "Checking for valid response"
+log "Checking for valid response"
 echo $response | grep -i foo
 
 # Running a background process to keep access the
@@ -40,18 +40,18 @@ echo $response | grep -i foo
 ( watch -n1 curl http://$FISSION_ROUTER/$fn ) > /dev/null 2>&1 &
 pid=$!
 
-echo_log "Updating function"
+log "Updating function"
 echo 'module.exports = function(context, callback) { callback(200, "bar!\n"); }' > bar.js
 fission fn update --name $fn --code bar.js
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Waiting for router to update cache"
+log "Waiting for router to update cache"
 sleep 10
 
-echo_log "Doing an HTTP GET on the function's route"
+log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo_log "Checking for valid response again"
+log "Checking for valid response again"
 echo $response | grep -i bar
 
 kill -15 $pid
@@ -59,4 +59,4 @@ kill -15 $pid
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo_log "All done."
+log "All done."

--- a/test/tests/test_internal_routes.sh
+++ b/test/tests/test_internal_routes.sh
@@ -9,38 +9,38 @@ set -euo pipefail
 
 ROOT=$(dirname $0)/../..
 
-echo "Pre-test cleanup"
+echo_log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo "Creating nodejs env"
+echo_log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo "Writing functions"
+echo_log "Writing functions"
 f1=f1-$(date +%s)
 f2=f2-$(date +%s)
-echo $f1 $f2
+echo_log $f1 $f2
 
 for f in $f1 $f2
 do
     echo "module.exports = function(context, callback) { callback(200, \"$f\n\"); }" > $f.js
 done
 
-echo "Creating functions"
+echo_log "Creating functions"
 for f in $f1 $f2
 do
     fission fn create --name $f --env nodejs --code $f.js
     trap "fission fn delete --name $f" EXIT
 done
 
-echo "Waiting for router to catch up"
+echo_log "Waiting for router to catch up"
 sleep 2
 
-echo "Testing internal routes"
+echo_log "Testing internal routes"
 for f in $f1 $f2
 do
     response=$(curl http://$FISSION_ROUTER/fission-function/$f)
     echo $response | grep $f
 done
 
-echo "All done."
+echo_log "All done."

--- a/test/tests/test_internal_routes.sh
+++ b/test/tests/test_internal_routes.sh
@@ -9,38 +9,38 @@ set -euo pipefail
 
 ROOT=$(dirname $0)/../..
 
-echo_log "Pre-test cleanup"
+log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo_log "Creating nodejs env"
+log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo_log "Writing functions"
+log "Writing functions"
 f1=f1-$(date +%s)
 f2=f2-$(date +%s)
-echo_log $f1 $f2
+log $f1 $f2
 
 for f in $f1 $f2
 do
     echo "module.exports = function(context, callback) { callback(200, \"$f\n\"); }" > $f.js
 done
 
-echo_log "Creating functions"
+log "Creating functions"
 for f in $f1 $f2
 do
     fission fn create --name $f --env nodejs --code $f.js
     trap "fission fn delete --name $f" EXIT
 done
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 2
 
-echo_log "Testing internal routes"
+log "Testing internal routes"
 for f in $f1 $f2
 do
     response=$(curl http://$FISSION_ROUTER/fission-function/$f)
     echo $response | grep $f
 done
 
-echo_log "All done."
+log "All done."

--- a/test/tests/test_logging/test_function_logs.sh
+++ b/test/tests/test_logging/test_function_logs.sh
@@ -8,39 +8,39 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-logtest-$(date +%N)
 
 function cleanup {
-    echo "Cleanup route"
+    echo_log "Cleanup route"
     var=$(fission route list | grep $fn | awk '{print $1;}')
     fission route delete --name $var
-    echo "delete logfile"
+    echo_log "delete logfile"
     rm "/tmp/logfile"
 }
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo "Pre-test cleanup"
+echo_log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo "Creating nodejs env"
+echo_log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo "Creating function"
+echo_log "Creating function"
 fission fn create --name $fn --env nodejs --code log.js
 trap "fission fn delete --name $fn" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 trap cleanup EXIT
 
-echo "Waiting for router to catch up"
+echo_log "Waiting for router to catch up"
 sleep 15
 
-echo "Doing 4 HTTP GETs on the function's route"
+echo_log "Doing 4 HTTP GETs on the function's route"
 for i in 1 2 3 4
 do
     curl -s http://$FISSION_ROUTER/$fn
 done
 
-echo "Grabbing logs, should have 4 calls in logs"
+echo_log "Grabbing logs, should have 4 calls in logs"
 
 sleep 15
 
@@ -52,15 +52,15 @@ then
     fission function logs --name $fn --detail > /tmp/logfile
 fi
 
-echo "---function logs---"
+echo_log "---function logs---"
 cat /tmp/logfile
-echo "------"
+echo_log "------"
 num=$(grep 'log test' /tmp/logfile | wc -l)
-echo $num logs found
+echo_log $num logs found
 
 if [ $num -ne 4 ]
 then
-    echo "Test Failed: expected 4, found $num logs"
+    echo_log "Test Failed: expected 4, found $num logs"
 fi
 
-echo "All done."
+echo_log "All done."

--- a/test/tests/test_logging/test_function_logs.sh
+++ b/test/tests/test_logging/test_function_logs.sh
@@ -62,5 +62,5 @@ if [ $num -ne 4 ]
 then
     echo "Test Failed: expected 4, found $num logs"
 fi
- 
+
 echo "All done."

--- a/test/tests/test_logging/test_function_logs.sh
+++ b/test/tests/test_logging/test_function_logs.sh
@@ -8,39 +8,39 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-logtest-$(date +%N)
 
 function cleanup {
-    echo_log "Cleanup route"
+    log "Cleanup route"
     var=$(fission route list | grep $fn | awk '{print $1;}')
     fission route delete --name $var
-    echo_log "delete logfile"
+    log "delete logfile"
     rm "/tmp/logfile"
 }
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo_log "Pre-test cleanup"
+log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo_log "Creating nodejs env"
+log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo_log "Creating function"
+log "Creating function"
 fission fn create --name $fn --env nodejs --code log.js
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 trap cleanup EXIT
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 15
 
-echo_log "Doing 4 HTTP GETs on the function's route"
+log "Doing 4 HTTP GETs on the function's route"
 for i in 1 2 3 4
 do
     curl -s http://$FISSION_ROUTER/$fn
 done
 
-echo_log "Grabbing logs, should have 4 calls in logs"
+log "Grabbing logs, should have 4 calls in logs"
 
 sleep 15
 
@@ -52,15 +52,15 @@ then
     fission function logs --name $fn --detail > /tmp/logfile
 fi
 
-echo_log "---function logs---"
+log "---function logs---"
 cat /tmp/logfile
-echo_log "------"
+log "------"
 num=$(grep 'log test' /tmp/logfile | wc -l)
-echo_log $num logs found
+log $num logs found
 
 if [ $num -ne 4 ]
 then
-    echo_log "Test Failed: expected 4, found $num logs"
+    log "Test Failed: expected 4, found $num logs"
 fi
 
-echo_log "All done."
+log "All done."

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -7,30 +7,30 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-hello-$(date +%N)
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo "Pre-test cleanup"
+echo_log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo "Creating nodejs env"
+echo_log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo "Creating function"
+echo_log "Creating function"
 fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js
 trap "fission fn delete --name $fn" EXIT
 
-echo "Creating route"
+echo_log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo "Waiting for router to catch up"
+echo_log "Waiting for router to catch up"
 sleep 3
 
-echo "Doing an HTTP GET on the function's route"
+echo_log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo "Checking for valid response"
+echo_log "Checking for valid response"
 echo $response | grep -i hello
 
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo "All done."
+echo_log "All done."

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -7,30 +7,30 @@ ROOT=$(dirname $0)/../..
 fn=nodejs-hello-$(date +%N)
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo_log "Pre-test cleanup"
+log "Pre-test cleanup"
 fission env delete --name nodejs || true
 
-echo_log "Creating nodejs env"
+log "Creating nodejs env"
 fission env create --name nodejs --image fission/node-env
 trap "fission env delete --name nodejs" EXIT
 
-echo_log "Creating function"
+log "Creating function"
 fission fn create --name $fn --env nodejs --code $ROOT/examples/nodejs/hello.js
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 3
 
-echo_log "Doing an HTTP GET on the function's route"
+log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
 
-echo_log "Checking for valid response"
+log "Checking for valid response"
 echo $response | grep -i hello
 
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo_log "All done."
+log "All done."

--- a/test/tests/test_package_command.sh
+++ b/test/tests/test_package_command.sh
@@ -14,7 +14,7 @@ PYTHON_BUILDER_IMAGE=gcr.io/fission-ci/python-env-builder:test
 fn=python-srcbuild-$(date +%s)
 
 waitBuild() {
-    echo_log "Waiting for builder manager to finish the build"
+    log "Waiting for builder manager to finish the build"
     
     while true; do
       kubectl --namespace default get packages $1 -o jsonpath='{.status.buildstatus}'|grep succeeded
@@ -26,11 +26,11 @@ waitBuild() {
 export -f waitBuild
 
 checkFunctionResponse() {
-    echo_log "Doing an HTTP GET on the function's route"
+    log "Doing an HTTP GET on the function's route"
     response=$(curl http://$FISSION_ROUTER/$1)
 
-    echo_log "Checking for valid response"
-    echo_log $response
+    log "Checking for valid response"
+    log $response
     echo $response | grep -i "$2"
 }
 
@@ -38,7 +38,7 @@ waitEnvBuilder() {
     env=$1
     envRV=$(kubectl -n default get environments ${env} -o jsonpath='{.metadata.resourceVersion}')
 
-    echo_log "Waiting for env builder to catch up"
+    log "Waiting for env builder to catch up"
 
     while true; do
       kubectl -n fission-builder get pod -l envName=${env},envResourceVersion=${envRV} \
@@ -50,46 +50,46 @@ waitEnvBuilder() {
 }
 export -f waitEnvBuilder
 
-echo_log "Pre-test cleanup"
+log "Pre-test cleanup"
 fission env delete --name python || true
 
-echo_log "Creating python env"
+log "Creating python env"
 fission env create --name python --image $PYTHON_RUNTIME_IMAGE --builder $PYTHON_BUILDER_IMAGE
 trap "fission env delete --name python" EXIT
 
 timeout 180s bash -c "waitEnvBuilder python"
 
-echo_log "Creating pacakage with source archive"
+log "Creating pacakage with source archive"
 zip -jr demo-src-pkg.zip $ROOT/examples/python/sourcepkg/
 pkgName=$(fission package create --src demo-src-pkg.zip --env python --buildcmd "./build.sh"| cut -f2 -d' '| tr -d \')
 
 # wait for build to finish at most 60s
 timeout 60s bash -c "waitBuild $pkgName"
 
-echo_log "Creating function " $fn
+log "Creating function " $fn
 fission fn create --name $fn --pkg $pkgName --entrypoint "user.main"
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 3
   
 checkFunctionResponse $fn 'a: 1 b: {c: 3, d: 4}'
 
-echo_log "Creating package with deploy archive"
+log "Creating package with deploy archive"
 mkdir testDir
 touch testDir/__init__.py
 printf 'def main():\n    return "Hello, world!"' > testDir/hello.py
 zip -jr demo-deploy-pkg.zip testDir/
 pkgName=$(fission package create --deploy demo-deploy-pkg.zip --env python| cut -f2 -d' '| tr -d \')
 
-echo_log "Updating function " $fn
+log "Updating function " $fn
 fission fn update --name $fn --pkg $pkgName --entrypoint "hello.main"
 trap "fission fn delete --name $fn" EXIT
 
-echo_log "Waiting for router to update cache"
+log "Waiting for router to update cache"
 sleep 3
 
 checkFunctionResponse $fn 'Hello, world!'
@@ -97,4 +97,4 @@ checkFunctionResponse $fn 'Hello, world!'
 # crappy cleanup, improve this later
 kubectl get httptrigger -o name | tail -1 | cut -f2 -d'/' | xargs kubectl delete httptrigger
 
-echo_log "All done."
+log "All done."

--- a/test/tests/test_pass.sh
+++ b/test/tests/test_pass.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # This doesn't test fission, just the test framework. It ensures we
 # have the right environment, that's all.
 
-echo "Test test, please ignore."
+echo_log "Test test, please ignore."
 
-echo $FISSION_URL
-echo $FISSION_ROUTER
+echo_log $FISSION_URL
+echo_log $FISSION_ROUTER
 which fission

--- a/test/tests/test_pass.sh
+++ b/test/tests/test_pass.sh
@@ -5,8 +5,8 @@ set -euo pipefail
 # This doesn't test fission, just the test framework. It ensures we
 # have the right environment, that's all.
 
-echo_log "Test test, please ignore."
+log "Test test, please ignore."
 
-echo_log $FISSION_URL
-echo_log $FISSION_ROUTER
+log $FISSION_URL
+log $FISSION_ROUTER
 which fission

--- a/test/tests/test_secret_cfgmap/test_secret_cfgmap.sh
+++ b/test/tests/test_secret_cfgmap/test_secret_cfgmap.sh
@@ -15,7 +15,7 @@ cp cfgmap.py.template cfgmap.py
 sed -i "s/{{ FN_CFGMAP }}/${fn_cfgmap}/g" cfgmap.py
 
 function cleanup {
-    echo_log "Cleanup everything"
+    log "Cleanup everything"
     kubectl delete secret -n default ${fn_secret}
     kubectl delete configmap -n default ${fn_cfgmap}
     fission function delete --name ${fn_secret}
@@ -30,84 +30,84 @@ function cleanup {
 }
 
 # Create a hello world function in nodejs, test it with an http trigger
-echo_log "Pre-test cleanup"
+log "Pre-test cleanup"
 fission env delete --name python || true
 
-echo_log "Creating python env"
+log "Creating python env"
 fission env create --name python --image fission/python-env
 trap "fission env delete --name python" EXIT
 
-echo_log "Creating secret"
+log "Creating secret"
 kubectl create secret generic ${fn_secret} --from-literal=TEST_KEY="TESTVALUE" -n default
 trap "kubectl delete secret ${fn_secret} -n default" EXIT
 
 
-echo_log "Creating function with secret"
+log "Creating function with secret"
 fission fn create --name ${fn_secret} --env python --code secret.py --secret ${fn_secret}
 trap "fission fn delete --name ${fn_secret}" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function ${fn_secret} --url /${fn_secret} --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 5
 
-echo_log "HTTP GET on the function's route"
+log "HTTP GET on the function's route"
 res=$(curl http://${FISSION_ROUTER}/${fn_secret})
 val='TESTVALUE'
 
 if [[ ${res} != ${val} ]]
 then
-	echo_log "test secret failed"
+	log "test secret failed"
 	cleanup
 	exit 1
 fi
-echo_log "test secret passed"
+log "test secret passed"
 
-echo_log "Creating configmap"
+log "Creating configmap"
 kubectl create configmap ${fn_cfgmap} --from-literal=TEST_KEY=TESTVALUE -n default
 trap "kubectl delete configmap ${fn_cfgmap} -n default" EXIT
 
-echo_log "creating function with configmap"
+log "creating function with configmap"
 fission fn create --name ${fn_cfgmap} --env python --code cfgmap.py --configmap ${fn_cfgmap}
 trap "fission fn delete --name ${fn_cfgmap}" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function ${fn_cfgmap} --url /${fn_cfgmap} --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 5
 
-echo_log "HTTP GET on the function's route"
+log "HTTP GET on the function's route"
 rescfg=$(curl http://${FISSION_ROUTER}/${fn_cfgmap})
 
 if [ ${rescfg} != ${val} ]
 then
-	echo_log "test cfgmap failed"
+	log "test cfgmap failed"
 	cleanup
 	exit 1
 fi
-echo_log "test configmap passed"
+log "test configmap passed"
 
-echo_log "testing creating a function without a secret or configmap"
+log "testing creating a function without a secret or configmap"
 fission function create --name ${fn} --env python --code empty.py
 trap "fission fn delete --name ${fn}" EXIT
 
-echo_log "Creating route"
+log "Creating route"
 fission route create --function ${fn} --url /${fn} --method GET
 
-echo_log "Waiting for router to catch up"
+log "Waiting for router to catch up"
 sleep 5
 
-echo_log "HTTP GET on the function's route"
+log "HTTP GET on the function's route"
 resnormal=$(curl http://${FISSION_ROUTER}/${fn})
 if [ ${resnormal} != "yes" ]
 then
-	echo_log "test empty failed"
+	log "test empty failed"
 	cleanup
 	exit 1
 fi
-echo_log "test empty passed"
+log "test empty passed"
 
-echo_log "All done."
+log "All done."
 trap "cleanup" EXIT


### PR DESCRIPTION
This PR is for https://github.com/fission/fission/issues/472

1. Readiness and liveness probes are added to most fission containers, along with corresponding `healthz` http handlers.
2. A signal Handler for SIGTERM (used by liveness probe to restart containers) is added to most fission containers so we have enough information to debug issues. 
(I found that the above 2 helped troubleshoot/get rid of most of the `getsockopt` errors in my CI runs.)
4. For helm install failures,  `kubernetes events` and `tiller logs`( of previous 30 minutes ) are added to the CI logs.
5. Helm install timeout has been changed from 10 minutes to 9 minutes to prevent travis from killing the build script before dumping all logs and objects.( this because travis has a build timeout of 10 minutes too)
3. Added `--quiet` option to some commands in the test to gain some space in CI log since its limited in size.

With these changes, 4 continuous CI runs passed on this branch. ( https://travis-ci.org/fission/fission/branches for proof :))
These changes in no way have solved any existing bugs. But only has some extra logs and debugging information.
Oh and the `Unable to create listener: Error listen tcp6 [::1]:38644: bind: cannot assign requested address` warnings are gone!!

Also, changing the docker repo for ubuntu_slim docker image is coming in a separate PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/491)
<!-- Reviewable:end -->
