### PR TITLE
instead hard code by variable in error message

### DIFF
--- a/controller/packageApi.go
+++ b/controller/packageApi.go
@@ -18,9 +18,11 @@ package controller
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/dustin/go-humanize"
 	"github.com/gorilla/mux"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -64,12 +66,14 @@ func (a *API) PackageApiCreate(w http.ResponseWriter, r *http.Request) {
 
 	// Ensure size limits
 	if len(f.Spec.Source.Literal) > int(fission.ArchiveLiteralSizeLimit) {
-		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")
+		err := fission.MakeError(fission.ErrorInvalidArgument,
+			fmt.Sprintf("Package literal larger than %s", humanize.Bytes(uint64(fission.ArchiveLiteralSizeLimit))))
 		a.respondWithError(w, err)
 		return
 	}
 	if len(f.Spec.Deployment.Literal) > int(fission.ArchiveLiteralSizeLimit) {
-		err := fission.MakeError(fission.ErrorInvalidArgument, "Package literal larger than 256K")
+		err := fission.MakeError(fission.ErrorInvalidArgument,
+			fmt.Sprintf("Package literal larger than %s", humanize.Bytes(uint64(fission.ArchiveLiteralSizeLimit))))
 		a.respondWithError(w, err)
 		return
 	}

--- a/glide.lock
+++ b/glide.lock
@@ -430,3 +430,5 @@ testImports:
   - difflib
 - name: github.com/stretchr/objx
   version: 8a3f7159479fbc75b30357fbc48f380b7320f08e
+- name: github.com/dustin/go-humanize
+  version: 02af3965c54e8cacf948b97fef38925c4120652c

--- a/glide.yaml
+++ b/glide.yaml
@@ -63,4 +63,4 @@ import:
 - package: github.com/hashicorp/errwrap
 - package: github.com/prometheus/client_golang
   version: v0.8.0
-
+- package: github.com/dustin/go-humanize


### PR DESCRIPTION
`ArchiveLiteralSizeLimit` has constant value. When encountering the package error here, we should warn the exact `ArchiveLiteralSizeLimit` value, but not `256KB` hard code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/735)
<!-- Reviewable:end -->
