### PR TITLE
Add --dry option to view the generated spec without saving

### DIFF
--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -34,7 +34,7 @@ func Commands() *cobra.Command {
 		Optional: []flag.Flag{flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret,
-			flag.EnvExternalNetwork, flag.EnvKeepArchive, flag.NamespaceEnvironment, flag.SpecSave},
+			flag.EnvExternalNetwork, flag.EnvKeepArchive, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -75,10 +75,10 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	}
 
 	// if we're writing a spec, don't call the API
-	// save to spec file
-	if input.Bool(flagkey.SpecSave) {
+	// save to spec file or display the spec to console
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
 		specFile := fmt.Sprintf("env-%v.yaml", m.Name)
-		err = spec.SpecSave(*opts.env, specFile)
+		err = spec.SpecSave(*opts.env, specFile, input)
 		if err != nil {
 			return errors.Wrap(err, "error creating environment spec")
 		}

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -48,7 +48,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave},
+			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -301,8 +301,9 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) error {
 	// if we're writing a spec, don't create the function
-	if input.Bool(flagkey.SpecSave) {
-		err := spec.SpecSave(*opts.function, opts.specFile)
+	// save to spec file or display the spec to console
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
+		err := spec.SpecSave(*opts.function, opts.specFile, input)
 		if err != nil {
 			return errors.Wrap(err, "error creating function spec")
 		}

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.HtUrl, flag.HtFnName},
 		Optional: []flag.Flag{flag.HtName, flag.HtMethod, flag.HtIngress,
 			flag.HtIngressRule, flag.HtIngressAnnotation, flag.HtIngressTLS,
-			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave},
+			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
@@ -157,9 +157,10 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
 	// if we're writing a spec, don't call the API
-	if input.Bool(flagkey.SpecSave) {
+	// save to spec file or display the spec to console
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
 		specFile := fmt.Sprintf("route-%v.yaml", opts.trigger.Metadata.Name)
-		err := spec.SpecSave(*opts.trigger, specFile)
+		err := spec.SpecSave(*opts.trigger, specFile, input)
 		if err != nil {
 			return errors.Wrap(err, "error creating HTTP trigger spec")
 		}

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.KwFnName},
-		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.KwNamespace, flag.NamespaceFunction, flag.SpecSave},
+		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.KwNamespace, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 		// TODO: add label selector flag
 		// flag.KwLabelsFlag
 	})

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -103,9 +103,10 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
 	// if we're writing a spec, don't call the API
-	if input.Bool(flagkey.SpecSave) {
+	// save to spec file or display the spec to console
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
 		specFile := fmt.Sprintf("kubewatch-%v.yaml", opts.watcher.Metadata.Name)
-		err := spec.SpecSave(*opts.watcher, specFile)
+		err := spec.SpecSave(*opts.watcher, specFile, input)
 		if err != nil {
 			return errors.Wrap(err, "error creating kubewatch spec")
 		}

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.MqtFnName, flag.MqtTopic},
 		Optional: []flag.Flag{flag.MqtName, flag.MqtMQType, flag.MqtRespTopic,
 			flag.MqtErrorTopic, flag.MqtMaxRetries, flag.MqtMsgContentType,
-			flag.NamespaceFunction, flag.SpecSave},
+			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 	})
 
 	updateCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -148,9 +148,10 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
 	// if we're writing a spec, don't call the API
-	if input.Bool(flagkey.SpecSave) {
+	// save to spec file or display the spec to console
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
 		specFile := fmt.Sprintf("mqtrigger-%v.yaml", opts.trigger.Metadata.Name)
-		err := spec.SpecSave(*opts.trigger, specFile)
+		err := spec.SpecSave(*opts.trigger, specFile, input)
 		if err != nil {
 			return errors.Wrap(err, "error creating message queue trigger spec")
 		}

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd,
-			flag.NamespacePackage, flag.NamespaceEnvironment, flag.SpecSave},
+			flag.NamespacePackage, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
 	})
 
 	getSrcCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -134,7 +134,7 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 		if len(specFile) > 0 { // we should do this in all cases, i think
 			pkgStatus = fv1.BuildStatusNone
 		}
-		deployment, err := CreateArchive(client, deployArchiveFiles, noZip, insecure, deployChecksum, specDir, specFile)
+		deployment, err := CreateArchive(client, input, deployArchiveFiles, noZip, insecure, deployChecksum, specDir, specFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating source archive")
 		}
@@ -144,7 +144,7 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 		}
 	}
 	if len(srcArchiveFiles) > 0 {
-		source, err := CreateArchive(client, srcArchiveFiles, false, insecure, srcChecksum, specDir, specFile)
+		source, err := CreateArchive(client, input, srcArchiveFiles, false, insecure, srcChecksum, specDir, specFile)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating deploy archive")
 		}
@@ -189,7 +189,7 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 			return &pkg.Metadata, nil
 		}
 
-		err = spec.SpecSave(*pkg, specFile)
+		err = spec.SpecSave(*pkg, specFile, input)
 		if err != nil {
 			return nil, errors.Wrap(err, "error saving package spec")
 		}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -31,6 +31,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/fission.io/v1"
 	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	spectypes "github.com/fission/fission/pkg/fission-cli/cmd/spec/types"
@@ -45,7 +46,7 @@ import (
 // create an archive upload spec in the specs directory; otherwise
 // upload the archive using client.  noZip avoids zipping the
 // includeFiles, but is ignored if there's more than one includeFile.
-func CreateArchive(client client.Interface, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
+func CreateArchive(client client.Interface, input cli.Input, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
 	// get root dir
 	var rootDir string
 	var err error
@@ -56,7 +57,6 @@ func CreateArchive(client client.Interface, includeFiles []string, noZip bool, i
 			return nil, errors.Wrapf(err, "error getting root directory of spec directory")
 		}
 	}
-
 	errs := utils.MultiErrorWithFormat()
 	fileURL := ""
 
@@ -163,7 +163,7 @@ func CreateArchive(client client.Interface, includeFiles []string, noZip bool, i
 			aus.Name = oldAus.Name
 		} else {
 			// save the uploadspec
-			err := spec.SpecSave(*aus, specFile)
+			err := spec.SpecSave(*aus, specFile, input)
 			if err != nil {
 				return nil, errors.Wrapf(err, "write spec file %v", specFile)
 			}

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -132,7 +132,7 @@ func UpdatePackage(input cli.Input, client client.Interface, pkg *fv1.Package) (
 	}
 
 	if input.IsSet(flagkey.PkgSrcArchive) {
-		srcArchive, err := CreateArchive(client, srcArchiveFiles, noZip, insecure, srcChecksum, "", "")
+		srcArchive, err := CreateArchive(client, input, srcArchiveFiles, noZip, insecure, srcChecksum, "", "")
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating source archive")
 		}
@@ -148,7 +148,7 @@ func UpdatePackage(input cli.Input, client client.Interface, pkg *fv1.Package) (
 	}
 
 	if input.IsSet(flagkey.PkgDeployArchive) || input.IsSet(flagkey.PkgCode) {
-		deployArchive, err := CreateArchive(client, deployArchiveFiles, noZip, insecure, deployChecksum, "", "")
+		deployArchive, err := CreateArchive(client, input, deployArchiveFiles, noZip, insecure, deployChecksum, "", "")
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating deploy archive")
 		}

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Optional: []flag.Flag{flag.TtName, flag.TtFnName,
-			flag.TtCron, flag.NamespaceFunction, flag.SpecSave},
+			flag.TtCron, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 	})
 
 	updateCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -111,9 +111,10 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
 	// if we're writing a spec, don't call the API
-	if input.Bool(flagkey.SpecSave) {
+	// save to spec file or display the spec to console
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
 		specFile := fmt.Sprintf("timetrigger-%v.yaml", opts.trigger.Metadata.Name)
-		err := spec.SpecSave(*opts.trigger, specFile)
+		err := spec.SpecSave(*opts.trigger, specFile, input)
 		if err != nil {
 			return errors.Wrap(err, "error creating time trigger spec")
 		}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -170,6 +170,7 @@ var (
 	SpecWait     = Flag{Type: Bool, Name: flagkey.SpecWait, Usage: "Wait for package builds"}
 	SpecWatch    = Flag{Type: Bool, Name: flagkey.SpecWatch, Usage: "Watch local files for change, and re-apply specs as necessary"}
 	SpecDelete   = Flag{Type: Bool, Name: flagkey.SpecDelete, Usage: "Allow apply to delete resources that no longer exist in the specification"}
+	SpecDry      = Flag{Type: Bool, Name: flagkey.SpecDry, Usage: "View the generated specs"}
 
 	SupportOutput = Flag{Type: String, Name: flagkey.SupportOutput, Short: "o", Usage: "Output directory to save dump archive/files", DefaultValue: flagkey.DefaultSpecOutputDir}
 	SupportNoZip  = Flag{Type: Bool, Name: flagkey.SupportNoZip, Usage: "Save dump information into multiple files instead of single zip file"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -125,6 +125,7 @@ const (
 	SpecWait     = "wait"
 	SpecWatch    = "watch"
 	SpecDelete   = "delete"
+	SpecDry      = "dry"
 
 	SupportOutput = Output
 	SupportNoZip  = "nozip"


### PR DESCRIPTION
Resolves #895 
Adding --dry option to view the generated spec. It can be used with --spec as well. 
We can view and save the spec at same time, if we will provide --dry and --spec in same command. --spec will work same as previously ( specs directory is required) but you can view your generated specs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1483)
<!-- Reviewable:end -->
