### PR TITLE
Validate command flag input by adding cli hook

### DIFF
--- a/fission/main.go
+++ b/fission/main.go
@@ -381,7 +381,8 @@ func flagValueParser(args []string) error {
 
 	// find out all flag indexes
 	for i, v := range args {
-		if strings.HasPrefix(v, "--") {
+		// support both flags with "--" and "-"
+		if strings.HasPrefix(v, "-") {
 			flagIndexes = append(flagIndexes, i)
 		}
 	}
@@ -392,7 +393,11 @@ func flagValueParser(args []string) error {
 	for i := 0; i < len(flagIndexes)-1; i++ {
 		// if the difference between the flag index i and i+1
 		// is bigger then 2 means that CLI receives extra arguments
-		// for one flag.
+		// for one flag. For example,
+		// 1. fission fn create --name e1 --code examples/nodejs/* --env nodejs ...
+		//    The wildcard will be extracted to multiple files and cause the difference between `--code` and `--env` large than 2.
+		// 2. fission fn create --spec --name e1 ...
+		//    The difference between --spec and --name is 1.
 		if flagIndexes[i+1]-flagIndexes[i] > 2 {
 			index := flagIndexes[i]
 			errorFlags = append(errorFlags, args[index])


### PR DESCRIPTION
Fix #1014 
```
$ fission fn create name t4
Fatal error: No valid flags are provided. Please ensure flag name has "--" prefix.

$ fission fn create --name t4 --env nodejs \
  --code /github.com/fission/fission/examples/nodejs/* --minscale 0 --maxscale 4 \
  --executortype newdeploy sfdfhjdhkjsdf
Fatal error: Unable to parse flags: --code, --executortype
The argument should have only one input value. Please quote the input value if it contains wildcard characters(*).
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1017)
<!-- Reviewable:end -->
