### PR TITLE
Fix unit test testCRD random failure problem

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -46,7 +46,7 @@ import (
 
 // return the number of pods in the given namespace matching the given labels
 func countPods(kubeClient *kubernetes.Clientset, ns string, labelz map[string]string) int {
-	pods, err := kubeClient.Pods(ns).List(metav1.ListOptions{
+	pods, err := kubeClient.CoreV1().Pods(ns).List(metav1.ListOptions{
 		LabelSelector: labels.Set(labelz).AsSelector().String(),
 	})
 	if err != nil {
@@ -56,7 +56,7 @@ func countPods(kubeClient *kubernetes.Clientset, ns string, labelz map[string]st
 }
 
 func createTestNamespace(kubeClient *kubernetes.Clientset, ns string) {
-	_, err := kubeClient.Namespaces().Create(&apiv1.Namespace{
+	_, err := kubeClient.CoreV1().Namespaces().Create(&apiv1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: ns,
 		},
@@ -69,7 +69,7 @@ func createTestNamespace(kubeClient *kubernetes.Clientset, ns string) {
 
 // create a nodeport service
 func createSvc(kubeClient *kubernetes.Clientset, ns string, name string, targetPort int, nodePort int32, labels map[string]string) *apiv1.Service {
-	svc, err := kubeClient.Services(ns).Create(&apiv1.Service{
+	svc, err := kubeClient.CoreV1().Services(ns).Create(&apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
@@ -112,6 +112,7 @@ func TestExecutor(t *testing.T) {
 	testId := rand.Intn(999)
 	fissionNs := fmt.Sprintf("test-%v", testId)
 	functionNs := fmt.Sprintf("test-function-%v", testId)
+	builderNs := "fission-builder"
 
 	// skip test if no cluster available for testing
 	kubeconfig := os.Getenv("KUBECONFIG")
@@ -129,10 +130,10 @@ func TestExecutor(t *testing.T) {
 
 	// create the test's namespaces
 	createTestNamespace(kubeClient, fissionNs)
-	defer kubeClient.Namespaces().Delete(fissionNs, nil)
+	defer kubeClient.CoreV1().Namespaces().Delete(fissionNs, nil)
 
 	createTestNamespace(kubeClient, functionNs)
-	defer kubeClient.Namespaces().Delete(functionNs, nil)
+	defer kubeClient.CoreV1().Namespaces().Delete(functionNs, nil)
 
 	// make sure CRD types exist on cluster
 	err = crd.EnsureFissionCRDs(apiExtClient)
@@ -165,7 +166,7 @@ func TestExecutor(t *testing.T) {
 
 	// create poolmgr
 	port := 9999
-	err = StartExecutor(fissionNs, functionNs, port)
+	err = StartExecutor(fissionNs, functionNs, builderNs, port)
 	if err != nil {
 		log.Panicf("failed to start poolmgr: %v", err)
 	}
@@ -230,11 +231,11 @@ func TestExecutor(t *testing.T) {
 	labels := map[string]string{"functionName": f.Metadata.Name}
 	var fetcherPort int32 = 30001
 	fetcherSvc := createSvc(kubeClient, functionNs, fmt.Sprintf("%v-%v", f.Metadata.Name, "fetcher"), 8000, fetcherPort, labels)
-	defer kubeClient.Services(functionNs).Delete(fetcherSvc.ObjectMeta.Name, nil)
+	defer kubeClient.CoreV1().Services(functionNs).Delete(fetcherSvc.ObjectMeta.Name, nil)
 
 	var funcSvcPort int32 = 30002
 	functionSvc := createSvc(kubeClient, functionNs, f.Metadata.Name, 8888, funcSvcPort, labels)
-	defer kubeClient.Services(functionNs).Delete(functionSvc.ObjectMeta.Name, nil)
+	defer kubeClient.CoreV1().Services(functionNs).Delete(functionSvc.ObjectMeta.Name, nil)
 
 	// the main test: get a service for a given function
 	t1 := time.Now()


### PR DESCRIPTION
Kubernetes watch returns a sequence changes of CRD resources. In some cases, the older changes will be returned and break the test. To prevent this, we wait for a couple of seconds to ensure we get all changes from the server and then verify the content of the object.
https://travis-ci.org/fission/fission/builds/505781138#L1337-L1371

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1120)
<!-- Reviewable:end -->
