### PR TITLE
fix a panic bug caused by err.Error()

### DIFF
--- a/pkg/mqtrigger/messageQueue/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka.go
@@ -214,7 +214,7 @@ func kafkaMsgHandler(kafka *Kafka, producer sarama.SyncProducer, trigger *fv1.Me
 	}
 	if resp.StatusCode != 200 {
 		errorHandler(kafka.logger, trigger, producer, url,
-			errors.Wrapf(err, "request returned failure: %v", resp.StatusCode))
+			fmt.Errorf("request returned failure: %v", resp.StatusCode))
 		return false
 	}
 	if len(trigger.Spec.ResponseTopic) > 0 {

--- a/pkg/mqtrigger/messageQueue/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka.go
@@ -17,6 +17,7 @@ limitations under the License.
 package messageQueue
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"


### PR DESCRIPTION
fix bug: 
funciton errorHandler use err.Error(), that will cause panic, because errors.Wrapf("request returned failure: %v", resp.StatusCode) return nil
<pre>
panic: runtime error: invalid memory address or nil pointer dereference

/go/src/github.com/fission/fission/pkg/mqtrigger/messageQueue/kafka.go:256
</pre>

@life1347

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1271)
<!-- Reviewable:end -->
