### PR TITLE
Remove FISSION_ROUTER for fn test

### DIFF
--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -58,17 +58,16 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 	}
 
 	routerURL := os.Getenv("FISSION_ROUTER")
-	if len(routerURL) == 0 {
-		// Portforward to the fission router
-		localRouterPort, err := util.SetupPortForward(util.GetFissionNamespace(), "application=fission-router")
-		if err != nil {
-			return err
-		}
-		routerURL = "127.0.0.1:" + localRouterPort
-	} else {
-		console.Verbose(2, "Env FISSION_ROUTER: %v", routerURL)
-		routerURL = strings.TrimPrefix(routerURL, "http://")
+	if len(routerURL) != 0 {
+		console.Warn("The environment variable FISSION_ROUTER is no longer supported for this command")
 	}
+
+	// Portforward to the fission router
+	localRouterPort, err := util.SetupPortForward(util.GetFissionNamespace(), "application=fission-router")
+	if err != nil {
+		return err
+	}
+	routerURL = "127.0.0.1:" + localRouterPort
 
 	fnUri := m.Name
 	if m.Namespace != metav1.NamespaceDefault {


### PR DESCRIPTION
Removing use of environment variable FISSION_ROUTER for `fission fn test`
The check for the variable is in a `if` block. Removing the `if` doesn't harm with some modification.
Added a warning for the user.

Resolves https://github.com/fission/fission/issues/1404

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1465)
<!-- Reviewable:end -->
