### PR TITLE
Use short gracePeriod during test for function with newdeploy manager as executor type

### DIFF
--- a/executor/cleanup.go
+++ b/executor/cleanup.go
@@ -70,13 +70,6 @@ func cleanup(client *kubernetes.Clientset, namespace string, instanceId string) 
 		return err
 	}
 
-	// Pods might still be running user functions, so we give them
-	// a few minutes before terminating them.  This time is the
-	// maximum function runtime, plus the time a router might
-	// still route to an old instance, i.e. router cache expiry
-	// time.
-	time.Sleep(6 * time.Minute)
-
 	err = cleanupPods(client, namespace, instanceId)
 	if err != nil {
 		return err

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -147,7 +147,7 @@ func (deploy *NewDeploy) getDeploymentSpec(fn *crd.Function, env *crd.Environmen
 
 	targetFilename := "user"
 
-	gracePeriodSeconds := int64(6 * 60)
+	gracePeriodSeconds := fission.DefaultTerminationGracePeriod
 	if env.Spec.TerminationGracePeriod > 0 {
 		gracePeriodSeconds = env.Spec.TerminationGracePeriod
 	}

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -479,7 +479,7 @@ func (gp *GenericPool) createPool() error {
 
 	// Use long terminationGracePeriodSeconds for connection draining in case that
 	// pod still runs user functions.
-	gracePeriodSeconds := int64(6 * 60)
+	gracePeriodSeconds := fission.DefaultTerminationGracePeriod
 	if gp.env.Spec.TerminationGracePeriod > 0 {
 		gracePeriodSeconds = gp.env.Spec.TerminationGracePeriod
 	}

--- a/test/tests/test_backend_newdeploy.sh
+++ b/test/tests/test_backend_newdeploy.sh
@@ -9,7 +9,7 @@ log "NewDeploy ExecutorType: Pre-test cleanup"
 fission env delete --name nodejs || true
 
 log "Creating nodejs env"
-fission env create --name nodejs --image fission/node-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
+fission env create --name nodejs --image fission/node-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256 --graceperiod 1
 trap "fission env delete --name nodejs" EXIT
 
 # TODO Imporve test code by reusing common blocks

--- a/test/tests/test_fn_update/test_configmap_update.sh
+++ b/test/tests/test_fn_update/test_configmap_update.sh
@@ -16,7 +16,7 @@ cp ../test_secret_cfgmap/cfgmap.py.template cfgmap.py
 sed -i "s/{{ FN_CFGMAP }}/${old_cfgmap}/g" cfgmap.py
 
 log "Creating env $env"
-fission env create --name $env --image fission/python-env
+fission env create --name $env --image fission/python-env --graceperiod 1
 trap "fission env delete --name $env" EXIT
 
 log "Creating configmap $old_cfgmap"

--- a/test/tests/test_fn_update/test_env_update.sh
+++ b/test/tests/test_fn_update/test_env_update.sh
@@ -11,7 +11,7 @@ env_new=python-$(date +%N)
 fn=hellopy-$(date +%N)
 
 log "Creating env $env_old"
-fission env create --name $env_old --image fission/python-env
+fission env create --name $env_old --image fission/python-env --graceperiod 1
 trap "fission env delete --name $env_old" EXIT
 
 log "Creating function $fn"

--- a/test/tests/test_fn_update/test_nd_pkg_update.sh
+++ b/test/tests/test_fn_update/test_nd_pkg_update.sh
@@ -32,7 +32,7 @@ printf 'def main():\n    return "Hello, world!"' > test_dir/hello.py
 zip -jr test-deploy-pkg.zip test_dir/
 
 log "Creating environment"
-fission env create --name $env --image fission/python-env:latest --builder fission/python-builder:latest --mincpu 40 --maxcpu 80 --minmemory 64 --maxmemory 128 --poolsize 2
+fission env create --name $env --image fission/python-env:latest --builder fission/python-builder:latest --mincpu 40 --maxcpu 80 --minmemory 64 --maxmemory 128 --poolsize 2 --graceperiod 1
 
 log "Creating functiom"
 fission fn create --name $fn_name --env $env --deploy test-deploy-pkg.zip --entrypoint "hello.main" --executortype newdeploy --minscale 1 --maxscale 4 --targetcpu 50

--- a/test/tests/test_fn_update/test_poolmgr_nd.sh
+++ b/test/tests/test_fn_update/test_poolmgr_nd.sh
@@ -10,7 +10,7 @@ env=python-$(date +%N)
 fn=hellopython-$(date +%N)
 
 log "Creating Python env $env"
-fission env create --name $env --image fission/python-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
+fission env create --name $env --image fission/python-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256 --graceperiod 1
 trap "fission env delete --name $env" EXIT
 
 log "Creating function $fn"

--- a/test/tests/test_fn_update/test_resource_change.sh
+++ b/test/tests/test_fn_update/test_resource_change.sh
@@ -20,7 +20,7 @@ minmem2=512
 maxmem2=768
 
 log "Creating Python env $env"
-fission env create --name $env --image fission/python-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
+fission env create --name $env --image fission/python-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256 --graceperiod 1
 trap "fission env delete --name $env" EXIT
 
 log "Creating function $fn"

--- a/test/tests/test_fn_update/test_scale_change.sh
+++ b/test/tests/test_fn_update/test_scale_change.sh
@@ -13,7 +13,7 @@ targetMaxScale=6
 targetCpuPercent=60
 
 log "Creating Python env $env"
-fission env create --name $env --image fission/python-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
+fission env create --name $env --image fission/python-env --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256 --graceperiod 1
 trap "fission env delete --name $env" EXIT
 
 log "Creating function $fn"

--- a/test/tests/test_fn_update/test_secret_update.sh
+++ b/test/tests/test_fn_update/test_secret_update.sh
@@ -16,7 +16,7 @@ cp ../test_secret_cfgmap/secret.py.template secret.py
 sed -i "s/{{ FN_SECRET }}/${old_secret}/g" secret.py
 
 log "Creating env $env"
-fission env create --name $env --image fission/python-env
+fission env create --name $env --image fission/python-env --graceperiod 1
 trap "fission env delete --name $env" EXIT
 
 log "Creating secret $old_secret"

--- a/test/tests/test_obj_create_in_diff_ns.sh
+++ b/test/tests/test_obj_create_in_diff_ns.sh
@@ -67,8 +67,8 @@ internal_route_test_1() {
 
 new_deploy_mgr_and_internal_route_test_2() {
     log "Starting new_deploy_mgr_and_internal_route_test_1 with env in default ns"
-    fission env create --name python --image fission/python-env
-    fission fn create --name func5 --env python --code testDir1/hello.py --minscale 1 --maxscale 4 --executortype newdeploy --graceperiod 1
+    fission env create --name python --image fission/python-env --graceperiod 1
+    fission fn create --name func5 --env python --code testDir1/hello.py --minscale 1 --maxscale 4 --executortype newdeploy
     sleep 15
 
     # function is loaded in $FISSION_NAMESPACE because func object was created in default ns

--- a/test/tests/test_obj_create_in_diff_ns.sh
+++ b/test/tests/test_obj_create_in_diff_ns.sh
@@ -68,7 +68,7 @@ internal_route_test_1() {
 new_deploy_mgr_and_internal_route_test_2() {
     log "Starting new_deploy_mgr_and_internal_route_test_1 with env in default ns"
     fission env create --name python --image fission/python-env
-    fission fn create --name func5 --env python --code testDir1/hello.py --minscale 1 --maxscale 4 --executortype newdeploy
+    fission fn create --name func5 --env python --code testDir1/hello.py --minscale 1 --maxscale 4 --executortype newdeploy --graceperiod 1
     sleep 15
 
     # function is loaded in $FISSION_NAMESPACE because func object was created in default ns

--- a/test/tests/test_secret_cfgmap/test_secret_cfgmap.sh
+++ b/test/tests/test_secret_cfgmap/test_secret_cfgmap.sh
@@ -53,7 +53,7 @@ log "Pre-test cleanup"
 fission env delete --name python || true
 
 log "Creating python env"
-fission env create --name python --image fission/python-env
+fission env create --name python --image fission/python-env --graceperiod 1
 trap "fission env delete --name python" EXIT
 
 log "Creating secret"

--- a/types.go
+++ b/types.go
@@ -182,6 +182,14 @@ const (
 )
 
 const (
+	// Pods might still be running user functions, so we give them
+	// a few minutes before terminating them.  This time is the
+	// maximum function runtime, plus the time a router might
+	// still route to an old instance, i.e. router cache expiry time.
+	DefaultTerminationGracePeriod int64 = int64(6 * 60)
+)
+
+const (
 	FissionBuilderSA = "fission-builder"
 	FissionFetcherSA = "fission-fetcher"
 


### PR DESCRIPTION
### Root cause
The requests sent to old function pod during the function update process and caused test failure.

### Solution
As a temp workaround, use short terminalGracePeriod so that the traffic can be sent to new function pod in short time.

But the behavior of traffic redirection conflicts with the steps described in [Termination of Pods](https://kubernetes.io/docs/concepts/workloads/pods/pod/). At step 5, the function pod is removed from endpoints list for service and should not redirect any requests after that. So even a longer terminalGracePeriod should not affect the traffic redirection. Any comment or thought is welcome.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/730)
<!-- Reviewable:end -->
