### PR TITLE
Upgrade environment dependencies for security alert

### DIFF
--- a/environments/python/requirements.txt
+++ b/environments/python/requirements.txt
@@ -2,7 +2,7 @@ flask ~= 0.12.3
 bjoern
 httplib2
 python-dateutil
-requests==2.7.0
+requests==2.20.0
 redis
 hiredis
 gevent

--- a/environments/ruby/Gemfile.lock
+++ b/environments/ruby/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    rack (2.0.3)
+    rack (2.0.6)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Two security alerts for environment dependencies
1. https://github.com/fission/fission/network/alert/environments/ruby/Gemfile.lock/rack/open
2. https://github.com/fission/fission/network/alert/environments/python/requirements.txt/requests/open

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1006)
<!-- Reviewable:end -->
