### PR TITLE
logs: change timestamp to ISO

### DIFF
--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -21,13 +21,16 @@ import (
 	"os"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/fission/fission/cmd/builder/app"
 )
 
 // Usage: builder <shared volume path>
 func main() {
-	logger, err := zap.NewProduction()
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}

--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -20,13 +20,16 @@ import (
 	"log"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/fission/fission/cmd/fetcher/app"
 )
 
 // Usage: fetcher <shared volume path>
 func main() {
-	logger, err := zap.NewProduction()
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -27,6 +27,7 @@ import (
 	docopt "github.com/docopt/docopt-go"
 	"go.opencensus.io/trace"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/fission/fission/cmd/fission-bundle/mqtrigger"
 	"github.com/fission/fission/pkg/buildermgr"
@@ -236,17 +237,21 @@ Options:
 
 	var logger *zap.Logger
 	var err error
+	var config zap.Config
 
 	isDebugEnv, _ := strconv.ParseBool(os.Getenv("DEBUG_ENV"))
 	if isDebugEnv {
-		logger, err = zap.NewDevelopment()
-	} else {
-		config := zap.NewProductionConfig()
+		config = zap.NewDevelopmentConfig()
 		config.DisableStacktrace = true
-		logger, err = config.Build()
+		config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	} else {
+		config = zap.NewProductionConfig()
+		config.DisableStacktrace = true
+		config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	}
+	logger, err = config.Build()
 	if err != nil {
-		log.Fatalf("can't initialize zap logger: %v", err)
+		log.Fatalf("I can't initialize zap logger: %v", err)
 	}
 	defer logger.Sync()
 

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/docopt/docopt-go"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/fission/fission/pkg/info"
 )
@@ -34,7 +35,10 @@ func getStringArgWithDefault(arg interface{}, defaultValue string) string {
 }
 
 func main() {
-	logger, err := zap.NewProduction()
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}

--- a/environments/tensorflow-serving/server.go
+++ b/environments/tensorflow-serving/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -188,7 +189,11 @@ func readinessProbeHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
-	logger, err := zap.NewProduction()
+
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -30,7 +30,8 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
-	"k8s.io/api/core/v1"
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -365,7 +366,10 @@ func TestMain(m *testing.M) {
 	})
 	defer kubeClient.CoreV1().Namespaces().Delete(testNS, nil)
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+
 	panicIf(err)
 
 	go Start(logger, 8888, true)

--- a/pkg/crd/crd_test.go
+++ b/pkg/crd/crd_test.go
@@ -24,7 +24,8 @@ import (
 
 	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap"
-	"k8s.io/api/core/v1"
+	"go.uber.org/zap/zapcore"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -428,7 +429,10 @@ func TestCrd(t *testing.T) {
 		return
 	}
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+
 	panicIf(err)
 
 	fc, kubeClient, apiExtClient, err := MakeFissionClient()

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -126,7 +127,9 @@ func TestExecutor(t *testing.T) {
 	createTestNamespace(kubeClient, functionNs)
 	defer kubeClient.CoreV1().Namespaces().Delete(functionNs, nil)
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	// make sure CRD types exist on cluster

--- a/pkg/executor/fscache/functionServiceCache_test.go
+++ b/pkg/executor/fscache/functionServiceCache_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -19,7 +20,9 @@ func panicIf(err error) {
 }
 
 func TestFunctionServiceCache(t *testing.T) {
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	fsc := MakeFunctionServiceCache(logger)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -163,7 +164,9 @@ func symlinkReaper(zapLogger *zap.Logger) {
 }
 
 func Start() {
-	zapLogger, err := zap.NewProduction()
+	config := zap.NewProductionConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	zapLogger, err := config.Build()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}

--- a/pkg/mqtrigger/messageQueue/azurequeuestorage/asq_test.go
+++ b/pkg/mqtrigger/messageQueue/azurequeuestorage/asq_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -110,7 +111,9 @@ func (m *azureHTTPClientMock) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestNewStorageConnectionMissingAccountName(t *testing.T) {
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	connection, err := New(logger, messageQueue.Config{
@@ -122,7 +125,9 @@ func TestNewStorageConnectionMissingAccountName(t *testing.T) {
 }
 
 func TestNewStorageConnectionMissingAccessKey(t *testing.T) {
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	_ = os.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "accountname")
@@ -136,7 +141,9 @@ func TestNewStorageConnectionMissingAccessKey(t *testing.T) {
 }
 
 func TestNewStorageConnection(t *testing.T) {
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	_ = os.Setenv("AZURE_STORAGE_ACCOUNT_NAME", "accountname")
@@ -292,7 +299,9 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 	service.On("GetQueue", QueueName).Return(queue).Once()
 	service.On("GetQueue", QueueName+AzurePoisonQueueSuffix).Return(poisonQueue).Once()
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	// Create the storage connection and subscribe to the trigger
@@ -440,7 +449,9 @@ func runAzureStorageQueueTest(t *testing.T, count int, output bool) {
 		service.On("GetQueue", OutputQueueName).Return(outputQueue).Times(count)
 	}
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	// Create the storage connection and subscribe to the trigger

--- a/pkg/router/functionHandler_test.go
+++ b/pkg/router/functionHandler_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -57,7 +58,11 @@ func TestFunctionProxying(t *testing.T) {
 	log.Printf("Created backend svc at %v", backendURL)
 
 	fnMeta := metav1.ObjectMeta{Name: "foo", Namespace: metav1.NamespaceDefault}
-	logger, err := zap.NewDevelopment()
+
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+
 	panicIf(err)
 
 	fmap := makeFunctionServiceMap(logger, 0)
@@ -96,7 +101,10 @@ func TestFunctionProxying(t *testing.T) {
 }
 
 func TestProxyErrorHandler(t *testing.T) {
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+
 	assert.Nil(t, err)
 
 	fh := &functionHandler{

--- a/pkg/router/functionServiceMap_test.go
+++ b/pkg/router/functionServiceMap_test.go
@@ -21,12 +21,15 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestFunctionServiceMap(t *testing.T) {
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	m := makeFunctionServiceMap(logger, 0)

--- a/pkg/router/mutablemux_test.go
+++ b/pkg/router/mutablemux_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func OldHandler(responseWriter http.ResponseWriter, request *http.Request) {
@@ -64,7 +65,9 @@ func TestMutableMux(t *testing.T) {
 	log.Print("Create mutable router")
 	muxRouter := mux.NewRouter()
 	muxRouter.HandleFunc("/", OldHandler)
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	mr := NewMutableRouter(logger, muxRouter)

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -43,7 +44,9 @@ func TestRouter(t *testing.T) {
 	testResponseString := "hi"
 	testServiceUrl := createBackendService(testResponseString)
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	// set up the cache with this fake service

--- a/pkg/storagesvc/client/storagesvc_test.go
+++ b/pkg/storagesvc/client/storagesvc_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/ory/dockertest"
 	dc "github.com/ory/dockertest/docker"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -79,7 +80,9 @@ func startS3StorageService(endpoint, bucketName, subDir string) {
 	// testID := uniuri.NewLen(8)
 	port := 8081
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	log.Println("starting storage svc")
@@ -195,7 +198,9 @@ func TestLocalStorageService(t *testing.T) {
 	testID := uniuri.NewLen(8)
 	port := 8080
 
-	logger, err := zap.NewDevelopment()
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
 	panicIf(err)
 
 	log.Println("starting storage svc")


### PR DESCRIPTION
Signed-off-by: sahil-lakhwani <sahilakhwani@gmail.com>

All the logger today use Unix timestamp  in the log statements which is of little use for any operations on the logs
This PR is an effort to change that to ISO format imestamps
example: ` {"level":"info","ts":"2020-09-09T12:54:44.622Z","caller":"fission-bundle/main.go:130","msg":"skipping trace exporter registration"}`


Tested: The change has been tested with all components wherever the changes related to logs are made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1708)
<!-- Reviewable:end -->
