### PR TITLE
Convert go-env Dockerfile into a multi-stage build

### DIFF
--- a/environments/go/Dockerfile
+++ b/environments/go/Dockerfile
@@ -1,6 +1,6 @@
 ARG GO_VERSION=1.9.2
 
-FROM golang:${GO_VERSION}
+FROM golang:${GO_VERSION} AS builder
 
 ENV GOPATH /usr
 ENV APP	   ${GOPATH}/src/github.com/fission/fission/environments/go
@@ -10,7 +10,12 @@ ADD server.go   ${APP}
 
 WORKDIR ${APP}
 RUN go get
-RUN go build -o /server server.go
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o /server server.go
+
+FROM alpine:3.7
+WORKDIR /
+COPY --from=builder /server /
+RUN apk -U add ca-certificates
 
 ENTRYPOINT ["/server"]
 EXPOSE 8888


### PR DESCRIPTION
Converting to a multi-stage build reduces the size of the final image from ~750MB to ~15MB.

Fixes #624

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/683)
<!-- Reviewable:end -->
