### PR TITLE
Revert change of product name in  README

### DIFF
--- a/pkg/fission-cli/spec.go
+++ b/pkg/fission-cli/spec.go
@@ -88,7 +88,7 @@ resources on the cluster to resources in this directory.
 
 All resources created by 'fission spec apply' are annotated with this UID.  Resources on
 the cluster that are _not_ annotated with this UID are never modified or deleted by
-fv1.
+fission.
 
 `
 


### PR DESCRIPTION
Looks like it was caught up in the package rename search and replace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1250)
<!-- Reviewable:end -->
