### PR TITLE
Switch from Heapster to Metric Server

### DIFF
--- a/charts/fission-all/requirements.lock
+++ b/charts/fission-all/requirements.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: prometheus
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 7.1.0
-digest: sha256:867c8666d4dee6ae36b0e418f132f3187fd189bcbb36875f2c06e3fbe2402cfe
-generated: 2019-01-03T16:29:53.158684+01:00
+- name: metrics-server
+  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 2.8.2
+digest: sha256:3e42abb66122a9ae4ce8222222d7b6bb8a0943d1eb0f72c2f73cbe3965c08ebf
+generated: 2019-07-03T15:32:44.621446+05:30

--- a/charts/fission-all/requirements.yaml
+++ b/charts/fission-all/requirements.yaml
@@ -3,3 +3,7 @@ dependencies:
     version: 7.1.0
     repository: https://kubernetes-charts.storage.googleapis.com
     condition: prometheusDeploy
+  - name: metrics-server
+    version: 2.8.2
+    repository: https://kubernetes-charts.storage.googleapis.com
+    condition: heapster,metricServer.enabled

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -450,50 +450,6 @@ spec:
 {{- if .Values.extraCoreComponmentPodConfig }}
 {{ toYaml .Values.extraCoreComponmentPodConfig | indent 6 -}}
 {{- end }}
-
-{{- if .Values.heapster }}
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: heapster
-  namespace: kube-system
-  labels:
-    svc: heapster
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    kubernetes.io/cluster-service: 'true'
-    kubernetes.io/name: heapster
-spec:
-  type: ClusterIP 
-  ports:
-  - port: 80
-    targetPort: 8082
-  selector:
-    svc: heapster
----
-apiVersion: extensions/v1beta1
-kind: Deployment
-metadata:
-  name: heapster
-  namespace: kube-system
-  labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-spec:
-  replicas: 1
-  template:
-    metadata:
-      labels:
-        svc: heapster
-    spec:
-      containers:
-      - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.5.0
-        imagePullPolicy: {{ .Values.pullPolicy }}
-        command: 
-        - /heapster
-        - --source=kubernetes:https://kubernetes.default
-      serviceAccount: {{ .Release.Namespace }}/fission-svc
-{{- end }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -131,8 +131,12 @@ analytics: true
 ## Internally used for generating an analytics job for non-helm installs
 analyticsNonHelmInstall: false
 
-## Enable Heapster only in clusters where heapster does not exist already
-heapster: false
+## Enable Metric server, for backward compatibility the flag `heapster: false/true` also works
+## For overriding additional values from Metric Server chart, use Helm's child parent format (https://helm.sh/docs/developing_charts/#using-the-child-parent-format)
+metricServer: 
+  enabled: true
+
+
 
 ## Archive pruner is a garbage collector for archives on the fission storage service.
 ## This interval configures the frequency at which it runs inside the storagesvc pod.


### PR DESCRIPTION
This fixes https://github.com/fission/fission/issues/812 

But there are issues/docs updates needed as people typically face issues with insecure certs etc. which need sending appropriate arguments to metric server. Related issues:

Cloud: https://github.com/kubernetes-incubator/metrics-server/issues/157

Minikube/Local envs: https://github.com/kubernetes-incubator/metrics-server/issues/167

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1219)
<!-- Reviewable:end -->
