### PR TITLE
List/Delete HTTP triggers by function

### DIFF
--- a/pkg/fission-cli/httptrigger.go
+++ b/pkg/fission-cli/httptrigger.go
@@ -18,12 +18,12 @@ package fission_cli
 
 import (
 	"fmt"
-	"github.com/hashicorp/go-multierror"
 	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/satori/go.uuid"
 	"github.com/urfave/cli"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/fission-cli/httptrigger.go
+++ b/pkg/fission-cli/httptrigger.go
@@ -327,7 +327,7 @@ func htDelete(c *cli.Context) error {
 		if err != nil {
 			errs = multierror.Append(errs, err)
 		} else {
-			fmt.Printf("trigger '%v' deleted\n", htName)
+			fmt.Printf("trigger '%v' deleted\n", name)
 		}
 	}
 

--- a/pkg/fission-cli/main.go
+++ b/pkg/fission-cli/main.go
@@ -148,14 +148,15 @@ func NewCliApp() *cli.App {
 	htIngressRuleFlag := cli.StringFlag{Name: "ingressrule", Usage: "Host for Ingress rule: --ingressrule host=path (the format of host/path depends on what ingress controller you used)"}
 	htIngressAnnotationFlag := cli.StringSliceFlag{Name: "ingressannotation", Usage: "Annotation for Ingress: --ingressannotation key=value (the format of annotation depends on what ingress controller you used)"}
 	htIngressTLSFlag := cli.StringFlag{Name: "ingresstls", Usage: "Name of the Secret contains TLS key and crt for Ingress (the usability of TLS features depends on what ingress controller you used)"}
-	htFnNameFlag := cli.StringSliceFlag{Name: "function", Usage: "Name(s) of the function for this trigger. If 2 functions are supplied with this flag, traffic gets routed to them based on weights supplied with --weight flag."}
+	htFnNameFlag := cli.StringSliceFlag{Name: "function", Usage: "Name(s) of the function for this trigger. (If 2 functions are supplied with this flag, traffic gets routed to them based on weights supplied with --weight flag.)"}
 	htFnWeightFlag := cli.IntSliceFlag{Name: "weight", Usage: "Weight for each function supplied with --function flag, in the same order. Used for canary deployment"}
+	htFnFilterFlag := cli.StringFlag{Name: "function", Usage: "Name of the function for trigger(s)"}
 	htSubcommands := []cli.Command{
 		{Name: "create", Aliases: []string{"add"}, Usage: "Create HTTP trigger", Flags: []cli.Flag{htNameFlag, htMethodFlag, htUrlFlag, htFnNameFlag, htIngressRuleFlag, htIngressAnnotationFlag, htIngressTLSFlag, htIngressFlag, fnNamespaceFlag, specSaveFlag, htFnWeightFlag, htHostFlag}, Action: htCreate},
 		{Name: "get", Usage: "Get HTTP trigger", Flags: []cli.Flag{htNameFlag}, Action: htGet},
 		{Name: "update", Usage: "Update HTTP trigger", Flags: []cli.Flag{htNameFlag, triggerNamespaceFlag, htFnNameFlag, htIngressRuleFlag, htIngressAnnotationFlag, htIngressTLSFlag, htIngressFlag, htFnWeightFlag, htHostFlag}, Action: htUpdate},
-		{Name: "delete", Usage: "Delete HTTP trigger", Flags: []cli.Flag{htNameFlag, triggerNamespaceFlag}, Action: htDelete},
-		{Name: "list", Usage: "List HTTP triggers", Flags: []cli.Flag{triggerNamespaceFlag}, Action: htList},
+		{Name: "delete", Usage: "Delete HTTP trigger", Flags: []cli.Flag{htNameFlag, triggerNamespaceFlag, htFnFilterFlag}, Action: htDelete},
+		{Name: "list", Usage: "List HTTP triggers", Flags: []cli.Flag{triggerNamespaceFlag, htFnFilterFlag}, Action: htList},
 	}
 
 	// timetriggers


### PR DESCRIPTION
Previously, a user has to delete HTTP triggers point to the same function one by one. This PR adds new flag --function to list & delete commands. So that user can delete or list all triggers with the same function. However, this feature is not working for triggers with canary deployment setup.

Fix #1327 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1327)
<!-- Reviewable:end -->
