### PR TITLE
Formatted specifiers are not compatible with variables

### DIFF
--- a/executor/poolmgr/funcwatcher.go
+++ b/executor/poolmgr/funcwatcher.go
@@ -76,7 +76,7 @@ func (gpm *GenericPoolManager) makeFuncController(fissionClient *crd.FissionClie
 				if err != nil {
 					log.Printf("Error : %v creating %s RoleBinding", err, fission.SecretConfigMapGetterRB)
 				} else {
-					log.Printf("Successfully set up rolebinding for fetcher SA: %s.%s, in func's ns for func : %s", fission.FissionFetcherSA, envNs, fn.Metadata.Name, fn.Metadata.Namespace)
+					log.Printf("Successfully set up rolebinding for fetcher SA: %s.%s, in func's ns for func : %s/%s", fission.FissionFetcherSA, envNs, fn.Metadata.Namespace, fn.Metadata.Name)
 				}
 
 				if istioEnabled {


### PR DESCRIPTION
It missed specifier for namespace.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>