### PR TITLE
Environment warning message bugfix

### DIFF
--- a/fission/environment.go
+++ b/fission/environment.go
@@ -57,9 +57,7 @@ func envCreate(c *cli.Context) error {
 
 	envList, err := client.EnvironmentList(envNamespace)
 	if err == nil && len(envList) > 0 {
-		warn(fmt.Sprintf("%d environment(s) are present in this ns: %s. All these envs share"+
-			" the same service account token, with previleges to view secrets of all the functions referencing them. "+
-			"Envs can be created in different ns if isolation is needed", len(envList), envNamespace))
+		verbose("%d environment(s) are present in the %s namespace.  These environments are not isolated from each other; use separate namespaces if you need isolation.", len(envList), envNamespace)
 	}
 
 	var poolsize int

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -57,7 +57,7 @@ func envCreate(c *cli.Context) error {
 
 	envList, err := client.EnvironmentList(envNamespace)
 	if err == nil && len(envList) > 0 {
-		verbose("%d environment(s) are present in the %s namespace.  These environments are not isolated from each other; use separate namespaces if you need isolation.", len(envList), envNamespace)
+		verbose(2, "%d environment(s) are present in the %s namespace.  These environments are not isolated from each other; use separate namespaces if you need isolation.", len(envList), envNamespace)
 	}
 
 	var poolsize int


### PR DESCRIPTION
This simplifies the message when there are multiple environments in the same namespace.  It also moves it into the verbose category.  Otherwise we'd see it too often, I think.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/725)
<!-- Reviewable:end -->
