### PR TITLE
ruby-v2-specializer and added support for X-FORWARDED-HOST header

### DIFF
--- a/environments/ruby/fission/specializerv2.rb
+++ b/environments/ruby/fission/specializerv2.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'benchmark'
+require 'json'
+
+module Fission
+
+  module SpecializerV2
+    def self.call(env)
+      request = Request.new(env)
+      body    = request.body.string
+
+      request.logger.info("Body #{body}")
+
+      body         = JSON.parse(body)
+      filepath     = body['filepath']
+      functionname = body['functionName']
+      module_name, func_name = functionname.split('.')
+
+      request.logger.info("Codepath defaulting to #{filepath}")
+
+      if(File.directory?(filepath))
+        time = Benchmark.measure { Dir["#{filepath}/*.rb"].each {|file| require file } }
+      else
+        time = Benchmark.measure { load filepath }
+      end
+
+      func_name = func_name || "handler"
+      alias :"handler" :"#{func_name}"
+
+      request.logger.info("User code loaded in #{(time.real * 1000).round(3)}ms")
+
+      Rack::Response.new([], 202).finish
+
+    rescue => e
+      request.logger.error(%(Specialization failed - #{e}\n#{e.backtrace.join("\n")}))
+      Rack::Response.new(['500 Internal Server Error'], 500, {}).finish
+    end
+  end
+end

--- a/environments/ruby/server.rb
+++ b/environments/ruby/server.rb
@@ -2,20 +2,46 @@
 
 require 'rack'
 require 'logger'
+require 'socket'
 
 require_relative 'fission/specializer'
+require_relative 'fission/specializerv2'
 require_relative 'fission/handler'
+
+fission_port = 8888
+address_list = Socket.ip_address_list.map { |address| "http://#{address.ip_address}:#{fission_port}" }
+address_list = address_list.push("")
 
 app = Rack::Builder.new do
   use Rack::Logger, Logger::DEBUG
 
-  map "/specialize" do
-    run Fission::Specializer
+  # Root cause:
+  # d23b210 https://github.com/fission/fission/commit/d23b210f4ef6ac8684783b320855445ad1568e4c
+  # X-Forwarded-Host header added by router/functionHandler.go:413
+  # Requires webrick to explicitly add handler for specific server ip.
+  # As pointed in: rack/rack#990 https://github.com/rack/rack/issues/990
+  address_list.each do |address|
+      map "#{address}/specialize" do
+        run Fission::Specializer
+      end
+
+      map "#{address}/v2/specialize" do
+        run Fission::SpecializerV2
+      end
+
+      map "#{address}/healthz" do
+        run ->(env) {[200, {'Content-Type' => 'text/html'}, ['']] }
+      end
+
+      map "#{address}/readniess-healthz" do
+        run ->(env) {[200, {'Content-Type' => 'text/html'}, ['']] }
+      end
+
+      map "#{address}/" do
+        run Fission::Handler
+      end
   end
 
-  map "/" do
-    run Fission::Handler
-  end
 end
 
-Rack::Handler::WEBrick.run app, Host: '0.0.0.0', Port: 8888
+Rack::Handler::WEBrick.run app, Host: '0.0.0.0', Port: fission_port


### PR DESCRIPTION
Hi, I implemented "v2/specializer" for a ruby environment but I still cannot trigger the function from host. :s I include here a dump, any Ideas?

```
$ fission env create --name ruby --version 3 --poolsize 1 --image XXXXXXXX/ruby-env
$ fission fn test --name hellorb
Error calling function hellorb: 404 Not Found: /Fatal error: Failed to execute get logs request: Post /proxy/logs/hellorb: unsupported protocol scheme ""
   2/2     Running   0          8m36s
$ kubectl logs ruby-poolmgr-default-XXXXXXXXXX-XXXXX -n fission-function -c ruby
[2019-01-18 22:26:47] INFO  WEBrick 1.3.1
[2019-01-18 22:26:47] INFO  ruby 2.4.1 (2017-03-22) [x86_64-linux]
[2019-01-18 22:26:47] INFO  WEBrick::HTTPServer#start: pid=1 port=8888
I, [2019-01-18T22:30:24.790673 #1]  INFO -- : Body {"filepath":"/userfunc/user","functionName":"","url":"","FunctionMetadata":{"name":"hellorb","namespace":"default","selfLink":"/apis/fission.io/v1/namespaces/default/functions/hellorb","uid":"9d6db679-1b70-11e9-8541-d850e656c2a0","resourceVersion":"252851","generation":1,"creationTimestamp":"2019-01-18T22:30:10Z"},"envVersion":3}
I, [2019-01-18T22:30:24.790786 #1]  INFO -- : Codepath defaulting to /userfunc/user
I, [2019-01-18T22:30:24.804188 #1]  INFO -- : User code loaded in 13.317ms
127.0.0.1 - - [18/Jan/2019:22:30:24 UTC] "POST /v2/specialize HTTP/1.1" 202 0
- -> /v2/specialize
10.1.1.1 - - [18/Jan/2019:22:30:24 UTC] "GET / HTTP/1.1" 404 12
- -> /
```
When I run the following command inside pod's bash it works:
`curl localhost:8888`

But why it happens with ruby? Nodejs and Python are working well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1066)
<!-- Reviewable:end -->
