### PR TITLE
Skaffold kind

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -40,6 +40,10 @@ This template generates the image name for the deployment depending on the value
 {{- if .Values.repository -}}
     {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
 {{- else -}}
+  {{- if .Values.imageTag -}}
     {{ .Values.image }}:{{ .Values.imageTag }}    
+  {{- else -}}
+    {{ .Values.image }}
+  {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -45,7 +45,7 @@ This template generates the image name for the deployment depending on the value
   {{- end }}
 {{- else -}}
   {{- if eq .Values.imageTag "" -}}
-    {{ .Values.image }}:
+    {{ .Values.image }}
   {{- else -}}
     {{ .Values.image }}:{{ .Values.imageTag }}
   {{- end }}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -38,12 +38,16 @@ This template generates the image name for the deployment depending on the value
 */}}
 {{- define "fission-bundleImage" -}}
 {{- if .Values.repository -}}
-    {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
-{{- else -}}
-  {{- if .Values.imageTag -}}
-    {{ .Values.image }}:{{ .Values.imageTag }}    
+  {{- if eq .Values.imageTag "" -}}
+    {{ .Values.repository }}/{{ .Values.image }}
   {{- else -}}
-    {{ .Values.image }}
+    {{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}
+  {{- end }}
+{{- else -}}
+  {{- if eq .Values.imageTag "" -}}
+    {{ .Values.image }}:
+  {{- else -}}
+    {{ .Values.image }}:{{ .Values.imageTag }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -210,7 +210,11 @@ spec:
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}"]
         env:
         - name: FETCHER_IMAGE
+        {{- if .Values.fetcher.imageTag }}
           value: "{{ .Values.fetcher.image }}:{{ .Values.fetcher.imageTag }}"
+        {{- else }}
+          value: "{{ .Values.fetcher.image }}"
+        {{- end }}
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
         - name: RUNTIME_IMAGE_PULL_POLICY
@@ -282,7 +286,11 @@ spec:
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]
         env:
         - name: FETCHER_IMAGE
+        {{- if .Values.fetcher.imageTag }}
           value: "{{ .Values.fetcher.image }}:{{ .Values.fetcher.imageTag }}"
+        {{- else }}
+          value: "{{ .Values.fetcher.image }}"
+        {{- end }}
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
         - name: BUILDER_IMAGE_PULL_POLICY
@@ -642,7 +650,11 @@ spec:
     spec:
       containers:
       - name: mqtrigger
+      {{- if .Values.imageTag }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+      {{- else }}
+        image: "{{ .Values.image }}"
+      {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
@@ -732,7 +744,11 @@ spec:
     spec:
       containers:
       - name: mqtrigger
+      {{- if .Values.imageTag }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+      {{- else }}
+        image: "{{ .Values.image }}"
+      {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}"]

--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -210,10 +210,10 @@ spec:
         args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}"]
         env:
         - name: FETCHER_IMAGE
-        {{- if .Values.fetcher.imageTag }}
-          value: "{{ .Values.fetcher.image }}:{{ .Values.fetcher.imageTag }}"
-        {{- else }}
+        {{- if eq .Values.fetcher.imageTag "" }}
           value: "{{ .Values.fetcher.image }}"
+        {{- else }}
+          value: "{{ .Values.fetcher.image }}:{{ .Values.fetcher.imageTag }}"
         {{- end }}
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
@@ -286,10 +286,10 @@ spec:
         args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]
         env:
         - name: FETCHER_IMAGE
-        {{- if .Values.fetcher.imageTag }}
-          value: "{{ .Values.fetcher.image }}:{{ .Values.fetcher.imageTag }}"
-        {{- else }}
+        {{- if eq .Values.fetcher.imageTag "" }}
           value: "{{ .Values.fetcher.image }}"
+        {{- else }}
+          value: "{{ .Values.fetcher.image }}:{{ .Values.fetcher.imageTag }}"
         {{- end }}
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
@@ -650,10 +650,10 @@ spec:
     spec:
       containers:
       - name: mqtrigger
-      {{- if .Values.imageTag }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-      {{- else }}
+      {{- if eq .Values.imageTag "" }}
         image: "{{ .Values.image }}"
+      {{- else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
       {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
@@ -744,10 +744,10 @@ spec:
     spec:
       containers:
       - name: mqtrigger
-      {{- if .Values.imageTag }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-      {{- else }}
+      {{- if eq .Values.imageTag "" }}
         image: "{{ .Values.image }}"
+      {{- else }}
+        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
       {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]

--- a/charts/fission-all/templates/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit.yaml
@@ -109,11 +109,7 @@ spec:
 {{- end }}
       containers:
         - name: logger
-{{ if .Values.repository }}
-          image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ else }}
-          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-{{ end }}
+          image: {{ include "fission-bundleImage" . | quote }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           env:
             - name: NODE_NAME

--- a/charts/fission-all/templates/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-job.yaml
@@ -26,7 +26,11 @@ spec:
       restartPolicy: Never
       containers:
       - name: pre-upgrade-job
+      {{- if .Values.imageTag }}
         image: {{ .Values.preUpgradeChecksImage }}:{{ .Values.imageTag }}
+      {{- else }}
+        image: {{ .Values.preUpgradeChecksImage }}
+      {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: [ "/pre-upgrade-checks" ]
         args: ["--fn-pod-namespace", "{{ .Values.functionNamespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,6 +1,7 @@
 ####################################
 # This file can be used with Skaffold (https://github.com/GoogleContainerTools/skaffold) to
 # build and deploy Fission to Kubernetes cluster.
+# Skaffold version v1.10.1 is used for this configuration.
 ############## Usage ##############
 # Skaffold CLI should be installed on your machine. 
 # Replace <DOCKERHUB_REPO> with your registry repo/org name
@@ -9,45 +10,102 @@
 ############## Future Improvement/Limitations ##############
 # 1) [LOW]  Add profiles to suit various deployment needs
 ####################################
-apiVersion: skaffold/v2beta1
+apiVersion: skaffold/v2beta4
 kind: Config
 build:
   artifacts:
-    - image: <DOCKERHUB_REPO>/fission
+    - image: "fission"
       context: .
       docker:
         dockerfile: cmd/fission-bundle/Dockerfile.fission-bundle
-    - image: <DOCKERHUB_REPO>/fetcher
+    - image: "fetcher"
       docker:
         dockerfile: cmd/fetcher/Dockerfile.fission-fetcher
-    - image: <DOCKERHUB_REPO>/preupgradechecks
+    - image: "preupgradechecks"
       docker:
         dockerfile: cmd/preupgradechecks/Dockerfile.fission-preupgradechecks
-  tagPolicy:
-    envTemplate:
-      template: "{{.IMAGE_NAME}}:{{.TAG}}"
+  # tagPolicy:
+  #   envTemplate:
+  #     template: "{{.IMAGE_NAME}}:{{.TAG}}"
 
 deploy:
   helm:
+    flags:
+      upgrade:
+        ["--timeout=3m", "--install", "--force", "--debug"]
+      install:
+        ["--timeout=3m","--debug"]
     releases:
       - name: fission
         chartPath: ./charts/fission-all
         valuesFiles:
           - ./charts/fission-all/values.yaml
         namespace: "fission"
+        artifactOverrides:
+          image: "fission"
+          preUpgradeChecksImage: "preupgradechecks"
+          fetcher.image: "fetcher"        
         setValues:
           namespace: fission
-          repository: index.docker.io
-        # The env template values only should go in setValueTemplates, all other overrides in setValues
-        setValueTemplates:
-          image: <DOCKERHUB_REPO>/fission
-          preUpgradeChecksImage: <DOCKERHUB_REPO>/preupgradechecks
-          fetcher.image: <DOCKERHUB_REPO>/fetcher
-          fetcher.imageTag: "{{.TAG}}"
-          imageTag: "{{.TAG}}"
+          fetcher.imageTag: "latest"
+          imageTag: "latest"
+          repository: "index.docker.io"
+          routerServiceType: LoadBalancer
+        # setValueTemplates:
+        #   # image: fission
+        #   # preUpgradeChecksImage: preupgradechecks
+        #   # fetcher.image: fetcher
+        #   fetcher.imageTag: ""
+        #   imageTag: ""
         wait: true
         recreatePods: false
         packaged: null
         imageStrategy:
           fqn: null
           helm: null
+
+profiles:
+  - name: cloud
+    patches:
+      # - op: replace
+      #   path: /deploy/helm/releases/0/setValues
+      #   value: {}
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/imageTag
+        value: ""
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/fetcher.imageTag
+        value: ""
+     # - op: replace
+      #   path: /deploy/helm/releases/0/artifactOverrides
+      #   value: {}
+        
+  - name: kind
+    patches:
+      # - op: replace
+      #   path: /deploy/helm/releases/0/setValueTemplates
+      #   value: {}
+      # - op: replace
+      #   path: /build/tagPolicy
+      #   value: {}
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/imageTag
+        value: ""
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/fetcher.imageTag
+        value: ""
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/repository
+        value: ""
+      - op: replace
+        path: /deploy/helm/releases/0/setValues/routerServiceType
+        value: "NodePort"
+      - op: replace
+        path: /deploy/helm/releases/0/artifactOverrides/image
+        value: "fission"
+      - op: replace
+        path: /deploy/helm/releases/0/artifactOverrides/preUpgradeChecksImage
+        value: "preupgradechecks"
+      - op: replace
+        path: /deploy/helm/releases/0/artifactOverrides/fetcher.image
+        value: "fetcher"        

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -4,29 +4,25 @@
 # Skaffold version v1.10.1 is used for this configuration.
 ############## Usage ##############
 # Skaffold CLI should be installed on your machine. 
-# Replace <DOCKERHUB_REPO> with your registry repo/org name
-# Run `TAG=1313 skaffold run` to build and deploy with helm - where replace value of tag to what you want to use as tag for image
-# Run`skaffold build` to only build and push images
-############## Future Improvement/Limitations ##############
-# 1) [LOW]  Add profiles to suit various deployment needs
+# For building & deploying to Cloud Provider
+# $ `skaffold run` 
+# For building & deploying to Kind cluster use Kind profile
+# $ `skaffold run -p kind`
 ####################################
 apiVersion: skaffold/v2beta4
 kind: Config
 build:
   artifacts:
-    - image: "fission"
+    - image: fission
       context: .
       docker:
         dockerfile: cmd/fission-bundle/Dockerfile.fission-bundle
-    - image: "fetcher"
+    - image: fetcher
       docker:
         dockerfile: cmd/fetcher/Dockerfile.fission-fetcher
-    - image: "preupgradechecks"
+    - image: preupgradechecks
       docker:
         dockerfile: cmd/preupgradechecks/Dockerfile.fission-preupgradechecks
-  # tagPolicy:
-  #   envTemplate:
-  #     template: "{{.IMAGE_NAME}}:{{.TAG}}"
 
 deploy:
   helm:
@@ -47,16 +43,10 @@ deploy:
           fetcher.image: "fetcher"        
         setValues:
           namespace: fission
-          fetcher.imageTag: "latest"
-          imageTag: "latest"
           repository: "index.docker.io"
           routerServiceType: LoadBalancer
-        # setValueTemplates:
-        #   # image: fission
-        #   # preUpgradeChecksImage: preupgradechecks
-        #   # fetcher.image: fetcher
-        #   fetcher.imageTag: ""
-        #   imageTag: ""
+          fetcher.imageTag: ""
+          imageTag: ""
         wait: true
         recreatePods: false
         packaged: null
@@ -65,47 +55,25 @@ deploy:
           helm: null
 
 profiles:
-  - name: cloud
+  - name: fast1
+    build:
+      artifacts:
+        - image: fission
+          context: .
+          docker:
+            dockerfile: cmd/fission-bundle/Dockerfile.fission-bundle
+  - name: fast2
     patches:
-      # - op: replace
-      #   path: /deploy/helm/releases/0/setValues
-      #   value: {}
-      - op: replace
-        path: /deploy/helm/releases/0/setValues/imageTag
-        value: ""
       - op: replace
         path: /deploy/helm/releases/0/setValues/fetcher.imageTag
-        value: ""
-     # - op: replace
-      #   path: /deploy/helm/releases/0/artifactOverrides
-      #   value: {}
-        
+        value: "latest"
+
+
   - name: kind
     patches:
-      # - op: replace
-      #   path: /deploy/helm/releases/0/setValueTemplates
-      #   value: {}
-      # - op: replace
-      #   path: /build/tagPolicy
-      #   value: {}
-      - op: replace
-        path: /deploy/helm/releases/0/setValues/imageTag
-        value: ""
-      - op: replace
-        path: /deploy/helm/releases/0/setValues/fetcher.imageTag
-        value: ""
       - op: replace
         path: /deploy/helm/releases/0/setValues/repository
         value: ""
       - op: replace
         path: /deploy/helm/releases/0/setValues/routerServiceType
         value: "NodePort"
-      - op: replace
-        path: /deploy/helm/releases/0/artifactOverrides/image
-        value: "fission"
-      - op: replace
-        path: /deploy/helm/releases/0/artifactOverrides/preUpgradeChecksImage
-        value: "preupgradechecks"
-      - op: replace
-        path: /deploy/helm/releases/0/artifactOverrides/fetcher.image
-        value: "fetcher"        

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -47,6 +47,7 @@ deploy:
           routerServiceType: LoadBalancer
           fetcher.imageTag: ""
           imageTag: ""
+          prometheus.enable: false
         wait: true
         recreatePods: false
         packaged: null
@@ -55,20 +56,6 @@ deploy:
           helm: null
 
 profiles:
-  - name: fast1
-    build:
-      artifacts:
-        - image: fission
-          context: .
-          docker:
-            dockerfile: cmd/fission-bundle/Dockerfile.fission-bundle
-  - name: fast2
-    patches:
-      - op: replace
-        path: /deploy/helm/releases/0/setValues/fetcher.imageTag
-        value: "latest"
-
-
   - name: kind
     patches:
       - op: replace


### PR DESCRIPTION
This PR changes the Skaffold and some manifests to make it work with cloud clusters as well as with Kind. This will enable a seamless way of building and deploying across both the targets.

Future improvements could be:

- Build the only fission-bundle image and skip Fetcher and preupgradecheck (Most cases fetcher and upgrade won't change a lot). This is right now not working with Skaffold patches but works by commenting lines in build and artifactOverrides sections.

- Debugging support

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1700)
<!-- Reviewable:end -->
