### PR TITLE
Added ARM64 jobs to .travis.yml file and Updated the STATICCHECK_VERSION to support arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 
 dist: trusty
 
+arch:
+  - amd64
+  - arm64
+
 branches:
   only:
     - master
@@ -28,7 +32,7 @@ services:
 before_install:
   - sudo apt-get update
 #  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
-  - sudo apt-get -y install apache2-utils parallel realpath
+  - sudo apt-get -y install apache2-utils parallel coreutils
   - sudo sysctl net.ipv6.conf.all.disable_ipv6=0
 
 install:

--- a/hack/travis-kube-setup.sh
+++ b/hack/travis-kube-setup.sh
@@ -14,11 +14,19 @@ then
 fi
 
 # Get staticcheck
-STATICCHECK_VERSION=2019.2.3
+STATICCHECK_VERSION=2020.1.4
+
+if [ "$(uname -m)" == "aarch64" ]
+then
+    arch="arm64"
+else
+    arch="amd64"
+fi
+
 if [ ! -f $TOOL_DIR/staticcheck ] || (staticcheck -version | grep -v $STATICCHECK_VERSION)
 then
-    curl -LO https://github.com/dominikh/go-tools/releases/download/${STATICCHECK_VERSION}/staticcheck_linux_amd64.tar.gz
-    tar xzvf staticcheck_linux_amd64.tar.gz
+    curl -LO https://github.com/dominikh/go-tools/releases/download/${STATICCHECK_VERSION}/staticcheck_linux_${arch}.tar.gz
+    tar xzvf staticcheck_linux_${arch}.tar.gz
     mv staticcheck/staticcheck $TOOL_DIR/staticcheck
 fi
 
@@ -33,9 +41,9 @@ fi
 HELM_VERSION=2.14.0
 if [ ! -f $K8SCLI_DIR/helm ] || (helm version --client | grep -v $HELM_VERSION)
 then
-    curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz
+    curl -LO https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-${arch}.tar.gz
     tar xzvf helm-*.tar.gz
-    mv linux-amd64/helm $K8SCLI_DIR/helm
+    mv linux-${arch}/helm $K8SCLI_DIR/helm
 fi
 
 # If we don't have gcloud credentials, bail out of these tests.
@@ -48,7 +56,7 @@ fi
 # Get kubectl
 if [ ! -f $K8SCLI_DIR/kubectl ]
 then
-   curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+   curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${arch}/kubectl
    chmod +x ./kubectl
    mv kubectl $K8SCLI_DIR/kubectl
 fi

--- a/pkg/controller/client/v1/function.go
+++ b/pkg/controller/client/v1/function.go
@@ -107,7 +107,7 @@ func (c *Function) Get(m *metav1.ObjectMeta) (*fv1.Function, error) {
 func (c *Function) GetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) {
 	relativeUrl := fmt.Sprintf("functions/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
-	relativeUrl += fmt.Sprintf("&deploymentraw=1")
+	relativeUrl += "&deploymentraw=1"
 
 	resp, err := c.client.Get(relativeUrl)
 	if err != nil {

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -718,7 +718,7 @@ func (deploy *NewDeploy) fnDelete(fn *fv1.Function) error {
 	_, err = deploy.fsCache.DeleteOld(fsvc, time.Second*0)
 	if err != nil {
 		multierr = multierror.Append(multierr,
-			errors.Wrap(err, fmt.Sprintf("error deleting the function from cache")))
+			errors.Wrap(err, "error deleting the function from cache"))
 	}
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -441,7 +441,7 @@ func (fr *FissionResources) Validate(input cli.Input) ([]string, error) {
 		}
 
 		if len(t.Spec.Host) > 0 {
-			warnings = append(warnings, (fmt.Sprintf("Host in HTTPTrigger spec.Host is now marked as deprecated, see 'help' for details")))
+			warnings = append(warnings, "Host in HTTPTrigger spec.Host is now marked as deprecated, see 'help' for details")
 		}
 		result = multierror.Append(result, t.Validate())
 	}
@@ -475,12 +475,12 @@ func (fr *FissionResources) Validate(input cli.Input) ([]string, error) {
 	for _, e := range fr.Environments {
 		environments[fmt.Sprintf("%s:%s", e.ObjectMeta.Name, e.ObjectMeta.Namespace)] = struct{}{}
 		if ((e.Spec.Runtime.Container != nil) && (e.Spec.Runtime.PodSpec != nil)) || ((e.Spec.Builder.Container != nil) && (e.Spec.Builder.PodSpec != nil)) {
-			warnings = append(warnings, fmt.Sprintf("You have provided both - container spec and pod spec and while merging the pod spec will take precedence."))
+			warnings = append(warnings, "You have provided both - container spec and pod spec and while merging the pod spec will take precedence.")
 		}
 		// Unlike CLI can change the environment version silently,
 		// we have to warn the user to modify spec file when this takes place.
 		if e.Spec.Poolsize != 3 && e.Spec.Version < 3 {
-			warnings = append(warnings, fmt.Sprintf("Poolsize can only be configured when environment version equals to 3, default poolsize 3 will be used for creating environment pool."))
+			warnings = append(warnings, "Poolsize can only be configured when environment version equals to 3, default poolsize 3 will be used for creating environment pool.")
 		}
 	}
 
@@ -493,7 +493,7 @@ func (fr *FissionResources) Validate(input cli.Input) ([]string, error) {
 			warnings = append(warnings, fmt.Sprintf("SpecializationTimeout in function spec.InvokeStrategy.ExecutionStrategy should be a value equal to or greater than %v", fv1.DefaultSpecializationTimeOut))
 		}
 		if f.Spec.FunctionTimeout <= 0 {
-			warnings = append(warnings, fmt.Sprintf("FunctionTimeout in function spec should be a field which should have a value greater than 0"))
+			warnings = append(warnings, "FunctionTimeout in function spec should be a field which should have a value greater than 0")
 		}
 	}
 	// (ErrorOrNil returns nil if there were no errors appended.)

--- a/pkg/mqtrigger/scalermanager_test.go
+++ b/pkg/mqtrigger/scalermanager_test.go
@@ -9,7 +9,6 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -91,7 +90,7 @@ func Test_getEnvVarlist(t *testing.T) {
 
 	routerURL := "http://router.fission/fission-function"
 
-	secret := &v1.Secret{
+	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-kafka-secrets",
 			Namespace: namespace,
@@ -471,7 +470,7 @@ func Test_getAuthTriggerSpec(t *testing.T) {
 	}
 
 	namespace := apiv1.NamespaceDefault
-	secret := &v1.Secret{
+	secret := &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-kafka-secrets",
 			Namespace: namespace,

--- a/pkg/storagesvc/client/storagesvc_test.go
+++ b/pkg/storagesvc/client/storagesvc_test.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -57,10 +58,18 @@ func MakeTestFile(size int) *os.File {
 	return f
 }
 
+func checkArch() string {
+	if runtime.GOARCH == "arm64" {
+		return "RELEASE.2020-07-24T22-43-05Z-arm64"
+	} else {
+		return "latest"
+	}
+}
+
 func runMinioDockerContainer(pool *dockertest.Pool) *dockertest.Resource {
 	options := &dockertest.RunOptions{
 		Repository: "minio/minio",
-		Tag:        "latest",
+		Tag:        checkArch(),
 		Cmd:        []string{"server", "/data"},
 		PortBindings: map[dc.Port][]dc.PortBinding{
 			"9000/tcp": {{HostIP: "", HostPort: "9000"}},


### PR DESCRIPTION
Following files has been modified :

- Added arch: arm64 and replaced realpath with coreutils in travis file

- Updated STATICCHECK_VERSION which has arm64 support. Added check to download the ARM64 binary for helm and STATICCHECK in .hack/travis-kube-setup.sh

- Added docker minio tag which supports arm64 for creating Minio that supports arm64 in pkg/storagesvc/client/storagesvc_test.go

- Issues related to Static Check S1039 have been resolved in pkg/controller/client/v1/function.go, pkg/executor/executortype/newdeploy/newdeploymgr.go and pkg/fission-cli/cmd/spec/spec.go

- Issues related to Static Check ST1019 have been resolved in pkg/mqtrigger/scalermanager_test.go

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1689)
<!-- Reviewable:end -->
