### PR TITLE
Uses proper way to get server URL

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -599,7 +599,7 @@ func fnLogs(c *cli.Context) error {
 	checkErr(err, "get function")
 
 	// request the controller to establish a proxy server to the database.
-	logDB, err := logdb.GetLogDB(dbType, c.GlobalString("server"))
+	logDB, err := logdb.GetLogDB(dbType, getServerUrl())
 	if err != nil {
 		fatal("failed to connect log database")
 	}
@@ -671,7 +671,7 @@ func fnPods(c *cli.Context) error {
 
 	// client first sends db query to the controller, then the controller
 	// will establish a proxy server that bridges the client and the database.
-	logDB, err := logdb.GetLogDB(dbType, c.GlobalString("server"))
+	logDB, err := logdb.GetLogDB(dbType, getServerUrl())
 	if err != nil {
 		fatal("failed to connect log database")
 	}

--- a/fission/logdb/influxdb.go
+++ b/fission/logdb/influxdb.go
@@ -98,7 +98,7 @@ func (influx InfluxDB) GetLogs(filter LogFilter) ([]LogEntry, error) {
 	logEntries := []LogEntry{}
 	response, err := influx.query(query)
 	if err != nil {
-		return logEntries, nil
+		return logEntries, err
 	}
 	for _, r := range response.Results {
 		for _, series := range r.Series {


### PR DESCRIPTION
There were two problems with `fission fn logs` implementation on client side:

1. In case of error, it was returning null so user feedback was missing that there is an error in getting logs

2. After port forward implementation, the proper way to get server URL was missing in `GetLogDB`

That was the reason that test_function_log.sh was failing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/587)
<!-- Reviewable:end -->
