### PR TITLE
Fixed golangci-lint issues: /fission/pkg

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -74,7 +74,13 @@ func MakeBuilder(logger *zap.Logger, sharedVolumePath string) *Builder {
 
 func (builder *Builder) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Write([]byte(info.BuildInfo().String()))
+	_, err := w.Write([]byte(info.BuildInfo().String()))
+	if err != nil {
+		builder.logger.Error(
+			"error writing response",
+			zap.Error(err),
+		)
+	}
 }
 
 func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
@@ -149,7 +155,13 @@ func (builder *Builder) reply(w http.ResponseWriter, pkgFilename string, buildLo
 	// should write header before writing the body,
 	// or client will receive HTTP 200 regardless the real status code
 	w.WriteHeader(statusCode)
-	w.Write(rBody)
+	_, err = w.Write(rBody)
+	if err != nil {
+		builder.logger.Error(
+			"error writing response",
+			zap.Error(err),
+		)
+	}
 }
 
 func (builder *Builder) build(command string, srcPkgPath string, deployPkgPath string) (string, error) {

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -81,7 +81,12 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 	if err != nil {
 		return
 	}
-	defer buildCache.Delete(key)
+	defer func() {
+		err := buildCache.Delete(key)
+		if err != nil {
+			pkgw.logger.Error("error deleting key from cache", zap.String("key", key), zap.Error(err))
+		}
+	}()
 
 	pkgw.logger.Info("starting build for package", zap.String("package_name", srcpkg.ObjectMeta.Name), zap.String("resource_version", srcpkg.ObjectMeta.ResourceVersion))
 
@@ -95,8 +100,16 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 	if k8serrors.IsNotFound(err) {
 		e := "environment does not exist"
 		pkgw.logger.Error(e, zap.String("environment", pkg.Spec.Environment.Name))
-		updatePackage(pkgw.logger, pkgw.fissionClient, pkg,
+		_, er := updatePackage(pkgw.logger, pkgw.fissionClient, pkg,
 			fv1.BuildStatusFailed, fmt.Sprintf("%s: %q", e, pkg.Spec.Environment.Name), nil)
+		if er != nil {
+			pkgw.logger.Error(
+				"error updating package",
+				zap.String("package_name", pkg.ObjectMeta.Name),
+				zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+				zap.Error(er),
+			)
+		}
 		return
 	}
 
@@ -173,7 +186,15 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 			uploadResp, buildLogs, err := buildPackage(ctx, pkgw.logger, pkgw.fissionClient, builderNs, pkgw.storageSvcUrl, pkg)
 			if err != nil {
 				pkgw.logger.Error("error building package", zap.Error(err), zap.String("package_name", pkg.ObjectMeta.Name))
-				updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				_, er := updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				if er != nil {
+					pkgw.logger.Error(
+						"error updating package",
+						zap.String("package_name", pkg.ObjectMeta.Name),
+						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+						zap.Error(er),
+					)
+				}
 				return
 			}
 
@@ -185,7 +206,15 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 				e := "error getting function list"
 				pkgw.logger.Error(e, zap.Error(err))
 				buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-				updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				_, er := updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				if er != nil {
+					pkgw.logger.Error(
+						"error updating package",
+						zap.String("package_name", pkg.ObjectMeta.Name),
+						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+						zap.Error(er),
+					)
+				}
 			}
 
 			// A package may be used by multiple functions. Update
@@ -201,7 +230,15 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 						e := "error updating function package resource version"
 						pkgw.logger.Error(e, zap.Error(err))
 						buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-						updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+						_, er := updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+						if er != nil {
+							pkgw.logger.Error(
+								"error updating package",
+								zap.String("package_name", pkg.ObjectMeta.Name),
+								zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+								zap.Error(er),
+							)
+						}
 						return
 					}
 				}
@@ -211,7 +248,15 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 				fv1.BuildStatusSucceeded, buildLogs, uploadResp)
 			if err != nil {
 				pkgw.logger.Error("error updating package info", zap.Error(err), zap.String("package_name", pkg.ObjectMeta.Name))
-				updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				_, er := updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				if er != nil {
+					pkgw.logger.Error(
+						"error updating package",
+						zap.String("package_name", pkg.ObjectMeta.Name),
+						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+						zap.Error(er),
+					)
+				}
 				return
 			}
 
@@ -221,8 +266,16 @@ func (pkgw *packageWatcher) build(buildCache *cache.Cache, srcpkg *fv1.Package) 
 		time.Sleep(healthCheckBackOff.GetNext())
 	}
 	// build timeout
-	updatePackage(pkgw.logger, pkgw.fissionClient, pkg,
+	_, err = updatePackage(pkgw.logger, pkgw.fissionClient, pkg,
 		fv1.BuildStatusFailed, "Build timeout due to environment builder not ready", nil)
+	if err != nil {
+		pkgw.logger.Error(
+			"error updating package",
+			zap.String("package_name", pkg.ObjectMeta.Name),
+			zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+			zap.Error(err),
+		)
+	}
 
 	pkgw.logger.Error("max retries exceeded in building source package, timeout due to environment builder not ready",
 		zap.String("package", fmt.Sprintf("%s.%s", pkg.ObjectMeta.Name, pkg.ObjectMeta.Namespace)))

--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -166,7 +166,10 @@ func (api *API) getLogDBConfig(dbType string) logDBConfig {
 
 func (api *API) HomeHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Write([]byte(info.ApiInfo().String()))
+	_, err := w.Write([]byte(info.ApiInfo().String()))
+	if err != nil {
+		api.respondWithError(w, err)
+	}
 }
 
 func (api *API) ApiVersionMismatchHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -129,7 +129,7 @@ func TestFunctionApi(t *testing.T) {
 	testFunc.ObjectMeta.Name = "bar"
 	m2, err := g.Client().V1().Function().Create(testFunc)
 	panicIf(err)
-	defer g.Client().V1().Function().Delete(m2)
+	defer panicIf(g.Client().V1().Function().Delete(m2))
 
 	funcs, err := g.Client().V1().Function().List(testNS)
 	panicIf(err)
@@ -173,7 +173,7 @@ func TestHTTPTriggerApi(t *testing.T) {
 
 	m, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
-	defer g.Client().V1().HTTPTrigger().Delete(m)
+	defer panicIf(g.Client().V1().HTTPTrigger().Delete(m))
 
 	_, err = g.Client().V1().HTTPTrigger().Create(testTrigger)
 	assertNameReuseFailure(err, "httptrigger")
@@ -198,7 +198,7 @@ func TestHTTPTriggerApi(t *testing.T) {
 	testTrigger.Spec.RelativeURL = "/hi2"
 	m2, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
-	defer g.Client().V1().HTTPTrigger().Delete(m2)
+	defer panicIf(g.Client().V1().HTTPTrigger().Delete(m2))
 
 	ts, err := g.Client().V1().HTTPTrigger().List(testNS)
 	panicIf(err)
@@ -227,7 +227,7 @@ func TestEnvironmentApi(t *testing.T) {
 
 	m, err := g.Client().V1().Environment().Create(testEnv)
 	panicIf(err)
-	defer g.Client().V1().Environment().Delete(m)
+	defer panicIf(g.Client().V1().Environment().Delete(m))
 
 	_, err = g.Client().V1().Environment().Create(testEnv)
 	assertNameReuseFailure(err, "environment")
@@ -246,7 +246,7 @@ func TestEnvironmentApi(t *testing.T) {
 
 	m2, err := g.Client().V1().Environment().Create(testEnv)
 	panicIf(err)
-	defer g.Client().V1().Environment().Delete(m2)
+	defer panicIf(g.Client().V1().Environment().Delete(m2))
 
 	ts, err := g.Client().V1().Environment().List(testNS)
 	panicIf(err)
@@ -276,7 +276,7 @@ func TestWatchApi(t *testing.T) {
 
 	m, err := g.Client().V1().KubeWatcher().Create(testWatch)
 	panicIf(err)
-	defer g.Client().V1().KubeWatcher().Delete(m)
+	defer panicIf(g.Client().V1().KubeWatcher().Delete(m))
 
 	_, err = g.Client().V1().KubeWatcher().Create(testWatch)
 	assertNameReuseFailure(err, "watch")
@@ -291,7 +291,7 @@ func TestWatchApi(t *testing.T) {
 	testWatch.ObjectMeta.Name = "yyy"
 	m2, err := g.Client().V1().KubeWatcher().Create(testWatch)
 	panicIf(err)
-	defer g.Client().V1().KubeWatcher().Delete(m2)
+	defer panicIf(g.Client().V1().KubeWatcher().Delete(m2))
 
 	ws, err := g.Client().V1().KubeWatcher().List(testNS)
 	panicIf(err)
@@ -317,7 +317,7 @@ func TestTimeTriggerApi(t *testing.T) {
 
 	m, err := g.Client().V1().TimeTrigger().Create(testTrigger)
 	panicIf(err)
-	defer g.Client().V1().TimeTrigger().Delete(m)
+	defer panicIf(g.Client().V1().TimeTrigger().Delete(m))
 
 	_, err = g.Client().V1().TimeTrigger().Create(testTrigger)
 	assertNameReuseFailure(err, "trigger")
@@ -359,12 +359,13 @@ func TestMain(m *testing.M) {
 
 	// testNS isolation for running multiple CI builds concurrently.
 	testNS = uuid.NewV4().String()
-	kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
+	_, err = kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: testNS,
 		},
 	})
-	defer kubeClient.CoreV1().Namespaces().Delete(testNS, nil)
+	panicIf(err)
+	defer panicIf(kubeClient.CoreV1().Namespaces().Delete(testNS, nil))
 
 	config := zap.NewDevelopmentConfig()
 	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder

--- a/pkg/controller/client/v1/function.go
+++ b/pkg/controller/client/v1/function.go
@@ -107,7 +107,7 @@ func (c *Function) Get(m *metav1.ObjectMeta) (*fv1.Function, error) {
 func (c *Function) GetRawDeployment(m *metav1.ObjectMeta) ([]byte, error) {
 	relativeUrl := fmt.Sprintf("functions/%v", m.Name)
 	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
-	relativeUrl += fmt.Sprintf("&deploymentraw=1")
+	relativeUrl += "&deploymentraw=1"
 
 	resp, err := c.client.Get(relativeUrl)
 	if err != nil {

--- a/pkg/controller/functionApi.go
+++ b/pkg/controller/functionApi.go
@@ -353,7 +353,10 @@ func getContainerLog(kubernetesClient *kubernetes.Clientset, w http.ResponseWrit
 
 		msg := fmt.Sprintf("\n%v\nFunction: %v\nEnvironment: %v\nNamespace: %v\nPod: %v\nContainer: %v\nNode: %v\n%v\n", seq,
 			fn.ObjectMeta.Name, fn.Spec.Environment.Name, pod.Namespace, pod.Name, container.Name, pod.Spec.NodeName, seq)
-		w.Write([]byte(msg))
+		_, err = w.Write([]byte(msg))
+		if err != nil {
+			return errors.Wrap(err, "error writing response")
+		}
 
 		_, err = io.Copy(w, podLogs)
 		if err != nil {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -116,7 +116,10 @@ func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 
 func (fetcher *Fetcher) VersionHandler(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	w.Write([]byte(info.BuildInfo().String()))
+	_, err := w.Write([]byte(info.BuildInfo().String()))
+	if err != nil {
+		fetcher.logger.Error("error writing response", zap.Error(err))
+	}
 }
 
 func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {
@@ -506,7 +509,12 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	fetcher.logger.Info("completed upload request")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write(rBody)
+	_, err = w.Write(rBody)
+	if err != nil {
+		e := "error writing response"
+		fetcher.logger.Error(e, zap.Error(err))
+		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
+	}
 }
 
 func (fetcher *Fetcher) rename(src string, dst string) error {

--- a/pkg/fission-cli/cliwrapper/driver/cobra/cobra.go
+++ b/pkg/fission-cli/cliwrapper/driver/cobra/cobra.go
@@ -95,9 +95,9 @@ func optionalFlags(cmd *cobra.Command, flags ...flag.Flag) {
 		toCobraFlag(cmd, f, false)
 		if f.Deprecated {
 			usage := fmt.Sprintf("Use --%v instead. The flag still works for now and will be removed in future", f.Substitute)
-			cmd.Flags().MarkDeprecated(f.Name, usage)
+			cmd.Flags().MarkDeprecated(f.Name, usage) //nolint: errCheck
 		} else if f.Hidden {
-			cmd.Flags().MarkHidden(f.Name)
+			cmd.Flags().MarkHidden(f.Name) //nolint: errCheck
 		}
 	}
 }
@@ -105,7 +105,7 @@ func optionalFlags(cmd *cobra.Command, flags ...flag.Flag) {
 func requiredFlags(cmd *cobra.Command, flags ...flag.Flag) {
 	for _, f := range flags {
 		toCobraFlag(cmd, f, false)
-		cmd.MarkFlagRequired(f.Name)
+		cmd.MarkFlagRequired(f.Name) //nolint: errCheck
 	}
 }
 

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -441,7 +441,7 @@ func (fr *FissionResources) Validate(input cli.Input) ([]string, error) {
 		}
 
 		if len(t.Spec.Host) > 0 {
-			warnings = append(warnings, (fmt.Sprintf("Host in HTTPTrigger spec.Host is now marked as deprecated, see 'help' for details")))
+			warnings = append(warnings, "Host in HTTPTrigger spec.Host is now marked as deprecated, see 'help' for details")
 		}
 		result = multierror.Append(result, t.Validate())
 	}
@@ -475,25 +475,25 @@ func (fr *FissionResources) Validate(input cli.Input) ([]string, error) {
 	for _, e := range fr.Environments {
 		environments[fmt.Sprintf("%s:%s", e.ObjectMeta.Name, e.ObjectMeta.Namespace)] = struct{}{}
 		if ((e.Spec.Runtime.Container != nil) && (e.Spec.Runtime.PodSpec != nil)) || ((e.Spec.Builder.Container != nil) && (e.Spec.Builder.PodSpec != nil)) {
-			warnings = append(warnings, fmt.Sprintf("You have provided both - container spec and pod spec and while merging the pod spec will take precedence."))
+			warnings = append(warnings, "You have provided both - container spec and pod spec and while merging the pod spec will take precedence.")
 		}
 		// Unlike CLI can change the environment version silently,
 		// we have to warn the user to modify spec file when this takes place.
 		if e.Spec.Poolsize != 3 && e.Spec.Version < 3 {
-			warnings = append(warnings, fmt.Sprintf("Poolsize can only be configured when environment version equals to 3, default poolsize 3 will be used for creating environment pool."))
+			warnings = append(warnings, "Poolsize can only be configured when environment version equals to 3, default poolsize 3 will be used for creating environment pool.")
 		}
 	}
 
 	for _, f := range fr.Functions {
 		if _, ok := environments[fmt.Sprintf("%s:%s", f.Spec.Environment.Name, f.Spec.Environment.Namespace)]; !ok {
-			warnings = append(warnings, fmt.Sprintf("Environment %s is referenced in function %s but not declared in specs", f.Spec.Environment.Name, f.ObjectMeta.Name))
+			warnings = append(warnings, "Environment %s is referenced in function %s but not declared in specs", f.Spec.Environment.Name, f.ObjectMeta.Name)
 		}
 		strategy := f.Spec.InvokeStrategy.ExecutionStrategy
 		if strategy.ExecutorType == fv1.ExecutorTypeNewdeploy && strategy.SpecializationTimeout < fv1.DefaultSpecializationTimeOut {
 			warnings = append(warnings, fmt.Sprintf("SpecializationTimeout in function spec.InvokeStrategy.ExecutionStrategy should be a value equal to or greater than %v", fv1.DefaultSpecializationTimeOut))
 		}
 		if f.Spec.FunctionTimeout <= 0 {
-			warnings = append(warnings, fmt.Sprintf("FunctionTimeout in function spec should be a field which should have a value greater than 0"))
+			warnings = append(warnings, "FunctionTimeout in function spec should be a field which should have a value greater than 0")
 		}
 	}
 	// (ErrorOrNil returns nil if there were no errors appended.)

--- a/pkg/kubewatcher/kubewatcher.go
+++ b/pkg/kubewatcher/kubewatcher.go
@@ -111,13 +111,13 @@ func (kw *KubeWatcher) svc() {
 			// Remove old watches
 			for uid, ws := range kw.watches {
 				if _, ok := newWatchUids[uid]; !ok {
-					kw.removeWatch(&ws.watch)
+					kw.removeWatch(&ws.watch) //nolint: errCheck
 				}
 			}
 			// Add new watches
 			for _, w := range req.watches {
 				if _, ok := kw.watches[w.ObjectMeta.UID]; !ok {
-					kw.addWatch(&w)
+					kw.addWatch(&w) //nolint: errCheck
 				}
 			}
 			req.responseChannel <- &kubeWatcherResponse{error: nil}

--- a/pkg/kubewatcher/watchSync.go
+++ b/pkg/kubewatcher/watchSync.go
@@ -51,7 +51,10 @@ func (ws *WatchSync) syncSvc() {
 			ws.logger.Fatal("failed to get Kubernetes watch trigger list", zap.Error(err))
 		}
 
-		ws.kubeWatcher.Sync(watches.Items)
+		err = ws.kubeWatcher.Sync(watches.Items)
+		if err != nil {
+			ws.logger.Fatal("failed to sync watches", zap.Error(err))
+		}
 		time.Sleep(3 * time.Second)
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -170,7 +170,7 @@ func Start() {
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}
-	defer zapLogger.Sync()
+	defer log.Fatal(zapLogger.Sync())
 
 	if _, err := os.Stat(fissionSymlinkPath); os.IsNotExist(err) {
 		zapLogger.Info("symlink path not exist, create it",

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -170,7 +170,13 @@ func Start() {
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}
-	defer log.Fatal(zapLogger.Sync())
+
+	defer func() {
+		err := zapLogger.Sync()
+		if err != nil {
+			log.Fatalf("failed to sync zap logger: %v", err)
+		}
+	}()
 
 	if _, err := os.Stat(fissionSymlinkPath); os.IsNotExist(err) {
 		zapLogger.Info("symlink path not exist, create it",

--- a/pkg/mqtrigger/messageQueue/azurequeuestorage/asq.go
+++ b/pkg/mqtrigger/messageQueue/azurequeuestorage/asq.go
@@ -319,7 +319,7 @@ func pollAzureQueueSubscription(conn AzureStorageConnection, sub *AzureQueueSubs
 }
 
 func invokeTriggeredFunction(conn AzureStorageConnection, sub *AzureQueueSubscription, message AzureMessage) {
-	defer message.Delete(nil)
+	defer message.Delete(nil) //nolint: errCheck
 
 	conn.logger.Info("making HTTP request to invoke function", zap.String("function_url", sub.functionURL))
 

--- a/pkg/mqtrigger/messageQueue/azurequeuestorage/asq_test.go
+++ b/pkg/mqtrigger/messageQueue/azurequeuestorage/asq_test.go
@@ -329,7 +329,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, subscription)
 
-	connection.Unsubscribe(subscription)
+	panicIf(connection.Unsubscribe(subscription))
 
 	mock.AssertExpectationsForObjects(t, httpClient, message, poisonMessage, queue, poisonQueue, service)
 }
@@ -480,7 +480,7 @@ func runAzureStorageQueueTest(t *testing.T, count int, output bool) {
 	require.NoError(t, err)
 	require.NotNil(t, subscription)
 
-	connection.Unsubscribe(subscription)
+	panicIf(connection.Unsubscribe(subscription))
 
 	mock.AssertExpectationsForObjects(t, httpClient, message, outputMessage, queue, outputQueue, service)
 }

--- a/pkg/newcache/poolcache_test.go
+++ b/pkg/newcache/poolcache_test.go
@@ -30,7 +30,7 @@ func TestPoolCache(t *testing.T) {
 		log.Panicf("expected 2 items")
 	}
 
-	c.DeleteValue("func2", "ip2")
+	checkErr(c.DeleteValue("func2", "ip2"))
 
 	c.MarkAvailable("func", "ip")
 	cc = c.ListAvailableValue()
@@ -41,7 +41,7 @@ func TestPoolCache(t *testing.T) {
 	_, err := c.GetValue("func")
 	checkErr(err)
 
-	c.DeleteValue("func", "ip")
+	checkErr(c.DeleteValue("func", "ip"))
 
 	_, err = c.GetValue("func")
 	if err == nil {

--- a/pkg/storagesvc/client/storagesvc_test.go
+++ b/pkg/storagesvc/client/storagesvc_test.go
@@ -126,7 +126,12 @@ func TestS3StorageService(t *testing.T) {
 		log.Fatalf("Could not connect to docker: %s", err)
 	}
 
-	defer pool.Purge(resource)
+	defer func() {
+		err := pool.Purge(resource)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	// Start storagesvc
 	bucketName := "test-s3-service"

--- a/pkg/storagesvc/stowClient.go
+++ b/pkg/storagesvc/stowClient.go
@@ -171,8 +171,7 @@ func (client *StowClient) getItemIDsWithFilter(filterFunc filter, filterFuncPara
 	for {
 		items, cursor, err = client.container.Items(stow.NoPrefix, cursor, PaginationSize)
 		if err != nil {
-			errors.Wrap(err, "error getting items from container")
-			return nil, err
+			return nil, errors.Wrap(err, "error getting items from container")
 		}
 
 		for _, item := range items {

--- a/pkg/timer/timer.go
+++ b/pkg/timer/timer.go
@@ -127,7 +127,7 @@ func (timer *Timer) syncCron(triggers []fv1.TimeTrigger) error {
 
 func (timer *Timer) newCron(t fv1.TimeTrigger) *cron.Cron {
 	c := cron.New()
-	c.AddFunc(t.Spec.Cron, func() {
+	c.AddFunc(t.Spec.Cron, func() { //nolint: errCheck
 		headers := map[string]string{
 			"X-Fission-Timer-Name": t.ObjectMeta.Name,
 		}

--- a/pkg/timer/timerSync.go
+++ b/pkg/timer/timerSync.go
@@ -55,7 +55,7 @@ func (ws *TimerSync) syncSvc() {
 			}
 			ws.logger.Fatal("failed to get time trigger list", zap.Error(err))
 		}
-		ws.timer.Sync(triggers.Items)
+		ws.timer.Sync(triggers.Items) //nolint: errCheck
 
 		// TODO switch to watches
 		time.Sleep(3 * time.Second)


### PR DESCRIPTION
This PR addresses issues reported by `golangci-lint` in the package `/fission/pkg/`.

Inline with issue #1835 

```
  ~/go/src/github.com/gauravgahlot/fission/pkg (master) ✔  
➜ golangci-lint run                 

logger/logger.go:173:22: Error return value of `zapLogger.Sync` is not checked (errcheck)
	defer zapLogger.Sync()
	                    ^
fission-cli/cliwrapper/driver/cobra/cobra.go:98:30: Error return value of `(*github.com/spf13/pflag.FlagSet).MarkDeprecated` is not checked (errcheck)
			cmd.Flags().MarkDeprecated(f.Name, usage)
			                          ^
fission-cli/cliwrapper/driver/cobra/cobra.go:100:26: Error return value of `(*github.com/spf13/pflag.FlagSet).MarkHidden` is not checked (errcheck)
			cmd.Flags().MarkHidden(f.Name)
			                      ^
fission-cli/cliwrapper/driver/cobra/cobra.go:108:23: Error return value of `cmd.MarkFlagRequired` is not checked (errcheck)
		cmd.MarkFlagRequired(f.Name)
		                    ^
storagesvc/client/storagesvc_test.go:129:18: Error return value of `pool.Purge` is not checked (errcheck)
	defer pool.Purge(resource)
	                ^
timer/timer.go:130:11: Error return value of `c.AddFunc` is not checked (errcheck)
	c.AddFunc(t.Spec.Cron, func() {
	         ^
timer/timerSync.go:58:16: Error return value of `ws.timer.Sync` is not checked (errcheck)
		ws.timer.Sync(triggers.Items)
		             ^
controller/client/v1/function.go:110:17: S1039: unnecessary use of fmt.Sprintf (gosimple)
	relativeUrl += fmt.Sprintf("&deploymentraw=1")
	               ^
kubewatcher/kubewatcher.go:114:20: Error return value of `kw.removeWatch` is not checked (errcheck)
					kw.removeWatch(&ws.watch)
					              ^
kubewatcher/kubewatcher.go:120:17: Error return value of `kw.addWatch` is not checked (errcheck)
					kw.addWatch(&w)
					           ^
kubewatcher/watchSync.go:54:22: Error return value of `ws.kubeWatcher.Sync` is not checked (errcheck)
		ws.kubeWatcher.Sync(watches.Items)
		                   ^
fetcher/fetcher.go:119:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte(info.BuildInfo().String()))
	       ^
fetcher/fetcher.go:509:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write(rBody)
	       ^
controller/api.go:169:9: Error return value of `w.Write` is not checked (errcheck)
	w.Write([]byte(info.ApiInfo().String()))
	       ^
controller/api_test.go:132:41: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.FunctionInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().Function().Delete(m2)
	                                       ^
controller/api_test.go:176:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.HTTPTriggerInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().HTTPTrigger().Delete(m)
	                                          ^
controller/api_test.go:201:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.HTTPTriggerInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().HTTPTrigger().Delete(m2)
	                                          ^
controller/api_test.go:230:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.EnvironmentInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().Environment().Delete(m)
	                                          ^
controller/api_test.go:249:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.EnvironmentInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().Environment().Delete(m2)
	                                          ^
controller/api_test.go:279:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.KubeWatcherInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().KubeWatcher().Delete(m)
	                                          ^
controller/api_test.go:294:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.KubeWatcherInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().KubeWatcher().Delete(m2)
	                                          ^
controller/api_test.go:320:44: Error return value of `(github.com/fission/fission/pkg/controller/client/v1.TimeTriggerInterface).Delete` is not checked (errcheck)
	defer g.Client().V1().TimeTrigger().Delete(m)
	                                          ^
controller/api_test.go:362:41: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.NamespaceInterface).Create` is not checked (errcheck)
	kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
	                                       ^
controller/api_test.go:367:47: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.NamespaceInterface).Delete` is not checked (errcheck)
	defer kubeClient.CoreV1().Namespaces().Delete(testNS, nil)
	                                             ^
mqtrigger/messageQueue/azurequeuestorage/asq.go:322:22: Error return value of `message.Delete` is not checked (errcheck)
	defer message.Delete(nil)
	                    ^
mqtrigger/messageQueue/azurequeuestorage/asq_test.go:332:24: Error return value of `connection.Unsubscribe` is not checked (errcheck)
	connection.Unsubscribe(subscription)
	                      ^
mqtrigger/messageQueue/azurequeuestorage/asq_test.go:483:24: Error return value of `connection.Unsubscribe` is not checked (errcheck)
	connection.Unsubscribe(subscription)
	                      ^
storagesvc/storagesvc.go:68:22: Error return value of `r.ParseMultipartForm` is not checked (errcheck)
	r.ParseMultipartForm(0)
	                    ^
storagesvc/stowClient.go:174:15: Error return value of `errors.Wrap` is not checked (errcheck)
			errors.Wrap(err, "error getting items from container")
			           ^
fission-cli/cmd/spec/spec.go:444:33: S1039: unnecessary use of fmt.Sprintf (gosimple)
			warnings = append(warnings, (fmt.Sprintf("Host in HTTPTrigger spec.Host is now marked as deprecated, see 'help' for details")))
			                             ^
fission-cli/cmd/spec/spec.go:478:32: S1039: unnecessary use of fmt.Sprintf (gosimple)
			warnings = append(warnings, fmt.Sprintf("You have provided both - container spec and pod spec and while merging the pod spec will take precedence."))
			                            ^
crd/crd_test.go:72:11: Error return value of `fi.Delete` is not checked (errcheck)
	fi.Delete(function.ObjectMeta.Name, nil)
	         ^
crd/crd_test.go:120:17: Error return value of `fi.Delete` is not checked (errcheck)
	defer fi.Delete(f.ObjectMeta.Name, nil)
	               ^
crd/crd_test.go:170:11: Error return value of `ei.Delete` is not checked (errcheck)
	ei.Delete(environment.ObjectMeta.Name, nil)
	         ^
crd/crd_test.go:214:17: Error return value of `ei.Delete` is not checked (errcheck)
	defer ei.Delete(e.ObjectMeta.Name, nil)
	               ^
crd/crd_test.go:262:11: Error return value of `ei.Delete` is not checked (errcheck)
	ei.Delete(httpTrigger.ObjectMeta.Name, nil)
	         ^
crd/crd_test.go:445:41: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.NamespaceInterface).Create` is not checked (errcheck)
	kubeClient.CoreV1().Namespaces().Create(&v1.Namespace{
	                                       ^
crd/crd_test.go:450:47: Error return value of `(k8s.io/client-go/kubernetes/typed/core/v1.NamespaceInterface).Delete` is not checked (errcheck)
	defer kubeClient.CoreV1().Namespaces().Delete(testNS, nil)
	                                             ^
crd/crd_test.go:138:3: ineffectual assignment to `recvd` (ineffassign)
		recvd = true
		^
crd/crd_test.go:232:3: ineffectual assignment to `recvd` (ineffassign)
		recvd = true
		^
crd/crd_test.go:324:3: ineffectual assignment to `recvd` (ineffassign)
		recvd = true
		^
buildermgr/pkgwatcher.go:84:25: Error return value of `buildCache.Delete` is not checked (errcheck)
	defer buildCache.Delete(key)
	                       ^
buildermgr/pkgwatcher.go:98:16: Error return value of `updatePackage` is not checked (errcheck)
		updatePackage(pkgw.logger, pkgw.fissionClient, pkg,
		             ^
buildermgr/pkgwatcher.go:176:18: Error return value of `updatePackage` is not checked (errcheck)
				updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
				             ^
buildermgr/pkgwatcher.go:188:18: Error return value of `updatePackage` is not checked (errcheck)
				updatePackage(pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
				             ^
newcache/poolcache_test.go:33:15: Error return value of `c.DeleteValue` is not checked (errcheck)
	c.DeleteValue("func2", "ip2")
	             ^
newcache/poolcache_test.go:44:15: Error return value of `c.DeleteValue` is not checked (errcheck)
	c.DeleteValue("func", "ip")
	             ^
```