### PR TITLE
Break & Stop the build immediately if a non-zero exit code was returned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,17 @@ install:
 env:
   - KUBECONFIG=${HOME}/.kube/config PATH=$HOME/k8scli:${PATH}
 
-script:
+before_script:
   - cd ${TRAVIS_BUILD_DIR}
-  - glide install -v
-  - ./fission-bundle/build.sh
   - hack/verify-gofmt.sh
   - hack/verify-govet.sh
+  - glide install -v
+  - go build -o fission/fission fission/*.go
+  - ./fission-bundle/build.sh
   - hack/runtests.sh
+
+script:
+  - cd ${TRAVIS_BUILD_DIR}
   - test/build_and_test.sh
   - test/upgrade/fission_upgrade_test.sh
 


### PR DESCRIPTION
### Description
Sometimes the build is failed due to a non-zero exit code was returned in the early stage, however, the build keeps running and still failed in the end. This behavior costs lots of time to wait for the build result.

### Solution

Follow the instruction here: https://docs.travis-ci.com/user/customizing-the-build/#Breaking-the-Build
`If before_install, install or before_script returns a non-zero exit code, the build is errored and stops immediately.`
Move some of script from `scripts` to `before_script` stage so that minor problems can be found before long running build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/790)
<!-- Reviewable:end -->
