### PR TITLE
Add retry subcommand to pkg command

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -481,7 +481,7 @@ func fnUpdate(c *cli.Context) error {
 			log.Fatal("Package is used by multiple functions, use --force to force update")
 		}
 
-		pkgMetadata = updatePackage(client, pkg, envName, envNamespace, srcArchiveName, deployArchiveName, buildcmd)
+		pkgMetadata = updatePackage(client, pkg, envName, envNamespace, srcArchiveName, deployArchiveName, buildcmd, false)
 		checkErr(err, fmt.Sprintf("update package '%v'", pkgName))
 
 		fmt.Printf("package '%v' updated\n", pkgMetadata.GetName())

--- a/fission/main.go
+++ b/fission/main.go
@@ -241,6 +241,7 @@ func main() {
 	pkgSubCommands := []cli.Command{
 		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgNamespaceFlag, pkgEnvironmentFlag, envNamespaceFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag}, Action: pkgCreate},
 		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag, pkgEnvironmentFlag, envNamespaceFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgForceFlag}, Action: pkgUpdate},
+		{Name: "retry", Usage: "Try to rebuild failed package", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag}, Action: pkgRetry},
 		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag, pkgOutputFlag}, Action: pkgSourceGet},
 		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag, pkgOutputFlag}, Action: pkgDeployGet},
 		{Name: "info", Usage: "Show package information", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag}, Action: pkgInfo},

--- a/fission/main.go
+++ b/fission/main.go
@@ -241,7 +241,7 @@ func main() {
 	pkgSubCommands := []cli.Command{
 		{Name: "create", Usage: "Create new package", Flags: []cli.Flag{pkgNamespaceFlag, pkgEnvironmentFlag, envNamespaceFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag}, Action: pkgCreate},
 		{Name: "update", Usage: "Update package", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag, pkgEnvironmentFlag, envNamespaceFlag, pkgSrcArchiveFlag, pkgDeployArchiveFlag, pkgBuildCmdFlag, pkgForceFlag}, Action: pkgUpdate},
-		{Name: "retry", Usage: "Try to rebuild failed package", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag}, Action: pkgRetry},
+		{Name: "rebuild", Usage: "Rebuild a failed package", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag}, Action: pkgRebuild},
 		{Name: "getsrc", Usage: "Get source archive content", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag, pkgOutputFlag}, Action: pkgSourceGet},
 		{Name: "getdeploy", Usage: "Get deployment archive content", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag, pkgOutputFlag}, Action: pkgDeployGet},
 		{Name: "info", Usage: "Show package information", Flags: []cli.Flag{pkgNameFlag, pkgNamespaceFlag}, Action: pkgInfo},

--- a/fission/package.go
+++ b/fission/package.go
@@ -410,7 +410,7 @@ func pkgRebuild(c *cli.Context) error {
 
 	updatePackage(client, pkg, "", "", "", "", "", true)
 
-	fmt.Printf("Set package '%v' to %v state\n", pkg.Metadata.Name, fission.BuildStatusPending)
+	fmt.Printf("Retrying build for pkg %v. Use \"fission pkg info --name %v\" to view status.\n", pkg.Metadata.Name, pkg.Metadata.Name)
 
 	return nil
 }

--- a/fission/package.go
+++ b/fission/package.go
@@ -388,7 +388,7 @@ func pkgDelete(c *cli.Context) error {
 	return nil
 }
 
-func pkgRetry(c *cli.Context) error {
+func pkgRebuild(c *cli.Context) error {
 	client := getClient(c.GlobalString("server"))
 
 	pkgName := c.String("name")

--- a/fission/package.go
+++ b/fission/package.go
@@ -410,7 +410,7 @@ func pkgRetry(c *cli.Context) error {
 
 	updatePackage(client, pkg, "", "", "", "", "", true)
 
-	fmt.Printf("Set package '%v' to pending state\n", pkg.Metadata.Name)
+	fmt.Printf("Set package '%v' to %v state\n", pkg.Metadata.Name, fission.BuildStatusPending)
 
 	return nil
 }


### PR DESCRIPTION
Currently, CLI doesn't have a convenient way to retry on a failed package. You have to update one of flag to trigger build process. That's really not an ideal way for retrying failed package.

This PR add `retry` subcommand to `pkg` command, it helps user to do retry without updating anything. 

Turn this

```
$ fission pkg update --name restapi-go-pkg --env go
```

into this

```
$ fission pkg retry --name restapi-go-pkg
Set package 'restapi-go-pkg' to pending state
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/808)
<!-- Reviewable:end -->
