### PR TITLE
Add fake client for local command operation

### DIFF
--- a/cmd/fission-cli/app/app.go
+++ b/cmd/fission-cli/app/app.go
@@ -44,13 +44,19 @@ func App() *cobra.Command {
 		PersistentPreRunE: wrapper.Wrapper(
 			func(input cli.Input) error {
 				console.Verbosity = input.Int(flagkey.Verbosity)
-				serverUrl, err := util.GetServerURL(input)
-				if err != nil {
-					return err
+
+				if input.IsSet(flagkey.ClientOnly) {
+					// TODO: use fake rest client for offline spec generation
+					cmd.SetClientset(client.MakeFakeClientset(nil))
+				} else {
+					serverUrl, err := util.GetServerURL(input)
+					if err != nil {
+						return err
+					}
+					restClient := rest.NewRESTClient(serverUrl)
+					cmd.SetClientset(client.MakeClientset(restClient))
 				}
-				restClient := rest.NewRESTClient(serverUrl)
-				// TODO: use fake rest client for offline spec generation
-				cmd.SetClientset(client.MakeClientset(restClient))
+
 				return nil
 			},
 		),

--- a/pkg/controller/client/fake_client.go
+++ b/pkg/controller/client/fake_client.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Fission Authors.
+Copyright 2016 The Fission Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,24 +14,30 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package version
+package client
 
 import (
-	"github.com/spf13/cobra"
-
-	"github.com/fission/fission/pkg/fission-cli/flag"
-	wrapper "github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra"
+	"github.com/fission/fission/pkg/controller/client/rest"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	"github.com/fission/fission/pkg/controller/client/v1/fake"
 )
 
-func Commands() *cobra.Command {
-	command := &cobra.Command{
-		Use:   "version",
-		Short: "Show client/server version information",
-		RunE:  wrapper.Wrapper(Version),
+type (
+	FakeClientset struct {
+		v1         v1.V1Interface
 	}
-	wrapper.SetFlags(command, flag.FlagSet{
-		Optional: []flag.Flag{flag.ClientOnly},
-	})
+)
 
-	return command
+func MakeFakeClientset(restClient rest.Interface) Interface {
+	return &FakeClientset{
+		v1: fake.MakeV1Client(nil),
+	}
+}
+
+func (c *FakeClientset) V1() v1.V1Interface {
+	return c.v1
+}
+
+func (c *FakeClientset) ServerURL() string {
+	return ""
 }

--- a/pkg/controller/client/fake_client.go
+++ b/pkg/controller/client/fake_client.go
@@ -24,7 +24,7 @@ import (
 
 type (
 	FakeClientset struct {
-		v1         v1.V1Interface
+		v1 v1.V1Interface
 	}
 )
 

--- a/pkg/controller/client/v1/fake/fake_canaryconfig.go
+++ b/pkg/controller/client/v1/fake/fake_canaryconfig.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeCanaryConfig struct {}
+)
+
+func newCanaryConfigClient(c *v1.V1) v1.CanaryConfigInterface {
+	return &FakeCanaryConfig{}
+}
+
+func (c *FakeCanaryConfig) Create(canaryConf *fv1.CanaryConfig) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeCanaryConfig) Get(m *metav1.ObjectMeta) (*fv1.CanaryConfig, error) {
+	return nil, nil
+}
+
+func (c *FakeCanaryConfig) Update(canaryConf *fv1.CanaryConfig) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeCanaryConfig) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeCanaryConfig) List(ns string) ([]fv1.CanaryConfig, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_canaryconfig.go
+++ b/pkg/controller/client/v1/fake/fake_canaryconfig.go
@@ -19,12 +19,12 @@ package fake
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeCanaryConfig struct {}
+	FakeCanaryConfig struct{}
 )
 
 func newCanaryConfigClient(c *v1.V1) v1.CanaryConfigInterface {

--- a/pkg/controller/client/v1/fake/fake_environment.go
+++ b/pkg/controller/client/v1/fake/fake_environment.go
@@ -19,12 +19,12 @@ package fake
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeEnvironment struct {}
+	FakeEnvironment struct{}
 )
 
 func newEnvironmentClient(c *v1.V1) v1.EnvironmentInterface {

--- a/pkg/controller/client/v1/fake/fake_environment.go
+++ b/pkg/controller/client/v1/fake/fake_environment.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeEnvironment struct {}
+)
+
+func newEnvironmentClient(c *v1.V1) v1.EnvironmentInterface {
+	return &FakeEnvironment{}
+}
+
+func (c *FakeEnvironment) Create(env *fv1.Environment) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeEnvironment) Get(m *metav1.ObjectMeta) (*fv1.Environment, error) {
+	return nil, nil
+}
+
+func (c *FakeEnvironment) Update(env *fv1.Environment) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeEnvironment) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeEnvironment) List(ns string) ([]fv1.Environment, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_function.go
+++ b/pkg/controller/client/v1/fake/fake_function.go
@@ -19,12 +19,12 @@ package fake
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeFunction struct {}
+	FakeFunction struct{}
 )
 
 func newFunctionClient(c *v1.V1) v1.FunctionInterface {

--- a/pkg/controller/client/v1/fake/fake_function.go
+++ b/pkg/controller/client/v1/fake/fake_function.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeFunction struct {}
+)
+
+func newFunctionClient(c *v1.V1) v1.FunctionInterface {
+	return &FakeFunction{}
+}
+
+func (c *FakeFunction) Create(f *fv1.Function) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeFunction) Get(m *metav1.ObjectMeta) (*fv1.Function, error) {
+	return nil, nil
+}
+
+func (c *FakeFunction) GetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) {
+	return nil, nil
+}
+
+func (c *FakeFunction) Update(f *fv1.Function) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeFunction) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeFunction) List(functionNamespace string) ([]fv1.Function, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_httptrigger.go
+++ b/pkg/controller/client/v1/fake/fake_httptrigger.go
@@ -19,12 +19,12 @@ package fake
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeHTTPTrigger struct {}
+	FakeHTTPTrigger struct{}
 )
 
 func newHTTPTriggerClient(c *v1.V1) v1.HTTPTriggerInterface {

--- a/pkg/controller/client/v1/fake/fake_httptrigger.go
+++ b/pkg/controller/client/v1/fake/fake_httptrigger.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeHTTPTrigger struct {}
+)
+
+func newHTTPTriggerClient(c *v1.V1) v1.HTTPTriggerInterface {
+	return &FakeHTTPTrigger{}
+}
+
+func (c *FakeHTTPTrigger) Create(t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeHTTPTrigger) Get(m *metav1.ObjectMeta) (*fv1.HTTPTrigger, error) {
+	return nil, nil
+}
+
+func (c *FakeHTTPTrigger) Update(t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeHTTPTrigger) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeHTTPTrigger) List(triggerNamespace string) ([]fv1.HTTPTrigger, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_kuberneteswatchtrigger.go
+++ b/pkg/controller/client/v1/fake/fake_kuberneteswatchtrigger.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeKubeWatcher struct {}
+)
+
+func newKubeWatcher(c *v1.V1) v1.KubeWatcherInterface {
+	return &FakeKubeWatcher{}
+}
+
+func (c *FakeKubeWatcher) Create(w *fv1.KubernetesWatchTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeKubeWatcher) Get(m *metav1.ObjectMeta) (*fv1.KubernetesWatchTrigger, error) {
+	return nil, nil
+}
+
+func (c *FakeKubeWatcher) Update(w *fv1.KubernetesWatchTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeKubeWatcher) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeKubeWatcher) List(ns string) ([]fv1.KubernetesWatchTrigger, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_kuberneteswatchtrigger.go
+++ b/pkg/controller/client/v1/fake/fake_kuberneteswatchtrigger.go
@@ -19,12 +19,12 @@ package fake
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeKubeWatcher struct {}
+	FakeKubeWatcher struct{}
 )
 
 func newKubeWatcher(c *v1.V1) v1.KubeWatcherInterface {

--- a/pkg/controller/client/v1/fake/fake_misc.go
+++ b/pkg/controller/client/v1/fake/fake_misc.go
@@ -27,7 +27,7 @@ import (
 
 // TODO: we should remove this interface, having this for now is for backward compatibility.
 type (
-	FakeMisc struct {}
+	FakeMisc struct{}
 )
 
 func newMiscClient(c *v1.V1) v1.MiscInterface {

--- a/pkg/controller/client/v1/fake/fake_misc.go
+++ b/pkg/controller/client/v1/fake/fake_misc.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	"io"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/info"
+)
+
+// TODO: we should remove this interface, having this for now is for backward compatibility.
+type (
+	FakeMisc struct {}
+)
+
+func newMiscClient(c *v1.V1) v1.MiscInterface {
+	return &FakeMisc{}
+}
+
+func (c *FakeMisc) SecretGet(m *metav1.ObjectMeta) (*apiv1.Secret, error) {
+	return nil, nil
+}
+
+func (c *FakeMisc) ConfigMapGet(m *metav1.ObjectMeta) (*apiv1.ConfigMap, error) {
+	return nil, nil
+}
+
+func (c *FakeMisc) GetSvcURL(label string) (string, error) {
+	return "", nil
+}
+
+func (c *FakeMisc) ServerInfo() (*info.ServerInfo, error) {
+	return &info.ServerInfo{}, nil
+}
+
+func (c *FakeMisc) PodLogs(m *metav1.ObjectMeta) (io.ReadCloser, int, error) {
+	return nil, 0, nil
+}

--- a/pkg/controller/client/v1/fake/fake_mqtrigger.go
+++ b/pkg/controller/client/v1/fake/fake_mqtrigger.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeMessageQueueTrigger struct {}
+)
+
+func newMessageQueueTrigger(c *v1.V1) v1.MessageQueueTriggerInterface {
+	return &FakeMessageQueueTrigger{}
+}
+
+func (c *FakeMessageQueueTrigger) Create(t *fv1.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeMessageQueueTrigger) Get(m *metav1.ObjectMeta) (*fv1.MessageQueueTrigger, error) {
+	return nil, nil
+}
+
+func (c *FakeMessageQueueTrigger) Update(mqTrigger *fv1.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeMessageQueueTrigger) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeMessageQueueTrigger) List(mqType string, ns string) ([]fv1.MessageQueueTrigger, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_mqtrigger.go
+++ b/pkg/controller/client/v1/fake/fake_mqtrigger.go
@@ -19,12 +19,12 @@ package fake
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeMessageQueueTrigger struct {}
+	FakeMessageQueueTrigger struct{}
 )
 
 func newMessageQueueTrigger(c *v1.V1) v1.MessageQueueTriggerInterface {

--- a/pkg/controller/client/v1/fake/fake_package.go
+++ b/pkg/controller/client/v1/fake/fake_package.go
@@ -25,7 +25,7 @@ import (
 )
 
 type (
-	FakePackage struct {}
+	FakePackage struct{}
 )
 
 func newPackageClient(c *v1.V1) v1.PackageInterface {

--- a/pkg/controller/client/v1/fake/fake_package.go
+++ b/pkg/controller/client/v1/fake/fake_package.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakePackage struct {}
+)
+
+func newPackageClient(c *v1.V1) v1.PackageInterface {
+	return &FakePackage{}
+}
+
+func (c *FakePackage) Create(f *fv1.Package) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakePackage) Get(m *metav1.ObjectMeta) (*fv1.Package, error) {
+	return nil, nil
+}
+
+func (c *FakePackage) Update(f *fv1.Package) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakePackage) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakePackage) List(pkgNamespace string) ([]fv1.Package, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_timetrigger.go
+++ b/pkg/controller/client/v1/fake/fake_timetrigger.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+type (
+	FakeTimeTrigger struct {}
+)
+
+func newTimeTriggerClient(c *v1.V1) v1.TimeTriggerInterface {
+	return &FakeTimeTrigger{}
+}
+
+func (c *FakeTimeTrigger) Create(t *fv1.TimeTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeTimeTrigger) Get(m *metav1.ObjectMeta) (*fv1.TimeTrigger, error) {
+	return nil, nil
+}
+
+func (c *FakeTimeTrigger) Update(t *fv1.TimeTrigger) (*metav1.ObjectMeta, error) {
+	return nil, nil
+}
+
+func (c *FakeTimeTrigger) Delete(m *metav1.ObjectMeta) error {
+	return nil
+}
+
+func (c *FakeTimeTrigger) List(ns string) ([]fv1.TimeTrigger, error) {
+	return nil, nil
+}

--- a/pkg/controller/client/v1/fake/fake_timetrigger.go
+++ b/pkg/controller/client/v1/fake/fake_timetrigger.go
@@ -25,7 +25,7 @@ import (
 )
 
 type (
-	FakeTimeTrigger struct {}
+	FakeTimeTrigger struct{}
 )
 
 func newTimeTriggerClient(c *v1.V1) v1.TimeTriggerInterface {

--- a/pkg/controller/client/v1/fake/fake_v1.go
+++ b/pkg/controller/client/v1/fake/fake_v1.go
@@ -17,12 +17,12 @@ limitations under the License.
 package fake
 
 import (
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
 	"github.com/fission/fission/pkg/controller/client/rest"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (
-	FakeV1 struct {}
+	FakeV1 struct{}
 )
 
 func MakeV1Client(restClient rest.Interface) *FakeV1 {

--- a/pkg/controller/client/v1/fake/fake_v1.go
+++ b/pkg/controller/client/v1/fake/fake_v1.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
+)
+
+type (
+	FakeV1 struct {}
+)
+
+func MakeV1Client(restClient rest.Interface) *FakeV1 {
+	return &FakeV1{}
+}
+
+func (c *FakeV1) Misc() v1.MiscInterface {
+	return newMiscClient(nil)
+}
+
+func (c *FakeV1) CanaryConfig() v1.CanaryConfigInterface {
+	return newCanaryConfigClient(nil)
+}
+
+func (c *FakeV1) Environment() v1.EnvironmentInterface {
+	return newEnvironmentClient(nil)
+}
+
+func (c *FakeV1) Function() v1.FunctionInterface {
+	return newFunctionClient(nil)
+}
+
+func (c *FakeV1) HTTPTrigger() v1.HTTPTriggerInterface {
+	return newHTTPTriggerClient(nil)
+}
+
+func (c *FakeV1) KubeWatcher() v1.KubeWatcherInterface {
+	return newKubeWatcher(nil)
+}
+
+func (c *FakeV1) MessageQueueTrigger() v1.MessageQueueTriggerInterface {
+	return newMessageQueueTrigger(nil)
+}
+
+func (c *FakeV1) Package() v1.PackageInterface {
+	return newPackageClient(nil)
+}
+
+func (c *FakeV1) TimeTrigger() v1.TimeTriggerInterface {
+	return newTimeTriggerClient(nil)
+}

--- a/pkg/fission-cli/cmd/version/command.go
+++ b/pkg/fission-cli/cmd/version/command.go
@@ -19,8 +19,8 @@ package version
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/fission/fission/pkg/fission-cli/flag"
 	wrapper "github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra"
+	"github.com/fission/fission/pkg/fission-cli/flag"
 )
 
 func Commands() *cobra.Command {

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -70,6 +70,8 @@ var (
 	GlobalVerbosity = Flag{Type: Int, Name: flagkey.Verbosity, Short: "v", Usage: "CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)", DefaultValue: 1}
 	GlobalServer    = Flag{Type: String, Name: flagkey.Server, Usage: "Server URL"}
 
+	ClientOnly      = Flag{Type: Bool, Name: flagkey.ClientOnly, Usage: "If set, the CLI won't connect to remote server"}
+
 	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", DefaultValue: metav1.NamespaceDefault}
 	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", DefaultValue: metav1.NamespaceDefault}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -70,7 +70,7 @@ var (
 	GlobalVerbosity = Flag{Type: Int, Name: flagkey.Verbosity, Short: "v", Usage: "CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)", DefaultValue: 1}
 	GlobalServer    = Flag{Type: String, Name: flagkey.Server, Usage: "Server URL"}
 
-	ClientOnly      = Flag{Type: Bool, Name: flagkey.ClientOnly, Usage: "If set, the CLI won't connect to remote server"}
+	ClientOnly = Flag{Type: Bool, Name: flagkey.ClientOnly, Usage: "If set, the CLI won't connect to remote server"}
 
 	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", DefaultValue: metav1.NamespaceDefault}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -19,6 +19,7 @@ package flagkey
 const (
 	Verbosity = "verbosity"
 	Server    = "server"
+	ClientOnly    = "client-only"
 
 	resourceName = "name"
 	force        = "force"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -17,9 +17,9 @@ limitations under the License.
 package flagkey
 
 const (
-	Verbosity = "verbosity"
-	Server    = "server"
-	ClientOnly    = "client-only"
+	Verbosity  = "verbosity"
+	Server     = "server"
+	ClientOnly = "client-only"
 
 	resourceName = "name"
 	force        = "force"


### PR DESCRIPTION
This PR adds a fake controller client for local CLI operations like offline spec generation or for unit test purposes. The fake client now only implements the "Version()" function and more functions will be implemented once we figure out how to achieve the goals mentioned above.

Fix #1514



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1515)
<!-- Reviewable:end -->
