### PR TITLE
Fix unable to update the function value of route

### DIFF
--- a/controller/httpTriggerApi.go
+++ b/controller/httpTriggerApi.go
@@ -50,12 +50,17 @@ func (a *API) HTTPTriggerApiList(w http.ResponseWriter, r *http.Request) {
 	a.respondWithSuccess(w, resp)
 }
 
+// checkHTTPTriggerDuplicates checks whether the tuple (Method, Host, URL) is duplicate or not.
 func (a *API) checkHTTPTriggerDuplicates(t *crd.HTTPTrigger) error {
 	triggers, err := a.fissionClient.HTTPTriggers(metav1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 	for _, ht := range triggers.Items {
+		if ht.Metadata.UID == t.Metadata.UID {
+			// Same resource. No need to check.
+			continue
+		}
 		if ht.Spec.RelativeURL == t.Spec.RelativeURL && ht.Spec.Method == t.Spec.Method && ht.Spec.Host == t.Spec.Host {
 			return fission.MakeError(fission.ErrorNameExists,
 				fmt.Sprintf("HTTPTrigger with same Host, URL & method already exists (%v)",


### PR DESCRIPTION
Fixes #1074

The route is failed to update if only update its function.
The root cause is in `checkHTTPTriggerDuplicates`. The function checks if the tuple of (Method, Host, URL) of route is duplicate before create/update. But if one only updates the "function" value of a route, `checkHTTPTriggerDuplicates` will always return error because the new resource and old resource are duplicates.
```
# success, because no duplicate (Method, Host, URL) exists
fission route update --name xxx --url /new_rul

# fail, because it and itself(old resource) are duplicates!
fission route update --name xxx --function fn2
```

To solve this, I add code to check UID before checking the tuple (Method, Host, URL).
If the UID is the same, it means `ht` is the exact resource which is going to be update.
In this case, skip the check because it's meaningless.
