### PR TITLE
 Update nats streaming image name in values.yaml and deployments yaml 

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -910,6 +910,8 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.awskinesis.image }}:{{ .Values.mqt_keda.connector_images.awskinesis.tag }}"           
         - name: AWS-SQS-QUEUE_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.aws_sqs.image }}:{{ .Values.mqt_keda.connector_images.aws_sqs.tag }}"
+        - name: STAN_IMAGE
+          value: "{{ .Values.mqt_keda.connector_images.nats_steaming.image }}:{{ .Values.mqt_keda.connector_images.nats_steaming.tag }}"          
       serviceAccountName: fission-svc
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -323,6 +323,9 @@ mqt_keda:
     awskinesis:
       image: fission/keda-awskinesis-http-connector
       tag: 1
-    aws-sqs-queue:
+    aws_sqs:
       image: fission/keda-aws-sqs-http-connector
+      tag: 1
+    nats_steaming:
+      image: fission/keda-nats-streaming-http-connector
       tag: 1

--- a/charts/fission-core/templates/deployment.yaml
+++ b/charts/fission-core/templates/deployment.yaml
@@ -492,6 +492,8 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.awskinesis.image }}:{{ .Values.mqt_keda.connector_images.awskinesis.tag }}"            
         - name: AWS-SQS-QUEUE_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.aws_sqs.image }}:{{ .Values.mqt_keda.connector_images.aws_sqs.tag }}"
+        - name: STAN_IMAGE
+          value: "{{ .Values.mqt_keda.connector_images.nats_steaming.image }}:{{ .Values.mqt_keda.connector_images.nats_steaming.tag }}"          
       serviceAccountName: fission-svc
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}

--- a/charts/fission-core/values.yaml
+++ b/charts/fission-core/values.yaml
@@ -212,6 +212,9 @@ mqt_keda:
     awskinesis:
       image: fission/keda-awskinesis-http-connector
       tag: 1
-    aws-sqs-queue:
+    aws_sqs:
       image: fission/keda-aws-sqs-http-connector
+      tag: 1
+    nats_steaming:
+      image: fission/keda-nats-streaming-http-connector
       tag: 1


### PR DESCRIPTION
Added new http keda connector for nats streaming in https://github.com/fission/keda-connectors repo, so to use that with fission i have included that in chat's deployment and values yaml file of fission-all and fission-core folder under mq_keda section

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1839)
<!-- Reviewable:end -->
