### PR TITLE
Fix spec doesn't update status of failed package when applying spec files

### DIFF
--- a/examples/go/specs/env.yaml
+++ b/examples/go/specs/env.yaml
@@ -7,7 +7,6 @@ spec:
   version: 2
   builder:
     command: build
-    image: fission/go-builder:0.6.0
+    image: fission/go-builder-1.12:1.5.0
   runtime:
-    image: fission/go-env:0.6.0
-
+    image: fission/go-env-1.12:1.5.0

--- a/examples/go/specs/function-hello.yaml
+++ b/examples/go/specs/function-hello.yaml
@@ -31,6 +31,7 @@ spec:
   environment:
     name: go
     namespace: default
+  functionTimeout: 60
   package:
     functionName: Handler
     packageref:

--- a/pkg/fission-cli/spec.go
+++ b/pkg/fission-cli/spec.go
@@ -746,7 +746,7 @@ func applyPackages(fclient *client.Client, fr *spec.FissionResources, delete boo
 				keep = true
 			}
 
-			if keep {
+			if keep && existingObj.Status.BuildStatus == fv1.BuildStatusSucceeded {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.Metadata)] = existingObj.Metadata
 			} else {
@@ -760,6 +760,12 @@ func applyPackages(fclient *client.Client, fr *spec.FissionResources, delete boo
 				if err != nil {
 					// log and ignore
 					fmt.Printf("Error waiting for package '%v' build, ignoring\n", o.Metadata.Name)
+					pkg = &o
+				}
+
+				// update status in order to rebuild the package again
+				if pkg.Status.BuildStatus == fv1.BuildStatusFailed {
+					pkg.Status.BuildStatus = fv1.BuildStatusPending
 				}
 
 				newmeta, err := fclient.PackageUpdate(pkg)


### PR DESCRIPTION
Previously, the spec doesn't update the package status if nothing
in the spec file changed. Due to this, the failed package will
always stay in the failed state.

This PR adds a check to see whether a package is in the failed state.
If yes, then changes the state to pending for builder manager to rebuild it.

Fix #1092

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1332)
<!-- Reviewable:end -->
