### PR TITLE
Update readme to point to the proper link

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ See the [examples](examples) directory for more.
 Running Fission on your Cluster
 ===============================
 
-See the [installation guide](http://fission.io/docs/latest/installation/).
+See the [installation guide](http://docs.fission.io/latest/installation).
 
 Compiling Fission
 =================
 
-See the [compilation guide](http://fission.io/docs/latest/compilation/).
+See the [compilation guide](http://docs.fission.io/latest/contributing/compiling/).
 
 Status
 ======


### PR DESCRIPTION
It looks like at some point these readme links got out of sync with the website url schema. This PR fixes some of those links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/628)
<!-- Reviewable:end -->
