### PR TITLE
Charts: Improves custom properties

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -64,6 +64,7 @@ Parameter | Description | Default
 `debugEnv` | If there are any pod specialization errors when a function is triggered and this flag is set to true, the error summary is returned as part of http response | `true`
 `prometheus.enabled` | Set to true if prometheus needs to be deployed along with fission | `true` in `fission-all`, `false` in `fission-core`
 `prometheus.serviceEndpoint` | If prometheus.enabled is false, please assign the prometheus service URL that is accessible by components. | `nil`
+`prometheus.port` | Set here the port where your Prometheus server is listening to | `8080`
 `canaryDeployment.enabled` | Set to true if you need canary deployment feature | `true` in `fission-all`, `false` in `fission-core`
 `extraCoreComponentPodConfig` | Extend the container specs for the core fission pods. Can be used to add things like affinty/tolerations/nodeSelectors/etc. | None
 `executor.adoptExistingResources` | If true, executor will try to adopt existing resources created by the old executor instance. | `false`

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "8080"
+        prometheus.io/port: {{ .Values.prometheus.port | default 8080 }}
     spec:
       containers:
       - name: executor

--- a/charts/fission-all/templates/post-install-job.yaml
+++ b/charts/fission-all/templates/post-install-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}-{{ .Chart.Version }}
+  name: {{ template "fullname" . }}-{{ .Chart.Version }}-post-install
   labels:
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.

--- a/charts/fission-all/templates/post-upgrade-job.yaml
+++ b/charts/fission-all/templates/post-upgrade-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}-{{ .Chart.Version }}
+  name: {{ template "fullname" . }}-{{ .Chart.Version }}-post-upgrade
   labels:
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.

--- a/charts/fission-all/templates/router.yaml
+++ b/charts/fission-all/templates/router.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "8080"
+        prometheus.io/port: {{ .Values.prometheus.port | default 8080 }}
     spec:
       containers:
       - name: router

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -244,6 +244,9 @@ prometheus:
   ## that is accessible by components.
   serviceEndpoint: ""
 
+  ## declare the Prometheus port that should be used on your Fission installation
+  port: 8080
+
 ## set this flag to false if you dont need canary deployment feature
 canaryDeployment:
   enabled: true

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -200,7 +200,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "8080"
+        prometheus.io/port: {{ .Values.prometheus.port | default 8080 }}
     spec:
       containers:
       - name: executor

--- a/charts/fission-core/templates/post-install-job.yaml
+++ b/charts/fission-core/templates/post-install-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}-{{ .Chart.Version }}
+  name: {{ template "fullname" . }}-{{ .Chart.Version }}-post-install
   labels:
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.

--- a/charts/fission-core/templates/post-upgrade-job.yaml
+++ b/charts/fission-core/templates/post-upgrade-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}-{{ .Chart.Version }}
+  name: {{ template "fullname" . }}-{{ .Chart.Version }}-post-upgrade
   labels:
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.

--- a/charts/fission-core/templates/router.yaml
+++ b/charts/fission-core/templates/router.yaml
@@ -26,7 +26,7 @@ spec:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/path: "/metrics"
-        prometheus.io/port: "8080"
+        prometheus.io/port: {{ .Values.prometheus.port | default 8080 }}
     spec:
       containers:
       - name: router

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -178,6 +178,9 @@ prometheus:
   ## that is accessible by components.
   serviceEndpoint: ""
 
+  ## declare the Prometheus port that should be used on your Fission installation
+  port: 8080
+
 ## set this flag to false if you dont need canary deployment feature
 canaryDeployment:
   enabled: false


### PR DESCRIPTION
## ☕ Purpose

During our installation of Fission using `Argo`, we've noticed that, by default, there are some missing custom properties and minor bugs on Fission charts. They are:

- We can't set a custom Prometheus port
- The `post-install` and `post-upgrade` jobs name is the same

We managed to fix those using `sed` after fetching Fission yaml, but it would be highly appreciated if we could contribute by fixing those 2 points.

On this PR I've added the `prometheus.port` to the `core` and `all` charts, and also added a suffix to the jobs, to prevent errors when installing directly with `kubectl apply`

## 🧐 Checklist

- [x] Adds a suffix to prevent duplicated job names
- [x] Adds a custom Prometheus port option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1548)
<!-- Reviewable:end -->
