### PR TITLE
Temporarily disable building JVM image during CI builds

### DIFF
--- a/test/build.sh
+++ b/test/build.sh
@@ -28,12 +28,12 @@ build_and_push_fetcher $FETCHER_IMAGE:$TAG $REPO/go-mod-image-cache
 build_and_push_builder $BUILDER_IMAGE:$TAG $REPO/go-mod-image-cache
 
 build_and_push_env_runtime python $REPO/python-env:$TAG ""
-build_and_push_env_runtime jvm $REPO/jvm-env:$TAG ""
+#build_and_push_env_runtime jvm $REPO/jvm-env:$TAG ""
 build_and_push_env_runtime go $REPO/go-env:$TAG "1.12"
 build_and_push_env_runtime tensorflow-serving $REPO/tensorflow-serving-env:$TAG ""
 
 build_and_push_env_builder python $REPO/python-env-builder:$TAG $BUILDER_IMAGE:$TAG ""
-build_and_push_env_builder jvm $REPO/jvm-env-builder:$TAG $BUILDER_IMAGE:$TAG ""
+#build_and_push_env_builder jvm $REPO/jvm-env-builder:$TAG $BUILDER_IMAGE:$TAG ""
 build_and_push_env_builder go $REPO/go-env-builder:$TAG $BUILDER_IMAGE:$TAG "1.12"
 
 build_fission_cli

--- a/test/test_utils.sh
+++ b/test/test_utils.sh
@@ -504,8 +504,8 @@ run_all_tests() {
     export PYTHON_BUILDER_IMAGE=gcr.io/$GKE_PROJECT_NAME/python-env-builder:${imageTag}
     export GO_RUNTIME_IMAGE=gcr.io/$GKE_PROJECT_NAME/go-env:${imageTag}
     export GO_BUILDER_IMAGE=gcr.io/$GKE_PROJECT_NAME/go-env-builder:${imageTag}
-    export JVM_RUNTIME_IMAGE=gcr.io/$GKE_PROJECT_NAME/jvm-env:${imageTag}
-    export JVM_BUILDER_IMAGE=gcr.io/$GKE_PROJECT_NAME/jvm-env-builder:${imageTag}
+    # export JVM_RUNTIME_IMAGE=gcr.io/$GKE_PROJECT_NAME/jvm-env:${imageTag}
+    # export JVM_BUILDER_IMAGE=gcr.io/$GKE_PROJECT_NAME/jvm-env-builder:${imageTag}
     export TS_RUNTIME_IMAGE=gcr.io/$GKE_PROJECT_NAME/tensorflow-serving-env:${imageTag}
 
     set +e


### PR DESCRIPTION
Keep receiving the following error messages, which is related to the upstream package service problem, when building JVM images and blocks the CI. 

```
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project io.fission:env-java:0.0.1-SNAPSHOT (/usr/src/myapp/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for io.fission:env-java:0.0.1-SNAPSHOT: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:2.0.1.RELEASE from/to central (https://repo.maven.apache.org/maven2): Access denied to: https://repo.maven.apache.org/maven2/org/springframework/boot/spring-boot-starter-parent/2.0.1.RELEASE/spring-boot-starter-parent-2.0.1.RELEASE.pom , ReasonPhrase:Forbidden. and 'parent.relativePath' points at wrong local POM @ line 11, column 10 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
```

Disable building JVM image during CI builds for now and will revert once it becomes stable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1503)
<!-- Reviewable:end -->
