### PR TITLE
Disabling test_env_vars.sh test till #704 is fixed. 

### DIFF
--- a/test/tests/test_env_vars.sh
+++ b/test/tests/test_env_vars.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-
+#test:disabled
 set -euo pipefail
 
 # test_env_vars.sh - tests whether a user is able to add environment variables to a Fission environment deployment


### PR DESCRIPTION
Disabling the test until #704 is fixed. 
This test fails way often and leads to time spent in rebuilding.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/815)
<!-- Reviewable:end -->
