### PR TITLE
Add sequential flag to mqtrigger

### DIFF
--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -792,6 +792,11 @@ type (
 		// - Structs are merged and variables from pod spec take precedence
 		// +optional
 		PodSpec *apiv1.PodSpec `json:"podspec,omitempty"`
+
+		// Whether to consume messages sequentially or concurrently, by default its 'false'.
+		// Not all MessageQueueTypes support this flag
+		// +optional
+		Sequential bool `json:"sequenti
 	}
 
 	// TimeTriggerSpec invokes the specific function at a time or

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 		Optional: []flag.Flag{flag.MqtFnName, flag.MqtTopic, flag.MqtRespTopic, flag.MqtErrorTopic,
 			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.NamespaceTrigger, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtMetadata,
-			flag.MqtSecret, flag.MqtKind},
+			flag.MqtSecret, flag.MqtKind, flag.MqtSequential},
 	})
 
 	deleteCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -115,6 +115,8 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		return errors.New("MaxReplicaCount must be greater than or equal to 0")
 	}
 
+	sequential := input.Bool(flagkey.MqtSequential)
+
 	metadata := make(map[string]string)
 	metadataParams := input.StringSlice(flagkey.MqtMetadata)
 	_ = util.UpdateMapFromStringSlice(&metadata, metadataParams)
@@ -166,6 +168,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			Metadata:         metadata,
 			Secret:           secret,
 			MqtKind:          mqtKind,
+			Sequential:       sequential,
 		},
 	}
 

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -58,11 +58,11 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-		"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+		"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE", "SEQUENTIAL")
 	for _, mqt := range mqts {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			mqt.ObjectMeta.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic, mqt.Spec.MaxRetries, mqt.Spec.ContentType)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+			mqt.ObjectMeta.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic, mqt.Spec.MaxRetries, mqt.Spec.ContentType, mqt.Spec.Sequential)
 	}
 	w.Flush()
 

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -68,6 +68,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	metadataParams := input.StringSlice(flagkey.MqtMetadata)
 	secret := input.String(flagkey.MqtSecret)
 	mqtKind := input.String(flagkey.MqtKind)
+	sequential := input.Bool(flagkey.MqtSequential)
 	// TODO : Find out if we can make a call to checkIfFunctionExists, in the same ns more importantly.
 
 	err = checkMQTopicAvailability(mqt.Spec.MessageQueueType, topic, respTopic)
@@ -127,6 +128,11 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.MqtKind) {
 		mqt.Spec.MqtKind = mqtKind
+		updated = true
+	}
+
+	if input.IsSet(flagkey.MqtSequential) {
+		mqt.Spec.Sequential = sequential
 		updated = true
 	}
 

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -350,10 +350,10 @@ func ShowMQTriggers(mqts []fv1.MessageQueueTrigger) {
 	if len(mqts) > 0 {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 		fmt.Printf("\nMessageQueue Triggers:\n")
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE")
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE", "SEQUENTIAL")
 		for _, mqt := range mqts {
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-				mqt.ObjectMeta.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic, mqt.Spec.MaxRetries, mqt.Spec.ContentType)
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+				mqt.ObjectMeta.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic, mqt.Spec.MaxRetries, mqt.Spec.ContentType, mqt.Spec.Sequential)
 		}
 		fmt.Fprintf(w, "\n")
 		w.Flush()

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -148,6 +148,7 @@ var (
 	MqtMetadata        = Flag{Type: StringSlice, Name: flagkey.MqtMetadata, Usage: "Metadata needed for connecting to source system in format: --metadata key1=value1 --metadata key2=value2"}
 	MqtSecret          = Flag{Type: String, Name: flagkey.MqtSecret, Usage: "Name of secret object", DefaultValue: ""}
 	MqtKind            = Flag{Type: String, Name: flagkey.MqtKind, Usage: "Kind of Message Queue Trigger, e.g. fission, keda", DefaultValue: "fission"}
+	MqtSequential      = Flag{Type: Bool, Name: flagkey.MqtSequential, Usage: "Consume messages sequentially instead of concurrently"}
 
 	EnvName                   = Flag{Type: String, Name: flagkey.EnvName, Usage: "Environment name"}
 	EnvPoolsize               = Flag{Type: Int, Name: flagkey.EnvPoolsize, Usage: "Size of the pool", DefaultValue: 3}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -101,6 +101,7 @@ const (
 	MqtMetadata        = "metadata"
 	MqtSecret          = "secret"
 	MqtKind            = "mqtkind"
+	MqtSequential      = "sequential"
 
 	EnvName            = resourceName
 	EnvPoolsize        = "poolsize"

--- a/pkg/mqtrigger/messageQueue/nats/nats.go
+++ b/pkg/mqtrigger/messageQueue/nats/nats.go
@@ -129,112 +129,120 @@ func (nats Nats) Unsubscribe(subscription messageQueue.Subscription) error {
 func msgHandler(nats *Nats, trigger *fv1.MessageQueueTrigger) func(*ns.Msg) {
 	return func(msg *ns.Msg) {
 
-		// Support other function ref types
-		if trigger.Spec.FunctionReference.Type != fv1.FunctionReferenceTypeFunctionName {
-			nats.logger.Fatal("unsupported function reference type for trigger",
-				zap.Any("function_reference_type", trigger.Spec.FunctionReference.Type),
-				zap.String("trigger", trigger.ObjectMeta.Name))
-		}
+		cb := func() {
+			// Support other function ref types
+			if trigger.Spec.FunctionReference.Type != fv1.FunctionReferenceTypeFunctionName {
+				nats.logger.Fatal("unsupported function reference type for trigger",
+					zap.Any("function_reference_type", trigger.Spec.FunctionReference.Type),
+					zap.String("trigger", trigger.ObjectMeta.Name))
+			}
 
-		// with the addition of multi-tenancy, the users can create functions in any namespace. however,
-		// the triggers can only be created in the same namespace as the function.
-		// so essentially, function namespace = trigger namespace.
-		url := nats.routerUrl + "/" + strings.TrimPrefix(utils.UrlForFunction(trigger.Spec.FunctionReference.Name, trigger.ObjectMeta.Namespace), "/")
-		nats.logger.Debug("making HTTP request", zap.String("url", url))
+			// with the addition of multi-tenancy, the users can create functions in any namespace. however,
+			// the triggers can only be created in the same namespace as the function.
+			// so essentially, function namespace = trigger namespace.
+			url := nats.routerUrl + "/" + strings.TrimPrefix(utils.UrlForFunction(trigger.Spec.FunctionReference.Name, trigger.ObjectMeta.Namespace), "/")
+			nats.logger.Debug("making HTTP request", zap.String("url", url))
 
-		headers := map[string]string{
-			"X-Fission-MQTrigger-Topic":      trigger.Spec.Topic,
-			"X-Fission-MQTrigger-RespTopic":  trigger.Spec.ResponseTopic,
-			"X-Fission-MQTrigger-ErrorTopic": trigger.Spec.ErrorTopic,
-			"Content-Type":                   trigger.Spec.ContentType,
-		}
+			headers := map[string]string{
+				"X-Fission-MQTrigger-Topic":      trigger.Spec.Topic,
+				"X-Fission-MQTrigger-RespTopic":  trigger.Spec.ResponseTopic,
+				"X-Fission-MQTrigger-ErrorTopic": trigger.Spec.ErrorTopic,
+				"Content-Type":                   trigger.Spec.ContentType,
+			}
 
-		// Create request
-		req, err := http.NewRequest("POST", url, bytes.NewReader(msg.Data))
+			// Create request
+			req, err := http.NewRequest("POST", url, bytes.NewReader(msg.Data))
 
-		if err != nil {
-			nats.logger.Error("failed to create HTTP request to invoke function",
-				zap.Error(err),
-				zap.String("function_url", url))
-			return
-		}
-
-		for k, v := range headers {
-			req.Header.Set(k, v)
-		}
-
-		var resp *http.Response
-		for attempt := 0; attempt <= trigger.Spec.MaxRetries; attempt++ {
-			// Make the request
-			resp, err = http.DefaultClient.Do(req)
 			if err != nil {
-				nats.logger.Error("sending function invocation request failed",
+				nats.logger.Error("failed to create HTTP request to invoke function",
+					zap.Error(err),
+					zap.String("function_url", url))
+				return
+			}
+
+			for k, v := range headers {
+				req.Header.Set(k, v)
+			}
+
+			var resp *http.Response
+			for attempt := 0; attempt <= trigger.Spec.MaxRetries; attempt++ {
+				// Make the request
+				resp, err = http.DefaultClient.Do(req)
+				if err != nil {
+					nats.logger.Error("sending function invocation request failed",
+						zap.Error(err),
+						zap.String("function_url", url),
+						zap.String("trigger", trigger.ObjectMeta.Name))
+					continue
+				}
+				if resp == nil {
+					continue
+				}
+				if err == nil && resp.StatusCode == http.StatusOK {
+					// Success, quit retrying
+					break
+				}
+			}
+
+			if resp == nil {
+				nats.logger.Warn("every function invocation retry failed; final retry gave empty response",
+					zap.String("function_url", url),
+					zap.String("trigger", trigger.ObjectMeta.Name))
+				return
+			}
+
+			defer resp.Body.Close()
+
+			body, bodyErr := ioutil.ReadAll(resp.Body)
+			if bodyErr != nil {
+				nats.logger.Error("error reading function invocation response",
 					zap.Error(err),
 					zap.String("function_url", url),
 					zap.String("trigger", trigger.ObjectMeta.Name))
-				continue
+				return
 			}
-			if resp == nil {
-				continue
-			}
-			if err == nil && resp.StatusCode == http.StatusOK {
-				// Success, quit retrying
-				break
-			}
-		}
 
-		if resp == nil {
-			nats.logger.Warn("every function invocation retry failed; final retry gave empty response",
-				zap.String("function_url", url),
-				zap.String("trigger", trigger.ObjectMeta.Name))
-			return
-		}
-
-		defer resp.Body.Close()
-
-		body, bodyErr := ioutil.ReadAll(resp.Body)
-		if bodyErr != nil {
-			nats.logger.Error("error reading function invocation response",
-				zap.Error(err),
-				zap.String("function_url", url),
-				zap.String("trigger", trigger.ObjectMeta.Name))
-			return
-		}
-
-		// Only the latest error response will be published to error topic
-		if err != nil || resp.StatusCode != 200 {
-			if len(trigger.Spec.ErrorTopic) > 0 && len(body) > 0 {
-				publishErr := nats.nsConn.Publish(trigger.Spec.ErrorTopic, body)
-				if publishErr != nil {
-					nats.logger.Error("failed to publish function invocation error to error topic",
-						zap.Error(publishErr),
-						zap.String("topic", trigger.Spec.ErrorTopic),
-						zap.String("function_url", url),
-						zap.String("trigger", trigger.ObjectMeta.Name))
-					// TODO: We will ack this message after max retries to prevent re-processing but
-					// this may cause message loss
+			// Only the latest error response will be published to error topic
+			if err != nil || resp.StatusCode != 200 {
+				if len(trigger.Spec.ErrorTopic) > 0 && len(body) > 0 {
+					publishErr := nats.nsConn.Publish(trigger.Spec.ErrorTopic, body)
+					if publishErr != nil {
+						nats.logger.Error("failed to publish function invocation error to error topic",
+							zap.Error(publishErr),
+							zap.String("topic", trigger.Spec.ErrorTopic),
+							zap.String("function_url", url),
+							zap.String("trigger", trigger.ObjectMeta.Name))
+						// TODO: We will ack this message after max retries to prevent re-processing but
+						// this may cause message loss
+					}
 				}
+				return
 			}
-			return
-		}
 
-		// Trigger acks message only if a request was processed successfully
-		err = msg.Ack()
-		if err != nil {
-			nats.logger.Error("failed to ack message after successful function invocation from trigger",
-				zap.Error(err),
-				zap.String("function_url", url),
-				zap.String("trigger", trigger.ObjectMeta.Name))
-		}
-
-		if len(trigger.Spec.ResponseTopic) > 0 {
-			err = nats.nsConn.Publish(trigger.Spec.ResponseTopic, body)
+			// Trigger acks message only if a request was processed successfully
+			err = msg.Ack()
 			if err != nil {
-				nats.logger.Error("failed to publish message with function invocation response to topic",
+				nats.logger.Error("failed to ack message after successful function invocation from trigger",
 					zap.Error(err),
-					zap.String("topic", trigger.Spec.ResponseTopic),
+					zap.String("function_url", url),
 					zap.String("trigger", trigger.ObjectMeta.Name))
 			}
+
+			if len(trigger.Spec.ResponseTopic) > 0 {
+				err = nats.nsConn.Publish(trigger.Spec.ResponseTopic, body)
+				if err != nil {
+					nats.logger.Error("failed to publish message with function invocation response to topic",
+						zap.Error(err),
+						zap.String("topic", trigger.Spec.ResponseTopic),
+						zap.String("trigger", trigger.ObjectMeta.Name))
+				}
+			}
+		}
+
+		if trigger.Spec.Sequential {
+			cb()
+		} else {
+			go cb()
 		}
 	}
 }

--- a/pkg/mqtrigger/messageQueue/nats/nats.go
+++ b/pkg/mqtrigger/messageQueue/nats/nats.go
@@ -160,12 +160,12 @@ func msgHandler(nats *Nats, trigger *fv1.MessageQueueTrigger) func(*ns.Msg) {
 				return
 			}
 
-			for k, v := range headers {
-				req.Header.Set(k, v)
-			}
-
 			var resp *http.Response
 			for attempt := 0; attempt <= trigger.Spec.MaxRetries; attempt++ {
+				for k, v := range headers {
+					req.Header.Set(k, v)
+				}
+
 				// Make the request
 				resp, err = http.DefaultClient.Do(req)
 				if err != nil {

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -275,6 +275,10 @@ func checkAndUpdateTriggerFields(mqt, newMqt *fv1.MessageQueueTrigger) bool {
 		mqt.Spec.PodSpec = newMqt.Spec.PodSpec
 		updated = true
 	}
+	if newMqt.Spec.Sequential != mqt.Spec.Sequential {
+		mqt.Spec.Sequential = newMqt.Spec.Sequential
+		updated = true
+	}
 
 	for key, value := range newMqt.Spec.Metadata {
 		if val, ok := mqt.Spec.Metadata[key]; ok && val != value {

--- a/pkg/mqtrigger/scalermanager_test.go
+++ b/pkg/mqtrigger/scalermanager_test.go
@@ -71,8 +71,9 @@ func Test_getEnvVarlist(t *testing.T) {
 				"consumerGroup":    "my-group",
 				"topic":            "topic",
 			},
-			Secret:  "test-kafka-secrets",
-			MqtKind: "keda",
+			Secret:     "test-kafka-secrets",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 
@@ -195,8 +196,9 @@ func Test_getEnvVarlist(t *testing.T) {
 				"consumerGroup":    "my-group",
 				"topic":            "topic",
 			},
-			Secret:  "test-kafka-secrets-invalid",
-			MqtKind: "keda",
+			Secret:     "test-kafka-secrets-invalid",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 
@@ -267,8 +269,9 @@ func Test_checkAndUpdateTriggerFields(t *testing.T) {
 				"consumerGroup":    "my-group",
 				"topic":            "topic",
 			},
-			Secret:  "test-kafka-secrets",
-			MqtKind: "keda",
+			Secret:     "test-kafka-secrets",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 	newMqt1 := &fv1.MessageQueueTrigger{
@@ -296,8 +299,9 @@ func Test_checkAndUpdateTriggerFields(t *testing.T) {
 				"consumerGroup":    "my-group-2",
 				"topic":            "my-topic",
 			},
-			Secret:  "new-test-kafka-secrets",
-			MqtKind: "keda",
+			Secret:     "new-test-kafka-secrets",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 
@@ -327,8 +331,9 @@ func Test_checkAndUpdateTriggerFields(t *testing.T) {
 				"consumerGroup":    "my-group",
 				"topic":            "topic",
 			},
-			Secret:  "test-kafka-secrets",
-			MqtKind: "keda",
+			Secret:     "test-kafka-secrets",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 	newMqt2 := &fv1.MessageQueueTrigger{
@@ -404,8 +409,9 @@ func Test_getAuthTriggerSpec(t *testing.T) {
 				"consumerGroup":    "my-group",
 				"topic":            "topic",
 			},
-			Secret:  "test-kafka-secrets",
-			MqtKind: "keda",
+			Secret:     "test-kafka-secrets",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 
@@ -516,8 +522,9 @@ func Test_getAuthTriggerSpec(t *testing.T) {
 				"consumerGroup":    "my-group",
 				"topic":            "topic",
 			},
-			Secret:  "test-kafka-no-secret",
-			MqtKind: "keda",
+			Secret:     "test-kafka-no-secret",
+			MqtKind:    "keda",
+			Sequential: false,
 		},
 	}
 


### PR DESCRIPTION
Fixes #1569 

Adds a `sequential` flag to the `mqtrigger` function. If set to `true`, consumes messages sequentially instead of concurrently.

I wasn't sure whether to add support for all 3 MQs (Kafka, Azure Queue Storage, NATS), as they currently have different behaviors (Kafka and Azure Queue Storage MQs currently consumes messages concurrently, while NATS MQ consumes messages sequentially). Therefore I separated the implementation for each MQ into its own commit so that they can be dropped if we decide not to support them.

Note that if support for the `sequential` flag is added to the NATS MQ, it is a breaking change, as it would mean changing the default behavior from sequential to concurrent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1814)
<!-- Reviewable:end -->
