### PR TITLE
Shorten poolmgr deployment name

### DIFF
--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -203,8 +203,12 @@ func (deploy *NewDeploy) getDeploymentSpec(fn *crd.Function, env *crd.Environmen
 
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: deployLabels,
 			Name:   deployName,
+			Labels: deployLabels,
+			Annotations: map[string]string{
+				"env-name": env.Metadata.Name,
+				"env-uuid": string(env.Metadata.UID),
+			},
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &replicas,
@@ -405,9 +409,8 @@ func (deploy *NewDeploy) createOrGetHpa(hpaName string, execStrategy *fission.Ex
 	if err != nil && k8s_err.IsNotFound(err) {
 		hpa := asv1.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      hpaName,
-				Namespace: depl.ObjectMeta.Namespace,
-				Labels:    depl.Labels,
+				Name:   hpaName,
+				Labels: depl.Labels,
 			},
 			Spec: asv1.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: asv1.CrossVersionObjectReference{

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -205,10 +205,6 @@ func (deploy *NewDeploy) getDeploymentSpec(fn *crd.Function, env *crd.Environmen
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   deployName,
 			Labels: deployLabels,
-			Annotations: map[string]string{
-				"env-name": env.Metadata.Name,
-				"env-uuid": string(env.Metadata.UID),
-			},
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &replicas,

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -547,9 +547,7 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 }
 
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
-	return fmt.Sprintf("%v-%v",
-		fn.Metadata.Name,
-		deploy.instanceID)
+	return fmt.Sprintf("newdeploy-%v-%v", strings.ToLower(fn.Metadata.Name), deploy.instanceID)
 }
 
 func (deploy *NewDeploy) getDeployLabels(fn *crd.Function, env *crd.Environment) map[string]string {

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -39,6 +39,7 @@ import (
 	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 	"github.com/fission/fission/executor/fscache"
+	"github.com/fission/fission/executor/util"
 )
 
 type (
@@ -547,17 +548,19 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 }
 
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
-	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v", strings.ToLower(fn.Metadata.Name), deploy.instanceID))
+	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v-%v", fn.Metadata.Name, fn.Metadata.Namespace, deploy.instanceID))
 }
 
 func (deploy *NewDeploy) getDeployLabels(fn *crd.Function, env *crd.Environment) map[string]string {
 	return map[string]string{
-		"environmentName":                 env.Metadata.Name,
-		"environmentUid":                  string(env.Metadata.UID),
-		"functionName":                    fn.Metadata.Name,
-		"functionUid":                     string(fn.Metadata.UID),
 		fission.EXECUTOR_INSTANCEID_LABEL: deploy.instanceID,
-		"executorType":                    fission.ExecutorTypeNewdeploy,
+		util.EXECUTOR_TYPE:                fission.ExecutorTypeNewdeploy,
+		util.ENVIRONMENT_NAME:             env.Metadata.Name,
+		util.ENVIRONMENT_NAMESPACE:        env.Metadata.Namespace,
+		util.ENVIRONMENT_UID:              string(env.Metadata.UID),
+		util.FUNCTION_NAME:                fn.Metadata.Name,
+		util.FUNCTION_NAMESPACE:           fn.Metadata.Namespace,
+		util.FUNCTION_UID:                 string(fn.Metadata.UID),
 	}
 }
 

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -547,7 +547,7 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 }
 
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
-	return fmt.Sprintf("newdeploy-%v-%v", strings.ToLower(fn.Metadata.Name), deploy.instanceID)
+	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v", strings.ToLower(fn.Metadata.Name), deploy.instanceID))
 }
 
 func (deploy *NewDeploy) getDeployLabels(fn *crd.Function, env *crd.Environment) map[string]string {

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/dchest/uniuri"
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -39,7 +40,6 @@ import (
 	"github.com/fission/fission"
 	"github.com/fission/fission/crd"
 	"github.com/fission/fission/executor/fscache"
-	"github.com/fission/fission/executor/util"
 )
 
 type (
@@ -548,19 +548,20 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 }
 
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
-	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v-%v", fn.Metadata.Name, fn.Metadata.Namespace, deploy.instanceID))
+	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v-%v",
+		fn.Metadata.Name, fn.Metadata.Namespace, uniuri.NewLen(8)))
 }
 
 func (deploy *NewDeploy) getDeployLabels(fn *crd.Function, env *crd.Environment) map[string]string {
 	return map[string]string{
 		fission.EXECUTOR_INSTANCEID_LABEL: deploy.instanceID,
-		util.EXECUTOR_TYPE:                fission.ExecutorTypeNewdeploy,
-		util.ENVIRONMENT_NAME:             env.Metadata.Name,
-		util.ENVIRONMENT_NAMESPACE:        env.Metadata.Namespace,
-		util.ENVIRONMENT_UID:              string(env.Metadata.UID),
-		util.FUNCTION_NAME:                fn.Metadata.Name,
-		util.FUNCTION_NAMESPACE:           fn.Metadata.Namespace,
-		util.FUNCTION_UID:                 string(fn.Metadata.UID),
+		fission.EXECUTOR_TYPE:             fission.ExecutorTypeNewdeploy,
+		fission.ENVIRONMENT_NAME:          env.Metadata.Name,
+		fission.ENVIRONMENT_NAMESPACE:     env.Metadata.Namespace,
+		fission.ENVIRONMENT_UID:           string(env.Metadata.UID),
+		fission.FUNCTION_NAME:             fn.Metadata.Name,
+		fission.FUNCTION_NAMESPACE:        fn.Metadata.Namespace,
+		fission.FUNCTION_UID:              string(fn.Metadata.UID),
 	}
 }
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -459,7 +459,7 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 // A pool is a deployment of generic containers for an env.  This
 // creates the pool but doesn't wait for any pods to be ready.
 func (gp *GenericPool) createPool() error {
-	poolDeploymentName := fmt.Sprintf("env-%v", strings.ToLower(gp.env.Metadata.Name))
+	poolDeploymentName := fmt.Sprintf("poolmgr-%v-%v", strings.ToLower(gp.env.Metadata.Name), gp.poolInstanceId)
 
 	fetcherResources, err := util.GetFetcherResources()
 	if err != nil {
@@ -483,8 +483,12 @@ func (gp *GenericPool) createPool() error {
 
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: poolDeploymentName,
-			Labels:       gp.labelsForPool,
+			Name:   poolDeploymentName,
+			Labels: gp.labelsForPool,
+			Annotations: map[string]string{
+				"env-name": gp.env.Metadata.Name,
+				"env-uuid": string(gp.env.Metadata.UID),
+			},
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &gp.replicas,

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -459,8 +459,7 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 // A pool is a deployment of generic containers for an env.  This
 // creates the pool but doesn't wait for any pods to be ready.
 func (gp *GenericPool) createPool() error {
-	poolDeploymentName := fmt.Sprintf("%v-%v-%v",
-		gp.env.Metadata.Name, gp.env.Metadata.UID, strings.ToLower(gp.poolInstanceId))
+	poolDeploymentName := fmt.Sprintf("env-%v", strings.ToLower(gp.env.Metadata.Name))
 
 	fetcherResources, err := util.GetFetcherResources()
 	if err != nil {
@@ -484,8 +483,8 @@ func (gp *GenericPool) createPool() error {
 
 	deployment := &v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:   poolDeploymentName,
-			Labels: gp.labelsForPool,
+			GenerateName: poolDeploymentName,
+			Labels:       gp.labelsForPool,
 		},
 		Spec: v1beta1.DeploymentSpec{
 			Replicas: &gp.replicas,

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -459,7 +459,7 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 // A pool is a deployment of generic containers for an env.  This
 // creates the pool but doesn't wait for any pods to be ready.
 func (gp *GenericPool) createPool() error {
-	poolDeploymentName := fmt.Sprintf("poolmgr-%v-%v", strings.ToLower(gp.env.Metadata.Name), gp.poolInstanceId)
+	poolDeploymentName := strings.ToLower(fmt.Sprintf("poolmgr-%v-%v", gp.env.Metadata.Name, gp.poolInstanceId))
 
 	fetcherResources, err := util.GetFetcherResources()
 	if err != nil {

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -174,10 +174,10 @@ func MakeGenericPool(
 func (gp *GenericPool) getDeployLabels() map[string]string {
 	return map[string]string{
 		fission.EXECUTOR_INSTANCEID_LABEL: gp.instanceId,
-		util.EXECUTOR_TYPE:                fission.ExecutorTypePoolmgr,
-		util.ENVIRONMENT_NAME:             gp.env.Metadata.Name,
-		util.ENVIRONMENT_NAMESPACE:        gp.env.Metadata.Namespace,
-		util.ENVIRONMENT_UID:              string(gp.env.Metadata.UID),
+		fission.EXECUTOR_TYPE:             fission.ExecutorTypePoolmgr,
+		fission.ENVIRONMENT_NAME:          gp.env.Metadata.Name,
+		fission.ENVIRONMENT_NAMESPACE:     gp.env.Metadata.Namespace,
+		fission.ENVIRONMENT_UID:           string(gp.env.Metadata.UID),
 	}
 }
 
@@ -462,7 +462,8 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 }
 
 func (gp *GenericPool) getPoolName() string {
-	return strings.ToLower(fmt.Sprintf("poolmgr-%v-%v-%v", gp.env.Metadata.Name, gp.env.Metadata.Namespace, gp.poolInstanceId))
+	return strings.ToLower(fmt.Sprintf("poolmgr-%v-%v-%v",
+		gp.env.Metadata.Name, gp.env.Metadata.Namespace, uniuri.NewLen(8)))
 }
 
 // A pool is a deployment of generic containers for an env.  This

--- a/executor/util/util.go
+++ b/executor/util/util.go
@@ -23,6 +23,16 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+const (
+	ENVIRONMENT_NAMESPACE = "environmentNamespace"
+	ENVIRONMENT_NAME      = "environmentName"
+	ENVIRONMENT_UID       = "environmentUid"
+	FUNCTION_NAMESPACE    = "functionNamespace"
+	FUNCTION_NAME         = "functionName"
+	FUNCTION_UID          = "functionUid"
+	EXECUTOR_TYPE         = "executorType"
+)
+
 func GetFetcherResources() (v1.ResourceRequirements, error) {
 	mincpu, err := resource.ParseQuantity(os.Getenv("FETCHER_MINCPU"))
 	if err != nil {

--- a/executor/util/util.go
+++ b/executor/util/util.go
@@ -23,16 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-const (
-	ENVIRONMENT_NAMESPACE = "environmentNamespace"
-	ENVIRONMENT_NAME      = "environmentName"
-	ENVIRONMENT_UID       = "environmentUid"
-	FUNCTION_NAMESPACE    = "functionNamespace"
-	FUNCTION_NAME         = "functionName"
-	FUNCTION_UID          = "functionUid"
-	EXECUTOR_TYPE         = "executorType"
-)
-
 func GetFetcherResources() (v1.ResourceRequirements, error) {
 	mincpu, err := resource.ParseQuantity(os.Getenv("FETCHER_MINCPU"))
 	if err != nil {

--- a/types.go
+++ b/types.go
@@ -123,6 +123,17 @@ const (
 	AllowedFunctionsPerContainerInfinite = fv1.AllowedFunctionsPerContainerInfinite
 )
 
+// executor kubernetes object label key
+const (
+	ENVIRONMENT_NAMESPACE = "environmentNamespace"
+	ENVIRONMENT_NAME      = "environmentName"
+	ENVIRONMENT_UID       = "environmentUid"
+	FUNCTION_NAMESPACE    = "functionNamespace"
+	FUNCTION_NAME         = "functionName"
+	FUNCTION_UID          = "functionUid"
+	EXECUTOR_TYPE         = "executorType"
+)
+
 const (
 	ExecutorTypePoolmgr   = fv1.ExecutorTypePoolmgr
 	ExecutorTypeNewdeploy = fv1.ExecutorTypeNewdeploy


### PR DESCRIPTION
PR https://github.com/fission/fission/pull/182 is a little bit old, create a new one instead.

The field `GenerateName` will cause newdeploy not able to find the correct hpa, svc and deploy to update/delete due to 3 resource's suffix are different. 

Since the original purpose of the PR is to shorten the name of deployment, so use `Name` but without `gp.env.Metadata.UID` in pool deployment name. Also, add environment information to annotation for troubleshooting when dumping the CRDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/975)
<!-- Reviewable:end -->
