### PR TITLE
Fix roundtripper doesn't increase request timeout setting after each retry

### DIFF
--- a/pkg/error/network/error.go
+++ b/pkg/error/network/error.go
@@ -26,7 +26,7 @@ import (
 
 type (
 	Error struct {
-		err error
+		err net.Error
 	}
 )
 
@@ -85,6 +85,28 @@ func (e Error) IsConnRefusedError() bool {
 			switch errno {
 			case syscall.ECONNREFUSED:
 				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// IsTimeoutError returns true if its a network timeout error
+func (e Error) IsTimeoutError() bool {
+	if e.err.Timeout() {
+		return true
+	}
+
+	opErr, ok := e.err.(*net.OpError)
+	if ok {
+		switch t := opErr.Err.(type) {
+		case *os.SyscallError:
+			if errno, ok := t.Err.(syscall.Errno); ok {
+				switch errno {
+				case syscall.ETIMEDOUT:
+					return true
+				}
 			}
 		}
 	}

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -100,7 +100,7 @@ func (c *Client) service() {
 							c.logger.Error("error tapping function service address", zap.Error(err), zap.String("address", u))
 						}
 					}
-					c.logger.Info("tapped services in batch", zap.Int("service_count", len(urls)))
+					c.logger.Debug("tapped services in batch", zap.Int("service_count", len(urls)))
 				}()
 			}
 		}

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -303,7 +303,7 @@ func (ts *HTTPTriggerSet) initFunctionController() (k8sCache.Store, k8sCache.Con
 						rr.functionMetadataMap[fn.Metadata.Name] != nil &&
 						rr.functionMetadataMap[fn.Metadata.Name].ResourceVersion != fn.Metadata.ResourceVersion {
 						// invalidate resolver cache
-						ts.logger.Info("invalidating resolver cache")
+						ts.logger.Debug("invalidating resolver cache")
 						err := ts.resolver.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
 						if err != nil {
 							ts.logger.Error("error deleting functionReferenceResolver cache", zap.Error(err))

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -253,7 +253,6 @@ func (ts *HTTPTriggerSet) initTriggerController() (k8sCache.Store, k8sCache.Cont
 					ts.logger.Error("unable to lookup function in functionRecorderMap", zap.Error(err))
 				} else {
 					ts.logger.Error("unable to lookup function in functionRecorderMap")
-
 				}
 			},
 			DeleteFunc: func(obj interface{}) {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -64,9 +64,7 @@ import (
 // request url ---[trigger]---> Function(name, deployment) ----[deployment]----> Function(name, uid) ----[pool mgr]---> k8s service url
 
 func router(ctx context.Context, logger *zap.Logger, httpTriggerSet *HTTPTriggerSet, resolver *functionReferenceResolver) *mutableRouter {
-	muxRouter := mux.NewRouter()
-	mr := NewMutableRouter(logger, muxRouter)
-	muxRouter.Use(utils.LoggingMiddleware(logger))
+	mr := NewMutableRouter(logger, mux.NewRouter())
 	httpTriggerSet.subscribeRouter(ctx, mr, resolver)
 	return mr
 }
@@ -170,7 +168,7 @@ func Start(logger *zap.Logger, port int, executorUrl string) {
 	svcAddrRetryCount, err := strconv.Atoi(svcAddrRetryCountStr)
 	if err != nil {
 		svcAddrRetryCount = 5
-		logger.Info("failed to parse service address retry count from 'ROUTER_SVC_ADDRESS_MAX_RETRIES' - set to the default value",
+		logger.Error("failed to parse service address retry count from 'ROUTER_ROUND_TRIP_SVC_ADDRESS_MAX_RETRIES' - set to the default value",
 			zap.Error(err),
 			zap.String("value", svcAddrRetryCountStr),
 			zap.Int("default", svcAddrRetryCount))
@@ -182,7 +180,7 @@ func Start(logger *zap.Logger, port int, executorUrl string) {
 	svcAddrUpdateTimeout, err := time.ParseDuration(os.Getenv("ROUTER_SVC_ADDRESS_UPDATE_TIMEOUT"))
 	if err != nil {
 		svcAddrUpdateTimeout = 30 * time.Second
-		logger.Info("failed to parse service address update timeout duration from 'ROUTER_ROUND_TRIP_SVC_ADDRESS_UPDATE_TIMEOUT' - set to the default value",
+		logger.Error("failed to parse service address update timeout duration from 'ROUTER_ROUND_TRIP_SVC_ADDRESS_UPDATE_TIMEOUT' - set to the default value",
 			zap.Error(err),
 			zap.String("value", svcAddrUpdateTimeoutStr),
 			zap.Duration("default", svcAddrUpdateTimeout))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -72,7 +72,7 @@ func LoggingMiddleware(logger *zap.Logger) func(next http.Handler) http.Handler 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			requestURI := r.RequestURI
-			if !strings.Contains(requestURI, "healthz") {
+			if !strings.HasSuffix(requestURI, "healthz") {
 				// Call the next handler, which can be another middleware in the chain, or the final handler.
 				handlers.CustomLoggingHandler(os.Stdout, next, func(writer io.Writer, params handlers.LogFormatterParams) {
 					host, _, err := net.SplitHostPort(params.Request.RemoteAddr)
@@ -81,7 +81,7 @@ func LoggingMiddleware(logger *zap.Logger) func(next http.Handler) http.Handler 
 						host = params.Request.RemoteAddr
 					}
 
-					logger.Info("handled",
+					logger.Debug("handled",
 						zap.String("host", host),
 						zap.String("method", params.Request.Method),
 						zap.String("uri", params.Request.RequestURI),


### PR DESCRIPTION
1. Fix roundtripper doesn't increase request timeout setting after each retry.
2. Fix "context canceled" problem when calling getServiceEntry due to short request timeout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1216)
<!-- Reviewable:end -->
