### PR TITLE
Add query options to `fission function test`

### DIFF
--- a/fission/main.go
+++ b/fission/main.go
@@ -130,6 +130,7 @@ func main() {
 	fnLogDBTypeFlag := cli.StringFlag{Name: "dbtype", Usage: "log database type, e.g. influxdb (currently only influxdb is supported)"}
 	fnBodyFlag := cli.StringFlag{Name: "body, b", Usage: "request body"}
 	fnHeaderFlag := cli.StringSliceFlag{Name: "header, H", Usage: "request headers"}
+	fnQueryFlag := cli.StringSliceFlag{Name: "query, q", Usage: "request query parameters: -q key1=value1 -q key2=value2"}
 	fnEntryPointFlag := cli.StringFlag{Name: "entrypoint", Usage: "entry point for environment v2 to load with"}
 	fnBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "build command for builder to run with"}
 	fnSecretFlag := cli.StringFlag{Name: "secret", Usage: "function access to secret, should be present in the same namespace as the function"}
@@ -148,7 +149,7 @@ func main() {
 		// so, in the future, if we end up using kubeconfig in fission cli and enforcing rolebindings to be created for users by admins etc, we can add this option at the time.
 		{Name: "list", Usage: "List all functions in a namespace if specified, else, list functions across all namespaces", Flags: []cli.Flag{fnNamespaceFlag}, Action: fnList},
 		{Name: "logs", Usage: "Display function logs", Flags: []cli.Flag{fnNameFlag, fnNamespaceFlag, fnPodFlag, fnFollowFlag, fnDetailFlag, fnLogDBTypeFlag, fnLogCountFlag}, Action: fnLogs},
-		{Name: "test", Usage: "Test a function", Flags: []cli.Flag{fnNameFlag, fnNamespaceFlag, fnEnvNameFlag, fnCodeFlag, fnSrcArchiveFlag, htMethodFlag, fnBodyFlag, fnHeaderFlag}, Action: fnTest},
+		{Name: "test", Usage: "Test a function", Flags: []cli.Flag{fnNameFlag, fnNamespaceFlag, fnEnvNameFlag, fnCodeFlag, fnSrcArchiveFlag, htMethodFlag, fnBodyFlag, fnHeaderFlag, fnQueryFlag}, Action: fnTest},
 	}
 
 	// httptriggers


### PR DESCRIPTION
This PR adds `--query, -q` options to the (already very useful) `function test` subcommand. I choose to use the `net/url` package for creating the url to avoid having to deal with query escaping and all that. Regardless of the query addition, using that package seems safer to detect invalid urls earlier.

The reason that I added it is that it would useful to have in the workflows CI, and that we (in my opinion) should not ignore these (query) settings which are common practice for REST-based APIs.

Resolves #401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/782)
<!-- Reviewable:end -->
