### PR TITLE
Check spec directory exists before reading spec files

### DIFF
--- a/examples/spec-example/hello/build.sh
+++ b/examples/spec-example/hello/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 # check syntax
-python -m compileall -l ${SRC_PKG}
+python3 -m compileall -l ${SRC_PKG}
 
 # install deps
-pip install -r ${SRC_PKG}/requirements.txt -t ${SRC_PKG} && cp -r ${SRC_PKG} ${DEPLOY_PKG}
+pip3 install -r ${SRC_PKG}/requirements.txt -t ${SRC_PKG} && cp -r ${SRC_PKG} ${DEPLOY_PKG}

--- a/examples/spec-example/specs/env.yaml
+++ b/examples/spec-example/specs/env.yaml
@@ -7,6 +7,6 @@ spec:
   version: 2
   builder:
     command: build
-    image: fission/python-build-env-2.7:0.4.0rc
+    image: fission/python-builder
   runtime:
-    image: fission/python-env-2.7:0.4.0rc
+    image: fission/python-env

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -523,7 +523,7 @@ func readSpecs(specDir string) (*FissionResources, error) {
 
 	// make sure spec directory exists before continue
 	if _, err := os.Stat(specDir); os.IsNotExist(err) {
-		fatal(fmt.Sprintf("Spec directory %v does not exist", specDir))
+		fatal(fmt.Sprintf("Spec directory %v doesn't exist. Please check directory path or run \"fission spec init\" to create it.", specDir))
 	}
 
 	fr := FissionResources{

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -520,6 +520,12 @@ func (fr *FissionResources) parseYaml(b []byte, loc *location) error {
 // readSpecs reads all specs in the specified directory and returns a parsed set of
 // fission resources.
 func readSpecs(specDir string) (*FissionResources, error) {
+
+	// make sure spec directory exists before continue
+	if _, err := os.Stat(specDir); os.IsNotExist(err) {
+		fatal(fmt.Sprintf("Spec directory %v does not exist", specDir))
+	}
+
 	fr := FissionResources{
 		packages:                make([]crd.Package, 0),
 		functions:               make([]crd.Function, 0),


### PR DESCRIPTION
### Root cause
`filepath.Walk` does nothing if spec directory does not exist

### Solution
1. Use `os.Stat` to check spec directory exists before reading spec files
2. Fix spec example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/709)
<!-- Reviewable:end -->
