### PR TITLE
Add go environment vendor directory support

### DIFF
--- a/environments/go/builder/Dockerfile
+++ b/environments/go/builder/Dockerfile
@@ -5,9 +5,9 @@ FROM ${BUILDER_IMAGE}
 
 FROM golang:${GO_VERSION}
 
-COPY --from=0 /builder /builder
-
 ENV GOPATH /usr
+WORKDIR ${GOPATH}
 
+COPY --from=0 /builder /builder
 ADD build.sh /usr/local/bin/build
 

--- a/environments/go/builder/build.sh
+++ b/environments/go/builder/build.sh
@@ -5,8 +5,8 @@ trap "rm -rf ${srcDir}" EXIT
 
 if [ -d ${SRC_PKG} ]
 then
-    cp -r ${SRC_PKG} ${srcDir}
     echo "Building in directory ${srcDir}"
+    cp -r ${SRC_PKG} ${srcDir}
 elif [ -f ${SRC_PKG} ]
 then
     echo "Building file ${SRC_PKG} in ${srcDir}"

--- a/environments/go/builder/build.sh
+++ b/environments/go/builder/build.sh
@@ -1,15 +1,19 @@
 #!/bin/sh
 
+set -eux
+
 srcDir=${GOPATH}/src/$(basename ${SRC_PKG})
+
 trap "rm -rf ${srcDir}" EXIT
 
 if [ -d ${SRC_PKG} ]
 then
     echo "Building in directory ${srcDir}"
-    cp -r ${SRC_PKG} ${srcDir}
+    ln -sf ${SRC_PKG} ${srcDir}
 elif [ -f ${SRC_PKG} ]
 then
     echo "Building file ${SRC_PKG} in ${srcDir}"
+    mkdir -p ${srcDir}
     cp ${SRC_PKG} ${srcDir}/function.go
 fi
 

--- a/environments/go/builder/build.sh
+++ b/environments/go/builder/build.sh
@@ -1,19 +1,17 @@
 #!/bin/sh
 
+srcDir=${GOPATH}/src/$(basename ${SRC_PKG})
+trap "rm -rf ${srcDir}" EXIT
+
 if [ -d ${SRC_PKG} ]
 then
-    echo "Building in directory ${SRC_PKG}"
-    cd ${SRC_PKG}
-    go build -buildmode=plugin -i -o ${DEPLOY_PKG} .
+    cp -r ${SRC_PKG} ${srcDir}
+    echo "Building in directory ${srcDir}"
 elif [ -f ${SRC_PKG} ]
 then
-    fn=$(basename ${SRC_PKG})
-    d=/tmp/$fn
-    mkdir $d
-    trap "rm -rf /tmp/$fn" EXIT
-    echo "Building file ${SRC_PKG} in $d"
-
-    cd $d
-    cp ${SRC_PKG} ./function.go
-    go build -buildmode=plugin -i -o ${DEPLOY_PKG} .
+    echo "Building file ${SRC_PKG} in ${srcDir}"
+    cp ${SRC_PKG} ${srcDir}/function.go
 fi
+
+cd ${srcDir}
+go build -buildmode=plugin -i -o ${DEPLOY_PKG} .

--- a/examples/go/vendor-example/main.go
+++ b/examples/go/vendor-example/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+    "go/vendordir/test"
+    "net/http"
+)
+
+// Handler is the entry point for this fission function
+func Handler(w http.ResponseWriter, r *http.Request) {
+	msg := test.Test()
+	w.Write([]byte(msg))
+}

--- a/examples/go/vendor-example/main.go
+++ b/examples/go/vendor-example/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-    "go/vendordir/test"
-    "net/http"
+	"go/vendordir/test"
+	"net/http"
 )
 
 // Handler is the entry point for this fission function

--- a/examples/go/vendor-example/vendor/go/vendordir/test/test.go
+++ b/examples/go/vendor-example/vendor/go/vendordir/test/test.go
@@ -1,0 +1,5 @@
+package test
+
+func Test() string {
+    return "vendor hello world"
+}

--- a/test/tests/test_environments/test_go_env.sh
+++ b/test/tests/test_environments/test_go_env.sh
@@ -82,7 +82,8 @@ timeout 60 bash -c "test_fn hello-go-poolmgr 'Hello'"
 log "Testing new deployment function"
 timeout 60 bash -c "test_fn hello-go-nd 'Hello'"
 
-zip -r vendor.zip vendor-example
+# Create zip file without top level directory (vendor-example)
+cd vendor-example && zip -r vendor.zip *
 
 pkgName=$(fission package create --src vendor.zip --env go| cut -f2 -d' '| tr -d \')
 


### PR DESCRIPTION
For now, vendor directory only works under `$GOPATH/src`.  With this PR, the go builder will first copy `SRC_PKG` to `${GOPATH}/src/<pkg_name>` and change work directory then do build process.

```
$ ls
total 656
-rw-r--r--@ 1 taching  staff   781B Jun 26 16:47 README.md
-rw-r--r--@ 1 taching  staff   2.1K Jul  2 18:01 accountFn.go
-rw-r--r--@ 1 taching  staff   2.5K Jul  2 16:54 accountFn_test.go
-rw-r--r--@ 1 taching  staff   288K Jul  4 16:08 bank.zip
-rw-r--r--@ 1 taching  staff   986B Jun 27 18:17 common.go
-rw-r--r--@ 1 taching  staff   698B Jul  2 16:58 glide.lock
-rw-r--r--@ 1 taching  staff   253B Jul  2 16:58 glide.yaml
-rw-r--r--@ 1 taching  staff   188B Jul  2 18:01 main.go
-rw-r--r--@ 1 taching  staff   318B Jun 27 17:52 types.go
drwxr-xr-x@ 3 taching  staff    96B Jul  2 16:58 vendor

$ fission pkg create --env go --src bank.zip
Package 'bank-zip-f40p' created

$ fission pkg info --name bank-zip-f40p
Name:        bank-zip-f40p
Environment: go
Status:      succeeded
Build Logs:
Building in directory /usr/src/bank-zip-f40p-za832p
```


⚠️ This PR not solves the package management yet. Users need to use any of package management tool to download dependencies to vendor directory first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/781)
<!-- Reviewable:end -->
