### PR TITLE
Add support for Kafka record headers

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -51,19 +51,20 @@ The following table lists the configurable parameters of the Fission chart and t
 
 * Extra configuration for `fission-all`
 
-| Parameter                       | Description                 | Default                                                    |
-| ------------------------------- | --------------------------- | ---------------------------------------------------------- |
-| `logger.influxdbAdmin`          | Log database admin username | `admin`                                                    |
-| `logger.fluentdImage`           | Logger fluentd image        | `fission/fluentd`                                          |
-| `fissionUiImage`                | Fission ui image            | `fission/fission-ui:0.1.0`                                 |
-| `nats.enabled`                | Nats streaming enabled   | `true`                                  |
-| `nats.authToken`                | Nats streaming auth token   | `defaultFissionAuthToken`(required if `nats.enabled` is `true`) |
-| `nats.clusterID`                | Nats streaming clusterID    | `fissionMQTrigger`(required if `nats.enabled` is `true`) |
-| `azureStorageQueue.enabled` * | Azure storage account name  | false |
-| `azureStorageQueue.accountName` | Azure storage account name  | None (required if `azureStorageQueue.enabled` is `true`) |
-| `azureStorageQueue.key`         | Azure storage access key    | None (required if `azureStorageQueue.enabled` is `true`) |
-| `kafka.enabled` *  | Kafka trigger enabled           | `false`                    |
-| `kafka.brokers`  | Kafka brokers uri               | `broker.kafka:9092`  (required if `kafka.enabled` is `true`)          |
+| Parameter                       | Description                 | Default                                                                 |
+| ------------------------------- | --------------------------- | ----------------------------------------------------------              |
+| `logger.influxdbAdmin`          | Log database admin username | `admin`                                                                 |
+| `logger.fluentdImage`           | Logger fluentd image        | `fission/fluentd`                                                       |
+| `fissionUiImage`                | Fission ui image            | `fission/fission-ui:0.1.0`                                              |
+| `nats.enabled`                  | Nats streaming enabled      | `true`                                                                  |
+| `nats.authToken`                | Nats streaming auth token   | `defaultFissionAuthToken`(required if `nats.enabled` is `true`)         |
+| `nats.clusterID`                | Nats streaming clusterID    | `fissionMQTrigger`(required if `nats.enabled` is `true`)                |
+| `azureStorageQueue.enabled` *   | Azure storage account name  | `false`                                                                 |
+| `azureStorageQueue.accountName` | Azure storage account name  | `None` (required if `azureStorageQueue.enabled` is `true`)              |
+| `azureStorageQueue.key`         | Azure storage access key    | `None` (required if `azureStorageQueue.enabled` is `true`)              |
+| `kafka.enabled` *               | Kafka trigger enabled       | `false`                                                                 |
+| `kafka.brokers`                 | Kafka brokers uri           | `broker.kafka:9092`  (required if `kafka.enabled` is `true`)            |
+| `kafka.version`                 | Kafka broker version        | `None` (should be `>= 0.11.0.0` to enable Kafka record headers support) |
 
 * - Please note that deploying of Azure Storage Queue or Kafka is not done by Fission chart and you will have to explicitly deploy them.
 

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -578,6 +578,8 @@ spec:
           value: kafka
         - name: MESSAGE_QUEUE_URL
           value: "{{.Values.kafka.brokers}}"
+        - name: MESSAGE_QUEUE_KAFKA_VERSION
+          value: "{{.Values.kafka.version}}"
       serviceAccount: fission-svc
 {{- end }}
 ---

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -73,6 +73,10 @@ azureStorageQueue:
 kafka:
   enabled: false
   brokers: 'broker.kafka:9092'
+  ## version of Kafka broker
+  ## Must be a string in the format "major.minor.veryMinor.patch"
+  ## Should be >= 0.11.0.0 to enable Kafka record headers support
+  # version: "0.11.0.0"
 
 ## Persist data to a persistent volume.
 persistence:

--- a/test/tests/mqtrigger/kafka/hellokafka.js
+++ b/test/tests/mqtrigger/kafka/hellokafka.js
@@ -1,9 +1,13 @@
 
 module.exports = async function (context) {
     console.log(context.request.body);
+    console.log("z-custom-name: " + context.request.headers['z-custom-name']);
+    console.log("x-fission-function-name: " + context.request.headers['x-fission-function-name']);
     let obj = context.request.body;
+    let headers = context.request.headers;
     return {
         status: 200,
+	headers: headers,
         body: obj
     };
 }

--- a/test/tests/mqtrigger/kafka/kafka_pub/kafka-pub.go
+++ b/test/tests/mqtrigger/kafka/kafka_pub/kafka-pub.go
@@ -14,14 +14,18 @@ func Handler(w http.ResponseWriter, r *http.Request) {
 	producerConfig.Producer.RequiredAcks = sarama.WaitForAll
 	producerConfig.Producer.Retry.Max = 10
 	producerConfig.Producer.Return.Successes = true
+	producerConfig.Version = sarama.V0_11_0_0
 	producer, err := sarama.NewSyncProducer(brokers, producerConfig)
 	fmt.Println("Created a new producer ", producer)
 	if err != nil {
 		panic(err)
 	}
+
+	headers := []sarama.RecordHeader{{Key: []byte("Z-Custom-Name"), Value: []byte("Kafka-Header-test")}}
 	_, _, err = producer.SendMessage(&sarama.ProducerMessage{
-		Topic: "testtopic",
-		Value: sarama.StringEncoder("{\"name\": \"testvalue\"}"),
+		Topic:   "testtopic",
+		Value:   sarama.StringEncoder("{\"name\": \"testvalue\"}"),
+		Headers: headers,
 	})
 
 	if err != nil {

--- a/test/tests/mqtrigger/kafka/test_kafka.sh
+++ b/test/tests/mqtrigger/kafka/test_kafka.sh
@@ -10,6 +10,7 @@ nodeenv="node-kafka"
 goenv="go-kafka"
 producerfunc="producer-func"
 consumerfunc="consumer-func"
+consumerfunc2="consumer-func2"
 
 log() {
     echo $1
@@ -29,6 +30,23 @@ test_mqmessage() {
     done
 }
 export -f test_mqmessage 
+
+test_fnmessage() {
+    # $1: functionName
+    # $2: container name
+    # $3: string to look for
+    echo "Checking for valid function log"
+
+    while true; do
+	response0=$(kubectl -nfission-function logs -l=functionName=$1 -c $2)
+	echo $response0 | grep -i "$3"
+	if [[ $? -eq 0 ]]; then
+	    break
+	fi
+	sleep 1
+    done
+}
+export -f test_fnmessage
 
 waitBuild() {
     log "Waiting for builder manager to finish the build"
@@ -50,6 +68,9 @@ cleanup() {
     fission env delete --name ${nodeenv} || true
     fission fn delete --name ${producerfunc} || true
     fission fn delete --name ${consumerfunc} || true
+    fission fn delete --name ${consumerfunc2} || true
+    fission mqt delete --name kafkatest || true
+    fission mqt delete --name kafkatest2 || true
 }
 export -f cleanup
 
@@ -64,25 +85,40 @@ fission env create --name ${goenv} --image fission/go-env --builder fission/go-b
 
 log "Creating package for Kafka producer"
 pushd $DIR/kafka_pub
+glide install
 zip -qr kafka.zip * 
 pkgName=$(fission package create --env ${goenv} --src kafka.zip|cut -f2 -d' '| tr -d \')
 
 log "pkgName=${pkgName}"
 popd
 
-gtimeout 60s bash -c "waitBuild $pkgName"
+timeout 120s bash -c "waitBuild $pkgName"
 log "Package ${pkgName} created"
 
 log "Creating function ${consumerfunc}"
 fission fn create --name ${consumerfunc} --env ${nodeenv} --code hellokafka.js 
 
+log "Creating function ${consumerfunc2}"
+fission fn create --name ${consumerfunc2} --env ${nodeenv} --code hellokafka.js
+
 log "Creating function ${producerfunc}"
 fission fn create --name ${producerfunc} --env ${goenv} --pkg ${pkgName} --entrypoint Handler
 
-log "Creating "
+log "Creating trigger kafkatest"
 fission mqt create --name kafkatest --function ${consumerfunc} --mqtype kafka --topic testtopic --resptopic resptopic
+
+log "Creating trigger kafkatest2"
+fission mqt create --name kafkatest2 --function ${consumerfunc2} --mqtype kafka --topic resptopic
 
 fission fn test --name ${producerfunc}
 
 log "Testing pool manager function"
-gtimeout 60 bash -c "test_mqmessage 'testvalue'"
+timeout 60 bash -c "test_mqmessage 'testvalue'"
+
+log "Testing the headers values in ${consumerfunc}"
+timeout 60 bash -c "test_fnmessage '${consumerfunc}' '${nodeenv}' 'z-custom-name: Kafka-Header-test'"
+
+log "Testing the header value in ${consumerfunc2}"
+timeout 60 bash -c "test_fnmessage '${consumerfunc2}' '${nodeenv}' 'z-custom-name: Kafka-Header-test'"
+# test if the Fission specific headers are overwritten
+timeout 60 bash -c "test_fnmessage '${consumerfunc2}' '${nodeenv}' 'x-fission-function-name: consumer-func2'"


### PR DESCRIPTION
- Add support for Kafka record headers

  - This makes sure that the headers received from a function are
  converted to Kafka record headers
  - Also extracts the headers from a Kafka record and sends them to
  function
  - ref: https://issues.apache.org/jira/browse/KAFKA-4208

- Make Kafka version configurable

  - Adds version field to Kafka struct
  - Adds `MESSAGE_QUEUE_KAFKA_VERSION` environment variable
  - Drop headers from Kafka record if specified Kafka version is `< 0.11.0.0`

- Update helm chart fission-all for Kafka record headers

  - Adds new field `kafka.version`
  - Sets the `MESSAGE_QUEUE_KAFKA_VERSION` environments variable to `kafka.version`


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1025)
<!-- Reviewable:end -->
