### PR TITLE
Clear message in case of function/pod failure

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -172,7 +172,6 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 	}
 
 	if fsvcErr != nil {
-		fsvcErr = errors.Wrap(fsvcErr, fmt.Sprintf("[%v] Error creating service for function", meta.Name))
 		log.Print(fsvcErr)
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -172,6 +172,7 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 	}
 
 	if fsvcErr != nil {
+		fsvcErr = errors.Wrap(fsvcErr, fmt.Sprintf("[%v] Error creating service for function", meta.Name))
 		log.Print(fsvcErr)
 	}
 

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -574,9 +574,26 @@ func (gp *GenericPool) waitForReadyPod() error {
 		}
 
 		if time.Since(startTime) > gp.podReadyTimeout {
+			podList, err := gp.kubernetesClient.CoreV1().Pods(gp.namespace).List(metav1.ListOptions{
+				LabelSelector: labels.Set(
+					gp.deployment.Spec.Selector.MatchLabels).AsSelector().String(),
+			})
+			if err != nil {
+
+			}
+
+			// Since even single pod is not ready, choosing the first pod to inspect is a good approximation. In future this can be done better
+			pod := podList.Items[0]
+			var podErr string
+			for _, cStatus := range pod.Status.ContainerStatuses {
+				if cStatus.Ready != true {
+					podErr = cStatus.State.Waiting.Reason + cStatus.State.Waiting.Message
+				}
+			}
+
 			return errors.Errorf(
-				"Timeout: waited too long for pod of deployment %v in namespace %v to be ready",
-				gp.deployment.ObjectMeta.Name, gp.namespace)
+				"Timeout: waited too long for pod of deployment %v in namespace %v to be ready, error: %v",
+				gp.deployment.ObjectMeta.Name, gp.namespace, podErr)
 		}
 		time.Sleep(1000 * time.Millisecond)
 	}

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -579,7 +579,7 @@ func (gp *GenericPool) waitForReadyPod() error {
 					gp.deployment.Spec.Selector.MatchLabels).AsSelector().String(),
 			})
 			if err != nil {
-
+				log.Printf("Error getting pod list after timeout waiting for ready pod: %v", err)
 			}
 
 			// Since even single pod is not ready, choosing the first pod to inspect is a good approximation. In future this can be done better

--- a/fission/function.go
+++ b/fission/function.go
@@ -803,7 +803,7 @@ func fnTest(c *cli.Context) error {
 
 	body, err := ioutil.ReadAll(resp.Body)
 	util.CheckErr(err, "read log response from pod")
-	fmt.Printf("Error calling function %s: %d %s", fnName, resp.StatusCode, string(body))
+	fmt.Printf("Error calling function %s: %d; Please try again or fix the error: %s", fnName, resp.StatusCode, string(body))
 	defer resp.Body.Close()
 	err = printPodLogs(c)
 	if err != nil {


### PR DESCRIPTION
Fixes #952 

This is not perfect but good for review fix. There are mainly two things that need to be fixed separately:

1) Right now the error is so long is because it is wrapped and passed on at every layer. This is great for tracing error but not for the end user. The challenge is determing which part of multiple errors is most useful for users. I don't know the solution yet, but the problem statement is fairly clear.

2) Currently, we are checking one pod since none is ready - there is room for future addition!



```
$ fission fn test --name hello
Error calling function hello: 500; Please try again or fix the error: Error updating service address entry for function hello_default: Internal error - Timeout: waited too long for pod of deployment python-poolmgr-default in namespace fission-function to be ready, error: ImagePullBackOffBack-off pulling image "fission/python"
```

The [error in article](https://medium.com/@bluszcz/serverless-microk8s-kubernetes-fcd6b875cd33) that user is facing is due to wrong image while creating environment. I think there is a separate bug for validating that image is accessible/exists before creating environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1069)
<!-- Reviewable:end -->
