### PR TITLE
Update fetcher.go directory and file permissions

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -58,7 +58,7 @@ type (
 )
 
 func makeVolumeDir(dirPath string) error {
-	return os.MkdirAll(dirPath, os.ModeDir|0700)
+	return os.MkdirAll(dirPath, os.ModeDir|0750)
 }
 
 func MakeFetcher(logger *zap.Logger, sharedVolumePath string, sharedSecretPath string, sharedConfigPath string) (*Fetcher, error) {
@@ -106,7 +106,7 @@ func verifyChecksum(fileChecksum, checksum *fv1.Checksum) error {
 func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 	for key, val := range dataMap {
 		writeFilePath := filepath.Join(dirPath, key)
-		err := ioutil.WriteFile(writeFilePath, val, 0600)
+		err := ioutil.WriteFile(writeFilePath, val, 0750)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to write file %s", writeFilePath)
 		}


### PR DESCRIPTION
When using custom environments with a non-root user, secrets and configmaps are inaccessible even if `fsGroup` is configured since the files are only accessible by the owner. Adding group read and execute allows `fsGroup` configuration to allow non-root users to access secrets and configmaps.

Say your Dockerfile has this user
```Dockerfile
ENV USER=fission \
    UID=1000 \
    GID=1000

RUN addgroup --gid "$GID" "$USER" \
    && adduser \
    --disabled-password \
    --gecos "" \
    --home "/" \
    --ingroup "$USER" \
    --no-create-home \
    --uid "$UID" \
    "$USER"

USER 1000

ENTRYPOINT ["python3"]
CMD ["server.py"]

```

Then your Fission environment would be

```yaml
apiVersion: fission.io/v1
kind: Environment
metadata:
  name: fission-secret
  namespace: default
spec:
  builder:
    command: build
    image: fission/python-builder
  imagepullsecret: your-pull-secret
  keeparchive: false
  poolsize: 3
  resources: {}
  runtime:
    podspec:
      securityContext:
        fsGroup: 1000
    image: your-custom-image/name:1.0
  version: 2

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1696)
<!-- Reviewable:end -->
