### PR TITLE
Fix newdeploy failed to find serviceEntry in cache

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"runtime/debug"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -111,11 +110,10 @@ func (api *API) respondWithSuccess(w http.ResponseWriter, resp []byte) {
 }
 
 func (api *API) respondWithError(w http.ResponseWriter, err error) {
-	debug.PrintStack()
-
 	// this error type comes with an HTTP code, so just use that
 	se, ok := err.(*kerrors.StatusError)
 	if ok {
+		api.logger.Error(err.Error(), zap.Int32("code", se.ErrStatus.Code))
 		http.Error(w, string(se.ErrStatus.Reason), int(se.ErrStatus.Code))
 		return
 	}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -207,6 +207,9 @@ func serveMetric(logger *zap.Logger) {
 // deploymgr and potential future executor types
 func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNamespace string, port int) error {
 	fissionClient, kubernetesClient, _, err := crd.MakeFissionClient()
+	if err != nil {
+		return errors.Wrap(err, "failed to get kubernetes client")
+	}
 
 	err = fissionClient.WaitForCRDs()
 	if err != nil {
@@ -219,10 +222,6 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 	}
 
 	restClient := fissionClient.GetCrdClient()
-	if err != nil {
-		return errors.Wrap(err, "failed to get kubernetes client")
-	}
-
 	fsCache := fscache.MakeFunctionServiceCache(logger)
 
 	poolID := strings.ToLower(uniuri.NewLen(8))


### PR DESCRIPTION
When a function with executor type newdeploy got created, Newdeploy
is expected to create deployment/HPA/service for it and insert serviceEntry
to the cache for later use. Once clients call the function, newdeploy returns
the serviceEntry to the router.

However, the log shows that the newdeploy was unable to find the entry and
prints "Resource not found - key 'xxx' not found". The root cause is that the
informer controller instead of processing items in parallel, it dispatches XXFunc
to process items one by one. So if there is any problem during the creation of the
kubernetes resource, it takes a longer time to process the next item and hence
the serviceEntry was not inserted before clients call the function.

This PR lets the newdeploy to process items in extra goroutines instead of blocking
the process loop. It's a workaround to solve the problem above, we should consider
using workqueue to solve it in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1349)
<!-- Reviewable:end -->
