### PR TITLE
fission servers should be configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"io/ioutil"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	Router Router `yaml:"router,omitempty"`
+}
+
+type Router struct {
+	DialTimeout  time.Duration `yaml:"dialtimeout,omitempty"`
+	AliveTimeout time.Duration `yaml:"alivetimeout,omitempty"`
+	MaxRetries   int           `yaml:"maxretries,omitempty"`
+}
+
+func LoadConfig(path string) (*Config, error) {
+	cfg := &Config{}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal(b, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, err
+}

--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,33 @@
+package context
+
+import (
+	"context"
+	"time"
+)
+
+const (
+	KeyDialTimeout  = "var.fission.router.dialtimeout"
+	KeyAliveTimeout = "var.fission.router.alivetimeout"
+	KeyMaxRetries   = "var.fission.router.maxretries"
+)
+
+func GetDialTimeout(ctx context.Context) time.Duration {
+	if timeout, ok := ctx.Value(KeyDialTimeout).(time.Duration); ok {
+		return timeout
+	}
+	return 0
+}
+
+func GetAliveTimeout(ctx context.Context) time.Duration {
+	if timeout, ok := ctx.Value(KeyAliveTimeout).(time.Duration); ok {
+		return timeout
+	}
+	return 0
+}
+
+func GetMaxRetries(ctx context.Context) int {
+	if retries, ok := ctx.Value(KeyMaxRetries).(int); ok {
+		return retries
+	}
+	return 0
+}

--- a/fission-bundle/Dockerfile
+++ b/fission-bundle/Dockerfile
@@ -1,3 +1,4 @@
 FROM alpine:3.4
 RUN apk add --update ca-certificates
 ADD fission-bundle /
+COPY config.yaml /etc/fission/config.yaml

--- a/fission-bundle/config.yaml
+++ b/fission-bundle/config.yaml
@@ -1,0 +1,4 @@
+router:
+  dialtimeout: 50ms
+  alivetimeout: 30s
+  maxretries: 10

--- a/fission-bundle/main.go
+++ b/fission-bundle/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/fission/fission"
 	"github.com/fission/fission/buildermgr"
+	"github.com/fission/fission/config"
 	"github.com/fission/fission/controller"
 	"github.com/fission/fission/executor"
 	"github.com/fission/fission/kubewatcher"
@@ -19,13 +20,15 @@ import (
 	"github.com/fission/fission/timer"
 )
 
+const configPath = "/etc/fission/config.yaml"
+
 func runController(port int) {
 	controller.Start(port)
 	log.Fatalf("Error: Controller exited.")
 }
 
-func runRouter(port int, executorUrl string) {
-	router.Start(port, executorUrl)
+func runRouter(port int, executorUrl string, cfg *config.Config) {
+	router.Start(port, executorUrl, cfg)
 	log.Fatalf("Error: Router exited.")
 }
 
@@ -154,6 +157,11 @@ Options:
 	routerUrl := getStringArgWithDefault(arguments["--routerUrl"], "http://router.fission")
 	storageSvcUrl := getStringArgWithDefault(arguments["--storageSvcUrl"], "http://storagesvc.fission")
 
+	cfg, err := config.LoadConfig(configPath)
+	if err != nil {
+		log.Fatalf("Error: %v", err)
+	}
+
 	if arguments["--controllerPort"] != nil {
 		port := getPort(arguments["--controllerPort"])
 		runController(port)
@@ -161,7 +169,7 @@ Options:
 
 	if arguments["--routerPort"] != nil {
 		port := getPort(arguments["--routerPort"])
-		runRouter(port, executorUrl)
+		runRouter(port, executorUrl, cfg)
 	}
 
 	if arguments["--executorPort"] != nil {

--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -36,6 +36,7 @@ import (
 type HTTPTriggerSet struct {
 	*functionServiceMap
 	*mutableRouter
+	context.Context
 
 	fissionClient     *crd.FissionClient
 	executor          *executorClient.Client
@@ -49,7 +50,7 @@ type HTTPTriggerSet struct {
 	funcController    k8sCache.Controller
 }
 
-func makeHTTPTriggerSet(fmap *functionServiceMap, fissionClient *crd.FissionClient,
+func makeHTTPTriggerSet(ctx context.Context, fmap *functionServiceMap, fissionClient *crd.FissionClient,
 	executor *executorClient.Client, crdClient *rest.RESTClient) (*HTTPTriggerSet, k8sCache.Store, k8sCache.Store) {
 	httpTriggerSet := &HTTPTriggerSet{
 		functionServiceMap: fmap,
@@ -61,10 +62,10 @@ func makeHTTPTriggerSet(fmap *functionServiceMap, fissionClient *crd.FissionClie
 	var tStore, fnStore k8sCache.Store
 	var tController, fnController k8sCache.Controller
 	if httpTriggerSet.crdClient != nil {
-		tStore, tController = httpTriggerSet.initTriggerController()
+		tStore, tController = httpTriggerSet.initTriggerController(ctx)
 		httpTriggerSet.triggerStore = tStore
 		httpTriggerSet.triggerController = tController
-		fnStore, fnController = httpTriggerSet.initFunctionController()
+		fnStore, fnController = httpTriggerSet.initFunctionController(ctx)
 		httpTriggerSet.funcStore = fnStore
 		httpTriggerSet.funcController = fnController
 	}
@@ -74,7 +75,7 @@ func makeHTTPTriggerSet(fmap *functionServiceMap, fissionClient *crd.FissionClie
 func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mr *mutableRouter, resolver *functionReferenceResolver) {
 	ts.resolver = resolver
 	ts.mutableRouter = mr
-	mr.updateRouter(ts.getRouter())
+	mr.updateRouter(ts.getRouter(ctx))
 
 	if ts.fissionClient == nil {
 		// Used in tests only.
@@ -93,7 +94,7 @@ func routerHealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-func (ts *HTTPTriggerSet) getRouter() *mux.Router {
+func (ts *HTTPTriggerSet) getRouter(ctx context.Context) *mux.Router {
 	muxRouter := mux.NewRouter()
 
 	// HTTP triggers setup by the user
@@ -121,6 +122,7 @@ func (ts *HTTPTriggerSet) getRouter() *mux.Router {
 			function:    rr.functionMetadata,
 			executor:    ts.executor,
 			httpTrigger: &trigger,
+			ctx:         ctx,
 		}
 
 		ht := muxRouter.HandleFunc(trigger.Spec.RelativeURL, fh.handler)
@@ -165,34 +167,34 @@ func (ts *HTTPTriggerSet) updateTriggerStatusFailed(ht *crd.HTTPTrigger, err err
 	// TODO
 }
 
-func (ts *HTTPTriggerSet) initTriggerController() (k8sCache.Store, k8sCache.Controller) {
+func (ts *HTTPTriggerSet) initTriggerController(ctx context.Context) (k8sCache.Store, k8sCache.Controller) {
 	resyncPeriod := 30 * time.Second
 	listWatch := k8sCache.NewListWatchFromClient(ts.crdClient, "httptriggers", metav1.NamespaceDefault, fields.Everything())
 	store, controller := k8sCache.NewInformer(listWatch, &crd.HTTPTrigger{}, resyncPeriod,
 		k8sCache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				ts.syncTriggers()
+				ts.syncTriggers(ctx)
 			},
 			DeleteFunc: func(obj interface{}) {
-				ts.syncTriggers()
+				ts.syncTriggers(ctx)
 			},
 			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-				ts.syncTriggers()
+				ts.syncTriggers(ctx)
 			},
 		})
 	return store, controller
 }
 
-func (ts *HTTPTriggerSet) initFunctionController() (k8sCache.Store, k8sCache.Controller) {
+func (ts *HTTPTriggerSet) initFunctionController(ctx context.Context) (k8sCache.Store, k8sCache.Controller) {
 	resyncPeriod := 30 * time.Second
 	listWatch := k8sCache.NewListWatchFromClient(ts.crdClient, "functions", metav1.NamespaceDefault, fields.Everything())
 	store, controller := k8sCache.NewInformer(listWatch, &crd.Function{}, resyncPeriod,
 		k8sCache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
-				ts.syncTriggers()
+				ts.syncTriggers(ctx)
 			},
 			DeleteFunc: func(obj interface{}) {
-				ts.syncTriggers()
+				ts.syncTriggers(ctx)
 			},
 			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
 				fn := newObj.(*crd.Function)
@@ -207,7 +209,7 @@ func (ts *HTTPTriggerSet) initFunctionController() (k8sCache.Store, k8sCache.Con
 						break
 					}
 				}
-				ts.syncTriggers()
+				ts.syncTriggers(ctx)
 			},
 		})
 	return store, controller
@@ -219,7 +221,7 @@ func (ts *HTTPTriggerSet) runWatcher(ctx context.Context, controller k8sCache.Co
 	}()
 }
 
-func (ts *HTTPTriggerSet) syncTriggers() {
+func (ts *HTTPTriggerSet) syncTriggers(ctx context.Context) {
 	// get triggers
 	latestTriggers := ts.triggerStore.List()
 	triggers := make([]crd.HTTPTrigger, len(latestTriggers))
@@ -237,5 +239,5 @@ func (ts *HTTPTriggerSet) syncTriggers() {
 	ts.functions = functions
 
 	// make a new router and use it
-	ts.mutableRouter.updateRouter(ts.getRouter())
+	ts.mutableRouter.updateRouter(ts.getRouter(ctx))
 }


### PR DESCRIPTION
Fix #699 .

This allow user to configurate server start-up parameters by config.yaml.
    
It just open the interface and template, to move a little variables from hard code to config file.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/700)
<!-- Reviewable:end -->
