### PR TITLE
Fix reverse proxy shows 404 not found when Istio enabled

### DIFF
--- a/environments/tensorflow-serving/server.go
+++ b/environments/tensorflow-serving/server.go
@@ -212,7 +212,7 @@ func main() {
 			req.URL.Scheme = "http"
 			req.URL.Host = "localhost:8501"
 			req.URL.Path = fmt.Sprintf("/v1/models/%v:%v", MODEL_NAME, API_TYPE)
-			req.Host = "localhost"
+			req.Host = "localhost:8501"
 		}
 
 		proxy := &httputil.ReverseProxy{

--- a/environments/tensorflow-serving/server.go
+++ b/environments/tensorflow-serving/server.go
@@ -212,6 +212,7 @@ func main() {
 			req.URL.Scheme = "http"
 			req.URL.Host = "localhost:8501"
 			req.URL.Path = fmt.Sprintf("/v1/models/%v:%v", MODEL_NAME, API_TYPE)
+			req.Host = "localhost"
 		}
 
 		proxy := &httputil.ReverseProxy{

--- a/pkg/controller/functionApi.go
+++ b/pkg/controller/functionApi.go
@@ -18,7 +18,6 @@ package controller
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -30,6 +29,7 @@ import (
 	restfulspec "github.com/emicklei/go-restful-openapi"
 	"github.com/go-openapi/spec"
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -258,10 +258,11 @@ func (a *API) FunctionLogsApiPost(w http.ResponseWriter, r *http.Request) {
 
 	svcUrl, err := url.Parse(dbCnf.httpURL)
 	if err != nil {
-		a.logger.Error("failed parse url to establish proxy to database for function logs",
+		msg := "failed parse url to establish proxy to database for function logs"
+		a.logger.Error(msg,
 			zap.Error(err),
 			zap.String("database_url", dbCnf.httpURL))
-		a.respondWithError(w, err)
+		a.respondWithError(w, errors.Wrap(err, msg))
 		return
 	}
 	// set up proxy server director

--- a/pkg/controller/functionApi.go
+++ b/pkg/controller/functionApi.go
@@ -261,6 +261,8 @@ func (a *API) FunctionLogsApiPost(w http.ResponseWriter, r *http.Request) {
 		a.logger.Error("failed parse url to establish proxy to database for function logs",
 			zap.Error(err),
 			zap.String("database_url", dbCnf.httpURL))
+		a.respondWithError(w, err)
+		return
 	}
 	// set up proxy server director
 	director := func(req *http.Request) {
@@ -269,6 +271,7 @@ func (a *API) FunctionLogsApiPost(w http.ResponseWriter, r *http.Request) {
 		req.URL.Scheme = svcUrl.Scheme
 		req.URL.Host = svcUrl.Host
 		req.URL.Path = svcUrl.Path
+		req.Host = svcUrl.Host
 		// set up http basic auth for database authentication
 		req.SetBasicAuth(dbCnf.username, dbCnf.password)
 	}

--- a/pkg/controller/storagesvc.go
+++ b/pkg/controller/storagesvc.go
@@ -69,6 +69,7 @@ func (api *API) StorageServiceProxy(w http.ResponseWriter, r *http.Request) {
 		req.URL.Scheme = ssUrl.Scheme
 		req.URL.Host = ssUrl.Host
 		req.URL.Path = "/v1/archive"
+		req.Host = ssUrl.Host
 	}
 	proxy := &httputil.ReverseProxy{
 		Director: director,

--- a/pkg/controller/workflowApiProxy.go
+++ b/pkg/controller/workflowApiProxy.go
@@ -24,6 +24,7 @@ func (api *API) WorkflowApiserverProxy(w http.ResponseWriter, r *http.Request) {
 		req.URL.Scheme = ssUrl.Scheme
 		req.URL.Host = ssUrl.Host
 		req.URL.Path = path
+		req.Host = ssUrl.Host
 	}
 	proxy := &httputil.ReverseProxy{
 		Director: director,

--- a/pkg/fission-cli/logdb/influxdb.go
+++ b/pkg/fission-cli/logdb/influxdb.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	influxdbClient "github.com/influxdata/influxdb/client/v2"
+	"github.com/pkg/errors"
 
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/log"
@@ -143,7 +144,7 @@ func (influx InfluxDB) query(query influxdbClient.Query) (*influxdbClient.Respon
 	queryURL.Path = path.Clean(fmt.Sprintf("%s/proxy/%s", queryURL.Path, INFLUXDB))
 	req, err := http.NewRequest(http.MethodPost, queryURL.String(), nil)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "error creating request for log proxy")
 	}
 
 	parametersBytes, err := json.Marshal(query.Parameters)


### PR DESCRIPTION
Istio sidecar proxy blocks all requests sent through the reverse proxy
to the target service if the request.Host is not properly set to the
internal target service host. This PR sets the target service hosts
before establishing the proxy for the client in order to pass the
Istio sidecar proxy check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1377)
<!-- Reviewable:end -->
