### PR TITLE
Use executor type as a delimiter to prevent deploy name conflict

### DIFF
--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -547,6 +547,10 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 }
 
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
+	// Use executor type as delimiter between function name and namespace to prevent deployment name conflict.
+	// For example:
+	// 1. fn-name: a-b fn-namespace: c => a-b-newdeploy-c
+	// 2. fn-name: a fn-namespace: b-c => a-newdeploy-b-c
 	return strings.ToLower(fmt.Sprintf("%v-newdeploy-%v", fn.Metadata.Name, fn.Metadata.Namespace))
 }
 

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dchest/uniuri"
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
@@ -548,8 +547,7 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 }
 
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
-	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v-%v",
-		fn.Metadata.Name, fn.Metadata.Namespace, uniuri.NewLen(8)))
+	return strings.ToLower(fmt.Sprintf("%v-newdeploy-%v", fn.Metadata.Name, fn.Metadata.Namespace))
 }
 
 func (deploy *NewDeploy) getDeployLabels(fn *crd.Function, env *crd.Environment) map[string]string {

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -462,6 +462,10 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 }
 
 func (gp *GenericPool) getPoolName() string {
+	// Use executor type as delimiter between function name and namespace to prevent deployment name conflict.
+	// For example:
+	// 1. fn-name: a-b fn-namespace: c => a-b-poolmgr-c
+	// 2. fn-name: a fn-namespace: b-c => a-poolmgr-b-c
 	return strings.ToLower(fmt.Sprintf("%v-poolmgr-%v", gp.env.Metadata.Name, gp.env.Metadata.Namespace))
 }
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -462,8 +462,7 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 }
 
 func (gp *GenericPool) getPoolName() string {
-	return strings.ToLower(fmt.Sprintf("poolmgr-%v-%v-%v",
-		gp.env.Metadata.Name, gp.env.Metadata.Namespace, uniuri.NewLen(8)))
+	return strings.ToLower(fmt.Sprintf("%v-poolmgr-%v", gp.env.Metadata.Name, gp.env.Metadata.Namespace))
 }
 
 // A pool is a deployment of generic containers for an env.  This


### PR DESCRIPTION
In some cases, the newdeploy creates multiple different name k8s objs for the same function after PR #975 .
This PR use `executor type` as a delimiter to fix the problem and also preventing the name conflict mentioned in PR975 comments.

For example:
1. fn-name: a-b fn-namespace: c => a-b-newdeploy-c
2. fn-name: a fn-namespace: b-c => a-newdeploy-b-c

Though the format is less beautiful but solves the problem without adding a random string to deploy name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1009)
<!-- Reviewable:end -->
