### PR TITLE
Use latest 1.14 go version in CI

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: setup go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: '1.14.0' 
+        go-version: '1.14.15'
 
     - name: Helm installation
       uses: Azure/setup-helm@v1


### PR DESCRIPTION
We are facing issue https://github.com/golang/go/issues/37436
in CI for multiple PRs. Trying to switch to latest go version from 1.14 tree.

Reference https://github.com/actions/go-versions/blob/main/versions-manifest.json
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>