### PR TITLE
Fix TravisCI go environment version to avoid go bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 language: go
 
 go:
-  - 1.11.x
+  - 1.11.6
 
 cache:
   directories:


### PR DESCRIPTION
From go release history (https://golang.org/doc/devel/release.html#go1.11)
and travis ci build history, looks like 1.11.7 and 1.11.8 contains unknown
bugs that breaks build. To avoid this, fix go version to 1.11.6 for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1154)
<!-- Reviewable:end -->
