### PR TITLE
docker-distribution version bump for windows compatibility

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -36,7 +36,7 @@ imports:
 - name: github.com/dgrijalva/jwt-go
   version: 01aeca54ebda6e0fbfafd0a524d234159c05ec20
 - name: github.com/docker/distribution
-  version: cd27f179f2c10c5d300e6d09025b538c475b0d51
+  version: db713e127ba35bd15595113df56ee964de24637a
   subpackages:
   - digest
   - reference


### PR DESCRIPTION
@soamvasani @erwinvaneyk  This is to fix the issues with Windows development discussed in Slack, specifically to address the folder shown here https://github.com/docker/distribution/tree/cd27f179f2c10c5d300e6d09025b538c475b0d51/contrib/docker-integration/generated_certs.d , which contains several files with colons in the file names. The effect of that is that git is unable to pull the entire repo due to an error being thrown by Windows on the attempted file creation. The folder is removed in commit sha db713e127ba35bd15595113df56ee964de24637a, with differences between the commits shown here https://github.com/docker/distribution/compare/cd27f179f2c10c5d300e6d09025b538c475b0d51...db713e127ba35bd15595113df56ee964de24637a . I think it's worth bringing up the question of whether a larger version bump should be attempted at this point just since we're already doing this, but I would direct that question to the primary maintainers of the repo.

I have already manually confirmed that after blowing out glide cache I was able to run `glide install -v` successfully with the new commit sha referenced in the lockfile.

Longer term, it would also be beneficial to look into a way to either run the integration test suite on windows (it is currently written in bash), perhaps by containerizing the tests; or by finding a way to run CI checks against fork-PRs so I don't need to bug you guys to test relatively minor commits before passing already existing sanity checks. If I end up making more PRs against the platform I'll probably go ahead and just make the test container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/691)
<!-- Reviewable:end -->
