### PR TITLE
Fixes the backward compatibility with older environment versions

### DIFF
--- a/executor/cleanup.go
+++ b/executor/cleanup.go
@@ -202,6 +202,14 @@ func cleanupDeployments(client *kubernetes.Clientset, namespace string, instance
 			logErr("cleaning up deployment", err)
 			// ignore err
 		}
+		// Backward compatibility with older label name
+		pid, pok := dep.ObjectMeta.Labels[fission.POOLMGR_INSTANCEID_LABEL]
+		if pok && pid != instanceId {
+			log.Printf("Cleaning up deployment %v", dep.ObjectMeta.Name)
+			err := client.ExtensionsV1beta1().Deployments(namespace).Delete(dep.ObjectMeta.Name, nil)
+			logErr("cleaning up deployment", err)
+			// ignore err
+		}
 	}
 	return nil
 }
@@ -214,6 +222,13 @@ func cleanupReplicaSets(client *kubernetes.Clientset, namespace string, instance
 	for _, rs := range rsList.Items {
 		id, ok := rs.ObjectMeta.Labels[fission.EXECUTOR_INSTANCEID_LABEL]
 		if ok && id != instanceId {
+			log.Printf("Cleaning up replicaset %v", rs.ObjectMeta.Name)
+			err := client.ExtensionsV1beta1().ReplicaSets(namespace).Delete(rs.ObjectMeta.Name, nil)
+			logErr("cleaning up replicaset", err)
+		}
+		// Backward compatibility with older label name
+		pid, pok := rs.ObjectMeta.Labels[fission.POOLMGR_INSTANCEID_LABEL]
+		if pok && pid != instanceId {
 			log.Printf("Cleaning up replicaset %v", rs.ObjectMeta.Name)
 			err := client.ExtensionsV1beta1().ReplicaSets(namespace).Delete(rs.ObjectMeta.Name, nil)
 			logErr("cleaning up replicaset", err)
@@ -235,6 +250,15 @@ func cleanupPods(client *kubernetes.Clientset, namespace string, instanceId stri
 			logErr("cleaning up pod", err)
 			// ignore err
 		}
+		// Backward compatibility with older label name
+		pid, pok := pod.ObjectMeta.Labels[fission.POOLMGR_INSTANCEID_LABEL]
+		if pok && pid != instanceId {
+			log.Printf("Cleaning up pod %v", pod.ObjectMeta.Name)
+			err := client.CoreV1().Pods(namespace).Delete(pod.ObjectMeta.Name, nil)
+			logErr("cleaning up pod", err)
+			// ignore err
+		}
+
 	}
 	return nil
 }

--- a/types.go
+++ b/types.go
@@ -314,6 +314,7 @@ type (
 )
 
 const EXECUTOR_INSTANCEID_LABEL string = "executorInstanceId"
+const POOLMGR_INSTANCEID_LABEL string = "poolmgrInstanceId"
 
 const (
 	ChecksumTypeSHA256 ChecksumType = "sha256"


### PR DESCRIPTION
This fixes the compatibility part of the issue #506. There are two things that had to be done to make this work in a correct way:

- Add a check that if `env.Spec.Version < 3` then default `poolsize` to 3
- Since we changed the name from `poolmgrInstanceId` to `executorInstanceId` - we had to add a check for previously created deployments etc. to be cleaned up. Technically this is one time activity after upgrade and can be done manually - so can remove if that is what we conclude to do. Or we can leave for 2 releases and then remove it.

The testing that is done to prove that change works is described below:

### Test with 0.4.0

**Install Helm**
```helm install --name fission --namespace fission https://github.com/fission/fission/releases/download/0.4.1/fission-all-0.4.1.tgz```


**Create environment & verify**

```
$ fission env create --name node --image fission/node-env:latest
environment 'node' created

$ k -n default get environment node -o yaml
apiVersion: fission.io/v1
kind: Environment
metadata:
  clusterName: ""
  creationTimestamp: 2018-02-23T08:22:01Z
  deletionGracePeriodSeconds: null
  deletionTimestamp: null
  initializers: null
  name: node
  namespace: default
  resourceVersion: "5625578"
  selfLink: /apis/fission.io/v1/namespaces/default/environments/node
  uid: 9f5703df-1872-11e8-9bd0-42010aa00010
spec:
  allowedFunctionsPerContainer: ""
  builder:
    command: ""
    image: ""
  documentationurl: ""
  runtime:
    functionendpointport: 0
    image: fission/node-env:latest
    loadendpointpath: ""
    loadendpointport: 0
  version: 1


$ fpod
NAME                                                              READY     STATUS    RESTARTS   AGE
node-9f5703df-1872-11e8-9bd0-42010aa00010-xouku8bf-7cf6549f6vv8   2/2       Running   0          1m
node-9f5703df-1872-11e8-9bd0-42010aa00010-xouku8bf-7cf6549m57cq   2/2       Running   0          1m
node-9f5703df-1872-11e8-9bd0-42010aa00010-xouku8bf-7cf6549npc75   2/2       Running   0          1m
```
**Test with a function**

```
$ fission fn create --name hello --env node --code ../../fission_work/hello.js
function 'hello' created

$ curl http://$FISSION_ROUTER/fission-function/hello
Hello, Fission!
```

### Reproducing the issue

If we upgrade to the current master on top of the above-installed release, you will run into:

```
$ fission env list
NAME UID                                  IMAGE                   POOLSIZE MINCPU MAXCPU MINMEMORY MAXMEMORY
node 9f5703df-1872-11e8-9bd0-42010aa00010 fission/node-env:latest 0        0      0      0         0

$ curl http://$FISSION_ROUTER/fission-function/hello
Internal server error (fission)
```

### After fix (This PR)

```
$ fission env list
NAME UID                                  IMAGE                   POOLSIZE MINCPU MAXCPU MINMEMORY MAXMEMORY
node 9f5703df-1872-11e8-9bd0-42010aa00010 fission/node-env:latest 0        0      0      0         0

$ curl http://$FISSION_ROUTER/fission-function/hello
Hello, Fission!
```
You can also notice the pool getting created despite the poolsize being zero, because the env version is 1:
```
$ fpod
NAME                                                              READY     STATUS    RESTARTS   AGE
node-9f5703df-1872-11e8-9bd0-42010aa00010-r5i5ovyf-f5987dc5pm57   2/2       Running   0          29m
node-9f5703df-1872-11e8-9bd0-42010aa00010-r5i5ovyf-f5987dcctqxn   2/2       Running   0          26m
node-9f5703df-1872-11e8-9bd0-42010aa00010-r5i5ovyf-f5987dcln2z2   2/2       Running   0          29m
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/508)
<!-- Reviewable:end -->
