### PR TITLE
Support arm builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,8 @@ before_install:
 #  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - sudo apt-get -y install apache2-utils parallel realpath
   - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
+  - echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json
+  - sudo service docker restart
 
 install:
   - hack/travis-kube-setup.sh

--- a/cmd/fission-bundle/Dockerfile.fission-bundle
+++ b/cmd/fission-bundle/Dockerfile.fission-bundle
@@ -31,7 +31,7 @@ ARG BUILDVERSION=unknown
 ARG BUILDDATE=unknown
 # E.g. BUILDDATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=0 go build \
     -o /go/bin/fission-bundle \
     -gcflags=-trimpath=$GOPATH \
     -asmflags=-trimpath=$GOPATH \

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -86,7 +86,7 @@ build_and_push_go_mod_cache_image() {
     gcloud_login
 
     gcloud docker -- pull $image_tag
-    docker build -q -t $image_tag -f $ROOT/cmd/fission-bundle/Dockerfile.fission-bundle --cache-from ${image_tag} --target godep --build-arg GITCOMMIT=$(getGitCommit) --build-arg BUILDDATE=$(getDate) --build-arg BUILDVERSION=$(getVersion) .
+    docker buildx build --platform linux/amd64,linux/arm64 -t $image_tag -f $ROOT/cmd/fission-bundle/Dockerfile.fission-bundle --cache-from ${image_tag} --target godep --build-arg GITCOMMIT=$(getGitCommit) --build-arg BUILDDATE=$(getDate) --build-arg BUILDVERSION=$(getVersion) .
 
     gcloud docker -- push $image_tag &
     travis_fold_end go_mod_cache_image


### PR DESCRIPTION
This is my second attempt, since my first attempt QEMU support is a lot better and using go 1.13 is no longer required #1421

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1473)
<!-- Reviewable:end -->
