### PR TITLE
Allow to set API type for tensorflow serving environment

### DIFF
--- a/examples/tensorflow-serving/README.md
+++ b/examples/tensorflow-serving/README.md
@@ -15,9 +15,10 @@ $ fission pkg create --env tensorflow --deploy half_plus_two.zip
 
 ## Create Function
 
-Here, the `--entrypoint` represents the name of top directory contains trained model.
+Here, the `--entrypoint` represents the name of the top directory contains the trained model and what kind of API the model supports.
+Currently, three API are supported: `predict`, `classify`, `regress`. `predict` API will be used if no API kind was given.
 
 ```bash
-$ fission fn create --name t1 --pkg <pkg name> --env tensorflow --entrypoint "half_plus_two"
+$ fission fn create --name t1 --pkg <pkg name> --env tensorflow --entrypoint "half_plus_two:predict"
 $ fission fn test --name t1 --body '{"instances": [1.0, 2.0, 0.0]}' --method POST
 ```


### PR DESCRIPTION
Tensorflow Serving supports three kinds of API: predict, classify, regress. In order to fully support possible API types, this PR adds code to split the entry point with separator ":" to get model name and the API type separately. And append the API type to proxy URL when receiving the requests.

```
$ fission fn create --name t1 --pkg <pkg name> \
    --env tensorflow --entrypoint "half_plus_two:regress"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1371)
<!-- Reviewable:end -->
