### PR TITLE
This change fixes an error in a yaml file in the fission-core chart.

### DIFF
--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -144,14 +144,14 @@ spec:
         readinessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 1
           periodSeconds: 1
           failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
@@ -180,14 +180,14 @@ spec:
         readinessProbe:
           httpGet:
             path: "/router-healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 1
           periodSeconds: 1
           failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/router-healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
@@ -238,14 +238,14 @@ spec:
         readinessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 1
           periodSeconds: 1
           failureThreshold: 30
         livenessProbe:
           httpGet:
             path: "/healthz"
-            port: "8888"
+            port: 8888
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc


### PR DESCRIPTION
The Deployment definition for executor, controller, router contains readines/liveness probes. The port definition for those probes should be numbers, instead of string, i.e. port: "8888" should be port 8888.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/563)
<!-- Reviewable:end -->
