### PR TITLE
Fix adopted deployment uses old fetcher image

### DIFF
--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -71,7 +71,7 @@ func (deploy *NewDeploy) createOrGetDeployment(fn *fv1.Function, env *fv1.Enviro
 			existingDepl.Spec.Template.Spec.TerminationGracePeriodSeconds = deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
 			existingDepl, err = deploy.kubernetesClient.AppsV1().Deployments(deployNamespace).Update(existingDepl)
 			if err != nil {
-				deploy.logger.Warn("error patching executor instance ID of deploy", zap.Error(err),
+				deploy.logger.Warn("error adopting deploy", zap.Error(err),
 					zap.String("deploy", deployName), zap.String("ns", deployNamespace))
 				return nil, err
 			}

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -459,8 +459,8 @@ func (gp *GenericPool) createPool() error {
 	depl, err := gp.kubernetesClient.AppsV1().Deployments(gp.namespace).Get(deployment.Name, metav1.GetOptions{})
 	if err == nil {
 		if depl.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != gp.instanceId {
-			patch := fmt.Sprintf(`{"metadata":{"annotations":{"%v":"%v"}}}`, fv1.EXECUTOR_INSTANCEID_LABEL, gp.instanceId)
-			depl, err = gp.kubernetesClient.AppsV1().Deployments(gp.namespace).Patch(deployment.Name, k8sTypes.StrategicMergePatchType, []byte(patch))
+			deployment.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] = gp.instanceId
+			depl, err = gp.kubernetesClient.AppsV1().Deployments(gp.namespace).Update(deployment)
 		}
 		gp.deployment = depl
 		return err


### PR DESCRIPTION
When a new executor starts up, it adopts the orphan kubernetes resources created 
by the old executor instance. However, the adopted resource won't reflect the changes 
come with the new executor, for example, the fetcher image inside won't be changed. 

To solve this, executor updates the resource spec (HPA/Deployment/Service) with the 
latest resources spec. By doing this, we can prevent the inconsistency between resources 
created by different executor instance, also minimizes the impact on users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1447)
<!-- Reviewable:end -->
