### PR TITLE
Fix accidentally removed timestamp when listing package

### DIFF
--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"sort"
 	"text/tabwriter"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -88,7 +89,7 @@ func (opts *ListSubCommand) run(flags cli.Input) error {
 			show = false
 		}
 		if show {
-			fmt.Fprintf(w, "%v\t%v\t%v\n", pkg.Metadata.Name, pkg.Status.BuildStatus, pkg.Spec.Environment.Name)
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", pkg.Metadata.Name, pkg.Status.BuildStatus, pkg.Spec.Environment.Name, pkg.Status.LastUpdateTimestamp.Format(time.RFC822))
 		}
 	}
 


### PR DESCRIPTION
The last update timestamp was accidentally removed when resolving conflict in PR #1341 . This PR aims to fix the issue mentioned in https://github.com/fission/fission/pull/1334#issuecomment-547922249 .