### PR TITLE
Add more meaningful error messages to executor when getServiceForFunction

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -115,6 +115,11 @@ func (executor *Executor) serveCreateFuncServices() {
 
 				// get the function service from the cache
 				fsvc, err := executor.fsCache.GetByFunction(m)
+
+				// fsCache return error when the entry does not exist/expire.
+				// It normally happened if there are multiple requests are
+				// waiting for the same function and executor failed to cre-
+				// ate service for function.
 				err = errors.New(fmt.Sprintf("Error getting service for function %v: %v", m.Name, err))
 				req.respChan <- &createFuncServiceResponse{
 					funcSvc: fsvc,

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -17,6 +17,7 @@ limitations under the License.
 package executor
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"runtime/debug"
@@ -25,6 +26,7 @@ import (
 	"time"
 
 	"github.com/dchest/uniuri"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -113,6 +115,7 @@ func (executor *Executor) serveCreateFuncServices() {
 
 				// get the function service from the cache
 				fsvc, err := executor.fsCache.GetByFunction(m)
+				err = errors.New(fmt.Sprintf("Error getting service for function %v: %v", m.Name, err))
 				req.respChan <- &createFuncServiceResponse{
 					funcSvc: fsvc,
 					err:     err,
@@ -145,10 +148,12 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 		return nil, err
 	}
 
+	var fsvc *fscache.FuncSvc
+	var fsvcErr error
+
 	switch executorType {
 	case fission.ExecutorTypeNewdeploy:
-		fs, err := executor.ndm.GetFuncSvc(meta)
-		return fs, err
+		fsvc, fsvcErr = executor.ndm.GetFuncSvc(meta)
 	default:
 		pool, err := executor.gpm.GetPool(env)
 		if err != nil {
@@ -157,9 +162,15 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 		// from GenericPool -> get one function container
 		// (this also adds to the cache)
 		log.Printf("[%v] getting function service from pool", meta.Name)
-		fsvc, err := pool.GetFuncSvc(meta)
-		return fsvc, err
+		fsvc, fsvcErr = pool.GetFuncSvc(meta)
 	}
+
+	if fsvcErr != nil {
+		fsvcErr = errors.New(fmt.Sprintf("[%v] Error creating service for function: %v", meta.Name, fsvcErr))
+		log.Print(fsvcErr)
+	}
+
+	return fsvc, fsvcErr
 }
 
 func (executor *Executor) getFunctionEnv(m *metav1.ObjectMeta) (*crd.Environment, error) {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -120,7 +120,7 @@ func (executor *Executor) serveCreateFuncServices() {
 				// It normally happened if there are multiple requests are
 				// waiting for the same function and executor failed to cre-
 				// ate service for function.
-				err = errors.New(fmt.Sprintf("Error getting service for function %v: %v", m.Name, err))
+				err = errors.Wrap(err, fmt.Sprintf("Error getting service for function %v in namespace %v", m.Name, m.Namespace))
 				req.respChan <- &createFuncServiceResponse{
 					funcSvc: fsvc,
 					err:     err,
@@ -171,7 +171,7 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 	}
 
 	if fsvcErr != nil {
-		fsvcErr = errors.New(fmt.Sprintf("[%v] Error creating service for function: %v", meta.Name, fsvcErr))
+		fsvcErr = errors.Wrap(fsvcErr, fmt.Sprintf("[%v] Error creating service for function", meta.Name))
 		log.Print(fsvcErr)
 	}
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -19,7 +19,6 @@ package poolmgr
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -32,7 +31,7 @@ import (
 	"time"
 
 	"github.com/dchest/uniuri"
-
+	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -662,7 +661,9 @@ func (gp *GenericPool) waitForReadyPod() error {
 		depl, err := gp.kubernetesClient.ExtensionsV1beta1().Deployments(gp.namespace).Get(
 			gp.deployment.ObjectMeta.Name, metav1.GetOptions{})
 		if err != nil {
-			err = errors.New(fmt.Sprintf("Error waiting for ready pod: %v", err))
+			err = errors.Wrap(err, fmt.Sprintf(
+				"Error waiting for ready pod of deployment %v in namespace %v",
+				gp.deployment.ObjectMeta.Name, gp.namespace))
 			log.Print(err)
 			return err
 		}
@@ -673,7 +674,9 @@ func (gp *GenericPool) waitForReadyPod() error {
 		}
 
 		if time.Since(startTime) > gp.podReadyTimeout {
-			return errors.New("timeout: waited too long for pod to be ready")
+			return errors.Errorf(
+				"Timeout: waited too long for pod of deployment %v in namespace %v to be ready",
+				gp.deployment.ObjectMeta.Name, gp.namespace)
 		}
 		time.Sleep(1000 * time.Millisecond)
 	}

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -662,9 +662,11 @@ func (gp *GenericPool) waitForReadyPod() error {
 		depl, err := gp.kubernetesClient.ExtensionsV1beta1().Deployments(gp.namespace).Get(
 			gp.deployment.ObjectMeta.Name, metav1.GetOptions{})
 		if err != nil {
-			log.Printf("err: %v", err)
+			err = errors.New(fmt.Sprintf("Error waiting for ready pod: %v", err))
+			log.Print(err)
 			return err
 		}
+
 		gp.deployment = depl
 		if gp.deployment.Status.AvailableReplicas > 0 {
 			return nil


### PR DESCRIPTION
### Description 
Router sends requests to executor to get service for function, however, exectuor replies error without some useful information/message. This PR appends message/information to error message to provide more clues when debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/752)
<!-- Reviewable:end -->
