### PR TITLE
feat: support external nats streaming

### DIFF
--- a/charts/README.md
+++ b/charts/README.md
@@ -91,6 +91,8 @@ Parameter | Description | Default
 `nats.enabled` | Nats streaming enabled | `true`
 `nats.authToken` | Nats streaming auth token | `defaultFissionAuthToken`
 `nats.clusterID` | Nats streaming clusterID | `fissionMQTrigger`
+`nats.clientID`  | Client name registered with nats streaming | `fission`
+`nats.queueGroup` | Queue group registered with nats streaming | `fission-messageQueueNatsTrigger`
 `natsStreamingPort` | Nats streaming service port | `31316`
 `azureStorageQueue.enabled` | Azure storage account name | `false`
 `azureStorageQueue.key` | Azure storage account name | `""`

--- a/charts/README.md
+++ b/charts/README.md
@@ -89,6 +89,8 @@ Parameter | Description | Default
 `logger.fluentdImage` | Logger fluentbit image | `fluent/fluent-bit`
 `logger.fluentdImageTag` | Logger fluentbit image tag | `1.0.4`
 `nats.enabled` | Nats streaming enabled | `true`
+`nats.external` | Use external Nats installation | `false`
+`nats.hostaddress` | Address of NATS cluster | `nats-streaming:4222`
 `nats.authToken` | Nats streaming auth token | `defaultFissionAuthToken`
 `nats.clusterID` | Nats streaming clusterID | `fissionMQTrigger`
 `nats.clientID`  | Client name registered with nats streaming | `fission`

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -594,10 +594,10 @@ spec:
         - name: MESSAGE_QUEUE_CLIENT_ID
           value: {{ .Values.nats.clientID }}
         - name: MESSAGE_QUEUE_URL
-        {{- if not .Values.nats.url }}
-          value: nats://{{ .Values.nats.authToken }}@nats-streaming:4222
+        {{- if .Values.nats.authToken }}
+          value: nats://{{ .Values.nats.authToken }}@{{ .Values.nats.hostaddress }}
         {{- else }}
-          value: {{ .Values.nats.url }}
+          value: nats://{{ .Values.nats.hostaddress }}
         {{- end }}
         - name: TRACE_JAEGER_COLLECTOR_ENDPOINT
           value: "{{ .Values.traceCollectorEndpoint }}"

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -507,6 +507,7 @@ spec:
 #      serviceAccountName: fission-svc
 
 {{- if .Values.nats.enabled }}
+{{- if not .Values.nats.external }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -555,6 +556,7 @@ spec:
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -585,8 +587,18 @@ spec:
         env:
         - name: MESSAGE_QUEUE_TYPE
           value: nats-streaming
+        - name: MESSAGE_QUEUE_CLUSTER_ID
+          value: {{ .Values.nats.clusterID }}
+        - name: MESSAGE_QUEUE_QUEUE_GROUP
+          value: {{ .Values.nats.queueGroup }}
+        - name: MESSAGE_QUEUE_CLIENT_ID
+          value: {{ .Values.nats.clientID }}
         - name: MESSAGE_QUEUE_URL
+        {{- if not .Values.nats.url }}
           value: nats://{{ .Values.nats.authToken }}@nats-streaming:4222
+        {{- else }}
+          value: {{ .Values.nats.url }}
+        {{- end }}
         - name: TRACE_JAEGER_COLLECTOR_ENDPOINT
           value: "{{ .Values.traceCollectorEndpoint }}"
         - name: TRACING_SAMPLING_RATE

--- a/charts/fission-all/templates/svc.yaml
+++ b/charts/fission-all/templates/svc.yaml
@@ -41,7 +41,7 @@ spec:
   selector:
     svc: controller
 
-{{- if .Values.nats.enabled }}
+{{- if and .Values.nats.enabled (not .Values.nats.external) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -29,6 +29,7 @@ controllerPort: 31313
 routerPort: 31314
 
 ## Port at which NATS streaming service should be exposed
+## (only if nats enabled and not external)
 natsStreamingPort: 31316
 
 ## Set to false if you create the namespaces manually
@@ -132,8 +133,15 @@ router:
 ### NATS Streaming, enabled by default
 nats:
   enabled: true
+  external: false
+
+  # nats URL for use with external nats. If set will override template;
+  # pass authToken explicitly if necessary
+  url: ''
   authToken: "defaultFissionAuthToken"
   clusterID: "fissionMQTrigger"
+  clientID: "fission"
+  queueGroup: "fission-messageQueueNatsTrigger"
 
 ## Azure-storage-queue: enable and configure the details
 azureStorageQueue:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -132,15 +132,26 @@ router:
 ## Message queue trigger config
 ### NATS Streaming, enabled by default
 nats:
+  # whether or not to use NATS
   enabled: true
+
+  # if true, don't install NATS, but
   external: false
 
-  # nats URL for use with external nats. If set will override template;
-  # pass authToken explicitly if necessary
-  url: ''
+  # Address of NATS server (domain:port)
+  # change from default for external NATS
+  hostaddress: 'nats-streaming:4222'
+
+  # Authorization token to use with NATS
   authToken: "defaultFissionAuthToken"
+
+  # NATS streaming clusterID
   clusterID: "fissionMQTrigger"
+
+  # Client name registered with NATS streaming 
   clientID: "fission"
+
+  # Queue group registered with NATS streaming 
   queueGroup: "fission-messageQueueNatsTrigger"
 
 ## Azure-storage-queue: enable and configure the details

--- a/pkg/mqtrigger/messageQueue/nats/nats.go
+++ b/pkg/mqtrigger/messageQueue/nats/nats.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
 	nsUtil "github.com/nats-io/nats-streaming-server/util"
@@ -34,16 +35,32 @@ import (
 	"github.com/fission/fission/pkg/utils"
 )
 
+var natsClusterID string
+var natsQueueGroup string
+var natsClientID string
+
 func init() {
+	natsClusterID = os.Getenv("MESSAGE_QUEUE_CLUSTER_ID")
+	if natsClusterID == "" {
+		natsClusterID = defaultNatsClusterID
+	}
+	natsClientID = os.Getenv("MESSAGE_QUEUE_CLIENT_ID")
+	if natsClientID == "" {
+		natsClientID = defaultNatsClientID
+	}
+	natsQueueGroup = os.Getenv("MESSAGE_QUEUE_QUEUE_GROUP")
+	if natsQueueGroup == "" {
+		natsQueueGroup = defaultNatsQueueGroup
+	}
 	factory.Register(fv1.MessageQueueTypeNats, &Factory{})
 	validator.Register(fv1.MessageQueueTypeNats, IsTopicValid)
 }
 
 const (
-	natsClusterID  = "fissionMQTrigger"
-	natsProtocol   = "nats://"
-	natsClientID   = "fission"
-	natsQueueGroup = "fission-messageQueueNatsTrigger"
+	natsProtocol          = "nats://"
+	defaultNatsClusterID  = "fissionMQTrigger"
+	defaultNatsClientID   = "fission"
+	defaultNatsQueueGroup = "fission-messageQueueNatsTrigger"
 )
 
 type (


### PR DESCRIPTION
Adds support for an external nats cluster to helm fission-all chart. Also supports configuration of clusterID, clientID and queue group. 

Addresses:
* https://github.com/fission/fission/issues/1553
* https://github.com/fission/fission/issues/1549

The `nats` section of the helm chart adds:
*  external: false
*  url: ''
*  authToken: "defaultFissionAuthToken"
*  clusterID: "fissionMQTrigger"
*  clientID: "fission"
*  queueGroup: "fission-messageQueueNatsTrigger"

`url` empty uses current url template. `external` true removes the nats streaming cluster deployment and the service that exposes it.

In the mqtrigger/messageQueue/nats package, environment variables are consumed:
* MESSAGE_QUEUE_CLUSTER_ID
* MESSAGE_QUEUE_CLIENT_ID
* MESSAGE_QUEUE_QUEUE_GROUP

I wasn't sure where to document these. I made no changes to the other message queue trigger implementations. I did push a public docker image to `factfiber/fission-bundle:latest`, and run fission with values:
```
image: factfiber/fission-bundle
imageTag: latest
nats:
  url: nats://nats-cluster.nats-io.svc.cluster.local:4222
  external: true
  clusterID: "nats-streaming-cluster"
```
This ran successfully against a cluster-scoped streaming server in the `nats-io` namespace. There are no tests in the PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1554)
<!-- Reviewable:end -->
