### PR TITLE
Handle SIGTERM signal in mqtrigger subscriber

### DIFF
--- a/test/tests/mqtrigger/nats/stan-sub/main.go
+++ b/test/tests/mqtrigger/nats/stan-sub/main.go
@@ -23,6 +23,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
 
 	nats "github.com/nats-io/nats.go"
@@ -168,10 +169,10 @@ func main() {
 	// Run cleanup when signal is received
 	signalChan := make(chan os.Signal, 1)
 	cleanupDone := make(chan bool)
-	signal.Notify(signalChan, os.Interrupt)
+	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
-		for range signalChan {
-			fmt.Printf("\nReceived an interrupt, unsubscribing and closing connection...\n\n")
+		for sig := range signalChan {
+			fmt.Printf("\nReceived signal %s, unsubscribing and closing connection...\n\n", sig.String())
 			// Do not unsubscribe a durable on exit, except if asked to.
 			if durable == "" || unsubscribe {
 				sub.Unsubscribe()

--- a/test/tests/mqtrigger/nats/test_mqtrigger.sh
+++ b/test/tests/mqtrigger/nats/test_mqtrigger.sh
@@ -59,7 +59,7 @@ go run $DIR/stan-pub/main.go -s $FISSION_NATS_STREAMING_URL -c $clusterID -id $p
 # Wait for message on response topic 
 #
 log "Waiting for response"
-response=$(timeout 5s go run $DIR/stan-sub/main.go --last -s $FISSION_NATS_STREAMING_URL -c $clusterID -id $subClientID $resptopic 2>&1 || true)
+response=$(timeout 10s go run $DIR/stan-sub/main.go --last -s $FISSION_NATS_STREAMING_URL -c $clusterID -id $subClientID $resptopic 2>&1 || true)
 log "Output from subscriber"
 echo "$response"
 echo "$response" | grep "$expectedRespOutput"

--- a/test/tests/mqtrigger/nats/test_mqtrigger_error.sh
+++ b/test/tests/mqtrigger/nats/test_mqtrigger_error.sh
@@ -63,7 +63,7 @@ go run $DIR/stan-pub/main.go -s $FISSION_NATS_STREAMING_URL -c $clusterID -id $p
 # Wait for message on error topic
 #
 log "Waiting for response"
-response=$(timeout 5s go run $DIR/stan-sub/main.go --last -s $FISSION_NATS_STREAMING_URL -c $clusterID -id $subClientID $errortopic 2>&1 || true)
+response=$(timeout 10s go run $DIR/stan-sub/main.go --last -s $FISSION_NATS_STREAMING_URL -c $clusterID -id $subClientID $errortopic 2>&1 || true)
 log "Output from subscriber"
 echo "$response"
 echo "$response" | grep "$expectedRespOutput"


### PR DESCRIPTION
In test_mqtrigger.sh and test_mqtrigger_error.sh tests, we timeout program
if not received right output. Ensuring we capture timeout signal and do program
cleanup accordingly. Also printing due to which signal program failed.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>