### PR TITLE
Fix fn test failed to query logs from log database

### DIFF
--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -138,7 +138,11 @@ func Commands() *cobra.Command {
 	wrapper.SetFlags(testCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{flag.HtMethod, flag.FnTestHeader, flag.FnTestBody,
-			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction},
+			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction,
+			// for getting log from log database if
+			// we failed to get logs from function pod.
+			flag.FnLogDBType,
+		},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -73,7 +73,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 	// request the controller to establish a proxy server to the database.
 	logDB, err := logdb.GetLogDB(dbType, server)
 	if err != nil {
-		return errors.New("failed to connect log database")
+		return errors.Wrapf(err, "failed to get log database")
 	}
 
 	requestChan := make(chan struct{})

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -119,13 +119,13 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 
 	if resp.StatusCode < 400 {
 		fmt.Print(string(body))
-
 		return nil
 	}
 
 	fmt.Printf("Error calling function %s: %d; Please try again or fix the error: %s", m.Name, resp.StatusCode, string(body))
 	err = printPodLogs(input)
 	if err != nil {
+		fmt.Printf("Error getting function logs from pod: %v. Try to get logs from log database", err)
 		return Log(input)
 	}
 

--- a/test/tests/test_ingress.sh
+++ b/test/tests/test_ingress.sh
@@ -75,9 +75,11 @@ createFn() {
 
     log "Creating function"
     fission fn create --name $functionName --env $env --code $ROOT/examples/nodejs/hello.js
+    sleep 3
 
     log "Doing an HTTP GET on the function's route"
     response=$(fission fn test --name $functionName)
+    echo $response
 
     log "Checking for valid response"
     echo $response | grep -i hello


### PR DESCRIPTION
When `fn test` failed to retrieve logs from the function
pod, it turns to query logs from the log database. However,
the logdb type flag is not set to `fn test`, hence the logdb
type is empty (even without default value) and causes `fn logs`
returns an error due to unable to find the corresponding log
database type.

This PR adds logdb type flag to `fn test` to resolve the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1401)
<!-- Reviewable:end -->
