### PR TITLE
Let executor type manages how to do cleanup for old kubeobjects

### DIFF
--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -53,4 +53,7 @@ type ExecutorType interface {
 
 	// AdoptOrphanResources adopts existing resources created by the deleted executor.
 	AdoptExistingResources()
+
+	// CleanupOldExecutorObjects cleans up resources created by old executor instances
+	CleanupOldExecutorObjects()
 }

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -411,7 +411,7 @@ func (deploy *NewDeploy) createOrGetHpa(hpaName string, execStrategy *fv1.Execut
 				return nil, err
 			}
 		}
-		return cHpa, err
+		return cHpa, nil
 	}
 	return nil, err
 }


### PR DESCRIPTION
Add CleanupOldExecutorObjects to executor type interface in order
to let an executor type manages how to clean up the resources it created.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1455)
<!-- Reviewable:end -->
