### PR TITLE
GitPod for Fission

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -69,7 +69,7 @@ RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
 LABEL dazzle/layer=lang-go
 LABEL dazzle/test=tests/lang-go.yaml
 USER gitpod
-ENV GO_VERSION=1.14 \
+ENV GO_VERSION=1.12 \
     GOPATH=$HOME/go-packages \
     GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -48,68 +48,45 @@ RUN sudo echo "Running 'sudo' for Gitpod: success" && \
     mkdir /home/gitpod/.bashrc.d && \
     (echo; echo "for i in \$(ls \$HOME/.bashrc.d/*); do source \$i; done"; echo) >> /home/gitpod/.bashrc
 
+### Install C/C++ compiler and associated tools ###
+LABEL dazzle/layer=lang-c
+LABEL dazzle/test=tests/lang-c.yaml
+USER root
+RUN curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
+    && echo "deb https://apt.llvm.org/disco/ llvm-toolchain-disco main" >> /etc/apt/sources.list.d/llvm.list \
+    && apt-get update \
+    && apt-get install -yq \
+        clang-format \
+        clang-tidy \
+        # clang-tools \ # breaks the build atm
+        clangd \
+        gdb \
+        lld \
+    && cp /var/lib/dpkg/status /var/lib/apt/dazzle-marks/lang-c.status \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
 ### Go ###
-LABEL fission/layer=lang-go
-LABEL fission/test=tests/lang-go.yaml
+LABEL dazzle/layer=lang-go
+LABEL dazzle/test=tests/lang-go.yaml
 USER gitpod
-ENV GO_VERSION=1.12 \
+ENV GO_VERSION=1.14 \
     GOPATH=$HOME/go-packages \
     GOROOT=$HOME/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
-RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar xzs && \
-# install VS Code Go tools from https://github.com/Microsoft/vscode-go/blob/0faec7e5a8a69d71093f08e035d33beb3ded8626/src/goInstallTools.ts#L19-L45
-    go get -u -v \
-        github.com/mdempsky/gocode \
-        github.com/uudashr/gopkgs/cmd/gopkgs \
-        github.com/ramya-rao-a/go-outline \
-        github.com/acroca/go-symbols \
-        golang.org/x/tools/cmd/guru \
-        golang.org/x/tools/cmd/gorename \
-        github.com/fatih/gomodifytags \
-        github.com/haya14busa/goplay/cmd/goplay \
-        github.com/josharian/impl \
-        github.com/tylerb/gotype-live \
-        github.com/rogpeppe/godef \
-        github.com/zmb3/gogetdoc \
-        golang.org/x/tools/cmd/goimports \
-        github.com/sqs/goreturns \
-        winterdrache.de/goformat/goformat \
-        golang.org/x/lint/golint \
-        github.com/cweill/gotests/... \
-        github.com/alecthomas/gometalinter \
-        honnef.co/go/tools/... \
-        github.com/golangci/golangci-lint/cmd/golangci-lint \
-        github.com/mgechev/revive \
-        github.com/sourcegraph/go-langserver \
-        github.com/go-delve/delve/cmd/dlv \
-        github.com/davidrjenni/reftools/cmd/fillstruct \
-        github.com/godoctor/godoctor && \
-    GO111MODULE=on go get -u -v \
-        golang.org/x/tools/gopls@latest && \
-    go get -u -v -d github.com/stamblerre/gocode && \
-    go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode && \
-    rm -rf $GOPATH/src && \
-    sudo rm -rf $GOPATH/pkg && \
-    rm -rf /home/gitpod/.cache/go
+RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar xzs
 # user Go packages
 ENV GOPATH=/workspace/go \
     PATH=/workspace/go/bin:$PATH
 
 ### Docker client ###
+USER root
 RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     # 'cosmic' not supported
     && add-apt-repository -yu "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" \
     && apt-get install -yq docker-ce-cli=5:18.09.0~3-0~ubuntu-bionic \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
-### Kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
-   chmod +x ./kubectl \
-   mv kubectl $K8SCLI_DIR/kubectl
+### Kubectl & Helm To be added for deployment
 
-### Helm ###
-RUN curl -fsSL https://get.helm.sh/helm-v3.0.1-linux-amd64.tar.gz \
-    | tar -xzvC /usr/local/bin --strip-components=1 \
-    && helm completion bash > /usr/share/bash-completion/completions/helm
 
 USER gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,109 @@
+FROM ubuntu:trusty
+
+USER gitpod
+
+### base ###
+RUN yes | unminimize \
+    && apt-get install -yq \
+    apache2-utils \
+    parallel \
+    realpath \
+    zip \
+    unzip \
+    less \
+    jq \
+    nano \
+    software-properties-common \
+    sudo \
+    && locale-gen en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+
+### Git ###
+RUN add-apt-repository -y ppa:git-core/ppa \
+    && apt-get install -yq git \
+    && rm -rf /var/lib/apt/lists/*
+
+### Gitpod user ###
+# '-l': see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user
+RUN useradd -l -u 33333 -G sudo -md /home/gitpod -s /bin/bash -p gitpod gitpod \
+    # passwordless sudo for users in the 'sudo' group
+    && sed -i.bkp -e 's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' /etc/sudoers
+ENV HOME=/home/gitpod
+WORKDIR $HOME
+# custom Bash prompt
+RUN { echo && echo "PS1='\[\e]0;\u \w\a\]\[\033[01;32m\]\u\[\033[00m\] \[\033[01;34m\]\w\[\033[00m\] \\\$ '" ; } >> .bashrc
+
+### Gitpod user (2) ###
+USER gitpod
+# use sudo so that user does not get sudo usage info on (the first) login
+RUN sudo echo "Running 'sudo' for Gitpod: success" && \
+    # create .bashrc.d folder and source it in the bashrc
+    mkdir /home/gitpod/.bashrc.d && \
+    (echo; echo "for i in \$(ls \$HOME/.bashrc.d/*); do source \$i; done"; echo) >> /home/gitpod/.bashrc
+
+### Go ###
+LABEL dazzle/layer=lang-go
+LABEL dazzle/test=tests/lang-go.yaml
+USER gitpod
+ENV GO_VERSION=1.12 \
+    GOPATH=$HOME/go-packages \
+    GOROOT=$HOME/go
+ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH
+RUN curl -fsSL https://storage.googleapis.com/golang/go$GO_VERSION.linux-amd64.tar.gz | tar xzs && \
+# install VS Code Go tools from https://github.com/Microsoft/vscode-go/blob/0faec7e5a8a69d71093f08e035d33beb3ded8626/src/goInstallTools.ts#L19-L45
+    go get -u -v \
+        github.com/mdempsky/gocode \
+        github.com/uudashr/gopkgs/cmd/gopkgs \
+        github.com/ramya-rao-a/go-outline \
+        github.com/acroca/go-symbols \
+        golang.org/x/tools/cmd/guru \
+        golang.org/x/tools/cmd/gorename \
+        github.com/fatih/gomodifytags \
+        github.com/haya14busa/goplay/cmd/goplay \
+        github.com/josharian/impl \
+        github.com/tylerb/gotype-live \
+        github.com/rogpeppe/godef \
+        github.com/zmb3/gogetdoc \
+        golang.org/x/tools/cmd/goimports \
+        github.com/sqs/goreturns \
+        winterdrache.de/goformat/goformat \
+        golang.org/x/lint/golint \
+        github.com/cweill/gotests/... \
+        github.com/alecthomas/gometalinter \
+        honnef.co/go/tools/... \
+        github.com/golangci/golangci-lint/cmd/golangci-lint \
+        github.com/mgechev/revive \
+        github.com/sourcegraph/go-langserver \
+        github.com/go-delve/delve/cmd/dlv \
+        github.com/davidrjenni/reftools/cmd/fillstruct \
+        github.com/godoctor/godoctor && \
+    GO111MODULE=on go get -u -v \
+        golang.org/x/tools/gopls@latest && \
+    go get -u -v -d github.com/stamblerre/gocode && \
+    go build -o $GOPATH/bin/gocode-gomod github.com/stamblerre/gocode && \
+    rm -rf $GOPATH/src && \
+    sudo rm -rf $GOPATH/pkg && \
+    rm -rf /home/gitpod/.cache/go
+# user Go packages
+ENV GOPATH=/workspace/go \
+    PATH=/workspace/go/bin:$PATH
+
+### Docker client ###
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
+    # 'cosmic' not supported
+    && add-apt-repository -yu "deb [arch=amd64] https://download.docker.com/linux/ubuntu bionic stable" \
+    && apt-get install -yq docker-ce-cli=5:18.09.0~3-0~ubuntu-bionic \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
+
+### Kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
+   chmod +x ./kubectl \
+   mv kubectl $K8SCLI_DIR/kubectl
+
+### Helm ###
+RUN curl -fsSL https://get.helm.sh/helm-v3.0.1-linux-amd64.tar.gz \
+    | tar -xzvC /usr/local/bin --strip-components=1 \
+    && helm completion bash > /usr/share/bash-completion/completions/helm
+
+USER gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -87,6 +87,17 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 ### Kubectl & Helm To be added for deployment
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.16.0/bin/linux/amd64/kubectl \
+    && chmod +x ./kubectl \
+    && sudo mv kubectl /usr/local/bin
 
+RUN curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 \
+    && chmod 700 get_helm.sh \
+    && ./get_helm.sh
+
+### Skaffold for Dev workflow
+RUN curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 \
+    && chmod +x skaffold \
+    && sudo mv skaffold /usr/local/bin
 
 USER gitpod

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,19 +1,27 @@
-FROM ubuntu:trusty
+FROM buildpack-deps:disco
 
 ### base ###
 RUN yes | unminimize \
     && apt-get install -yq \
-    apache2-utils \
-    parallel \
-    realpath \
-    zip \
-    unzip \
-    less \
-    jq \
-    nano \
-    software-properties-common \
-    sudo \
-    && locale-gen en_US.UTF-8
+        zip \
+        unzip \
+        bash-completion \
+        build-essential \
+        htop \
+        jq \
+        less \
+        locales \
+        man-db \
+        nano \
+        software-properties-common \
+        sudo \
+        time \
+        vim \
+        multitail \
+        lsof \
+    && locale-gen en_US.UTF-8 \
+    && mkdir /var/lib/apt/dazzle-marks \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
 
 ENV LANG=en_US.UTF-8
 

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -41,8 +41,8 @@ RUN sudo echo "Running 'sudo' for Gitpod: success" && \
     (echo; echo "for i in \$(ls \$HOME/.bashrc.d/*); do source \$i; done"; echo) >> /home/gitpod/.bashrc
 
 ### Go ###
-LABEL dazzle/layer=lang-go
-LABEL dazzle/test=tests/lang-go.yaml
+LABEL fission/layer=lang-go
+LABEL fission/test=tests/lang-go.yaml
 USER gitpod
 ENV GO_VERSION=1.12 \
     GOPATH=$HOME/go-packages \

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,5 @@
 FROM ubuntu:trusty
 
-USER gitpod
-
 ### base ###
 RUN yes | unminimize \
     && apt-get install -yq \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image:
+  file: .gitpod.Dockerfile
+
+#ports:
+#  - port: 3000
+#    onOpen: open-preview
+
+tasks:
+  - init: echo 'Builing Fission Go Code' # 
+    command: go mod download

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,17 @@
 image:
   file: .gitpod.Dockerfile
 
-#ports:
-#  - port: 3000
-#    onOpen: open-preview
-
 tasks:
-  - init: echo 'Builing Fission Go Code' # 
+  - init: echo 'Builing Fission Go Code'
     command: go mod download
+
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: false
+    addComment: false
+    addBadge: false
+    addLabel: false

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 [![Build Status](https://travis-ci.org/fission/fission.svg?branch=master)](https://travis-ci.org/fission/fission)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fission/fission)](https://goreportcard.com/report/github.com/fission/fission)
-[fission.io](http://fission.io) | [@fissionio](http://twitter.com/fissionio) | [Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/fission/fission) 
+
+[fission.io](http://fission.io) | [@fissionio](http://twitter.com/fissionio) | [Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE)
+
 
 <img src="https://docs.fission.io/images/logo.png" width="300">
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/fission/fission.svg?branch=master)](https://travis-ci.org/fission/fission)
 [![Go Report Card](https://goreportcard.com/badge/github.com/fission/fission)](https://goreportcard.com/report/github.com/fission/fission)
-
 [fission.io](http://fission.io) | [@fissionio](http://twitter.com/fissionio) | [Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/fission/fission) 
 
 <img src="https://docs.fission.io/images/logo.png" width="300">
 


### PR DESCRIPTION
This PR adds [Gitpod](https://www.gitpod.io/) for Fission with a base image that has Go, Docker client, etc. installed. This itself is not sufficient for developing Fission fully on Gitpod though. Some of the following are still needed for making Gitpod fully usable for Fission Development.

- [ ] Ability to build docker images from source from within Gitpod (Dependent on https://github.com/gitpod-io/gitpod/issues/1337) along with Kind installed for cluster

_**OR**_

- [ ] A way to configure a remote Kubernetes cluster and potentially using Kaniko/buildah etc. in the remote cluster

**Additionally** following is needed

- [ ] Kubectl, Helm, VSCode extensions installed in the base image

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1564)
<!-- Reviewable:end -->
