### PR TITLE
Remove prometheus server connectivity test during controller initialization

### DIFF
--- a/canaryconfigmgr/prometheusClient.go
+++ b/canaryconfigmgr/prometheusClient.go
@@ -44,7 +44,6 @@ func MakePrometheusClient(logger *zap.Logger, prometheusSvc string) (*Prometheus
 
 	apiQueryClient := promClient.NewQueryAPI(promApiClient)
 
-	logger.Info("successfully made prometheus client with service", zap.String("service", prometheusSvc))
 	return &PrometheusApiClient{
 		logger: logger.Named("prometheus_api_client"),
 		client: apiQueryClient,

--- a/canaryconfigmgr/prometheusClient.go
+++ b/canaryconfigmgr/prometheusClient.go
@@ -44,21 +44,6 @@ func MakePrometheusClient(logger *zap.Logger, prometheusSvc string) (*Prometheus
 
 	apiQueryClient := promClient.NewQueryAPI(promApiClient)
 
-	// By default, the prometheus client library doesn't test server connectivity when creating
-	// prometheus client. As a workaround, here we send out a test query string to ensure that
-	// prometheus server is running.
-	for i := 0; i < 15; i++ {
-		_, err = apiQueryClient.Query(context.Background(), "http_requests_total", time.Now())
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-
-	if err != nil {
-		return nil, errors.Wrap(err, "error sending test query to prometheus server")
-	}
-
 	logger.Info("successfully made prometheus client with service", zap.String("service", prometheusSvc))
 	return &PrometheusApiClient{
 		logger: logger.Named("prometheus_api_client"),


### PR DESCRIPTION
The prometheus server may not up in a short time or a cluster doesn’t have a storage class config. Because of this, the connectivity test will increase controller initialization time and so the controller will fail at readiness probe detection. Since we don’t want to delay the time that controller comes up also canary config manager prints error log when it failed at connecting to prometheus server, I remove the connectivity test here.

Fix #1165 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1179)
<!-- Reviewable:end -->
