### PR TITLE
Replace sleep with wait in several test scripts

### DIFF
--- a/fission/admin.go
+++ b/fission/admin.go
@@ -47,21 +47,15 @@ func updateSessionRV(newRVstr string) error {
 		// nothing to update, "new" isn't new enough
 		return nil
 	}
-	fmt.Printf("setting rv to %v", newRVstr) //xxx
 
 	// write to temp and rename file (file renames are usually atomic)
 	fnTemp := fn + ".tmp"
 	err = ioutil.WriteFile(fnTemp, []byte(newRVstr), 0600)
 	if err != nil {
-		fmt.Println("xxx 1 err = %v", err)
 		return err
 	}
 
-	err = os.Rename(fnTemp, fn)
-	if err != nil {
-		fmt.Println("xxx 2 err = %v", err)
-	}
-	return err
+	return os.Rename(fnTemp, fn)
 }
 
 // Get current router rv.  If wantRVstr specified, wait for router to

--- a/fission/admin.go
+++ b/fission/admin.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+func getSessionRV() string {
+	fn := os.Getenv("FISSION_SESSION_FILE")
+	if len(fn) == 0 {
+		return ""
+	}
+	rv, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return ""
+	}
+	return string(rv)
+}
+
+func updateSessionRV(newRVstr string) error {
+	fn := os.Getenv("FISSION_SESSION_FILE")
+	if len(fn) == 0 {
+		// we're not tracking the session, no error
+		return nil
+	}
+
+	// ensure that the new rv is a uint64
+	newRV, err := strconv.ParseUint(newRVstr, 10, 64)
+	if err != nil {
+		return err
+	}
+
+	// proceed if new rv is newer than old (or if old doesn't exist or is invalid)
+	oldRVstr := getSessionRV()
+	var oldRV uint64
+	oldRV, err = strconv.ParseUint(oldRVstr, 10, 64)
+	// if the existing rv state has an invalid value, we update it anyway
+	if err == nil && newRV <= oldRV {
+		// nothing to update, "new" isn't new enough
+		return nil
+	}
+	fmt.Printf("setting rv to %v", newRVstr) //xxx
+
+	// write to temp and rename file (file renames are usually atomic)
+	fnTemp := fn + ".tmp"
+	err = ioutil.WriteFile(fnTemp, []byte(newRVstr), 0600)
+	if err != nil {
+		fmt.Println("xxx 1 err = %v", err)
+		return err
+	}
+
+	err = os.Rename(fnTemp, fn)
+	if err != nil {
+		fmt.Println("xxx 2 err = %v", err)
+	}
+	return err
+}
+
+// Get current router rv.  If wantRVstr specified, wait for router to
+// catch up to wantRV.
+func routerLatestUpdate(rvmURL, wantRVstr string) (string, error) {
+
+	startTime := time.Now()
+
+	// the rv we need, as an int
+	var wantRV uint64
+	if len(wantRVstr) > 0 {
+		var err error
+		wantRV, err = strconv.ParseUint(wantRVstr, 10, 64)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	for {
+		resp, err := http.Get(rvmURL)
+		if err != nil {
+			return "", err
+		}
+
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return "", err
+		}
+		resp.Body.Close()
+
+		haveRVstr := string(body)
+
+		// if we're not waiting, we're done
+		if wantRV == 0 {
+			return haveRVstr, nil
+		}
+
+		// if we're waiting, compare what we have and what we want
+		var haveRV uint64
+		haveRV, err = strconv.ParseUint(haveRVstr, 10, 64)
+		if err != nil {
+			return "", err
+		}
+
+		// we have all the updates we need, stop waiting
+		if haveRV >= wantRV {
+			fmt.Printf("waited %v; done\n", time.Since(startTime))
+			return haveRVstr, nil
+		}
+
+		// timeout, quit
+		if time.Since(startTime) > time.Minute {
+			return "", errors.New(fmt.Sprintf("Timeout waiting for latest update %v", wantRVstr))
+		}
+
+		// wait, repeat
+		time.Sleep(500 * time.Millisecond)
+	}
+}
+
+func adminRouterLatestUpdate(c *cli.Context) error {
+	routerURL := getRouterURL(c)
+	routerURL = strings.TrimSuffix(routerURL, "/")
+	rvmURL := fmt.Sprintf("http://%v/_lastResourceVersion", routerURL)
+
+	wait := false
+	if c.Bool("wait") {
+		wait = true
+	}
+
+	wantRV := getSessionRV()
+	if wait && len(wantRV) == 0 {
+		msg := "Nothing to wait for, ignoring --wait"
+		fmt.Println(msg)
+		return errors.New(msg)
+	}
+
+	update, err := routerLatestUpdate(rvmURL, wantRV)
+	if err != nil {
+		msg := fmt.Sprintf("Error getting latest router update: %v", err)
+		fmt.Println(msg)
+		return errors.New(msg)
+	}
+	if !wait {
+		fmt.Println(update)
+	}
+	return nil
+}

--- a/fission/httptrigger.go
+++ b/fission/httptrigger.go
@@ -173,8 +173,10 @@ func htCreate(c *cli.Context) error {
 		return nil
 	}
 
-	_, err = client.HTTPTriggerCreate(ht)
+	triggerMeta, err := client.HTTPTriggerCreate(ht)
 	util.CheckErr(err, "create HTTP trigger")
+
+	updateSessionRV(triggerMeta.ResourceVersion) // ignore error
 
 	fmt.Printf("trigger '%v' created\n", triggerName)
 	return err
@@ -262,8 +264,10 @@ func htUpdate(c *cli.Context) error {
 		ht.Spec.Host = c.String("host")
 	}
 
-	_, err = client.HTTPTriggerUpdate(ht)
+	triggerMeta, err := client.HTTPTriggerUpdate(ht)
 	util.CheckErr(err, "update HTTP trigger")
+
+	updateSessionRV(triggerMeta.ResourceVersion) // ignore error
 
 	fmt.Printf("trigger '%v' updated\n", htName)
 	return nil

--- a/router/resourceversions.go
+++ b/router/resourceversions.go
@@ -33,6 +33,10 @@ type (
 )
 
 func (rvm *ResourceVersionMonitor) Update(rv string) error {
+	if rvm == nil {
+		return nil
+	}
+
 	rvm.mutex.Lock()
 	defer rvm.mutex.Unlock()
 
@@ -48,6 +52,10 @@ func (rvm *ResourceVersionMonitor) Update(rv string) error {
 }
 
 func (rvm *ResourceVersionMonitor) Get() string {
+	if rvm == nil {
+		return ""
+	}
+
 	rvm.mutex.Lock()
 	defer rvm.mutex.Unlock()
 

--- a/router/resourceversions.go
+++ b/router/resourceversions.go
@@ -1,0 +1,55 @@
+package router
+
+/*
+
+Warning: This stuff is wrong in theory but works in practice.  Don't
+use it for anything other than test automation.
+
+The idea is:
+
+1. We need some way for test scripts to wait long enough for the
+router controllers to have caught up with the CRDs.
+
+2. "resourceVersion" is a monotonically increasing number in practice,
+since it comes from etcd's raft index.  We aren't supposed to use this
+information; the Kubernetes API docs are clear that resourceVersion is
+to be treated as an opaque string that isn't even necessarily a
+number.  So we're violating some abstraction layers here for test
+efficiency.
+
+*/
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+type (
+	ResourceVersionMonitor struct {
+		mutex  sync.Mutex
+		latest uint64
+	}
+)
+
+func (rvm *ResourceVersionMonitor) Update(rv string) error {
+	rvm.mutex.Lock()
+	defer rvm.mutex.Unlock()
+
+	var rvNumber uint64
+	rvNumber, err := strconv.ParseUint(rv, 10, 64)
+	if err != nil {
+		return err
+	}
+	if rvNumber > rvm.latest {
+		rvm.latest = rvNumber
+	}
+	return nil
+}
+
+func (rvm *ResourceVersionMonitor) Get() string {
+	rvm.mutex.Lock()
+	defer rvm.mutex.Unlock()
+
+	return fmt.Sprintf("%v", rvm.latest)
+}

--- a/router/router.go
+++ b/router/router.go
@@ -81,9 +81,6 @@ func serveMetric() {
 }
 
 func Start(port int, executorUrl string) {
-	// setup a signal handler for SIGTERM
-	fission.SetupStackTraceHandler()
-
 	fmap := makeFunctionServiceMap(time.Minute)
 
 	frmap := makeFunctionRecorderMap(time.Minute)
@@ -124,12 +121,14 @@ func Start(port int, executorUrl string) {
 		log.Fatalf("Failed to parse max retry times: %v", err)
 	}
 
-	triggers, _, fnStore := makeHTTPTriggerSet(fmap, frmap, trmap, fissionClient, kubeClient, executor, restClient, &tsRoundTripperParams{
-		timeout:         timeout,
-		timeoutExponent: timeoutExponent,
-		keepAlive:       keepAlive,
-		maxRetries:      maxRetries,
-	})
+	rvm := &ResourceVersionMonitor{}
+	triggers, _, fnStore := makeHTTPTriggerSet(fmap, frmap, trmap, rvm, fissionClient, kubeClient, executor, restClient,
+		&tsRoundTripperParams{
+			timeout:         timeout,
+			timeoutExponent: timeoutExponent,
+			keepAlive:       keepAlive,
+			maxRetries:      maxRetries,
+		})
 
 	resolver := makeFunctionReferenceResolver(fnStore)
 

--- a/router/router_test.go
+++ b/router/router_test.go
@@ -51,7 +51,7 @@ func TestRouter(t *testing.T) {
 	trmap := makeTriggerRecorderMap(time.Minute)
 
 	// HTTP trigger set with a trigger for this function
-	triggers, _, _ := makeHTTPTriggerSet(fmap, frmap, trmap, nil, nil, nil, nil,
+	triggers, _, _ := makeHTTPTriggerSet(fmap, frmap, trmap, nil, nil, nil, nil, nil,
 		&tsRoundTripperParams{
 			timeout:         50 * time.Millisecond,
 			timeoutExponent: 2,

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -466,7 +466,7 @@ run_test() {
     file=$1
 
     # Used by `fission admin router-latest-update --wait`
-    export FISSION_SESSION_FILE=$(mktemp /tmp/fission-session)
+    export FISSION_SESSION_FILE=$(mktemp /tmp/fission-session-XXXXXX)
     
     test_name=${file#${ROOT}/test/tests}
     test_path=${file}

--- a/test/tests/recordreplay/test_record_greetings.sh
+++ b/test/tests/recordreplay/test_record_greetings.sh
@@ -27,7 +27,7 @@ echo "Creating http trigger"
 generated=$(fission route create --function $fn --method POST --url greetings | awk '{print $2}'| tr -d "'")
 
 # Wait until trigger is created
-sleep 5
+fission admin router-latest-update --wait
 
 echo "Creating recorder"
 recName="gacrux"

--- a/test/tests/recordreplay/test_record_rv.sh
+++ b/test/tests/recordreplay/test_record_rv.sh
@@ -31,7 +31,7 @@ echo "Creating trigger B"
 generatedB=$(fission route create --function $fn --method GET --url rvB | awk '{print $2}'| tr -d "'")
 
 # Wait until triggers are created
-sleep 5
+fission admin router-latest-update --wait
 
 echo "Creating recorder by function"
 recName="regulus"
@@ -47,7 +47,7 @@ recordedStatusA="$(fission records view --from 5s --to 0s -v | awk 'FNR == 2 {pr
 expectedSA="200OK"
 
 # Separate records
-sleep 5
+sleep 2
 
 echo "Issuing cURL request to urlB:"
 respB=$(curl -X GET "http://$FISSION_ROUTER/rvB?time=9&date=Tuesday")
@@ -77,7 +77,7 @@ recordedStatusA="$(fission records view --from 5s --to 0s -v | awk 'FNR == 2 {pr
 expectedSA=""
 
 # Separate records
-sleep 5
+sleep 2
 
 echo "Issuing cURL request to urlB:"
 respB=$(curl -X GET "http://$FISSION_ROUTER/rvB?time=9&date=Tuesday")

--- a/test/tests/recordreplay/test_recorder_update.sh
+++ b/test/tests/recordreplay/test_recorder_update.sh
@@ -29,7 +29,7 @@ echo "Creating http trigger"
 generated=$(fission route create --function $fn --method GET --url rv | awk '{print $2}'| tr -d "'")
 
 # Wait until trigger is created
-sleep 5
+fission admin router-latest-update --wait
 
 echo "Creating recorder"
 recName="regulus"

--- a/test/tests/test_annotations.sh
+++ b/test/tests/test_annotations.sh
@@ -96,7 +96,10 @@ spec:
 EOM
 log_exec kubectl -n ${RESOURCE_NS} apply -f ${ENV_SPEC_FILE}
 
-sleep 15
+# XXX why sleep here if we're polling anyway?
+#sleep 15
+
+
 # Wait for runtime and build env to be deployed
 retry getPodName ${FUNCTION_NS} ${ENV} | grep '.\+'
 runtimePod=$(getPodName ${FUNCTION_NS} ${ENV})

--- a/test/tests/test_backend_newdeploy.sh
+++ b/test/tests/test_backend_newdeploy.sh
@@ -35,7 +35,8 @@ log "Creating route"
 fission route create --function $fn0 --url /$fn0 --method GET
 
 log "Waiting for router & newdeploy deployment creation"
-sleep 5
+fission admin router-latest-update --wait
+kubectl wait deployment --namespace fission-function --for condition=available --timeout 180s -l functionName=$fn0
 
 log "Doing an HTTP GET on the function's route"
 response0=$(curl http://$FISSION_ROUTER/$fn0)
@@ -53,10 +54,11 @@ log "Creating route"
 fission route create --function $fn1 --url /$fn1 --method GET
 
 log "Waiting for router & newdeploy deployment creation"
-sleep 5
+fission admin router-latest-update --wait
+kubectl wait deployment --namespace fission-function --for condition=available --timeout 180s -l functionName=$fn1
 
 log "Doing an HTTP GET on the function's route"
-response1=$(curl http://$FISSION_ROUTER/$fn0)
+response1=$(curl http://$FISSION_ROUTER/$fn1)
 
 log "Checking for valid response"
 echo $response1 | grep -i hello

--- a/test/tests/test_backend_poolmgr.sh
+++ b/test/tests/test_backend_poolmgr.sh
@@ -32,7 +32,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)

--- a/test/tests/test_buildermgr.sh
+++ b/test/tests/test_buildermgr.sh
@@ -82,7 +82,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 3
+fission admin router-latest-update --wait
 
 pkg=$(kubectl --namespace default get functions $fn -o jsonpath='{.spec.package.packageref.name}')
 

--- a/test/tests/test_env_vars.sh
+++ b/test/tests/test_env_vars.sh
@@ -100,7 +100,8 @@ spec:
 EOM
 log_exec kubectl -n ${RESOURCE_NS} apply -f ${ENV_SPEC_FILE}
 
-sleep 15
+#sleep 15 # why do we need this sleep?
+
 # Wait for runtime and build env to be deployed
 retry getPodName ${FUNCTION_NS} ${ENV} | grep '.\+'
 runtimePod=$(getPodName ${FUNCTION_NS} ${ENV})

--- a/test/tests/test_environments/test_go_env.sh
+++ b/test/tests/test_environments/test_go_env.sh
@@ -13,13 +13,13 @@ cleanup() {
 wait_for_builder() {
     JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'
 
-    # wait for tiller ready
+    # wait for builder ready
     while true; do
       kubectl --namespace fission-builder get pod -l envName=go -o jsonpath="$JSONPATH" | grep "Ready=True"
       if [[ $? -eq 0 ]]; then
           break
       fi
-      sleep 5
+      sleep 1
     done
 }
 
@@ -74,7 +74,7 @@ fission route create --function hello-go-poolmgr --url /hello-go-poolmgr --metho
 fission route create --function hello-go-nd --url /hello-go-nd --method GET
 
 log "Waiting for router & pools to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Testing pool manager function"
 timeout 60 bash -c "test_fn hello-go-poolmgr 'Hello'"
@@ -95,7 +95,7 @@ fission fn update --name hello-go-poolmgr --pkg $pkgName
 fission fn update --name hello-go-nd --pkg $pkgName
 
 log "Waiting for router & pools to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Testing pool manager function with new package"
 timeout 60 bash -c "test_fn hello-go-poolmgr 'vendor'"

--- a/test/tests/test_environments/test_java_builder.sh
+++ b/test/tests/test_environments/test_java_builder.sh
@@ -27,7 +27,7 @@ test_pkg() {
     echo "Checking for valid response"
 
     while true; do
-      response0=$(kubectl get -ndefault package $1 -o=jsonpath='{.status.buildstatus}')
+      response0=$(kubectl get -n default package $1 -o=jsonpath='{.status.buildstatus}')
       echo $response0 | grep -i $2
       if [[ $? -eq 0 ]]; then
         break
@@ -66,7 +66,7 @@ log "Creating route for new deployment function"
 fission route create --function nbuilderhello --url /nbuilderhello --method GET
 
 log "Waiting for router & pools to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Testing pool manager function"
 timeout 60 bash -c "test_fn pbuilderhello 'Hello'"

--- a/test/tests/test_environments/test_java_env.sh
+++ b/test/tests/test_environments/test_java_env.sh
@@ -46,7 +46,7 @@ log "Creating route for new deployment function"
 fission route create --function hellon --url /hellon --method GET
 
 log "Waiting for router & pools to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Testing pool manager function"
 timeout 60 bash -c "test_fn hellop 'Hello'"

--- a/test/tests/test_fn_update/fnupdate_utils.sh
+++ b/test/tests/test_fn_update/fnupdate_utils.sh
@@ -6,6 +6,7 @@
 
 set -euo pipefail
 
+# Infinitely polls a function until it returns the response we expect.
 test_fn() {
     echo "Doing an HTTP GET on the function's route"
     echo "Checking for valid response"

--- a/test/tests/test_fn_update/test_configmap_update.sh
+++ b/test/tests/test_fn_update/test_configmap_update.sh
@@ -45,7 +45,7 @@ log "Creating route"
 fission route create --function ${fn_name} --url /${fn_name} --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Testing function"
 timeout 60 bash -c "test_fn $fn_name 'TESTVALUE'"

--- a/test/tests/test_fn_update/test_env_update.sh
+++ b/test/tests/test_fn_update/test_env_update.sh
@@ -34,7 +34,7 @@ log "Creating route for function $fn"
 fission route create --function ${fn} --url /${fn} --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn 'world'"
 

--- a/test/tests/test_fn_update/test_idle_objects_reaper.sh
+++ b/test/tests/test_fn_update/test_idle_objects_reaper.sh
@@ -35,8 +35,8 @@ log "Creating route for function $fn"
 fission route create --function ${fn}-nd --url /${fn}-nd --method GET
 fission route create --function ${fn}-gpm --url /${fn}-gpm --method GET
 
-log "Waiting for update to catch up"
-sleep 5
+log "Waiting for router to catch up"
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn ${fn}-nd 'world'"
 timeout 60 bash -c "test_fn ${fn}-gpm 'world'"

--- a/test/tests/test_fn_update/test_nd_pkg_update.sh
+++ b/test/tests/test_fn_update/test_nd_pkg_update.sh
@@ -51,7 +51,7 @@ log "Creating route"
 fission route create --function $fn_name --url /$fn_name --method GET
 
 log "Waiting for router & newdeploy deployment creation"
-sleep 5
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn_name 'world'"
 
@@ -63,7 +63,7 @@ log "Updating function with updated package"
 fission fn update --name $fn_name --deploy test-deploy-pkg.zip --entrypoint "hello.main" --executortype newdeploy --minscale 1 --maxscale 4 --targetcpu 50
 
 log "Waiting for deployment to update"
-sleep 5
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn_name 'fission'"
 

--- a/test/tests/test_fn_update/test_poolmgr_nd.sh
+++ b/test/tests/test_fn_update/test_poolmgr_nd.sh
@@ -31,7 +31,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn 'world'"
 
@@ -39,7 +39,7 @@ log "Updating function $fn executor type to new deployment"
 fission fn update --name $fn --code $ROOT/examples/python/hello.py --minscale 1 --maxscale 4 --executortype newdeploy
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn 'world'"
 
@@ -47,6 +47,6 @@ log "Updating function $fn executor type back to pool manager"
 fission fn update --name $fn --code $ROOT/examples/python/hello.py --executortype poolmgr
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn 'world'"

--- a/test/tests/test_fn_update/test_resource_change.sh
+++ b/test/tests/test_fn_update/test_resource_change.sh
@@ -42,7 +42,7 @@ log "Creating route"
 fission route create --function ${fn} --url /${fn} --method GET
 
 log "Waiting for updates to take effect"
-sleep 5
+fission admin router-latest-update --wait
 
 #If variable not used, shell assumes 'function' to be a real function
 func=function

--- a/test/tests/test_fn_update/test_scale_change.sh
+++ b/test/tests/test_fn_update/test_scale_change.sh
@@ -34,16 +34,14 @@ fission fn create --name $fn --env $env --code $ROOT/examples/python/hello.py --
 log "Creating route for function $fn"
 fission route create --function ${fn} --url /${fn} --method GET
 
-log "Waiting for update to catch up"
-sleep 5
+log "Waiting for router update"
+fission admin router-latest-update --wait
 
 timeout 60 bash -c "test_fn $fn 'world'"
 
 log "Updating function scale and target CPU percent for $fn"
 fission fn update --name $fn --code $ROOT/examples/python/hello.py --minscale $targetMinScale --maxscale $targetMaxScale --targetcpu $targetCpuPercent --executortype newdeploy --mincpu 20 --maxcpu 100 --minmemory 128 --maxmemory 256
 
-log "Waiting for update to catch up"
-sleep 5
 
 #If variable not used, shell assumes 'function' to be a real function
 func=function

--- a/test/tests/test_fn_update/test_secret_update.sh
+++ b/test/tests/test_fn_update/test_secret_update.sh
@@ -46,7 +46,7 @@ log "Creating route"
 fission route create --function ${fn_name} --url /${fn_name} --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "Testing function"
 timeout 60 bash -c "test_fn $fn_name 'TESTVALUE'"

--- a/test/tests/test_function_update.sh
+++ b/test/tests/test_function_update.sh
@@ -35,7 +35,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 10
+fission admin router-latest-update --wait
 
 log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)
@@ -54,7 +54,7 @@ echo 'module.exports = function(context, callback) { callback(200, "bar!\n"); }'
 fission fn update --name $fn --code bar.js
 
 log "Waiting for router to update cache"
-sleep 10
+fission admin router-latest-update --wait
 
 log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)

--- a/test/tests/test_ingress.sh
+++ b/test/tests/test_ingress.sh
@@ -17,6 +17,7 @@ trap "cleanup $route_name" EXIT
 
 log "Route $route_name created"
 
+# wait for fission to create ingress resource
 sleep 5
 
 log "Ingresses matching this trigger:"
@@ -34,6 +35,7 @@ fi
 log "Modifying the route by adding host"
 fission route update --name $route_name --host $hostName --function $functionName
 
+# wait for fission to update k8s ingress resource
 sleep 2
 
 actual_host=$(kubectl get ing -l 'functionName='$functionName',triggerName='$route_name --all-namespaces -o=jsonpath='{.items[0].spec.rules[0].host}')

--- a/test/tests/test_internal_routes.sh
+++ b/test/tests/test_internal_routes.sh
@@ -45,7 +45,7 @@ do
 done
 
 log "Waiting for router to catch up"
-sleep 2
+fission admin router-latest-update --wait
 
 log "Testing internal routes"
 for f in $f1 $f2

--- a/test/tests/test_logging/test_function_logs.sh
+++ b/test/tests/test_logging/test_function_logs.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
 set -euo pipefail
 
 ROOT=$(dirname $0)/../..
@@ -33,7 +32,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 15
+fission admin router-latest-update --wait
 
 log "Doing 4 HTTP GETs on the function's route"
 for i in 1 2 3 4

--- a/test/tests/test_node_hello_http.sh
+++ b/test/tests/test_node_hello_http.sh
@@ -32,7 +32,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 3
+fission admin router-latest-update --wait
 
 log "Doing an HTTP GET on the function's route"
 response=$(curl http://$FISSION_ROUTER/$fn)

--- a/test/tests/test_package_command.sh
+++ b/test/tests/test_package_command.sh
@@ -86,7 +86,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to catch up"
-sleep 3
+fission admin router-latest-update --wait
   
 checkFunctionResponse $fn 'a: 1 b: {c: 3, d: 4}'
 
@@ -101,7 +101,7 @@ log "Updating function " $fn
 fission fn update --name $fn --pkg $pkgName --entrypoint "hello.main"
 
 log "Waiting for router to update cache"
-sleep 3
+fission admin router-latest-update --wait
 
 checkFunctionResponse $fn 'Hello, world!'
 

--- a/test/tests/test_router_cache_invalidation.sh
+++ b/test/tests/test_router_cache_invalidation.sh
@@ -47,7 +47,7 @@ log "Creating route"
 fission route create --function $fn --url /$fn --method GET
 
 log "Waiting for router to update cache"
-sleep 5
+fission admin router-latest-update --wait
 
 http_status=`curl -sw "%{http_code}" http://$FISSION_ROUTER/$fn -o /dev/null`
 log "http_status: $http_status"

--- a/test/tests/test_secret_cfgmap/test_secret_cfgmap.sh
+++ b/test/tests/test_secret_cfgmap/test_secret_cfgmap.sh
@@ -72,7 +72,7 @@ log "Creating route"
 fission route create --function ${fn_secret} --url /${fn_secret} --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 checkFunctionResponse ${fn_secret} 'TESTVALUE' 'secret'
 
@@ -84,7 +84,7 @@ log "Creating route"
 fission route create --function ${fn_secret}-1 --url /${fn_secret}-1 --method GET
 
 log "Waiting for router catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 checkFunctionResponse ${fn_secret}-1 'NEWVAL' 'secret'
 
@@ -98,7 +98,7 @@ log "Creating route"
 fission route create --function ${fn_cfgmap} --url /${fn_cfgmap} --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 checkFunctionResponse ${fn_cfgmap} 'TESTVALUE' 'configmap'
 
@@ -110,7 +110,7 @@ log "Creating route"
 fission route create --function ${fn_cfgmap}-1 --url /${fn_cfgmap}-1 --method GET
 
 log "Waiting for router catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 checkFunctionResponse ${fn_cfgmap}-1 'NEWVAL' 'configmap'
 
@@ -121,7 +121,7 @@ log "Creating route"
 fission route create --function ${fn} --url /${fn} --method GET
 
 log "Waiting for router to catch up"
-sleep 5
+fission admin router-latest-update --wait
 
 log "HTTP GET on the function's route"
 resnormal=$(curl http://${FISSION_ROUTER}/${fn})


### PR DESCRIPTION
1. Allow CLI to wait for router controllers

When a script or a human user creates some resources (functions,
triggers), the router notices these changes and updates its config.
However the user or script has no way of knowing when the router has
completed this task.

This change adds: (1) a router API endpoint that returns the highest
among the ResourceVersions of all functions and httptriggers it has
seen, and (2) A cli change that writes the RV of any created or
updated function or trigger into a file (3) A cli change that waits for the
router's reported RV to match the one written into the file.

[This thing is a violation of abstraction layers.  It assumes that
RVs are monotonically increasing uint64s while the K8s API only
guarantees that they are unique strings (not even numbers).  However
K8s gets these numbers from the etcd index, which is (I think) the Raft
log index, which does increase monotonically (I think).]

2. Use the new CLI in tests to reduce unconditional sleeps

3. Use the new (K8s 1.11) `kubectl wait` feature to remove a few more sleeps from tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/912)
<!-- Reviewable:end -->
