### PR TITLE
Adding JVM heap options to environment

### DIFF
--- a/environments/jvm/Dockerfile
+++ b/environments/jvm/Dockerfile
@@ -6,5 +6,5 @@ RUN mvn -f /usr/src/myapp/pom.xml clean package
 FROM openjdk:8-jdk-alpine
 VOLUME /tmp
 COPY --from=BUILD /usr/src/myapp/target/env-java-0.0.1-SNAPSHOT.jar /app.jar
-ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar","--server.port=8888"]
+ENTRYPOINT java ${JVM_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /app.jar --server.port=8888
 EXPOSE 8888


### PR DESCRIPTION
This PR solves #925 and enables providing options to JVM heap.  The heap options can be passed with spec file for environment as shown in example below:

```
apiVersion: fission.io/v1
kind: Environment
metadata:
  creationTimestamp: null
  name: jvm
  namespace: default
spec:
  TerminationGracePeriod: 360
  builder: {}
  keeparchive: true
  poolsize: 3
  resources: {}
  runtime:
    functionendpointport: 0
    image: fission/jvm-env
    loadendpointpath: ""
    loadendpointport: 0
    container:
      env:
      - name: JVM_OPTS
        value: "-Xms256M -Xmx1024M"
  version: 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/936)
<!-- Reviewable:end -->
