### PR TITLE
Show fission deployment version with cli

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,7 +72,7 @@ func MakeBuilder(sharedVolumePath string) *Builder {
 
 func (builder *Builder) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.VersionInfo())
+	fmt.Fprintf(w, fission.VersionInfo().String())
 }
 
 func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,7 +72,7 @@ func MakeBuilder(sharedVolumePath string) *Builder {
 
 func (builder *Builder) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.GetVersionInfo())
+	fmt.Fprintf(w, fission.VersionInfo())
 }
 
 func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -33,6 +33,8 @@ import (
 	"time"
 
 	"github.com/dchest/uniuri"
+
+	"github.com/fission/fission"
 )
 
 const (
@@ -66,6 +68,11 @@ func MakeBuilder(sharedVolumePath string) *Builder {
 	return &Builder{
 		sharedVolumePath: sharedVolumePath,
 	}
+}
+
+func (builder *Builder) VersionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, fission.GetVersionInfo())
 }
 
 func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {

--- a/builder/cmd/build.sh
+++ b/builder/cmd/build.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
 version=$1
+if [ -z $version ]; then
+    version=$(git rev-parse HEAD)
+fi
+
 date=$2
+if [ -z $date ]; then
+    date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+fi
+
 gitcommit=$3
+if [ -z $gitcommit ]; then
+    gitcommit=$(git rev-parse HEAD)
+fi
+
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-X github.com/fission/fission.GitCommit=$gitcommit -X github.com/fission/fission.BuildDate=$date -X github.com/fission/fission.Version=$version" -o builder .
 

--- a/builder/cmd/build.sh
+++ b/builder/cmd/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -o builder .
+version=$1
+date=$2
+gitcommit=$3
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-X github.com/fission/fission.GitCommit=$gitcommit -X github.com/fission/fission.BuildDate=$date -X github.com/fission/fission.Version=$version" -o builder .
 

--- a/builder/cmd/main.go
+++ b/builder/cmd/main.go
@@ -38,6 +38,7 @@ func main() {
 	builder := builder.MakeBuilder(dir)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", builder.Handler)
+	mux.HandleFunc("/version", builder.VersionHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/controller/api.go
+++ b/controller/api.go
@@ -137,7 +137,7 @@ func (api *API) getLogDBConfig(dbType string) logDBConfig {
 
 func (api *API) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, "{\"message\": \"Fission API\", \"version\": \"0.6.0\"}\n")
+	fmt.Fprintf(w, fission.GetVersionInfo())
 }
 
 func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/controller/api.go
+++ b/controller/api.go
@@ -137,7 +137,7 @@ func (api *API) getLogDBConfig(dbType string) logDBConfig {
 
 func (api *API) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.VersionInfo())
+	fmt.Fprintf(w, fission.VersionInfo().String())
 }
 
 func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/controller/api.go
+++ b/controller/api.go
@@ -137,7 +137,7 @@ func (api *API) getLogDBConfig(dbType string) logDBConfig {
 
 func (api *API) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.GetVersionInfo())
+	fmt.Fprintf(w, fission.VersionInfo())
 }
 
 func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/environments/fetcher/cmd/build.sh
+++ b/environments/fetcher/cmd/build.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -o fetcher .
+version=$1
+date=$2
+gitcommit=$3
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-X github.com/fission/fission.GitCommit=$gitcommit -X github.com/fission/fission.BuildDate=$date -X github.com/fission/fission.Version=$version" -o fetcher .

--- a/environments/fetcher/cmd/build.sh
+++ b/environments/fetcher/cmd/build.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 version=$1
+if [ -z $version ]; then
+    version=$(git rev-parse HEAD)
+fi
+
 date=$2
+if [ -z $date ]; then
+    date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+fi
+
 gitcommit=$3
+if [ -z $gitcommit ]; then
+    gitcommit=$(git rev-parse HEAD)
+fi
+
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-X github.com/fission/fission.GitCommit=$gitcommit -X github.com/fission/fission.BuildDate=$date -X github.com/fission/fission.Version=$version" -o fetcher .

--- a/environments/fetcher/cmd/main.go
+++ b/environments/fetcher/cmd/main.go
@@ -71,6 +71,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", fetcher.FetchHandler)
 	mux.HandleFunc("/upload", fetcher.UploadHandler)
+	mux.HandleFunc("/version", fetcher.VersionHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -165,7 +165,7 @@ func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 
 func (fetcher *Fetcher) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.GetVersionInfo())
+	fmt.Fprintf(w, fission.VersionInfo())
 }
 
 func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -165,7 +165,7 @@ func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 
 func (fetcher *Fetcher) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.VersionInfo())
+	fmt.Fprintf(w, fission.VersionInfo().String())
 }
 
 func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -163,6 +163,11 @@ func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 	return nil
 }
 
+func (fetcher *Fetcher) VersionHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	fmt.Fprintf(w, fission.GetVersionInfo())
+}
+
 func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(w, "only POST is supported on this endpoint", http.StatusMethodNotAllowed)

--- a/fission-bundle/build.sh
+++ b/fission-bundle/build.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 version=$1
+if [ -z $version ]; then
+    version=$(git rev-parse HEAD)
+fi
+
 date=$2
+if [ -z $date ]; then
+    date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+fi
+
 gitcommit=$3
+if [ -z $gitcommit ]; then
+    gitcommit=$(git rev-parse HEAD)
+fi
+
 CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-X github.com/fission/fission.GitCommit=$gitcommit -X github.com/fission/fission.BuildDate=$date -X github.com/fission/fission.Version=$version"

--- a/fission-bundle/build.sh
+++ b/fission-bundle/build.sh
@@ -1,2 +1,5 @@
 #!/bin/sh
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH
+version=$1
+date=$2
+gitcommit=$3
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH -ldflags "-X github.com/fission/fission.GitCommit=$gitcommit -X github.com/fission/fission.BuildDate=$date -X github.com/fission/fission.Version=$version"

--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -140,7 +140,7 @@ Options:
   --builderMgr                    Start builder manager.
   --version                       Print version information
 `
-	version := fmt.Sprintf("Fission Bundle Version: %v", fission.VersionInfo())
+	version := fmt.Sprintf("Fission Bundle Version: %v", fission.VersionInfo().String())
 	arguments, err := docopt.Parse(usage, nil, true, version, false)
 	if err != nil {
 		log.Fatalf("Error: %v", err)

--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -140,7 +140,7 @@ Options:
   --builderMgr                    Start builder manager.
   --version                       Print version information
 `
-	version := fmt.Sprintf("Fission Bundle Version: %v", fission.GetVersionInfo())
+	version := fmt.Sprintf("Fission Bundle Version: %v", fission.VersionInfo())
 	arguments, err := docopt.Parse(usage, nil, true, version, false)
 	if err != nil {
 		log.Fatalf("Error: %v", err)

--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"strconv"
 
 	"github.com/docopt/docopt-go"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/buildermgr"
 	"github.com/fission/fission/controller"
 	"github.com/fission/fission/executor"
@@ -120,6 +122,7 @@ Usage:
   fission-bundle --builderMgr [--storageSvcUrl=<url>] [--envbuilder-namespace=<namespace>]
   fission-bundle --timer [--routerUrl=<url>]
   fission-bundle --mqt   [--routerUrl=<url>]
+  fission-bundle --version
 Options:
   --controllerPort=<port>         Port that the controller should listen on.
   --routerPort=<port>             Port that the router should listen on.
@@ -135,8 +138,10 @@ Options:
   --timer                         Start Timer.
   --mqt                           Start message queue trigger.
   --builderMgr                    Start builder manager.
+  --version                       Print version information
 `
-	arguments, err := docopt.Parse(usage, nil, true, "fission-bundle", false)
+	version := fmt.Sprintf("Fission Bundle Version: %v", fission.GetVersionInfo())
+	arguments, err := docopt.Parse(usage, nil, true, version, false)
 	if err != nil {
 		log.Fatalf("Error: %v", err)
 	}

--- a/fission/main.go
+++ b/fission/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		clientVer := version.VersionInfo()
+		clientVer := version.VersionInfo().String()
 		serverVer := getFissionAPIVersion(value)
 		fmt.Printf("Client Version: %v\nServer Version: %v", clientVer, serverVer)
 	}
@@ -266,7 +266,6 @@ func main() {
 		{Name: "spec", Aliases: []string{"specs"}, Usage: "Manage a declarative app specification", Subcommands: specSubCommands},
 		{Name: "upgrade", Aliases: []string{}, Usage: "Upgrade tool from fission v0.1", Subcommands: upgradeSubCommands},
 		{Name: "tpr2crd", Aliases: []string{}, Usage: "Migrate tool for TPR to CRD", Subcommands: migrateSubCommands},
-		//{Name: "version", Aliases: []string{"v"}, Usage: "Print the client and server version information", Action: getVersionInfo},
 	}
 
 	app.Run(os.Args)

--- a/fission/main.go
+++ b/fission/main.go
@@ -46,18 +46,18 @@ func getKubeConfigPath() string {
 	return kubeConfig
 }
 
-func getFissionAPIVersion(apiUrl string) string {
+func getFissionAPIVersion(apiUrl string) (string, error) {
 	resp, err := http.Get(apiUrl)
 	if err != nil {
-		fatal(fmt.Sprintf("Error connection Fission API server: %v", err))
+		return "", err
 	}
 	defer resp.Body.Close()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		fatal(fmt.Sprintf("Error parsing Fission API version: %v", err))
+		return "", err
 	}
-	return strings.TrimRight(string(body), "\n")
+	return strings.TrimRight(string(body), "\n"), nil
 }
 
 func main() {
@@ -81,8 +81,13 @@ func main() {
 
 	cli.VersionPrinter = func(c *cli.Context) {
 		clientVer := version.VersionInfo().String()
-		serverVer := getFissionAPIVersion(value)
-		fmt.Printf("Client Version: %v\nServer Version: %v", clientVer, serverVer)
+		fmt.Printf("Client Version: %v\n", clientVer)
+		serverVer, err := getFissionAPIVersion(value)
+		if err != nil {
+			fmt.Printf("Error getting Fission API version: %v", err)
+		} else {
+			fmt.Printf("Server Version: %v", serverVer)
+		}
 	}
 
 	app.Flags = []cli.Flag{

--- a/fission/main.go
+++ b/fission/main.go
@@ -80,7 +80,7 @@ func main() {
 	}
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		clientVer := version.GetVersionInfo()
+		clientVer := version.VersionInfo()
 		serverVer := getFissionAPIVersion(value)
 		fmt.Printf("Client Version: %v\nServer Version: %v", clientVer, serverVer)
 	}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -90,11 +90,13 @@ push_fission_bundle_image() {
 
 build_fetcher_image() {
     local version=$1
+    local date=$2
+    local gitcommit=$3
     local tag=fission/fetcher:$version
 
     pushd $DIR/environments/fetcher/cmd
 
-    ./build.sh
+    ./build.sh $version $date $gitcommit
     docker build -t $tag .
     docker tag $tag fission/fetcher:latest
 
@@ -109,11 +111,13 @@ push_fetcher_image() {
 
 build_builder_image() {
     local version=$1
+    local date=$2
+    local gitcommit=$3
     local tag=fission/builder:$version
 
     pushd $DIR/builder/cmd
 
-    ./build.sh
+    ./build.sh $version $date $gitcommit
     docker build -t $tag .
     docker tag $tag fission/builder:latest
 
@@ -280,8 +284,8 @@ build_all() {
     mkdir -p $BUILDDIR
     
     build_fission_bundle_image $version $date $gitcommit
-    build_fetcher_image $version
-    build_builder_image $version
+    build_fetcher_image $version $date $gitcommit
+    build_builder_image $version $date $gitcommit
     build_logger_image $version
     build_all_cli $version $date $gitcommit
     build_charts $version

--- a/version.go
+++ b/version.go
@@ -21,9 +21,9 @@ import (
 )
 
 var (
-	GitCommit string // $(git rev-parse HEAD)
-	BuildDate string // $(date -u +'%Y-%m-%dT%H:%M:%SZ')
-	Version   string
+	GitCommit string // $(git rev-parse HEAD) (1b4716ab84903b2e477135a3dc5afdb07f685cb7)
+	BuildDate string // $(date -u +'%Y-%m-%dT%H:%M:%SZ') (2018-03-08T18:54:38Z)
+	Version   string // fission release version (0.6.0)
 )
 
 type (

--- a/version.go
+++ b/version.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fission
+
+import (
+	"encoding/json"
+)
+
+var (
+	GitCommit string // $(git rev-parse HEAD)
+	BuildDate string // $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	Version   string
+)
+
+type (
+	Info struct {
+		GitCommit string `json:"GitCommit,omitempty"`
+		BuildDate string `json:"BuildDate,omitempty"`
+		Version   string `json:"Version,omitempty"`
+	}
+)
+
+func GetVersionInfo() string {
+	info := Info{
+		GitCommit: GitCommit,
+		BuildDate: BuildDate,
+		Version:   Version,
+	}
+	v, _ := json.Marshal(info)
+	return string(v)
+}

--- a/version.go
+++ b/version.go
@@ -34,7 +34,7 @@ type (
 	}
 )
 
-func GetVersionInfo() string {
+func VersionInfo() string {
 	info := Info{
 		GitCommit: GitCommit,
 		BuildDate: BuildDate,

--- a/version.go
+++ b/version.go
@@ -34,12 +34,15 @@ type (
 	}
 )
 
-func VersionInfo() string {
-	info := Info{
+func VersionInfo() Info {
+	return Info{
 		GitCommit: GitCommit,
 		BuildDate: BuildDate,
 		Version:   Version,
 	}
+}
+
+func (info Info) String() string {
 	v, _ := json.Marshal(info)
 	return string(v)
 }


### PR DESCRIPTION
Set fission version through go `ldflags`. Following is the command output. (https://github.com/fission/fission/issues/362)
```
$ fission --version
Client Version: {"GitCommit":"84bf6d32ed9eccba48f0016fecc3bec94a47f043","BuildDate":"2018-03-08T15:54:56Z","Version":"test"}
Server Version: {"GitCommit":"81db94f3db335efbc209994b5bdaaafde4f9cec5","BuildDate":"2018-03-08T16:23:48Z","Version":"dummy-version"}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/538)
<!-- Reviewable:end -->
