### PR TITLE
Fix no kubeobjs get created if fn created before env creation

### DIFF
--- a/pkg/apis/fission.io/v1/types.go
+++ b/pkg/apis/fission.io/v1/types.go
@@ -381,7 +381,6 @@ type (
 		TargetCPUPercent int
 
 		// This is the timeout setting for executor to wait for pod specialization.
-		// Currently, only newdeploy utilizes this value.
 		SpecializationTimeout int
 	}
 


### PR DESCRIPTION
When a function is created before the creation of environment it's used, the newdeploy will not be able to create kube objs. Hence no function service record is inserted into the cache.

When getFuncSvc is called, the newdeploy tries to find the record in service cache in order to create kube objs with the same name used in previous kubeobjs creation. However, due to no record in the cache, a NotFound error is returned directly and causes the problem. To solve this, we use fn meta UID to ensure we always get the same obj name instead of getting it from cache.

Fix #1426

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1428)
<!-- Reviewable:end -->
