### PR TITLE
Fix the namespace mismatch problem when deploying with a single YAML file

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -205,7 +205,7 @@ spec:
         image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
+        args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
         env:
         - name: FETCHER_IMAGE
           value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -205,7 +205,7 @@ spec:
         image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--fission-namespace", "{{ .Release.Namespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
+        args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}", "--collectorEndpoint", "{{ .Values.traceCollectorEndpoint }}"]
         env:
         - name: FETCHER_IMAGE
           value: "{{ .Values.fetcherImage }}:{{ .Values.fetcherImageTag }}"

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -50,8 +50,8 @@ func runRouter(logger *zap.Logger, port int, executorUrl string) {
 	logger.Fatal("router exited")
 }
 
-func runExecutor(logger *zap.Logger, port int, fissionNamespace, functionNamespace, envBuilderNamespace string) {
-	err := executor.StartExecutor(logger, fissionNamespace, functionNamespace, envBuilderNamespace, port)
+func runExecutor(logger *zap.Logger, port int, functionNamespace, envBuilderNamespace string) {
+	err := executor.StartExecutor(logger, functionNamespace, envBuilderNamespace, port)
 	if err != nil {
 		logger.Fatal("error starting executor", zap.Error(err))
 	}
@@ -253,7 +253,6 @@ Options:
 	}
 
 	functionNs := getStringArgWithDefault(arguments["--namespace"], "fission-function")
-	fissionNs := getStringArgWithDefault(arguments["--fission-namespace"], "fission")
 	envBuilderNs := getStringArgWithDefault(arguments["--envbuilder-namespace"], "fission-builder")
 
 	executorUrl := getStringArgWithDefault(arguments["--executorUrl"], "http://executor.fission")
@@ -272,7 +271,7 @@ Options:
 
 	if arguments["--executorPort"] != nil {
 		port := getPort(logger, arguments["--executorPort"])
-		runExecutor(logger, port, fissionNs, functionNs, envBuilderNs)
+		runExecutor(logger, port, functionNs, envBuilderNs)
 	}
 
 	if arguments["--kubewatcher"] == true {

--- a/hack/release-build.sh
+++ b/hack/release-build.sh
@@ -223,9 +223,9 @@ build_yamls() {
         popd
 
         # for minikube and other environments that don't support LoadBalancer
-        helm template ${c} -n ${releaseName} --set analytics=false,analyticsNonHelmInstall=true,serviceType=NodePort,routerServiceType=NodePort > ${c}-${version}-minikube.yaml
+        helm template ${c} -n ${releaseName} --namespace fission --set analytics=false,analyticsNonHelmInstall=true,serviceType=NodePort,routerServiceType=NodePort > ${c}-${version}-minikube.yaml
         # for environments that support LoadBalancer
-        helm template ${c} -n ${releaseName} --set analytics=false,analyticsNonHelmInstall=true > ${c}-${version}.yaml
+        helm template ${c} -n ${releaseName} --namespace fission --set analytics=false,analyticsNonHelmInstall=true > ${c}-${version}.yaml
 
         # copy yaml files to build directory
         mv *.yaml ${BUILDDIR}/yamls/

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -205,7 +205,7 @@ func serveMetric(logger *zap.Logger) {
 
 // StartExecutor Starts executor and the executor components such as Poolmgr,
 // deploymgr and potential future executor types
-func StartExecutor(logger *zap.Logger, fissionNamespace string, functionNamespace string, envBuilderNamespace string, port int) error {
+func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNamespace string, port int) error {
 	fissionClient, kubernetesClient, _, err := crd.MakeFissionClient()
 
 	err = fissionClient.WaitForCRDs()

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -175,7 +175,7 @@ func TestExecutor(t *testing.T) {
 
 	// create poolmgr
 	port := 9999
-	err = StartExecutor(logger, fissionNs, functionNs, "fission-builder", port)
+	err = StartExecutor(logger, functionNs, "fission-builder", port)
 	if err != nil {
 		log.Panicf("failed to start poolmgr: %v", err)
 	}


### PR DESCRIPTION
If a user deploys fission in the namespace which is different from the one in the single YAML file generated by helm, fission components won't be able to talk to each other due to the wrong namespace appends after the service address.

This PR adds `--namespace` when generating the YAML file to prevent the mismatch problem.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1344)
<!-- Reviewable:end -->
