### PR TITLE
Fix SEGFAULT issue when buildmgr failed to update package

### DIFF
--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -131,12 +131,12 @@ func updatePackage(fissionClient *crd.FissionClient,
 	}
 
 	// update package spec
-	pkg, err := fissionClient.Packages(metav1.NamespaceDefault).Update(pkg)
+	newPkg, err := fissionClient.Packages(metav1.NamespaceDefault).Update(pkg)
 	if err != nil {
 		log.Printf("Error updating package: %v", err)
 		return nil, err
 	}
 
 	// return resource version for function to update function package ref
-	return pkg, nil
+	return newPkg, nil
 }

--- a/buildermgr/pkgwatcher.go
+++ b/buildermgr/pkgwatcher.go
@@ -88,7 +88,7 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *crd.Package) 
 	if err != nil {
 		e := fmt.Sprintf("Error setting package pending state: %v", err)
 		log.Println(e)
-		updatePackage(pkgw.fissionClient, pkg, fission.BuildStatusFailed, e, nil)
+		updatePackage(pkgw.fissionClient, srcpkg, fission.BuildStatusFailed, e, nil)
 		return
 	}
 


### PR DESCRIPTION
This is the follow up PR to PR #626 . Looks like the issue is not really fix last time...
Test this PR locally and confirm the problem solved.