### PR TITLE
Fix newdeploy backend failed to delete deployment due to incorrect resource version

### DIFF
--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -480,7 +480,6 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 
 	var delError error
 
-
 	// GetByFunction uses resource version as part of cache key, however,
 	// the resource version in function metadata will be changed when a function
 	// is deleted and cause newdeploy backend fails to delete the entry.

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -488,7 +488,7 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 	// fsvc entry.
 	fsvc, err := deploy.fsCache.GetByFunctionUID(fn.Metadata.UID)
 	if err != nil {
-		log.Printf("fsvc not fonud in cache: %v", fn.Metadata)
+		log.Printf("fsvc not found in cache: %v", fn.Metadata)
 		delError = err
 		return nil, err
 	}

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -480,7 +480,13 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 
 	var delError error
 
-	fsvc, err := deploy.fsCache.GetByFunction(&fn.Metadata)
+
+	// GetByFunction uses resource version as part of cache key, however,
+	// the resource version in function metadata will be changed when a function
+	// is deleted and cause newdeploy backend fails to delete the entry.
+	// Use GetByFunctionUID instead of GetByFunction here to find correct
+	// fsvc entry.
+	fsvc, err := deploy.fsCache.GetByFunctionUID(fn.Metadata.UID)
 	if err != nil {
 		log.Printf("fsvc not fonud in cache: %v", fn.Metadata)
 		delError = err


### PR DESCRIPTION
### What happened

Newdeploy backend does not delete function related kubobject after the function was deleted.

### Root cause

GetByFunction uses resource version as part of cache key, however, the resource version in function metadata will be changed when a function is deleted and cause newdeploy backend fails to delete the entry. 

### Solution

Use GetByFunctionUID instead of GetByFunction here to find correct fsvc entry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/657)
<!-- Reviewable:end -->
