### PR TITLE
Logger daemonset's update strategy

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -458,7 +458,8 @@ spec:
         - name: fission-log
           hostPath:
               path: /var/log/fission
-
+  updateStrategy:
+    type: RollingUpdate
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
The default update strategy for DaemonSet is `OnDelete` (Meaning the user has to go and manually delete the pod). This has been the default strategy and is still there for backward compatibility. We should instead switch to `RollingUpdate` so that users don't have to intervene in case logger changes.

https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#daemonset-update-strategy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/714)
<!-- Reviewable:end -->
