### PR TITLE
Adopt existing orphan kubernetes resources when executor starts up

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -17,7 +17,6 @@ limitations under the License.
 package executor
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -164,8 +163,8 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 		err = et.TapService(svcHost)
 		if err != nil {
 			errs = multierror.Append(errs,
-				errors.Wrapf(err, "'%v' failed to tap function '%v/%v' with service url '%v'",
-					req.FnMetadata.Namespace, req.FnMetadata.Name, req.ServiceUrl, req.FnExecutorType))
+				errors.Wrapf(err, "'%v' failed to tap function '%v' in '%v' with service url '%v'",
+					req.FnMetadata.Name, req.FnMetadata.Namespace, req.ServiceUrl, req.FnExecutorType))
 		}
 	}
 
@@ -192,16 +191,7 @@ func (executor *Executor) GetHandler() http.Handler {
 }
 
 func (executor *Executor) Serve(port int) {
-	executor.logger.Info("starting executor", zap.Int("port", port))
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	for _, et := range executor.executorTypes {
-		et.Run(ctx)
-	}
-
-	executor.cms.Run(ctx)
+	executor.logger.Info("starting executor API", zap.Int("port", port))
 	address := fmt.Sprintf(":%v", port)
 	err := http.ListenAndServe(address, &ochttp.Handler{
 		Handler: executor.GetHandler(),

--- a/pkg/executor/cms/cmscontroller.go
+++ b/pkg/executor/cms/cmscontroller.go
@@ -83,7 +83,7 @@ func initConfigmapController(logger *zap.Logger, fissionClient *crd.FissionClien
 				}
 				funcs, err := getConfigmapRelatedFuncs(logger, &newCm.ObjectMeta, fissionClient)
 				if err != nil {
-					logger.Error("Failed to get functions related to secret", zap.String("secret_name", newCm.ObjectMeta.Name), zap.String("secret_namespace", newCm.ObjectMeta.Namespace))
+					logger.Error("Failed to get functions related to configmap", zap.String("configmap_name", newCm.ObjectMeta.Name), zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))
 				}
 				recyclePods(logger, funcs, types)
 			}

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -50,4 +50,7 @@ type ExecutorType interface {
 
 	// RefreshFuncPods refreshes function pods if the secrets/configmaps pods reference to get updated.
 	RefreshFuncPods(*zap.Logger, fv1.Function) error
+
+	// AdoptOrphanResources adopts existing resources created by the deleted executor.
+	AdoptOrphanResources()
 }

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -456,7 +456,7 @@ func (deploy *NewDeploy) fnCreate(fn *fv1.Function, firstcreate bool) (*fscache.
 
 	objName := deploy.getObjName(fn)
 	deployLabels := deploy.getDeployLabels(fn.Metadata, env.Metadata)
-	deployAnnotations := deploy.getDeployAnnotations()
+	deployAnnotations := deploy.getDeployAnnotations(fn.Metadata)
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns
@@ -686,7 +686,7 @@ func (deploy *NewDeploy) updateFuncDeployment(fn *fv1.Function, env *fv1.Environ
 		ns = fn.Metadata.Namespace
 	}
 
-	newDeployment, err := deploy.getDeploymentSpec(fn, env, fnObjName, ns, deployLabels, deploy.getDeployAnnotations())
+	newDeployment, err := deploy.getDeploymentSpec(fn, env, fnObjName, ns, deployLabels, deploy.getDeployAnnotations(fn.Metadata))
 	if err != nil {
 		deploy.updateStatus(fn, err, "failed to get new deployment spec while updating function")
 		return err
@@ -745,20 +745,20 @@ func (deploy *NewDeploy) getObjName(fn *fv1.Function) string {
 
 func (deploy *NewDeploy) getDeployLabels(fnMeta metav1.ObjectMeta, envMeta metav1.ObjectMeta) map[string]string {
 	return map[string]string{
-		types.EXECUTOR_TYPE:             string(fv1.ExecutorTypeNewdeploy),
-		types.ENVIRONMENT_NAME:          envMeta.Name,
-		types.ENVIRONMENT_NAMESPACE:     envMeta.Namespace,
-		types.ENVIRONMENT_UID:           string(envMeta.UID),
-		types.FUNCTION_NAME:             fnMeta.Name,
-		types.FUNCTION_NAMESPACE:        fnMeta.Namespace,
-		types.FUNCTION_UID:              string(fnMeta.UID),
-		types.FUNCTION_RESOURCE_VERSION: fnMeta.ResourceVersion,
+		types.EXECUTOR_TYPE:         string(fv1.ExecutorTypeNewdeploy),
+		types.ENVIRONMENT_NAME:      envMeta.Name,
+		types.ENVIRONMENT_NAMESPACE: envMeta.Namespace,
+		types.ENVIRONMENT_UID:       string(envMeta.UID),
+		types.FUNCTION_NAME:         fnMeta.Name,
+		types.FUNCTION_NAMESPACE:    fnMeta.Namespace,
+		types.FUNCTION_UID:          string(fnMeta.UID),
 	}
 }
 
-func (deploy *NewDeploy) getDeployAnnotations() map[string]string {
+func (deploy *NewDeploy) getDeployAnnotations(fnMeta metav1.ObjectMeta) map[string]string {
 	return map[string]string{
 		types.EXECUTOR_INSTANCEID_LABEL: deploy.instanceID,
+		types.FUNCTION_RESOURCE_VERSION: fnMeta.ResourceVersion,
 	}
 }
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -301,10 +301,10 @@ func (deploy *NewDeploy) AdoptOrphanResources() {
 
 				_, err = deploy.fnCreate(fn, true)
 				if err != nil {
-					deploy.logger.Warn("Failed to adopt resources for function", zap.Error(err))
+					deploy.logger.Warn("failed to adopt resources for function", zap.Error(err))
 					return
 				}
-				deploy.logger.Info("Adopt resources for function", zap.String("function", fn.Metadata.Name))
+				deploy.logger.Info("adopt resources for function", zap.String("function", fn.Metadata.Name))
 			}()
 		}
 	}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -317,7 +317,7 @@ func (gpm *GenericPoolManager) AdoptOrphanResources() {
 			fnName, ok1 := pod.Labels[types.FUNCTION_NAME]
 			fnNS, ok2 := pod.Labels[types.FUNCTION_NAMESPACE]
 			fnUID, ok3 := pod.Labels[types.FUNCTION_UID]
-			fnRV, ok4 := pod.Labels[types.FUNCTION_RESOURCE_VERSION]
+			fnRV, ok4 := pod.Annotations[types.FUNCTION_RESOURCE_VERSION]
 			envName, ok5 := pod.Labels[types.ENVIRONMENT_NAME]
 			envNS, ok6 := pod.Labels[types.ENVIRONMENT_NAMESPACE]
 			svcHost, ok7 := pod.Annotations[types.ANNOTATION_SVC_HOST]

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -121,13 +121,18 @@ const (
 
 // executor kubernetes object label key
 const (
-	ENVIRONMENT_NAMESPACE = "environmentNamespace"
-	ENVIRONMENT_NAME      = "environmentName"
-	ENVIRONMENT_UID       = "environmentUid"
-	FUNCTION_NAMESPACE    = "functionNamespace"
-	FUNCTION_NAME         = "functionName"
-	FUNCTION_UID          = "functionUid"
-	EXECUTOR_TYPE         = "executorType"
+	ENVIRONMENT_NAMESPACE     = "environmentNamespace"
+	ENVIRONMENT_NAME          = "environmentName"
+	ENVIRONMENT_UID           = "environmentUid"
+	FUNCTION_NAMESPACE        = "functionNamespace"
+	FUNCTION_NAME             = "functionName"
+	FUNCTION_UID              = "functionUid"
+	FUNCTION_RESOURCE_VERSION = "functionResourceVersion"
+	EXECUTOR_TYPE             = "executorType"
+)
+
+const (
+	ANNOTATION_SVC_HOST = "svcHost"
 )
 
 const (

--- a/test/utils.sh
+++ b/test/utils.sh
@@ -166,8 +166,8 @@ export FISSION_NATS_STREAMING_URL="http://defaultFissionAuthToken@$(kubectl -n $
 ## To change the environment image setting for CI test, please refer run_all_tests() in test_utils.sh.
 export PYTHON_RUNTIME_IMAGE=${PYTHON_RUNTIME_IMAGE:-fission/python-env}
 export PYTHON_BUILDER_IMAGE=${PYTHON_BUILDER_IMAGE:-fission/python-builder}
-export GO_RUNTIME_IMAGE=${GO_RUNTIME_IMAGE:-fission/go-env}
-export GO_BUILDER_IMAGE=${GO_BUILDER_IMAGE:-fission/go-builder}
+export GO_RUNTIME_IMAGE=${GO_RUNTIME_IMAGE:-fission/go-env-1.12}
+export GO_BUILDER_IMAGE=${GO_BUILDER_IMAGE:-fission/go-builder-1.12}
 export JVM_RUNTIME_IMAGE=${JVM_RUNTIME_IMAGE:-fission/jvm-env}
 export JVM_BUILDER_IMAGE=${JVM_BUILDER_IMAGE:-fission/jvm-builder}
 export NODE_RUNTIME_IMAGE=${NODE_RUNTIME_IMAGE:-fission/node-env}


### PR DESCRIPTION
Previously, once the executor is deleted for reasons (like upgrade or cluster scale-in), 
the new executor deletes all existing resources created by the old executor and creates 
new one. This mechanism becomes a problem when there are requests connecting to the 
existing pods. Also in the worst case, the cluster may not have enough resources to create 
new pods and cause service downtime.

This PR let each executor type adopts existing resources before starting the executor 
API services, and so the alive connections won't experience failure. However, the requests 
send to the function that doesn't have alive function pods will still fail due to the 
executor is in bootstrapping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1443)
<!-- Reviewable:end -->
