### PR TITLE
Fix truncated body returned from router

### DIFF
--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -86,9 +86,10 @@ type (
 
 	// A layer on top of http.DefaultTransport, with retries.
 	RetryingRoundTripper struct {
-		logger      *zap.Logger
-		funcHandler *functionHandler
-		timeout     int
+		logger           *zap.Logger
+		funcHandler      *functionHandler
+		funcTimeout      time.Duration
+		closeContextFunc *context.CancelFunc
 	}
 
 	// To keep the request body open during retries, we create an interface with Close operation being a no-op.
@@ -145,7 +146,7 @@ func (w *fakeCloseReadCloser) RealClose() error {
 // inside ServeHttp function of the reverseProxy.
 // Earlier, GetServiceForFunction was called inside handler function and fission explicitly set http status code to 500
 // if it returned an error.
-func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Set forwarded host header if not exists
 	roundTripper.addForwardedHostHeader(req)
 
@@ -267,28 +268,16 @@ func (roundTripper RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Res
 
 		roundTripper.logger.Debug("request headers", zap.Any("headers", req.Header))
 
-		// Creating context for client
-		if roundTripper.timeout <= 0 {
-			roundTripper.timeout = fv1.DEFAULT_FUNCTION_TIMEOUT
-		}
-
-		roundTripper.logger.Debug("Creating context for request for ", zap.Any("time", roundTripper.timeout))
-		// pass request context as parent context for the case
-		// that user aborts connection before timeout. Otherwise,
-		// the request won't be canceled until the deadline exceeded
-		// which may be a potential security issue.
-		ctx, closeCtx := context.WithTimeout(req.Context(), time.Duration(roundTripper.timeout)*time.Second)
-
 		// forward the request to the function service
-		resp, err = ocRoundTripper.RoundTrip(req.WithContext(ctx))
-		closeCtx()
+		req = roundTripper.setContext(req)
+		resp, err = ocRoundTripper.RoundTrip(req)
 
 		if err == nil {
 			// Track metrics
 			httpMetricLabels.code = resp.StatusCode
 			funcMetricLabels.cached = serviceUrlFromCache
 
-			functionCallCompleted(funcMetricLabels, httpMetricLabels,
+			go functionCallCompleted(funcMetricLabels, httpMetricLabels,
 				overhead, time.Since(startTime), resp.ContentLength)
 
 			// return response back to user
@@ -373,6 +362,26 @@ func (roundTripper RetryingRoundTripper) getDefaultTransport() *http.Transport {
 	}
 }
 
+func (roundTripper *RetryingRoundTripper) setContext(req *http.Request) *http.Request {
+	if roundTripper.closeContextFunc != nil {
+		(*roundTripper.closeContextFunc)()
+	}
+	// pass request context as parent context for the case
+	// that user aborts connection before timeout. Otherwise,
+	// the request won't be canceled until the deadline exceeded
+	// which may be a potential security issue.
+	ctx, closeCtx := context.WithTimeout(req.Context(), roundTripper.funcTimeout)
+	roundTripper.closeContextFunc = &closeCtx
+
+	return req.WithContext(ctx)
+}
+
+func (roundTripper *RetryingRoundTripper) closeContext() {
+	if roundTripper.closeContextFunc != nil {
+		(*roundTripper.closeContextFunc)()
+	}
+}
+
 func (fh *functionHandler) tapService(serviceUrl *url.URL) {
 	if fh.executor == nil {
 		return
@@ -408,20 +417,35 @@ func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *h
 		}
 	}
 
-	var timeout int = fv1.DEFAULT_FUNCTION_TIMEOUT
-	if fh.functionTimeoutMap != nil {
-		timeout = fh.functionTimeoutMap[fh.function.GetUID()]
+	fnTimeout := fh.functionTimeoutMap[fh.function.GetUID()]
+	if fnTimeout == 0 {
+		fnTimeout = fv1.DEFAULT_FUNCTION_TIMEOUT
+	}
+
+	rrt := &RetryingRoundTripper{
+		logger:      fh.logger.Named("roundtripper"),
+		funcHandler: &fh,
+		funcTimeout: time.Duration(fnTimeout)*time.Second,
 	}
 
 	proxy := &httputil.ReverseProxy{
 		Director: director,
-		Transport: &RetryingRoundTripper{
-			logger:      fh.logger.Named("roundtripper"),
-			funcHandler: &fh,
-			timeout:     timeout,
-		},
+		Transport: rrt,
 		ErrorHandler: getProxyErrorHandler(fh.logger, fh.function),
 	}
+
+	defer func() {
+		// If the context is closed when RoundTrip returns, client may receive
+		// truncated response body due to "context canceled" error. To avoid
+		// this, we need to close request context after proxy.ServeHTTP finished.
+		//
+		// NOTE: rrt.closeContext() must be put in the defer function; otherwise,
+		// reverseProxy may panic when failed to write response and the context
+		// will not be closed.
+		//
+		// ref: https://github.com/golang/go/issues/28239
+		rrt.closeContext()
+	}()
 
 	proxy.ServeHTTP(responseWriter, request)
 }

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -425,12 +425,12 @@ func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *h
 	rrt := &RetryingRoundTripper{
 		logger:      fh.logger.Named("roundtripper"),
 		funcHandler: &fh,
-		funcTimeout: time.Duration(fnTimeout)*time.Second,
+		funcTimeout: time.Duration(fnTimeout) * time.Second,
 	}
 
 	proxy := &httputil.ReverseProxy{
-		Director: director,
-		Transport: rrt,
+		Director:     director,
+		Transport:    rrt,
 		ErrorHandler: getProxyErrorHandler(fh.logger, fh.function),
 	}
 


### PR DESCRIPTION
If the context of request is closed before ReverseProxy finishing writing
a huge response body to the response writer, the client will only receive
a truncated response body.

To solve this, we move the context cancel after ReverseProxy finished.

Fix #1409

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1420)
<!-- Reviewable:end -->
