### PR TITLE
Support encoded path in router

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -69,6 +69,7 @@ Parameter | Description | Default
 `router.svcAddressMaxRetries` | Max retries times for router to retry on a certain service URL returns from cache/executor | `5`
 `router.svcAddressUpdateTimeout` | The length of update lock expiry time for router to get a service URL returns from executor | `30`
 `router.svcAnnotations` | Annotations for router service | None
+`router.useEncodedPath` | For router to match encoded path. If true, "/foo%2Fbar" will match the path "/{var}"; Otherwise, it will match the path "/foo/bar". | `false`
 `router.roundTrip.disableKeepAlive` | Disable transport keep-alive for fast switching function version | `true`
 `router.roundTrip.keepAliveTime` | The keep-alive period for an active network connection to function pod | `30s`
 `router.roundTrip.timeout` | HTTP transport request timeout | `50ms`

--- a/charts/fission-all/templates/router.yaml
+++ b/charts/fission-all/templates/router.yaml
@@ -53,10 +53,12 @@ spec:
             value: {{ .Values.router.svcAddressMaxRetries | default 5 | quote }}
           - name: ROUTER_SVC_ADDRESS_UPDATE_TIMEOUT
             value: {{ .Values.router.svcAddressUpdateTimeout | default "30s" | quote }}
-          - name: DEBUG_ENV
-            value: {{ .Values.debugEnv | quote }}
           - name: TRACING_SAMPLING_RATE
             value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
+          - name: USE_ENCODED_PATH
+            value: {{ .Values.router.useEncodedPath | default false | quote }}
+          - name: DEBUG_ENV
+            value: {{ .Values.debugEnv | quote }}
 {{- if .Values.analytics }}
           - name: ANALYTICS_URL
             value: "https://g.fission.sh/metrics"

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -66,6 +66,12 @@ router:
   ## Add annotations for router
   # svcAnnotations:
   #   cloud.google.com/load-balancer-type: Internal
+  
+  ## For router to match encoded path.
+  ## If true, "/foo%2Fbar" will match the path "/{var}";
+  ## Otherwise, it will match the path "/foo/bar".
+  useEncodedPath: false
+  
   roundTrip:
     ## If true, router will disable the HTTP keep-alive which result in performance degradation.
     ## But it ensures that router can redirect new coming requests to new function pods.

--- a/charts/fission-core/templates/router.yaml
+++ b/charts/fission-core/templates/router.yaml
@@ -53,10 +53,12 @@ spec:
             value: {{ .Values.router.svcAddressMaxRetries | default 5 | quote }}
           - name: ROUTER_SVC_ADDRESS_UPDATE_TIMEOUT
             value: {{ .Values.router.svcAddressUpdateTimeout | default "30s" | quote }}
-          - name: DEBUG_ENV
-            value: {{ .Values.debugEnv | quote }}
           - name: TRACING_SAMPLING_RATE
             value: {{ .Values.traceSamplingRate | default "0.5" | quote }}
+          - name: USE_ENCODED_PATH
+            value: {{ .Values.router.useEncodedPath | default false | quote }}
+          - name: DEBUG_ENV
+            value: {{ .Values.debugEnv | quote }}
 {{- if .Values.analytics }}
           - name: ANALYTICS_URL
             value: "https://g.fission.sh/metrics"

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -53,6 +53,12 @@ router:
   ## Add annotations for router
   # svcAnnotations:
   #   cloud.google.com/load-balancer-type: Internal
+  
+  ## For router to match encoded path.
+  ## If true, "/foo%2Fbar" will match the path "/{var}";
+  ## Otherwise, it will match the path "/foo/bar".
+  useEncodedPath: false
+  
   roundTrip:
     ## If true, router will disable the HTTP keep-alive which result in performance degradation.
     ## But it ensures that router can redirect new coming requests to new function pods.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -63,7 +63,16 @@ import (
 // request url ---[trigger]---> Function(name, deployment) ----[deployment]----> Function(name, uid) ----[pool mgr]---> k8s service url
 
 func router(ctx context.Context, logger *zap.Logger, httpTriggerSet *HTTPTriggerSet, resolver *functionReferenceResolver) *mutableRouter {
-	mr := NewMutableRouter(logger, mux.NewRouter())
+	var mr *mutableRouter
+
+	// see issue https://github.com/fission/fission/issues/1317
+	useEncodedPath, _ := strconv.ParseBool(os.Getenv("USE_ENCODED_PATH"))
+	if useEncodedPath {
+		mr = NewMutableRouter(logger, mux.NewRouter().UseEncodedPath())
+	} else {
+		mr = NewMutableRouter(logger, mux.NewRouter())
+	}
+
 	httpTriggerSet.subscribeRouter(ctx, mr, resolver)
 	return mr
 }


### PR DESCRIPTION
Encoded path means the URL path contains encoded string like "/foo%2Fbar".
Gorilla/Mux by default doesn't enable encoded path support, you need to enable
it when initializing the router.

This PR adds a new environment variable USE_ENCODED_PATH to router
deployment to enable encoded path support.

Fix #1317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1347)
<!-- Reviewable:end -->
