### PR TITLE
[python-env] Add OpenTracing support

### DIFF
--- a/environments/python/lib/tracing.py
+++ b/environments/python/lib/tracing.py
@@ -1,0 +1,73 @@
+from jaeger_client import Config
+from flask import request, make_response, g
+from opentracing.propagation import Format
+import logging
+
+logger = logging.getLogger("lib.tracing")
+# Tracer is created globally and initialized only once because of
+# following bug.
+# https://github.com/jaegertpracing/jaeger-client-python/issues/50
+# We won't be calling tracer.close()
+tracer = None
+
+
+def initialize_tracing(func):
+    """
+    Decorator which initializes the tracing related stuff.
+    It creates tracer and a new span.
+    Also extracts and injects the headers required for Jaeger tracing
+    to work across multiple functions
+
+    :param func: Function object
+    :returns: decorated function
+    """
+    def inner():
+        global tracer
+        fission_func_name = request.headers.get("X-Fission-Function-Name",
+                                                "name")
+        span_name = fission_func_name + "-span"
+        if tracer is None:
+            tracer = _init_tracer(fission_func_name)
+        span_ctx = tracer.extract(Format.HTTP_HEADERS, request.headers)
+        response = None
+        with tracer.start_span(span_name, child_of=span_ctx) as span:
+            span.set_tag("generated-by", "lib.tracing")
+            generated_headers = dict()
+            tracer.inject(span, Format.HTTP_HEADERS, generated_headers)
+            # User may want to set tags on span or use the generated_headers
+            g.span = span
+            g.generated_headers = generated_headers
+            # User may return a None, string or object of response
+            # Supported types:
+            # http://flask.pocoo.org/docs/1.0/api/#flask.Flask.make_response
+            func_resp = func()
+            if func_resp is None:
+                response = make_response()
+            else:
+                response = make_response(func_resp)
+            for key, value in generated_headers.items():
+                response.headers[key] = value
+        return response
+    return inner
+
+
+def _init_tracer(service):
+    """
+    This takes a name of service and creates new tracer using
+    jaeger_client.
+    reporting_host is taken from environment variable
+    JAEGER_AGENT_HOST
+    reporting_port is taken from environment variable
+    JAEGER_AGENT_PORT
+
+    :param service: name of service (string)
+    :returns: tracer object
+    """
+    client_config = Config(
+        config={
+            "sampler": {"type": "const", "param": 1},
+            "logging": True,
+        },
+        service_name=service,
+    )
+    return client_config.new_tracer()

--- a/environments/python/requirements.txt
+++ b/environments/python/requirements.txt
@@ -2,7 +2,9 @@ flask ~= 0.12.3
 bjoern
 httplib2
 python-dateutil
-requests==2.20.0
+requests == 2.20.0
 redis
 hiredis
 gevent
+opentracing >= 2,<3
+jaeger-client >= 3.13.0,<4


### PR DESCRIPTION
This makes it possible to trace the calls made to Fission functions created with Python environment.
In addition to things discussed in #200 this makes it possible to trace things if the function is making calls to things which are outside the Fission platform (with the help of headers). Like some request to external API end point.

#### SUMMARY OF CHANGES
- Uses global tracer which won't be closed
  - As the `Tracer.close()` is not synchronous we can't create and close
    it for every request as it does not wait for the UDP sender to flush
    all the packets correctly. Instead use same tracer while function is
    alive is the better option for now
- Takes reporting_host and reporting_port from env variable
  - This needs `jaeger_client >= 3.13.0`
  - Uses the environment variable `JAEGER_AGENT_HOST` and
    `JAEGER_AGENT_PORT` to get the value
  - This must be set to correct value while creating the fission
    function environment
- Saves the `span` and `generated_headers` in `g`
  - This way user can use the span and set tags or use the
    `generated_headers` while sending external request from within the
    function code
- Decorates the `userfunc` in specialize call
  - If the value of environment variable `ENABLE_TRACING` is set then
    decorate the userfunc with `initialize_tracing` from `lib.tracing`

#### TODO
- [ ] Update the Python environment docs 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1039)
<!-- Reviewable:end -->
