### PR TITLE
Python Env: Support JSON Object return

### DIFF
--- a/environments/python/server.py
+++ b/environments/python/server.py
@@ -78,7 +78,7 @@ def f():
     #   g.myKey = myValue
     # And the user func can then access that (after doing a "from flask import g").
     #
-    return userfunc()
+    return "%s" %(userfunc())
 
 #
 # Logging setup.  TODO: Loglevel hard-coded for now. We could allow


### PR DESCRIPTION
If one Python function return a json data (Python `dict`), error will happen:

```
TypeError: 'dict' object is not callable
```

So, I reformat the return part to string type, then the objects can be parsed successfully.

The example:

```
def main():
    return {0: "Hello", 1: "World"}
```

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/692)
<!-- Reviewable:end -->
