### PR TITLE
Check pod container ready state

### DIFF
--- a/common.go
+++ b/common.go
@@ -108,10 +108,17 @@ func IsNetworkDialError(err error) bool {
 	return false
 }
 
-// IsReadyPod checks that all containers in a pod are ready and returns true if so
+// IsReadyPod checks both all containers in a pod are ready and the .metadata.DeletionTimestamp
+// is nil. Return true if so
 func IsReadyPod(pod *apiv1.Pod) bool {
 	// since its a utility function, just ensuring there is no nil pointer exception
 	if pod == nil {
+		return false
+	}
+
+	// pod is in "Terminating" status if deletionTimestamp is not nil
+	// https://github.com/kubernetes/kubernetes/issues/61376
+	if pod.ObjectMeta.DeletionTimestamp != nil {
 		return false
 	}
 

--- a/common.go
+++ b/common.go
@@ -108,8 +108,8 @@ func IsNetworkDialError(err error) bool {
 	return false
 }
 
-// IsReadyPod checks both all containers in a pod are ready and the .metadata.DeletionTimestamp
-// is nil. Return true if so
+// IsReadyPod checks both all containers in a pod are ready and whether
+// the .metadata.DeletionTimestamp is nil.
 func IsReadyPod(pod *apiv1.Pod) bool {
 	// since its a utility function, just ensuring there is no nil pointer exception
 	if pod == nil {

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -226,9 +226,8 @@ func (gp *GenericPool) _choosePod(newLabels map[string]string) (*apiv1.Pod, erro
 		for i := range podList.Items {
 			pod := podList.Items[i]
 
-			// If a pod has no IP or any of pod's containers
-			// is not in ready state, it's not ready.
-			if len(pod.Status.PodIP) == 0 || !fission.IsReadyPod(&pod) {
+			// Ignore not ready pod here
+			if !fission.IsReadyPod(&pod) {
 				continue
 			}
 


### PR DESCRIPTION
Notice there is an issue(https://github.com/kubernetes/kubernetes/issues/61376) indicates that `status.phase` of pod is in `Running` even when the pod is in `Terminating` state. 

This PR aims to resolve the problem to prevent the terminating pod was selected by poolmgr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/861)
<!-- Reviewable:end -->
