### PR TITLE
Add links to examples for each Fission environment

### DIFF
--- a/environments/binary/README.md
+++ b/environments/binary/README.md
@@ -7,6 +7,7 @@ Use Cases
 - Execute arbitrary binaries (such as common sysadmin tools)
 - Get support in _any_ programming language by executing the generated executable.
 
+
 ⚠️ **Words of Caution** ⚠️
 
 The environment runs on an alpine image with some additional utility commandline tools installed, such as 'grep'. 
@@ -15,6 +16,8 @@ Dockerfile and build a new binary environment. See 'Compiling' for instructions.
 
 When executing functions using binaries, **ensure that the executable is built for the right architecture**. 
 Using the default binary environment this means that the binary should be build for Linux.
+
+Looking for ready-to-run examples? See the [binary examples directory](../../examples/binary).
 
 ## Usage
 To get started with the latest binary environment:
@@ -42,8 +45,6 @@ HTTP_CONTENT-TYPE
 
 The body of HTTP piped over the STDIN to the executable. 
 All output that is provided to the server over the STDOUT will be transformed into the HTTP response.
-
-See the [README](../../examples/binary/README.md) in the binary examples directory for additional usage instructions.
 
 ## Compiling
 

--- a/environments/dotnet/README.md
+++ b/environments/dotnet/README.md
@@ -31,7 +31,8 @@ public class FissionFunction {
 }
 ```
 
-Please see examples below.
+Please see examples below, or if you are looking for ready-to-run examples, see 
+the [DotNet examples directory](../../examples/dotnet).
 
 ## Rebuilding and pushing the image
 

--- a/environments/dotnet20/README.md
+++ b/environments/dotnet20/README.md
@@ -31,7 +31,8 @@ public class FissionFunction {
 }
 ```
 
-Please see examples below.
+Please see examples below, or if you are looking for ready-to-run examples, see 
+the [DotNet20 examples directory](../../examples/dotnet20).
 
 ## Rebuilding and pushing the image
 

--- a/environments/go/README.md
+++ b/environments/go/README.md
@@ -4,6 +4,8 @@ This is the Go environment for Fission.
 
 It's a Docker image containing a Go runtime, along with a dynamic loader.
 
+Looking for ready-to-run examples? See the [Go examples directory](../../examples/go).
+
 ## Build this image
 
 ```
@@ -34,7 +36,3 @@ fission env update --name go --image USER/go-runtime --builder USER/go-builder
 
 After this, fission functions that have the env parameter set to the
 same environment name as this command will use this environment.
-
-## Creating functions to use this image
-
-See the [examples README](examples/go/README.md).

--- a/environments/jvm/README.md
+++ b/environments/jvm/README.md
@@ -6,6 +6,8 @@ It's a Docker image containing a OpenJDK8 runtime, along with a
 dynamic loader.  A few dependencies are included in the
 pom.xml file.
 
+Looking for ready-to-run examples? See the [JVM examples directory](../../examples/jvm).
+
 ## Customizing this image
 
 To add package dependencies, edit pom.xml to add what you

--- a/environments/nodejs/README.md
+++ b/environments/nodejs/README.md
@@ -6,6 +6,8 @@ It's a Docker image containing a NodeJS runtime, along with a dynamic
 loader.  A few common dependencies are included in the package.json
 file.
 
+Looking for ready-to-run examples? See the [NodeJS examples directory](../../examples/nodejs).
+
 ## Customizing this image
 
 To add package dependencies, edit package.json to add what you need,

--- a/environments/perl/README.md
+++ b/environments/perl/README.md
@@ -9,6 +9,8 @@ It is implemented using the lightweight web application framework
 Since Twiggy is implemented with [AnyEvent](https://metacpan.org/pod/AnyEvent),
 you can write async code using AnyEvent in your function.
 
+Looking for ready-to-run examples? See the [Perl examples directory](../../examples/perl).
+
 ## Build this image
    
 ```

--- a/environments/php7/README.md
+++ b/environments/php7/README.md
@@ -4,7 +4,7 @@ This is the PHP environment for Fission.
 
 It's a Docker image containing a PHP 7.3 runtime. This image use php:7.3-cli base image with the built-in PHP server
 
-This environment didn't force you to use class or create a main function.
+This environment does not force you to use a specific class or create a main function.
 
 A few common extensions are included :
 - curl
@@ -21,6 +21,8 @@ A few common extensions are included :
 - SimpleXML
 - xmlrpc
 - zip
+
+Looking for ready-to-run examples? See the [PHP examples directory](../../examples/php).
 
 ## Customizing this image
 

--- a/environments/python/README.md
+++ b/environments/python/README.md
@@ -6,6 +6,8 @@ It's a Docker image containing a Python 3.5 runtime, along with a
 dynamic loader.  A few common dependencies are included in the
 requirements.txt file.
 
+Looking for ready-to-run examples? See the [Python examples directory](../../examples/python).
+
 ## Customizing this image
 
 To add package dependencies, edit requirements.txt to add what you

--- a/environments/ruby/README.md
+++ b/environments/ruby/README.md
@@ -17,6 +17,8 @@ The `Fission::Request` object is a subclass of `Rack::Request` and
 provides access to parameters and headers. See `fission/request.rb`
 for the public api.
 
+Looking for ready-to-run examples? See the [Ruby examples directory](../../examples/ruby).
+
 ## Customizing this image
 
 To add package dependencies, edit Gemfile to add what you
@@ -50,7 +52,3 @@ Or, if you already have an environment, you can update its image:
 
 After this, fission functions that have the env parameter set to the
 same environment name as this command will use this environment.
-
-## Creating functions to use this image
-
-See the [examples README](examples/ruby/README.md).


### PR DESCRIPTION
I noticed that environment READMEs tend to have either no link to the examples, 
or have a link at the far bottom of the document. This PR resolves adds a direct 
link to examples of each environment near the top of the README.
I tried to keep the text consistent, but (for example for the DotNet environments) I
merged it into existing text to avoid having to spend time ensuring that the flow 
of the text is (accidentally) broken.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1090)
<!-- Reviewable:end -->
