### PR TITLE
Fix go-server failed to load plugin

### DIFF
--- a/environments/go/server.go
+++ b/environments/go/server.go
@@ -158,7 +158,7 @@ func specializeHandlerV2() func(http.ResponseWriter, *http.Request) {
 				return
 			} else {
 				log.Printf("unknown error looking for code path(%v): %v", loadreq.FilePath, err)
-				err = fmt.Errorf( "unknown error: %v", err)
+				err = fmt.Errorf("unknown error: %v", err)
 				w.WriteHeader(http.StatusInternalServerError)
 				w.Write([]byte(err.Error()))
 				return

--- a/environments/go/server.go
+++ b/environments/go/server.go
@@ -119,7 +119,7 @@ func specializeHandler() func(http.ResponseWriter, *http.Request) {
 		userFunc, err = loadPlugin(CODE_PATH, "Handler")
 		if err != nil {
 			err = fmt.Errorf("error specializing function: %v", err)
-			log.Printf(err.Error())
+			log.Println(err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
 			return
@@ -169,7 +169,7 @@ func specializeHandlerV2() func(http.ResponseWriter, *http.Request) {
 		userFunc, err = loadPlugin(loadreq.FilePath, loadreq.FunctionName)
 		if err != nil {
 			err = fmt.Errorf("error specializing function: %v", err)
-			log.Printf(err.Error())
+			log.Println(err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 			w.Write([]byte(err.Error()))
 			return


### PR DESCRIPTION
The 3rd party package version used by the go server may be different from the one in the user's source code and will cause plugin version mismatched. Hence, we should never import any external packages except the Fission or built-in packages.

This PR replaces all 3rd-party packages with built-in packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1469)
<!-- Reviewable:end -->
