### PR TITLE
Move to new CI cluster

### DIFF
--- a/test/cluster/main.tf
+++ b/test/cluster/main.tf
@@ -7,11 +7,11 @@ terraform {
 
 provider "google" {
   version = "~> 2.7"
-  project = "fission-ci"
+  project = "infracloud-fission-infra"
 }
 
-resource "google_container_cluster" "fission-ci-1" {
-  name                     = "fission-ci-1"
+resource "google_container_cluster" "fission-ci" {
+  name                     = "fission-ci"
   description              = ""
   min_master_version       = "1.13.6-gke.0"
   network                  = "projects/fission-ci/global/networks/default"
@@ -26,7 +26,7 @@ resource "google_container_cluster" "fission-ci-1" {
 resource "google_container_node_pool" "pool-v1" {
   name     = "pool-v1"
   location = "us-central1-a"
-  cluster  = google_container_cluster.fission-ci-1.name
+  cluster  = google_container_cluster.fission-ci.name
 
   node_config {
     machine_type = "n1-standard-2"

--- a/test/tests/test_ingress.sh
+++ b/test/tests/test_ingress.sh
@@ -113,6 +113,9 @@ checkIngress $routeName "" $relativeUrl "" ""
 
 fission route delete --name $routeName
 
+TEST_ID=$(generate_test_id)
+
+routeName="ingress-$TEST_ID"
 relativeUrl="/itest-$TEST_ID/{url}"
 wildcardPath="/itest-$TEST_ID/*"
 realPath="itest-$TEST_ID/test"

--- a/test/upgrade/fission_upgrade_test.sh
+++ b/test/upgrade/fission_upgrade_test.sh
@@ -72,7 +72,7 @@ upgrade_tests
 
 ## Build images for Upgrade
 
-REPO=gcr.io/fission-ci
+REPO=gcr.io/$GKE_PROJECT_NAME
 IMAGE=fission-bundle
 FETCHER_IMAGE=$REPO/fetcher
 BUILDER_IMAGE=$REPO/builder


### PR DESCRIPTION
Don't know somehow after moving to the new CI cluster with newer Kubernetes version (13 -> 15) the informer delete event arrives router after ~20secs and causes failure of ingress test. In order to not block the CI, this PR modified the ingress test script to regenerates the TEST_ID before creating a new trigger to avoid the name conflict issue.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1500)
<!-- Reviewable:end -->
