### PR TITLE
Fix Istio-proxy cannot collect HTTP-level information

### DIFF
--- a/pkg/executor/newdeploy/newdeploy.go
+++ b/pkg/executor/newdeploy/newdeploy.go
@@ -217,6 +217,13 @@ func (deploy *NewDeploy) getDeploymentSpec(fn *fv1.Function, env *fv1.Environmen
 									},
 								},
 							},
+							// https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
+							Ports: []apiv1.ContainerPort{
+								{
+									Name:          "http-env",
+									ContainerPort: int32(8888),
+								},
+							},
 							Resources: resources,
 						}, env.Spec.Runtime.Container),
 					},
@@ -362,14 +369,9 @@ func (deploy *NewDeploy) createOrGetSvc(deployLabels map[string]string, svcName 
 			Spec: apiv1.ServiceSpec{
 				Ports: []apiv1.ServicePort{
 					{
-						Name:       "runtime-env-port",
+						Name:       "http-env",
 						Port:       int32(80),
 						TargetPort: intstr.FromInt(8888),
-					},
-					{
-						Name:       "fetcher-port",
-						Port:       int32(8000),
-						TargetPort: intstr.FromInt(8000),
 					},
 				},
 				Selector: deployLabels,

--- a/pkg/executor/poolmgr/funcwatcher.go
+++ b/pkg/executor/poolmgr/funcwatcher.go
@@ -106,20 +106,15 @@ func (gpm *GenericPoolManager) makeFuncController(fissionClient *crd.FissionClie
 							Type: apiv1.ServiceTypeClusterIP,
 							Ports: []apiv1.ServicePort{
 								// Service port name should begin with a recognized prefix, or the traffic will be
-								// treated as TCP traffic. (https://istio.io/docs/setup/kubernetes/sidecar-injection.html)
-								// Originally the ports' name are similar to "http-fetch" and "http-specialize".
-								// But for istio 0.5.1, istio-proxy return unexpected 431 error with such naming.
-								// https://github.com/istio/istio/issues/928
-								// Workaround: remove prefix
-								// TODO: prepend prefix once the bug fixed
+								// treated as TCP traffic. (https://istio.io/docs/setup/kubernetes/additional-setup/requirements/)
 								{
-									Name:       "fetch",
+									Name:       "http-fetcher",
 									Protocol:   apiv1.ProtocolTCP,
 									Port:       8000,
 									TargetPort: intstr.FromInt(8000),
 								},
 								{
-									Name:       "specialize",
+									Name:       "http-env",
 									Protocol:   apiv1.ProtocolTCP,
 									Port:       8888,
 									TargetPort: intstr.FromInt(8888),


### PR DESCRIPTION
Fix #548 

Known issue: Jaeger shows <trace-without-root-span> (This may related to Istio problem.)
<img width="1353" alt="Screen Shot 2019-06-20 at 6 12 27 AM" src="https://user-images.githubusercontent.com/202578/59804973-84eff400-9322-11e9-9841-efa175a2fdbf.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1209)
<!-- Reviewable:end -->
