### PR TITLE
Change alpine base image from 3.10 to 3.13

### DIFF
--- a/cmd/builder/Dockerfile.fission-builder
+++ b/cmd/builder/Dockerfile.fission-builder
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 go build \
     -asmflags=-trimpath=$GOPATH \
     -ldflags "-X github.com/fission/fission/pkg/info.GitCommit=${GITCOMMIT} -X github.com/fission/fission/pkg/info.BuildDate=${BUILDDATE} -X github.com/fission/fission/pkg/info.Version=${BUILDVERSION}"
 
-FROM alpine:3.10 as base
+FROM alpine:3.13 as base
 RUN apk add --update ca-certificates
 COPY --from=builder /go/bin/builder /
 EXPOSE 8001

--- a/cmd/fetcher/Dockerfile.fission-fetcher
+++ b/cmd/fetcher/Dockerfile.fission-fetcher
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 go build \
     -asmflags=-trimpath=$GOPATH \
     -ldflags "-X github.com/fission/fission/pkg/info.GitCommit=${GITCOMMIT} -X github.com/fission/fission/pkg/info.BuildDate=${BUILDDATE} -X github.com/fission/fission/pkg/info.Version=${BUILDVERSION}"
 
-FROM alpine:3.10 as base
+FROM alpine:3.13 as base
 RUN apk add --update ca-certificates
 COPY --from=builder /go/bin/fetcher /
 EXPOSE 8000

--- a/cmd/fission-bundle/Dockerfile.fission-bundle
+++ b/cmd/fission-bundle/Dockerfile.fission-bundle
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 go build \
     -asmflags=-trimpath=$GOPATH \
     -ldflags "-X github.com/fission/fission/pkg/info.GitCommit=${GITCOMMIT} -X github.com/fission/fission/pkg/info.BuildDate=${BUILDDATE} -X github.com/fission/fission/pkg/info.Version=${BUILDVERSION}"
 
-FROM alpine:3.10 as base
+FROM alpine:3.13 as base
 RUN apk add --update ca-certificates
 COPY --from=builder /go/bin/fission-bundle /
 

--- a/cmd/preupgradechecks/Dockerfile.fission-preupgradechecks
+++ b/cmd/preupgradechecks/Dockerfile.fission-preupgradechecks
@@ -37,7 +37,7 @@ RUN CGO_ENABLED=0 go build \
     -asmflags=-trimpath=$GOPATH \
     -ldflags "-X github.com/fission/fission/pkg/info.GitCommit=${GITCOMMIT} -X github.com/fission/fission/pkg/info.BuildDate=${BUILDDATE} -X github.com/fission/fission/pkg/info.Version=${BUILDVERSION}"
 
-FROM alpine:3.10 as base
+FROM alpine:3.13 as base
 RUN apk add --update ca-certificates
 COPY --from=builder /go/bin/pre-upgrade-checks /
 


### PR DESCRIPTION
Alpine 3.10 has reached end-of-support. Using alpine 3.13 instead.
Reference: https://alpinelinux.org/releases/