### PR TITLE
gevent-based python environment

### DIFF
--- a/environments/python/Dockerfile
+++ b/environments/python/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN apk update
-RUN apk add --no-cache python3 python3-dev build-base libev-dev
+RUN apk add --no-cache python3 python3-dev build-base
 RUN pip3 install --upgrade pip
 RUN rm -r /root/.cache
 
@@ -11,4 +11,3 @@ RUN pip3 install -r requirements.txt
 
 ENTRYPOINT ["python3"]
 CMD ["server.py"]
-

--- a/environments/python/Dockerfile-2.7
+++ b/environments/python/Dockerfile-2.7
@@ -1,7 +1,7 @@
 FROM alpine:3.5
 
 RUN apk update
-RUN apk add --no-cache python python-dev build-base py-pip libev-dev
+RUN apk add --no-cache python python-dev build-base py-pip
 RUN pip install --upgrade pip
 RUN rm -r /root/.cache
 
@@ -11,4 +11,3 @@ RUN pip install -r requirements.txt
 
 ENTRYPOINT ["python"]
 CMD ["server.py"]
-

--- a/environments/python/requirements.txt
+++ b/environments/python/requirements.txt
@@ -1,5 +1,5 @@
 Flask===0.11.1
-bjoern
+gevent
 httplib2
 python-dateutil
 requests==2.7.0

--- a/environments/python/server.py
+++ b/environments/python/server.py
@@ -4,9 +4,9 @@ import logging
 import sys
 import imp
 import os
-import bjoern
 
 from flask import Flask, request, abort, g
+from gevent.pywsgi import WSGIServer
 
 app = Flask(__name__)
 
@@ -100,4 +100,5 @@ def setup_logger(loglevel):
 #
 setup_logger(logging.DEBUG)
 app.logger.info("Starting server")
-bjoern.run(app, '0.0.0.0', 8888, reuse_port=True)
+server = WSGIServer(('', 8888), app)
+server.serve_forever()


### PR DESCRIPTION
This improves WSGI server's qps under high traffic. For that we introduce `gevent` library.

Like `bjoern`, it runs a WSGI server.

What's more, it throws server into multi-thread under high traffic environment.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>


Below is the comparison of performance between current server and `gevent` server.

With 256 concurrence, 99% requests are finished in 282 ms with `gevent`, quickly than 3815 ms before improvment.

### bjoern
```
$ ab -c 256 -n 8192 http://127.0.0.1:8888/healthz

Benchmarking 127.0.0.1 (be patient)
.......
Finished 8192 requests


Server Software:        
Server Hostname:        127.0.0.1
Server Port:            8888

Document Path:          /healthz
Document Length:        0 bytes

Concurrency Level:      256
Time taken for tests:   4.012 seconds
Complete requests:      8192
Failed requests:        0
Total transferred:      794624 bytes
HTML transferred:       0 bytes
Requests per second:    2041.74 [#/sec] (mean)
Time per request:       125.383 [ms] (mean)
Time per request:       0.490 [ms] (mean, across all concurrent requests)
Transfer rate:          193.41 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0   46 362.0      0    3010
Processing:    10   75  96.9     47    1639
Waiting:        9   75  96.9     47    1639
Total:         13  121 452.1     47    3827

Percentage of the requests served within a certain time (ms)
  50%     47
  66%     86
  75%     97
  80%    100
  90%    108
  95%    124
  98%    157
  99%   3815
 100%   3827 (longest request)
```

### genvet
```
$ ab -c 256 -n 8192 http://127.0.0.1:8888/healthz

Benchmarking 127.0.0.1 (be patient)
.......
Finished 8192 requests


Server Software:        
Server Hostname:        127.0.0.1
Server Port:            8888

Document Path:          /healthz
Document Length:        0 bytes

Concurrency Level:      256
Time taken for tests:   6.388 seconds
Complete requests:      8192
Failed requests:        0
Total transferred:      1097728 bytes
HTML transferred:       0 bytes
Requests per second:    1282.43 [#/sec] (mean)
Time per request:       199.621 [ms] (mean)
Time per request:       0.780 [ms] (mean, across all concurrent requests)
Transfer rate:          167.82 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    2  38.4      0    1004
Processing:    16  194  35.3    189     392
Waiting:       15  193  35.3    189     392
Total:         28  196  52.7    189    1225

Percentage of the requests served within a certain time (ms)
  50%    189
  66%    197
  75%    215
  80%    223
  90%    244
  95%    265
  98%    275
  99%    282
 100%   1225 (longest request)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/686)
<!-- Reviewable:end -->
