### PR TITLE
Fix executor doesn't apply user-configured container spec correctly

### DIFF
--- a/hack/runtests.sh
+++ b/hack/runtests.sh
@@ -30,7 +30,7 @@ echo "" > coverage.txt
 
 # The executor unit test only works with NodePort-type services for
 # now. So disable it for our travis ci tests except some partial tests.
-for d in $(go list ./... | grep -v '/vendor/' | grep -v 'examples/go' | grep -v 'benchmark') github.com/fission/fission/pkg/executor/util; do
+for d in $(go list ./... | grep -v '/vendor/' | grep -v 'examples/go' | grep -v executor | grep -v 'benchmark') github.com/fission/fission/pkg/executor/util; do
     go test -v -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt

--- a/hack/runtests.sh
+++ b/hack/runtests.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
-set -euxo pipefail
+set -exo pipefail
 
-if [ ! -f ${KUBECONFIG} ]
+if [ ! -z "${KUBECONFIG}" ]
 then
-    unset KUBECONFIG
-else
-    K="kubectl --kubeconfig $KUBECONFIG --namespace default"
-    if $K get configmap ok-to-destroy
+    if [ ! -f "${KUBECONFIG}" ]
     then
-    set +e  # do not break if crd not found
-    $K delete functions --all
-    $K delete environments --all
-    $K delete httptriggers --all
-    $K delete kuberneteswatchtriggers --all
-    $K delete messagequeuetriggers --all
-    $K delete packages --all
-    $K delete timetriggers --all
-    set -e
+        unset KUBECONFIG
+    else
+        K="kubectl --kubeconfig $KUBECONFIG --namespace default"
+        if $K get configmap ok-to-destroy
+        then
+        set +e  # do not break if crd not found
+        $K delete functions --all
+        $K delete environments --all
+        $K delete httptriggers --all
+        $K delete kuberneteswatchtriggers --all
+        $K delete messagequeuetriggers --all
+        $K delete packages --all
+        $K delete timetriggers --all
+        set -e
+        fi
     fi
 fi
 
@@ -26,8 +29,8 @@ set +x
 echo "" > coverage.txt
 
 # The executor unit test only works with NodePort-type services for
-# now. So disable it for our travis ci tests.
-for d in $(go list ./... | grep -v '/vendor/' | grep -v 'examples/go' | grep -v executor | grep -v 'benchmark'); do
+# now. So disable it for our travis ci tests except some partial tests.
+for d in $(go list ./... | grep -v '/vendor/' | grep -v 'examples/go' | grep -v 'benchmark') github.com/fission/fission/pkg/executor/util; do
     go test -v -coverprofile=profile.out -covermode=atomic $d
     if [ -f profile.out ]; then
         cat profile.out >> coverage.txt

--- a/pkg/executor/util/merge.go
+++ b/pkg/executor/util/merge.go
@@ -64,13 +64,11 @@ func MergePodSpec(srcPodSpec *apiv1.PodSpec, targetPodSpec *apiv1.PodSpec) (*api
 
 	// Get item from spec, if they exist in deployment - merge, else append
 	// Same pattern for all lists (Mergo can not handle lists)
-	// At some point this is better done with generics/reflection?
+	// TODO: At some point this is better done with generics/reflection?
 	err := mergeContainerLists(srcPodSpec, targetPodSpec)
 	if err != nil {
 		multierr = multierror.Append(multierr, err)
 	}
-
-	log.Printf("spec %v", srcPodSpec)
 
 	err = mergeInitContainerList(srcPodSpec, targetPodSpec)
 	if err != nil {
@@ -162,8 +160,6 @@ func mergeContainerLists(srcPodSpec *apiv1.PodSpec, targetPodSpec *apiv1.PodSpec
 	for _, container := range targetContainers {
 		srcPodSpec.Containers = append(srcPodSpec.Containers, container)
 	}
-
-	log.Printf("loop merge: %v", srcPodSpec)
 
 	return multierr.ErrorOrNil()
 }

--- a/pkg/executor/util/merge_test.go
+++ b/pkg/executor/util/merge_test.go
@@ -33,75 +33,28 @@ func Test_checkConflicts(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "container name",
-			args: args{
-				[]apiv1.Container{
-					{
-						Name: "test1",
-					},
-					{
-						Name: "test2",
-					},
-					{
-						Name: "test3",
-					},
-				},
-			},
+			name:    "container name",
+			args:    args{[]apiv1.Container{{Name: "test1"}, {Name: "test2"}, {Name: "test3"}}},
 			wantErr: false,
 		},
 		{
-			name: "pass non-slice",
-			args: args{
-				apiv1.Container{
-					Name: "test1",
-				},
-			},
+			name:    "pass non-slice",
+			args:    args{apiv1.Container{Name: "test1"}},
 			wantErr: true,
 		},
 		{
-			name: "conflict container name",
-			args: args{
-				[]interface{}{
-					apiv1.Container{
-						Name: "test1",
-					},
-					apiv1.Container{
-						Name: "test1",
-					},
-					apiv1.Container{
-						Name: "test3",
-					},
-				},
-			},
+			name:    "conflict container name",
+			args:    args{[]interface{}{apiv1.Container{Name: "test1"}, apiv1.Container{Name: "test1"}, apiv1.Container{Name: "test3"}}},
 			wantErr: true,
 		},
 		{
-			name: "different types",
-			args: args{
-				[]interface{}{
-					apiv1.VolumeMount{
-						Name: "test1",
-					},
-					apiv1.EnvFromSource{
-						Prefix:       "",
-						ConfigMapRef: nil,
-						SecretRef:    nil,
-					},
-				},
-			},
+			name:    "different types",
+			args:    args{[]interface{}{apiv1.VolumeMount{Name: "test1"}, apiv1.EnvFromSource{Prefix: "", ConfigMapRef: nil, SecretRef: nil}}},
 			wantErr: true,
 		},
 		{
-			name: "type without target field",
-			args: args{
-				[]interface{}{
-					apiv1.EnvFromSource{
-						Prefix:       "",
-						ConfigMapRef: nil,
-						SecretRef:    nil,
-					},
-				},
-			},
+			name:    "type without target field",
+			args:    args{[]interface{}{apiv1.EnvFromSource{Prefix: "", ConfigMapRef: nil, SecretRef: nil}}},
 			wantErr: true,
 		},
 	}
@@ -142,227 +95,52 @@ func Test_mergeContainer(t *testing.T) {
 			name: "normal-merge",
 			args: args{
 				dst: &apiv1.Container{
-					Name:       "test",
-					Image:      "foobar",
-					Command:    []string{"a"},
-					Args:       []string{"b"},
-					WorkingDir: "/tmp",
-					Ports: []apiv1.ContainerPort{
-						{
-							Name:     "http1",
-							HostPort: 123,
-						},
-					},
-					EnvFrom: []apiv1.EnvFromSource{
-						{
-							Prefix: "asd",
-						},
-					},
-					Env: []apiv1.EnvVar{
-						{
-							Name:  "foobar",
-							Value: "dummy",
-						},
-					},
-					Resources: apiv1.ResourceRequirements{
-						Limits: apiv1.ResourceList{
-							apiv1.ResourceCPU: resource.Quantity{
-								Format: "limit",
-							},
-						},
-					},
-					VolumeMounts: []apiv1.VolumeMount{
-						{
-							Name:      "volm",
-							ReadOnly:  true,
-							MountPath: "/tmp/foobar",
-						},
-					},
-					VolumeDevices: []apiv1.VolumeDevice{
-						{
-							Name:       "vold",
-							DevicePath: "hello",
-						},
-					},
-					LivenessProbe: &apiv1.Probe{
-						Handler:             apiv1.Handler{},
-						InitialDelaySeconds: 1,
-						TimeoutSeconds:      2,
-						PeriodSeconds:       3,
-						SuccessThreshold:    4,
-						FailureThreshold:    5,
-					},
-					ReadinessProbe: &apiv1.Probe{
-						Handler:             apiv1.Handler{},
-						InitialDelaySeconds: 1,
-						TimeoutSeconds:      2,
-						PeriodSeconds:       3,
-						SuccessThreshold:    4,
-						FailureThreshold:    5,
-					},
-					Lifecycle:                nil,
-					TerminationMessagePath:   "",
-					TerminationMessagePolicy: "",
-					ImagePullPolicy:          "IfNotPresent",
-					SecurityContext:          nil,
-					Stdin:                    false,
-					StdinOnce:                false,
-					TTY:                      false,
+					Name:            "test",
+					Image:           "foobar",
+					Command:         []string{"a"},
+					Args:            []string{"b"},
+					WorkingDir:      "/tmp",
+					Ports:           []apiv1.ContainerPort{{Name: "http1", HostPort: 123}},
+					EnvFrom:         []apiv1.EnvFromSource{{Prefix: "asd"}},
+					Env:             []apiv1.EnvVar{{Name: "foobar", Value: "dummy"}},
+					Resources:       apiv1.ResourceRequirements{Limits: apiv1.ResourceList{apiv1.ResourceCPU: resource.Quantity{Format: "limit"}}},
+					VolumeMounts:    []apiv1.VolumeMount{{Name: "volm", ReadOnly: true, MountPath: "/tmp/foobar"}},
+					VolumeDevices:   []apiv1.VolumeDevice{{Name: "vold", DevicePath: "hello"}},
+					LivenessProbe:   &apiv1.Probe{Handler: apiv1.Handler{}, InitialDelaySeconds: 1, TimeoutSeconds: 2, PeriodSeconds: 3, SuccessThreshold: 4, FailureThreshold: 5},
+					ReadinessProbe:  &apiv1.Probe{Handler: apiv1.Handler{}, InitialDelaySeconds: 1, TimeoutSeconds: 2, PeriodSeconds: 3, SuccessThreshold: 4, FailureThreshold: 5},
+					ImagePullPolicy: "IfNotPresent",
 				},
 				src: &apiv1.Container{
-					Name:       "test",
-					Image:      "foobar-1",
-					Command:    []string{"a", "c"},
-					Args:       []string{"b", "d"},
-					WorkingDir: "/tmp/qwer",
-					Ports: []apiv1.ContainerPort{
-						{
-							Name:     "http2",
-							HostPort: 123,
-						},
-					},
-					EnvFrom: []apiv1.EnvFromSource{
-						{
-							Prefix: "asd",
-						},
-					},
-					Env: []apiv1.EnvVar{
-						{
-							Name:  "foobar1",
-							Value: "dummy",
-						},
-					},
-					Resources: apiv1.ResourceRequirements{
-						Limits: apiv1.ResourceList{
-							apiv1.ResourceCPU: resource.Quantity{
-								Format: "unlimit",
-							},
-							apiv1.ResourceMemory: resource.Quantity{
-								Format: "limit",
-							},
-						},
-					},
-					VolumeMounts: []apiv1.VolumeMount{
-						{
-							Name:      "volm1",
-							ReadOnly:  true,
-							MountPath: "/tmp/foobar",
-						},
-					},
-					VolumeDevices: []apiv1.VolumeDevice{
-						{
-							Name:       "vold1",
-							DevicePath: "hello",
-						},
-					},
-					LivenessProbe: &apiv1.Probe{
-						Handler:             apiv1.Handler{},
-						InitialDelaySeconds: 5,
-						TimeoutSeconds:      4,
-						PeriodSeconds:       3,
-						SuccessThreshold:    2,
-						FailureThreshold:    1,
-					},
-					ReadinessProbe: &apiv1.Probe{
-						Handler:             apiv1.Handler{},
-						InitialDelaySeconds: 5,
-						TimeoutSeconds:      4,
-						PeriodSeconds:       3,
-						SuccessThreshold:    2,
-						FailureThreshold:    1,
-					},
-					Lifecycle:                nil,
-					TerminationMessagePath:   "",
-					TerminationMessagePolicy: "",
-					ImagePullPolicy:          "Always",
-					SecurityContext:          nil,
-					Stdin:                    false,
-					StdinOnce:                false,
-					TTY:                      false,
+					Name:            "test",
+					Image:           "foobar-1",
+					Command:         []string{"a", "c"},
+					Args:            []string{"b", "d"},
+					WorkingDir:      "/tmp/qwer",
+					Ports:           []apiv1.ContainerPort{{Name: "http2", HostPort: 123}},
+					EnvFrom:         []apiv1.EnvFromSource{{Prefix: "asd"}},
+					Env:             []apiv1.EnvVar{{Name: "foobar1", Value: "dummy"}},
+					Resources:       apiv1.ResourceRequirements{Limits: apiv1.ResourceList{apiv1.ResourceCPU: resource.Quantity{Format: "unlimit"}, apiv1.ResourceMemory: resource.Quantity{Format: "limit"}}},
+					VolumeMounts:    []apiv1.VolumeMount{{Name: "volm1", ReadOnly: true, MountPath: "/tmp/foobar"}},
+					VolumeDevices:   []apiv1.VolumeDevice{{Name: "vold1", DevicePath: "hello"}},
+					LivenessProbe:   &apiv1.Probe{Handler: apiv1.Handler{}, InitialDelaySeconds: 5, TimeoutSeconds: 4, PeriodSeconds: 3, SuccessThreshold: 2, FailureThreshold: 1},
+					ReadinessProbe:  &apiv1.Probe{Handler: apiv1.Handler{}, InitialDelaySeconds: 5, TimeoutSeconds: 4, PeriodSeconds: 3, SuccessThreshold: 2, FailureThreshold: 1},
+					ImagePullPolicy: "Always",
 				},
 			},
 			want: &apiv1.Container{
-				Name:       "test",
-				Image:      "foobar-1",
-				Command:    []string{"a", "a", "c"},
-				Args:       []string{"b", "b", "d"},
-				WorkingDir: "/tmp/qwer",
-				Ports: []apiv1.ContainerPort{
-					{
-						Name:     "http1",
-						HostPort: 123,
-					},
-					{
-						Name:     "http2",
-						HostPort: 123,
-					},
-				},
-				EnvFrom: []apiv1.EnvFromSource{
-					{
-						Prefix: "asd",
-					},
-					{
-						Prefix: "asd",
-					},
-				},
-				Env: []apiv1.EnvVar{
-					{
-						Name:  "foobar",
-						Value: "dummy",
-					},
-					{
-						Name:  "foobar1",
-						Value: "dummy",
-					},
-				},
-				Resources: apiv1.ResourceRequirements{
-					Limits: apiv1.ResourceList{
-						apiv1.ResourceCPU: resource.Quantity{
-							Format: "unlimit",
-						},
-						apiv1.ResourceMemory: resource.Quantity{
-							Format: "limit",
-						},
-					},
-				},
-				VolumeMounts: []apiv1.VolumeMount{
-					{
-						Name:      "volm",
-						ReadOnly:  true,
-						MountPath: "/tmp/foobar",
-					},
-					{
-						Name:      "volm1",
-						ReadOnly:  true,
-						MountPath: "/tmp/foobar",
-					},
-				},
-				VolumeDevices: []apiv1.VolumeDevice{
-					{
-						Name:       "vold",
-						DevicePath: "hello",
-					},
-					{
-						Name:       "vold1",
-						DevicePath: "hello",
-					},
-				},
-				LivenessProbe: &apiv1.Probe{
-					Handler:             apiv1.Handler{},
-					InitialDelaySeconds: 5,
-					TimeoutSeconds:      4,
-					PeriodSeconds:       3,
-					SuccessThreshold:    2,
-					FailureThreshold:    1,
-				},
-				ReadinessProbe: &apiv1.Probe{
-					Handler:             apiv1.Handler{},
-					InitialDelaySeconds: 5,
-					TimeoutSeconds:      4,
-					PeriodSeconds:       3,
-					SuccessThreshold:    2,
-					FailureThreshold:    1,
-				},
+				Name:                     "test",
+				Image:                    "foobar-1",
+				Command:                  []string{"a", "a", "c"},
+				Args:                     []string{"b", "b", "d"},
+				WorkingDir:               "/tmp/qwer",
+				Ports:                    []apiv1.ContainerPort{{Name: "http1", HostPort: 123}, {Name: "http2", HostPort: 123}},
+				EnvFrom:                  []apiv1.EnvFromSource{{Prefix: "asd"}, {Prefix: "asd"}},
+				Env:                      []apiv1.EnvVar{{Name: "foobar", Value: "dummy"}, {Name: "foobar1", Value: "dummy"}},
+				Resources:                apiv1.ResourceRequirements{Limits: apiv1.ResourceList{apiv1.ResourceCPU: resource.Quantity{Format: "unlimit"}, apiv1.ResourceMemory: resource.Quantity{Format: "limit"}}},
+				VolumeMounts:             []apiv1.VolumeMount{{Name: "volm", ReadOnly: true, MountPath: "/tmp/foobar"}, {Name: "volm1", ReadOnly: true, MountPath: "/tmp/foobar"}},
+				VolumeDevices:            []apiv1.VolumeDevice{{Name: "vold", DevicePath: "hello"}, {Name: "vold1", DevicePath: "hello"}},
+				LivenessProbe:            &apiv1.Probe{Handler: apiv1.Handler{}, InitialDelaySeconds: 5, TimeoutSeconds: 4, PeriodSeconds: 3, SuccessThreshold: 2, FailureThreshold: 1},
+				ReadinessProbe:           &apiv1.Probe{Handler: apiv1.Handler{}, InitialDelaySeconds: 5, TimeoutSeconds: 4, PeriodSeconds: 3, SuccessThreshold: 2, FailureThreshold: 1},
 				Lifecycle:                nil,
 				TerminationMessagePath:   "",
 				TerminationMessagePolicy: "",
@@ -384,6 +162,171 @@ func Test_mergeContainer(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("mergeContainer() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeVolumeLists(t *testing.T) {
+	type args struct {
+		dst []apiv1.Volume
+		src []apiv1.Volume
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []apiv1.Volume
+		wantErr bool
+	}{
+		{
+			name: "merge volume list",
+			args: args{
+				dst: []apiv1.Volume{
+					{Name: "vol1", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/foo"}}},
+					{Name: "vol2", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/bar"}}},
+				},
+				src: []apiv1.Volume{
+					{Name: "vol3", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/foobar"}}},
+				},
+			},
+			want: []apiv1.Volume{
+				{Name: "vol1", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/foo"}}},
+				{Name: "vol2", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/bar"}}},
+				{Name: "vol3", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/foobar"}}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "conflict volume name",
+			args: args{
+				dst: []apiv1.Volume{
+					{Name: "vol1", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/foo"}}},
+					{Name: "vol2", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/bar"}}},
+				},
+				src: []apiv1.Volume{
+					{Name: "vol1", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/tmp/foobar"}}},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeVolumeLists(tt.args.dst, tt.args.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeVolumeLists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("mergeVolumeLists() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeContainerList(t *testing.T) {
+	type args struct {
+		dst []apiv1.Container
+		src []apiv1.Container
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    []apiv1.Container
+		wantErr bool
+	}{
+		{
+			name: "merge container with conflict name",
+			args: args{
+				dst: []apiv1.Container{
+					{Name: "foo", Image: "dummy-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+					{Name: "foo2", Image: "dummy-image-2", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				},
+				src: []apiv1.Container{
+					{Name: "foo", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "test", Value: "foobar"}}},
+					{Name: "foo2", Image: "my-custom-image-2", Env: []apiv1.EnvVar{{Name: "env3", Value: "foobar"}, {Name: "env4", Value: "barfoo"}}},
+				},
+			},
+			want: []apiv1.Container{
+				{Name: "foo", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}, {Name: "test", Value: "foobar"}}},
+				{Name: "foo2", Image: "my-custom-image-2", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}, {Name: "env3", Value: "foobar"}, {Name: "env4", Value: "barfoo"}}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "merge container with no conflict name",
+			args: args{
+				dst: []apiv1.Container{
+					{Name: "foo", Image: "dummy-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+					{Name: "foo2", Image: "dummy-image-2", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				},
+				src: []apiv1.Container{
+					{Name: "foo3", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "test", Value: "foobar"}}},
+					{Name: "foo4", Image: "my-custom-image-2", Env: []apiv1.EnvVar{{Name: "env3", Value: "foobar"}, {Name: "env4", Value: "barfoo"}}},
+				},
+			},
+			want: []apiv1.Container{
+				{Name: "foo", Image: "dummy-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				{Name: "foo2", Image: "dummy-image-2", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				{Name: "foo3", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "test", Value: "foobar"}}},
+				{Name: "foo4", Image: "my-custom-image-2", Env: []apiv1.EnvVar{{Name: "env3", Value: "foobar"}, {Name: "env4", Value: "barfoo"}}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "merge container with partial conflict name",
+			args: args{
+				dst: []apiv1.Container{
+					{Name: "foo", Image: "dummy-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+					{Name: "foo2", Image: "dummy-image-2", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				},
+				src: []apiv1.Container{
+					{Name: "foo", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "test", Value: "foobar"}}},
+					{Name: "foo4", Image: "my-custom-image-2", Env: []apiv1.EnvVar{{Name: "env3", Value: "foobar"}, {Name: "env4", Value: "barfoo"}}},
+				},
+			},
+			want: []apiv1.Container{
+				{Name: "foo", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}, {Name: "test", Value: "foobar"}}},
+				{Name: "foo2", Image: "dummy-image-2", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				{Name: "foo4", Image: "my-custom-image-2", Env: []apiv1.EnvVar{{Name: "env3", Value: "foobar"}, {Name: "env4", Value: "barfoo"}}},
+			},
+			wantErr: false,
+		},
+		{
+			name: "merge container with conflict environment variable",
+			args: args{
+				dst: []apiv1.Container{
+					{Name: "foo", Image: "dummy-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "foobar"}, {Name: "env2", Value: "barfoo"}}},
+				},
+				src: []apiv1.Container{
+					{Name: "foo", Image: "my-custom-image-1", Env: []apiv1.EnvVar{{Name: "env1", Value: "helloworld"}}},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := mergeContainerList(tt.args.dst, tt.args.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("mergeInitContainerList() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			for _, obj := range got {
+				match := false
+				for _, w := range tt.want {
+					if obj.Name == w.Name && reflect.DeepEqual(obj, w) {
+						match = true
+						break
+					}
+				}
+				if !match {
+					t.Errorf("mergeInitContainerList() got = %v, want %v", got, tt.want)
+					break
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The merge function executor used wasn't merge container correctly, and it
didn't merge all fields in spec except volumeMount & Env which confused people.

To apply user-configured container correctly, this PR changes the way of merge
and follows rules:

1. Slices are merged, and return an error if the elements in the slice have name conflicts.
2. Maps are merged, the value of map of dst container are overridden if the key is the same.
3. The rest of fields of dst container are overridden directly.

Fix #1322 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1339)
<!-- Reviewable:end -->
