### PR TITLE
Fix executor tries to create same name deployment

### DIFF
--- a/executor/api.go
+++ b/executor/api.go
@@ -89,11 +89,6 @@ func (executor *Executor) getServiceForFunction(m *metav1.ObjectMeta) (string, e
 	if resp.err != nil {
 		return "", resp.err
 	}
-	executor.fsCache.IncreaseColdStarts(m.Name, string(m.UID))
-	_, err = executor.fsCache.Add(*resp.funcSvc)
-	if err != nil {
-		return "", err
-	}
 	return resp.funcSvc.Address, resp.err
 }
 

--- a/executor/api.go
+++ b/executor/api.go
@@ -90,6 +90,10 @@ func (executor *Executor) getServiceForFunction(m *metav1.ObjectMeta) (string, e
 		return "", resp.err
 	}
 	executor.fsCache.IncreaseColdStarts(m.Name, string(m.UID))
+	_, err = executor.fsCache.Add(*resp.funcSvc)
+	if err != nil {
+		return "", err
+	}
 	return resp.funcSvc.Address, resp.err
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -160,6 +160,12 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 		log.Print(fsvcErr)
 	}
 
+	executor.fsCache.IncreaseColdStarts(meta.Name, string(meta.UID))
+	_, err = executor.fsCache.Add(*fsvc)
+	if err != nil {
+		return nil, err
+	}
+
 	return fsvc, fsvcErr
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -158,13 +158,14 @@ func (executor *Executor) createServiceForFunction(meta *metav1.ObjectMeta) (*fs
 	if fsvcErr != nil {
 		fsvcErr = errors.Wrap(fsvcErr, fmt.Sprintf("[%v] Error creating service for function", meta.Name))
 		log.Print(fsvcErr)
+	} else if fsvc != nil {
+		_, err = executor.fsCache.Add(*fsvc)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	executor.fsCache.IncreaseColdStarts(meta.Name, string(meta.UID))
-	_, err = executor.fsCache.Add(*fsvc)
-	if err != nil {
-		return nil, err
-	}
 
 	return fsvc, fsvcErr
 }

--- a/executor/fscache/functionServiceCache.go
+++ b/executor/fscache/functionServiceCache.go
@@ -175,14 +175,14 @@ func (fsc *FunctionServiceCache) GetByFunctionUID(uid types.UID) (*FuncSvc, erro
 func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 	err, existing := fsc.byFunction.Set(crd.CacheKey(fsvc.Function), &fsvc)
 	if err != nil {
-		if existing != nil {
+		if IsNameExistError(err) {
 			f := existing.(*FuncSvc)
 			err2 := fsc.TouchByAddress(f.Address)
 			if err2 != nil {
 				return nil, err2
 			}
 			fCopy := *f
-			return &fCopy, err
+			return &fCopy, nil
 		}
 		return nil, err
 	}

--- a/executor/newdeploy/newdeploy.go
+++ b/executor/newdeploy/newdeploy.go
@@ -127,9 +127,8 @@ func (deploy *NewDeploy) setupRBACObjs(deployNamespace string, fn *crd.Function)
 	return nil
 }
 
-func (deploy *NewDeploy) getDeployment(fn *crd.Function) (*v1beta1.Deployment, error) {
-	deployName := deploy.getObjName(fn)
-	return deploy.kubernetesClient.ExtensionsV1beta1().Deployments(fn.Metadata.Namespace).Get(deployName, metav1.GetOptions{})
+func (deploy *NewDeploy) getDeployment(ns, name string) (*v1beta1.Deployment, error) {
+	return deploy.kubernetesClient.ExtensionsV1beta1().Deployments(ns).Get(name, metav1.GetOptions{})
 }
 
 func (deploy *NewDeploy) updateDeployment(deployment *v1beta1.Deployment, ns string) error {
@@ -428,9 +427,8 @@ func (deploy *NewDeploy) createOrGetHpa(hpaName string, execStrategy *fission.Ex
 
 }
 
-func (deploy *NewDeploy) getHpa(ns string, fn *crd.Function) (*asv1.HorizontalPodAutoscaler, error) {
-	hpaName := deploy.getObjName(fn)
-	return deploy.kubernetesClient.AutoscalingV1().HorizontalPodAutoscalers(ns).Get(hpaName, metav1.GetOptions{})
+func (deploy *NewDeploy) getHpa(ns, name string) (*asv1.HorizontalPodAutoscaler, error) {
+	return deploy.kubernetesClient.AutoscalingV1().HorizontalPodAutoscalers(ns).Get(name, metav1.GetOptions{})
 }
 
 func (deploy *NewDeploy) updateHpa(hpa *asv1.HorizontalPodAutoscaler) error {
@@ -510,6 +508,7 @@ func (deploy *NewDeploy) waitForDeploy(depl *v1beta1.Deployment, replicas int32)
 	return nil, errors.New("failed to create deployment within timeout window")
 }
 
+// cleanupNewdeploy cleans all kubernetes objects related to function
 func (deploy *NewDeploy) cleanupNewdeploy(ns string, name string) error {
 	var multierr *multierror.Error
 

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -251,7 +251,7 @@ func (deploy *NewDeploy) fnCreate(fn *crd.Function, firstcreate bool) (*fscache.
 
 	kubeObjRefs := []apiv1.ObjectReference{
 		{
-			//obj.TypeMeta.Kind does not work hence this, needs investigationa and a fix
+			//obj.TypeMeta.Kind does not work hence this, needs investigation and a fix
 			Kind:            "deployment",
 			Name:            depl.ObjectMeta.Name,
 			APIVersion:      depl.TypeMeta.APIVersion,

--- a/executor/newdeploy/newdeploymgr.go
+++ b/executor/newdeploy/newdeploymgr.go
@@ -547,6 +547,7 @@ func (deploy *NewDeploy) fnDelete(fn *crd.Function) (*fscache.FuncSvc, error) {
 	return nil, multierr.ErrorOrNil()
 }
 
+// getObjName returns a unique name for kubernetes objects of function
 func (deploy *NewDeploy) getObjName(fn *crd.Function) string {
 	return strings.ToLower(fmt.Sprintf("newdeploy-%v-%v-%v", fn.Metadata.Name, fn.Metadata.Namespace, uniuri.NewLen(8)))
 }

--- a/executor/poolmgr/gp.go
+++ b/executor/poolmgr/gp.go
@@ -362,12 +362,9 @@ func (gp *GenericPool) specializePod(pod *apiv1.Pod, metadata *metav1.ObjectMeta
 	return nil
 }
 
+// getPoolName returns a unique name of an environment
 func (gp *GenericPool) getPoolName() string {
-	// Use executor type as delimiter between function name and namespace to prevent deployment name conflict.
-	// For example:
-	// 1. fn-name: a-b fn-namespace: c => a-b-poolmgr-c
-	// 2. fn-name: a fn-namespace: b-c => a-poolmgr-b-c
-	return strings.ToLower(fmt.Sprintf("%v-poolmgr-%v", gp.env.Metadata.Name, gp.env.Metadata.Namespace))
+	return strings.ToLower(fmt.Sprintf("poolmgr-%v-%v-%v", gp.env.Metadata.Name, gp.env.Metadata.Namespace, uniuri.NewLen(8)))
 }
 
 // A pool is a deployment of generic containers for an env.  This

--- a/executor/poolmgr/gpm.go
+++ b/executor/poolmgr/gpm.go
@@ -159,7 +159,7 @@ func (gpm *GenericPoolManager) service() {
 				if !ok || poolsize == 0 {
 					// Env no longer exists or pool size changed to zero
 
-					log.Printf("Destroying generic pool for environment [%v]", key)
+					log.Printf("Destroying generic pool for environment %v", pool.env.Metadata)
 					delete(gpm.pools, key)
 
 					// and delete the pool asynchronously.

--- a/test/tests/test_backend_newdeploy.sh
+++ b/test/tests/test_backend_newdeploy.sh
@@ -56,7 +56,7 @@ log "Waiting for router & newdeploy deployment creation"
 sleep 5
 
 log "Doing an HTTP GET on the function's route"
-response1=$(curl http://$FISSION_ROUTER/$fn0)
+response1=$(curl http://$FISSION_ROUTER/$fn1)
 
 log "Checking for valid response"
 echo $response1 | grep -i hello


### PR DESCRIPTION
Fix #1054 

The root cause of the issue was introduced by PR https://github.com/fission/fission/pull/1009/files .
To be short, even the CRD of environment was delete, it still takes time for executor (poolmgr) to destroy env pool. So, when a user can create a same name env, following logs will be shown.
```
2019/01/08 11:01:26 Error creating deployment for nodejs-poolmgr-default in kubernetes, err: deployments.extensions "nodejs-poolmgr-default" already exists
2019/01/08 11:01:26 eager-create pool failed: deployments.extensions "nodejs-poolmgr-default" already exists
```
In our cases, the previous test creates an env and delete it when test finished, then the next one creates a same name env, but failed to create pool due to the deploy name conflict like log above. So the executor selects the pod from the first created env pool. Then, executor starts to delete the env pool, and makes the pod state became Termination state.

To fix this problem, a unique name of deployment will be returned after this PR to prevent the name conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1082)
<!-- Reviewable:end -->
