### PR TITLE
Update influxdb image

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -386,7 +386,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: tutum/influxdb
+        image: influxdb
         env:
           - name: PRE_CREATE_DB
             value: fissionFunctionLog


### PR DESCRIPTION
The old image tutum/influxdb does not exist on DockerHub anymore.
Update template to point to the latest official influxdb image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/956)
<!-- Reviewable:end -->
