### PR TITLE
Prevent releasing idle connections because transport is shared.

### DIFF
--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -78,7 +78,6 @@ func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (resp *htt
 	// set the timeout for transport context
 	timeout := roundTripper.initialTimeout
 	transport := http.DefaultTransport.(*http.Transport)
-	defer transport.CloseIdleConnections()
 
 	// cache lookup to get serviceUrl
 	serviceUrl, err = roundTripper.funcHandler.fmap.lookup(roundTripper.funcHandler.function)


### PR DESCRIPTION
The transport in RoundTripper is the default transport and there's just one object shared between different http requests and releasing the idle Connections ended up releasing the idle connections that were established with the executor service address too. 

So every time a http request was made to get a service for function, the transport layer ended up having to dial a new connection (that was timing out due to various reasons). 

By removing the `CloseIdleConnections`, we minimize the need for transport to dial a new connection to executor for every request, thereby minimizing the occurrence of dial timeouts.