### PR TITLE
Update deprecated functions/methods calls

### DIFF
--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -256,7 +256,7 @@ Options:
 	defer logger.Sync()
 
 	version := fmt.Sprintf("Fission Bundle Version: %v", info.BuildInfo().String())
-	arguments, err := docopt.Parse(usage, nil, true, version, false)
+	arguments, err := docopt.ParseArgs(usage, nil, version)
 	if err != nil {
 		logger.Fatal("Could not parse command line arguments", zap.Error(err))
 	}

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -51,7 +51,7 @@ Options:
   --fn-pod-namespace=<podNamespace>                        Namespace where function pods get deployed.
   --envbuilder-namespace=<envBuilderNamespace>             Namespace where builder env pods are deployed.`
 
-	arguments, err := docopt.Parse(usage, nil, true, info.BuildInfo().String(), false)
+	arguments, err := docopt.ParseArgs(usage, nil, info.BuildInfo().String())
 	if err != nil {
 		logger.Fatal("Could not parse command line arguments", zap.Error(err))
 	}

--- a/pkg/mqtrigger/messageQueue/kafka/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka/kafka.go
@@ -212,7 +212,6 @@ func (kafka Kafka) getTLSConfig() (*tls.Config, error) {
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(kafka.authKeys["caCert"])
 	tlsConfig.RootCAs = caCertPool
-	tlsConfig.BuildNameToCertificate()
 
 	return &tlsConfig, nil
 }
@@ -323,7 +322,7 @@ func kafkaMsgHandler(kafka *Kafka, producer sarama.SyncProducer, trigger *fv1.Me
 		return
 	}
 	if resp.StatusCode != 200 {
-		errorString := string("request returned failure: " + string(resp.StatusCode))
+		errorString := string("request returned failure: " + strconv.Itoa(resp.StatusCode))
 		errorHeaders := generateErrorHeaders(errorString)
 		errorHandler(kafka.logger, trigger, producer, url,
 			fmt.Errorf("request returned failure: %v", resp.StatusCode), errorHeaders)


### PR DESCRIPTION
Running `golangci-lint` reports use of deprecated code:

```
fission on ~ master [$] via 🐹 v1.16.3
➜ golangci-lint run

pkg/mqtrigger/messageQueue/kafka/kafka.go:215:2: SA1019: tlsConfig.BuildNameToCertificate is deprecated: NameToCertificate only allows associating a single certificate with a given name. Leave that field nil to let the library select the first compatible chain from Certificates. (staticcheck)
	tlsConfig.BuildNameToCertificate()
	^

cmd/fission-bundle/main.go:259:20: SA1019: docopt.Parse is deprecated: Parse is provided for backward compatibility with the original docopt.go package. Please rather make use of ParseDoc, ParseArgs, or use your own custom Parser. (staticcheck)
	arguments, err := docopt.Parse(usage, nil, true, version, false)
	                  ^
cmd/preupgradechecks/main.go:54:20: SA1019: docopt.Parse is deprecated: Parse is provided for backward compatibility with the original docopt.go package. Please rather make use of ParseDoc, ParseArgs, or use your own custom Parser. (staticcheck)
	arguments, err := docopt.Parse(usage, nil, true, info.BuildInfo().String(), false)
```