### PR TITLE
Fixes #537 - warning should not be given when updating to newdeploy

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -510,7 +510,7 @@ func fnUpdate(c *cli.Context) error {
 		default:
 			fatal("Executor type must be one of 'poolmgr' or 'newdeploy', defaults to 'poolmgr'")
 		}
-		if c.IsSet("mincpu") || c.IsSet("maxcpu") || c.IsSet("minmemory") || c.IsSet("maxmemory") &&
+		if (c.IsSet("mincpu") || c.IsSet("maxcpu") || c.IsSet("minmemory") || c.IsSet("maxmemory")) &&
 			fnExecutor == fission.ExecutorTypePoolmgr {
 			warn("CPU/Memory specified for function with pool manager executor will be ignored in favor of resources specified at environment")
 		}


### PR DESCRIPTION
The warning should not be given when updating to new deploy executor type, as the warning is only applicable for pool manager type of functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/545)
<!-- Reviewable:end -->
