### PR TITLE
Adding routerUrl parameter for kubewatch, timer, message queue trigge…

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -300,7 +300,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--kubewatcher"]
+        args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---
@@ -469,7 +469,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--timer"]
+        args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 #
@@ -547,7 +547,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--mqt"]
+        args: ["--mqt", , "--routerUrl", "http://router.{{ .Release.Namespace }}"]
         env:
         - name: MESSAGE_QUEUE_TYPE
           value: {{ .Values.messageQueue.type }}

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -547,7 +547,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--mqt", , "--routerUrl", "http://router.{{ .Release.Namespace }}"]
+        args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
         env:
         - name: MESSAGE_QUEUE_TYPE
           value: {{ .Values.messageQueue.type }}

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -298,7 +298,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--kubewatcher"]
+        args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---
@@ -320,7 +320,7 @@ spec:
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--timer"]
+        args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
 
 ---


### PR DESCRIPTION
Issue : The default value for routerUrl (https://github.com/fission/fission/blob/master/fission-bundle/main.go#L154) that is being passed to `KubeWatcher`, `Timer` and `MessageQueueMgr` processes (https://github.com/fission/fission/blob/master/fission-bundle/main.go#L172-L181) is defaulting to `http://router.fission`.

Fix : Adding the routerUrl parameter to their deployment objects in charts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/591)
<!-- Reviewable:end -->
