### PR TITLE
Fetcher java changes

### DIFF
--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/mholt/archiver"
@@ -304,16 +303,11 @@ func (fetcher *Fetcher) Fetch(req FetchRequest) (int, error) {
 		}
 		manifestPath := tmpUnarchivePath + "/META-INF/MANIFEST.MF"
 		_, err = os.Stat(manifestPath)
-		fmt.Println("tmpPath=", tmpPath)
-		fmt.Println("tmpUnarchivePath=", tmpUnarchivePath)
 		//TODO - Find a better way to detect a Java Jar
 		//If /META-INF/MANIFEST.MF exists - it is a Java environment
 		if err != nil {
 			tmpPath = tmpUnarchivePath
-		} else {
-			tmpPath = strings.Replace(tmpPath, ".tmp", ".jar", -1)
 		}
-		fmt.Println("Final tmpPath=", tmpPath)
 
 	}
 

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/mholt/archiver"
@@ -301,7 +302,19 @@ func (fetcher *Fetcher) Fetch(req FetchRequest) (int, error) {
 			log.Println(err.Error())
 			return 500, err
 		}
-		tmpPath = tmpUnarchivePath
+		manifestPath := tmpUnarchivePath + "/META-INF/MANIFEST.MF"
+		_, err = os.Stat(manifestPath)
+		fmt.Println("tmpPath=", tmpPath)
+		fmt.Println("tmpUnarchivePath=", tmpUnarchivePath)
+		//TODO - Find a better way to detect a Java Jar
+		//If /META-INF/MANIFEST.MF exists - it is a Java environment
+		if err != nil {
+			tmpPath = tmpUnarchivePath
+		} else {
+			tmpPath = strings.Replace(tmpPath, ".tmp", ".jar", -1)
+		}
+		fmt.Println("Final tmpPath=", tmpPath)
+
 	}
 
 	// move tmp file to requested filename


### PR DESCRIPTION
Currently, I don't know of a good way to check if it is a Jar file (The way Go checks if it is zip file based on first 4 bytes of the file).

This implementation relies on `/META-INF/MANIFEST.MF` file in Jar file to determine that is a Jar/Java archive. Most of Java projects have this file. This is not a perfect solution, so need to check if we can find something better.

If the file is found to be JAR based on the presence of MANIFEST.MF, then instead of passing the exploded directory, the original file is passed to the environment.

This fixes #665 and is needed by #656

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/669)
<!-- Reviewable:end -->
