### PR TITLE
Change flag name to KeepArchive for backward compatibility

### DIFF
--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -54,10 +54,10 @@ func buildPackage(fissionClient *crd.FissionClient, envBuilderNamespace string,
 	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName))
 
 	fetchReq := &fetcher.FetchRequest{
-		FetchType:        fetcher.FETCH_SOURCE,
-		Package:          pkg.Metadata,
-		Filename:         srcPkgFilename,
-		NoExtractArchive: false,
+		FetchType:   fetcher.FETCH_SOURCE,
+		Package:     pkg.Metadata,
+		Filename:    srcPkgFilename,
+		KeepArchive: false,
 	}
 
 	// send fetch request to fetcher

--- a/buildermgr/common.go
+++ b/buildermgr/common.go
@@ -54,10 +54,10 @@ func buildPackage(fissionClient *crd.FissionClient, envBuilderNamespace string,
 	builderC := builderClient.MakeClient(fmt.Sprintf("http://%v:8001", svcName))
 
 	fetchReq := &fetcher.FetchRequest{
-		FetchType:      fetcher.FETCH_SOURCE,
-		Package:        pkg.Metadata,
-		Filename:       srcPkgFilename,
-		ExtractArchive: true,
+		FetchType:        fetcher.FETCH_SOURCE,
+		Package:          pkg.Metadata,
+		Filename:         srcPkgFilename,
+		NoExtractArchive: false,
 	}
 
 	// send fetch request to fetcher

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -29,14 +29,14 @@ type (
 	FetchRequestType int
 
 	FetchRequest struct {
-		FetchType        FetchRequestType             `json:"fetchType"`
-		Package          metav1.ObjectMeta            `json:"package"`
-		Url              string                       `json:"url"`
-		StorageSvcUrl    string                       `json:"storagesvcurl"`
-		Filename         string                       `json:"filename"`
-		Secrets          []fission.SecretReference    `json:"secretList"`
-		ConfigMaps       []fission.ConfigMapReference `json:"configMapList"`
-		NoExtractArchive bool                         `json:"noextract"`
+		FetchType     FetchRequestType             `json:"fetchType"`
+		Package       metav1.ObjectMeta            `json:"package"`
+		Url           string                       `json:"url"`
+		StorageSvcUrl string                       `json:"storagesvcurl"`
+		Filename      string                       `json:"filename"`
+		Secrets       []fission.SecretReference    `json:"secretList"`
+		ConfigMaps    []fission.ConfigMapReference `json:"configMapList"`
+		KeepArchive   bool                         `json:"keeparchive"`
 	}
 
 	// UploadRequest send from builder manager describes which
@@ -293,7 +293,7 @@ func (fetcher *Fetcher) Fetch(req FetchRequest) (int, error) {
 		}
 	}
 
-	if archiver.Zip.Match(tmpPath) && !req.NoExtractArchive {
+	if archiver.Zip.Match(tmpPath) && !req.KeepArchive {
 		// unarchive tmp file to a tmp unarchive path
 		tmpUnarchivePath := filepath.Join(fetcher.sharedVolumePath, uuid.NewV4().String())
 		err := fetcher.unarchive(tmpPath, tmpUnarchivePath)

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -29,14 +29,14 @@ type (
 	FetchRequestType int
 
 	FetchRequest struct {
-		FetchType      FetchRequestType             `json:"fetchType"`
-		Package        metav1.ObjectMeta            `json:"package"`
-		Url            string                       `json:"url"`
-		StorageSvcUrl  string                       `json:"storagesvcurl"`
-		Filename       string                       `json:"filename"`
-		Secrets        []fission.SecretReference    `json:"secretList"`
-		ConfigMaps     []fission.ConfigMapReference `json:"configMapList"`
-		ExtractArchive bool                         `json:"extractarchive"`
+		FetchType        FetchRequestType             `json:"fetchType"`
+		Package          metav1.ObjectMeta            `json:"package"`
+		Url              string                       `json:"url"`
+		StorageSvcUrl    string                       `json:"storagesvcurl"`
+		Filename         string                       `json:"filename"`
+		Secrets          []fission.SecretReference    `json:"secretList"`
+		ConfigMaps       []fission.ConfigMapReference `json:"configMapList"`
+		NoExtractArchive bool                         `json:"noextract"`
 	}
 
 	// UploadRequest send from builder manager describes which
@@ -293,7 +293,7 @@ func (fetcher *Fetcher) Fetch(req FetchRequest) (int, error) {
 		}
 	}
 
-	if archiver.Zip.Match(tmpPath) && req.ExtractArchive {
+	if archiver.Zip.Match(tmpPath) && !req.NotExtractArchive {
 		// unarchive tmp file to a tmp unarchive path
 		tmpUnarchivePath := filepath.Join(fetcher.sharedVolumePath, uuid.NewV4().String())
 		err := fetcher.unarchive(tmpPath, tmpUnarchivePath)

--- a/environments/fetcher/fetcher.go
+++ b/environments/fetcher/fetcher.go
@@ -293,7 +293,7 @@ func (fetcher *Fetcher) Fetch(req FetchRequest) (int, error) {
 		}
 	}
 
-	if archiver.Zip.Match(tmpPath) && !req.NotExtractArchive {
+	if archiver.Zip.Match(tmpPath) && !req.NoExtractArchive {
 		// unarchive tmp file to a tmp unarchive path
 		tmpUnarchivePath := filepath.Join(fetcher.sharedVolumePath, uuid.NewV4().String())
 		err := fetcher.unarchive(tmpPath, tmpUnarchivePath)

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -158,10 +158,10 @@ func (deploy *NewDeploy) getDeploymentSpec(fn *crd.Function, env *crd.Environmen
 			Namespace: fn.Spec.Package.PackageRef.Namespace,
 			Name:      fn.Spec.Package.PackageRef.Name,
 		},
-		Filename:         targetFilename,
-		Secrets:          fn.Spec.Secrets,
-		ConfigMaps:       fn.Spec.ConfigMaps,
-		NoExtractArchive: env.Spec.NoExtractArchive,
+		Filename:    targetFilename,
+		Secrets:     fn.Spec.Secrets,
+		ConfigMaps:  fn.Spec.ConfigMaps,
+		KeepArchive: env.Spec.KeepArchive,
 	}
 
 	loadReq := fission.FunctionLoadRequest{

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -158,10 +158,10 @@ func (deploy *NewDeploy) getDeploymentSpec(fn *crd.Function, env *crd.Environmen
 			Namespace: fn.Spec.Package.PackageRef.Namespace,
 			Name:      fn.Spec.Package.PackageRef.Name,
 		},
-		Filename:       targetFilename,
-		Secrets:        fn.Spec.Secrets,
-		ConfigMaps:     fn.Spec.ConfigMaps,
-		ExtractArchive: env.Spec.ExtractArchive,
+		Filename:         targetFilename,
+		Secrets:          fn.Spec.Secrets,
+		ConfigMaps:       fn.Spec.ConfigMaps,
+		NoExtractArchive: env.Spec.NoExtractArchive,
 	}
 
 	loadReq := fission.FunctionLoadRequest{

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -387,10 +387,10 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 			Namespace: fn.Spec.Package.PackageRef.Namespace,
 			Name:      fn.Spec.Package.PackageRef.Name,
 		},
-		Filename:       targetFilename,
-		Secrets:        fn.Spec.Secrets,
-		ConfigMaps:     fn.Spec.ConfigMaps,
-		ExtractArchive: gp.env.Spec.ExtractArchive,
+		Filename:         targetFilename,
+		Secrets:          fn.Spec.Secrets,
+		ConfigMaps:       fn.Spec.ConfigMaps,
+		NoExtractArchive: gp.env.Spec.NoExtractArchive,
 	})
 	if err != nil {
 		return err

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -387,10 +387,10 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 			Namespace: fn.Spec.Package.PackageRef.Namespace,
 			Name:      fn.Spec.Package.PackageRef.Name,
 		},
-		Filename:         targetFilename,
-		Secrets:          fn.Spec.Secrets,
-		ConfigMaps:       fn.Spec.ConfigMaps,
-		NoExtractArchive: gp.env.Spec.NoExtractArchive,
+		Filename:    targetFilename,
+		Secrets:     fn.Spec.Secrets,
+		ConfigMaps:  fn.Spec.ConfigMaps,
+		KeepArchive: gp.env.Spec.KeepArchive,
 	})
 	if err != nil {
 		return err

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -93,10 +93,7 @@ func envCreate(c *cli.Context) error {
 		}
 	}
 
-	noExtractArchive := false
-	if c.IsSet("noextract") {
-		noExtractArchive = c.Bool("noextract")
-	}
+	keepArchive := c.Bool("keeparchive")
 
 	// Environment API interface version is not specified and
 	// builder image is empty, set default interface version
@@ -124,7 +121,7 @@ func envCreate(c *cli.Context) error {
 			Resources:                    resourceReq,
 			AllowAccessToExternalNetwork: envExternalNetwork,
 			TerminationGracePeriod:       envGracePeriod,
-			NoExtractArchive:             noExtractArchive,
+			KeepArchive:                  keepArchive,
 		},
 	}
 
@@ -212,6 +209,10 @@ func envUpdate(c *cli.Context) error {
 
 	if c.IsSet("period") {
 		env.Spec.TerminationGracePeriod = c.Int64("period")
+	}
+
+	if c.IsSet("keeparchive") {
+		env.Spec.KeepArchive = c.Bool("keeparchive")
 	}
 
 	env.Spec.AllowAccessToExternalNetwork = envExternalNetwork

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -93,9 +93,9 @@ func envCreate(c *cli.Context) error {
 		}
 	}
 
-	extractArchive := true
-	if c.IsSet("extract") {
-		extractArchive = c.Bool("extract")
+	noExtractArchive := false
+	if c.IsSet("noextract") {
+		noExtractArchive = c.Bool("noextract")
 	}
 
 	// Environment API interface version is not specified and
@@ -124,7 +124,7 @@ func envCreate(c *cli.Context) error {
 			Resources:                    resourceReq,
 			AllowAccessToExternalNetwork: envExternalNetwork,
 			TerminationGracePeriod:       envGracePeriod,
-			ExtractArchive:               extractArchive,
+			NoExtractArchive:             noExtractArchive,
 		},
 	}
 

--- a/fission/main.go
+++ b/fission/main.go
@@ -202,14 +202,14 @@ func main() {
 	envImageFlag := cli.StringFlag{Name: "image", Usage: "Environment image URL"}
 	envBuilderImageFlag := cli.StringFlag{Name: "builder", Usage: "Environment builder image URL (optional)"}
 	envBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for environment builder to build source package (optional)"}
-	envExtractArchiveFlag := cli.BoolFlag{Name: "extractarchive, extract", Usage: "Extract the archive into a directory, defaults to true"}
+	envNoExtractArchiveFlag := cli.BoolFlag{Name: "noextractarchive, noextract", Usage: "Not to extract the archive into a directory, defaults to false"}
 	envExternalNetworkFlag := cli.BoolFlag{Name: "externalnetwork", Usage: "Allow environment access external network when istio feature enabled (optional, defaults to false)"}
 	envTerminationGracePeriodFlag := cli.Int64Flag{Name: "graceperiod, period", Value: 360, Usage: "The grace time (in seconds) for pod to perform connection draining before termination (optional)"}
 	envVersionFlag := cli.IntFlag{Name: "version", Value: 1, Usage: "Environment API version (1 means v1 interface)"}
 	envSubcommands := []cli.Command{
-		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envExtractArchiveFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag, envExternalNetworkFlag, envTerminationGracePeriodFlag, specSaveFlag}, Action: envCreate},
+		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envNoExtractArchiveFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag, envExternalNetworkFlag, envTerminationGracePeriodFlag, specSaveFlag}, Action: envCreate},
 		{Name: "get", Usage: "Get environment details", Flags: []cli.Flag{envNameFlag, envNamespaceFlag}, Action: envGet},
-		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envExtractArchiveFlag, minCpu, maxCpu, minMem, maxMem, envExternalNetworkFlag, envTerminationGracePeriodFlag}, Action: envUpdate},
+		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envNoExtractArchiveFlag, minCpu, maxCpu, minMem, maxMem, envExternalNetworkFlag, envTerminationGracePeriodFlag}, Action: envUpdate},
 		{Name: "delete", Usage: "Delete environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag}, Action: envDelete},
 		{Name: "list", Usage: "List all environments", Flags: []cli.Flag{envNamespaceFlag}, Action: envList},
 	}

--- a/fission/main.go
+++ b/fission/main.go
@@ -202,14 +202,14 @@ func main() {
 	envImageFlag := cli.StringFlag{Name: "image", Usage: "Environment image URL"}
 	envBuilderImageFlag := cli.StringFlag{Name: "builder", Usage: "Environment builder image URL (optional)"}
 	envBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for environment builder to build source package (optional)"}
-	envNoExtractArchiveFlag := cli.BoolFlag{Name: "noextractarchive, noextract", Usage: "Not to extract the archive into a directory, defaults to false"}
+	envKeepArchiveFlag := cli.BoolFlag{Name: "keeparchive", Usage: "Keep the archive instead of extracting it into a directory (optional, defaults to false)"}
 	envExternalNetworkFlag := cli.BoolFlag{Name: "externalnetwork", Usage: "Allow environment access external network when istio feature enabled (optional, defaults to false)"}
 	envTerminationGracePeriodFlag := cli.Int64Flag{Name: "graceperiod, period", Value: 360, Usage: "The grace time (in seconds) for pod to perform connection draining before termination (optional)"}
 	envVersionFlag := cli.IntFlag{Name: "version", Value: 1, Usage: "Environment API version (1 means v1 interface)"}
 	envSubcommands := []cli.Command{
-		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envNoExtractArchiveFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag, envExternalNetworkFlag, envTerminationGracePeriodFlag, specSaveFlag}, Action: envCreate},
+		{Name: "create", Aliases: []string{"add"}, Usage: "Add an environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envKeepArchiveFlag, minCpu, maxCpu, minMem, maxMem, envVersionFlag, envExternalNetworkFlag, envTerminationGracePeriodFlag, specSaveFlag}, Action: envCreate},
 		{Name: "get", Usage: "Get environment details", Flags: []cli.Flag{envNameFlag, envNamespaceFlag}, Action: envGet},
-		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envNoExtractArchiveFlag, minCpu, maxCpu, minMem, maxMem, envExternalNetworkFlag, envTerminationGracePeriodFlag}, Action: envUpdate},
+		{Name: "update", Usage: "Update environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag, envPoolsizeFlag, envImageFlag, envBuilderImageFlag, envBuildCmdFlag, envKeepArchiveFlag, minCpu, maxCpu, minMem, maxMem, envExternalNetworkFlag, envTerminationGracePeriodFlag}, Action: envUpdate},
 		{Name: "delete", Usage: "Delete environment", Flags: []cli.Flag{envNameFlag, envNamespaceFlag}, Action: envDelete},
 		{Name: "list", Usage: "List all environments", Flags: []cli.Flag{envNamespaceFlag}, Action: envList},
 	}

--- a/pkg/apis/fission.io/v1/typefields.go
+++ b/pkg/apis/fission.io/v1/typefields.go
@@ -271,9 +271,9 @@ type (
 		// Optional, defaults to 360 seconds
 		TerminationGracePeriod int64
 
-		// NoExtractArchive is used by fetcher to determine if the extracted archive
+		// KeepArchive is used by fetcher to determine if the extracted archive
 		// or unarchived file should be placed, which is then used by specialize handler
-		NoExtractArchive bool `json:"noextract"`
+		KeepArchive bool `json:"keeparchive"`
 	}
 
 	AllowedFunctionsPerContainer string

--- a/pkg/apis/fission.io/v1/typefields.go
+++ b/pkg/apis/fission.io/v1/typefields.go
@@ -271,9 +271,9 @@ type (
 		// Optional, defaults to 360 seconds
 		TerminationGracePeriod int64
 
-		// ExtractArchive is used by fetcher to determine if the extracted archive
+		// NoExtractArchive is used by fetcher to determine if the extracted archive
 		// or unarchived file should be placed, which is then used by specialize handler
-		ExtractArchive bool `json:"extractarchive,extract"`
+		NoExtractArchive bool `json:"noextract"`
 	}
 
 	AllowedFunctionsPerContainer string

--- a/test/tests/test_environments/test_java_env.sh
+++ b/test/tests/test_environments/test_java_env.sh
@@ -32,7 +32,7 @@ log "Creating the jar from application"
 docker run -it --rm  -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.5-jdk-8 mvn clean package
 
 log "Creating environment for Java"
-fission env create --name jvm --image gcr.io/fission-ci/jvm-env:test --version 2 --noextract=true
+fission env create --name jvm --image gcr.io/fission-ci/jvm-env:test --version 2 --keeparchive=true
 
 log "Creating pool manager & new deployment function for Java"
 fission fn create --name hellop --deploy target/hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar --env jvm --entrypoint io.fission.HelloWorld

--- a/test/tests/test_environments/test_java_env.sh
+++ b/test/tests/test_environments/test_java_env.sh
@@ -32,7 +32,7 @@ log "Creating the jar from application"
 docker run -it --rm  -v "$(pwd)":/usr/src/mymaven -w /usr/src/mymaven maven:3.5-jdk-8 mvn clean package
 
 log "Creating environment for Java"
-fission env create --name jvm --image gcr.io/fission-ci/jvm-env:test --version 2 --extract=false
+fission env create --name jvm --image gcr.io/fission-ci/jvm-env:test --version 2 --noextract=true
 
 log "Creating pool manager & new deployment function for Java"
 fission fn create --name hellop --deploy target/hello-world-1.0-SNAPSHOT-jar-with-dependencies.jar --env jvm --entrypoint io.fission.HelloWorld


### PR DESCRIPTION
### Description

A new flag `ExtractArchive` was adopted In 0.9.0, which is used by fetcher to see whether a archive needs to extract or not. However, if an environment was created with old CLI the value will be false due to golang default value for the empty field and make the breaking change.

### Solution

Rename the flag for backward compatibility.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/787)
<!-- Reviewable:end -->
