### PR TITLE
envns should be availabe in message line

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -180,7 +180,7 @@ func fnCreate(c *cli.Context) error {
 		})
 		if err != nil {
 			if e, ok := err.(fission.Error); ok && e.Code == fission.ErrorNotFound {
-				fmt.Printf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --image <image>`\n", envName, envName)
+				fmt.Printf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --envns %v --image <image>`\n", envName, envName, envNamespace)
 			} else {
 				checkErr(err, "retrieve environment information")
 			}


### PR DESCRIPTION
This line warn customer that dependent environment doesn’t exist, and present the command line
how to create env.

For variable `envNamespace` is specified, here the `envns` option should be available as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/734)
<!-- Reviewable:end -->
