### PR TITLE
Allow using URL as archive source when creating functions

### DIFF
--- a/pkg/fission-cli/cli.go
+++ b/pkg/fission-cli/cli.go
@@ -107,7 +107,7 @@ func NewCliApp() *cli.App {
 	fnCodeFlag := cli.StringFlag{Name: "code", Usage: "local path or URL for single file source code"}
 	fnDeployArchiveFlag := cli.StringSliceFlag{Name: "deployarchive, deploy", Usage: "local path or URL for deployment archive"}
 	fnSrcArchiveFlag := cli.StringSliceFlag{Name: "sourcearchive, src, source", Usage: "local path or URL for source archive"}
-	fnKeepURLFlag := cli.BoolFlag{Name: "keeparchiveurl, keepurl", Usage: "Keep the providing URL in archive instead of downloading file from it. (If true, no checksum will be generated for file integrity check. You must ensure the file won't be changed.)"}
+	fnKeepURLFlag := cli.BoolFlag{Name: "keeparchiveurl, keepurl", Usage: "Keep the providing URL in archive instead of downloading file from it. (If set, no checksum will be generated for file integrity check. You must ensure the file won't be changed.)"}
 	fnPkgNameFlag := cli.StringFlag{Name: "pkgname, pkg", Usage: "Name of the existing package (--deploy and --src and --env will be ignored), should be in the same namespace as the function"}
 	fnPodFlag := cli.StringFlag{Name: "pod", Usage: "function pod name, optional (use latest if unspecified)"}
 	fnFollowFlag := cli.BoolFlag{Name: "follow, f", Usage: "specify if the logs should be streamed"}
@@ -259,7 +259,7 @@ func NewCliApp() *cli.App {
 	pkgEnvironmentFlag := cli.StringFlag{Name: "env", Usage: "Environment name"}
 	pkgSrcArchiveFlag := cli.StringSliceFlag{Name: "sourcearchive, src", Usage: "Local path or URL for source archive"}
 	pkgDeployArchiveFlag := cli.StringSliceFlag{Name: "deployarchive, deploy", Usage: "Local path or URL for binary archive"}
-	pkgKeepURLFlag := cli.BoolFlag{Name: "keeparchiveurl, keepurl", Usage: "Keep the providing URL in archive instead of downloading file from it. (If true, no checksum will be generated for file integrity check. You must ensure the file won't be changed.)"}
+	pkgKeepURLFlag := cli.BoolFlag{Name: "keeparchiveurl, keepurl", Usage: "Keep the providing URL in archive instead of downloading file from it. (If set, no checksum will be generated for file integrity check. You must ensure the file won't be changed.)"}
 	pkgBuildCmdFlag := cli.StringFlag{Name: "buildcmd", Usage: "Build command for builder to run with"}
 	pkgOutputFlag := cli.StringFlag{Name: "output, o", Usage: "Output filename to save archive content"}
 	pkgStatusFlag := cli.StringFlag{Name: "status", Usage: `Filter packages by status`}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/dchest/uniuri"
 	"github.com/hashicorp/go-multierror"
@@ -41,15 +40,22 @@ import (
 // create an archive upload spec in the specs directory; otherwise
 // upload the archive using client.  noZip avoids zipping the
 // includeFiles, but is ignored if there's more than one includeFile.
-func CreateArchive(client *client.Client, includeFiles []string, noZip bool, specDir string, specFile string) (*fv1.Archive, error) {
+func CreateArchive(client *client.Client, includeFiles []string, noZip bool, keepURL bool, specDir string, specFile string) (*fv1.Archive, error) {
 
 	errs := &multierror.Error{}
+	fileURL := ""
 
 	// check files existence
 	for _, path := range includeFiles {
 		// ignore http files
-		if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
-			continue
+		if utils.IsURL(path) {
+			if len(includeFiles) > 1 {
+				// It's intentional to disallow the user to provide file
+				// and URL at the same time even the downloadURL is true.
+				return nil, errors.New("unable to create an archive that contains both file and URL")
+			}
+			fileURL = path
+			break
 		}
 
 		// Get files from inputs as number of files decide next steps
@@ -68,46 +74,67 @@ func CreateArchive(client *client.Client, includeFiles []string, noZip bool, spe
 	}
 
 	if len(specFile) > 0 {
-		// create an ArchiveUploadSpec and reference it from the archive
-		aus := &spectypes.ArchiveUploadSpec{
-			Name:         archiveName("", includeFiles),
-			IncludeGlobs: includeFiles,
-		}
+		var archive fv1.Archive
 
-		// check if this AUS exists in the specs; if so, don't create a new one
-		fr, err := spec.ReadSpecs(specDir)
-		util.CheckErr(err, "read specs")
-		if m := fr.SpecExists(aus, false, true); m != nil {
-			fmt.Printf("Re-using previously created archive %v\n", m.Name)
-			aus.Name = m.Name
+		if len(fileURL) > 0 {
+			archive = fv1.Archive{
+				Type: fv1.ArchiveTypeUrl,
+				URL:  fileURL,
+			}
 		} else {
-			// save the uploadspec
-			err := spec.SpecSave(*aus, specFile)
-			util.CheckErr(err, fmt.Sprintf("write spec file %v", specFile))
+			// create an ArchiveUploadSpec and reference it from the archive
+			aus := &spectypes.ArchiveUploadSpec{
+				Name:         archiveName("", includeFiles),
+				IncludeGlobs: includeFiles,
+			}
+
+			// check if this AUS exists in the specs; if so, don't create a new one
+			fr, err := spec.ReadSpecs(specDir)
+			util.CheckErr(err, "read specs")
+			if m := fr.SpecExists(aus, false, true); m != nil {
+				fmt.Printf("Re-using previously created archive %v\n", m.Name)
+				aus.Name = m.Name
+			} else {
+				// save the uploadspec
+				err := spec.SpecSave(*aus, specFile)
+				util.CheckErr(err, fmt.Sprintf("write spec file %v", specFile))
+			}
+
+			// create the archive object
+			archive = fv1.Archive{
+				Type: fv1.ArchiveTypeUrl,
+				URL:  fmt.Sprintf("%v%v", spec.ARCHIVE_URL_PREFIX, aus.Name),
+			}
 		}
 
-		// create the archive object
-		ar := &fv1.Archive{
-			Type: fv1.ArchiveTypeUrl,
-			URL:  fmt.Sprintf("%v%v", spec.ARCHIVE_URL_PREFIX, aus.Name),
-		}
-		return ar, nil
+		return &archive, nil
 	}
 
-	archivePath := makeArchiveFileIfNeeded("", includeFiles, noZip)
+	if len(fileURL) > 0 {
+		if keepURL {
+			return &fv1.Archive{
+				Type: fv1.ArchiveTypeUrl,
+				URL:  fileURL,
+			}, nil
+		}
+		// download the file before we archive it
+		dst := pkgutil.DownloadToTempFile(fileURL)
+		includeFiles = []string{dst}
+	}
 
+	archivePath := makeArchiveFile("", includeFiles, noZip)
 	ctx := context.Background()
-	return pkgutil.UploadArchive(ctx, client, archivePath)
+	return pkgutil.UploadArchiveFile(ctx, client, archivePath)
 }
 
-// Create an archive from the given list of input files, unless that
-// list has only one item and that item is either a zip file or a URL.
+// makeArchiveFile creates a zip file from the given list of input files,
+// unless that list has only one item and that item is a zip file.
 //
 // If the inputs have only one file and noZip is true, the file is
 // returned as-is with no zipping.  (This is used for compatibility
 // with v1 envs.)  noZip is IGNORED if there is more than one input
 // file.
-func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZip bool) string {
+func makeArchiveFile(archiveNameHint string, archiveInput []string, noZip bool) string {
 
 	// Unique name for the archive
 	archiveName := archiveName(archiveNameHint, archiveInput)
@@ -118,7 +145,7 @@ func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZi
 		util.CheckErr(err, "finding all globs")
 	}
 
-	// We have one file; if it's a zip file or a URL, no need to archive it
+	// We have one file; if it's a zip file, no need to archive it
 	if len(files) == 1 {
 		// make sure it exists
 		if _, err := os.Stat(files[0]); err != nil {
@@ -129,11 +156,6 @@ func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZi
 		if archiver.Zip.Match(files[0]) || noZip {
 			return files[0]
 		}
-
-		// if it's an HTTP URL, just use the URL.
-		if strings.HasPrefix(files[0], "http://") || strings.HasPrefix(files[0], "https://") {
-			return files[0]
-		}
 	}
 
 	// For anything else, create a new archive
@@ -142,13 +164,68 @@ func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZi
 		util.CheckErr(err, "create temporary archive directory")
 	}
 
-	archivePath, err := utils.MakeArchive(filepath.Join(tmpDir, archiveName), archiveInput...)
+	archivePath, err := utils.MakeZipArchive(filepath.Join(tmpDir, archiveName), archiveInput...)
 	if err != nil {
 		util.CheckErr(err, "create archive file")
 	}
 
 	return archivePath
 }
+
+//func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZip bool) string {
+//	// Unique name for the archive
+//	archiveName := archiveName(archiveNameHint, archiveInput)
+//
+//	var files []string
+//
+//	for _, f := range archiveInput {
+//		if utils.IsURL(f) {
+//			files = append(files, f)
+//		} else {
+//			// Get files from inputs as number of files decide next steps
+//			globs, err := utils.FindAllGlobs(archiveInput)
+//			if err != nil {
+//				util.CheckErr(err, "finding all globs")
+//			}
+//			files = append(files, globs...)
+//		}
+//	}
+//
+//	log.Verbose(3, "Archive files: %v", files)
+//
+//	// We have one file; if it's a zip file or a URL, no need to archive it
+//	if len(files) == 1 {
+//		file := files[0]
+//
+//		// if it's an HTTP URL, just use the URL.
+//		if utils.IsURL(file) {
+//			return file
+//		}
+//
+//		// make sure it exists
+//		if _, err := os.Stat(file); err != nil {
+//			util.CheckErr(err, fmt.Sprintf("open input file %v", file))
+//		}
+//
+//		// if it's an existing zip file OR we're not supposed to zip it, don't do anything
+//		if archiver.Zip.Match(file) || noZip {
+//			return file
+//		}
+//	}
+//
+//	// For anything else, create a new archive
+//	tmpDir, err := utils.GetTempDir()
+//	if err != nil {
+//		util.CheckErr(err, "create temporary archive directory")
+//	}
+//
+//	archivePath, err := utils.MakeArchive(filepath.Join(tmpDir, archiveName), archiveInput...)
+//	if err != nil {
+//		util.CheckErr(err, "create archive file")
+//	}
+//
+//	return archivePath
+//}
 
 // Name an archive
 func archiveName(givenNameHint string, includedFiles []string) string {

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -51,7 +51,7 @@ func CreateArchive(client *client.Client, includeFiles []string, noZip bool, kee
 		if utils.IsURL(path) {
 			if len(includeFiles) > 1 {
 				// It's intentional to disallow the user to provide file
-				// and URL at the same time even the downloadURL is true.
+				// and URL at the same time even the keepurl is false.
 				return nil, errors.New("unable to create an archive that contains both file and URL")
 			}
 			fileURL = path

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -172,61 +172,6 @@ func makeArchiveFile(archiveNameHint string, archiveInput []string, noZip bool) 
 	return archivePath
 }
 
-//func makeArchiveFileIfNeeded(archiveNameHint string, archiveInput []string, noZip bool) string {
-//	// Unique name for the archive
-//	archiveName := archiveName(archiveNameHint, archiveInput)
-//
-//	var files []string
-//
-//	for _, f := range archiveInput {
-//		if utils.IsURL(f) {
-//			files = append(files, f)
-//		} else {
-//			// Get files from inputs as number of files decide next steps
-//			globs, err := utils.FindAllGlobs(archiveInput)
-//			if err != nil {
-//				util.CheckErr(err, "finding all globs")
-//			}
-//			files = append(files, globs...)
-//		}
-//	}
-//
-//	log.Verbose(3, "Archive files: %v", files)
-//
-//	// We have one file; if it's a zip file or a URL, no need to archive it
-//	if len(files) == 1 {
-//		file := files[0]
-//
-//		// if it's an HTTP URL, just use the URL.
-//		if utils.IsURL(file) {
-//			return file
-//		}
-//
-//		// make sure it exists
-//		if _, err := os.Stat(file); err != nil {
-//			util.CheckErr(err, fmt.Sprintf("open input file %v", file))
-//		}
-//
-//		// if it's an existing zip file OR we're not supposed to zip it, don't do anything
-//		if archiver.Zip.Match(file) || noZip {
-//			return file
-//		}
-//	}
-//
-//	// For anything else, create a new archive
-//	tmpDir, err := utils.GetTempDir()
-//	if err != nil {
-//		util.CheckErr(err, "create temporary archive directory")
-//	}
-//
-//	archivePath, err := utils.MakeArchive(filepath.Join(tmpDir, archiveName), archiveInput...)
-//	if err != nil {
-//		util.CheckErr(err, "create archive file")
-//	}
-//
-//	return archivePath
-//}
-
 // Name an archive
 func archiveName(givenNameHint string, includedFiles []string) string {
 	if len(givenNameHint) > 0 {

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -152,20 +152,20 @@ func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespac
 	}
 
 	if len(srcArchiveFiles) > 0 {
-		srcArchiveMetadata, err := CreateArchive(client, srcArchiveFiles, false, keepURL, "", "")
+		srcArchive, err := CreateArchive(client, srcArchiveFiles, false, keepURL, "", "")
 		if err != nil {
 			return nil, err
 		}
-		pkg.Spec.Source = *srcArchiveMetadata
+		pkg.Spec.Source = *srcArchive
 		needToBuild = true
 	}
 
 	if len(deployArchiveFiles) > 0 {
-		deployArchiveMetadata, err := CreateArchive(client, deployArchiveFiles, noZip, keepURL, "", "")
+		deployArchive, err := CreateArchive(client, deployArchiveFiles, noZip, keepURL, "", "")
 		if err != nil {
 			return nil, err
 		}
-		pkg.Spec.Deployment = *deployArchiveMetadata
+		pkg.Spec.Deployment = *deployArchive
 		// Users may update the env, envNS and deploy archive at the same time,
 		// but without the source archive. In this case, we should set needToBuild to false
 		needToBuild = false

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -132,7 +132,7 @@ func (opts *UpdateSubCommand) run(flags cli.Input) error {
 }
 
 func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespace string,
-	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, forceRebuild bool, noZip bool, downloadURL bool) (*metav1.ObjectMeta, error) {
+	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, forceRebuild bool, noZip bool, keepURL bool) (*metav1.ObjectMeta, error) {
 
 	needToBuild := false
 
@@ -152,7 +152,7 @@ func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespac
 	}
 
 	if len(srcArchiveFiles) > 0 {
-		srcArchiveMetadata, err := CreateArchive(client, srcArchiveFiles, false, downloadURL, "", "")
+		srcArchiveMetadata, err := CreateArchive(client, srcArchiveFiles, false, keepURL, "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -161,7 +161,7 @@ func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespac
 	}
 
 	if len(deployArchiveFiles) > 0 {
-		deployArchiveMetadata, err := CreateArchive(client, deployArchiveFiles, noZip, downloadURL, "", "")
+		deployArchiveMetadata, err := CreateArchive(client, deployArchiveFiles, noZip, keepURL, "", "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -39,6 +39,7 @@ type UpdateSubCommand struct {
 	srcArchiveFiles    []string
 	deployArchiveFiles []string
 	buildcmd           string
+	keepURL            bool
 }
 
 func Update(flags cli.Input) error {
@@ -68,6 +69,7 @@ func (opts *UpdateSubCommand) complete(flags cli.Input) error {
 	opts.srcArchiveFiles = flags.StringSlice("src")
 	opts.deployArchiveFiles = flags.StringSlice("deploy")
 	opts.buildcmd = flags.String("buildcmd")
+	opts.keepURL = flags.Bool("keepurl")
 
 	if len(opts.srcArchiveFiles) > 0 && len(opts.deployArchiveFiles) > 0 {
 		return errors.New("Need either of --src or --deploy and not both arguments.")
@@ -111,7 +113,7 @@ func (opts *UpdateSubCommand) run(flags cli.Input) error {
 
 	newPkgMeta, err := UpdatePackage(opts.client, pkg,
 		opts.envName, opts.envNamespace, opts.srcArchiveFiles,
-		opts.deployArchiveFiles, opts.buildcmd, false, false)
+		opts.deployArchiveFiles, opts.buildcmd, false, false, opts.keepURL)
 	if err != nil {
 		return errors.Wrap(err, "update package")
 	}
@@ -130,7 +132,7 @@ func (opts *UpdateSubCommand) run(flags cli.Input) error {
 }
 
 func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespace string,
-	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, forceRebuild bool, noZip bool) (*metav1.ObjectMeta, error) {
+	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, forceRebuild bool, noZip bool, downloadURL bool) (*metav1.ObjectMeta, error) {
 
 	needToBuild := false
 
@@ -150,7 +152,7 @@ func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespac
 	}
 
 	if len(srcArchiveFiles) > 0 {
-		srcArchiveMetadata, err := CreateArchive(client, srcArchiveFiles, false, "", "")
+		srcArchiveMetadata, err := CreateArchive(client, srcArchiveFiles, false, downloadURL, "", "")
 		if err != nil {
 			return nil, err
 		}
@@ -159,7 +161,7 @@ func UpdatePackage(client *client.Client, pkg *fv1.Package, envName, envNamespac
 	}
 
 	if len(deployArchiveFiles) > 0 {
-		deployArchiveMetadata, err := CreateArchive(client, deployArchiveFiles, noZip, "", "")
+		deployArchiveMetadata, err := CreateArchive(client, deployArchiveFiles, noZip, downloadURL, "", "")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -281,7 +281,7 @@ func applyArchives(fclient *client.Client, specDir string, fr *FissionResources)
 			fmt.Printf("uploading archive %v\n", name)
 			// ar.URL is actually a local filename at this stage
 			ctx := context.Background()
-			uploadedAr, err := pkgutil.UploadArchive(ctx, fclient, ar.URL)
+			uploadedAr, err := pkgutil.UploadArchiveFile(ctx, fclient, ar.URL)
 			if err != nil {
 				return err
 			}
@@ -461,7 +461,7 @@ func localArchiveFromSpec(specDir string, aus *spectypes.ArchiveUploadSpec) (*fv
 		}, nil
 	} else {
 		// checksum
-		csum, err := utils.FileChecksum(archiveFileName)
+		csum, err := utils.GetFileChecksum(archiveFileName)
 		if err != nil {
 			return nil, fmt.Errorf("failed to calculate archive checksum for %v (%v): %v", aus.Name, archiveFileName, err)
 		}

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -146,7 +146,7 @@ func (opts *DumpSubCommand) do(flags cli.Input) error {
 	if !nozip {
 		defer os.RemoveAll(tempDir)
 		path := filepath.Join(outputDir, fmt.Sprintf("%v.zip", dumpName))
-		_, err := utils.MakeArchive(path, tempDir)
+		_, err := utils.MakeZipArchive(path, tempDir)
 		if err != nil {
 			fmt.Printf("Error creating archive for dump files: %v", err)
 			return err

--- a/pkg/fission-cli/function.go
+++ b/pkg/fission-cli/function.go
@@ -298,9 +298,11 @@ func fnCreate(c *cli.Context) error {
 		}
 
 		buildcmd := c.String("buildcmd")
+		keepURL := c.Bool("keepurl")
 
 		// create new package in the same namespace as the function.
-		pkgMetadata, err = _package.CreatePackage(c, client, fnNamespace, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip)
+		pkgMetadata, err = _package.CreatePackage(c, client, fnNamespace, envName, envNamespace,
+			srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip, keepURL)
 		util.CheckErr(err, "create package")
 	}
 
@@ -638,7 +640,9 @@ func fnUpdate(c *cli.Context) error {
 			log.Fatal("Package is used by multiple functions, use --force to force update")
 		}
 
-		pkgMetadata, err = _package.UpdatePackage(client, pkg, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, false, codeFlag)
+		keepURL := c.Bool("keepurl")
+
+		pkgMetadata, err = _package.UpdatePackage(client, pkg, envName, envNamespace, srcArchiveFiles, deployArchiveFiles, buildcmd, false, codeFlag, keepURL)
 		util.CheckErr(err, fmt.Sprintf("update package '%v'", pkgName))
 
 		fmt.Printf("package '%v' updated\n", pkgMetadata.GetName())

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
+)
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want bool
+	}{
+		{"http", "http://example.com", true},
+		{"https", "https://example.com", true},
+		{"file", "file://example.com", false},
+		{"filename", "foobar.zip", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsURL(tt.url); got != tt.want {
+				t.Errorf("IsURL() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetChecksum(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     io.Reader
+		want    *fv1.Checksum
+		wantErr bool
+	}{
+		{
+			name: "string case",
+			src:  bytes.NewReader([]byte("foobar hello world")),
+			want: &fv1.Checksum{
+				Type: "sha256",
+				Sum:  "99936be1902361c29745aef68bd818f5f08246fc695e2d6e4cc474daf79fed32",
+			},
+			wantErr: false,
+		},
+		{
+			name:    "empty reader",
+			src:     nil,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetChecksum(tt.src)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetChecksum() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetChecksum() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test/init_tools.sh
+++ b/test/init_tools.sh
@@ -54,6 +54,14 @@ if [ $(uname -s) == 'Darwin' ]; then
         exit 1
     fi
 
+    if command -v gsha256sum >/dev/null; then
+        sha256sum() { gsha256sum "$@"; }
+        export -f sha256sum
+    else
+        echo '"gsha256sum" command not found. Try "brew install coreutils".'
+        exit 1
+    fi
+
     find_executable() {
         path=$1; shift
         find $path -perm +111 -type f "$@"

--- a/test/tests/test_create_fn_with_url.sh
+++ b/test/tests/test_create_fn_with_url.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set -euo pipefail
+source $(dirname $0)/../utils.sh
+
+TEST_ID=$(generate_test_id)
+echo "TEST_ID = $TEST_ID"
+
+ROOT=$(dirname $0)/../..
+
+env=nodejs-$TEST_ID
+fn=nodejs-hello-$TEST_ID
+code_url=https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js
+base64val=$(wget -O- ${code_url} | base64)
+
+cleanup() {
+    log "Cleaning up..."
+    clean_resource_by_id $TEST_ID
+}
+
+if [ -z "${TEST_NOCLEANUP:-}" ]; then
+    trap cleanup EXIT
+else
+    log "TEST_NOCLEANUP is set; not cleaning up test artifacts afterwards."
+fi
+
+# Create a hello world function in nodejs, test it with an http trigger
+log "Creating nodejs env"
+fission env create --name $env --image $NODE_RUNTIME_IMAGE
+
+log "Creating function with file"
+fission fn create --name $fn --env $env --code ${code_url}
+
+pkg=$(kubectl -n default get functions ${fn} -o yaml|grep hello-js|awk '{print $2}')
+literal=$(kubectl -n default get packages ${pkg} -o yaml|grep "literal:"|awk '{print $2}')
+
+if [ ${literal} != ${base64val}  ]; then
+    log "have different literal value: ${literal} vs. ${base64val}"
+    exit 1
+fi
+
+log "Creating route"
+fission route create --function $fn --url /$fn --method GET
+
+log "Waiting for router to catch up"
+sleep 3
+
+log "Doing an HTTP GET on the function's route"
+response=$(curl --retry 5 http://$FISSION_ROUTER/$fn)
+
+log "Checking for valid response"
+echo $response | grep -i hello
+
+log "Update function with file URL"
+fission fn update --name $fn --env $env --code ${code_url} --keepurl
+
+pkg=$(kubectl -n default get functions ${fn} -o yaml|grep hello-js|awk '{print $2}')
+url=$(kubectl -n default get packages ${pkg} -o yaml|grep "://"|awk '{print $2}')
+
+if [ ${url} != ${code_url} ]; then
+    log "have different code url: ${url} vs. ${code_url}"
+    exit 1
+fi
+
+log "Doing an HTTP GET on the function's route"
+response=$(curl --retry 5 http://$FISSION_ROUTER/$fn)
+
+log "Checking for valid response"
+echo $response | grep -i hello
+
+log "All done."


### PR DESCRIPTION
Fix #441 

In case of large files, it takes a long time for user to download
the source from the URL and then upload it to StorgeSvc through
CLI.

This PR allows a user to use URL as the function source when creating a function
and provides a new flag "--keeparchiveurl" to let the user to decided
whether the CLI should download the file first or store the file URL in the
archive directly. If "--keeparchiveurl" is true, then no checksum will be
generated, it's the user's responsibility to ensure the file won't be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1360)
<!-- Reviewable:end -->
