### PR TITLE
Fixed golangci-lint issues: /fission/pkg/executor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,6 @@ require (
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1
@@ -81,3 +80,5 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/klog v0.3.3
 )
+
+go 1.13

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -94,7 +94,14 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 		return
 	}
 
-	w.Write([]byte(serviceName))
+	_, err = w.Write([]byte(serviceName))
+	if err != nil {
+		executor.logger.Error(
+			"error writing HTTP response",
+			zap.String("function", m.Name),
+			zap.Error(err),
+		)
+	}
 }
 
 // getServiceForFunction first checks if this function's service is cached, if yes, it validates the address.

--- a/pkg/executor/cms/cmscontroller.go
+++ b/pkg/executor/cms/cmscontroller.go
@@ -34,6 +34,7 @@ import (
 )
 
 type (
+	// ConfigSecretController represents a controller for configmaps and secrets
 	ConfigSecretController struct {
 		logger *zap.Logger
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -44,6 +44,7 @@ import (
 )
 
 type (
+	// Executor defines a fission function executor.
 	Executor struct {
 		logger *zap.Logger
 
@@ -55,6 +56,7 @@ type (
 		requestChan chan *createFuncServiceRequest
 		fsCreateWg  map[string]*sync.WaitGroup
 	}
+
 	createFuncServiceRequest struct {
 		function *fv1.Function
 		respChan chan *createFuncServiceResponse
@@ -66,6 +68,7 @@ type (
 	}
 )
 
+// MakeExecutor returns an Executor for given ExecutorType(s).
 func MakeExecutor(logger *zap.Logger, cms *cms.ConfigSecretController,
 	fissionClient *crd.FissionClient, types map[fv1.ExecutorType]executortype.ExecutorType) (*Executor, error) {
 	executor := &Executor{

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -102,9 +102,9 @@ func TestExecutor(t *testing.T) {
 	// run in a random namespace so we can have concurrent tests
 	// on a given cluster
 	rand.Seed(time.Now().UTC().UnixNano())
-	testId := rand.Intn(999)
-	fissionNs := fmt.Sprintf("test-%v", testId)
-	functionNs := fmt.Sprintf("test-function-%v", testId)
+	testID := rand.Intn(999)
+	fissionNs := fmt.Sprintf("test-%v", testID)
+	functionNs := fmt.Sprintf("test-function-%v", testID)
 
 	// skip test if no cluster available for testing
 	kubeconfig := os.Getenv("KUBECONFIG")

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -122,10 +122,20 @@ func TestExecutor(t *testing.T) {
 
 	// create the test's namespaces
 	createTestNamespace(kubeClient, fissionNs)
-	defer kubeClient.CoreV1().Namespaces().Delete(fissionNs, nil)
+	defer func() {
+		err := kubeClient.CoreV1().Namespaces().Delete(fissionNs, nil)
+		if err != nil {
+			log.Fatalf("failed to delete namespace: %v", err)
+		}
+	}()
 
 	createTestNamespace(kubeClient, functionNs)
-	defer kubeClient.CoreV1().Namespaces().Delete(functionNs, nil)
+	defer func() {
+		err := kubeClient.CoreV1().Namespaces().Delete(fissionNs, nil)
+		if err != nil {
+			log.Fatalf("failed to delete namespace: %v", err)
+		}
+	}()
 
 	config := zap.NewDevelopmentConfig()
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
@@ -228,11 +238,21 @@ func TestExecutor(t *testing.T) {
 	labels := map[string]string{"functionName": f.ObjectMeta.Name}
 	var fetcherPort int32 = 30001
 	fetcherSvc := createSvc(kubeClient, functionNs, fmt.Sprintf("%v-%v", f.ObjectMeta.Name, "fetcher"), 8000, fetcherPort, labels)
-	defer kubeClient.CoreV1().Services(functionNs).Delete(fetcherSvc.ObjectMeta.Name, nil)
+	defer func() {
+		err := kubeClient.CoreV1().Services(functionNs).Delete(fetcherSvc.ObjectMeta.Name, nil)
+		if err != nil {
+			log.Fatalf("failed to delete service: %v", err)
+		}
+	}()
 
 	var funcSvcPort int32 = 30002
 	functionSvc := createSvc(kubeClient, functionNs, f.ObjectMeta.Name, 8888, funcSvcPort, labels)
-	defer kubeClient.CoreV1().Services(functionNs).Delete(functionSvc.ObjectMeta.Name, nil)
+	defer func() {
+		err := kubeClient.CoreV1().Services(functionNs).Delete(functionSvc.ObjectMeta.Name, nil)
+		if err != nil {
+			log.Fatalf("failed to delete service: %v", err)
+		}
+	}()
 
 	// the main test: get a service for a given function
 	t1 := time.Now()

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -38,6 +38,7 @@ import (
 	"github.com/fission/fission/pkg/utils"
 )
 
+// Deployment Constants
 const (
 	DeploymentKind    = "Deployment"
 	DeploymentVersion = "apps/v1"

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -482,7 +482,7 @@ func (deploy *NewDeploy) fnCreate(fn *fv1.Function) (*fscache.FuncSvc, error) {
 	svc, err := deploy.createOrGetSvc(deployLabels, deployAnnotations, objName, ns)
 	if err != nil {
 		deploy.logger.Error("error creating service", zap.Error(err), zap.String("service", objName))
-		go deploy.cleanupNewdeploy(ns, objName)
+		go deploy.cleanupNewdeploy(ns, objName) //nolint: errcheck
 		return nil, errors.Wrapf(err, "error creating service %v", objName)
 	}
 	svcAddress := fmt.Sprintf("%v.%v", svc.Name, svc.Namespace)
@@ -490,14 +490,14 @@ func (deploy *NewDeploy) fnCreate(fn *fv1.Function) (*fscache.FuncSvc, error) {
 	depl, err := deploy.createOrGetDeployment(fn, env, objName, deployLabels, deployAnnotations, ns)
 	if err != nil {
 		deploy.logger.Error("error creating deployment", zap.Error(err), zap.String("deployment", objName))
-		go deploy.cleanupNewdeploy(ns, objName)
+		go deploy.cleanupNewdeploy(ns, objName) //nolint: errcheck
 		return nil, errors.Wrapf(err, "error creating deployment %v", objName)
 	}
 
 	hpa, err := deploy.createOrGetHpa(objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
 	if err != nil {
 		deploy.logger.Error("error creating HPA", zap.Error(err), zap.String("hpa", objName))
-		go deploy.cleanupNewdeploy(ns, objName)
+		go deploy.cleanupNewdeploy(ns, objName) //nolint: errcheck
 		return nil, errors.Wrapf(err, "error creating the HPA %v", objName)
 	}
 
@@ -739,7 +739,7 @@ func (deploy *NewDeploy) fnDelete(fn *fv1.Function) error {
 	_, err = deploy.fsCache.DeleteOld(fsvc, time.Second*0)
 	if err != nil {
 		multierr = multierror.Append(multierr,
-			errors.Wrap(err, fmt.Sprintf("error deleting the function from cache")))
+			errors.Wrap(err, "error deleting the function from cache"))
 	}
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -52,6 +52,7 @@ import (
 var _ executortype.ExecutorType = &NewDeploy{}
 
 type (
+	// NewDeploy represents an ExecutorType
 	NewDeploy struct {
 		logger *zap.Logger
 
@@ -78,6 +79,7 @@ type (
 	}
 )
 
+// MakeNewDeploy initializes and returns an instance of NewDeploy.
 func MakeNewDeploy(
 	logger *zap.Logger,
 	fissionClient *crd.FissionClient,
@@ -128,16 +130,19 @@ func MakeNewDeploy(
 	return nd
 }
 
+// Run start the function and environment controller along with an object reaper.
 func (deploy *NewDeploy) Run(ctx context.Context) {
 	go deploy.funcController.Run(ctx.Done())
 	go deploy.envController.Run(ctx.Done())
 	go deploy.idleObjectReaper()
 }
 
+// GetTypeName returns the executor type name.
 func (deploy *NewDeploy) GetTypeName() fv1.ExecutorType {
 	return fv1.ExecutorTypeNewdeploy
 }
 
+// GetFuncSvc returns a function service; error otherwise.
 func (deploy *NewDeploy) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	// TODO: client-go doesn't support to pass in context.
 	//  Once it supports context, we should change the signature of method.
@@ -145,23 +150,28 @@ func (deploy *NewDeploy) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fsc
 	return deploy.createFunction(fn)
 }
 
+// GetFuncSvcFromCache returns a function service from cache; error otherwise.
 func (deploy *NewDeploy) GetFuncSvcFromCache(fn *fv1.Function) (*fscache.FuncSvc, error) {
 	return deploy.fsCache.GetByFunction(&fn.ObjectMeta)
 }
 
+// DeleteFuncSvcFromCache deletes a function service from cache.
 func (deploy *NewDeploy) DeleteFuncSvcFromCache(fsvc *fscache.FuncSvc) {
 	deploy.fsCache.DeleteEntry(fsvc)
 }
 
+// UnTapService has not been implemented for NewDeployment.
 func (deploy *NewDeploy) UnTapService(key string, svcHost string) {
 	// Not Implemented for NewDeployment. Will be used when support of concurrent specialization of same function is added.
 }
 
+// GetTotalAvailable has not been implemented for NewDeployment.
 func (deploy *NewDeploy) GetTotalAvailable(fn *fv1.Function) int {
 	// Not Implemented for NewDeployment. Will be used when support of concurrent specialization of same function is added.
 	return 0
 }
 
+// TapService makes a TouchByAddress request to the cache.
 func (deploy *NewDeploy) TapService(svcHost string) error {
 	err := deploy.fsCache.TouchByAddress(svcHost)
 	if err != nil {
@@ -252,6 +262,7 @@ func (deploy *NewDeploy) RefreshFuncPods(logger *zap.Logger, f fv1.Function) err
 	return nil
 }
 
+// AdoptExistingResources attempts to adopt resources for functions in all namespaces.
 func (deploy *NewDeploy) AdoptExistingResources() {
 	fnList, err := deploy.fissionClient.CoreV1().Functions(metav1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
@@ -281,6 +292,7 @@ func (deploy *NewDeploy) AdoptExistingResources() {
 	wg.Wait()
 }
 
+// CleanupOldExecutorObjects cleans orphaned resources.
 func (deploy *NewDeploy) CleanupOldExecutorObjects() {
 	deploy.logger.Info("Newdeploy starts to clean orphaned resources", zap.String("instanceID", deploy.instanceID))
 

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -71,18 +71,6 @@ type (
 		readyPodQueue            workqueue.RateLimitingInterface
 		poolInstanceID           string // small random string to uniquify pod names
 		instanceID               string // poolmgr instance id
-		requestChannel           chan *choosePodRequest
-		stopCh                   context.CancelFunc
-	}
-
-	// serialize the choosing of pods so that choices don't conflict
-	choosePodRequest struct {
-		newLabels       map[string]string
-		responseChannel chan *choosePodResponse
-	}
-	choosePodResponse struct {
-		pod *apiv1.Pod
-		error
 	}
 )
 
@@ -130,7 +118,6 @@ func MakeGenericPool(
 		useSvc:                   false,       // defaults off -- svc takes a second or more to become routable, slowing cold start
 		useIstio:                 enableIstio, // defaults off -- istio integration requires pod relabeling and it takes a second or more to become routable, slowing cold start
 		stopReadyPodControllerCh: make(chan struct{}),
-		requestChannel:           make(chan *choosePodRequest),
 		poolInstanceID:           uniuri.NewLen(8),
 		instanceID:               instanceID,
 	}

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -276,7 +276,15 @@ func (gp *GenericPool) scheduleDeletePod(name string) {
 		// cleaned up.  (We need a better solutions for both those things; log
 		// aggregation and storage will help.)
 		gp.logger.Error("error in pod - scheduling cleanup", zap.String("pod", name))
-		gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(name, nil)
+		err := gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(name, nil)
+		if err != nil {
+			gp.logger.Error(
+				"error deleting pod",
+				zap.String("name", name),
+				zap.String("namespace", gp.namespace),
+				zap.Error(err),
+			)
+		}
 	}()
 }
 
@@ -553,7 +561,7 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 		// Remove old versions function pods
 		for _, pod := range podList.Items {
 			// Delete pod no matter what status it is
-			gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(pod.ObjectMeta.Name, nil)
+			gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(pod.ObjectMeta.Name, nil) //nolint errcheck
 		}
 	}
 

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -49,6 +49,7 @@ import (
 )
 
 type (
+	// GenericPool represents a generic environment pool
 	GenericPool struct {
 		logger                   *zap.Logger
 		env                      *fv1.Environment
@@ -60,19 +61,32 @@ type (
 		fsCache                  *fscache.FunctionServiceCache // cache funcSvc's by function, address and podname
 		useSvc                   bool                          // create k8s service for specialized pods
 		useIstio                 bool
-		poolInstanceId           string           // small random string to uniquify pod names
 		runtimeImagePullPolicy   apiv1.PullPolicy // pull policy for generic pool to created env deployment
 		kubernetesClient         *kubernetes.Clientset
 		fissionClient            *crd.FissionClient
-		instanceId               string // poolmgr instance id
 		fetcherConfig            *fetcherConfig.Config
 		stopReadyPodControllerCh chan struct{}
 		readyPodController       cache.Controller
 		readyPodIndexer          cache.Indexer
 		readyPodQueue            workqueue.RateLimitingInterface
+		poolInstanceID           string // small random string to uniquify pod names
+		instanceID               string // poolmgr instance id
+		requestChannel           chan *choosePodRequest
+		stopCh                   context.CancelFunc
+	}
+
+	// serialize the choosing of pods so that choices don't conflict
+	choosePodRequest struct {
+		newLabels       map[string]string
+		responseChannel chan *choosePodResponse
+	}
+	choosePodResponse struct {
+		pod *apiv1.Pod
+		error
 	}
 )
 
+// MakeGenericPool returns an instance of GenericPool
 func MakeGenericPool(
 	logger *zap.Logger,
 	fissionClient *crd.FissionClient,
@@ -83,7 +97,7 @@ func MakeGenericPool(
 	functionNamespace string,
 	fsCache *fscache.FunctionServiceCache,
 	fetcherConfig *fetcherConfig.Config,
-	instanceId string,
+	instanceID string,
 	enableIstio bool) (*GenericPool, error) {
 
 	gpLogger := logger.Named("generic_pool")
@@ -112,12 +126,13 @@ func MakeGenericPool(
 		functionNamespace:        functionNamespace,
 		podReadyTimeout:          podReadyTimeout,
 		fsCache:                  fsCache,
-		poolInstanceId:           uniuri.NewLen(8),
 		fetcherConfig:            fetcherConfig,
-		instanceId:               instanceId,
 		useSvc:                   false,       // defaults off -- svc takes a second or more to become routable, slowing cold start
 		useIstio:                 enableIstio, // defaults off -- istio integration requires pod relabeling and it takes a second or more to become routable, slowing cold start
 		stopReadyPodControllerCh: make(chan struct{}),
+		requestChannel:           make(chan *choosePodRequest),
+		poolInstanceID:           uniuri.NewLen(8),
+		instanceID:               instanceID,
 	}
 
 	gp.runtimeImagePullPolicy = utils.GetImagePullPolicy(os.Getenv("RUNTIME_IMAGE_PULL_POLICY"))
@@ -155,7 +170,7 @@ func (gp *GenericPool) getEnvironmentPoolLabels() map[string]string {
 
 func (gp *GenericPool) getDeployAnnotations() map[string]string {
 	return map[string]string{
-		fv1.EXECUTOR_INSTANCEID_LABEL: gp.instanceId,
+		fv1.EXECUTOR_INSTANCEID_LABEL: gp.instanceID,
 	}
 }
 
@@ -265,31 +280,31 @@ func (gp *GenericPool) scheduleDeletePod(name string) {
 	}()
 }
 
+// IsIPv6 validates if the podIP follows to IPv6 protocol
 func IsIPv6(podIP string) bool {
 	ip := net.ParseIP(podIP)
 	return ip != nil && strings.Contains(podIP, ":")
 }
 
-func (gp *GenericPool) getFetcherUrl(podIP string) string {
-	testUrl := os.Getenv("TEST_FETCHER_URL")
-	if len(testUrl) != 0 {
+func (gp *GenericPool) getFetcherURL(podIP string) string {
+	testURL := os.Getenv("TEST_FETCHER_URL")
+	if len(testURL) != 0 {
 		// it takes a second or so for the test service to
 		// become routable once a pod is relabeled. This is
 		// super hacky, but only runs in unit tests.
 		time.Sleep(5 * time.Second)
-		return testUrl
+		return testURL
 	}
+
 	isv6 := IsIPv6(podIP)
-	var baseUrl string
+	var baseURL string
 
 	if isv6 { // We use bracket if the IP is in IPv6.
-		baseUrl = fmt.Sprintf("http://[%v]:8000/", podIP)
+		baseURL = fmt.Sprintf("http://[%v]:8000/", podIP)
 	} else {
-		baseUrl = fmt.Sprintf("http://%v:8000/", podIP)
+		baseURL = fmt.Sprintf("http://%v:8000/", podIP)
 	}
-
-	return baseUrl
-
+	return baseURL
 }
 
 // specializePod chooses a pod, copies the required user-defined function to that pod
@@ -308,8 +323,8 @@ func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv
 	}
 
 	// tell fetcher to get the function.
-	fetcherUrl := gp.getFetcherUrl(podIP)
-	gp.logger.Info("calling fetcher to copy function", zap.String("function", fn.ObjectMeta.Name), zap.String("url", fetcherUrl))
+	fetcherURL := gp.getFetcherURL(podIP)
+	gp.logger.Info("calling fetcher to copy function", zap.String("function", fn.ObjectMeta.Name), zap.String("url", fetcherURL))
 
 	specializeReq := gp.fetcherConfig.NewSpecializeRequest(fn, gp.env)
 
@@ -317,7 +332,7 @@ func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv
 
 	// Fetcher will download user function to share volume of pod, and
 	// invoke environment specialize api for pod specialization.
-	err := fetcherClient.MakeClient(gp.logger, fetcherUrl).Specialize(ctx, &specializeReq)
+	err := fetcherClient.MakeClient(gp.logger, fetcherURL).Specialize(ctx, &specializeReq)
 	if err != nil {
 		return err
 	}
@@ -452,8 +467,8 @@ func (gp *GenericPool) createPool() error {
 
 	depl, err := gp.kubernetesClient.AppsV1().Deployments(gp.namespace).Get(deployment.Name, metav1.GetOptions{})
 	if err == nil {
-		if depl.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != gp.instanceId {
-			deployment.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] = gp.instanceId
+		if depl.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != gp.instanceID {
+			deployment.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] = gp.instanceID
 			// Update with the latest deployment spec. Kubernetes will trigger
 			// rolling update if spec is different from the one in the cluster.
 			depl, err = gp.kubernetesClient.AppsV1().Deployments(gp.namespace).Update(deployment)

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -456,7 +456,7 @@ func (gpm *GenericPoolManager) service() {
 					delete(gpm.pools, key)
 
 					// and delete the pool asynchronously.
-					go pool.destroy()
+					go pool.destroy() //nolint errcheck
 				}
 			}
 			// no response, caller doesn't wait
@@ -501,8 +501,14 @@ func (gpm *GenericPoolManager) getFunctionEnv(fn *fv1.Function) (*fv1.Environmen
 
 	// cache for future lookups
 	m := fn.ObjectMeta
-	gpm.functionEnv.Set(crd.CacheKey(&m), env)
-
+	_, err = gpm.functionEnv.Set(crd.CacheKey(&m), env)
+	if err != nil {
+		gpm.logger.Error(
+			"failed to set the key",
+			zap.String("function", fn.Name),
+			zap.Error(err),
+		)
+	}
 	return env, nil
 }
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -66,7 +66,7 @@ type (
 		fissionClient  *crd.FissionClient
 		functionEnv    *cache.Cache
 		fsCache        *fscache.FunctionServiceCache
-		instanceId     string
+		instanceID     string
 		requestChannel chan *request
 
 		enableIstio   bool
@@ -97,7 +97,7 @@ func MakeGenericPoolManager(
 	kubernetesClient *kubernetes.Clientset,
 	functionNamespace string,
 	fetcherConfig *fetcherConfig.Config,
-	instanceId string) executortype.ExecutorType {
+	instanceID string) executortype.ExecutorType {
 
 	gpmLogger := logger.Named("generic_pool_manager")
 
@@ -109,7 +109,7 @@ func MakeGenericPoolManager(
 		fissionClient:          fissionClient,
 		functionEnv:            cache.MakeCache(10*time.Second, 0),
 		fsCache:                fscache.MakeFunctionServiceCache(gpmLogger),
-		instanceId:             instanceId,
+		instanceID:             instanceID,
 		requestChannel:         make(chan *request),
 		defaultIdlePodReapTime: 2 * time.Minute,
 		fetcherConfig:          fetcherConfig,
@@ -312,7 +312,7 @@ func (gpm *GenericPoolManager) AdoptExistingResources() {
 			// avoid too many requests arrive Kubernetes API server at the same time.
 			time.Sleep(time.Duration(rand.Intn(30)) * time.Millisecond)
 
-			patch := fmt.Sprintf(`{"metadata":{"annotations":{"%v":"%v"}}}`, fv1.EXECUTOR_INSTANCEID_LABEL, gpm.instanceId)
+			patch := fmt.Sprintf(`{"metadata":{"annotations":{"%v":"%v"}}}`, fv1.EXECUTOR_INSTANCEID_LABEL, gpm.instanceID)
 			pod, err = gpm.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(pod.Name, k8sTypes.StrategicMergePatchType, []byte(patch))
 			if err != nil {
 				// just log the error since it won't affect the function serving
@@ -387,19 +387,19 @@ func (gpm *GenericPoolManager) AdoptExistingResources() {
 }
 
 func (gpm *GenericPoolManager) CleanupOldExecutorObjects() {
-	gpm.logger.Info("Poolmanager starts to clean orphaned resources", zap.String("instanceID", gpm.instanceId))
+	gpm.logger.Info("Poolmanager starts to clean orphaned resources", zap.String("instanceID", gpm.instanceID))
 
 	errs := &multierror.Error{}
 	listOpts := metav1.ListOptions{
 		LabelSelector: labels.Set(map[string]string{fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypePoolmgr)}).AsSelector().String(),
 	}
 
-	err := reaper.CleanupDeployments(gpm.logger, gpm.kubernetesClient, gpm.instanceId, listOpts)
+	err := reaper.CleanupDeployments(gpm.logger, gpm.kubernetesClient, gpm.instanceID, listOpts)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 	}
 
-	err = reaper.CleanupPods(gpm.logger, gpm.kubernetesClient, gpm.instanceId, listOpts)
+	err = reaper.CleanupPods(gpm.logger, gpm.kubernetesClient, gpm.instanceID, listOpts)
 	if err != nil {
 		errs = multierror.Append(errs, err)
 	}
@@ -434,7 +434,7 @@ func (gpm *GenericPoolManager) service() {
 
 				pool, err = MakeGenericPool(gpm.logger,
 					gpm.fissionClient, gpm.kubernetesClient, req.env, poolsize,
-					ns, gpm.namespace, gpm.fsCache, gpm.fetcherConfig, gpm.instanceId, gpm.enableIstio)
+					ns, gpm.namespace, gpm.fsCache, gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio)
 				if err != nil {
 					req.responseChannel <- &response{error: err}
 					continue

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -312,9 +312,33 @@ func (fsc *FunctionServiceCache) _touchByAddress(address string) error {
 
 // DeleteEntry deletes a function service from cache.
 func (fsc *FunctionServiceCache) DeleteEntry(fsvc *FuncSvc) {
-	fsc.byFunction.Delete(crd.CacheKey(fsvc.Function))
-	fsc.byAddress.Delete(fsvc.Address)
-	fsc.byFunctionUID.Delete(fsvc.Function.UID)
+	msg := "error deleting function service"
+	err := fsc.byFunction.Delete(crd.CacheKey(fsvc.Function))
+	if err != nil {
+		fsc.logger.Error(
+			msg,
+			zap.String("function", fsvc.Function.Name),
+			zap.Error(err),
+		)
+	}
+
+	err = fsc.byAddress.Delete(fsvc.Address)
+	if err != nil {
+		fsc.logger.Error(
+			msg,
+			zap.String("function", fsvc.Function.Name),
+			zap.Error(err),
+		)
+	}
+
+	err = fsc.byFunctionUID.Delete(fsvc.Function.UID)
+	if err != nil {
+		fsc.logger.Error(
+			msg,
+			zap.String("function", fsvc.Function.Name),
+			zap.Error(err),
+		)
+	}
 
 	fsc.observeFuncRunningTime(fsvc.Function.Name, string(fsvc.Function.UID), fsvc.Atime.Sub(fsvc.Ctime).Seconds())
 	fsc.observeFuncAliveTime(fsvc.Function.Name, string(fsvc.Function.UID), time.Since(fsvc.Ctime).Seconds())
@@ -323,7 +347,15 @@ func (fsc *FunctionServiceCache) DeleteEntry(fsvc *FuncSvc) {
 
 // DeleteFunctionSvc deletes a function service at key composed of [function][address].
 func (fsc *FunctionServiceCache) DeleteFunctionSvc(fsvc *FuncSvc) {
-	fsc.connFunctionCache.DeleteValue(crd.CacheKey(fsvc.Function), fsvc.Address)
+	err := fsc.connFunctionCache.DeleteValue(crd.CacheKey(fsvc.Function), fsvc.Address)
+	if err != nil {
+		fsc.logger.Error(
+			"error deleting function service",
+			zap.Any("function", fsvc.Function.Name),
+			zap.Any("address", fsvc.Address),
+			zap.Error(err),
+		)
+	}
 }
 
 // DeleteOld deletes aged function service entries from cache.

--- a/pkg/executor/fscache/metrics.go
+++ b/pkg/executor/fscache/metrics.go
@@ -47,6 +47,7 @@ func init() {
 	prometheus.MustRegister(funcIsAlive)
 }
 
+// IncreaseColdStarts increments the counter by 1.
 func (fsc *FunctionServiceCache) IncreaseColdStarts(funcname, funcuid string) {
 	coldStarts.WithLabelValues(funcname, funcuid).Inc()
 }

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -68,7 +68,8 @@ func CleanupKubeObject(logger *zap.Logger, kubeClient *kubernetes.Clientset, kub
 	}
 }
 
-func CleanupDeployments(logger *zap.Logger, client *kubernetes.Clientset, instanceId string, listOps meta_v1.ListOptions) error {
+// CleanupDeployments deletes deployment(s) for a given instanceID
+func CleanupDeployments(logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
 	deploymentList, err := client.AppsV1().Deployments(meta_v1.NamespaceAll).List(listOps)
 	if err != nil {
 		return err
@@ -79,7 +80,7 @@ func CleanupDeployments(logger *zap.Logger, client *kubernetes.Clientset, instan
 			// Backward compatibility with older label name
 			id, ok = dep.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		if ok && id != instanceId {
+		if ok && id != instanceID {
 			logger.Info("cleaning up deployment", zap.String("deployment", dep.ObjectMeta.Name))
 			err := client.AppsV1().Deployments(dep.ObjectMeta.Namespace).Delete(dep.ObjectMeta.Name, &delOpt)
 			if err != nil {
@@ -94,7 +95,8 @@ func CleanupDeployments(logger *zap.Logger, client *kubernetes.Clientset, instan
 	return nil
 }
 
-func CleanupPods(logger *zap.Logger, client *kubernetes.Clientset, instanceId string, listOps meta_v1.ListOptions) error {
+// CleanupPods deletes pod(s) for a given instanceID
+func CleanupPods(logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
 	podList, err := client.CoreV1().Pods(meta_v1.NamespaceAll).List(listOps)
 	if err != nil {
 		return err
@@ -105,7 +107,7 @@ func CleanupPods(logger *zap.Logger, client *kubernetes.Clientset, instanceId st
 			// Backward compatibility with older label name
 			id, ok = pod.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		if ok && id != instanceId {
+		if ok && id != instanceID {
 			logger.Info("cleaning up pod", zap.String("pod", pod.ObjectMeta.Name))
 			err := client.CoreV1().Pods(pod.ObjectMeta.Namespace).Delete(pod.ObjectMeta.Name, nil)
 			if err != nil {
@@ -120,7 +122,8 @@ func CleanupPods(logger *zap.Logger, client *kubernetes.Clientset, instanceId st
 	return nil
 }
 
-func CleanupServices(logger *zap.Logger, client *kubernetes.Clientset, instanceId string, listOps meta_v1.ListOptions) error {
+// CleanupServices deletes service(s) for a given instanceID
+func CleanupServices(logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
 	svcList, err := client.CoreV1().Services(meta_v1.NamespaceAll).List(listOps)
 	if err != nil {
 		return err
@@ -131,7 +134,7 @@ func CleanupServices(logger *zap.Logger, client *kubernetes.Clientset, instanceI
 			// Backward compatibility with older label name
 			id, ok = svc.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		if ok && id != instanceId {
+		if ok && id != instanceID {
 			logger.Info("cleaning up service", zap.String("service", svc.ObjectMeta.Name))
 			err := client.CoreV1().Services(svc.ObjectMeta.Namespace).Delete(svc.ObjectMeta.Name, nil)
 			if err != nil {
@@ -146,7 +149,8 @@ func CleanupServices(logger *zap.Logger, client *kubernetes.Clientset, instanceI
 	return nil
 }
 
-func CleanupHpa(logger *zap.Logger, client *kubernetes.Clientset, instanceId string, listOps meta_v1.ListOptions) error {
+// CleanupHpa deletes horizontal pod autoscaler(s) for a given instanceID
+func CleanupHpa(logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
 	hpaList, err := client.AutoscalingV1().HorizontalPodAutoscalers(meta_v1.NamespaceAll).List(listOps)
 	if err != nil {
 		return err
@@ -158,7 +162,7 @@ func CleanupHpa(logger *zap.Logger, client *kubernetes.Clientset, instanceId str
 			// Backward compatibility with older label name
 			id, ok = hpa.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		if ok && id != instanceId {
+		if ok && id != instanceID {
 			logger.Info("cleaning up HPA", zap.String("hpa", hpa.ObjectMeta.Name))
 			err := client.AutoscalingV1().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(hpa.ObjectMeta.Name, nil)
 			if err != nil {
@@ -171,7 +175,6 @@ func CleanupHpa(logger *zap.Logger, client *kubernetes.Clientset, instanceId str
 		}
 	}
 	return nil
-
 }
 
 // CleanupRoleBindings periodically lists rolebindings across all namespaces and removes Service Accounts from them or

--- a/pkg/executor/util/merge.go
+++ b/pkg/executor/util/merge.go
@@ -54,6 +54,7 @@ func MergeContainer(dst *apiv1.Container, src *apiv1.Container) (*apiv1.Containe
 	return &dstC, errs.ErrorOrNil()
 }
 
+// MergePodSpec updates srcPodSpec with targetPodSpec fields if not empty
 func MergePodSpec(srcPodSpec *apiv1.PodSpec, targetPodSpec *apiv1.PodSpec) (*apiv1.PodSpec, error) {
 	if targetPodSpec == nil {
 		return srcPodSpec, nil

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -37,6 +37,7 @@ func ApplyImagePullSecret(secret string, podspec apiv1.PodSpec) *apiv1.PodSpec {
 	return &podspec
 }
 
+// WaitTimeout starts a wait group with timeout
 func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) {
 	waitCh := make(chan struct{})
 	go func() {


### PR DESCRIPTION
This PR addresses issues reported by `golangci-lint` in the package `/fission/pkg/executor`.

Inline with issue #1835 

**Reported Issues**
```
  ~/go/src/github.com/gauravgahlot/fission/pkg/executor (executor_fixes) ✔ 
➜ golangci-lint run             
executortype/newdeploy/newdeploymgr.go:473:29: Error return value of `deploy.cleanupNewdeploy` is not checked (errcheck)
		go deploy.cleanupNewdeploy(ns, objName)
		                          ^
executortype/newdeploy/newdeploymgr.go:481:29: Error return value of `deploy.cleanupNewdeploy` is not checked (errcheck)
		go deploy.cleanupNewdeploy(ns, objName)
		                          ^
executortype/newdeploy/newdeploymgr.go:488:29: Error return value of `deploy.cleanupNewdeploy` is not checked (errcheck)
		go deploy.cleanupNewdeploy(ns, objName)
		                          ^
executortype/newdeploy/newdeploymgr.go:730:21: S1039: unnecessary use of fmt.Sprintf (gosimple)
			errors.Wrap(err, fmt.Sprintf("error deleting the function from cache")))
			                 ^
api.go:97:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte(serviceName))
	       ^
executor_test.go:125:47: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.NamespaceInterface).Delete` is not checked (errcheck)
	defer kubeClient.CoreV1().Namespaces().Delete(fissionNs, nil)
	                                             ^
executor_test.go:128:47: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.NamespaceInterface).Delete` is not checked (errcheck)
	defer kubeClient.CoreV1().Namespaces().Delete(functionNs, nil)
	                                             ^
executor_test.go:231:55: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.ServiceInterface).Delete` is not checked (errcheck)
	defer kubeClient.CoreV1().Services(functionNs).Delete(fetcherSvc.ObjectMeta.Name, nil)
	                                                     ^
executor_test.go:235:55: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.ServiceInterface).Delete` is not checked (errcheck)
	defer kubeClient.CoreV1().Services(functionNs).Delete(functionSvc.ObjectMeta.Name, nil)
	                                                     ^
fscache/functionServiceCache.go:298:23: Error return value of `fsc.byFunction.Delete` is not checked (errcheck)
	fsc.byFunction.Delete(crd.CacheKey(fsvc.Function))
	                     ^
fscache/functionServiceCache.go:299:22: Error return value of `fsc.byAddress.Delete` is not checked (errcheck)
	fsc.byAddress.Delete(fsvc.Address)
	                    ^
fscache/functionServiceCache.go:300:26: Error return value of `fsc.byFunctionUID.Delete` is not checked (errcheck)
	fsc.byFunctionUID.Delete(fsvc.Function.UID)
	                        ^
fscache/functionServiceCache.go:308:35: Error return value of `fsc.connFunctionCache.DeleteValue` is not checked (errcheck)
	fsc.connFunctionCache.DeleteValue(crd.CacheKey(fsvc.Function), fsvc.Address)
	                                 ^
executortype/poolmgr/gp.go:311:57: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.PodInterface).Delete` is not checked (errcheck)
		gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(name, nil)
		                                                      ^
executortype/poolmgr/gp.go:632:58: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.PodInterface).Delete` is not checked (errcheck)
			gp.kubernetesClient.CoreV1().Pods(gp.namespace).Delete(pod.ObjectMeta.Name, nil)
			                                                      ^
executortype/poolmgr/gpm.go:459:21: Error return value of `pool.destroy` is not checked (errcheck)
					go pool.destroy()
					               ^
executortype/poolmgr/gpm.go:504:21: Error return value of `gpm.functionEnv.Set` is not checked (errcheck)
	gpm.functionEnv.Set(crd.CacheKey(&m), env)
	                   ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/1842)
<!-- Reviewable:end -->
