### PR TITLE
Adds default resources for fetcher pod

### DIFF
--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -32,13 +32,11 @@ import (
 	"time"
 
 	"github.com/dchest/uniuri"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
-	"k8s.io/client-go/pkg/api/v1"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 
@@ -47,6 +45,7 @@ import (
 	"github.com/fission/fission/environments/fetcher"
 	fetcherClient "github.com/fission/fission/environments/fetcher/client"
 	"github.com/fission/fission/executor/fscache"
+	"github.com/fission/fission/executor/util"
 )
 
 const POD_PHASE_RUNNING string = "Running"
@@ -435,7 +434,7 @@ func (gp *GenericPool) createPool() error {
 	poolDeploymentName := fmt.Sprintf("%v-%v-%v",
 		gp.env.Metadata.Name, gp.env.Metadata.UID, strings.ToLower(gp.poolInstanceId))
 
-	fetcherResources, err := gp.getFetcherResources()
+	fetcherResources, err := util.GetFetcherResources()
 	if err != nil {
 		return err
 	}
@@ -722,28 +721,4 @@ func (gp *GenericPool) destroy() error {
 	}
 
 	return nil
-}
-
-func (gp *GenericPool) getFetcherResources() (v1.ResourceRequirements, error) {
-	//TBD Hardcoded as of now, should be configurable?
-	mincpu, err := resource.ParseQuantity("5m")
-	minmem, err := resource.ParseQuantity("16Mi")
-	maxcpu, err := resource.ParseQuantity("40m")
-	maxmem, err := resource.ParseQuantity("128Mi")
-
-	if err != nil {
-		return v1.ResourceRequirements{}, err
-	}
-
-	fetcherResources := v1.ResourceRequirements{
-		Requests: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceCPU:    mincpu,
-			v1.ResourceMemory: minmem,
-		},
-		Limits: map[v1.ResourceName]resource.Quantity{
-			v1.ResourceCPU:    maxcpu,
-			v1.ResourceMemory: maxmem,
-		},
-	}
-	return fetcherResources, nil
 }

--- a/executor/util/util.go
+++ b/executor/util/util.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+var resources map[string]resource.Quantity
+
+func init() {
+	resources = make(map[string]resource.Quantity)
+	mincpu, _ := resource.ParseQuantity("10m")
+	resources["mincpu"] = mincpu
+	minmem, _ := resource.ParseQuantity("16Mi")
+	resources["minmem"] = minmem
+	maxcpu, _ := resource.ParseQuantity("40m")
+	resources["maxcpu"] = maxcpu
+	maxmem, _ := resource.ParseQuantity("128Mi")
+	resources["maxmem"] = maxmem
+}
+
+func GetFetcherResources() (v1.ResourceRequirements, error) {
+	fetcherResources := v1.ResourceRequirements{
+		Requests: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceCPU:    resources["mincpu"],
+			v1.ResourceMemory: resources["minmem"],
+		},
+		Limits: map[v1.ResourceName]resource.Quantity{
+			v1.ResourceCPU:    resources["maxcpu"],
+			v1.ResourceMemory: resources["maxmem"],
+		},
+	}
+	return fetcherResources, nil
+}


### PR DESCRIPTION
This PR adds default resources for Fetcher pod for both executors - pool manager and new deployment (And fixes #478 ). Currently, the resource numbers are based on experimentation. In future maybe we could look at the numbers from monitoring (Prometheus?)

Also, the getFetcherResources method is duplicated in both executors. On one hand, I wanted different fetcher resources for both but also wanted to avoid code duplication. I can not move the method up at executor level as it will cause cyclical dependency of packages, maybe create a util package within executor and then import in both executors?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/500)
<!-- Reviewable:end -->
