### PR TITLE
Add --dry option to view the spec without saving it

### DIFF
--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -34,7 +34,7 @@ func Commands() *cobra.Command {
 		Optional: []flag.Flag{flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret,
-			flag.EnvExternalNetwork, flag.EnvKeepArchive, flag.NamespaceEnvironment, flag.SpecSave},
+			flag.EnvExternalNetwork, flag.EnvKeepArchive, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDump},
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -47,6 +47,14 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+	// dump the spec to STDOUT if --dry option availabale
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*opts.env)
+		if err != nil {
+			return errors.Wrap(err, "Error displaying environment spec ")
+		}
+		return nil
+	}
 	return opts.run(input)
 }
 

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -48,7 +48,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave},
+			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDump},
 	})
 
 	getCmd := &cobra.Command{
@@ -94,7 +94,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave,
+			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDump,
 		},
 	})
 

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -58,6 +58,14 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+	// dump the spec to STDOUT
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*opts.function)
+		if err != nil {
+			return errors.Wrap(err, "Error displaying function spec ")
+		}
+		return nil
+	}
 	return opts.run(input)
 }
 

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.HtUrl, flag.HtFnName},
 		Optional: []flag.Flag{flag.HtName, flag.HtMethod, flag.HtIngress,
 			flag.HtIngressRule, flag.HtIngressAnnotation, flag.HtIngressTLS,
-			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave},
+			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave, flag.SpecDump},
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
@@ -48,6 +48,14 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	err := opts.complete(input)
 	if err != nil {
 		return err
+	}
+	// dump the spec to STDOUT
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*opts.trigger)
+		if err != nil {
+			return errors.Wrap(err, "Error displaying httptrigger spec ")
+		}
+		return nil
 	}
 	return opts.run(input)
 }
@@ -156,6 +164,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
+
 	// if we're writing a spec, don't call the API
 	if input.Bool(flagkey.SpecSave) {
 		specFile := fmt.Sprintf("route-%v.yaml", opts.trigger.Metadata.Name)

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.KwFnName},
-		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.KwNamespace, flag.NamespaceFunction, flag.SpecSave},
+		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.KwNamespace, flag.NamespaceFunction, flag.SpecSave, flag.SpecDump},
 		// TODO: add label selector flag
 		// flag.KwLabelsFlag
 	})

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -46,6 +46,15 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+	// dump the spec to STDOUT
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*opts.watcher)
+		if err != nil {
+			return errors.Wrap(err, "Error displaying kubewatch spec ")
+		}
+		return nil
+	}
+
 	return opts.run(input)
 }
 

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.MqtFnName, flag.MqtTopic},
 		Optional: []flag.Flag{flag.MqtName, flag.MqtMQType, flag.MqtRespTopic,
 			flag.MqtErrorTopic, flag.MqtMaxRetries, flag.MqtMsgContentType,
-			flag.NamespaceFunction, flag.SpecSave},
+			flag.NamespaceFunction, flag.SpecSave, flag.SpecDump},
 	})
 
 	updateCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -47,6 +47,15 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+	// dump the spec to STDOUT
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*opts.trigger)
+		if err != nil {
+			return errors.Wrap(err, "Error displaying message queue trigger spec ")
+		}
+		return nil
+	}
+
 	return opts.run(input)
 }
 
@@ -147,6 +156,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
+
 	// if we're writing a spec, don't call the API
 	if input.Bool(flagkey.SpecSave) {
 		specFile := fmt.Sprintf("mqtrigger-%v.yaml", opts.trigger.Metadata.Name)

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd,
-			flag.NamespacePackage, flag.NamespaceEnvironment, flag.SpecSave},
+			flag.NamespacePackage, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDump},
 	})
 
 	getSrcCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -175,6 +175,15 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 		},
 	}
 
+	// dump the spec to STDOUT
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*pkg)
+		if err != nil {
+			return &pkg.Metadata, errors.Wrap(err, "Error displaying package spec ")
+		}
+		return &pkg.Metadata, nil
+	}
+
 	if len(specFile) > 0 {
 		// if a package with the same spec exists, don't create a new spec file
 		fr, err := spec.ReadSpecs(util.GetSpecDir(input))

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -162,6 +162,78 @@ func save(data []byte, specDir string, specFile string) error {
 	return nil
 }
 
+// called from `fission * create --dry`
+func SpecDump(resource interface{}) error {
+	var meta metav1.ObjectMeta
+	var kind string
+
+	// make sure we're writing a known type
+	var data []byte
+	var err error
+	switch typedres := resource.(type) {
+	case types.ArchiveUploadSpec:
+		typedres.Kind = "ArchiveUploadSpec"
+		meta = metav1.ObjectMeta{
+			Name: typedres.Name,
+		}
+		kind = typedres.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.Package:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "Package"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.Function:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "Function"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.Environment:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "Environment"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.HTTPTrigger:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "HTTPTrigger"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.KubernetesWatchTrigger:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "KubernetesWatchTrigger"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.MessageQueueTrigger:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "MessageQueueTrigger"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	case fv1.TimeTrigger:
+		typedres.TypeMeta.APIVersion = fv1.CRD_VERSION
+		typedres.TypeMeta.Kind = "TimeTrigger"
+		meta = typedres.Metadata
+		kind = typedres.TypeMeta.Kind
+		data, err = yaml.Marshal(typedres)
+	default:
+		return fmt.Errorf("can't save resource %#v", resource)
+	}
+	if err != nil {
+		return errors.Wrap(err, "Couldn't marshal YAML")
+	}
+
+	// Print the specs
+	console.Info(fmt.Sprintf("\n%v", (string(data))))
+	console.Info(fmt.Sprintf("\n To save this Spec %v '%v/%v' use  --spec option",
+		kind, meta.Namespace, meta.Name))
+	return nil
+}
+
 // called from `fission * create --spec`
 func SpecSave(resource interface{}, specFile string) error {
 	var meta metav1.ObjectMeta

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Optional: []flag.Flag{flag.TtName, flag.TtFnName,
-			flag.TtCron, flag.NamespaceFunction, flag.SpecSave},
+			flag.TtCron, flag.NamespaceFunction, flag.SpecSave, flag.SpecDump},
 	})
 
 	updateCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -49,6 +49,15 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+	// dump the spec to STDOUT
+	if input.Bool(flagkey.SpecDump) {
+		err := spec.SpecDump(*opts.trigger)
+		if err != nil {
+			return errors.Wrap(err, "Error displaying time trigger spec ")
+		}
+		return nil
+	}
+
 	return opts.run(input)
 }
 

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -170,6 +170,7 @@ var (
 	SpecWait     = Flag{Type: Bool, Name: flagkey.SpecWait, Usage: "Wait for package builds"}
 	SpecWatch    = Flag{Type: Bool, Name: flagkey.SpecWatch, Usage: "Watch local files for change, and re-apply specs as necessary"}
 	SpecDelete   = Flag{Type: Bool, Name: flagkey.SpecDelete, Usage: "Allow apply to delete resources that no longer exist in the specification"}
+	SpecDump     = Flag{Type: Bool, Name: flagkey.SpecDump, Usage: "View the generated specs"}
 
 	SupportOutput = Flag{Type: String, Name: flagkey.SupportOutput, Short: "o", Usage: "Output directory to save dump archive/files", DefaultValue: flagkey.DefaultSpecOutputDir}
 	SupportNoZip  = Flag{Type: Bool, Name: flagkey.SupportNoZip, Usage: "Save dump information into multiple files instead of single zip file"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -125,6 +125,7 @@ const (
 	SpecWait     = "wait"
 	SpecWatch    = "watch"
 	SpecDelete   = "delete"
+	SpecDump     = "dry"
 
 	SupportOutput = Output
 	SupportNoZip  = "nozip"


### PR DESCRIPTION
Resolves #895 
Adding --dry option, by using this we can view the generated spec without saving it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1480)
<!-- Reviewable:end -->
