### PR TITLE
bug fix: spec dir flag

### DIFF
--- a/fission/spec.go
+++ b/fission/spec.go
@@ -115,7 +115,7 @@ type (
 )
 
 func getSpecDir(c *cli.Context) string {
-	specDir := c.String("specs")
+	specDir := c.String("specdir")
 	if len(specDir) == 0 {
 		specDir = "specs"
 	}


### PR DESCRIPTION
Here the flag name should be `specdir`, not `specs`, that should match to:

```go
specDirFlag := cli.StringFlag{Name: "specdir", Usage: "Directory to store specs, defaults to ./specs"}
```

in fission/main.go

Currently it cause the specific specs dir not to work.

```
$ fission spec apply --specdir <my spec dir>
Everything up to date.
```

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/595)
<!-- Reviewable:end -->
