### PR TITLE
Fix logger init container has no permission to create directory

### DIFF
--- a/charts/fission-all/config/fluentbit.conf
+++ b/charts/fission-all/config/fluentbit.conf
@@ -10,7 +10,7 @@
     Path ${LOG_PATH}
     Mem_Buf_Limit 5MB
     Parser docker
-    DB /var/log/fission/flb_kube.db
+    DB /fluent-bit/db/flb_kube.db
     Skip_Long_Lines   On
     Refresh_Interval  10
 

--- a/charts/fission-all/templates/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit.yaml
@@ -40,7 +40,7 @@ spec:
         - name: init
           image: busybox
           imagePullPolicy: {{ .Values.pullPolicy }}
-          command: ['mkdir', '-p', '/var/log/fission']
+          command: ['mkdir', '-p', '/fission']
           volumeMounts:
             - name: container-log
               mountPath: /var/log/
@@ -62,9 +62,12 @@ spec:
           command: ["/fission-bundle"]
           args: ["--logger"]
           volumeMounts:
+            - name: function-pod-log
+              mountPath: /fission
+              readOnly: false
             - name: container-log
               mountPath: /var/log/
-              readOnly: false
+              readOnly: true
             - name: docker-log
               mountPath: /var/lib/docker/containers
               readOnly: true
@@ -95,19 +98,28 @@ spec:
                   name: influxdb
                   key: password
             - name: LOG_PATH
-              value: /var/log/fission/*.log
+              value: /fission/*.log
           volumeMounts:
+            - name: function-pod-log
+              mountPath: /fission
+              readOnly: false
             - name: container-log
               mountPath: /var/log/
-              readOnly: false
+              readOnly: true
             - name: docker-log
               mountPath: /var/lib/docker/containers
               readOnly: true
             - name: fluentbit-config
               mountPath: /fluent-bit/etc/
               readOnly: true
+            - name: fluentbit-db
+              mountPath: /fluent-bit/db/
+              readOnly: false
       serviceAccountName: fission-svc
       volumes:
+        # for log symlink
+        - name: function-pod-log
+          emptyDir: {}
         - name: container-log
           hostPath:
             path: /var/log/
@@ -118,5 +130,36 @@ spec:
         - name: fluentbit-config
           configMap:
             name: {{ .Release.Name }}-fission-fluentbit
+        - name: fluentbit-db
+        {{- if .Values.logger.fluentdPersistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.logger.fluentdPersistence.existingClaim | default "fission-fluentbit-pvc" }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
   updateStrategy:
     type: RollingUpdate
+---
+{{- if and .Values.logger.fluentdPersistence.enabled (not .Values.logger.fluentdPersistence.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: fission-fluentbit-pvc
+  labels:
+    app: fission-fluentbit
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  accessModes:
+    - {{ .Values.logger.fluentdPersistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.logger.fluentdPersistence.size | quote }}
+  {{- if .Values.logger.fluentdPersistence.storageClass }}
+  {{- if (eq "-" .Values.logger.fluentdPersistence.storageClass) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.logger.fluentdPersistence.storageClass | quote }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -57,6 +57,28 @@ logger:
   fluentdImageRepository: index.docker.io
   fluentdImage: fluent/fluent-bit
   fluentdImageTag: 1.0.4
+  
+  fluentdPersistence:
+    ## If true, fission will create/use a Persistent Volume Claim
+    ## If false, use emptyDir
+    ##
+    enabled: true
+  
+    ## A manually managed Persistent Volume Claim name
+    ## Requires persistence.enabled: true
+    ## If defined, PVC must be created manually before volume will be bound
+    ##
+    # existingClaim:
+  
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner. (gp2 on AWS, standard on
+    ##   GKE, AWS & OpenStack)
+    ##
+    # storageClass: "-"
+    accessMode: ReadWriteOnce
+    size: 1Gi
 
 ## Router config
 router:

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -40,7 +40,7 @@ var nodeName = os.Getenv("NODE_NAME")
 
 const (
 	originalContainerLogPath = "/var/log/containers"
-	fissionSymlinkPath       = "/var/log/fission"
+	fissionSymlinkPath       = "/fission"
 )
 
 func makePodLoggerController(zapLogger *zap.Logger, k8sClientSet *kubernetes.Clientset) k8sCache.Controller {


### PR DESCRIPTION
On the machine that doesn't allow the container to create sub-directory
in the directory that mounts into the container, the logger enters CrashLoopBackOff.

This PR changes the location of the symlink path to prevent the permission
problem when init container trying to create a directory and a new PV
is added for fluent-bit to store its database file.

Fix logger problem mentioned in https://github.com/fission/fission/issues/107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1405)
<!-- Reviewable:end -->
