### PR TITLE
Fixed the spec validation UX issue

### DIFF
--- a/common.go
+++ b/common.go
@@ -149,7 +149,7 @@ func MakeArchive(targetName string, globs ...string) (string, error) {
 	for _, glob := range globs {
 		f, err := filepath.Glob(glob)
 		if err != nil {
-			log.Warn(fmt.Sprintf("Invalid glob %v: %v", glob, err))
+			log.Log(fmt.Sprintf("Invalid glob %v: %v", glob, err))
 			return "", err
 		}
 		files = append(files, f...)

--- a/fission/function.go
+++ b/fission/function.go
@@ -173,16 +173,18 @@ func fnCreate(c *cli.Context) error {
 			log.Fatal("Need --env argument.")
 		}
 
-		// examine existence of given environment
-		_, err := client.EnvironmentGet(&metav1.ObjectMeta{
-			Namespace: envNamespace,
-			Name:      envName,
-		})
-		if err != nil {
-			if e, ok := err.(fission.Error); ok && e.Code == fission.ErrorNotFound {
-				fmt.Printf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --envns %v --image <image>`\n", envName, envName, envNamespace)
-			} else {
-				util.CheckErr(err, "retrieve environment information")
+		// examine existence of given environment. If specs - then spec validate will do it, don't check here.
+		if !spec {
+			_, err := client.EnvironmentGet(&metav1.ObjectMeta{
+				Namespace: envNamespace,
+				Name:      envName,
+			})
+			if err != nil {
+				if e, ok := err.(fission.Error); ok && e.Code == fission.ErrorNotFound {
+					log.Warn(fmt.Sprintf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --envns %v --image <image>`\n", envName, envName, envNamespace))
+				} else {
+					util.CheckErr(err, "retrieve environment information")
+				}
 			}
 		}
 

--- a/fission/httptrigger.go
+++ b/fission/httptrigger.go
@@ -80,6 +80,7 @@ func htCreate(c *cli.Context) error {
 		log.Fatal("Need a function name to create a trigger, use --function")
 	}
 	fnNamespace := c.String("fnNamespace")
+	spec := c.Bool("spec")
 
 	triggerUrl := c.String("url")
 	if len(triggerUrl) == 0 {
@@ -94,7 +95,11 @@ func htCreate(c *cli.Context) error {
 		method = "GET"
 	}
 
-	checkFunctionExistence(client, fnName, fnNamespace)
+	// For Specs, the spec validate checks for function reference
+	if !spec {
+		checkFunctionExistence(client, fnName, fnNamespace)
+	}
+
 	createIngress := false
 	if c.IsSet("createingress") {
 		createIngress = c.Bool("createingress")
@@ -123,7 +128,7 @@ func htCreate(c *cli.Context) error {
 	}
 
 	// if we're writing a spec, don't call the API
-	if c.Bool("spec") {
+	if spec {
 		specFile := fmt.Sprintf("route-%v.yaml", triggerName)
 		err := specSave(*ht, specFile)
 		util.CheckErr(err, "create HTTP trigger spec")

--- a/fission/log/log.go
+++ b/fission/log/log.go
@@ -32,6 +32,10 @@ func Fatal(msg interface{}) {
 }
 
 func Warn(msg interface{}) {
+	os.Stderr.WriteString(fmt.Sprintf("[WARNING] %v\n", msg))
+}
+
+func Log(msg interface{}) {
 	os.Stderr.WriteString(fmt.Sprintf("%v\n", msg))
 }
 

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -388,6 +388,19 @@ func (fr *FissionResources) validate() error {
 	// we do not error on unreferenced functions (you can call a function through workflows,
 	// `fission function test`, etc.)
 
+	// Index envs, warn on functions referencing an environment for which spes does not exist
+	environments := make(map[string]bool)
+	for _, e := range fr.environments {
+		environments[fmt.Sprintf("%s:%s", e.Metadata.Name, e.Metadata.Namespace)] = false
+	}
+
+	functions = make(map[string]bool)
+	for _, f := range fr.functions {
+		if _, ok := environments[fmt.Sprintf("%s:%s", f.Spec.Environment.Name, f.Spec.Environment.Namespace)]; !ok {
+			log.Warn(fmt.Sprintf("Environment %s is referred in function %s but not declared in specs", f.Spec.Environment.Name, f.Metadata.Name))
+		}
+	}
+
 	// (ErrorOrNil returns nil if there were no errors appended.)
 	return result.ErrorOrNil()
 }
@@ -961,7 +974,7 @@ func localArchiveFromSpec(specDir string, aus *ArchiveUploadSpec) (*fission.Arch
 		absGlob := rootDir + "/" + relativeGlob
 		f, err := filepath.Glob(absGlob)
 		if err != nil {
-			log.Warn(fmt.Sprintf("Invalid glob in archive %v: %v", aus.Name, relativeGlob))
+			log.Log(fmt.Sprintf("Invalid glob in archive %v: %v", aus.Name, relativeGlob))
 			return nil, err
 		}
 		files = append(files, f...)


### PR DESCRIPTION
This fixes #809 

For normal CLI creation, added `[WARNING]` so that it more clear to user. 

```
$ fission fn create  --name testfn --env gotest --code hello.js 
[WARNING] Environment "gotest" does not exist. Please create the environment before executing the function. 
For example: `fission env create --name gotest --envns default --image <image>`

function 'testfn' created

$ fission ht create --function gotest1 --url /gotest1 
function 'gotest1' does not exist, use 'fission function create --name gotest1 ...' to create the function
trigger '2ae7aa10-0629-4c65-97eb-3d249ac5227d' created
```

For specs - don't give a warning when creating the spec, instead, warn when validating spec (The route error for spec exists already and no code change for that):

```
$ fission fn create --spec --name testfn --env gotest --code hello.js 
$ fission spec validate
[WARNING] Environment gotest is referred in function testfn but not declared in specs

$ fission ht create --spec --function httest --url /goty 
$ fission spec validate
[WARNING] Environment gotest is referred in function testfn but not declared in specs
Error validating specs: 1 error occurred:
	* specs/route-5353a8c0-1483-4974-b469-2425b58cc18f.yaml:1: HTTPTrigger '5353a8c0-1483-4974-b469-2425b58cc18f' references unknown function 'httest'
```
