### PR TITLE
Changed Kafka topic name validation 

### DIFF
--- a/pkg/apis/fission.io/v1/validation.go
+++ b/pkg/apis/fission.io/v1/validation.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	validAzureQueueName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]*[a-z0-9]$")
-	validKafkaTopicName = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9\\-._]*[a-zA-Z0-9]$")
+	validKafkaTopicName = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9\-\._]*[a-zA-Z0-9]$")
 )
 
 type (

--- a/pkg/apis/fission.io/v1/validation.go
+++ b/pkg/apis/fission.io/v1/validation.go
@@ -36,7 +36,8 @@ const (
 
 var (
 	validAzureQueueName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]*[a-z0-9]$")
-	validKafkaTopicName = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9\-\._]*[a-zA-Z0-9]$")
+	// Need to use raw string to support escape sequence for - & . chars
+	validKafkaTopicName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9\-\._]*[a-zA-Z0-9]$`)
 )
 
 type (

--- a/pkg/apis/fission.io/v1/validation.go
+++ b/pkg/apis/fission.io/v1/validation.go
@@ -36,7 +36,7 @@ const (
 
 var (
 	validAzureQueueName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-]*[a-z0-9]$")
-	validKafkaTopicName = regexp.MustCompile("^[a-z0-9][a-z0-9\\-._]*[a-z0-9]$")
+	validKafkaTopicName = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9\\-._]*[a-zA-Z0-9]$")
 )
 
 type (


### PR DESCRIPTION
Currently, Kafka topic name validation does not allow capital case letters.

Fixes #1049

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1051)
<!-- Reviewable:end -->
