### PR TITLE
Bump Python environment to latest Alpine

### DIFF
--- a/environments/python/Dockerfile
+++ b/environments/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
## ☕ Purpose

During the implementation of Fission in our company infrastructure, I've noticed that the default runtime image for Python environments uses Python version `3.5`.

Most of our applications uses `^3.7` and the previous version is impossible to use for most of those.

I was planning to create a custom environment, but creating a custom environment just to bump 2 versions is overkill. In my opinion we should use `alpine' latest, which uses Python 3.7 instead.

## 🧐 Checklist

- [x] Bumps version of Docker image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1547)
<!-- Reviewable:end -->
