### PR TITLE
Change examples references to examples repostiory

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ aggregation &mdash; also helps with ops on your Fission deployment.
   $ fission env create --name nodejs --image fission/node-env
 
   # Create a function with a javascript one-liner that prints "hello world"
-  $ fission function create --name hello --env nodejs --code https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js
+  $ fission function create --name hello --env nodejs --code https://raw.githubusercontent.com/fission/examples/master/nodejs/hello.js
 
   # Run the function.  This takes about 100msec the first time.
   $ fission function test --name hello

--- a/charts/fission-all/templates/NOTES.txt
+++ b/charts/fission-all/templates/NOTES.txt
@@ -15,7 +15,7 @@ Windows:
   $ fission env create --name nodejs --image fission/node-env
 
   # Get a hello world
-  $ curl https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js > hello.js
+  $ curl https://raw.githubusercontent.com/fission/examples/master/nodejs/hello.js > hello.js
 
   # Register this function with Fission
   $ fission function create --name hello --env nodejs --code hello.js

--- a/charts/fission-core/templates/NOTES.txt
+++ b/charts/fission-core/templates/NOTES.txt
@@ -15,7 +15,7 @@ Windows:
   $ fission env create --name nodejs --image fission/node-env
 
   # Get a hello world
-  $ curl https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js > hello.js
+  $ curl https://raw.githubusercontent.com/fission/examples/master/nodejs/hello.js > hello.js
 
   # Register this function with Fission
   $ fission function create --name hello --env nodejs --code hello.js

--- a/test/tests/test_create_fn_with_url.sh
+++ b/test/tests/test_create_fn_with_url.sh
@@ -10,7 +10,7 @@ ROOT=$(dirname $0)/../..
 
 env=nodejs-$TEST_ID
 fn=nodejs-hello-$TEST_ID
-code_url=https://raw.githubusercontent.com/fission/fission/master/examples/nodejs/hello.js
+code_url=https://raw.githubusercontent.com/fission/examples/master/nodejs/hello.js
 base64val=$(wget -O- ${code_url} | base64)
 
 cleanup() {


### PR DESCRIPTION
Since we recently migrated all fission examples to fission/examples repository, we need to change
respective references.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>