### PR TITLE
ArchiveLiteralSizeLimit: Use Constant Instead Hard Code

### DIFF
--- a/controller/packageApi.go
+++ b/controller/packageApi.go
@@ -63,12 +63,12 @@ func (a *API) PackageApiCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Ensure size limits
-	if len(f.Spec.Source.Literal) > 256*1024 {
+	if len(f.Spec.Source.Literal) > int(fission.ArchiveLiteralSizeLimit) {
 		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")
 		a.respondWithError(w, err)
 		return
 	}
-	if len(f.Spec.Deployment.Literal) > 256*1024 {
+	if len(f.Spec.Deployment.Literal) > int(fission.ArchiveLiteralSizeLimit) {
 		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")
 		a.respondWithError(w, err)
 		return


### PR DESCRIPTION
This use constant to instead hard code for ArchiveLiteralSizeLimit. That ensure if the limitation
value is changed in cli, the controller server can follow it. Otherwise, the condition will return
error, and make error HTTP response.

Later, we should delete it in fission-cli, and make it configurable it chart, to work in fission-
servers only.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/731)
<!-- Reviewable:end -->
