### PR TITLE
Fix router health route not found if no HTTP triggers created

### DIFF
--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -71,7 +71,7 @@ func makeHTTPTriggerSet(logger *zap.Logger, fmap *functionServiceMap, frmap *fun
 		kubeClient:                 kubeClient,
 		executor:                   executor,
 		crdClient:                  crdClient,
-		updateRouterRequestChannel: make(chan struct{}),
+		updateRouterRequestChannel: make(chan struct{}, 10), // use buffer channel
 		tsRoundTripperParams:       params,
 		isDebugEnv:                 isDebugEnv,
 		svcAddrUpdateThrottler:     actionThrottler,
@@ -103,6 +103,7 @@ func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mr *mutableRouter
 		return
 	}
 	go ts.updateRouter()
+	go ts.syncTriggers()
 	go ts.runWatcher(ctx, ts.funcController)
 	go ts.runWatcher(ctx, ts.triggerController)
 	if ts.recorderSet.recController != nil {


### PR DESCRIPTION
Router readiness probe failed due to kubelet cannot find router healthz endpoint.
This is caused that the healthz endpoint is added only when there is any update request
send to the updateRouterRequestChannel, and makes router failed.

This PR sends an update request right before the router is started to avoid the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1333)
<!-- Reviewable:end -->
