### PR TITLE
Alpine OpenJDK not available anymore

### DIFF
--- a/environments/jvm/builder/Dockerfile
+++ b/environments/jvm/builder/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILDER_IMAGE=fission/builder:latest
 FROM ${BUILDER_IMAGE}
 
-## Section copied from the OpenJDK 8 Dockerfile
+## Section copied from the openjdk:8-jdk-alpine Dockerfile - (https://github.com/docker-library/openjdk/blob/47a6539cd18023dafb45db9013455136cc0bca07/8/jdk/alpine/Dockerfile)
 
 ENV LANG C.UTF-8
 RUN { \
@@ -15,8 +15,8 @@ RUN { \
 ENV JAVA_HOME /usr/lib/jvm/java-1.8-openjdk
 ENV PATH $PATH:/usr/lib/jvm/java-1.8-openjdk/jre/bin:/usr/lib/jvm/java-1.8-openjdk/bin
 
-ENV JAVA_VERSION 8u171
-ENV JAVA_ALPINE_VERSION 8.171.11-r0
+ENV JAVA_VERSION 8u181
+ENV JAVA_ALPINE_VERSION 8.181.13-r0
 
 RUN set -x \
     && apk add --no-cache \


### PR DESCRIPTION
The OpenJDK version previously available seems missing from Alpine repo, so to fix upgrading to latest available version

Related change in Dokerfile of the alpine OpenJDK:

https://github.com/docker-library/openjdk/commit/47a6539cd18023dafb45db9013455136cc0bca07#diff-fe1bcb93483d1e28f57338fb56f20cef

In longer term to avoid such issues, we need to find an alternative, related issue here: https://github.com/fission/fission/issues/984

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/985)
<!-- Reviewable:end -->
