### PR TITLE
handle duplicate archive and package specs; handle multifile archives better

### DIFF
--- a/fission/function.go
+++ b/fission/function.go
@@ -252,25 +252,25 @@ func fnCreate(c *cli.Context) error {
 			}
 		}
 
-		srcArchiveName := c.StringSlice("src")
-		var deployArchiveName []string
+		srcArchiveFiles := c.StringSlice("src")
+		var deployArchiveFiles []string
 		codeFlag := false
 		code := c.String("code")
 		if len(code) == 0 {
-			deployArchiveName = c.StringSlice("deploy")
+			deployArchiveFiles = c.StringSlice("deploy")
 		} else {
-			deployArchiveName = append(deployArchiveName, c.String("code"))
+			deployArchiveFiles = append(deployArchiveFiles, c.String("code"))
 			codeFlag = true
 		}
 		// fatal when both src & deploy archive are empty
-		if len(srcArchiveName) == 0 && len(deployArchiveName) == 0 {
+		if len(srcArchiveFiles) == 0 && len(deployArchiveFiles) == 0 {
 			log.Fatal("Need --deploy or --src argument.")
 		}
 
 		buildcmd := c.String("buildcmd")
 
 		// create new package in the same namespace as the function.
-		pkgMetadata = createPackage(client, fnNamespace, envName, envNamespace, srcArchiveName, deployArchiveName, buildcmd, specFile, codeFlag)
+		pkgMetadata = createPackage(client, fnNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, specFile, codeFlag)
 
 		fmt.Printf("package '%v' created\n", pkgMetadata.Name)
 	}
@@ -471,17 +471,17 @@ func fnUpdate(c *cli.Context) error {
 		envNamespace = ""
 	}
 
-	var deployArchiveName []string
+	var deployArchiveFiles []string
 	codeFlag := false
 	code := c.String("code")
 	if len(code) == 0 {
-		deployArchiveName = c.StringSlice("deploy")
+		deployArchiveFiles = c.StringSlice("deploy")
 	} else {
-		deployArchiveName = append(deployArchiveName, c.String("code"))
+		deployArchiveFiles = append(deployArchiveFiles, c.String("code"))
 		codeFlag = true
 	}
 
-	srcArchiveName := c.StringSlice("src")
+	srcArchiveFiles := c.StringSlice("src")
 	pkgName := c.String("pkg")
 	entrypoint := c.String("entrypoint")
 	buildcmd := c.String("buildcmd")
@@ -490,7 +490,7 @@ func fnUpdate(c *cli.Context) error {
 	secretName := c.String("secret")
 	cfgMapName := c.String("configmap")
 
-	if len(srcArchiveName) > 0 && len(deployArchiveName) > 0 {
+	if len(srcArchiveFiles) > 0 && len(deployArchiveFiles) > 0 {
 		log.Fatal("Need either of --src or --deploy and not both arguments.")
 	}
 
@@ -566,7 +566,7 @@ func fnUpdate(c *cli.Context) error {
 
 	pkgMetadata := &pkg.Metadata
 
-	if len(deployArchiveName) != 0 || len(srcArchiveName) != 0 || len(buildcmd) != 0 || len(envName) != 0 || len(envNamespace) != 0 {
+	if len(deployArchiveFiles) != 0 || len(srcArchiveFiles) != 0 || len(buildcmd) != 0 || len(envName) != 0 || len(envNamespace) != 0 {
 		fnList, err := getFunctionsByPackage(client, pkg.Metadata.Name, pkg.Metadata.Namespace)
 		util.CheckErr(err, "get function list")
 
@@ -574,7 +574,7 @@ func fnUpdate(c *cli.Context) error {
 			log.Fatal("Package is used by multiple functions, use --force to force update")
 		}
 
-		pkgMetadata, err = updatePackage(client, pkg, envName, envNamespace, srcArchiveName, deployArchiveName, buildcmd, false, codeFlag)
+		pkgMetadata, err = updatePackage(client, pkg, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, false, codeFlag)
 		util.CheckErr(err, fmt.Sprintf("update package '%v'", pkgName))
 
 		fmt.Printf("package '%v' updated\n", pkgMetadata.GetName())

--- a/fission/function.go
+++ b/fission/function.go
@@ -193,6 +193,7 @@ func fnCreate(c *cli.Context) error {
 		spec = true
 		specFile = fmt.Sprintf("function-%v.yaml", fnName)
 	}
+	specDir := getSpecDir(c)
 
 	// check for unique function names within a namespace
 	fnList, err := client.FunctionList(fnNamespace)
@@ -270,7 +271,7 @@ func fnCreate(c *cli.Context) error {
 		buildcmd := c.String("buildcmd")
 
 		// create new package in the same namespace as the function.
-		pkgMetadata = createPackage(client, fnNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, specFile, noZip)
+		pkgMetadata = createPackage(client, fnNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip)
 
 		fmt.Printf("package '%v' created\n", pkgMetadata.Name)
 	}

--- a/fission/function.go
+++ b/fission/function.go
@@ -254,13 +254,13 @@ func fnCreate(c *cli.Context) error {
 
 		srcArchiveFiles := c.StringSlice("src")
 		var deployArchiveFiles []string
-		codeFlag := false
+		noZip := false
 		code := c.String("code")
 		if len(code) == 0 {
 			deployArchiveFiles = c.StringSlice("deploy")
 		} else {
 			deployArchiveFiles = append(deployArchiveFiles, c.String("code"))
-			codeFlag = true
+			noZip = true
 		}
 		// fatal when both src & deploy archive are empty
 		if len(srcArchiveFiles) == 0 && len(deployArchiveFiles) == 0 {
@@ -270,7 +270,7 @@ func fnCreate(c *cli.Context) error {
 		buildcmd := c.String("buildcmd")
 
 		// create new package in the same namespace as the function.
-		pkgMetadata = createPackage(client, fnNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, specFile, codeFlag)
+		pkgMetadata = createPackage(client, fnNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, specFile, noZip)
 
 		fmt.Printf("package '%v' created\n", pkgMetadata.Name)
 	}

--- a/fission/main.go
+++ b/fission/main.go
@@ -100,7 +100,7 @@ func newCliApp() *cli.App {
 	fnEnvNameFlag := cli.StringFlag{Name: "env", Usage: "environment name for function"}
 	fnCodeFlag := cli.StringFlag{Name: "code", Usage: "local path or URL for source code"}
 	fnDeployArchiveFlag := cli.StringSliceFlag{Name: "deployarchive, deploy", Usage: "local path or URL for deployment archive"}
-	fnSrcArchiveFlag := cli.StringSliceFlag{Name: "sourcearchive, src", Usage: "local path or URL for source archive"}
+	fnSrcArchiveFlag := cli.StringSliceFlag{Name: "sourcearchive, src, source", Usage: "local path or URL for source archive"}
 	fnPkgNameFlag := cli.StringFlag{Name: "pkgname, pkg", Usage: "Name of the existing package (--deploy and --src and --env will be ignored), should be in the same namespace as the function"}
 	fnPodFlag := cli.StringFlag{Name: "pod", Usage: "function pod name, optional (use latest if unspecified)"}
 	fnFollowFlag := cli.BoolFlag{Name: "follow, f", Usage: "specify if the logs should be streamed"}

--- a/fission/package.go
+++ b/fission/package.go
@@ -590,7 +590,8 @@ func createPackage(client *client.Client, pkgNamespace string, envName string, e
 		// if a package sith the same spec exists, don't create a new spec file
 		fr, err := readSpecs(getSpecDir(nil))
 		util.CheckErr(err, "read specs")
-		if m := fr.specExists(*pkg, false, true); m != nil {
+		if m := fr.specExists(pkg, false, true); m != nil {
+			fmt.Printf("Re-using previously created package %v\n", m.Name)
 			return m
 		}
 

--- a/fission/package.go
+++ b/fission/package.go
@@ -691,13 +691,9 @@ func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZi
 	archiveName := archiveName(archiveNameHint, archiveInput)
 
 	// Get files from inputs as number of files decide next steps
-	files := make([]string, 0)
-	for _, glob := range archiveInput {
-		f, err := filepath.Glob(glob)
-		if err != nil {
-			log.Fatal(fmt.Sprintf("Invalid glob %v: %v", glob, err))
-		}
-		files = append(files, f...)
+	files, err := fission.FindAllGlobs(archiveInput)
+	if err != nil {
+		util.CheckErr(err, "finding all globs")
 	}
 
 	// We have one file; if it's a zip file or a URL, no need to archive it

--- a/fission/package.go
+++ b/fission/package.go
@@ -488,6 +488,7 @@ func createArchive(client *client.Client, includeFiles []string, noZip bool, spe
 		fr, err := readSpecs(specDir)
 		util.CheckErr(err, "read specs")
 		if m := fr.specExists(aus, false, true); m != nil {
+			fmt.Printf("Re-using previously created archive %v\n", m.Name)
 			aus.Name = m.Name
 		} else {
 			// save the uploadspec
@@ -709,7 +710,7 @@ func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZi
 		}
 
 		// if it's an HTTP URL, just use the URL.
-		if len(files) == 1 && (strings.HasPrefix(files[0], "http://") || strings.HasPrefix(files[0], "https://")) {
+		if strings.HasPrefix(files[0], "http://") || strings.HasPrefix(files[0], "https://") {
 			return files[0]
 		}
 	}

--- a/fission/package.go
+++ b/fission/package.go
@@ -690,21 +690,31 @@ func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZi
 	// Unique name for the archive
 	archiveName := archiveName(archiveNameHint, archiveInput)
 
+	// Get files from inputs as number of files decide next steps
+	files := make([]string, 0)
+	for _, glob := range archiveInput {
+		f, err := filepath.Glob(glob)
+		if err != nil {
+			log.Fatal(fmt.Sprintf("Invalid glob %v: %v", glob, err))
+		}
+		files = append(files, f...)
+	}
+
 	// We have one file; if it's a zip file or a URL, no need to archive it
-	if len(archiveInput) == 1 {
+	if len(files) == 1 {
 		// make sure it exists
-		if _, err := os.Stat(archiveInput[0]); err != nil {
-			util.CheckErr(err, fmt.Sprintf("open input file %v", archiveInput[0]))
+		if _, err := os.Stat(files[0]); err != nil {
+			util.CheckErr(err, fmt.Sprintf("open input file %v", files[0]))
 		}
 
 		// if it's an existing zip file OR we're not supposed to zip it, don't do anything
-		if archiver.Zip.Match(archiveInput[0]) || noZip {
-			return archiveInput[0]
+		if archiver.Zip.Match(files[0]) || noZip {
+			return files[0]
 		}
 
 		// if it's an HTTP URL, just use the URL.
-		if len(archiveInput) == 1 && (strings.HasPrefix(archiveInput[0], "http://") || strings.HasPrefix(archiveInput[0], "https://")) {
-			return archiveInput[0]
+		if len(files) == 1 && (strings.HasPrefix(files[0], "http://") || strings.HasPrefix(files[0], "https://")) {
+			return files[0]
 		}
 	}
 

--- a/fission/package.go
+++ b/fission/package.go
@@ -91,8 +91,7 @@ func pkgCreate(c *cli.Context) error {
 		log.Fatal("Need --src to specify source archive, or use --deploy to specify deployment archive.")
 	}
 
-	meta := createPackage(client, pkgNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, "", false)
-	fmt.Printf("Package '%v' created\n", meta.GetName())
+	createPackage(client, pkgNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, "", false)
 
 	return nil
 }
@@ -604,6 +603,7 @@ func createPackage(client *client.Client, pkgNamespace string, envName string, e
 	} else {
 		pkgMetadata, err := client.PackageCreate(pkg)
 		util.CheckErr(err, "create package")
+		fmt.Printf("Package '%v' created\n", pkgMetadata.GetName())
 		return pkgMetadata
 	}
 }

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -1790,7 +1790,6 @@ func specSave(resource interface{}, specFile string) error {
 func (fr *FissionResources) specExists(resource interface{}, compareMetadata bool, compareSpec bool) *metav1.ObjectMeta {
 	switch typedres := resource.(type) {
 	case *ArchiveUploadSpec:
-		fmt.Printf("Searching for: %#v\n", typedres)
 		for _, aus := range fr.archiveUploadSpecs {
 			if compareMetadata && aus.Name != typedres.Name {
 				continue

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -1790,16 +1790,18 @@ func specSave(resource interface{}, specFile string) error {
 func (fr *FissionResources) specExists(resource interface{}, compareMetadata bool, compareSpec bool) *metav1.ObjectMeta {
 	switch typedres := resource.(type) {
 	case *ArchiveUploadSpec:
+		fmt.Printf("Searching for: %#v\n", typedres)
 		for _, aus := range fr.archiveUploadSpecs {
 			if compareMetadata && aus.Name != typedres.Name {
 				continue
 			}
 			if compareSpec &&
-				!reflect.DeepEqual(aus.RootDir, typedres.RootDir) &&
-				!reflect.DeepEqual(aus.IncludeGlobs, typedres.IncludeGlobs) &&
-				!reflect.DeepEqual(aus.ExcludeGlobs, typedres.ExcludeGlobs) {
+				!(reflect.DeepEqual(aus.RootDir, typedres.RootDir) &&
+					reflect.DeepEqual(aus.IncludeGlobs, typedres.IncludeGlobs) &&
+					reflect.DeepEqual(aus.ExcludeGlobs, typedres.ExcludeGlobs)) {
 				continue
 			}
+			fmt.Printf("found: %#v\n", aus)
 			return &metav1.ObjectMeta{Name: aus.Name}
 		}
 		return nil

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -1784,7 +1784,7 @@ func specSave(resource interface{}, specFile string) error {
 	return nil
 }
 
-// Returns true if the given resource exists in the specs, false
+// Returns metadata if the given resource exists in the specs, nil
 // otherwise.  compareMetadata and compareSpec control how the
 // equality check is performed.
 func (fr *FissionResources) specExists(resource interface{}, compareMetadata bool, compareSpec bool) *metav1.ObjectMeta {
@@ -1800,7 +1800,6 @@ func (fr *FissionResources) specExists(resource interface{}, compareMetadata boo
 					reflect.DeepEqual(aus.ExcludeGlobs, typedres.ExcludeGlobs)) {
 				continue
 			}
-			fmt.Printf("found: %#v\n", aus)
 			return &metav1.ObjectMeta{Name: aus.Name}
 		}
 		return nil

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -854,7 +854,7 @@ func applyArchives(fclient *client.Client, specDir string, fr *FissionResources)
 		} else {
 			// doesn't exist, upload
 			fmt.Printf("uploading archive %v\n", name)
-			uploadedAr := createArchive(fclient, ar.URL, "")
+			uploadedAr := createArchive(fclient, ar.URL, []string{}, "")
 			archiveFiles[name] = *uploadedAr
 		}
 	}

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -1789,7 +1789,7 @@ func specSave(resource interface{}, specFile string) error {
 // equality check is performed.
 func (fr *FissionResources) specExists(resource interface{}, compareMetadata bool, compareSpec bool) *metav1.ObjectMeta {
 	switch typedres := resource.(type) {
-	case ArchiveUploadSpec:
+	case *ArchiveUploadSpec:
 		for _, aus := range fr.archiveUploadSpecs {
 			if compareMetadata && aus.Name != typedres.Name {
 				continue
@@ -1803,7 +1803,7 @@ func (fr *FissionResources) specExists(resource interface{}, compareMetadata boo
 			return &metav1.ObjectMeta{Name: aus.Name}
 		}
 		return nil
-	case crd.Package:
+	case *crd.Package:
 		for _, p := range fr.packages {
 			if compareMetadata && !reflect.DeepEqual(p.Metadata, typedres.Metadata) {
 				continue

--- a/fission/spec.go
+++ b/fission/spec.go
@@ -854,7 +854,8 @@ func applyArchives(fclient *client.Client, specDir string, fr *FissionResources)
 		} else {
 			// doesn't exist, upload
 			fmt.Printf("uploading archive %v\n", name)
-			uploadedAr := createArchive(fclient, ar.URL, []string{}, "")
+			// ar.URL is actually a local filename at this stage
+			uploadedAr := uploadArchive(fclient, ar.URL)
 			archiveFiles[name] = *uploadedAr
 		}
 	}

--- a/fission/upgrade.go
+++ b/fission/upgrade.go
@@ -293,7 +293,7 @@ func upgradeRestoreState(c *cli.Context) error {
 		tmpfile.Close()
 
 		// upload
-		archive := createArchive(client, tmpfile.Name(), []string{}, "")
+		archive := uploadArchive(client, tmpfile.Name())
 		os.Remove(tmpfile.Name())
 
 		// create pkg

--- a/fission/upgrade.go
+++ b/fission/upgrade.go
@@ -293,7 +293,7 @@ func upgradeRestoreState(c *cli.Context) error {
 		tmpfile.Close()
 
 		// upload
-		archive := createArchive(client, tmpfile.Name(), "")
+		archive := createArchive(client, tmpfile.Name(), []string{}, "")
 		os.Remove(tmpfile.Name())
 
 		// create pkg


### PR DESCRIPTION
3 changes:

1. Archives with multiple files were being handled with only one input file (when multiple --src flags were provided)
2. Avoid creating a zip file when we don't need to
3. Check for duplicate ArchiveUploadSpecs and Package.Specs before writing them to the spec dir 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1018)
<!-- Reviewable:end -->
