### PR TITLE
Detect fission namespace in cli

### DIFF
--- a/fission/main.go
+++ b/fission/main.go
@@ -25,10 +25,6 @@ import (
 
 func getFissionNamespace() string {
 	fissionNamespace := os.Getenv("FISSION_NAMESPACE")
-	if len(fissionNamespace) == 0 {
-		// TODO make this smarter, perhaps based on helm releases
-		fissionNamespace = "fission"
-	}
 	return fissionNamespace
 }
 

--- a/fission/main.go
+++ b/fission/main.go
@@ -33,6 +33,10 @@ func getKubeConfigPath() string {
 	if len(kubeConfig) == 0 {
 		home := os.Getenv("HOME")
 		kubeConfig = filepath.Join(home, ".kube", "config")
+
+		if _, err := os.Stat(kubeConfig); os.IsNotExist(err) {
+			fatal("Couldn't find kubeconfig file. Set the KUBECONFIG environment variable to your kubeconfig's path.")
+		}
 	}
 	return kubeConfig
 }


### PR DESCRIPTION
This PR removes the hard coded default "fission" namespace that I added in the last PR, replacing it with some logic to figure out where fission is installed and connecting to it.  If there is more than one fission install, error out with a useful message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/519)
<!-- Reviewable:end -->
