### PR TITLE
Initial addition of openapischemav3 to support kubectl explain

### DIFF
--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -175,7 +175,8 @@ func EnsureFissionCRDs(logger *zap.Logger, clientset *apiextensionsclient.Client
 					Plural:   "packages",
 					Singular: "package",
 				},
-				Validation: packageValidation,
+				PreserveUnknownFields: boolPtr(false),
+				Validation:            packageValidation,
 			},
 		},
 		// CanaryConfig: configuration for canary deployment of functions

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -58,10 +58,6 @@ func ensureCRD(logger *zap.Logger, clientset *apiextensionsclient.Clientset, crd
 	return err
 }
 
-func boolPtr(b bool) *bool {
-	return &b
-}
-
 // Ensure CRDs
 func EnsureFissionCRDs(logger *zap.Logger, clientset *apiextensionsclient.Clientset) error {
 	crds := []apiextensionsv1beta1.CustomResourceDefinition{
@@ -179,8 +175,7 @@ func EnsureFissionCRDs(logger *zap.Logger, clientset *apiextensionsclient.Client
 					Plural:   "packages",
 					Singular: "package",
 				},
-				PreserveUnknownFields: boolPtr(false),
-				Validation:            packageValidation,
+				Validation: packageValidation,
 			},
 		},
 		// CanaryConfig: configuration for canary deployment of functions

--- a/pkg/crd/crd.go
+++ b/pkg/crd/crd.go
@@ -31,119 +31,6 @@ const (
 	crdVersion   = "v1"
 )
 
-var (
-	functionValidation = &apiextensionsv1beta1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-			Type:        "object",
-			Description: "Function in fission is something that Fission executes. It’s usually a module with one entry point, and that entry point is a function with a certain interface.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"spec": {
-					Type:        "object",
-					Description: "Specification of the desired behaviour of the Function",
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"environment": {
-							Type:        "object",
-							Description: "Environments are the language-specific parts of Fission. An Environment contains just enough software to build and run a Fission Function.",
-						},
-						"package": {
-							Type:        "object",
-							Description: "A Package is a Fission object containing a Deployment Archive and a Source Archive (if any). A Package also references a certain environment.",
-						},
-						"secrets": {
-							Type:        "array",
-							Description: "Reference to a list of secrets.",
-							Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-								Schema: &apiextensionsv1beta1.JSONSchemaProps{
-									Type: "object",
-								},
-							},
-						},
-						"configmaps": {
-							Type:        "array",
-							Description: "Reference to a list of configmaps.",
-							Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
-								Schema: &apiextensionsv1beta1.JSONSchemaProps{
-									Type: "object",
-								},
-							},
-						},
-						"resources": {
-							Type:        "object",
-							Description: "ResourceRequirements describes the compute resource requirements. This is only for newdeploy to set up resource limitation when creating deployment for a function.",
-						},
-						"invokeStrategy": {
-							Type:        "object",
-							Description: "InvokeStrategy is a set of controls which affect how function executes",
-						},
-						"functionTimeout": {
-							Type:        "integer",
-							Description: " FunctionTimeout provides a maximum amount of duration within which a request for a particular function execution should be complete.\nThis is optional. If not specified default value will be taken as 60s",
-						},
-						"idletimeout": {
-							Type:        "object",
-							Description: "IdleTimeout specifies the length of time that a function is idle before the function pod(s) are eligible for deletion. If no traffic to the function is detected within the idle timeout, the executor will then recycle the function pod(s) to release resources.",
-						},
-					},
-				},
-			},
-		},
-	}
-	environmentValidation = &apiextensionsv1beta1.CustomResourceValidation{
-		OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
-			Type:        "object",
-			Description: "Environments are the language-specific parts of Fission. An Environment contains just enough software to build and run a Fission Function.",
-			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"spec": {
-					Type:        "object",
-					Description: "Specification of the desired behaviour of the Environment",
-					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-						"version": {
-							Type:        "integer",
-							Description: "Version is the Environment API version",
-						},
-						"runtime": {
-							Type:        "object",
-							Description: "Runtime is configuration for running function, like container image etc.",
-						},
-						"builder": {
-							Type:        "object",
-							Description: "Builder is configuration for builder manager to launch environment builder to build source code into deployable binary.",
-						},
-						"allowedFunctionsPerContainer": {
-							Type:        "object",
-							Description: "Allowed functions per container. Allowed Values: single, multiple",
-						},
-						"allowAccessToExternalNetwork": {
-							Type:        "boolean",
-							Description: "To enable accessibility of external network for builder/function pod, set to 'true'.",
-						},
-						"resources": {
-							Type:        "object",
-							Description: "The request and limit CPU/MEM resource setting for poolmanager to set up pods in the pre-warm pool.",
-						},
-						"poolsize": {
-							Type:        "integer",
-							Description: "The initial pool size for environment",
-						},
-						"terminationGracePeriod": {
-							Type:        "integer",
-							Description: "The grace time for pod to perform connection draining before termination. The unit is in seconds.",
-						},
-						"keeparchive": {
-							Type:        "boolean",
-							Description: "KeepArchive is used by fetcher to determine if the extracted archive or unarchived file should be placed, which is then used by specialize handler.",
-						},
-						"imagepullsecret": {
-							Type:        "string",
-							Description: "ImagePullSecret is the secret for Kubernetes to pull an image from a private registry.",
-						},
-					},
-				},
-			},
-		},
-	}
-)
-
 // ensureCRD checks if the given CRD type exists, and creates it if
 // needed. (Note that this creates the CRD type; it doesn't create any
 // _instances_ of that type.)
@@ -292,6 +179,8 @@ func EnsureFissionCRDs(logger *zap.Logger, clientset *apiextensionsclient.Client
 					Plural:   "packages",
 					Singular: "package",
 				},
+				PreserveUnknownFields: boolPtr(false),
+				Validation:            packageValidation,
 			},
 		},
 		// CanaryConfig: configuration for canary deployment of functions

--- a/pkg/crd/crdvalidations.go
+++ b/pkg/crd/crdvalidations.go
@@ -27,14 +27,13 @@ var (
 			Type:        "object",
 			Description: "Specification of the desired behaviour of the Function",
 			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"environment": environmentSchema,
-				"package":     packageSchema,
+				"environment": environmentReferenceSchema,
+				"package":     functionPackageRefSchema,
 				"secrets":     secretReferenceSchema,
 				"configmaps":  configMapReferenceSchema,
 				"resources": {
 					Type:        "object",
 					Description: "ResourceRequirements describes the compute resource requirements. This is only for newdeploy to set up resource limitation when creating deployment for a function.",
-					Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 				},
 				"InvokeStrategy": invokeStrategySchema,
 				"functionTimeout": {
@@ -74,11 +73,7 @@ var (
 					Description: "Version is the Environment API version",
 				},
 				"runtime": runtimeSchema,
-				"builder": {
-					Type:        "object",
-					Description: "Builder is configuration for builder manager to launch environment builder to build source code into deployable binary.",
-					Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
-				},
+				"builder": builderSchema,
 				"allowedFunctionsPerContainer": {
 					Type:        "string",
 					Description: "Allowed functions per container. Allowed Values: single, multiple",
@@ -90,7 +85,6 @@ var (
 				"resources": {
 					Type:        "object",
 					Description: "The request and limit CPU/MEM resource setting for poolmanager to set up pods in the pre-warm pool.",
-					Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 				},
 				"poolsize": {
 					Type:        "integer",
@@ -134,7 +128,7 @@ var (
 			Type:        "object",
 			Description: "Specification of the desired behaviour of the package",
 			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
-				"environment": environmentSchema,
+				"environment": environmentReferenceSchema,
 				"source":      archiveSchema,
 				"deployment":  archiveSchema,
 				"configmaps":  configMapReferenceSchema,
@@ -186,13 +180,13 @@ var (
 
 var (
 	checksumSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
-		"sum": {
-			Type:        "string",
-			Description: " Sum is hex encoded chechsum value.",
-		},
 		"type": {
 			Type:        "string",
 			Description: "ChecksumType specifies the checksum algorithm, such as sha256, used for a checksum.",
+		},
+		"sum": {
+			Type:        "string",
+			Description: " Sum is hex encoded chechsum value.",
 		},
 	}
 	checksumSchema = apiextensionsv1beta1.JSONSchemaProps{
@@ -203,6 +197,57 @@ var (
 )
 
 // Children of Function crd schema
+var (
+	environmentReferenceSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"namespace": {
+			Type:        "string",
+			Description: "Namespace for corresponding Environment",
+		},
+		"name": {
+			Type:        "string",
+			Description: "Name of the Environment to use",
+		},
+	}
+	environmentReferenceSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Reference to Fission Environment type custom resource.",
+		Properties:  environmentReferenceSchemaProps,
+	}
+)
+
+var (
+	packageRefSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"namespace": {
+			Type:        "string",
+			Description: "Namespace for corresponding Package",
+		},
+		"name": {
+			Type:        "string",
+			Description: "Name of the Package to use",
+		},
+		"resourceversion": {
+			Type:        "string",
+			Description: "Including resource version in the reference forces the function to be updated on package update, making it possible to cache the function based on its metadata.",
+		},
+	}
+	functionPackageRefSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"packageref": {
+			Type:        "object",
+			Description: "Package Reference",
+			Properties:  packageRefSchemaProps,
+		},
+		"functionName": {
+			Type:        "string",
+			Description: "FunctionName specifies a specific function within the package. This allows functions to share packages, by having different functions within the same package.",
+		},
+	}
+	functionPackageRefSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "FunctionPackageRef includes the reference to the package.",
+		Properties:  functionPackageRefSchemaProps,
+	}
+)
+
 var (
 	secretReferenceSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"namespace": {
@@ -305,12 +350,10 @@ var (
 		"container": {
 			Type:        "object",
 			Description: "(Optional) Container allows the modification of the deployed runtime container using the Kubernetes Container spec. Fission overrides the following fields: Name, Image (set to the Runtime.Image), TerminationMessagePath, ImagePullPolicy\n You can set either PodSpec or Container, but not both.",
-			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 		},
 		"podspec": {
 			Type:        "object",
 			Description: "(Optional) Podspec allows modification of deployed runtime pod with Kubernetes PodSpec.\n You can set either PodSpec or Container, but not both.",
-			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 		},
 	}
 	runtimeSchema = apiextensionsv1beta1.JSONSchemaProps{
@@ -332,12 +375,10 @@ var (
 		"container": {
 			Type:        "object",
 			Description: "(Optional) Container allows the modification of the deployed runtime container using the Kubernetes Container spec. Fission overrides the following fields: Name, Image (set to the Runtime.Image), TerminationMessagePath, ImagePullPolicy\n You can set either PodSpec or Container, but not both.",
-			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 		},
 		"podspec": {
 			Type:        "object",
 			Description: "(Optional) Podspec allows modification of deployed runtime pod with Kubernetes PodSpec.\n You can set either PodSpec or Container, but not both.",
-			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 		},
 	}
 	builderSchema = apiextensionsv1beta1.JSONSchemaProps{
@@ -346,3 +387,7 @@ var (
 		Properties:  builderSchemaProps,
 	}
 )
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/pkg/crd/crdvalidations.go
+++ b/pkg/crd/crdvalidations.go
@@ -152,6 +152,7 @@ var (
 				},
 				"lastUpdateTimestamp": {
 					Type:        "string",
+					Nullable:    true,
 					Description: "LastUpdateTimestamp will store the timestamp the package was last updated metav1.Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.",
 				},
 			},

--- a/pkg/crd/crdvalidations.go
+++ b/pkg/crd/crdvalidations.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	// Function validation schema properties
 	functionSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"spec": {
 			Type:        "object",
@@ -33,33 +34,36 @@ var (
 				"resources": {
 					Type:        "object",
 					Description: "ResourceRequirements describes the compute resource requirements. This is only for newdeploy to set up resource limitation when creating deployment for a function.",
+					Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 				},
-				"invokeStrategy": {
-					Type:        "object",
-					Description: "InvokeStrategy is a set of controls which affect how function executes",
-				},
+				"InvokeStrategy": invokeStrategySchema,
 				"functionTimeout": {
 					Type:        "integer",
 					Description: " FunctionTimeout provides a maximum amount of duration within which a request for a particular function execution should be complete.\nThis is optional. If not specified default value will be taken as 60s",
 				},
 				"idletimeout": {
-					Type:        "object",
+					Type:        "integer",
 					Description: "IdleTimeout specifies the length of time that a function is idle before the function pod(s) are eligible for deletion. If no traffic to the function is detected within the idle timeout, the executor will then recycle the function pod(s) to release resources.",
 				},
 			},
 		},
 	}
+
+	// Function validation schema
 	functionSchema = apiextensionsv1beta1.JSONSchemaProps{
 		Type:        "object",
 		Description: "Function in fission is something that Fission executes. It’s usually a module with one entry point, and that entry point is a function with a certain interface.",
 		Properties:  functionSchemaProps,
 	}
+
+	// Function validation object
 	functionValidation = &apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &functionSchema,
 	}
 )
 
 var (
+	// Environment validation schema properties
 	environmentSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"spec": {
 			Type:        "object",
@@ -69,16 +73,14 @@ var (
 					Type:        "integer",
 					Description: "Version is the Environment API version",
 				},
-				"runtime": {
-					Type:        "object",
-					Description: "Runtime is configuration for running function, like container image etc.",
-				},
+				"runtime": runtimeSchema,
 				"builder": {
 					Type:        "object",
 					Description: "Builder is configuration for builder manager to launch environment builder to build source code into deployable binary.",
+					Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 				},
 				"allowedFunctionsPerContainer": {
-					Type:        "object",
+					Type:        "string",
 					Description: "Allowed functions per container. Allowed Values: single, multiple",
 				},
 				"allowAccessToExternalNetwork": {
@@ -88,6 +90,7 @@ var (
 				"resources": {
 					Type:        "object",
 					Description: "The request and limit CPU/MEM resource setting for poolmanager to set up pods in the pre-warm pool.",
+					Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
 				},
 				"poolsize": {
 					Type:        "integer",
@@ -95,6 +98,7 @@ var (
 				},
 				"terminationGracePeriod": {
 					Type:        "integer",
+					Format:      "int64",
 					Description: "The grace time for pod to perform connection draining before termination. The unit is in seconds.",
 				},
 				"keeparchive": {
@@ -109,17 +113,22 @@ var (
 		},
 	}
 
+	// Environment validation schema
 	environmentSchema = apiextensionsv1beta1.JSONSchemaProps{
 		Type:        "object",
 		Description: "Environments are the language-specific parts of Fission. An Environment contains just enough software to build and run a Fission Function.",
 		Properties:  environmentSchemaProps,
 	}
+
+	// Environment validation object
 	environmentValidation = &apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &environmentSchema,
 	}
 )
 
 var (
+
+	// Package validation schema properties
 	packageSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"spec": {
 			Type:        "object",
@@ -136,35 +145,21 @@ var (
 			},
 		},
 	}
+
+	// Package validation schema
 	packageSchema = apiextensionsv1beta1.JSONSchemaProps{
 		Type:        "object",
 		Description: "A Package is a Fission object containing a Deployment Archive and a Source Archive (if any). A Package also references a certain environment.",
 		Properties:  packageSchemaProps,
 	}
 
+	// Environment validation object
 	packageValidation = &apiextensionsv1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &packageSchema,
 	}
 )
 
-var (
-	checksumSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
-		"sum": {
-			Type:        "string",
-			Description: " Sum is hex encoded chechsum value.",
-		},
-		"type": {
-			Type:        "string",
-			Description: "ChecksumType specifies the checksum algorithm, such as sha256, used for a checksum.",
-		},
-	}
-	checksumSchema = apiextensionsv1beta1.JSONSchemaProps{
-		Type:        "object",
-		Description: "Checksum of package contents when the contents are stored outside the Package struct. Type is the checksum algorithm;  sha256 is the only currently supported one. Sum is hex  encoded.",
-		Properties:  checksumSchemaProps,
-	}
-)
-
+// Children of Package crd schema
 var (
 	archiveSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"type": {
@@ -190,6 +185,25 @@ var (
 )
 
 var (
+	checksumSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"sum": {
+			Type:        "string",
+			Description: " Sum is hex encoded chechsum value.",
+		},
+		"type": {
+			Type:        "string",
+			Description: "ChecksumType specifies the checksum algorithm, such as sha256, used for a checksum.",
+		},
+	}
+	checksumSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Checksum of package contents when the contents are stored outside the Package struct. Type is the checksum algorithm;  sha256 is the only currently supported one. Sum is hex  encoded.",
+		Properties:  checksumSchemaProps,
+	}
+)
+
+// Children of Function crd schema
+var (
 	secretReferenceSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"namespace": {
 			Type:        "string",
@@ -206,7 +220,8 @@ var (
 		Properties:  secretReferenceSchemaProps,
 	}
 	secretReferenceSchema = apiextensionsv1beta1.JSONSchemaProps{
-		Type: "array",
+		Type:     "array",
+		Nullable: true,
 		Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
 			Schema: &secretReferenceObjectSchema,
 		},
@@ -231,9 +246,103 @@ var (
 	}
 
 	configMapReferenceSchema = apiextensionsv1beta1.JSONSchemaProps{
-		Type: "array",
+		Type:     "array",
+		Nullable: true,
 		Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
 			Schema: &configMapReferenceObjectSchema,
 		},
+	}
+)
+
+var (
+	executionStrategySchema = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"ExecutorType": {
+			Type:        "string",
+			Description: "ExecutorType is the executor type of a function used. Defaults to poolmgr. Available value: poolmgr, newdeploy",
+		},
+		"MinScale": {
+			Type:        "integer",
+			Description: "Only for newdeploy to set up minimum replicas of deployment.",
+		},
+		"MaxScale": {
+			Type:        "integer",
+			Description: "Only for newdeploy to set up maximum replicas of deployment.",
+		},
+		"TargetCPUPercent": {
+			Type:        "integer",
+			Description: "Only for newdeploy to set up target CPU utilization of HPA.",
+		},
+		"SpecializationTimeout": {
+			Type:        "integer",
+			Description: "Timeout setting for executor to wait for pod specialization.",
+		},
+	}
+	invokeStrategySchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"ExecutionStrategy": {
+			Type:        "object",
+			Description: "ExecutionStrategy specifies low-level parameters for function execution, such as the number of instances.",
+			Properties:  executionStrategySchema,
+		},
+		"StrategyType": {
+			Type:        "string",
+			Description: "StrategyType is the strategy type of a function.",
+		},
+	}
+	invokeStrategySchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "InvokeStrategy is a set of controls over how the function executes. It affects the performance and resource usage of the function. An InvokeStrategy is of one of two types: ExecutionStrategy, which controls low-level parameters such as which ExecutorType to use, when to autoscale, minimum and maximum number of running instances, etc.",
+		Properties:  invokeStrategySchemaProps,
+	}
+)
+
+// Children of Environment crd schema
+var (
+	runtimeSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"image": {
+			Type:        "string",
+			Description: "Image for containing the language runtime.",
+		},
+		"container": {
+			Type:        "object",
+			Description: "(Optional) Container allows the modification of the deployed runtime container using the Kubernetes Container spec. Fission overrides the following fields: Name, Image (set to the Runtime.Image), TerminationMessagePath, ImagePullPolicy\n You can set either PodSpec or Container, but not both.",
+			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
+		},
+		"podspec": {
+			Type:        "object",
+			Description: "(Optional) Podspec allows modification of deployed runtime pod with Kubernetes PodSpec.\n You can set either PodSpec or Container, but not both.",
+			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
+		},
+	}
+	runtimeSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Runtime is configuration for running function, like container image etc.",
+		Properties:  runtimeSchemaProps,
+	}
+)
+var (
+	builderSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"image": {
+			Type:        "string",
+			Description: "Image for containing the language runtime.",
+		},
+		"command": {
+			Type:        "string",
+			Description: "(Optional) Default build command to run for this build environment.",
+		},
+		"container": {
+			Type:        "object",
+			Description: "(Optional) Container allows the modification of the deployed runtime container using the Kubernetes Container spec. Fission overrides the following fields: Name, Image (set to the Runtime.Image), TerminationMessagePath, ImagePullPolicy\n You can set either PodSpec or Container, but not both.",
+			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
+		},
+		"podspec": {
+			Type:        "object",
+			Description: "(Optional) Podspec allows modification of deployed runtime pod with Kubernetes PodSpec.\n You can set either PodSpec or Container, but not both.",
+			Properties:  map[string]apiextensionsv1beta1.JSONSchemaProps{},
+		},
+	}
+	builderSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "(Optional) Builder is configuration for builder manager to launch environment builder to build source code into deployable binary.",
+		Properties:  builderSchemaProps,
 	}
 )

--- a/pkg/crd/crdvalidations.go
+++ b/pkg/crd/crdvalidations.go
@@ -126,7 +126,7 @@ var (
 	packageSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
 		"spec": {
 			Type:        "object",
-			Description: "Specification of the desired behaviour of the package",
+			Description: "Specification of the desired behaviour of the package.",
 			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
 				"environment": environmentReferenceSchema,
 				"source":      archiveSchema,
@@ -135,6 +135,24 @@ var (
 				"buildcmd": {
 					Type:        "string",
 					Description: "BuildCommand is a custom build command that builder used to build the source archive.",
+				},
+			},
+		},
+		"status": {
+			Type:        "object",
+			Description: "PackageStatus contains the build status of a package also the build log for examination.",
+			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				"buildstatus": {
+					Type:        "string",
+					Description: "BuildStatus is the package build status.",
+				},
+				"buildlog": {
+					Type:        "string",
+					Description: "BuildCommand is a custom build command that builder used to build the source archive.",
+				},
+				"lastUpdateTimestamp": {
+					Type:        "string",
+					Description: "LastUpdateTimestamp will store the timestamp the package was last updated metav1.Time is a wrapper around time.Time which supports correct marshaling to YAML and JSON.",
 				},
 			},
 		},

--- a/pkg/crd/crdvalidations.go
+++ b/pkg/crd/crdvalidations.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import (
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+var (
+	functionSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"spec": {
+			Type:        "object",
+			Description: "Specification of the desired behaviour of the Function",
+			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				"environment": environmentSchema,
+				"package":     packageSchema,
+				"secrets":     secretReferenceSchema,
+				"configmaps":  configMapReferenceSchema,
+				"resources": {
+					Type:        "object",
+					Description: "ResourceRequirements describes the compute resource requirements. This is only for newdeploy to set up resource limitation when creating deployment for a function.",
+				},
+				"invokeStrategy": {
+					Type:        "object",
+					Description: "InvokeStrategy is a set of controls which affect how function executes",
+				},
+				"functionTimeout": {
+					Type:        "integer",
+					Description: " FunctionTimeout provides a maximum amount of duration within which a request for a particular function execution should be complete.\nThis is optional. If not specified default value will be taken as 60s",
+				},
+				"idletimeout": {
+					Type:        "object",
+					Description: "IdleTimeout specifies the length of time that a function is idle before the function pod(s) are eligible for deletion. If no traffic to the function is detected within the idle timeout, the executor will then recycle the function pod(s) to release resources.",
+				},
+			},
+		},
+	}
+	functionSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Function in fission is something that Fission executes. It’s usually a module with one entry point, and that entry point is a function with a certain interface.",
+		Properties:  functionSchemaProps,
+	}
+	functionValidation = &apiextensionsv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &functionSchema,
+	}
+)
+
+var (
+	environmentSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"spec": {
+			Type:        "object",
+			Description: "Specification of the desired behaviour of the Environment",
+			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				"version": {
+					Type:        "integer",
+					Description: "Version is the Environment API version",
+				},
+				"runtime": {
+					Type:        "object",
+					Description: "Runtime is configuration for running function, like container image etc.",
+				},
+				"builder": {
+					Type:        "object",
+					Description: "Builder is configuration for builder manager to launch environment builder to build source code into deployable binary.",
+				},
+				"allowedFunctionsPerContainer": {
+					Type:        "object",
+					Description: "Allowed functions per container. Allowed Values: single, multiple",
+				},
+				"allowAccessToExternalNetwork": {
+					Type:        "boolean",
+					Description: "To enable accessibility of external network for builder/function pod, set to 'true'.",
+				},
+				"resources": {
+					Type:        "object",
+					Description: "The request and limit CPU/MEM resource setting for poolmanager to set up pods in the pre-warm pool.",
+				},
+				"poolsize": {
+					Type:        "integer",
+					Description: "The initial pool size for environment",
+				},
+				"terminationGracePeriod": {
+					Type:        "integer",
+					Description: "The grace time for pod to perform connection draining before termination. The unit is in seconds.",
+				},
+				"keeparchive": {
+					Type:        "boolean",
+					Description: "KeepArchive is used by fetcher to determine if the extracted archive or unarchived file should be placed, which is then used by specialize handler.",
+				},
+				"imagepullsecret": {
+					Type:        "string",
+					Description: "ImagePullSecret is the secret for Kubernetes to pull an image from a private registry.",
+				},
+			},
+		},
+	}
+
+	environmentSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Environments are the language-specific parts of Fission. An Environment contains just enough software to build and run a Fission Function.",
+		Properties:  environmentSchemaProps,
+	}
+	environmentValidation = &apiextensionsv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &environmentSchema,
+	}
+)
+
+var (
+	packageSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"spec": {
+			Type:        "object",
+			Description: "Specification of the desired behaviour of the package",
+			Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+				"environment": environmentSchema,
+				"source":      archiveSchema,
+				"deployment":  archiveSchema,
+				"configmaps":  configMapReferenceSchema,
+				"buildcmd": {
+					Type:        "string",
+					Description: "BuildCommand is a custom build command that builder used to build the source archive.",
+				},
+			},
+		},
+	}
+	packageSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "A Package is a Fission object containing a Deployment Archive and a Source Archive (if any). A Package also references a certain environment.",
+		Properties:  packageSchemaProps,
+	}
+
+	packageValidation = &apiextensionsv1beta1.CustomResourceValidation{
+		OpenAPIV3Schema: &packageSchema,
+	}
+)
+
+var (
+	checksumSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"sum": {
+			Type:        "string",
+			Description: " Sum is hex encoded chechsum value.",
+		},
+		"type": {
+			Type:        "string",
+			Description: "ChecksumType specifies the checksum algorithm, such as sha256, used for a checksum.",
+		},
+	}
+	checksumSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Checksum of package contents when the contents are stored outside the Package struct. Type is the checksum algorithm;  sha256 is the only currently supported one. Sum is hex  encoded.",
+		Properties:  checksumSchemaProps,
+	}
+)
+
+var (
+	archiveSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"type": {
+			Type:        "string",
+			Description: "Type defines how the package is specified: literal or url.",
+		},
+		"literal": {
+			Type:        "string",
+			Format:      "byte",
+			Description: "Literal contents of the package.",
+		},
+		"url": {
+			Type:        "string",
+			Description: "URL references a package.",
+		},
+		"checksum": checksumSchema,
+	}
+	archiveSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Package contains or references a collection of source or binary files.",
+		Properties:  archiveSchemaProps,
+	}
+)
+
+var (
+	secretReferenceSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"namespace": {
+			Type:        "string",
+			Description: "Namespace for corresponding secret",
+		},
+		"name": {
+			Type:        "string",
+			Description: "Name of the secret to use",
+		},
+	}
+	secretReferenceObjectSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Reference to a Kubernetes secret.",
+		Properties:  secretReferenceSchemaProps,
+	}
+	secretReferenceSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type: "array",
+		Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+			Schema: &secretReferenceObjectSchema,
+		},
+	}
+)
+
+var (
+	configMapReferenceSchemaProps = map[string]apiextensionsv1beta1.JSONSchemaProps{
+		"namespace": {
+			Type:        "string",
+			Description: "Namespace for corresponding ConfigMap",
+		},
+		"name": {
+			Type:        "string",
+			Description: "Name of the ConfigMap to use",
+		},
+	}
+	configMapReferenceObjectSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type:        "object",
+		Description: "Reference to a Kubernetes ConfigMap.",
+		Properties:  configMapReferenceSchemaProps,
+	}
+
+	configMapReferenceSchema = apiextensionsv1beta1.JSONSchemaProps{
+		Type: "array",
+		Items: &apiextensionsv1beta1.JSONSchemaPropsOrArray{
+			Schema: &configMapReferenceObjectSchema,
+		},
+	}
+)


### PR DESCRIPTION
Added initial handling to support "kubectl explain" for fission crds.
Issue: https://github.com/fission/fission/issues/1668

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1685)
<!-- Reviewable:end -->
