### PR TITLE
Update README.md - link added to license (#1743)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ The following companies, organizations, and individuals support Fission's ongoin
 
 # Licensing
 
-Fission is under the Apache 2.0 license.
+Fission is under the [Apache 2.0](https://github.com/fission/fission/blob/master/LICENSE) license.


### PR DESCRIPTION
Hyperlink added to the Apache 2.0 license, now if we click on the license that will show Apache 2.0 license

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1744)
<!-- Reviewable:end -->
