### PR TITLE
Build error formatting on fission spec apply --wait

### DIFF
--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -88,7 +88,7 @@ func Commands() *cobra.Command {
 	infoCmd := &cobra.Command{
 		Use:   "info",
 		Short: "Show package information",
-		RunE:  wrapper.Wrapper(List),
+		RunE:  wrapper.Wrapper(Info),
 	}
 	wrapper.SetFlags(infoCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
@@ -98,7 +98,7 @@ func Commands() *cobra.Command {
 	rebuildCmd := &cobra.Command{
 		Use:   "rebuild",
 		Short: "Rebuild a failed package",
-		RunE:  wrapper.Wrapper(List),
+		RunE:  wrapper.Wrapper(Rebuild),
 	}
 	wrapper.SetFlags(rebuildCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -17,15 +17,13 @@ limitations under the License.
 package _package
 
 import (
-	"fmt"
-	"os"
-	"text/tabwriter"
-
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"os"
 
 	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
@@ -57,7 +55,7 @@ func (opts *InfoSubCommand) do(input cli.Input) error {
 
 func (opts *InfoSubCommand) complete(input cli.Input) error {
 	opts.name = input.String(flagkey.PkgName)
-	opts.namespace = input.String("pkgNamespace")
+	opts.namespace = input.String(flagkey.NamespacePackage)
 	return nil
 }
 
@@ -69,13 +67,6 @@ func (opts *InfoSubCommand) run(input cli.Input) error {
 	if err != nil {
 		return errors.Wrapf(err, "error finding package %s", opts.name)
 	}
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\n", "Name:", pkg.Metadata.Name)
-	fmt.Fprintf(w, "%v\t%v\n", "Environment:", pkg.Spec.Environment.Name)
-	fmt.Fprintf(w, "%v\t%v\n", "Status:", pkg.Status.BuildStatus)
-	fmt.Fprintf(w, "%v\n%v", "Build Logs:", pkg.Status.BuildLog)
-	w.Flush()
-
+	pkgutil.PrintPackageSummary(os.Stdout, pkg)
 	return nil
 }

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -17,9 +17,10 @@ limitations under the License.
 package _package
 
 import (
+	"os"
+
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"os"
 
 	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"text/tabwriter"
 
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -174,4 +175,16 @@ func DownloadStoragesvcURL(client *client.Client, fileUrl string) (io.ReadCloser
 	}
 
 	return reader, nil
+}
+
+// PrintPackageSummary prints package information and build logs.
+func PrintPackageSummary(writer io.Writer, pkg *fv1.Package) {
+	// replace escaped line breaker character
+	buildlog := strings.ReplaceAll(pkg.Status.BuildLog, `\n`, "\n")
+	w := tabwriter.NewWriter(writer, 0, 0, 1, ' ', 0)
+	fmt.Fprintf(w, "%v\t%v\n", "Name:", pkg.Metadata.Name)
+	fmt.Fprintf(w, "%v\t%v\n", "Environment:", pkg.Spec.Environment.Name)
+	fmt.Fprintf(w, "%v\t%v\n", "Status:", pkg.Status.BuildStatus)
+	fmt.Fprintf(w, "%v\n%v", "Build Logs:", buildlog)
+	w.Flush()
 }

--- a/pkg/fission-cli/cmd/package/util/util_test.go
+++ b/pkg/fission-cli/cmd/package/util/util_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
+)
+
+func TestPrintPackageSummary(t *testing.T) {
+
+	pkg := &fv1.Package{
+		Metadata: metav1.ObjectMeta{
+			Name:      "foobar",
+			Namespace: "dummy",
+		},
+		Status: fv1.PackageStatus{
+			BuildStatus: "failed",
+			BuildLog:    "dummy-build-log",
+		},
+	}
+
+	expected := `Name:        foobar\nEnvironment: \nStatus:      failed\nBuild Logs:\ndummy-build-log`
+	writer := &bytes.Buffer{}
+	PrintPackageSummary(writer, pkg)
+
+	gotWriter := strings.ReplaceAll(writer.String(), "\n", `\n`)
+	if gotWriter != expected {
+		t.Errorf("PrintPackageBuildLog() = %v, want %v", gotWriter, expected)
+	}
+}

--- a/pkg/fission-cli/cmd/spec/buildwatch.go
+++ b/pkg/fission-cli/cmd/spec/buildwatch.go
@@ -26,6 +26,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
 	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	"github.com/fission/fission/pkg/types"
 )
 
@@ -98,15 +99,12 @@ func (w *packageBuildWatcher) watch(ctx context.Context) {
 			if _, printed := w.finished[k]; printed {
 				continue
 			}
-			if pkg.Status.BuildStatus == types.BuildStatusFailed {
+			if pkg.Status.BuildStatus == types.BuildStatusFailed ||
+				pkg.Status.BuildStatus == types.BuildStatusSucceeded {
 				w.finished[k] = true
-				fmt.Printf("--- Build FAILED: ---\n%v\n------\n", pkg.Status.BuildLog)
-			} else if pkg.Status.BuildStatus == types.BuildStatusSucceeded {
-				w.finished[k] = true
-				fmt.Printf("--- Build SUCCEEDED ---\n")
-				if len(pkg.Status.BuildLog) > 0 {
-					fmt.Printf("%v\n------\n", pkg.Status.BuildLog)
-				}
+				fmt.Printf("------\n")
+				util.PrintPackageSummary(os.Stdout, &pkg)
+				fmt.Printf("------\n")
 			}
 		}
 


### PR DESCRIPTION
The character `\n` in buildlog stores in package status
are escaped and so when we have to replace them with
actual line breaker.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1403)
<!-- Reviewable:end -->
