### PR TITLE
Change time precision for fluentd influxdb plugin to nano second

### DIFF
--- a/logger/fluentd/fluent.conf
+++ b/logger/fluentd/fluent.conf
@@ -40,7 +40,7 @@
     user  "#{ENV['INFLUXDB_USERNAME']}"
     password  "#{ENV['INFLUXDB_PASSWD']}"
     use_ssl false
-    time_precision s
+    time_precision ns
     tag_keys ["funcuid"]
     sequence_tag _seq
     buffer_type file


### PR DESCRIPTION
Notice some logs get lost if set time_precission to second, change it to nanosecond can mitigate the failure problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/646)
<!-- Reviewable:end -->
