### PR TITLE
Fix the logger not working

### DIFF
--- a/charts/fission-all/templates/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit.yaml
@@ -32,6 +32,14 @@ spec:
       labels:
         svc: logger
     spec:
+      initContainers:
+        - name: init
+          image: busybox
+          command: ['mkdir', '-p', '/var/log/fission']
+          volumeMounts:
+            - name: container-log
+              mountPath: /var/log/
+              readOnly: false
       containers:
         - name: logger
           image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -78,7 +86,7 @@ spec:
           volumeMounts:
             - name: container-log
               mountPath: /var/log/
-              readOnly: true
+              readOnly: false
             - name: docker-log
               mountPath: /var/lib/docker/containers
               readOnly: true

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -170,6 +170,14 @@ func Start() {
 	}
 	defer zapLogger.Sync()
 
+	if _, err := os.Stat(fissionSymlinkPath); os.IsNotExist(err) {
+		zapLogger.Info("symlink path not exist, create it",
+			zap.String("fissionSymlinkPath", fissionSymlinkPath))
+		err = os.Mkdir(fissionSymlinkPath, 0755)
+		if err != nil {
+			zapLogger.Fatal("error creating fissionSymlinkPath", zap.Error(err))
+		}
+	}
 	go symlinkReaper(zapLogger)
 	_, kubernetesClient, _, err := crd.MakeFissionClient()
 	if err != nil {


### PR DESCRIPTION
#### Problem
- logger can't create symlink because `/var/log/fission` does not exist. The test can pass because `/var/log` is a `hostPath` volume and `/var/log/fission` already exists on all nodes.
- fluentbit cannot open database `/var/log/fission/flb_kube.db`

#### Solution
- Use an init container to create `/var/log/fission`.
- Create `fissionSymlinkPath` if it does not exist when logger start. It's in case if the log path changed in the future or someone run logger directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1166)
<!-- Reviewable:end -->
