### PR TITLE
Update aws-kinesis image name in values.yaml

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -902,6 +902,8 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.kafka.image }}:{{ .Values.mqt_keda.connector_images.kafka.tag }}"
         - name: RABBITMQ_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.rabbitmq.image }}:{{ .Values.mqt_keda.connector_images.rabbitmq.tag }}"
+        - name: AWS-KINESIS-STREAM_IMAGE
+          value: "{{ .Values.mqt_keda.connector_images.awskinesis.image }}:{{ .Values.mqt_keda.connector_images.awskinesis.tag }}"           
       serviceAccountName: fission-svc
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -317,3 +317,6 @@ mqt_keda:
     rabbitmq:
       image: fission/keda-rabbitmq-http-connector
       tag: 1
+    awskinesis:
+      image: fission/keda-awskinesis-http-connector
+      tag: 1

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -486,6 +486,8 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.kafka.image }}:{{ .Values.mqt_keda.connector_images.kafka.tag }}"
         - name: RABBITMQ_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.rabbitmq.image }}:{{ .Values.mqt_keda.connector_images.rabbitmq.tag }}"
+        - name: AWS-KINESIS-STREAM_IMAGE
+          value: "{{ .Values.mqt_keda.connector_images.awskinesis.image }}:{{ .Values.mqt_keda.connector_images.awskinesis.tag }}"            
       serviceAccountName: fission-svc
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -208,3 +208,6 @@ mqt_keda:
     rabbitmq:
       image: fission/keda-rabbitmq-http-connector
       tag: 1
+    awskinesis:
+      image: fission/keda-awskinesis-http-connector
+      tag: 1


### PR DESCRIPTION
Added new http keda connector for kinesis in https://github.com/fission/keda-connectors repo, so to use that with fission i have included that in chat's deployment and values yaml file of fission-all and fission-core folder under mq_keda section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1817)
<!-- Reviewable:end -->
