### PR TITLE
Add time trigger cron spec examination tool

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -72,7 +72,7 @@ func MakeBuilder(sharedVolumePath string) *Builder {
 
 func (builder *Builder) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.VersionInfo().String())
+	fmt.Fprintf(w, fission.BuildInfo().String())
 }
 
 func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {

--- a/controller/api.go
+++ b/controller/api.go
@@ -155,7 +155,7 @@ func (api *API) getLogDBConfig(dbType string) logDBConfig {
 
 func (api *API) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.VersionInfo().String())
+	fmt.Fprintf(w, fission.ApiInfo().String())
 }
 
 func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/controller/client/client.go
+++ b/controller/client/client.go
@@ -18,7 +18,9 @@ package client
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -87,4 +89,26 @@ func (c *Client) handleCreateResponse(resp *http.Response) ([]byte, error) {
 	}
 	body, err := ioutil.ReadAll(resp.Body)
 	return body, err
+}
+
+func (c *Client) ServerInfo() (*fission.ServerInfo, error) {
+	url := fmt.Sprintf(c.Url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &fission.ServerInfo{}
+	err = json.Unmarshal(body, info)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, nil
 }

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -165,7 +165,7 @@ func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 
 func (fetcher *Fetcher) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	fmt.Fprintf(w, fission.VersionInfo().String())
+	fmt.Fprintf(w, fission.BuildInfo().String())
 }
 
 func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {

--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -140,7 +140,7 @@ Options:
   --builderMgr                    Start builder manager.
   --version                       Print version information
 `
-	version := fmt.Sprintf("Fission Bundle Version: %v", fission.VersionInfo().String())
+	version := fmt.Sprintf("Fission Bundle Version: %v", fission.BuildInfo().String())
 	arguments, err := docopt.Parse(usage, nil, true, version, false)
 	if err != nil {
 		log.Fatalf("Error: %v", err)

--- a/fission/main.go
+++ b/fission/main.go
@@ -165,11 +165,12 @@ func main() {
 	ttFnNameFlag := cli.StringFlag{Name: "function", Usage: "Function name"}
 	ttRoundFlag := cli.IntFlag{Name: "round", Value: 1, Usage: "Get next N rounds of invocation time"}
 	ttSubcommands := []cli.Command{
-		{Name: "create", Aliases: []string{"add"}, Usage: "Create Time trigger", Flags: []cli.Flag{ttNameFlag, ttFnNameFlag, fnNamespaceFlag, ttCronFlag, specSaveFlag}, Action: ttCreate},
-		{Name: "get", Usage: "Get Time trigger", Flags: []cli.Flag{triggerNamespaceFlag}, Action: ttGet},
-		{Name: "update", Usage: "Update Time trigger", Flags: []cli.Flag{ttNameFlag, triggerNamespaceFlag, ttCronFlag, ttFnNameFlag}, Action: ttUpdate},
-		{Name: "delete", Usage: "Delete Time trigger", Flags: []cli.Flag{ttNameFlag, triggerNamespaceFlag}, Action: ttDelete},
-		{Name: "list", Usage: "List Time triggers", Flags: []cli.Flag{triggerNamespaceFlag}, Action: ttList},
+		{Name: "create", Aliases: []string{"add"}, Usage: "Create time trigger", Flags: []cli.Flag{ttNameFlag, ttFnNameFlag, fnNamespaceFlag, ttCronFlag, specSaveFlag}, Action: ttCreate},
+		{Name: "get", Usage: "Get time trigger", Flags: []cli.Flag{triggerNamespaceFlag}, Action: ttGet},
+		{Name: "update", Usage: "Update time trigger", Flags: []cli.Flag{ttNameFlag, triggerNamespaceFlag, ttCronFlag, ttFnNameFlag}, Action: ttUpdate},
+		{Name: "delete", Usage: "Delete time trigger", Flags: []cli.Flag{ttNameFlag, triggerNamespaceFlag}, Action: ttDelete},
+		{Name: "list", Usage: "List time triggers", Flags: []cli.Flag{triggerNamespaceFlag}, Action: ttList},
+		{Name: "test", Usage: "Test time trigger cron spec", Flags: []cli.Flag{ttCronFlag, ttRoundFlag}, Action: ttTest},
 	}
 
 	// Message queue trigger

--- a/fission/main.go
+++ b/fission/main.go
@@ -18,13 +18,10 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"path/filepath"
-	"strings"
 
-	version "github.com/fission/fission"
+	"github.com/fission/fission"
 	"github.com/urfave/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -45,20 +42,6 @@ func getKubeConfigPath() string {
 		}
 	}
 	return kubeConfig
-}
-
-func getFissionAPIVersion(apiUrl string) (string, error) {
-	resp, err := http.Get(apiUrl)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimRight(string(body), "\n"), nil
 }
 
 func getServerUrl() string {
@@ -87,15 +70,16 @@ func main() {
 	app := cli.NewApp()
 	app.Name = "fission"
 	app.Usage = "Serverless functions for Kubernetes"
-	app.Version = version.Version
+	app.Version = fission.Version
 
 	cli.VersionPrinter = func(c *cli.Context) {
-		clientVer := version.VersionInfo().String()
+		clientVer := fission.BuildInfo().String()
 		fmt.Printf("Client Version: %v\n", clientVer)
-		serverVer, err := getFissionAPIVersion(getServerUrl())
+		serverInfo, err := getClient(getServerUrl()).ServerInfo()
 		if err != nil {
 			fmt.Printf("Error getting Fission API version: %v", err)
 		} else {
+			serverVer := serverInfo.Build.String()
 			fmt.Printf("Server Version: %v\n", serverVer)
 		}
 	}

--- a/fission/main.go
+++ b/fission/main.go
@@ -161,7 +161,7 @@ func main() {
 
 	// timetriggers
 	ttNameFlag := cli.StringFlag{Name: "name", Usage: "Time Trigger name"}
-	ttCronFlag := cli.StringFlag{Name: "cron", Usage: "Time Trigger cron spec. e.g. '5 * * * * *' the function will be invoked at 5 seconds every minute. Or more descriptive way like '@every 5m', '@hourly'"}
+	ttCronFlag := cli.StringFlag{Name: "cron", Usage: "Time trigger cron spec with each asterisk representing respectively second, minute, hour, the day of the month, month and day of the week. Also supports readable formats like '@every 5m', '@hourly'"}
 	ttFnNameFlag := cli.StringFlag{Name: "function", Usage: "Function name"}
 	ttRoundFlag := cli.IntFlag{Name: "round", Value: 1, Usage: "Get next N rounds of invocation time"}
 	ttSubcommands := []cli.Command{

--- a/fission/main.go
+++ b/fission/main.go
@@ -96,7 +96,7 @@ func main() {
 		if err != nil {
 			fmt.Printf("Error getting Fission API version: %v", err)
 		} else {
-			fmt.Printf("Server Version: %v", serverVer)
+			fmt.Printf("Server Version: %v\n", serverVer)
 		}
 	}
 
@@ -177,8 +177,9 @@ func main() {
 
 	// timetriggers
 	ttNameFlag := cli.StringFlag{Name: "name", Usage: "Time Trigger name"}
-	ttCronFlag := cli.StringFlag{Name: "cron", Usage: "Time Trigger cron spec ('0 30 * * *', '@every 5m', '@hourly')"}
+	ttCronFlag := cli.StringFlag{Name: "cron", Usage: "Time Trigger cron spec ('0 30 * * * *', '@every 5m', '@hourly')"}
 	ttFnNameFlag := cli.StringFlag{Name: "function", Usage: "Function name"}
+	ttRoundFlag := cli.IntFlag{Name: "round", Value: 1, Usage: "Get next N rounds of invocation time"}
 	ttSubcommands := []cli.Command{
 		{Name: "create", Aliases: []string{"add"}, Usage: "Create Time trigger", Flags: []cli.Flag{ttNameFlag, ttFnNameFlag, fnNamespaceFlag, ttCronFlag, specSaveFlag}, Action: ttCreate},
 		{Name: "get", Usage: "Get Time trigger", Flags: []cli.Flag{triggerNamespaceFlag}, Action: ttGet},

--- a/fission/main.go
+++ b/fission/main.go
@@ -161,7 +161,7 @@ func main() {
 
 	// timetriggers
 	ttNameFlag := cli.StringFlag{Name: "name", Usage: "Time Trigger name"}
-	ttCronFlag := cli.StringFlag{Name: "cron", Usage: "Time Trigger cron spec ('0 30 * * * *', '@every 5m', '@hourly')"}
+	ttCronFlag := cli.StringFlag{Name: "cron", Usage: "Time Trigger cron spec. e.g. '5 * * * * *' the function will be invoked at 5 seconds every minute. Or more descriptive way like '@every 5m', '@hourly'"}
 	ttFnNameFlag := cli.StringFlag{Name: "function", Usage: "Function name"}
 	ttRoundFlag := cli.IntFlag{Name: "round", Value: 1, Usage: "Get next N rounds of invocation time"}
 	ttSubcommands := []cli.Command{
@@ -170,7 +170,7 @@ func main() {
 		{Name: "update", Usage: "Update time trigger", Flags: []cli.Flag{ttNameFlag, triggerNamespaceFlag, ttCronFlag, ttFnNameFlag}, Action: ttUpdate},
 		{Name: "delete", Usage: "Delete time trigger", Flags: []cli.Flag{ttNameFlag, triggerNamespaceFlag}, Action: ttDelete},
 		{Name: "list", Usage: "List time triggers", Flags: []cli.Flag{triggerNamespaceFlag}, Action: ttList},
-		{Name: "test", Usage: "Test time trigger cron spec", Flags: []cli.Flag{ttCronFlag, ttRoundFlag}, Action: ttTest},
+		{Name: "showschedule", Aliases: []string{"show"}, Usage: "Show schedule for cron spec", Flags: []cli.Flag{ttCronFlag, ttRoundFlag}, Action: ttTest},
 	}
 
 	// Message queue trigger

--- a/info.go
+++ b/info.go
@@ -18,6 +18,7 @@ package fission
 
 import (
 	"encoding/json"
+	"time"
 )
 
 var (
@@ -27,22 +28,53 @@ var (
 )
 
 type (
-	Info struct {
+	BuildMeta struct {
 		GitCommit string `json:"GitCommit,omitempty"`
 		BuildDate string `json:"BuildDate,omitempty"`
 		Version   string `json:"Version,omitempty"`
 	}
+
+	Time struct {
+		Timezone    string    `json:"Timezone,omitempty"`
+		CurrentTime time.Time `json:"CurrentTime,omitempty"`
+	}
+
+	ServerInfo struct {
+		Build      BuildMeta `json:"Build,omitempty"`
+		ServerTime Time      `json:"ServerTime,omitempty"`
+	}
 )
 
-func VersionInfo() Info {
-	return Info{
+func BuildInfo() BuildMeta {
+	return BuildMeta{
 		GitCommit: GitCommit,
 		BuildDate: BuildDate,
 		Version:   Version,
 	}
 }
 
-func (info Info) String() string {
+func (info BuildMeta) String() string {
+	v, _ := json.Marshal(info)
+	return string(v)
+}
+
+func TimeInfo() Time {
+	t := time.Now()
+	zone, _ := t.Local().Zone()
+	return Time{
+		Timezone:    zone,
+		CurrentTime: t,
+	}
+}
+
+func ApiInfo() ServerInfo {
+	return ServerInfo{
+		Build:      BuildInfo(),
+		ServerTime: TimeInfo(),
+	}
+}
+
+func (info ServerInfo) String() string {
 	v, _ := json.Marshal(info)
 	return string(v)
 }


### PR DESCRIPTION
Address #678 
1. Add time trigger spec examination tool
```
$ fission tt create --name h4 --function h1 --cron "@every 30m"
trigger 'h4' created
Current Server Time:    2018-05-29T16:19:52Z
Next 1 invocation:      2018-05-29T16:49:52Z
```

2. Show next invocation time when creating/updating time trigger
```
$ fission tt test --cron "@every 5s" --round 5
Current Server Time:    2018-05-29T16:20:50Z
Next 1 invocation:      2018-05-29T16:20:55Z
Next 2 invocation:      2018-05-29T16:21:00Z
Next 3 invocation:      2018-05-29T16:21:05Z
Next 4 invocation:      2018-05-29T16:21:10Z
Next 5 invocation:      2018-05-29T16:21:15Z
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/680)
<!-- Reviewable:end -->
