### PR TITLE
Fix components crash before crds creation

### DIFF
--- a/buildermgr/buildermgr.go
+++ b/buildermgr/buildermgr.go
@@ -31,6 +31,11 @@ func Start(storageSvcUrl string, envBuilderNamespace string) error {
 		return err
 	}
 
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
+	}
+
 	envWatcher := makeEnvironmentWatcher(fissionClient, kubernetesClient, envBuilderNamespace)
 	go envWatcher.watchEnvironments()
 

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -37,7 +37,10 @@ func Start(port int) {
 		log.Fatalf("Failed to create fission CRDs: %v", err)
 	}
 
-	fc.WaitForCRDs()
+	err = fc.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
+	}
 
 	api, err := MakeAPI()
 	if err != nil {

--- a/crd/client.go
+++ b/crd/client.go
@@ -169,7 +169,7 @@ func waitForCRDs(crdClient *rest.RESTClient) error {
 			return nil
 		}
 
-		if time.Since(start) > 60*time.Second {
+		if time.Since(start) > 30*time.Second {
 			return errors.New("timeout waiting for CRDs")
 		}
 	}

--- a/crd/client.go
+++ b/crd/client.go
@@ -169,7 +169,7 @@ func waitForCRDs(crdClient *rest.RESTClient) error {
 			return nil
 		}
 
-		if time.Since(start) > 30*time.Second {
+		if time.Since(start) > 60*time.Second {
 			return errors.New("timeout waiting for CRDs")
 		}
 	}
@@ -212,8 +212,8 @@ func (fc *FissionClient) Packages(ns string) PackageInterface {
 	return MakePackageInterface(fc.crdClient, ns)
 }
 
-func (fc *FissionClient) WaitForCRDs() {
-	waitForCRDs(fc.crdClient)
+func (fc *FissionClient) WaitForCRDs() error {
+	return waitForCRDs(fc.crdClient)
 }
 func (fc *FissionClient) GetCrdClient() *rest.RESTClient {
 	return fc.crdClient

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -193,6 +193,12 @@ func StartExecutor(fissionNamespace string, functionNamespace string, port int) 
 	fission.SetupStackTraceHandler()
 
 	fissionClient, kubernetesClient, _, err := crd.MakeFissionClient()
+
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
+	}
+
 	restClient := fissionClient.GetCrdClient()
 	if err != nil {
 		log.Printf("Failed to get kubernetes client: %v", err)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -138,7 +138,11 @@ func TestExecutor(t *testing.T) {
 	if err != nil {
 		log.Panicf("failed to ensure crds: %v", err)
 	}
-	fissionClient.WaitForCRDs()
+
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Panicf("failed to wait crds: %v", err)
+	}
 
 	// create an env on the cluster
 	env, err := fissionClient.Environments(fissionNs).Create(&crd.Environment{

--- a/kubewatcher/main.go
+++ b/kubewatcher/main.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kubewatcher
 
 import (
+	"log"
+
 	"github.com/fission/fission/crd"
 	"github.com/fission/fission/publisher"
 )
@@ -26,6 +28,12 @@ func Start(routerUrl string) error {
 	if err != nil {
 		return err
 	}
+
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
+	}
+
 	poster := publisher.MakeWebhookPublisher(routerUrl)
 	kubeWatch := MakeKubeWatcher(kubeClient, poster)
 	MakeWatchSync(fissionClient, kubeWatch)

--- a/mqtrigger/main.go
+++ b/mqtrigger/main.go
@@ -30,6 +30,11 @@ func Start(routerUrl string) error {
 		log.Fatalf("Failed to get fission client: %v", err)
 	}
 
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
+	}
+
 	// Message queue type: nats is the only supported one for now
 	mqType := os.Getenv("MESSAGE_QUEUE_TYPE")
 	mqUrl := os.Getenv("MESSAGE_QUEUE_URL")

--- a/router/router.go
+++ b/router/router.go
@@ -82,6 +82,11 @@ func Start(port int, executorUrl string) {
 		log.Fatalf("Error connecting to kubernetes API: %v", err)
 	}
 
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
+	}
+
 	restClient := fissionClient.GetCrdClient()
 
 	executor := executorClient.MakeClient(executorUrl)

--- a/timer/main.go
+++ b/timer/main.go
@@ -17,6 +17,8 @@ limitations under the License.
 package timer
 
 import (
+	"log"
+
 	"github.com/fission/fission/crd"
 	"github.com/fission/fission/publisher"
 )
@@ -25,6 +27,11 @@ func Start(routerUrl string) error {
 	fissionClient, _, _, err := crd.MakeFissionClient()
 	if err != nil {
 		return err
+	}
+
+	err = fissionClient.WaitForCRDs()
+	if err != nil {
+		log.Fatalf("Error waiting for CRDs: %v", err)
 	}
 
 	poster := publisher.MakeWebhookPublisher(routerUrl)


### PR DESCRIPTION
Some of the components use listwatch to watch CRDs changes. The component pod will enter crash state if it starts before CRDs exist.
```
2018/04/03 09:17:28 Creating NewDeploy ExecutorType
2018/04/03 09:17:28 starting executor at port 8888
E0403 09:17:28.388019       1 reflector.go:201] src/github.com/fission/fission/executor/newdeploy/newdeploymgr.go:142: Failed to list *crd.Function: the server could not find the requested resource (get functions.fission.io)
2018/04/03 09:17:28 Failed to get environment list: the server could not find the requested resource (get environments.fission.io)
```
This PR tends to solve this problem by adding `WaitForCRDs` to components startup process. Also, fix `ensureCRD` return nil while the error may not be empty. 

https://github.com/fission/fission/issues/585

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/602)
<!-- Reviewable:end -->
