### PR TITLE
Return Kubernetes full error message

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -113,7 +113,7 @@ func (api *API) respondWithError(w http.ResponseWriter, err error) {
 	se, ok := err.(*kerrors.StatusError)
 	if ok {
 		api.logger.Error(err.Error(), zap.Int32("code", se.ErrStatus.Code))
-		http.Error(w, string(se.ErrStatus.Reason), int(se.ErrStatus.Code))
+		http.Error(w, se.Error(), int(se.ErrStatus.Code))
 		return
 	}
 


### PR DESCRIPTION
This PR let the controller returns the detail error message 
of kubernetes error which makes users understand what's
happening instead of meanless error msg.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1560)
<!-- Reviewable:end -->
