### PR TITLE
Replace Werkzeug  with Bjoern as underlying WSGI server

### DIFF
--- a/environments/python/Dockerfile
+++ b/environments/python/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN apk update
-RUN apk add --no-cache python3 python3-dev build-base
+RUN apk add --no-cache python3 python3-dev build-base libev-dev
 RUN pip3 install --upgrade pip
 RUN rm -r /root/.cache
 

--- a/environments/python/Dockerfile-2.7
+++ b/environments/python/Dockerfile-2.7
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN apk update
-RUN apk add --no-cache python python-dev build-base py-pip
+RUN apk add --no-cache python python-dev build-base py-pip libev-dev
 RUN pip install --upgrade pip
 RUN rm -r /root/.cache
 

--- a/environments/python/requirements.txt
+++ b/environments/python/requirements.txt
@@ -1,4 +1,5 @@
 Flask===0.11.1
+bjoern
 httplib2
 python-dateutil
 requests==2.7.0

--- a/environments/python/server.py
+++ b/environments/python/server.py
@@ -4,6 +4,7 @@ import logging
 import sys
 import imp
 import os
+import bjoern
 
 from flask import Flask, request, abort, g
 
@@ -99,4 +100,4 @@ def setup_logger(loglevel):
 #
 setup_logger(logging.DEBUG)
 app.logger.info("Starting server")
-app.run(host='0.0.0.0', port=8888)
+bjoern.run(app, '0.0.0.0', 8888, reuse_port=True)


### PR DESCRIPTION
Werkzeug as underlying WSGI server of Flask is not suitable for serving high load traffic. After some research and end up using Bjoern as the alternative. The performance graph will be attached later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/672)
<!-- Reviewable:end -->
