### PR TITLE
Handle multiple http methods in one http trigger

### DIFF
--- a/router/httpTriggers.go
+++ b/router/httpTriggers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -132,7 +133,7 @@ func (ts *HTTPTriggerSet) getRouter() *mux.Router {
 		}
 
 		ht := muxRouter.HandleFunc(trigger.Spec.RelativeURL, fh.handler)
-		ht.Methods(trigger.Spec.Method)
+		ht.Methods(strings.Split(trigger.Spec.Method, ",")...)
 		if trigger.Spec.Host != "" {
 			ht.Host(trigger.Spec.Host)
 		}


### PR DESCRIPTION
Address issue https://github.com/fission/fission/issues/796
Consider the backward compatibility of spec files and existing trigger so not to rename fields from `Method` to `Methods` in the end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/839)
<!-- Reviewable:end -->
