### PR TITLE
Fix spec failed to archive single directory

### DIFF
--- a/fission/spec.go
+++ b/fission/spec.go
@@ -965,9 +965,21 @@ func localArchiveFromSpec(specDir string, aus *ArchiveUploadSpec) (*fission.Arch
 
 	// if it's just one file, use its path directly
 	var archiveFileName string
+	var isSingleFile bool
+
 	if len(files) == 1 {
-		archiveFileName = files[0]
-	} else {
+		// check whether a path destination is file or directory
+		f, err := os.Stat(files[0])
+		if err != nil {
+			return nil, err
+		}
+		if !f.IsDir() {
+			isSingleFile = true
+			archiveFileName = files[0]
+		}
+	}
+
+	if len(files) > 1 || !isSingleFile {
 		// zip up the file list
 		archiveFile, err := ioutil.TempFile("", fmt.Sprintf("fission-archive-%v", aus.Name))
 		if err != nil {


### PR DESCRIPTION
### Description

If `ArchiveUploadSpec` only contains one path to directory 
```
kind: ArchiveUploadSpec
name: web-pkg-zip
include:
  - "web"
```

the spec command returns error.
```
$ fission spec apply
Failed to read ./web: read ./web: is a directory
```

### Root cause
The path in files may be a path to directory, need to check whether a path's destination is a file or a directory.
https://github.com/fission/fission/blob/6123873d2a860790d76ff5a774ad6f0c66e12a90/fission/spec.go#L968-L970