### PR TITLE
Enhanced routing support

### DIFF
--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -401,11 +401,13 @@ func (spec EnvironmentSpec) Validate() error {
 func (spec HTTPTriggerSpec) Validate() error {
 	result := &multierror.Error{}
 
-	switch spec.Method {
-	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
-		http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace: // no op
-	default:
-		result = multierror.Append(result, MakeValidationErr(ErrorUnsupportedType, "HTTPTriggerSpec.Method", spec.Method, "not a valid HTTP method"))
+	for _, httpMethod := range strings.Split(spec.Method, ",") {
+		switch httpMethod {
+		case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch,
+			http.MethodDelete, http.MethodConnect, http.MethodOptions, http.MethodTrace: // no op
+		default:
+			result = multierror.Append(result, MakeValidationErr(ErrorUnsupportedType, "HTTPTriggerSpec.Method", httpMethod, "not a valid HTTP method"))
+		}
 	}
 
 	result = multierror.Append(result, spec.FunctionReference.Validate())

--- a/pkg/controller/httpTriggerApi.go
+++ b/pkg/controller/httpTriggerApi.go
@@ -131,6 +131,7 @@ func (a *API) checkHTTPTriggerDuplicates(t *fv1.HTTPTrigger) error {
 			// Same resource. No need to check.
 			continue
 		}
+		// TODO: Compare with multiple methods sorted.
 		if ht.Spec.RelativeURL == t.Spec.RelativeURL && ht.Spec.Method == t.Spec.Method && ht.Spec.Host == t.Spec.Host {
 			return ferror.MakeError(ferror.ErrorNameExists,
 				fmt.Sprintf("HTTPTrigger with same Host, URL & method already exists (%v)",

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -343,7 +343,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		triggerUrl = fmt.Sprintf("/%s", triggerUrl)
 	}
 
-	method, err := httptrigger.GetMethod(input.String(flagkey.HtMethod))
+	method, err := httptrigger.GetMethods(input.String(flagkey.HtMethod))
 	if err != nil {
 		return errors.Wrap(err, "error getting HTTP trigger method")
 	}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -141,6 +141,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 }
 
 func doHTTPRequest(ctx context.Context, url string, headers []string, method, body string) (*http.Response, error) {
+	// TODO: check if GetMethods should be called.
 	method, err := httptrigger.GetMethod(method)
 	if err != nil {
 		return nil, err

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -220,13 +221,19 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 			req.URL.Scheme = roundTripper.serviceURL.Scheme
 			req.URL.Host = roundTripper.serviceURL.Host
 
-			// To keep the function run container simple, it
-			// doesn't do any routing.  In the future if we have
-			// multiple functions per container, we could use the
-			// function metadata here.
-			// leave the query string intact (req.URL.RawQuery)
-			req.URL.Path = "/"
-
+			if strings.HasSuffix(roundTripper.funcHandler.httpTrigger.Spec.RelativeURL, "/*") {
+				// If prefix based route mentioned, then pass to app by filtering
+				prefixURL := strings.TrimPrefix(req.URL.Path, strings.TrimSuffix(roundTripper.funcHandler.httpTrigger.Spec.RelativeURL, "/*"))
+				roundTripper.logger.Debug("prefix request URL", zap.Any("url", prefixURL))
+				req.URL.Path = prefixURL
+			} else {
+				// To keep the function run container simple, it
+				// doesn't do any routing.  In the future if we have
+				// multiple functions per container, we could use the
+				// function metadata here.
+				// leave the query string intact (req.URL.RawQuery)
+				req.URL.Path = "/"
+			}
 			// Overwrite request host with internal host,
 			// or request will be blocked in some situations
 			// (e.g. istio-proxy)

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -19,6 +19,7 @@ package router
 import (
 	"context"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -167,8 +168,16 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router 
 			}
 		}
 
-		ht := muxRouter.HandleFunc(trigger.Spec.RelativeURL, fh.handler)
-		ht.Methods(trigger.Spec.Method)
+		var ht *mux.Route
+
+		if strings.HasSuffix(trigger.Spec.RelativeURL, "/*") {
+			urlWithoutSuffix := strings.TrimSuffix(trigger.Spec.RelativeURL, "*")
+			ht = muxRouter.PathPrefix(urlWithoutSuffix).HandlerFunc(fh.handler)
+		} else {
+			ht = muxRouter.HandleFunc(trigger.Spec.RelativeURL, fh.handler)
+			ht.Methods(trigger.Spec.Method)
+		}
+
 		if trigger.Spec.Host != "" {
 			ht.Host(trigger.Spec.Host)
 		}

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -175,7 +175,8 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router 
 			ht = muxRouter.PathPrefix(urlWithoutSuffix).HandlerFunc(fh.handler)
 		} else {
 			ht = muxRouter.HandleFunc(trigger.Spec.RelativeURL, fh.handler)
-			ht.Methods(trigger.Spec.Method)
+			// Split for multiple values and pass to lower function
+			ht.Methods(strings.Split(trigger.Spec.Method, ",")...)
 		}
 
 		if trigger.Spec.Host != "" {


### PR DESCRIPTION
### Tasks
- [x] POC: Enable prefix based routing
- [x] POC: Enable multiple HTTP verbs for route
- [ ] Decide if we should add custom field in HTTPTrigger Spec for prefix based route
- [ ] Decide if we should convert method in HTTPTrigger Spec to list instead of string
- [ ] Update relative documentation 
- [ ] Add applicable testcases 
- [ ] Add sample in Fission

### Usage
1. Create a kind cluster
2. Checkout branch `enhanced-routing-support`
3. Deploy Fission with Skaffold
```bash
skaffold run -p kind
```
4. Rebuild Fission CLI
```bash
go build -o cmd/fission-cli/fission ./cmd/fission-cli/
cp  ./cmd/fission-cli/fission /usr/local/bin/fission
```

### Testing
Use this app for verifying changes.
https://github.com/sanketsudake/fission-nextjs-function


