### PR TITLE
OnlyOnce preupgrade check

### DIFF
--- a/cmd/preupgradechecks/preupgradechecks.go
+++ b/cmd/preupgradechecks/preupgradechecks.go
@@ -87,7 +87,7 @@ func (client *PreUpgradeTaskClient) LatestSchemaApplied() error {
 		return errors.New("Could not get the Function CRD")
 	}
 	// Any new field added in Function spec can be checked here provided the substring matches the description in CRD Validation of the field
-	if !strings.Contains(crd.Spec.String(), "RequestsPerPod") && !strings.Contains(crd.Spec.String(), "OnceOnly") {
+	if !strings.Contains(crd.Spec.String(), "RequestsPerPod") || !strings.Contains(crd.Spec.String(), "OnceOnly") {
 		return errors.New("Apply the newer CRDs before upgrading")
 	}
 	return nil

--- a/cmd/preupgradechecks/preupgradechecks.go
+++ b/cmd/preupgradechecks/preupgradechecks.go
@@ -87,7 +87,7 @@ func (client *PreUpgradeTaskClient) LatestSchemaApplied() error {
 		return errors.New("Could not get the Function CRD")
 	}
 	// Any new field added in Function spec can be checked here provided the substring matches the description in CRD Validation of the field
-	if !strings.Contains(crd.Spec.String(), "RequestsPerPod") {
+	if !strings.Contains(crd.Spec.String(), "RequestsPerPod") && !strings.Contains(crd.Spec.String(), "OnceOnly") {
 		return errors.New("Apply the newer CRDs before upgrading")
 	}
 	return nil


### PR DESCRIPTION
Note: the newer CRDs are not present in this commit or the latest branch yet. 
Newer CRDs are generated in this PR:
https://github.com/fission/fission/pull/2033

Signed-off-by: Harsh Thakur <harshthakur9030@gmail.com>