### PR TITLE
Bug Fix: Fission Client should exit 1 when creating function with environment not found

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -178,7 +178,7 @@ func fnCreate(c *cli.Context) error {
 		})
 		if err != nil {
 			if e, ok := err.(fission.Error); ok && e.Code == fission.ErrorNotFound {
-				fatal(fmt.Sprintf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --image <image>`\n", envName, envName))
+				fatal(fmt.Sprintf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --envns %v --image <image>`\n", envName, envName, envNamespace))
 			} else {
 				checkErr(err, "retrieve environment information")
 			}

--- a/fission/function.go
+++ b/fission/function.go
@@ -178,7 +178,7 @@ func fnCreate(c *cli.Context) error {
 		})
 		if err != nil {
 			if e, ok := err.(fission.Error); ok && e.Code == fission.ErrorNotFound {
-				fmt.Printf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --image <image>`\n", envName, envName)
+				fatal(fmt.Sprintf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --image <image>`\n", envName, envName))
 			} else {
 				checkErr(err, "retrieve environment information")
 			}


### PR DESCRIPTION
The older mechanism, in the case of environment not exist, allows program to go on, and create a bad function.

This let customer get a incorrect result, and set up a unworkable function.
    
Actually we should stop the program when environment not found, and return failed result, with the error message.

Signed-off-by: xiekeyang <keyang.xie@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/732)
<!-- Reviewable:end -->
