### PR TITLE
Fix status code for rate limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/fission/fission
 
-go 1.14
-
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	github.com/Azure/azure-sdk-for-go v12.4.0-beta+incompatible

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/fission/fission
 
+go 1.14
+
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.1.0
 	github.com/Azure/azure-sdk-for-go v12.4.0-beta+incompatible
@@ -25,7 +27,6 @@ require (
 	github.com/go-ini/ini v1.62.0 // indirect
 	github.com/go-openapi/spec v0.17.2
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/gorilla/mux v1.7.0
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/graymeta/stow v0.0.0-20180719215413-7b5498c561bb
@@ -40,12 +41,9 @@ require (
 	github.com/nats-io/nats.go v1.9.1
 	github.com/nats-io/stan.go v0.6.0
 	github.com/nwaples/rardecode v1.1.0 // indirect
-	github.com/onsi/ginkgo v1.7.0 // indirect
-	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
-	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/common v0.4.1
@@ -53,15 +51,12 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/ulikunitz/xz v0.5.9 // indirect
 	github.com/wcharczuk/go-chart v2.0.1+incompatible
 	go.opencensus.io v0.22.4
-	go.uber.org/multierr v1.5.0 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb
-	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f

--- a/pkg/router/functionHandler_test.go
+++ b/pkg/router/functionHandler_test.go
@@ -65,5 +65,5 @@ func TestProxyErrorHandler(t *testing.T) {
 
 	respRecorder = httptest.NewRecorder()
 	errHandler(respRecorder, req, errors.New("dummy"))
-	assert.Equal(t, http.StatusBadGateway, respRecorder.Code)
+	assert.Equal(t, http.StatusInternalServerError, respRecorder.Code)
 }


### PR DESCRIPTION
Signed-off-by: Harsh Thakur <harshthakur9030@gmail.com>

Fixes https://github.com/fission/fission/issues/1875
Returns the correct status code for rate limits. 
Since there's no way to fetch correct response code from RoundTrip, had to rely on parsing it from the error message. 

Also, I think we  shouldn't retry when we hit the rate limit, instead user is expected to retry later. This way, we avoid holding requests for long time and save resources. 