### PR TITLE
Fix issues when specifying resources/scales during updating/creation process

### DIFF
--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -361,23 +361,23 @@ func (deploy *NewDeploy) getResources(env *crd.Environment, fn *crd.Function) ap
 		resources.Limits = make(map[apiv1.ResourceName]resource.Quantity)
 	}
 	// Only override the once specified at function, rest default to values from env.
-	_, ok := fn.Spec.Resources.Requests[apiv1.ResourceCPU]
-	if ok {
+	val, ok := fn.Spec.Resources.Requests[apiv1.ResourceCPU]
+	if ok && !val.IsZero() {
 		resources.Requests[apiv1.ResourceCPU] = fn.Spec.Resources.Requests[apiv1.ResourceCPU]
 	}
 
-	_, ok = fn.Spec.Resources.Requests[apiv1.ResourceMemory]
-	if ok {
+	val, ok = fn.Spec.Resources.Requests[apiv1.ResourceMemory]
+	if ok && !val.IsZero() {
 		resources.Requests[apiv1.ResourceMemory] = fn.Spec.Resources.Requests[apiv1.ResourceMemory]
 	}
 
-	_, ok = fn.Spec.Resources.Limits[apiv1.ResourceCPU]
-	if ok {
+	val, ok = fn.Spec.Resources.Limits[apiv1.ResourceCPU]
+	if ok && !val.IsZero() {
 		resources.Limits[apiv1.ResourceCPU] = fn.Spec.Resources.Limits[apiv1.ResourceCPU]
 	}
 
-	_, ok = fn.Spec.Resources.Limits[apiv1.ResourceMemory]
-	if ok {
+	val, ok = fn.Spec.Resources.Limits[apiv1.ResourceMemory]
+	if ok && !val.IsZero() {
 		resources.Limits[apiv1.ResourceMemory] = fn.Spec.Resources.Limits[apiv1.ResourceMemory]
 	}
 

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -323,10 +323,17 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 		limitResources[v1.ResourceMemory] = memLimit
 	}
 
-	if limitResources[v1.ResourceCPU].Cmp(requestResources[v1.ResourceCPU]) < 0 {
+	limitCPU := limitResources[v1.ResourceCPU]
+	requestCPU := requestResources[v1.ResourceCPU]
+
+	if limitCPU.Cmp(requestCPU) < 0 {
 		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greate than MaxCPU (%v)", limitResources[v1.ResourceCPU], requestResources[v1.ResourceCPU]))
 	}
-	if limitResources[v1.ResourceMemory].Cmp(requestResources[v1.ResourceMemory]) < 0 {
+
+	limitMem := limitResources[v1.ResourceMemory]
+	requestMem := requestResources[v1.ResourceMemory]
+
+	if limitMem.Cmp(requestMem) < 0 {
 		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greate than MaxMemory (%v)", limitResources[v1.ResourceMemory], requestResources[v1.ResourceMemory]))
 	}
 

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -330,7 +330,7 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 	if limitCPU.IsZero() {
 		limitResources[v1.ResourceCPU] = requestCPU
 	} else if limitCPU.Cmp(requestCPU) < 0 {
-		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greate than MaxCPU (%v)", requestCPU.String(), limitCPU.String()))
+		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greater than MaxCPU (%v)", requestCPU.String(), limitCPU.String()))
 	}
 
 	limitMem := limitResources[v1.ResourceMemory]
@@ -339,7 +339,7 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 	if limitMem.IsZero() {
 		limitResources[v1.ResourceMemory] = requestMem
 	} else if limitMem.Cmp(requestMem) < 0 {
-		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greate than MaxMemory (%v)", requestMem.String(), limitMem.String()))
+		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greater than MaxMemory (%v)", requestMem.String(), limitMem.String()))
 	}
 
 	resources = v1.ResourceRequirements{

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -219,7 +219,7 @@ func envUpdate(c *cli.Context) error {
 	env.Spec.AllowAccessToExternalNetwork = envExternalNetwork
 
 	if c.IsSet("mincpu") || c.IsSet("maxcpu") || c.IsSet("minmemory") || c.IsSet("maxmemory") || c.IsSet("minscale") || c.IsSet("maxscale") {
-		log.Fatal("Currently it's not support to update resources limits/requests after creating the environment, please recreate it instead.")
+		log.Fatal("Updating resource limits/requests for existing environments is currently unsupported; re-create the environment instead.")
 	}
 
 	_, err = client.EnvironmentUpdate(env)
@@ -299,6 +299,7 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 	}
 
 	var limitResources map[v1.ResourceName]resource.Quantity
+
 	if len(resources.Limits) == 0 {
 		limitResources = make(map[v1.ResourceName]resource.Quantity)
 	} else {
@@ -326,20 +327,25 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 	limitCPU := limitResources[v1.ResourceCPU]
 	requestCPU := requestResources[v1.ResourceCPU]
 
-	if limitCPU.Cmp(requestCPU) < 0 {
-		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greate than MaxCPU (%v)", limitResources[v1.ResourceCPU], requestResources[v1.ResourceCPU]))
+	if limitCPU.IsZero() {
+		limitResources[v1.ResourceCPU] = requestCPU
+	} else if limitCPU.Cmp(requestCPU) < 0 {
+		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greate than MaxCPU (%v)", requestCPU.String(), limitCPU.String()))
 	}
 
 	limitMem := limitResources[v1.ResourceMemory]
 	requestMem := requestResources[v1.ResourceMemory]
 
-	if limitMem.Cmp(requestMem) < 0 {
-		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greate than MaxMemory (%v)", limitResources[v1.ResourceMemory], requestResources[v1.ResourceMemory]))
+	if limitMem.IsZero() {
+		limitResources[v1.ResourceMemory] = requestMem
+	} else if limitMem.Cmp(requestMem) < 0 {
+		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greate than MaxMemory (%v)", requestMem.String(), limitMem.String()))
 	}
 
 	resources = v1.ResourceRequirements{
 		Requests: requestResources,
 		Limits:   limitResources,
 	}
+
 	return resources
 }

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -218,6 +218,10 @@ func envUpdate(c *cli.Context) error {
 
 	env.Spec.AllowAccessToExternalNetwork = envExternalNetwork
 
+	if c.IsSet("mincpu") || c.IsSet("maxcpu") || c.IsSet("minmemory") || c.IsSet("maxmemory") || c.IsSet("minscale") || c.IsSet("maxscale") {
+		log.Fatal("Currently it's not support to update resources limits/requests after creating the environment, please recreate it instead.")
+	}
+
 	_, err = client.EnvironmentUpdate(env)
 	util.CheckErr(err, "update environment")
 
@@ -317,6 +321,13 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 			log.Fatal("Failed to parse maxmemory")
 		}
 		limitResources[v1.ResourceMemory] = memLimit
+	}
+
+	if limitResources[v1.ResourceCPU].Cmp(requestResources[v1.ResourceCPU]) < 0 {
+		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greate than MaxCPU (%v)", limitResources[v1.ResourceCPU], requestResources[v1.ResourceCPU]))
+	}
+	if limitResources[v1.ResourceMemory].Cmp(requestResources[v1.ResourceMemory]) < 0 {
+		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greate than MaxMemory (%v)", limitResources[v1.ResourceMemory], requestResources[v1.ResourceMemory]))
 	}
 
 	resources = v1.ResourceRequirements{

--- a/fission/environment.go
+++ b/fission/environment.go
@@ -327,7 +327,7 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 	limitCPU := limitResources[v1.ResourceCPU]
 	requestCPU := requestResources[v1.ResourceCPU]
 
-	if limitCPU.IsZero() {
+	if limitCPU.IsZero() && !requestCPU.IsZero() {
 		limitResources[v1.ResourceCPU] = requestCPU
 	} else if limitCPU.Cmp(requestCPU) < 0 {
 		log.Fatal(fmt.Sprintf("MinCPU (%v) cannot be greater than MaxCPU (%v)", requestCPU.String(), limitCPU.String()))
@@ -336,7 +336,7 @@ func getResourceReq(c *cli.Context, resources v1.ResourceRequirements) v1.Resour
 	limitMem := limitResources[v1.ResourceMemory]
 	requestMem := requestResources[v1.ResourceMemory]
 
-	if limitMem.IsZero() {
+	if limitMem.IsZero() && !requestMem.IsZero() {
 		limitResources[v1.ResourceMemory] = requestMem
 	} else if limitMem.Cmp(requestMem) < 0 {
 		log.Fatal(fmt.Sprintf("MinMemory (%v) cannot be greater than MaxMemory (%v)", requestMem.String(), limitMem.String()))

--- a/fission/function.go
+++ b/fission/function.go
@@ -101,6 +101,10 @@ func getInvokeStrategy(c *cli.Context, existingInvokeStrategy *fission.InvokeStr
 	}
 
 	if fnExecutor == fission.ExecutorTypePoolmgr {
+		if c.IsSet("targetcpu") || c.IsSet("minscale") || c.IsSet("maxscale") {
+			log.Fatal("To set target CPU or min/max scale for function, please specify \"--executortype newdeploy\"")
+		}
+
 		if c.IsSet("mincpu") || c.IsSet("maxcpu") || c.IsSet("minmemory") || c.IsSet("maxmemory") {
 			log.Warn("To limit CPU/Memory for function with executor type \"poolmgr\", please specify resources limits when creating environment")
 		}

--- a/fission/function_test.go
+++ b/fission/function_test.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli"
+
+	"github.com/fission/fission"
+)
+
+func TestGetInvokeStrategy(t *testing.T) {
+	cases := []struct {
+		testArgs               map[string]string
+		existingInvokeStrategy *fission.InvokeStrategy
+		expectedResult         *fission.InvokeStrategy
+		expectError            bool
+	}{
+		{
+			// case: use default executor poolmgr
+			testArgs:               map[string]string{},
+			existingInvokeStrategy: nil,
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType: fission.ExecutorTypePoolmgr,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: executor type set to poolmgr
+			testArgs:               map[string]string{"executortype": fission.ExecutorTypePoolmgr},
+			existingInvokeStrategy: nil,
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType: fission.ExecutorTypePoolmgr,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: executor type set to newdeploy
+			testArgs:               map[string]string{"executortype": fission.ExecutorTypeNewdeploy},
+			existingInvokeStrategy: nil,
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         DEFAULT_MIN_SCALE,
+					MaxScale:         DEFAULT_MIN_SCALE,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: executor type change from poolmgr to newdeploy
+			testArgs: map[string]string{"executortype": fission.ExecutorTypeNewdeploy},
+			existingInvokeStrategy: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType: fission.ExecutorTypePoolmgr,
+				},
+			},
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         DEFAULT_MIN_SCALE,
+					MaxScale:         DEFAULT_MIN_SCALE,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: executor type change from newdeploy to poolmgr
+			testArgs: map[string]string{"executortype": fission.ExecutorTypePoolmgr},
+			existingInvokeStrategy: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         DEFAULT_MIN_SCALE,
+					MaxScale:         DEFAULT_MIN_SCALE,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType: fission.ExecutorTypePoolmgr,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: minscale < maxscale
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"minscale":     "2",
+				"maxscale":     "3",
+			},
+			existingInvokeStrategy: nil,
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         3,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: minscale > maxscale
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"minscale":     "5",
+				"maxscale":     "3",
+			},
+			existingInvokeStrategy: nil,
+			expectedResult:         nil,
+			expectError:            true,
+		},
+		{
+			// case: maxscale not specified
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"minscale":     "5",
+			},
+			existingInvokeStrategy: nil,
+			expectedResult:         nil,
+			expectError:            true,
+		},
+		{
+			// case: minscale not specified
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"maxscale":     "3",
+			},
+			existingInvokeStrategy: nil,
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         DEFAULT_MIN_SCALE,
+					MaxScale:         3,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: maxscale set to 0
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"maxscale":     "0",
+			},
+			existingInvokeStrategy: nil,
+			expectedResult:         nil,
+			expectError:            true,
+		},
+		{
+			// case: maxscale set to 9 when existing is 5
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"maxscale":     "9",
+			},
+			existingInvokeStrategy: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         5,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         9,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: change nothing for existing strategy
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+			},
+			existingInvokeStrategy: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         5,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         5,
+					TargetCPUPercent: DEFAULT_TARGET_CPU_PERCENTAGE,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: set target cpu percentage
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"targetcpu":    "50",
+			},
+			existingInvokeStrategy: nil,
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         DEFAULT_MIN_SCALE,
+					MaxScale:         DEFAULT_MIN_SCALE,
+					TargetCPUPercent: 50,
+				},
+			},
+			expectError: false,
+		},
+		{
+			// case: change target cpu percentage
+			testArgs: map[string]string{
+				"executortype": fission.ExecutorTypeNewdeploy,
+				"targetcpu":    "20",
+			},
+			existingInvokeStrategy: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         5,
+					TargetCPUPercent: 88,
+				},
+			},
+			expectedResult: &fission.InvokeStrategy{
+				StrategyType: fission.StrategyTypeExecution,
+				ExecutionStrategy: fission.ExecutionStrategy{
+					ExecutorType:     fission.ExecutorTypeNewdeploy,
+					MinScale:         2,
+					MaxScale:         5,
+					TargetCPUPercent: 20,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for i, c := range cases {
+		fmt.Printf("=== Test Case %v ===\n", i)
+
+		app := newCliApp()
+		set := flag.NewFlagSet("test-cmd", 0)
+		ctx := cli.NewContext(app, set, nil)
+
+		for k, v := range c.testArgs {
+			set.String(k, v, "")
+			ctx.Set(k, v)
+		}
+
+		strategy, err := getInvokeStrategy(ctx, c.existingInvokeStrategy)
+		if c.expectError {
+			assert.NotNil(t, err)
+			if err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			assert.Nil(t, err)
+			assert.NoError(t, strategy.Validate(), fmt.Sprintf("Failed at test case %v", i))
+			assert.Equal(t, *c.expectedResult, *strategy)
+		}
+	}
+}

--- a/fission/log/log.go
+++ b/fission/log/log.go
@@ -27,12 +27,12 @@ var (
 )
 
 func Fatal(msg interface{}) {
-	os.Stderr.WriteString(fmt.Sprintf("[FATAL] %v\n", msg))
+	os.Stderr.WriteString(fmt.Sprintf("Fatal error: %v\n", msg))
 	os.Exit(1)
 }
 
 func Warn(msg interface{}) {
-	os.Stderr.WriteString(fmt.Sprintf("[WARNING] %v\n", msg))
+	os.Stderr.WriteString(fmt.Sprintf("Warning: %v\n", msg))
 }
 
 func Info(msg interface{}) {

--- a/fission/log/log.go
+++ b/fission/log/log.go
@@ -27,7 +27,7 @@ var (
 )
 
 func Fatal(msg interface{}) {
-	os.Stderr.WriteString(fmt.Sprintf("%v\n", msg))
+	os.Stderr.WriteString(fmt.Sprintf("[FATAL] %v\n", msg))
 	os.Exit(1)
 }
 

--- a/fission/main.go
+++ b/fission/main.go
@@ -78,9 +78,9 @@ func main() {
 	maxCpu := cli.IntFlag{Name: "maxcpu", Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
 	minMem := cli.IntFlag{Name: "minmemory", Usage: "Minimum memory to be assigned to pod (In megabyte)"}
 	maxMem := cli.IntFlag{Name: "maxmemory", Usage: "Maximum memory to be assigned to pod (In megabyte)"}
-	minScale := cli.IntFlag{Name: "minscale", Value: 1, Usage: "Minimum number of pods (Uses resource inputs to configure HPA)"}
+	minScale := cli.IntFlag{Name: "minscale", Usage: "Minimum number of pods (Uses resource inputs to configure HPA)"}
 	maxScale := cli.IntFlag{Name: "maxscale", Usage: "Maximum number of pods (Uses resource inputs to configure HPA)"}
-	targetcpu := cli.IntFlag{Name: "targetcpu", Value: 80, Usage: "Target average CPU usage percentage across pods for scaling"}
+	targetcpu := cli.IntFlag{Name: "targetcpu", Usage: "Target average CPU usage percentage across pods for scaling"}
 
 	// functions
 	fnNameFlag := cli.StringFlag{Name: "name", Usage: "function name"}
@@ -102,7 +102,7 @@ func main() {
 	fnCfgMapFlag := cli.StringFlag{Name: "configmap", Usage: "function access to configmap, should be present in the same namespace as the function"}
 	fnLogCountFlag := cli.StringFlag{Name: "recordcount", Usage: "the n most recent log records"}
 	fnForceFlag := cli.BoolFlag{Name: "force", Usage: "Force update a package even if it is used by one or more functions"}
-	fnExecutorTypeFlag := cli.StringFlag{Name: "executortype", Usage: "Executor type for execution; one of 'poolmgr', 'newdeploy' defaults to 'poolmgr'"}
+	fnExecutorTypeFlag := cli.StringFlag{Name: "executortype", Value: fission.ExecutorTypePoolmgr, Usage: "Executor type for execution; one of 'poolmgr', 'newdeploy' defaults to 'poolmgr'"}
 
 	fnSubcommands := []cli.Command{
 		{Name: "create", Usage: "Create new function (and optionally, an HTTP route to it)", Flags: []cli.Flag{fnNameFlag, fnNamespaceFlag, fnEnvNameFlag, envNamespaceFlag, specSaveFlag, fnCodeFlag, fnSrcArchiveFlag, fnDeployArchiveFlag, fnEntryPointFlag, fnBuildCmdFlag, fnPkgNameFlag, htUrlFlag, htMethodFlag, minCpu, maxCpu, minMem, maxMem, minScale, maxScale, fnExecutorTypeFlag, targetcpu, fnCfgMapFlag, fnSecretFlag}, Action: fnCreate},

--- a/fission/main.go
+++ b/fission/main.go
@@ -74,12 +74,12 @@ func main() {
 	htUrlFlag := cli.StringFlag{Name: "url", Usage: "URL pattern (See gorilla/mux supported patterns)"}
 
 	// Resource & scale related flags (Used in env and function)
-	minCpu := cli.StringFlag{Name: "mincpu", Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
-	maxCpu := cli.StringFlag{Name: "maxcpu", Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
-	minMem := cli.StringFlag{Name: "minmemory", Usage: "Minimum memory to be assigned to pod (In megabyte)"}
-	maxMem := cli.StringFlag{Name: "maxmemory", Usage: "Maximum memory to be assigned to pod (In megabyte)"}
-	minScale := cli.StringFlag{Name: "minscale", Usage: "Minimum number of pods (Uses resource inputs to configure HPA)"}
-	maxScale := cli.StringFlag{Name: "maxscale", Usage: "Maximum number of pods (Uses resource inputs to configure HPA)"}
+	minCpu := cli.IntFlag{Name: "mincpu", Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
+	maxCpu := cli.IntFlag{Name: "maxcpu", Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
+	minMem := cli.IntFlag{Name: "minmemory", Usage: "Minimum memory to be assigned to pod (In megabyte)"}
+	maxMem := cli.IntFlag{Name: "maxmemory", Usage: "Maximum memory to be assigned to pod (In megabyte)"}
+	minScale := cli.IntFlag{Name: "minscale", Value: 1, Usage: "Minimum number of pods (Uses resource inputs to configure HPA)"}
+	maxScale := cli.IntFlag{Name: "maxscale", Usage: "Maximum number of pods (Uses resource inputs to configure HPA)"}
 	targetcpu := cli.IntFlag{Name: "targetcpu", Value: 80, Usage: "Target average CPU usage percentage across pods for scaling"}
 
 	// functions

--- a/fission/main.go
+++ b/fission/main.go
@@ -38,6 +38,11 @@ func cliHook(c *cli.Context) error {
 }
 
 func main() {
+	fmt.Println(os.Args)
+	newCliApp().Run(os.Args)
+}
+
+func newCliApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "fission"
 	app.Usage = "Serverless functions for Kubernetes"
@@ -309,7 +314,7 @@ func main() {
 	}
 	app.Before = cliHook
 	app.CommandNotFound = handleCommandNotFound
-	app.Run(os.Args)
+	return app
 }
 
 func handleCommandNotFound(ctx *cli.Context, subCommand string) {

--- a/fission/main.go
+++ b/fission/main.go
@@ -38,7 +38,6 @@ func cliHook(c *cli.Context) error {
 }
 
 func main() {
-	fmt.Println(os.Args)
 	newCliApp().Run(os.Args)
 }
 

--- a/pkg/apis/fission.io/v1/validation.go
+++ b/pkg/apis/fission.io/v1/validation.go
@@ -329,19 +329,19 @@ func (es ExecutionStrategy) Validate() error {
 		result = multierror.Append(result, MakeValidationErr(ErrorUnsupportedType, "ExecutionStrategy.ExecutorType", es.ExecutorType, "not a valid executor type"))
 	}
 
-	if es.MinScale < 0 {
-		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MinScale", es.MinScale, "minimum scale must be greater or equal to 0"))
-	}
-
-	if es.MaxScale <= 0 {
-		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater than 0"))
-	}
-
-	if es.MaxScale < es.MinScale {
-		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater or equal to minimum scale"))
-	}
-
 	if es.ExecutorType == ExecutorTypeNewdeploy {
+		if es.MinScale < 0 {
+			result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MinScale", es.MinScale, "minimum scale must be greater or equal to 0"))
+		}
+
+		if es.MaxScale <= 0 {
+			result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater than 0"))
+		}
+
+		if es.MaxScale < es.MinScale {
+			result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater or equal to minimum scale"))
+		}
+
 		if es.TargetCPUPercent <= 0 || es.TargetCPUPercent > 100 {
 			result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.TargetCPUPercent", es.TargetCPUPercent, "TargetCPUPercent must be a value between 1 - 100"))
 		}

--- a/pkg/apis/fission.io/v1/validation.go
+++ b/pkg/apis/fission.io/v1/validation.go
@@ -337,8 +337,10 @@ func (es ExecutionStrategy) Validate() error {
 		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater or equal to minimum scale"))
 	}
 
-	if es.TargetCPUPercent <= 0 || es.TargetCPUPercent > 100 {
-		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.TargetCPUPercent", es.TargetCPUPercent, "TargetCPUPercent must be a value between 1 - 100"))
+	if es.ExecutorType == ExecutorTypeNewdeploy {
+		if es.TargetCPUPercent <= 0 || es.TargetCPUPercent > 100 {
+			result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.TargetCPUPercent", es.TargetCPUPercent, "TargetCPUPercent must be a value between 1 - 100"))
+		}
 	}
 
 	return result.ErrorOrNil()

--- a/pkg/apis/fission.io/v1/validation.go
+++ b/pkg/apis/fission.io/v1/validation.go
@@ -333,6 +333,10 @@ func (es ExecutionStrategy) Validate() error {
 		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MinScale", es.MinScale, "minimum scale must be greater or equal to 0"))
 	}
 
+	if es.MaxScale <= 0 {
+		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater than 0"))
+	}
+
 	if es.MaxScale < es.MinScale {
 		result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "ExecutionStrategy.MaxScale", es.MaxScale, "maximum scale must be greater or equal to minimum scale"))
 	}


### PR DESCRIPTION
To fix part of https://github.com/fission/fission/issues/955 (minscale to 1) and some other issues when specifying resources/scales during updating/creation process.

1. default minscale to 1
2. fix failed to update min/max resources in one time.
3. fix user can create env with improper req/limits resource.
4. add `[FATAL]` to CLI log message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/970)
<!-- Reviewable:end -->
