### PR TITLE
Add extraCoreComponmentPodConfig helm value to allow setting 

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `debugEnv` | If there are any pod specialization errors when a function is triggered and this flag is set to true, the error summary is returned as part of http response | `true`
 `prometheusDeploy` | Set to true if prometheus needs to be deployed along with fission | `true` in `fission-all`, `false` in `fission-core`
 `canaryDeployment.enabled` | Set to true if you need canary deployment feature | `true` in `fission-all`, `false` in `fission-core`
+`extraCoreComponmentPodConfig` | Extend the container specs for the core fission pods. Can be used to add things like affinty/tolerations/nodeSelectors/etc. | None
 
 ### Extra configuration for `fission-all`
 

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -163,6 +163,9 @@ spec:
       - name: config-volume
         configMap:
           name: feature-config
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -235,7 +238,9 @@ spec:
         - containerPort: 8888
           name: http
       serviceAccount: fission-svc
-
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -316,7 +321,9 @@ spec:
         - containerPort: 8888
           name: http
       serviceAccount: fission-svc
-
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -359,7 +366,9 @@ spec:
         - name: FETCHER_MAXMEM
           value: {{ .Values.fetcherMaxMem | default "128Mi" | quote }}          
       serviceAccount: fission-svc
-
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -384,7 +393,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
       serviceAccount: fission-svc
-
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -432,7 +443,9 @@ spec:
               secretKeyRef:
                 name: influxdb
                 key: password
-
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 {{- if .Values.heapster }}
 ---
 apiVersion: v1
@@ -497,7 +510,9 @@ spec:
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
-
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 #
 # This is commented out until fission-ui allows configuring the
 # namespace. Right now it just crashes if Release.Namespace !=
@@ -554,6 +569,9 @@ spec:
         - containerPort: 4222
           hostPort: 4222
           protocol: TCP
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -583,6 +601,8 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}          
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
 {{- end }}
 
 {{- if .Values.kafka.enabled }}
@@ -617,6 +637,8 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}          
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
 {{- end }}
 
 {{- if .Values.azureStorageQueue.enabled }}
@@ -654,6 +676,8 @@ spec:
               name: azure-storage-account-key
               key: key
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
 {{- end }}
 ---
 apiVersion: extensions/v1beta1
@@ -705,4 +729,7 @@ spec:
           claimName: {{ .Values.persistence.existingClaim | default "fission-storage-pvc" }}
       {{- else }}
         emptyDir: {}
-      {{- end -}}
+      {{- end }}
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -163,9 +163,9 @@ spec:
       - name: config-volume
         configMap:
           name: feature-config
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -238,9 +238,9 @@ spec:
         - containerPort: 8888
           name: http
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -321,9 +321,9 @@ spec:
         - containerPort: 8888
           name: http
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -366,9 +366,9 @@ spec:
         - name: FETCHER_MAXMEM
           value: {{ .Values.fetcherMaxMem | default "128Mi" | quote }}          
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -393,9 +393,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -443,9 +443,9 @@ spec:
               secretKeyRef:
                 name: influxdb
                 key: password
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+        {{- if .Values.extraCoreComponmentPodConfig }}
+          {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+        {{- end }}
 {{- if .Values.heapster }}
 ---
 apiVersion: v1
@@ -510,9 +510,9 @@ spec:
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 #
 # This is commented out until fission-ui allows configuring the
 # namespace. Right now it just crashes if Release.Namespace !=
@@ -569,9 +569,9 @@ spec:
         - containerPort: 4222
           hostPort: 4222
           protocol: TCP
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+    {{- if .Values.extraCoreComponmentPodConfig }}
+      {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+    {{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -601,8 +601,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}          
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 {{- end }}
 
 {{- if .Values.kafka.enabled }}
@@ -637,8 +638,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}          
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 {{- end }}
 
 {{- if .Values.azureStorageQueue.enabled }}
@@ -676,9 +678,10 @@ spec:
               name: azure-storage-account-key
               key: key
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
+{{- end }}      
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -730,6 +733,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{- end }}
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -106,6 +106,24 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
 
+## Extend the container specs for the core fission pods. 
+## Can be used to add things like affinty/tolerations/nodeSelectors/etc.
+## For example:
+## extraCoreComponmentPodConfig:
+##   affinity:
+##     nodeAffinity:
+##       requiredDuringSchedulingIgnoredDuringExecution:
+##         nodeSelectorTerms:
+##           - matchExpressions:
+##             - key: capability
+##               operator: In
+##               values:
+##                 - app
+extraCoreComponmentPodConfig:
+#  affinity:
+#  tolerations:
+#  nodeSelector:
+
 ## Analytics let us count how many people installed fission. Set to
 ## false to disable analytics.
 analytics: true

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -164,6 +164,9 @@ spec:
       - name: config-volume
         configMap:
           name: feature-config
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -232,6 +235,9 @@ spec:
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 
 ---
 apiVersion: v1
@@ -306,6 +312,9 @@ spec:
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -349,6 +358,9 @@ spec:
         - name: FETCHER_MAXMEM
           value: {{ .Values.fetcherMaxMem | default "128Mi" | quote }}          
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -374,6 +386,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -399,6 +414,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
       serviceAccount: fission-svc
+{{- if .Values.extraCoreComponmentPodConfig }}
+{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+{{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -437,4 +455,7 @@ spec:
           claimName: {{ .Values.persistence.existingClaim | default "fission-storage-pvc" }}
       {{- else }}
         emptyDir: {}
-      {{- end -}}
+      {{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -164,9 +164,9 @@ spec:
       - name: config-volume
         configMap:
           name: feature-config
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -235,9 +235,9 @@ spec:
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 
 ---
 apiVersion: v1
@@ -312,9 +312,9 @@ spec:
           initialDelaySeconds: 35
           periodSeconds: 5
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -358,9 +358,9 @@ spec:
         - name: FETCHER_MAXMEM
           value: {{ .Values.fetcherMaxMem | default "128Mi" | quote }}          
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -386,9 +386,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 
 ---
 apiVersion: extensions/v1beta1
@@ -414,9 +414,9 @@ spec:
         - name: TRACING_SAMPLING_RATE
           value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
       serviceAccount: fission-svc
-{{- if .Values.extraCoreComponmentPodConfig }}
-{{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
-{{- end }}
+      {{- if .Values.extraCoreComponmentPodConfig }}
+        {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
+      {{- end }}
 
 ---
 apiVersion: extensions/v1beta1

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -68,6 +68,24 @@ persistence:
   accessMode: ReadWriteOnce
   size: 8Gi
 
+## Extend the container specs for the core fission pods. 
+## Can be used to add things like affinty/tolerations/nodeSelectors/etc.
+## For example:
+## extraCoreComponmentPodConfig:
+##   affinity:
+##     nodeAffinity:
+##       requiredDuringSchedulingIgnoredDuringExecution:
+##         nodeSelectorTerms:
+##           - matchExpressions:
+##             - key: capability
+##               operator: In
+##               values:
+##                 - app
+extraCoreComponmentPodConfig:
+#  affinity:
+#  tolerations:
+#  nodeSelector:
+
 ## Analytics let us count how many people installed fission. Set to
 ## false to disable analytics.
 analytics: true


### PR DESCRIPTION
of affinty/tolerations/nodeSelectors/etc on core pods

Alter ego of https://github.com/fission/fission/pull/1170 for integration tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1186)
<!-- Reviewable:end -->
