### PR TITLE
Create Dockerfile.centos8

### DIFF
--- a/environments/python/Dockerfile.centos8
+++ b/environments/python/Dockerfile.centos8
@@ -1,0 +1,18 @@
+FROM centos:latest
+
+WORKDIR /app
+
+RUN yum -y groupinstall 'Development Tools'
+RUN yum -y install glibc.x86_64
+RUN yum -y install python38.x86_64 python38-devel.x86_64 
+RUN yum install -y libev-devel.x86_64 
+RUN pip3 install --upgrade pip && pip3 install wheel
+RUN rm -r /root/.cache
+
+COPY . /app
+RUN pip3 install -r requirements.txt
+
+#Symbolic link needs to point from /usr/local/bin/python to whatever location python is using in your distro
+RUN ln -sf /usr/bin/python3 /usr/local/bin/python
+ENTRYPOINT ["python3"] 
+CMD ["server.py"]


### PR DESCRIPTION
Showing how to create environment in distro other than alpine (centos8 in this case). In order to fix any issues with the path with python, one must create a symbolic link from the expect alpine location to where the python binary is located in your distro.

This solves issue # 1780 (Official support for non-alpine environments) as it allows for environments to use a linux distro that is not alpine by solving the issues that arise with the path for python.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1819)
<!-- Reviewable:end -->
