### PR TITLE
Default values for FISSION_* env vars

### DIFF
--- a/Documentation/docs-site/content/installation/installation.en.md
+++ b/Documentation/docs-site/content/installation/installation.en.md
@@ -119,39 +119,6 @@ $ curl -Lo fission https://github.com/fission/fission/releases/download/0.5.0/fi
 For Windows, you can use the linux binary on WSL. Or you can download
 this windows executable: [fission.exe](https://github.com/fission/fission/releases/download/0.5.0/fission-cli-windows.exe)
 
-### Set environment vars
-
-Set the FISSION_URL and FISSION_ROUTER environment variables.
-FISSION_URL is used by the fission CLI to find the server.
-(FISSION_ROUTER is only needed for the examples below to work.)
-
-#### Minikube
-
-If you're using minikube, use these commands:
-
-```
-  $ export FISSION_URL=http://$(minikube ip):31313
-  $ export FISSION_ROUTER=$(minikube ip):31314
-```
-#### Cloud setups
-
-Save the external IP addresses of controller and router services in
-FISSION_URL and FISSION_ROUTER, respectively.  Wait for services to
-get IP addresses (check this with ```kubectl --namespace fission get
-svc```).  Then:
-
-##### AWS
-```
-  $ export FISSION_URL=http://$(kubectl --namespace fission get svc controller -o=jsonpath='{..hostname}')
-  $ export FISSION_ROUTER=$(kubectl --namespace fission get svc router -o=jsonpath='{..hostname}')
-```
-
-##### GCP
-```
-  $ export FISSION_URL=http://$(kubectl --namespace fission get svc controller -o=jsonpath='{..ip}')
-  $ export FISSION_ROUTER=$(kubectl --namespace fission get svc router -o=jsonpath='{..ip}')
-```
-
 ### Run an example
 
 Finally, you're ready to use Fission!
@@ -163,9 +130,7 @@ $ curl -LO https://raw.githubusercontent.com/fission/fission/master/examples/nod
 
 $ fission function create --name hello --env nodejs --code hello.js
 
-$ fission route create --method GET --url /hello --function hello
-
-$ curl http://$FISSION_ROUTER/hello
+$ fission function test --name hello
 Hello, world!
 ```
 

--- a/charts/fission-all/templates/NOTES.txt
+++ b/charts/fission-all/templates/NOTES.txt
@@ -9,47 +9,17 @@ Linux:
 Windows:
   For Windows, you can use the linux binary on WSL. Or you can download this windows executable: https://github.com/fission/fission/releases/download/0.5.0/fission-cli-windows.exe
 
-2. Set the FISSION environment variables.
+2. You're ready to use Fission!
 
-{{- if contains "NodePort" .Values.serviceType }}
-  $ export FISSION_URL=http://$(minikube ip):{{ .Values.controllerPort }}
-
-{{- else if contains "LoadBalancer" .Values.serviceType }}
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl --namespace fission get -w svc' and 'kubectl --namespace fission get svc -w controller'
-
-  $ export FISSION_URL=http://$(kubectl --namespace fission get svc controller -o=jsonpath='{..ip}')
-
-{{- else if contains "ClusterIP" .Values.serviceType }}
-  $ export FISSION_NAMESPACE={{ .Release.Namespace }}
-  $ export KUBECONFIG=${HOME}/.kube/config
-
-{{- end }}
-
-{{- if contains "NodePort" .Values.routerServiceType }}
-  $ export FISSION_ROUTER=$(minikube ip):{{ .Values.routerPort }}
-
-{{- else if contains "LoadBalancer" .Values.routerServiceType }}
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status by running 'kubectl --namespace fission get -w svc' and 'kubectl --namespace fission get svc -w router'
-  $ export FISSION_ROUTER=$(kubectl --namespace fission get svc router -o=jsonpath='{..ip}')
-
-{{- else if contains "ClusterIP" .Values.routerServiceType }}
-  $ export KUBECONFIG=${HOME}/.kube/config
-  $ curl -Lo port-forward-router.sh https://github.com/fission/fission/port-forward-router.sh && chmod +x port-forward-router.sh && ./port-forward-router.sh {{ .Release.Namespace }} router 9999
-  $ export FISSION_ROUTER=127.0.0.1:9999
-
-{{- end }}
-
-3. Finally, you're ready to use Fission!
-
+  # Create an environment
   $ fission env create --name nodejs --image fission/node-env
 
+  # Get a hello world
   $ curl https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js > hello.js
 
+  # Register this function with Fission
   $ fission function create --name hello --env nodejs --code hello.js
 
-  $ fission route create --method GET --url /hello --function hello
-
-  $ curl http://$FISSION_ROUTER/hello
+  # Run this function
+  $ fission function test --name hello
   Hello, world!

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -168,6 +168,7 @@ spec:
   template:
     metadata:
       labels:
+        application: fission-router
         svc: router
     spec:
       containers:

--- a/charts/fission-all/templates/svc.yaml
+++ b/charts/fission-all/templates/svc.yaml
@@ -4,6 +4,7 @@ metadata:
   name: router
   labels:
     svc: router
+    application: fission-router
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   type: {{ .Values.routerServiceType }}
@@ -23,6 +24,7 @@ metadata:
   name: controller
   labels:
     svc: controller
+    application: fission-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   type: {{ .Values.serviceType }}

--- a/charts/fission-core/templates/NOTES.txt
+++ b/charts/fission-core/templates/NOTES.txt
@@ -9,47 +9,17 @@ Linux:
 Windows:
   For Windows, you can use the linux binary on WSL. Or you can download this windows executable: https://github.com/fission/fission/releases/download/0.5.0/fission-cli-windows.exe
 
-2. Set the FISSION_URL and FISSION_ROUTER environment variables.
+2. You're ready to use Fission!
 
-{{- if contains "NodePort" .Values.serviceType }}
-  $ export FISSION_URL=http://$(minikube ip):{{ .Values.controllerPort }}
-
-{{- else if contains "LoadBalancer" .Values.serviceType }}
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status of by running 'kubectl --namespace fission get -w svc' and 'kubectl --namespace fission get svc -w controller'
-
-  $ export FISSION_URL=http://$(kubectl --namespace fission get svc controller -o=jsonpath='{..ip}')
-
-{{- else if contains "ClusterIP" .Values.serviceType }}
-  $ export FISSION_NAMESPACE={{ .Release.Namespace }}
-  $ export KUBECONFIG=${HOME}/.kube/config
-
-{{- end }}
-
-{{- if contains "NodePort" .Values.routerServiceType }}
-  $ export FISSION_ROUTER=$(minikube ip):{{ .Values.routerPort }}
-
-{{- else if contains "LoadBalancer" .Values.routerServiceType }}
-  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-        You can watch the status by running 'kubectl --namespace fission get -w svc' and 'kubectl --namespace fission get svc -w router'
-  $ export FISSION_ROUTER=$(kubectl --namespace fission get svc router -o=jsonpath='{..ip}')
-
-{{- else if contains "ClusterIP" .Values.routerServiceType }}
-  $ export KUBECONFIG=${HOME}/.kube/config
-  $ curl -Lo port-forward-router.sh https://github.com/fission/fission/port-forward-router.sh && chmod +x port-forward-router.sh && ./port-forward-router.sh {{ .Release.Namespace }} router 9999
-  $ export FISSION_ROUTER=127.0.0.1:9999
-
-{{- end }}
-
-3. Finally, you're ready to use Fission!
-
+  # Create an environment
   $ fission env create --name nodejs --image fission/node-env
 
+  # Get a hello world
   $ curl https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js > hello.js
 
+  # Register this function with Fission
   $ fission function create --name hello --env nodejs --code hello.js
 
-  $ fission route create --method GET --url /hello --function hello
-
-  $ curl http://$FISSION_ROUTER/hello
+  # Run this function
+  $ fission function test --name hello
   Hello, world!

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -168,6 +168,7 @@ spec:
   template:
     metadata:
       labels:
+        application: fission-router
         svc: router
     spec:
       containers:

--- a/charts/fission-core/templates/svc.yaml
+++ b/charts/fission-core/templates/svc.yaml
@@ -4,6 +4,7 @@ metadata:
   name: router
   labels:
     svc: router
+    application: fission-router
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   type: {{ .Values.routerServiceType }}
@@ -23,6 +24,7 @@ metadata:
   name: controller
   labels:
     svc: controller
+    application: fission-api
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
 spec:
   type: {{ .Values.serviceType }}

--- a/fission/function.go
+++ b/fission/function.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -639,7 +639,6 @@ func fnPods(c *cli.Context) error {
 }
 
 func fnTest(c *cli.Context) error {
-	//we can port-forward the router specifically for this method
 	fnName := c.String("name")
 	if len(fnName) == 0 {
 		fatal("Need function name to be specified with --name")
@@ -647,27 +646,12 @@ func fnTest(c *cli.Context) error {
 
 	routerURL := os.Getenv("FISSION_ROUTER")
 	if len(routerURL) == 0 {
-		localRouterPort, err := findFreePort()
-		if err != nil {
-			fatal(fmt.Sprintf("Error finding unused port for router :%s", err.Error()))
-		}
-
-		fissionNamespace := os.Getenv("FISSION_NAMESPACE")
-		go func() {
-			err := runportForward("router", localRouterPort, fissionNamespace)
-			if err != nil {
-				fatal(err.Error())
-			}
-		}()
-
-		for {
-			conn, _ := net.DialTimeout("tcp", net.JoinHostPort("", localRouterPort), time.Second)
-			if conn != nil {
-				conn.Close()
-				break
-			}
-		}
+		// Portforward to the fission router
+		localRouterPort := setupPortForward(getKubeConfigPath(),
+			getFissionNamespace(), "application=fission-router")
 		routerURL = "127.0.0.1:" + localRouterPort
+	} else {
+		routerURL = strings.TrimPrefix(routerURL, "http://")
 	}
 
 	url := fmt.Sprintf("http://%s/fission-function/%s", routerURL, fnName)


### PR DESCRIPTION
This makes set up easier for new users.  Users can still set
FISSION_NAMESPACE but it will default to "fission".  Users can also
still set KUBECONFIG, but it will default to $HOME/.kube/config.

Also, update the post-install chart notes.txt and the install guide to
use "fission function test" as the first step after install.  This
means that if there's anything wrong with the setup, the user will see
useful errors instead of "internal server error".  Also, they can test
their setup without worrying about nodeports or ingresses or whatever.

All existing functionality of FISSION_URL and FISSION_ROUTER continues
to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/518)
<!-- Reviewable:end -->
