### PR TITLE
Add validate function to crd resource and do validate before creation/update

### DIFF
--- a/common.go
+++ b/common.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"syscall"
@@ -29,6 +30,10 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/imdario/mergo"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+var (
+	validAzureQueueName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]*[a-z0-9]$")
 )
 
 func UrlForFunction(name string) string {

--- a/common.go
+++ b/common.go
@@ -22,7 +22,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"syscall"
@@ -30,10 +29,6 @@ import (
 	"github.com/gorilla/handlers"
 	"github.com/imdario/mergo"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-)
-
-var (
-	validAzureQueueName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]*[a-z0-9]$")
 )
 
 func UrlForFunction(name string) string {

--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -148,6 +148,7 @@ func TestHTTPTriggerApi(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 		},
 		Spec: fission.HTTPTriggerSpec{
+			Method:      http.MethodGet,
 			RelativeURL: "/hello",
 			FunctionReference: fission.FunctionReference{
 				Type: fission.FunctionReferenceTypeFunctionName,

--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -69,9 +70,8 @@ func assertNotFoundFailure(err error, name string) {
 
 func assertCronSpecFails(err error) {
 	assert(err != nil, "using an invalid cron spec must fail")
-	fe, ok := err.(fission.Error)
-	assert(ok, "error must be a fission Error")
-	assert(fe.Code == fission.ErrorInvalidArgument, "error must be a invalid argument error")
+	ok := strings.Contains(err.Error(), "not a valid cron spec")
+	assert(ok, "invalid cron spec must fail")
 }
 
 func TestFunctionApi(t *testing.T) {

--- a/controller/api_test.go
+++ b/controller/api_test.go
@@ -82,10 +82,16 @@ func TestFunctionApi(t *testing.T) {
 		},
 		Spec: fission.FunctionSpec{
 			Environment: fission.EnvironmentReference{
-				Name: "nodejs",
+				Name:      "nodejs",
+				Namespace: metav1.NamespaceDefault,
 			},
 			Package: fission.FunctionPackageRef{
 				FunctionName: "xxx",
+				PackageRef: fission.PackageRef{
+					Namespace:       metav1.NamespaceDefault,
+					Name:            "xxx",
+					ResourceVersion: "12345",
+				},
 			},
 		},
 	}

--- a/controller/client/environment.go
+++ b/controller/client/environment.go
@@ -24,10 +24,16 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
 func (c *Client) EnvironmentCreate(env *crd.Environment) (*metav1.ObjectMeta, error) {
+	errs := env.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("Environment", errs)
+	}
+
 	reqbody, err := json.Marshal(env)
 	if err != nil {
 		return nil, err
@@ -78,6 +84,11 @@ func (c *Client) EnvironmentGet(m *metav1.ObjectMeta) (*crd.Environment, error) 
 }
 
 func (c *Client) EnvironmentUpdate(env *crd.Environment) (*metav1.ObjectMeta, error) {
+	errs := env.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("Environment", errs)
+	}
+
 	reqbody, err := json.Marshal(env)
 	if err != nil {
 		return nil, err

--- a/controller/client/environment.go
+++ b/controller/client/environment.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) EnvironmentCreate(env *crd.Environment) (*metav1.ObjectMeta, error) {
-	errs := env.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("Environment", errs)
+	err := env.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("Environment", err)
 	}
 
 	reqbody, err := json.Marshal(env)
@@ -84,9 +84,9 @@ func (c *Client) EnvironmentGet(m *metav1.ObjectMeta) (*crd.Environment, error) 
 }
 
 func (c *Client) EnvironmentUpdate(env *crd.Environment) (*metav1.ObjectMeta, error) {
-	errs := env.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("Environment", errs)
+	err := env.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("Environment", err)
 	}
 
 	reqbody, err := json.Marshal(env)

--- a/controller/client/function.go
+++ b/controller/client/function.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) FunctionCreate(f *crd.Function) (*metav1.ObjectMeta, error) {
-	errs := f.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("Function", errs)
+	err := f.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("Function", err)
 	}
 
 	reqbody, err := json.Marshal(f)
@@ -98,9 +98,9 @@ func (c *Client) FunctionGetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) 
 }
 
 func (c *Client) FunctionUpdate(f *crd.Function) (*metav1.ObjectMeta, error) {
-	errs := f.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("Function", errs)
+	err := f.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("Function", err)
 	}
 
 	reqbody, err := json.Marshal(f)

--- a/controller/client/function.go
+++ b/controller/client/function.go
@@ -24,10 +24,15 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
 func (c *Client) FunctionCreate(f *crd.Function) (*metav1.ObjectMeta, error) {
+	errs := f.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("Function", errs)
+	}
 
 	reqbody, err := json.Marshal(f)
 	if err != nil {
@@ -93,6 +98,11 @@ func (c *Client) FunctionGetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) 
 }
 
 func (c *Client) FunctionUpdate(f *crd.Function) (*metav1.ObjectMeta, error) {
+	errs := f.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("Function", errs)
+	}
+
 	reqbody, err := json.Marshal(f)
 	if err != nil {
 		return nil, err

--- a/controller/client/httptrigger.go
+++ b/controller/client/httptrigger.go
@@ -24,10 +24,16 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
 func (c *Client) HTTPTriggerCreate(t *crd.HTTPTrigger) (*metav1.ObjectMeta, error) {
+	errs := t.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("HTTPTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
@@ -78,6 +84,11 @@ func (c *Client) HTTPTriggerGet(m *metav1.ObjectMeta) (*crd.HTTPTrigger, error) 
 }
 
 func (c *Client) HTTPTriggerUpdate(t *crd.HTTPTrigger) (*metav1.ObjectMeta, error) {
+	errs := t.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("HTTPTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(t)
 	if err != nil {
 		return nil, err

--- a/controller/client/httptrigger.go
+++ b/controller/client/httptrigger.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) HTTPTriggerCreate(t *crd.HTTPTrigger) (*metav1.ObjectMeta, error) {
-	errs := t.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("HTTPTrigger", errs)
+	err := t.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("HTTPTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)
@@ -84,9 +84,9 @@ func (c *Client) HTTPTriggerGet(m *metav1.ObjectMeta) (*crd.HTTPTrigger, error) 
 }
 
 func (c *Client) HTTPTriggerUpdate(t *crd.HTTPTrigger) (*metav1.ObjectMeta, error) {
-	errs := t.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("HTTPTrigger", errs)
+	err := t.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("HTTPTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)

--- a/controller/client/kuberneteswatchtrigger.go
+++ b/controller/client/kuberneteswatchtrigger.go
@@ -29,6 +29,11 @@ import (
 )
 
 func (c *Client) WatchCreate(w *crd.KubernetesWatchTrigger) (*metav1.ObjectMeta, error) {
+	errs := w.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("KubernetesWatchTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(w)
 	if err != nil {
 		return nil, err

--- a/controller/client/kuberneteswatchtrigger.go
+++ b/controller/client/kuberneteswatchtrigger.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) WatchCreate(w *crd.KubernetesWatchTrigger) (*metav1.ObjectMeta, error) {
-	errs := w.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("KubernetesWatchTrigger", errs)
+	err := w.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("KubernetesWatchTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(w)

--- a/controller/client/mqtrigger.go
+++ b/controller/client/mqtrigger.go
@@ -24,10 +24,16 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
 func (c *Client) MessageQueueTriggerCreate(t *crd.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
+	errs := t.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("MessageQueueTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
@@ -78,6 +84,11 @@ func (c *Client) MessageQueueTriggerGet(m *metav1.ObjectMeta) (*crd.MessageQueue
 }
 
 func (c *Client) MessageQueueTriggerUpdate(mqTrigger *crd.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
+	errs := mqTrigger.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("MessageQueueTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(mqTrigger)
 	if err != nil {
 		return nil, err

--- a/controller/client/mqtrigger.go
+++ b/controller/client/mqtrigger.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) MessageQueueTriggerCreate(t *crd.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
-	errs := t.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("MessageQueueTrigger", errs)
+	err := t.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("MessageQueueTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)
@@ -84,9 +84,9 @@ func (c *Client) MessageQueueTriggerGet(m *metav1.ObjectMeta) (*crd.MessageQueue
 }
 
 func (c *Client) MessageQueueTriggerUpdate(mqTrigger *crd.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
-	errs := mqTrigger.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("MessageQueueTrigger", errs)
+	err := mqTrigger.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("MessageQueueTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(mqTrigger)

--- a/controller/client/package.go
+++ b/controller/client/package.go
@@ -24,10 +24,15 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
 func (c *Client) PackageCreate(f *crd.Package) (*metav1.ObjectMeta, error) {
+	errs := f.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("Package", errs)
+	}
 
 	reqbody, err := json.Marshal(f)
 	if err != nil {
@@ -79,6 +84,11 @@ func (c *Client) PackageGet(m *metav1.ObjectMeta) (*crd.Package, error) {
 }
 
 func (c *Client) PackageUpdate(f *crd.Package) (*metav1.ObjectMeta, error) {
+	errs := f.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("Package", errs)
+	}
+
 	reqbody, err := json.Marshal(f)
 	if err != nil {
 		return nil, err

--- a/controller/client/package.go
+++ b/controller/client/package.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) PackageCreate(f *crd.Package) (*metav1.ObjectMeta, error) {
-	errs := f.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("Package", errs)
+	err := f.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("Package", err)
 	}
 
 	reqbody, err := json.Marshal(f)
@@ -84,9 +84,9 @@ func (c *Client) PackageGet(m *metav1.ObjectMeta) (*crd.Package, error) {
 }
 
 func (c *Client) PackageUpdate(f *crd.Package) (*metav1.ObjectMeta, error) {
-	errs := f.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("Package", errs)
+	err := f.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("Package", err)
 	}
 
 	reqbody, err := json.Marshal(f)

--- a/controller/client/timetrigger.go
+++ b/controller/client/timetrigger.go
@@ -29,9 +29,9 @@ import (
 )
 
 func (c *Client) TimeTriggerCreate(t *crd.TimeTrigger) (*metav1.ObjectMeta, error) {
-	errs := t.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("TimeTrigger", errs)
+	err := t.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("TimeTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)
@@ -84,9 +84,9 @@ func (c *Client) TimeTriggerGet(m *metav1.ObjectMeta) (*crd.TimeTrigger, error) 
 }
 
 func (c *Client) TimeTriggerUpdate(t *crd.TimeTrigger) (*metav1.ObjectMeta, error) {
-	errs := t.Validate()
-	if len(errs) > 0 {
-		return nil, fission.AggregateValidationErrors("TimeTrigger", errs)
+	err := t.Validate()
+	if err != nil {
+		return nil, fission.AggregateValidationErrors("TimeTrigger", err)
 	}
 
 	reqbody, err := json.Marshal(t)

--- a/controller/client/timetrigger.go
+++ b/controller/client/timetrigger.go
@@ -24,10 +24,16 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 )
 
 func (c *Client) TimeTriggerCreate(t *crd.TimeTrigger) (*metav1.ObjectMeta, error) {
+	errs := t.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("TimeTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(t)
 	if err != nil {
 		return nil, err
@@ -78,6 +84,11 @@ func (c *Client) TimeTriggerGet(m *metav1.ObjectMeta) (*crd.TimeTrigger, error) 
 }
 
 func (c *Client) TimeTriggerUpdate(t *crd.TimeTrigger) (*metav1.ObjectMeta, error) {
+	errs := t.Validate()
+	if len(errs) > 0 {
+		return nil, fission.AggregateValidationErrors("TimeTrigger", errs)
+	}
+
 	reqbody, err := json.Marshal(t)
 	if err != nil {
 		return nil, err

--- a/controller/crd.go
+++ b/controller/crd.go
@@ -17,9 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	"errors"
-	"regexp"
-
 	"github.com/fission/fission/crd"
 )
 
@@ -29,12 +26,4 @@ func makeCRDBackedAPI() (*API, error) {
 		return nil, err
 	}
 	return &API{fissionClient: fissionClient, kubernetesClient: kubernetesClient}, nil
-}
-
-func validateResourceName(name string) error {
-	re := regexp.MustCompile(`[a-z0-9]([-a-z0-9]*[a-z0-9])?`)
-	if len(re.FindString(name)) != len(name) {
-		return errors.New("Name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'")
-	}
-	return nil
 }

--- a/controller/environmentApi.go
+++ b/controller/environmentApi.go
@@ -60,12 +60,6 @@ func (a *API) EnvironmentApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = validateResourceName(env.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	enew, err := a.fissionClient.Environments(env.Metadata.Namespace).Create(&env)
 	if err != nil {
 		a.respondWithError(w, err)

--- a/controller/functionApi.go
+++ b/controller/functionApi.go
@@ -73,12 +73,6 @@ func (a *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = validateResourceName(f.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	fnew, err := a.fissionClient.Functions(f.Metadata.Namespace).Create(&f)
 	if err != nil {
 		a.respondWithError(w, err)

--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -74,12 +74,6 @@ func (a *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = validateResourceName(t.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	// Ensure we don't have a duplicate HTTP route defined (same URL and method)
 	err = a.checkHTTPTriggerDuplicates(&t)
 	if err != nil {

--- a/controller/mqTriggerApi.go
+++ b/controller/mqTriggerApi.go
@@ -57,12 +57,6 @@ func (a *API) MessageQueueTriggerApiCreate(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	err = validateResourceName(mqTrigger.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	tnew, err := a.fissionClient.MessageQueueTriggers(mqTrigger.Metadata.Namespace).Create(&mqTrigger)
 	if err != nil {
 		a.respondWithError(w, err)

--- a/controller/packageApi.go
+++ b/controller/packageApi.go
@@ -58,12 +58,6 @@ func (a *API) PackageApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = validateResourceName(f.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	// Ensure size limits
 	if len(f.Spec.Source.Literal) > 256*1024 {
 		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")

--- a/controller/timeTriggerApi.go
+++ b/controller/timeTriggerApi.go
@@ -59,12 +59,6 @@ func (a *API) TimeTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = validateResourceName(t.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	// validate
 	_, err = cron.Parse(t.Spec.Cron)
 	if err != nil {

--- a/controller/watchApi.go
+++ b/controller/watchApi.go
@@ -58,12 +58,6 @@ func (a *API) WatchApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = validateResourceName(watch.Metadata.Name)
-	if err != nil {
-		a.respondWithError(w, err)
-		return
-	}
-
 	// TODO check for duplicate watches
 
 	wnew, err := a.fissionClient.KubernetesWatchTriggers(watch.Metadata.Namespace).Create(&watch)

--- a/crd/types.go
+++ b/crd/types.go
@@ -151,14 +151,14 @@ func (ht *HTTPTrigger) GetObjectKind() schema.ObjectKind {
 func (w *KubernetesWatchTrigger) GetObjectKind() schema.ObjectKind {
 	return &w.TypeMeta
 }
-func (w *TimeTrigger) GetObjectKind() schema.ObjectKind {
-	return &w.TypeMeta
+func (t *TimeTrigger) GetObjectKind() schema.ObjectKind {
+	return &t.TypeMeta
 }
-func (w *MessageQueueTrigger) GetObjectKind() schema.ObjectKind {
-	return &w.TypeMeta
+func (m *MessageQueueTrigger) GetObjectKind() schema.ObjectKind {
+	return &m.TypeMeta
 }
-func (w *Package) GetObjectKind() schema.ObjectKind {
-	return &w.TypeMeta
+func (p *Package) GetObjectKind() schema.ObjectKind {
+	return &p.TypeMeta
 }
 
 func (f *Function) GetObjectMeta() metav1.Object {
@@ -173,14 +173,14 @@ func (ht *HTTPTrigger) GetObjectMeta() metav1.Object {
 func (w *KubernetesWatchTrigger) GetObjectMeta() metav1.Object {
 	return &w.Metadata
 }
-func (w *TimeTrigger) GetObjectMeta() metav1.Object {
-	return &w.Metadata
+func (t *TimeTrigger) GetObjectMeta() metav1.Object {
+	return &t.Metadata
 }
-func (w *MessageQueueTrigger) GetObjectMeta() metav1.Object {
-	return &w.Metadata
+func (m *MessageQueueTrigger) GetObjectMeta() metav1.Object {
+	return &m.Metadata
 }
-func (w *Package) GetObjectMeta() metav1.Object {
-	return &w.Metadata
+func (p *Package) GetObjectMeta() metav1.Object {
+	return &p.Metadata
 }
 
 func (fl *FunctionList) GetObjectKind() schema.ObjectKind {
@@ -198,11 +198,11 @@ func (wl *KubernetesWatchTriggerList) GetObjectKind() schema.ObjectKind {
 func (wl *TimeTriggerList) GetObjectKind() schema.ObjectKind {
 	return &wl.TypeMeta
 }
-func (wl *MessageQueueTriggerList) GetObjectKind() schema.ObjectKind {
-	return &wl.TypeMeta
+func (ml *MessageQueueTriggerList) GetObjectKind() schema.ObjectKind {
+	return &ml.TypeMeta
 }
-func (wl *PackageList) GetObjectKind() schema.ObjectKind {
-	return &wl.TypeMeta
+func (pl *PackageList) GetObjectKind() schema.ObjectKind {
+	return &pl.TypeMeta
 }
 
 func (fl *FunctionList) GetListMeta() metav1.List {
@@ -220,9 +220,106 @@ func (wl *KubernetesWatchTriggerList) GetListMeta() metav1.List {
 func (wl *TimeTriggerList) GetListMeta() metav1.List {
 	return &wl.Metadata
 }
-func (wl *MessageQueueTriggerList) GetListMeta() metav1.List {
-	return &wl.Metadata
+func (ml *MessageQueueTriggerList) GetListMeta() metav1.List {
+	return &ml.Metadata
 }
-func (wl *PackageList) GetListMeta() metav1.List {
-	return &wl.Metadata
+func (pl *PackageList) GetListMeta() metav1.List {
+	return &pl.Metadata
+}
+
+func validateMetadata(field string, m metav1.ObjectMeta) []error {
+	return fission.ValidateKubeReference(field, m.Name, m.Namespace)
+}
+
+func (p *Package) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("Package", p.Metadata)...)
+	errs = append(errs, p.Spec.Validate()...)
+	errs = append(errs, p.Status.Validate()...)
+	return errs
+}
+
+func (pl *PackageList) Validate() (errs []error) {
+	// not validate ListMeta
+	for _, p := range pl.Items {
+		errs = append(errs, p.Validate()...)
+	}
+	return errs
+}
+
+func (f *Function) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("Function", f.Metadata)...)
+	errs = append(errs, f.Spec.Validate()...)
+	return errs
+}
+
+func (fl *FunctionList) Validate() (errs []error) {
+	for _, f := range fl.Items {
+		errs = append(errs, f.Validate()...)
+	}
+	return errs
+}
+
+func (e *Environment) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("Environment", e.Metadata)...)
+	errs = append(errs, e.Spec.Validate()...)
+	return errs
+}
+
+func (el *EnvironmentList) Validate() (errs []error) {
+	for _, e := range el.Items {
+		errs = append(errs, e.Validate()...)
+	}
+	return errs
+}
+
+func (h *HTTPTrigger) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("HTTPTrigger", h.Metadata)...)
+	errs = append(errs, h.Spec.Validate()...)
+	return errs
+}
+
+func (hl *HTTPTriggerList) Validate() (errs []error) {
+	for _, h := range hl.Items {
+		errs = append(errs, h.Validate()...)
+	}
+	return errs
+}
+
+func (k *KubernetesWatchTrigger) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("KubernetesWatchTrigger", k.Metadata)...)
+	errs = append(errs, k.Spec.Validate()...)
+	return errs
+}
+
+func (kl *KubernetesWatchTriggerList) Validate() (errs []error) {
+	for _, k := range kl.Items {
+		errs = append(errs, k.Validate()...)
+	}
+	return errs
+}
+
+func (t *TimeTrigger) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("TimeTrigger", t.Metadata)...)
+	errs = append(errs, t.Spec.Validate()...)
+	return errs
+}
+
+func (tl *TimeTriggerList) Validate() (errs []error) {
+	for _, t := range tl.Items {
+		errs = append(errs, t.Validate()...)
+	}
+	return errs
+}
+
+func (m *MessageQueueTrigger) Validate() (errs []error) {
+	errs = append(errs, validateMetadata("MessageQueueTrigger", m.Metadata)...)
+	errs = append(errs, m.Spec.Validate()...)
+	return errs
+}
+
+func (ml *MessageQueueTriggerList) Validate() (errs []error) {
+	for _, m := range ml.Items {
+		errs = append(errs, m.Validate()...)
+	}
+	return errs
 }

--- a/crd/types.go
+++ b/crd/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package crd
 
 import (
+	"github.com/hashicorp/go-multierror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -227,99 +228,134 @@ func (pl *PackageList) GetListMeta() metav1.List {
 	return &pl.Metadata
 }
 
-func validateMetadata(field string, m metav1.ObjectMeta) []error {
+func validateMetadata(field string, m metav1.ObjectMeta) error {
 	return fission.ValidateKubeReference(field, m.Name, m.Namespace)
 }
 
-func (p *Package) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("Package", p.Metadata)...)
-	errs = append(errs, p.Spec.Validate()...)
-	errs = append(errs, p.Status.Validate()...)
-	return errs
+func (p *Package) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("Package", p.Metadata),
+		p.Spec.Validate(),
+		p.Status.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (pl *PackageList) Validate() (errs []error) {
+func (pl *PackageList) Validate() error {
+	var result *multierror.Error
 	// not validate ListMeta
 	for _, p := range pl.Items {
-		errs = append(errs, p.Validate()...)
+		result = multierror.Append(result, p.Validate())
 	}
-	return errs
+	return result.ErrorOrNil()
 }
 
-func (f *Function) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("Function", f.Metadata)...)
-	errs = append(errs, f.Spec.Validate()...)
-	return errs
+func (f *Function) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("Function", f.Metadata),
+		f.Spec.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (fl *FunctionList) Validate() (errs []error) {
+func (fl *FunctionList) Validate() error {
+	var result *multierror.Error
 	for _, f := range fl.Items {
-		errs = append(errs, f.Validate()...)
+		result = multierror.Append(result, f.Validate())
 	}
-	return errs
+	return result.ErrorOrNil()
 }
 
-func (e *Environment) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("Environment", e.Metadata)...)
-	errs = append(errs, e.Spec.Validate()...)
-	return errs
+func (e *Environment) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("Environment", e.Metadata),
+		e.Spec.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (el *EnvironmentList) Validate() (errs []error) {
+func (el *EnvironmentList) Validate() error {
+	var result *multierror.Error
 	for _, e := range el.Items {
-		errs = append(errs, e.Validate()...)
+		result = multierror.Append(result, e.Validate())
 	}
-	return errs
+	return result.ErrorOrNil()
 }
 
-func (h *HTTPTrigger) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("HTTPTrigger", h.Metadata)...)
-	errs = append(errs, h.Spec.Validate()...)
-	return errs
+func (h *HTTPTrigger) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("HTTPTrigger", h.Metadata),
+		h.Spec.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (hl *HTTPTriggerList) Validate() (errs []error) {
+func (hl *HTTPTriggerList) Validate() error {
+	var result *multierror.Error
 	for _, h := range hl.Items {
-		errs = append(errs, h.Validate()...)
+		result = multierror.Append(result, h.Validate())
 	}
-	return errs
+	return result.ErrorOrNil()
 }
 
-func (k *KubernetesWatchTrigger) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("KubernetesWatchTrigger", k.Metadata)...)
-	errs = append(errs, k.Spec.Validate()...)
-	return errs
+func (k *KubernetesWatchTrigger) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("KubernetesWatchTrigger", k.Metadata),
+		k.Spec.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (kl *KubernetesWatchTriggerList) Validate() (errs []error) {
+func (kl *KubernetesWatchTriggerList) Validate() error {
+	var result *multierror.Error
 	for _, k := range kl.Items {
-		errs = append(errs, k.Validate()...)
+		result = multierror.Append(result, k.Validate())
 	}
-	return errs
+	return result
 }
 
-func (t *TimeTrigger) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("TimeTrigger", t.Metadata)...)
-	errs = append(errs, t.Spec.Validate()...)
-	return errs
+func (t *TimeTrigger) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("TimeTrigger", t.Metadata),
+		t.Spec.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (tl *TimeTriggerList) Validate() (errs []error) {
+func (tl *TimeTriggerList) Validate() error {
+	var result *multierror.Error
 	for _, t := range tl.Items {
-		errs = append(errs, t.Validate()...)
+		result = multierror.Append(result, t.Validate())
 	}
-	return errs
+	return result.ErrorOrNil()
 }
 
-func (m *MessageQueueTrigger) Validate() (errs []error) {
-	errs = append(errs, validateMetadata("MessageQueueTrigger", m.Metadata)...)
-	errs = append(errs, m.Spec.Validate()...)
-	return errs
+func (m *MessageQueueTrigger) Validate() error {
+	var result *multierror.Error
+
+	result = multierror.Append(result,
+		validateMetadata("MessageQueueTrigger", m.Metadata),
+		m.Spec.Validate())
+
+	return result.ErrorOrNil()
 }
 
-func (ml *MessageQueueTriggerList) Validate() (errs []error) {
+func (ml *MessageQueueTriggerList) Validate() error {
+	var result *multierror.Error
 	for _, m := range ml.Items {
-		errs = append(errs, m.Validate()...)
+		result = multierror.Append(result, m.Validate())
 	}
-	return errs
+	return result.ErrorOrNil()
 }

--- a/fission/httptrigger.go
+++ b/fission/httptrigger.go
@@ -63,6 +63,7 @@ func checkFunctionExistence(fissionClient *client.Client, fnName string) {
 		Name:      fnName,
 		Namespace: metav1.NamespaceDefault,
 	}
+
 	_, err := fissionClient.FunctionGet(meta)
 	if err != nil {
 		fmt.Printf("function '%v' does not exist, use 'fission function create --name %v ...' to create the function\n", fnName, fnName)

--- a/fission/main.go
+++ b/fission/main.go
@@ -201,7 +201,6 @@ func main() {
 	envBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for environment builder to build source package (optional)"}
 	envExternalNetworkFlag := cli.BoolFlag{Name: "externalnetwork", Usage: "Allow environment access external network when istio feature enabled (optional, defaults to false)"}
 	envTerminationGracePeriodFlag := cli.Int64Flag{Name: "graceperiod, period", Usage: "The grace time for pod to perform connection draining before termination (optional, defaults to 360 seconds)"}
-
 	envVersionFlag := cli.IntFlag{Name: "version", Usage: "Environment API version: defaults to 1 (means v1 interface)"}
 	envSubcommands := []cli.Command{
 		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag, envExternalNetworkFlag, envTerminationGracePeriodFlag, specSaveFlag}, Action: envCreate},

--- a/fission/migrate.go
+++ b/fission/migrate.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fission/fission"
 	"github.com/fission/fission/controller/client"
 	"github.com/fission/fission/crd"
-	"github.com/fission/fission/mqtrigger/messageQueue"
 )
 
 type (
@@ -55,7 +54,7 @@ func migrateDumpTPRResource(client *client.Client, filename string) {
 	checkErr(err, "dump watches")
 	timeTriggers, err := client.TimeTriggerList()
 	checkErr(err, "dump time triggers")
-	mqTriggers, err := client.MessageQueueTriggerList(messageQueue.NATS)
+	mqTriggers, err := client.MessageQueueTriggerList(fission.MessageQueueTypeNats)
 	checkErr(err, "dump message queue triggers")
 
 	tprResource := TPRResource{

--- a/fission/mqtrigger.go
+++ b/fission/mqtrigger.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
-	"github.com/fission/fission/mqtrigger/messageQueue"
 )
 
 func mqtCreate(c *cli.Context) error {
@@ -42,14 +41,14 @@ func mqtCreate(c *cli.Context) error {
 		fatal("Need a function name to create a trigger, use --function")
 	}
 
-	mqType := c.String("mqtype")
-	switch mqType {
+	var mqType fission.MessageQueueType
+	switch c.String("mqtype") {
 	case "":
-		mqType = messageQueue.NATS
-	case messageQueue.NATS:
-		mqType = messageQueue.NATS
-	case messageQueue.ASQ:
-		mqType = messageQueue.ASQ
+		mqType = fission.MessageQueueTypeNats
+	case fission.MessageQueueTypeNats:
+		mqType = fission.MessageQueueTypeNats
+	case fission.MessageQueueTypeASQ:
+		mqType = fission.MessageQueueTypeASQ
 	default:
 		fatal("Unknown message queue type, currently only \"nats-streaming, azure-storage-queue \" is supported")
 	}
@@ -194,9 +193,9 @@ func mqtList(c *cli.Context) error {
 	return nil
 }
 
-func checkMQTopicAvailability(mqType string, topics ...string) {
+func checkMQTopicAvailability(mqType fission.MessageQueueType, topics ...string) {
 	for _, t := range topics {
-		if len(t) > 0 && !messageQueue.IsTopicValid(mqType, t) {
+		if len(t) > 0 && !fission.IsTopicValid(mqType, t) {
 			fatal(fmt.Sprintf("Invalid topic for %s: %s", mqType, t))
 		}
 	}

--- a/fission/upgrade.go
+++ b/fission/upgrade.go
@@ -360,7 +360,7 @@ func upgradeRestoreState(c *cli.Context) error {
 			Metadata: *crdMetadataFromV1Metadata(&t.Metadata, v1state.NameChanges),
 			Spec: fission.MessageQueueTriggerSpec{
 				FunctionReference: *functionRefFromV1Metadata(&t.Function, v1state.NameChanges),
-				MessageQueueType:  t.MessageQueueType,
+				MessageQueueType:  fission.MessageQueueTypeNats, // only NATS is supported at that time (v1 types)
 				Topic:             t.Topic,
 				ResponseTopic:     t.ResponseTopic,
 			},

--- a/mqtrigger/messageQueue/asq_test.go
+++ b/mqtrigger/messageQueue/asq_test.go
@@ -104,7 +104,7 @@ func (m *azureHTTPClientMock) Do(req *http.Request) (*http.Response, error) {
 
 func TestNewStorageConnectionMissingAccountName(t *testing.T) {
 	connection, err := newAzureStorageConnection(DummyRouterURL, MessageQueueConfig{
-		MQType: ASQ,
+		MQType: fission.MessageQueueTypeASQ,
 		Url:    "",
 	})
 	require.Nil(t, connection)
@@ -114,7 +114,7 @@ func TestNewStorageConnectionMissingAccountName(t *testing.T) {
 func TestNewStorageConnectionMissingAccessKey(t *testing.T) {
 	_ = os.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "accountname")
 	connection, err := newAzureStorageConnection(DummyRouterURL, MessageQueueConfig{
-		MQType: ASQ,
+		MQType: fission.MessageQueueTypeASQ,
 		Url:    "",
 	})
 	_ = os.Unsetenv("AZURE_STORAGE_ACCOUNT_NAME")
@@ -291,7 +291,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 				Type: fission.FunctionReferenceTypeFunctionName,
 				Name: FunctionName,
 			},
-			MessageQueueType: ASQ,
+			MessageQueueType: fission.MessageQueueTypeASQ,
 			Topic:            QueueName,
 			ContentType:      ContentType,
 		},
@@ -434,7 +434,7 @@ func runAzureStorageQueueTest(t *testing.T, count int, output bool) {
 				Type: fission.FunctionReferenceTypeFunctionName,
 				Name: FunctionName,
 			},
-			MessageQueueType: ASQ,
+			MessageQueueType: fission.MessageQueueTypeASQ,
 			Topic:            QueueName,
 			ResponseTopic:    responseTopic,
 			ContentType:      ContentType,

--- a/mqtrigger/messageQueue/messageQueue.go
+++ b/mqtrigger/messageQueue/messageQueue.go
@@ -18,7 +18,6 @@ package messageQueue
 
 import (
 	"errors"
-	"regexp"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -29,18 +28,9 @@ import (
 )
 
 const (
-	NATS string = "nats-streaming"
-	ASQ  string = "azure-storage-queue"
-)
-
-const (
 	ADD_TRIGGER requestType = iota
 	DELETE_TRIGGER
 	GET_ALL_TRIGGERS
-)
-
-var (
-	validAzureQueueName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]*[a-z0-9]$")
 )
 
 type (
@@ -92,9 +82,9 @@ func MakeMessageQueueTriggerManager(fissionClient *crd.FissionClient, routerUrl 
 		fissionClient: fissionClient,
 	}
 	switch mqConfig.MQType {
-	case NATS:
+	case fission.MessageQueueTypeNats:
 		messageQueue, err = makeNatsMessageQueue(routerUrl, mqConfig)
-	case ASQ:
+	case fission.MessageQueueTypeASQ:
 		messageQueue, err = newAzureStorageConnection(routerUrl, mqConfig)
 	default:
 		err = errors.New("No matched message queue type found")
@@ -230,14 +220,4 @@ func (mqt *MessageQueueTriggerManager) syncTriggers() {
 		// TODO replace with a watch
 		time.Sleep(3 * time.Second)
 	}
-}
-
-func IsTopicValid(mqType string, topic string) bool {
-	switch mqType {
-	case NATS:
-		return isTopicValidForNats(topic)
-	case ASQ:
-		return len(topic) >= 3 && len(topic) <= 63 && validAzureQueueName.MatchString(topic)
-	}
-	return false
 }

--- a/types.go
+++ b/types.go
@@ -99,6 +99,7 @@ type (
 		// package update, making it possible to cache the function based on its metadata.
 		ResourceVersion string `json:"resourceversion,omitempty"`
 	}
+
 	FunctionPackageRef struct {
 		PackageRef PackageRef `json:"packageref"`
 

--- a/types.go
+++ b/types.go
@@ -289,11 +289,13 @@ type (
 		FunctionReference FunctionReference `json:"functionref"`
 	}
 
+	MessageQueueType string
+
 	// MessageQueueTriggerSpec defines a binding from a topic in a
 	// message queue to a function.
 	MessageQueueTriggerSpec struct {
 		FunctionReference FunctionReference `json:"functionref"`
-		MessageQueueType  string            `json:"messageQueueType"`
+		MessageQueueType  MessageQueueType  `json:"messageQueueType"`
 		Topic             string            `json:"topic"`
 		ResponseTopic     string            `json:"respTopic,omitempty"`
 		ContentType       string            `json:"contentType"`
@@ -385,6 +387,11 @@ const (
 	SharedVolumePackages   = "packages"
 	SharedVolumeSecrets    = "secrets"
 	SharedVolumeConfigmaps = "configmaps"
+)
+
+const (
+	MessageQueueTypeNats = "nats-streaming"
+	MessageQueueTypeASQ  = "azure-storage-queue"
 )
 
 const (

--- a/validation.go
+++ b/validation.go
@@ -1,0 +1,306 @@
+/*
+Copyright 2018 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fission
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+type ErrorType int
+
+type ValidationError struct {
+	Type     ErrorType
+	Field    string
+	BadValue interface{}
+	Detail   string
+}
+
+func (e ValidationError) Error() string {
+	errMsg := fmt.Sprintf("%v: ", e.Field)
+
+	switch e.Type {
+	case ErrorUnsupportedType:
+		errMsg += fmt.Sprintf("Unsupported type: %v", e.BadValue)
+	case ErrorInvalidValue:
+		errMsg += fmt.Sprintf("Invalid value: %v", e.BadValue)
+	case ErrorInvalidObject:
+		errMsg += fmt.Sprintf("Invalid object: %v", e.BadValue)
+	default:
+		errMsg += fmt.Sprintf("Unknown error type: %v", e.BadValue)
+	}
+	if len(e.Detail) > 0 {
+		errMsg += fmt.Sprintf(": %v", e.Detail)
+	}
+
+	return errMsg
+}
+
+func AggregateValidationErrors(objName string, errs []error) error {
+	errMsg := fmt.Sprintf("Invalid fission %v object:\n", objName)
+	for _, err := range errs {
+		errMsg += fmt.Sprintf("* %v\n", err.Error())
+	}
+	return errors.New(errMsg)
+}
+
+func MakeValidationErr(errType ErrorType, field string, val interface{}, detail ...string) ValidationError {
+	return ValidationError{
+		Type:     errType,
+		Field:    field,
+		BadValue: val,
+		Detail:   fmt.Sprintf("%v", detail),
+	}
+}
+
+const (
+	ErrorUnsupportedType = iota
+	ErrorInvalidValue
+	ErrorInvalidObject
+)
+
+type Resource interface {
+	Validate() []error
+}
+
+func ValidateKubeLabel(field string, labels map[string]string) (errs []error) {
+	for k, v := range labels {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, fmt.Sprintf("%v.key.%v", field, k), k, validation.IsQualifiedName(k)...))
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, fmt.Sprintf("%v.value.%v", field, v), v, validation.IsValidLabelValue(v)...))
+	}
+	return errs
+}
+
+func ValidateKubePort(field string, port int) (errs []error) {
+	e := validation.IsValidPortNum(port)
+	if len(e) > 0 {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, field, port, e...))
+	}
+	return errs
+}
+
+func ValidateKubeName(field string, val string) (errs []error) {
+	e := validation.IsDNS1123Label(val)
+	if len(e) > 0 {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, field, val, e...))
+	}
+	return errs
+}
+
+func ValidateKubeReference(refName string, name string, namespace string) (errs []error) {
+	errs = append(errs, ValidateKubeName(fmt.Sprintf("%v.Name", refName), name)...)
+	errs = append(errs, ValidateKubeName(fmt.Sprintf("%v.Namespace", refName), namespace)...)
+	return errs
+}
+
+func (archive Archive) Validate() (errs []error) {
+	switch archive.Type {
+	case ArchiveTypeLiteral, ArchiveTypeUrl: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "Archive.Type", archive.Type, "not a valid archive type"))
+	}
+	switch archive.Checksum.Type {
+	case ChecksumTypeSHA256: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "Archive.Checksum.Type", archive.Checksum.Type, "not a valid checksum type"))
+	}
+	return errs
+}
+
+func (ref EnvironmentReference) Validate() (errs []error) {
+	errs = append(errs, ValidateKubeReference("EnvironmentReference", ref.Name, ref.Namespace)...)
+	return errs
+}
+
+func (ref SecretReference) Validate() (errs []error) {
+	errs = append(errs, ValidateKubeReference("SecretReference", ref.Name, ref.Namespace)...)
+	return errs
+}
+
+func (ref ConfigMapReference) Validate() (errs []error) {
+	errs = append(errs, ValidateKubeReference("ConfigMapReference", ref.Name, ref.Namespace)...)
+	return errs
+}
+
+func (spec PackageSpec) Validate() (errs []error) {
+	for _, r := range []Resource{spec.Environment, spec.Source, spec.Deployment} {
+		errs = append(errs, r.Validate()...)
+	}
+	return errs
+}
+
+func (sts PackageStatus) Validate() (errs []error) {
+	switch sts.BuildStatus {
+	case BuildStatusPending, BuildStatusRunning, BuildStatusSucceeded, BuildStatusFailed, BuildStatusNone: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "PackageStatus.BuildStatus", sts.BuildStatus, "not a valid build status"))
+	}
+	return errs
+}
+
+func (ref PackageRef) Validate() (errs []error) {
+	errs = append(errs, ValidateKubeReference("PackageRef", ref.Name, ref.Namespace)...)
+	return errs
+}
+
+func (ref FunctionPackageRef) Validate() (errs []error) {
+	errs = append(errs, ref.PackageRef.Validate()...)
+	errs = append(errs, ValidateKubeName("FunctionPackageRef.FunctionName", ref.FunctionName)...)
+	return errs
+}
+
+func (spec FunctionSpec) Validate() (errs []error) {
+	for _, r := range []Resource{spec.Environment, spec.Package} {
+		errs = append(errs, r.Validate()...)
+	}
+	for _, s := range spec.Secrets {
+		errs = append(errs, s.Validate()...)
+	}
+	for _, c := range spec.ConfigMaps {
+		errs = append(errs, c.Validate()...)
+	}
+	errs = append(errs, spec.InvokeStrategy.Validate()...)
+	return errs
+}
+
+func (is InvokeStrategy) Validate() (errs []error) {
+	switch is.StrategyType {
+	case StrategyTypeExecution: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "InvokeStrategy.StrategyType", is.StrategyType, "not a valid valid strategy"))
+	}
+	errs = append(errs, is.ExecutionStrategy.Validate()...)
+	return errs
+}
+
+func (es ExecutionStrategy) Validate() (errs []error) {
+	switch es.ExecutorType {
+	case ExecutorTypeNewdeploy, ExecutorTypePoolmgr: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "ExecutionStrategy.ExecutorType", es.ExecutorType, "not a valid executor type"))
+	}
+	if es.MinScale < 0 {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MinScale", es.MinScale, "minimum scale must be greater or equal to 0"))
+	}
+	if es.MaxScale < es.MinScale {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater or equal to minimum scale"))
+	}
+	if es.TargetCPUPercent <= 0 || es.TargetCPUPercent > 100 {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.TargetCPUPercent", es.TargetCPUPercent, "TargetCPUPercent must be a value between 1 - 100"))
+	}
+	return errs
+}
+
+func (ref FunctionReference) Validate() (errs []error) {
+	switch ref.Type {
+	case FunctionReferenceTypeFunctionName: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "FunctionReference.Type", ref.Type, "not a valid function reference type"))
+	}
+	errs = append(errs, ValidateKubeName("FunctionReference.Name", ref.Name)...)
+	return errs
+}
+
+func (runtime Runtime) Validate() (errs []error) {
+	errs = append(errs, ValidateKubePort("Runtime.LoadEndpointPort", int(runtime.LoadEndpointPort))...)
+	errs = append(errs, ValidateKubePort("Runtime.FunctionEndpointPort", int(runtime.FunctionEndpointPort))...)
+	return errs
+}
+
+func (builder Builder) Validate() (errs []error) {
+	// do nothing for now
+	return nil
+}
+
+func (spec EnvironmentSpec) Validate() (errs []error) {
+	if spec.Version < 1 && spec.Version > 3 {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "EnvironmentSpec.Version", spec.Version, "not a valid environment version"))
+	}
+	for _, r := range []Resource{spec.Runtime, spec.Builder} {
+		errs = append(errs, r.Validate()...)
+	}
+	switch spec.AllowedFunctionsPerContainer {
+	case AllowedFunctionsPerContainerSingle, AllowedFunctionsPerContainerInfinite: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "EnvironmentSpec.AllowedFunctionsPerContainer", spec.AllowedFunctionsPerContainer, "not a valid value"))
+	}
+	if spec.Poolsize < 0 {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "EnvironmentSpec.Poolsize", spec.Poolsize, "Poolsize must be greater or equal to 0"))
+	}
+	return errs
+}
+
+func (spec HTTPTriggerSpec) Validate() (errs []error) {
+	switch spec.Method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
+		http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "HTTPTriggerSpec.Method", spec.Method, "not a valid HTTP method"))
+	}
+	errs = append(errs, spec.FunctionReference.Validate()...)
+	if len(spec.Host) > 0 {
+		e := validation.IsDNS1123Subdomain(spec.Host)
+		if len(e) > 0 {
+			errs = append(errs, MakeValidationErr(ErrorInvalidValue, "HTTPTriggerSpec.Host", spec.Host, e...))
+		}
+	}
+	return errs
+}
+
+func (spec KubernetesWatchTriggerSpec) Validate() (errs []error) {
+	switch spec.Type {
+	case "POD", "SERVICE", "REPLICATIONCONTROLLER", "JOB":
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "KubernetesWatchTriggerSpec.Type", spec.Type, "not a valid supported type"))
+	}
+	errs = append(errs, ValidateKubeName("KubernetesWatchTriggerSpec.Namespace", spec.Namespace)...)
+	errs = append(errs, ValidateKubeLabel("KubernetesWatchTriggerSpec.LabelSelector", spec.LabelSelector)...)
+	errs = append(errs, spec.FunctionReference.Validate()...)
+	return errs
+}
+
+func (spec MessageQueueTriggerSpec) Validate() (errs []error) {
+	errs = append(errs, spec.FunctionReference.Validate()...)
+
+	switch spec.MessageQueueType {
+	case MessageQueueTypeNats, MessageQueueTypeASQ: // no op
+	default:
+		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "MessageQueueTriggerSpec.MessageQueueType", spec.MessageQueueType, "not a supported message queue type"))
+	}
+
+	if !IsTopicValid(spec.MessageQueueType, spec.Topic) {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "MessageQueueTriggerSpec.Topic", spec.Topic, "not a valid topic"))
+	}
+
+	if len(spec.ResponseTopic) > 0 && !IsTopicValid(spec.MessageQueueType, spec.ResponseTopic) {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "MessageQueueTriggerSpec.ResponseTopic", spec.ResponseTopic, "not a valid topic"))
+	}
+
+	return errs
+}
+
+func (spec TimeTriggerSpec) Validate() (errs []error) {
+	err := IsValidCronSpec(spec.Cron)
+	if err != nil {
+		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "TimeTriggerSpec.Cron", spec.Cron, "not a valid cron spec"))
+	}
+	errs = append(errs, spec.FunctionReference.Validate()...)
+	return errs
+}

--- a/validation.go
+++ b/validation.go
@@ -174,11 +174,6 @@ func (ref PackageRef) Validate() (errs []error) {
 
 func (ref FunctionPackageRef) Validate() (errs []error) {
 	errs = append(errs, ref.PackageRef.Validate()...)
-
-	if len(ref.FunctionName) > 0 {
-		errs = append(errs, ValidateKubeName("FunctionPackageRef.FunctionName", ref.FunctionName)...)
-	}
-
 	return errs
 }
 

--- a/validation.go
+++ b/validation.go
@@ -111,15 +111,19 @@ func ValidateKubeReference(refName string, name string, namespace string) (errs 
 }
 
 func (archive Archive) Validate() (errs []error) {
-	switch archive.Type {
-	case ArchiveTypeLiteral, ArchiveTypeUrl: // no op
-	default:
-		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "Archive.Type", archive.Type, "not a valid archive type"))
+	if len(archive.Type) > 0 {
+		switch archive.Type {
+		case ArchiveTypeLiteral, ArchiveTypeUrl: // no op
+		default:
+			errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "Archive.Type", archive.Type, "not a valid archive type"))
+		}
 	}
-	switch archive.Checksum.Type {
-	case ChecksumTypeSHA256: // no op
-	default:
-		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "Archive.Checksum.Type", archive.Checksum.Type, "not a valid checksum type"))
+	if len(archive.Checksum.Type) > 0 {
+		switch archive.Checksum.Type {
+		case ChecksumTypeSHA256: // no op
+		default:
+			errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "Archive.Checksum.Type", archive.Checksum.Type, "not a valid checksum type"))
+		}
 	}
 	return errs
 }
@@ -219,8 +223,12 @@ func (ref FunctionReference) Validate() (errs []error) {
 }
 
 func (runtime Runtime) Validate() (errs []error) {
-	errs = append(errs, ValidateKubePort("Runtime.LoadEndpointPort", int(runtime.LoadEndpointPort))...)
-	errs = append(errs, ValidateKubePort("Runtime.FunctionEndpointPort", int(runtime.FunctionEndpointPort))...)
+	if runtime.LoadEndpointPort > 0 {
+		errs = append(errs, ValidateKubePort("Runtime.LoadEndpointPort", int(runtime.LoadEndpointPort))...)
+	}
+	if runtime.FunctionEndpointPort > 0 {
+		errs = append(errs, ValidateKubePort("Runtime.FunctionEndpointPort", int(runtime.FunctionEndpointPort))...)
+	}
 	return errs
 }
 
@@ -236,10 +244,12 @@ func (spec EnvironmentSpec) Validate() (errs []error) {
 	for _, r := range []Resource{spec.Runtime, spec.Builder} {
 		errs = append(errs, r.Validate()...)
 	}
-	switch spec.AllowedFunctionsPerContainer {
-	case AllowedFunctionsPerContainerSingle, AllowedFunctionsPerContainerInfinite: // no op
-	default:
-		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "EnvironmentSpec.AllowedFunctionsPerContainer", spec.AllowedFunctionsPerContainer, "not a valid value"))
+	if len(spec.AllowedFunctionsPerContainer) > 0 {
+		switch spec.AllowedFunctionsPerContainer {
+		case AllowedFunctionsPerContainerSingle, AllowedFunctionsPerContainerInfinite: // no op
+		default:
+			errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "EnvironmentSpec.AllowedFunctionsPerContainer", spec.AllowedFunctionsPerContainer, "not a valid value"))
+		}
 	}
 	if spec.Poolsize < 0 {
 		errs = append(errs, MakeValidationErr(ErrorInvalidValue, "EnvironmentSpec.Poolsize", spec.Poolsize, "Poolsize must be greater or equal to 0"))

--- a/validation.go
+++ b/validation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
 )
@@ -311,7 +312,7 @@ func (spec HTTPTriggerSpec) Validate() (errs []error) {
 }
 
 func (spec KubernetesWatchTriggerSpec) Validate() (errs []error) {
-	switch spec.Type {
+	switch strings.ToUpper(spec.Type) {
 	case "POD", "SERVICE", "REPLICATIONCONTROLLER", "JOB":
 	default:
 		errs = append(errs, MakeValidationErr(ErrorUnsupportedType, "KubernetesWatchTriggerSpec.Type", spec.Type, "not a valid supported type"))


### PR DESCRIPTION
Right now we have at least two ways to create fission resource: a) fission CLI b) spec YAML, which means that we need to write validate function in multiple places. 
That caused some problems:
1. Duplicate work to check field values in the different place
2. No unified error format

This PR tends to solve this problem by adding `Validate()` function to each fission object, and the function will be invoked before any resource creation/update. Also, add a new error message format which looks like following:

```
Failed to create HTTP trigger: Invalid fission HTTPTrigger object:
* FunctionReference.Name: Invalid value: findped.ts: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]
```

The new error message format will indicate what field is wrong with detail message.

With this PR, we can avoid to write duplicate code and make sure that the same validation logic is applied in different places. So far, there are still some validate function located in different place, need to move all of them to the same place in future PRs. 

#406 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/580)
<!-- Reviewable:end -->
