### PR TITLE
Testing with keep alive settings for connections

### DIFF
--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -94,7 +94,7 @@ func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (resp *htt
 	// set the timeout for transport context
 	timeout := roundTripper.initialTimeout
 	transport := http.DefaultTransport.(*http.Transport)
-	transport.DisableKeepAlives = true
+	//transport.DisableKeepAlives = true
 
 	// cache lookup to get serviceUrl
 	serviceUrl, err = roundTripper.funcHandler.fmap.lookup(roundTripper.funcHandler.function)

--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -94,6 +94,7 @@ func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (resp *htt
 	// set the timeout for transport context
 	timeout := roundTripper.initialTimeout
 	transport := http.DefaultTransport.(*http.Transport)
+	transport.DisableKeepAlives = true
 
 	// cache lookup to get serviceUrl
 	serviceUrl, err = roundTripper.funcHandler.fmap.lookup(roundTripper.funcHandler.function)

--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -94,6 +94,7 @@ func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (resp *htt
 	// set the timeout for transport context
 	timeout := roundTripper.initialTimeout
 	transport := http.DefaultTransport.(*http.Transport)
+	// Disables caching, Please refer to issue and specifically comment: https://github.com/fission/fission/issues/723#issuecomment-398781995
 	transport.DisableKeepAlives = true
 
 	// cache lookup to get serviceUrl

--- a/router/functionHandler.go
+++ b/router/functionHandler.go
@@ -94,7 +94,7 @@ func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (resp *htt
 	// set the timeout for transport context
 	timeout := roundTripper.initialTimeout
 	transport := http.DefaultTransport.(*http.Transport)
-	//transport.DisableKeepAlives = true
+	transport.DisableKeepAlives = true
 
 	// cache lookup to get serviceUrl
 	serviceUrl, err = roundTripper.funcHandler.fmap.lookup(roundTripper.funcHandler.function)

--- a/test/tests/test_fn_update/test_configmap_update.sh
+++ b/test/tests/test_fn_update/test_configmap_update.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Disabling for https://github.com/fission/fission/issues/723 will enable after resolution/cluster upgrade
-#test:disabled
 
 set -euo pipefail
 

--- a/test/tests/test_fn_update/test_nd_pkg_update.sh
+++ b/test/tests/test_fn_update/test_nd_pkg_update.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Disabling for https://github.com/fission/fission/issues/723 will enable after resolution/cluster upgrade
-#test:disabled
 
 set -euo pipefail
 

--- a/test/tests/test_fn_update/test_secret_update.sh
+++ b/test/tests/test_fn_update/test_secret_update.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-# Disabling for https://github.com/fission/fission/issues/723 will enable after resolution/cluster upgrade
-#test:disabled
 
 set -euo pipefail
 


### PR DESCRIPTION
This fix tries to address final finding from the issue https://github.com/fission/fission/issues/723 (The issue with router caching the POD IP address: https://github.com/fission/fission/issues/723#issuecomment-395952964 )

As can be seen from builds for commit - with the fix the tests pass and without it, they fail. Of course, the impact of this on the performance etc. is not clear here. Also, this issue has been seen only in CI cluster so far.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/742)
<!-- Reviewable:end -->
