### PR TITLE
Fix executor wrongly passes loop variable reference to function

### DIFF
--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -101,7 +101,8 @@ func (ts *HTTPTriggerSet) getRouter() *mux.Router {
 
 	// HTTP triggers setup by the user
 	homeHandled := false
-	for _, trigger := range ts.triggers {
+	for i := range ts.triggers {
+		trigger := ts.triggers[i]
 
 		// resolve function reference
 		rr, err := ts.resolver.resolve(trigger.Metadata.Namespace, &trigger.Spec.FunctionReference)


### PR DESCRIPTION
### Root cause

When investigating issues 695, found the bug in router. The reference of loop variable was being passed to function. (Not the root cause of 695)

https://github.com/fission/fission/blob/1ab1c3264ec8b68f4da225bef51db4ffe17c5659/router/httpTriggers.go#L112
https://github.com/fission/fission/blob/1ab1c3264ec8b68f4da225bef51db4ffe17c5659/router/httpTriggers.go#L127

And wrong metrics data will be collected.

https://github.com/fission/fission/blob/1b86c367a04aa07f0bedea96786201fe1948b164/router/functionHandler.go#L89-L92

### Solution

Get reference from slice element.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/751)
<!-- Reviewable:end -->
