### PR TITLE
Permit disabling pre-upgrade checks (because.. Istio)

### DIFF
--- a/charts/fission-all/templates/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preUpgradeChecks }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,3 +32,4 @@ spec:
         command: [ "/pre-upgrade-checks" ]
         args: ["--fn-pod-namespace", "{{ .Values.functionNamespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]
       serviceAccountName: fission-svc
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -258,6 +258,10 @@ heapster: false
 ## The value is in minutes.
 pruneInterval: 60
 
+# Allow user to disable pre-upgrade checks at their own peril
+# (in the event that something like Istio sidecars prevents any jobs from completing!)
+preUpgradeChecks: true
+
 ## Fission pre-install/pre-upgrade checks live in this image
 preUpgradeChecksImage: fission/pre-upgrade-checks
 

--- a/charts/fission-core/templates/pre-upgrade-job.yaml
+++ b/charts/fission-core/templates/pre-upgrade-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.preUpgradeChecks }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,3 +32,4 @@ spec:
         command: [ "/pre-upgrade-checks" ]
         args: ["--fn-pod-namespace", "{{ .Values.functionNamespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]
       serviceAccountName: fission-svc
+{{- end }}

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -36,6 +36,11 @@ functionNamespace: fission-function
 ## the release namespace)
 builderNamespace: fission-builder
 
+# Whether or not to create namespaces for builder/fetcher as part of the helm install
+# In some configurations, a service account may have privilegdes to deploy into a namespace, but not
+# to create additional namespaces (so the namespaces must be pre-prepared)
+createNamespace: true
+
 ## Enable istio integration
 enableIstio: false
 
@@ -161,6 +166,10 @@ analyticsNonHelmInstall: false
 ## This interval configures the frequency at which it runs inside the storagesvc pod.
 ## The value is in minutes.
 pruneInterval: 60
+
+# Allow user to disable pre-upgrade checks at their own peril
+# (in the event that something like Istio sidecars prevents any jobs from completing!)
+preUpgradeChecks: true
 
 ## Fission pre-install/pre-upgrade checks live in this image
 preUpgradeChecksImage: fission/pre-upgrade-checks


### PR DESCRIPTION
Hey guys,

We're using Istio in our cluster with mTLS, and as a result, every pod has an istio-proxy sidecar, managing the mTLS. This presents a problem for Jobs, since the sidecar hangs around after the job completes, resulting in an incomplete job.

Hopefully [this'll be solved in 1.19](https://github.com/kubernetes/enhancements/issues/753), but until then, I've added this PR to allow users like me to disable pre-upgrade checks (at their own peril).

Cheers!
D