### PR TITLE
Issue #1258: Allow empty repository tag in chart values.yaml

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -31,3 +31,13 @@ canary:
   {{- printf "\n" -}}
 {{- end -}}
 
+{{- define "fission-all-bundleImage" -}}
+{{- $repositoryName := .Values.repository -}}
+{{- $imageName := .Values.image -}}
+{{- $imageTag := .Values.imageTag | toString -}}
+{{- if .Values.repository }}
+        {{- printf " %s/%s:%s" $repositoryName $imageName $imageTag -}}
+{{- else }}
+        {{- printf " %s:%s" $imageName $imageTag -}}
+{{- end }}
+{{- end -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -34,7 +34,7 @@ canary:
 {{/*
 This template generates the image name for the deployment depending on the value of "repository" field in values.yaml file.
 */}}
-{{- define "fission-all-bundleImage" -}}
+{{- define "fission-bundleImage" -}}
 {{- if .Values.repository -}}
     {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
 {{- else -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -31,13 +31,13 @@ canary:
   {{- printf "\n" -}}
 {{- end -}}
 
+{{/*
+This template generates the image name for the deployment depending on the value of "repository" field in values.yaml file.
+*/}}
 {{- define "fission-all-bundleImage" -}}
-{{- $repositoryName := .Values.repository -}}
-{{- $imageName := .Values.image -}}
-{{- $imageTag := .Values.imageTag | toString -}}
-{{- if .Values.repository }}
-        {{- printf " %s/%s:%s" $repositoryName $imageName $imageTag -}}
-{{- else }}
-        {{- printf " %s:%s" $imageName $imageTag -}}
+{{- if .Values.repository -}}
+    {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
+{{- else -}}
+    {{ .Values.image }}:{{ .Values.imageTag }}    
 {{- end }}
 {{- end -}}

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -128,11 +128,7 @@ spec:
     spec:
       containers:
       - name: controller
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -196,11 +192,7 @@ spec:
     spec:
       containers:
       - name: router
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -293,11 +285,7 @@ spec:
     spec:
       containers:
       - name: executor
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -363,11 +351,7 @@ spec:
     spec:
       containers:
       - name: buildermgr
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -415,11 +399,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -543,11 +523,7 @@ spec:
     spec:
       containers:
       - name: timer
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
@@ -652,11 +628,7 @@ spec:
     spec:
       containers:
       - name: mqtrigger
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -772,11 +744,7 @@ spec:
     spec:
       containers:
       - name: storagesvc
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-all-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -192,7 +192,7 @@ spec:
     spec:
       containers:
       - name: router
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: executor
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -351,7 +351,7 @@ spec:
     spec:
       containers:
       - name: buildermgr
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -399,7 +399,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -523,7 +523,7 @@ spec:
     spec:
       containers:
       - name: timer
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
@@ -628,7 +628,7 @@ spec:
     spec:
       containers:
       - name: mqtrigger
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -744,7 +744,7 @@ spec:
     spec:
       containers:
       - name: storagesvc
-        image: {{ template "fission-all-bundleImage" . }}
+        image: {{ include "fission-all-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -128,7 +128,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -192,7 +192,7 @@ spec:
     spec:
       containers:
       - name: router
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: executor
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -351,7 +351,7 @@ spec:
     spec:
       containers:
       - name: buildermgr
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -399,7 +399,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -523,7 +523,7 @@ spec:
     spec:
       containers:
       - name: timer
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
@@ -628,7 +628,7 @@ spec:
     spec:
       containers:
       - name: mqtrigger
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -744,7 +744,7 @@ spec:
     spec:
       containers:
       - name: storagesvc
-        image: {{ include "fission-all-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -128,7 +128,11 @@ spec:
     spec:
       containers:
       - name: controller
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -192,7 +196,11 @@ spec:
     spec:
       containers:
       - name: router
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -285,7 +293,11 @@ spec:
     spec:
       containers:
       - name: executor
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -351,7 +363,11 @@ spec:
     spec:
       containers:
       - name: buildermgr
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -399,7 +415,11 @@ spec:
     spec:
       containers:
       - name: kubewatcher
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -523,7 +543,11 @@ spec:
     spec:
       containers:
       - name: timer
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
@@ -628,7 +652,11 @@ spec:
     spec:
       containers:
       - name: mqtrigger
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -744,7 +772,11 @@ spec:
     spec:
       containers:
       - name: storagesvc
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-all/templates/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit.yaml
@@ -42,7 +42,11 @@ spec:
               readOnly: false
       containers:
         - name: logger
+{{ if .Values.repository }}
           image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME
@@ -60,7 +64,11 @@ spec:
               mountPath: /var/lib/docker/containers
               readOnly: true
         - name: fluentbit
+{{- if .Values.repository }}
           image: "{{ .Values.logger.fluentdImageRepository }}/{{ .Values.logger.fluentdImage }}:{{ .Values.logger.fluentdImageTag }}"
+{{ else }}
+          image: "{{ .Values.logger.fluentdImage }}:{{ .Values.logger.fluentdImageTag }}"
+{{- end }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           # CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf"]
           command: ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluentbit.conf"]

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -10,6 +10,7 @@ serviceType: ClusterIP
 routerServiceType: LoadBalancer
 
 ## Image base repository
+## Leave it empty for using existing local image
 repository: index.docker.io
 
 ## Fission image repository

--- a/charts/fission-core/templates/_helpers.tpl
+++ b/charts/fission-core/templates/_helpers.tpl
@@ -29,3 +29,14 @@ canary:
   {{- end }}
   {{- printf "\n" -}}
 {{- end -}}
+
+{{- define "fission-core-bundleImage" -}}
+{{- $repositoryName := .Values.repository -}}
+{{- $imageName := .Values.image -}}
+{{- $imageTag := .Values.imageTag | toString -}}
+{{- if .Values.repository }}
+        {{- printf " %s/%s:%s" $repositoryName $imageName $imageTag -}}
+{{- else }}
+        {{- printf " %s:%s" $imageName $imageTag -}}
+{{- end }}
+{{- end -}}

--- a/charts/fission-core/templates/_helpers.tpl
+++ b/charts/fission-core/templates/_helpers.tpl
@@ -33,7 +33,7 @@ canary:
 {{/*
 This template generates the image name for the deployment depending on the value of "repository" field in values.yaml file.
 */}}
-{{- define "fission-core-bundleImage" -}}
+{{- define "fission-bundleImage" -}}
 {{- if .Values.repository -}}
     {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
 {{- else -}}

--- a/charts/fission-core/templates/_helpers.tpl
+++ b/charts/fission-core/templates/_helpers.tpl
@@ -30,13 +30,13 @@ canary:
   {{- printf "\n" -}}
 {{- end -}}
 
+{{/*
+This template generates the image name for the deployment depending on the value of "repository" field in values.yaml file.
+*/}}
 {{- define "fission-core-bundleImage" -}}
-{{- $repositoryName := .Values.repository -}}
-{{- $imageName := .Values.image -}}
-{{- $imageTag := .Values.imageTag | toString -}}
-{{- if .Values.repository }}
-        {{- printf " %s/%s:%s" $repositoryName $imageName $imageTag -}}
-{{- else }}
-        {{- printf " %s:%s" $imageName $imageTag -}}
+{{- if .Values.repository -}}
+    {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
+{{- else -}}
+    {{ .Values.image }}:{{ .Values.imageTag }}    
 {{- end }}
 {{- end -}}

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -129,11 +129,7 @@ spec:
     spec:
       containers:
       - name: controller
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -196,11 +192,7 @@ spec:
     spec:
       containers:
       - name: router
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -293,11 +285,7 @@ spec:
     spec:
       containers:
       - name: executor
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -359,11 +347,7 @@ spec:
     spec:
       containers:
       - name: buildermgr
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -409,11 +393,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -441,11 +421,7 @@ spec:
     spec:
       containers:
       - name: timer
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -474,11 +450,7 @@ spec:
     spec:
       containers:
       - name: storagesvc
-{{ if .Values.repository }}
-        image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+        image: {{ template "fission-core-bundleImage" . }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -129,7 +129,11 @@ spec:
     spec:
       containers:
       - name: controller
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -192,7 +196,11 @@ spec:
     spec:
       containers:
       - name: router
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -285,7 +293,11 @@ spec:
     spec:
       containers:
       - name: executor
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -347,7 +359,11 @@ spec:
     spec:
       containers:
       - name: buildermgr
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -393,7 +409,11 @@ spec:
     spec:
       containers:
       - name: kubewatcher
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -421,7 +441,11 @@ spec:
     spec:
       containers:
       - name: timer
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -450,7 +474,11 @@ spec:
     spec:
       containers:
       - name: storagesvc
+{{ if .Values.repository }}
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+{{ end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -192,7 +192,7 @@ spec:
     spec:
       containers:
       - name: router
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: executor
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -347,7 +347,7 @@ spec:
     spec:
       containers:
       - name: buildermgr
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -393,7 +393,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -421,7 +421,7 @@ spec:
     spec:
       containers:
       - name: timer
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -450,7 +450,7 @@ spec:
     spec:
       containers:
       - name: storagesvc
-        image: {{ include "fission-core-bundleImage" . | quote }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
     spec:
       containers:
       - name: controller
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -192,7 +192,7 @@ spec:
     spec:
       containers:
       - name: router
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -285,7 +285,7 @@ spec:
     spec:
       containers:
       - name: executor
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -347,7 +347,7 @@ spec:
     spec:
       containers:
       - name: buildermgr
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -393,7 +393,7 @@ spec:
     spec:
       containers:
       - name: kubewatcher
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--kubewatcher", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -421,7 +421,7 @@ spec:
     spec:
       containers:
       - name: timer
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--timer", "--routerUrl", "http://router.{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
@@ -450,7 +450,7 @@ spec:
     spec:
       containers:
       - name: storagesvc
-        image: {{ template "fission-core-bundleImage" . }}
+        image: {{ include "fission-core-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--storageServicePort", "8000", "--filePath", "/fission", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -10,6 +10,7 @@ serviceType: ClusterIP
 routerServiceType: LoadBalancer
 
 ## Image base repository
+## Leave it empty for using existing local image
 repository: index.docker.io
 
 ## Fission image repository


### PR DESCRIPTION
…yaml

This fix allows the empty repository tag in values.yaml file.
The changes are done in the templates of deployment and fluentbit where repository tag will be added
in the docker image name only when specified with some value in case of empty repository tag image name
contain the name of image and tag only.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1259)
<!-- Reviewable:end -->
