### PR TITLE
change image pull policy of builder manager

### DIFF
--- a/buildermgr/envwatcher.go
+++ b/buildermgr/envwatcher.go
@@ -547,7 +547,7 @@ func (envw *environmentWatcher) createBuilderDeployment(env *crd.Environment, ns
 						fission.MergeContainerSpecs(&apiv1.Container{
 							Name:                   "builder",
 							Image:                  env.Spec.Builder.Image,
-							ImagePullPolicy:        apiv1.PullAlways,
+							ImagePullPolicy:        apiv1.PullIfNotPresent,
 							TerminationMessagePath: "/dev/termination-log",
 							VolumeMounts: []apiv1.VolumeMount{
 								{


### PR DESCRIPTION
This changes image pull policy from `Always` to `IfNotPresent`. The previous
policy forbid customer to use the exact image existing on K8S Node.

And it should be OK to use fixed policy here. Customer need not set policy by
their own.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/793)
<!-- Reviewable:end -->
