### PR TITLE
Indicate HTTP status code by library const

### DIFF
--- a/controller/storagesvc.go
+++ b/controller/storagesvc.go
@@ -30,7 +30,7 @@ func (api *API) StorageServiceProxy(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := fmt.Sprintf("Error parsing url %v: %v", u, err)
 		log.Println(msg)
-		http.Error(w, msg, 500)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 	director := func(req *http.Request) {

--- a/controller/workflowApiProxy.go
+++ b/controller/workflowApiProxy.go
@@ -13,7 +13,7 @@ func (api *API) WorkflowApiserverProxy(w http.ResponseWriter, r *http.Request) {
 	ssUrl, err := url.Parse(u)
 	if err != nil {
 		msg := fmt.Sprintf("Error parsing url %v: %v", u, err)
-		http.Error(w, msg, 500)
+		http.Error(w, msg, http.StatusInternalServerError)
 		return
 	}
 

--- a/environments/binary/server.go
+++ b/environments/binary/server.go
@@ -46,7 +46,7 @@ type (
 
 func (bs *BinaryServer) SpecializeHandler(w http.ResponseWriter, r *http.Request) {
 	if specialized {
-		w.WriteHeader(400)
+		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte("Not a generic container"))
 		return
 	}

--- a/error.go
+++ b/error.go
@@ -32,19 +32,19 @@ func MakeError(code int, msg string) Error {
 }
 
 func MakeErrorFromHTTP(resp *http.Response) error {
-	if resp.StatusCode == 200 {
+	if resp.StatusCode == http.StatusOK {
 		return nil
 	}
 
 	var errCode int
 	switch resp.StatusCode {
-	case 400:
+	case http.StatusBadRequest:
 		errCode = ErrorInvalidArgument
-	case 403:
+	case http.StatusForbidden:
 		errCode = ErrorNotAuthorized
-	case 404:
+	case http.StatusNotFound:
 		errCode = ErrorNotFound
-	case 409:
+	case http.StatusConflict:
 		errCode = ErrorNameExists
 	default:
 		errCode = ErrorInternal
@@ -64,15 +64,15 @@ func (err Error) HTTPStatus() int {
 	var code int
 	switch err.Code {
 	case ErrorInvalidArgument:
-		code = 400
+		code = http.StatusBadRequest
 	case ErrorNotAuthorized:
-		code = 403
+		code = http.StatusForbidden
 	case ErrorNotFound:
-		code = 404
+		code = http.StatusNotFound
 	case ErrorNameExists:
-		code = 409
+		code = http.StatusConflict
 	default:
-		code = 500
+		code = http.StatusInternalServerError
 	}
 	return code
 }
@@ -85,7 +85,7 @@ func GetHTTPError(err error) (int, string) {
 		code = fe.HTTPStatus()
 		msg = fe.Message
 	} else {
-		code = 500
+		code = http.StatusInternalServerError
 		msg = err.Error()
 	}
 	return code, msg

--- a/executor/api.go
+++ b/executor/api.go
@@ -34,7 +34,7 @@ import (
 func (executor *Executor) getServiceForFunctionApi(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "Failed to read request", 500)
+		http.Error(w, "Failed to read request", http.StatusInternalServerError)
 		return
 	}
 
@@ -42,7 +42,7 @@ func (executor *Executor) getServiceForFunctionApi(w http.ResponseWriter, r *htt
 	m := metav1.ObjectMeta{}
 	err = json.Unmarshal(body, &m)
 	if err != nil {
-		http.Error(w, "Failed to parse request", 400)
+		http.Error(w, "Failed to parse request", http.StatusBadRequest)
 		return
 	}
 
@@ -97,7 +97,7 @@ func (executor *Executor) getServiceForFunction(m *metav1.ObjectMeta) (string, e
 func (executor *Executor) tapService(w http.ResponseWriter, r *http.Request) {
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		http.Error(w, "Failed to read request", 500)
+		http.Error(w, "Failed to read request", http.StatusInternalServerError)
 		return
 	}
 	svcName := string(body)
@@ -106,7 +106,7 @@ func (executor *Executor) tapService(w http.ResponseWriter, r *http.Request) {
 	err = executor.fsCache.TouchByAddress(svcHost)
 	if err != nil {
 		log.Printf("funcSvc tap error: %v", err)
-		http.Error(w, "Not found", 404)
+		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/fission/migrate.go
+++ b/fission/migrate.go
@@ -101,7 +101,7 @@ func migrateDeleteTPR(c *cli.Context) error {
 	checkErr(err, "delete tpr resources")
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == http.StatusNotFound {
 		msg := fmt.Sprintf("Server %v isn't support deleteTpr method. Use --server to point at a 0.4.0+ Fission server.", server)
 		fatal(msg)
 	}

--- a/fission/upgrade.go
+++ b/fission/upgrade.go
@@ -249,7 +249,7 @@ func upgradeDumpState(c *cli.Context) error {
 	// check v1
 	resp, err := http.Get(u + "/environments")
 	checkErr(err, "reach fission server")
-	if resp.StatusCode == 404 {
+	if resp.StatusCode == http.StatusNotFound {
 		msg := fmt.Sprintf("Server %v isn't a v1 Fission server. Use --server to point at a pre-0.2.x Fission server.", u)
 		fatal(msg)
 	}

--- a/mqtrigger/messageQueue/asq_test.go
+++ b/mqtrigger/messageQueue/asq_test.go
@@ -171,7 +171,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 		mock.MatchedBy(httpRequestMatcher(t, QueueName, "", "", ContentType, FunctionName, MessageBody)),
 	).Return(
 		&http.Response{
-			StatusCode: 500,
+			StatusCode: http.StatusInternalServerError,
 			Body:       ioutil.NopCloser(strings.NewReader("server error")),
 		},
 		nil,
@@ -181,7 +181,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 		mock.MatchedBy(httpRequestMatcher(t, QueueName, "", "1", ContentType, FunctionName, MessageBody)),
 	).Return(
 		&http.Response{
-			StatusCode: 404,
+			StatusCode: http.StatusNotFound,
 			Body:       ioutil.NopCloser(strings.NewReader("not found")),
 		},
 		nil,
@@ -191,7 +191,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 		mock.MatchedBy(httpRequestMatcher(t, QueueName, "", "2", ContentType, FunctionName, MessageBody)),
 	).Return(
 		&http.Response{
-			StatusCode: 400,
+			StatusCode: http.StatusBadRequest,
 			Body:       ioutil.NopCloser(strings.NewReader("bad request")),
 		},
 		nil,
@@ -201,7 +201,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 		mock.MatchedBy(httpRequestMatcher(t, QueueName, "", "3", ContentType, FunctionName, MessageBody)),
 	).Return(
 		&http.Response{
-			StatusCode: 403,
+			StatusCode: http.StatusForbidden,
 			Body:       ioutil.NopCloser(strings.NewReader("not authorized")),
 		},
 		nil,
@@ -338,7 +338,7 @@ func runAzureStorageQueueTest(t *testing.T, count int, output bool) {
 		responseTopic = OutputQueueName
 	}
 
-	// Mock a HTTP client that returns 200 with "output" for the body
+	// Mock a HTTP client that returns http.StatusOK with "output" for the body
 	httpClient := new(azureHTTPClientMock)
 	httpClient.bodyHandler = func(res *http.Response) {
 		res.Body = ioutil.NopCloser(strings.NewReader(FunctionResponse))
@@ -346,7 +346,7 @@ func runAzureStorageQueueTest(t *testing.T, count int, output bool) {
 	httpClient.On(
 		"Do",
 		mock.MatchedBy(httpRequestMatcher(t, QueueName, responseTopic, "", ContentType, FunctionName, MessageBody)),
-	).Return(&http.Response{StatusCode: 200}, nil).Times(count)
+	).Return(&http.Response{StatusCode: http.StatusOK}, nil).Times(count)
 
 	// Mock a queue message with "input" as the message body
 	message := new(azureMessageMock)


### PR DESCRIPTION
It had better to indicate HTTP status code by library const name, instead hard number.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/703)
<!-- Reviewable:end -->
