### PR TITLE
Update go environment errors for specializeHandlerV2

### DIFF
--- a/environments/go/server.go
+++ b/environments/go/server.go
@@ -153,14 +153,14 @@ func specializeHandlerV2(logger *zap.Logger) func(http.ResponseWriter, *http.Req
 			if os.IsNotExist(err) {
 				logger.Error("code path does not exist",
 					zap.Error(err),
-					zap.String("code_path", CODE_PATH))
+					zap.String("code_path", loadreq.FilePath))
 				w.WriteHeader(http.StatusNotFound)
-				w.Write([]byte(CODE_PATH + ": not found"))
+				w.Write([]byte(loadreq.FilePath + ": not found"))
 				return
 			} else {
 				logger.Error("unknown error looking for code path",
 					zap.Error(err),
-					zap.String("code_path", CODE_PATH))
+					zap.String("code_path", loadreq.FilePath))
 				err = errors.Wrap(err, "unknown error")
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(err.Error()))


### PR DESCRIPTION
The current error for v2 reports CODE_PATH instead of loadreq.FilePath

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1294)
<!-- Reviewable:end -->
