### PR TITLE
Add metrics to Router and Executor

### DIFF
--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -600,7 +600,7 @@ func (deploy *NewDeploy) fnCreate(fn *fv1.Function) (*fscache.FuncSvc, error) {
 		return fsvc, err
 	}
 
-	deploy.fsCache.IncreaseColdStarts(fn.ObjectMeta.Name, string(fn.ObjectMeta.UID))
+	deploy.fsCache.IncreaseColdStarts(fn.ObjectMeta.Name, string(fn.ObjectMeta.UID), fsvc.Cached)
 
 	return fsvc, nil
 }

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -285,7 +285,6 @@ func (gp *GenericPool) choosePod(newLabels map[string]string) (string, *apiv1.Po
 		gp.logger.Info("chose pod", zap.Any("labels", newLabels),
 			zap.String("pod", chosenPod.Name), zap.Duration("elapsed_time", time.Since(startTime)))
 
-		gp.fsCache.ObserveChoosePodTime(gp.env.Name, string(gp.env.ObjectMeta.UID), time.Since(startTime))
 		return key, chosenPod, nil
 	}
 }

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -285,6 +285,7 @@ func (gp *GenericPool) choosePod(newLabels map[string]string) (string, *apiv1.Po
 		gp.logger.Info("chose pod", zap.Any("labels", newLabels),
 			zap.String("pod", chosenPod.Name), zap.Duration("elapsed_time", time.Since(startTime)))
 
+		gp.fsCache.ObserveChoosePodTime(gp.env.Name, string(gp.env.ObjectMeta.UID), time.Since(startTime))
 		return key, chosenPod, nil
 	}
 }
@@ -347,6 +348,7 @@ func (gp *GenericPool) getFetcherURL(podIP string) string {
 // (via fetcher), and calls the function-run container to load it, resulting in a
 // specialized pod.
 func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv1.Function) error {
+	startTime := time.Now()
 	// for fetcher we don't need to create a service, just talk to the pod directly
 	podIP := pod.Status.PodIP
 	if len(podIP) == 0 {
@@ -370,9 +372,10 @@ func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv
 	// invoke environment specialize api for pod specialization.
 	err := fetcherClient.MakeClient(gp.logger, fetcherURL).Specialize(ctx, &specializeReq)
 	if err != nil {
+		gp.fsCache.ObserveSpecialisePodTime(gp.env.Name, string(gp.env.ObjectMeta.UID), false, time.Since(startTime))
 		return err
 	}
-
+	gp.fsCache.ObserveSpecialisePodTime(gp.env.Name, string(gp.env.ObjectMeta.UID), false, time.Since(startTime))
 	return nil
 }
 
@@ -696,7 +699,7 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 	gp.podFSVCMap.Store(pod.ObjectMeta.Name, []interface{}{crd.CacheKey(fsvc.Function), fsvc.Address})
 	gp.fsCache.AddFunc(*fsvc)
 
-	gp.fsCache.IncreaseColdStarts(fn.ObjectMeta.Name, string(fn.ObjectMeta.UID))
+	gp.fsCache.IncreaseColdStarts(fn.ObjectMeta.Name, string(fn.ObjectMeta.UID), fsvc.Cached)
 
 	return fsvc, nil
 }

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -57,8 +57,9 @@ type (
 		Executor          fv1.ExecutorType
 		CPULimit          resource.Quantity
 
-		Ctime time.Time
-		Atime time.Time
+		Cached bool
+		Ctime  time.Time
+		Atime  time.Time
 	}
 
 	// FunctionServiceCache represents the function service cache
@@ -227,7 +228,7 @@ func (fsc *FunctionServiceCache) AddFunc(fsvc FuncSvc) {
 	fsvc.Ctime = now
 	fsvc.Atime = now
 
-	fsc.setFuncAlive(fsvc.Function.Name, string(fsvc.Function.UID), true)
+	fsc.setFuncAlive(fsvc.Function.Name, string(fsvc.Function.UID), true, fsvc.Cached)
 }
 
 // SetCPUUtilizaton updates/sets CPUutilization in the pool cache
@@ -283,7 +284,7 @@ func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 		return nil, err
 	}
 
-	fsc.setFuncAlive(fsvc.Function.Name, string(fsvc.Function.UID), true)
+	fsc.setFuncAlive(fsvc.Function.Name, string(fsvc.Function.UID), true, fsvc.Cached)
 	return nil, nil
 }
 
@@ -344,9 +345,9 @@ func (fsc *FunctionServiceCache) DeleteEntry(fsvc *FuncSvc) {
 		)
 	}
 
-	fsc.observeFuncRunningTime(fsvc.Function.Name, string(fsvc.Function.UID), fsvc.Atime.Sub(fsvc.Ctime).Seconds())
-	fsc.observeFuncAliveTime(fsvc.Function.Name, string(fsvc.Function.UID), time.Since(fsvc.Ctime).Seconds())
-	fsc.setFuncAlive(fsvc.Function.Name, string(fsvc.Function.UID), false)
+	fsc.observeFuncRunningTime(fsvc.Function.Name, string(fsvc.Function.UID), fsvc.Atime.Sub(fsvc.Ctime).Seconds(), fsvc.Cached)
+	fsc.observeFuncAliveTime(fsvc.Function.Name, string(fsvc.Function.UID), time.Since(fsvc.Ctime).Seconds(), fsvc.Cached)
+	fsc.setFuncAlive(fsvc.Function.Name, string(fsvc.Function.UID), false, fsvc.Cached)
 }
 
 // DeleteFunctionSvc deletes a function service at key composed of [function][address].

--- a/pkg/executor/fscache/metrics.go
+++ b/pkg/executor/fscache/metrics.go
@@ -1,10 +1,13 @@
 package fscache
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
+	labelsStrings = []string{"funcname", "funcuid", "cached"}
 	// funcname: the function's name
 	// funcuid: the function's version id
 	coldStarts = prometheus.NewCounterVec(
@@ -12,7 +15,7 @@ var (
 			Name: "fission_cold_starts_total",
 			Help: "How many cold starts are made by funcname, funcuid.",
 		},
-		[]string{"funcname", "funcuid"},
+		labelsStrings,
 	)
 	funcRunningSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
@@ -20,7 +23,7 @@ var (
 			Help:       "The running time (last access - create) in seconds of the function.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"funcname", "funcuid"},
+		labelsStrings,
 	)
 	funcAliveSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
@@ -28,14 +31,31 @@ var (
 			Help:       "The alive time in seconds of the function.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"funcname", "funcuid"},
+		labelsStrings,
 	)
 	funcIsAlive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "fission_func_is_alive",
 			Help: "A binary value indicating is the funcname, funcuid alive",
 		},
-		[]string{"funcname", "funcuid"},
+		labelsStrings,
+	)
+	funcChoosePod = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "fission_func_choose_pod",
+			Help:       "Time taken to choose a pod, applicable to PoolManager only",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		},
+		labelsStrings,
+	)
+
+	funcSpecialisePod = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "fission_func_specialise_pod",
+			Help:       "Time taken to specialise a pod",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+		},
+		labelsStrings,
 	)
 	funcReapTime = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
@@ -66,24 +86,60 @@ func init() {
 }
 
 // IncreaseColdStarts increments the counter by 1.
-func (fsc *FunctionServiceCache) IncreaseColdStarts(funcname, funcuid string) {
-	coldStarts.WithLabelValues(funcname, funcuid).Inc()
+func (fsc *FunctionServiceCache) IncreaseColdStarts(funcname, funcuid string, cached bool) {
+	var c string
+	if cached == false {
+		c = "false"
+	}
+	c = "true"
+	coldStarts.WithLabelValues(funcname, funcuid, c).Inc()
 }
 
-func (fsc *FunctionServiceCache) observeFuncRunningTime(funcname, funcuid string, running float64) {
-	funcRunningSummary.WithLabelValues(funcname, funcuid).Observe(running)
+func (fsc *FunctionServiceCache) observeFuncRunningTime(funcname, funcuid string, running float64, cached bool) {
+	var c string
+	if cached == false {
+		c = "false"
+	}
+	c = "true"
+	funcRunningSummary.WithLabelValues(funcname, funcuid, c).Observe(running)
 }
 
-func (fsc *FunctionServiceCache) observeFuncAliveTime(funcname, funcuid string, alive float64) {
-	funcAliveSummary.WithLabelValues(funcname, funcuid).Observe(alive)
+func (fsc *FunctionServiceCache) observeFuncAliveTime(funcname, funcuid string, alive float64, cached bool) {
+	var c string
+	if cached == false {
+		c = "false"
+	}
+	c = "true"
+	funcAliveSummary.WithLabelValues(funcname, funcuid, c).Observe(alive)
 }
 
-func (fsc *FunctionServiceCache) setFuncAlive(funcname, funcuid string, isAlive bool) {
+// ObserveChoosePodTime observes the time taken to choose a pod
+func (fsc *FunctionServiceCache) ObserveChoosePodTime(envName, envuid string, duration time.Duration) {
+
+	funcChoosePod.WithLabelValues(envName, envuid).Observe(float64(duration.Nanoseconds()) / 1e9)
+}
+
+// ObserveSpecialisePodTime observes the time taken to choose a pod
+func (fsc *FunctionServiceCache) ObserveSpecialisePodTime(envName, envuid string, err bool, duration time.Duration) {
+
+	var e string
+	if err == false {
+		e = "false"
+	}
+	e = "true"
+	funcSpecialisePod.WithLabelValues(envName, envuid, e).Observe(float64(duration.Nanoseconds()) / 1e9)
+}
+func (fsc *FunctionServiceCache) setFuncAlive(funcname, funcuid string, isAlive bool, cached bool) {
+	var c string
+	if cached == false {
+		c = "false"
+	}
+	c = "true"
 	count := 0
 	if isAlive {
 		count = 1
 	}
-	funcIsAlive.WithLabelValues(funcname, funcuid).Set(float64(count))
+	funcIsAlive.WithLabelValues(funcname, funcuid, c).Set(float64(count))
 }
 
 // ReapTime is the amount of time taken to reap a pod

--- a/pkg/executor/fscache/metrics.go
+++ b/pkg/executor/fscache/metrics.go
@@ -49,11 +49,10 @@ var (
 		labelsStrings,
 	)
 
-	funcSpecialisePod = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name:       "fission_func_specialise_pod",
-			Help:       "Time taken to specialise a pod",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	funcSpecialisePod = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "fission_func_specialise_pod",
+			Help: "Time taken to specialise a pod",
 		},
 		labelsStrings,
 	)
@@ -81,35 +80,43 @@ func init() {
 	prometheus.MustRegister(funcRunningSummary)
 	prometheus.MustRegister(funcAliveSummary)
 	prometheus.MustRegister(funcIsAlive)
+<<<<<<< HEAD
 	prometheus.MustRegister(funcReapTime)
 	prometheus.MustRegister(idleTime)
+=======
+	prometheus.MustRegister(funcSpecialisePod)
+	prometheus.MustRegister(funcChoosePod)
+>>>>>>> 99ac163... Remove call to ready pod metric
 }
 
 // IncreaseColdStarts increments the counter by 1.
 func (fsc *FunctionServiceCache) IncreaseColdStarts(funcname, funcuid string, cached bool) {
 	var c string
-	if cached == false {
+	if cached {
+		c = "true"
+	} else {
 		c = "false"
 	}
-	c = "true"
 	coldStarts.WithLabelValues(funcname, funcuid, c).Inc()
 }
 
 func (fsc *FunctionServiceCache) observeFuncRunningTime(funcname, funcuid string, running float64, cached bool) {
 	var c string
-	if cached == false {
+	if cached {
+		c = "true"
+	} else {
 		c = "false"
 	}
-	c = "true"
 	funcRunningSummary.WithLabelValues(funcname, funcuid, c).Observe(running)
 }
 
 func (fsc *FunctionServiceCache) observeFuncAliveTime(funcname, funcuid string, alive float64, cached bool) {
 	var c string
-	if cached == false {
+	if cached {
+		c = "true"
+	} else {
 		c = "false"
 	}
-	c = "true"
 	funcAliveSummary.WithLabelValues(funcname, funcuid, c).Observe(alive)
 }
 
@@ -123,18 +130,20 @@ func (fsc *FunctionServiceCache) ObserveChoosePodTime(envName, envuid string, du
 func (fsc *FunctionServiceCache) ObserveSpecialisePodTime(envName, envuid string, err bool, duration time.Duration) {
 
 	var e string
-	if err == false {
+	if err {
+		e = "true"
+	} else {
 		e = "false"
 	}
-	e = "true"
 	funcSpecialisePod.WithLabelValues(envName, envuid, e).Observe(float64(duration.Nanoseconds()) / 1e9)
 }
 func (fsc *FunctionServiceCache) setFuncAlive(funcname, funcuid string, isAlive bool, cached bool) {
 	var c string
-	if cached == false {
+	if cached {
+		c = "true"
+	} else {
 		c = "false"
 	}
-	c = "true"
 	count := 0
 	if isAlive {
 		count = 1

--- a/pkg/executor/fscache/metrics.go
+++ b/pkg/executor/fscache/metrics.go
@@ -1,6 +1,7 @@
 package fscache
 
 import (
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -88,64 +89,32 @@ func init() {
 
 // IncreaseColdStarts increments the counter by 1.
 func (fsc *FunctionServiceCache) IncreaseColdStarts(funcname, funcuid string, cached bool) {
-	var c string
-	if cached {
-		c = "true"
-	} else {
-		c = "false"
-	}
-	coldStarts.WithLabelValues(funcname, funcuid, c).Inc()
+	coldStarts.WithLabelValues(funcname, funcuid, strconv.FormatBool(cached)).Inc()
 }
 
 func (fsc *FunctionServiceCache) observeFuncRunningTime(funcname, funcuid string, running float64, cached bool) {
-	var c string
-	if cached {
-		c = "true"
-	} else {
-		c = "false"
-	}
-	funcRunningSummary.WithLabelValues(funcname, funcuid, c).Observe(running)
+	funcRunningSummary.WithLabelValues(funcname, funcuid, strconv.FormatBool(cached)).Observe(running)
 }
 
 func (fsc *FunctionServiceCache) observeFuncAliveTime(funcname, funcuid string, alive float64, cached bool) {
-	var c string
-	if cached {
-		c = "true"
-	} else {
-		c = "false"
-	}
-	funcAliveSummary.WithLabelValues(funcname, funcuid, c).Observe(alive)
+	funcAliveSummary.WithLabelValues(funcname, funcuid, strconv.FormatBool(cached)).Observe(alive)
 }
 
 // ObserveChoosePodTime observes the time taken to choose a pod
 func (fsc *FunctionServiceCache) ObserveChoosePodTime(envName, envuid string, duration time.Duration) {
-
 	funcChoosePod.WithLabelValues(envName, envuid).Observe(float64(duration.Nanoseconds()) / 1e9)
 }
 
 // ObserveSpecialisePodTime observes the time taken to choose a pod
 func (fsc *FunctionServiceCache) ObserveSpecialisePodTime(envName, envuid string, err bool, duration time.Duration) {
-
-	var e string
-	if err {
-		e = "true"
-	} else {
-		e = "false"
-	}
-	funcSpecialisePod.WithLabelValues(envName, envuid, e).Observe(float64(duration.Nanoseconds()) / 1e9)
+	funcSpecialisePod.WithLabelValues(envName, envuid, strconv.FormatBool(err)).Observe(float64(duration.Nanoseconds()) / 1e9)
 }
 func (fsc *FunctionServiceCache) setFuncAlive(funcname, funcuid string, isAlive bool, cached bool) {
-	var c string
-	if cached {
-		c = "true"
-	} else {
-		c = "false"
-	}
 	count := 0
 	if isAlive {
 		count = 1
 	}
-	funcIsAlive.WithLabelValues(funcname, funcuid, c).Set(float64(count))
+	funcIsAlive.WithLabelValues(funcname, funcuid, strconv.FormatBool(cached)).Set(float64(count))
 }
 
 // ReapTime is the amount of time taken to reap a pod

--- a/pkg/executor/fscache/metrics.go
+++ b/pkg/executor/fscache/metrics.go
@@ -80,13 +80,10 @@ func init() {
 	prometheus.MustRegister(funcRunningSummary)
 	prometheus.MustRegister(funcAliveSummary)
 	prometheus.MustRegister(funcIsAlive)
-<<<<<<< HEAD
 	prometheus.MustRegister(funcReapTime)
 	prometheus.MustRegister(idleTime)
-=======
 	prometheus.MustRegister(funcSpecialisePod)
 	prometheus.MustRegister(funcChoosePod)
->>>>>>> 99ac163... Remove call to ready pod metric
 }
 
 // IncreaseColdStarts increments the counter by 1.

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -48,7 +48,7 @@ const (
 	// FORWARDED represents the 'Forwarded' request header
 	FORWARDED = "Forwarded"
 
-	// XForwardedHost represents the 'XForwardedHost' request header
+	// XForwardedHost represents the 'X-Forwarded-Host' request header
 	XForwardedHost = "X-Forwarded-Host"
 )
 

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -584,7 +584,9 @@ func (fn functionHandler) removeServiceEntryFromCache() {
 	fn.fmap.remove(&fn.function.ObjectMeta)
 }
 
-func (fh functionHandler) getServiceEntryFromExecutor() (serviceUrl *url.URL, err error) {
+// getServiceEntryFromExecutor returns service url entry returns from executor
+func (fh functionHandler) getServiceEntryFromExecutor() (*url.URL, error) {
+	startTime := time.Now()
 	// send a request to executor to specialize a new pod
 	fh.logger.Debug("function timeout specified", zap.Int("timeout", fh.function.Spec.FunctionTimeout))
 	timeout := 30 * time.Second
@@ -601,8 +603,13 @@ func (fh functionHandler) getServiceEntryFromExecutor() (serviceUrl *url.URL, er
 			zap.String("error_message", errMsg),
 			zap.Any("function", fh.function),
 			zap.Int("status_code", statusCode))
+		duration := time.Since(startTime)
+		observeServiceURLFetchTime(duration, true)
 		return nil, err
 	}
+	duration := time.Since(startTime)
+	observeServiceURLFetchTime(duration, false)
+
 	// parse the address into url
 	svcURL, err := url.Parse(fmt.Sprintf("http://%v", service))
 	if err != nil {

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -48,8 +48,8 @@ const (
 	// FORWARDED represents the 'Forwarded' request header
 	FORWARDED = "Forwarded"
 
-	// X_FORWARDED_HOST represents the 'X_FORWARDED_HOST' request header
-	X_FORWARDED_HOST = "X-Forwarded-Host"
+	// XForwardedHost represents the 'XForwardedHost' request header
+	XForwardedHost = "X-Forwarded-Host"
 )
 
 type (
@@ -391,6 +391,7 @@ func (fh *functionHandler) tapService(fn *fv1.Function, serviceURL *url.URL) {
 }
 
 func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {
+	fh.collectFunctionMetricBeforeProcessing(request)
 	if fh.httpTrigger != nil && fh.httpTrigger.Spec.FunctionReference.Type == fv1.FunctionReferenceTypeFunctionWeights {
 		// canary deployment. need to determine the function to send request to now
 		fn := getCanaryBackend(fh.functionMap, fh.fnWeightDistributionList)
@@ -494,7 +495,7 @@ func (roundTripper RetryingRoundTripper) addForwardedHostHeader(req *http.Reques
 	// for more detailed information, please visit:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
 
-	if len(req.Header.Get(FORWARDED)) > 0 || len(req.Header.Get(X_FORWARDED_HOST)) > 0 {
+	if len(req.Header.Get(FORWARDED)) > 0 || len(req.Header.Get(XForwardedHost)) > 0 {
 		// forwarded headers were set by external proxy, leave them intact
 		return
 	}
@@ -529,15 +530,15 @@ func (roundTripper RetryingRoundTripper) addForwardedHostHeader(req *http.Reques
 	}
 
 	req.Header.Set(FORWARDED, host)
-	req.Header.Set(X_FORWARDED_HOST, req.Host)
+	req.Header.Set(XForwardedHost, req.Host)
 }
 
 // unTapservice marks the serviceURL in executor's cache as inactive, so that it can be reused
-func (fh functionHandler) unTapService(fn *fv1.Function, serviceUrl *url.URL) error {
+func (fh functionHandler) unTapService(fn *fv1.Function, serviceURL *url.URL) error {
 	fh.logger.Info("UnTapService Called")
 	ctx, cancel := context.WithTimeout(context.Background(), fh.unTapServiceTimeout)
 	defer cancel()
-	err := fh.executor.UnTapService(ctx, fn.ObjectMeta, fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType, serviceUrl)
+	err := fh.executor.UnTapService(ctx, fn.ObjectMeta, fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType, serviceURL)
 	if err != nil {
 		statusCode, errMsg := ferror.GetHTTPError(err)
 		fh.logger.Error("error from UnTapService",
@@ -701,6 +702,24 @@ func (fh functionHandler) getProxyErrorHandler(start time.Time, rrt *RetryingRou
 	}
 }
 
+func (fh functionHandler) collectFunctionMetricBeforeProcessing(req *http.Request) {
+
+	// Metrics stuff
+	funcMetricLabels := &functionLabels{
+		namespace: fh.function.ObjectMeta.Namespace,
+		name:      fh.function.ObjectMeta.Name,
+	}
+	httpMetricLabels := &httpLabels{
+		method: req.Method,
+	}
+	if fh.httpTrigger != nil {
+		httpMetricLabels.host = fh.httpTrigger.Spec.Host
+		httpMetricLabels.path = fh.httpTrigger.Spec.RelativeURL
+	}
+	incrementRequest(funcMetricLabels, httpMetricLabels, string(fh.function.ObjectMeta.UID))
+
+}
+
 func (fh functionHandler) collectFunctionMetric(start time.Time, rrt *RetryingRoundTripper, req *http.Request, resp *http.Response) {
 	duration := time.Since(start)
 
@@ -726,7 +745,7 @@ func (fh functionHandler) collectFunctionMetric(start time.Time, rrt *RetryingRo
 	funcMetricLabels.cached = rrt.urlFromCache
 
 	functionCallCompleted(funcMetricLabels, httpMetricLabels,
-		duration, duration, resp.ContentLength)
+		duration, duration, resp.ContentLength, string(fh.function.ObjectMeta.UID))
 
 	// tapService before invoking roundTrip for the serviceUrl
 	if rrt.urlFromCache {

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"fmt"
+	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -176,11 +177,5 @@ func functionCallCompleted(f *functionLabels, h *httpLabels, overhead, duration 
 }
 
 func observeServiceURLFetchTime(duration time.Duration, err bool) {
-	var e string
-	if err {
-		e = "true"
-	} else {
-		e = "false"
-	}
-	serviceURLFetch.WithLabelValues(e).Observe(float64(duration.Nanoseconds()) / 1e9)
+	serviceURLFetch.WithLabelValues(strconv.FormatBool(err)).Observe(float64(duration.Nanoseconds()) / 1e9)
 }

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -43,7 +43,7 @@ var (
 	metricAddr = ":8080"
 
 	// function + http labels as strings
-	labelsStrings = []string{"cached", "namespace", "name", "host", "path", "method", "code", "funcuid"}
+	labelsStrings = []string{"namespace", "name", "host", "path", "method", "code", "funcuid"}
 
 	labelsStringsForIncomingRequests = []string{"namespace", "name", "host", "path", "method", "funcuid"}
 
@@ -110,14 +110,7 @@ func init() {
 }
 
 func labelsToStrings(f *functionLabels, h *httpLabels, funcuid string) []string {
-	var cached string
-	if f.cached {
-		cached = "true"
-	} else {
-		cached = "false"
-	}
 	return []string{
-		cached,
 		f.namespace,
 		f.name,
 		h.host,
@@ -129,7 +122,6 @@ func labelsToStrings(f *functionLabels, h *httpLabels, funcuid string) []string 
 }
 
 func labelsToStringsBeforeProcessing(f *functionLabels, h *httpLabels, funcuid string) []string {
-
 	return []string{
 		f.namespace,
 		f.name,

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -98,6 +98,14 @@ var (
 		},
 		labelsStringsForIncomingRequests,
 	)
+
+	serviceURLFetch = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "fission_service_fetch_time",
+			Help: "Time taken for Router to get the service URL",
+		},
+		[]string{"error"},
+	)
 )
 
 func init() {
@@ -107,6 +115,7 @@ func init() {
 	prometheus.MustRegister(functionCallOverhead)
 	prometheus.MustRegister(functionCallResponseSize)
 	prometheus.MustRegister(requestsReceived)
+	prometheus.MustRegister(serviceURLFetch)
 }
 
 func labelsToStrings(f *functionLabels, h *httpLabels, funcuid string) []string {
@@ -164,4 +173,14 @@ func functionCallCompleted(f *functionLabels, h *httpLabels, overhead, duration 
 	if respSize != -1 {
 		functionCallResponseSize.WithLabelValues(l...).Observe(float64(respSize))
 	}
+}
+
+func observeServiceURLFetchTime(duration time.Duration, err bool) {
+	var e string
+	if err {
+		e = "true"
+	} else {
+		e = "false"
+	}
+	serviceURLFetch.WithLabelValues(e).Observe(float64(duration.Nanoseconds()) / 1e9)
 }

--- a/pkg/router/requesthHeader.go
+++ b/pkg/router/requesthHeader.go
@@ -26,16 +26,16 @@ import (
 )
 
 const (
-	// HEADERS_FISSION_FUNCTION_PREFIX represents a function prefix request header
-	HEADERS_FISSION_FUNCTION_PREFIX = "Fission-Function"
+	// HeadersFissionFunctionPrefix represents a function prefix request header
+	HeadersFissionFunctionPrefix = "Fission-Function"
 )
 
 // setFunctionMetadataToHeaders set function metadata to request header
 func setFunctionMetadataToHeader(meta *metav1.ObjectMeta, request *http.Request) {
-	request.Header.Set(fmt.Sprintf("X-%s-Uid", HEADERS_FISSION_FUNCTION_PREFIX), string(meta.UID))
-	request.Header.Set(fmt.Sprintf("X-%s-Name", HEADERS_FISSION_FUNCTION_PREFIX), meta.Name)
-	request.Header.Set(fmt.Sprintf("X-%s-Namespace", HEADERS_FISSION_FUNCTION_PREFIX), meta.Namespace)
-	request.Header.Set(fmt.Sprintf("X-%s-ResourceVersion", HEADERS_FISSION_FUNCTION_PREFIX), meta.ResourceVersion)
+	request.Header.Set(fmt.Sprintf("X-%s-Uid", HeadersFissionFunctionPrefix), string(meta.UID))
+	request.Header.Set(fmt.Sprintf("X-%s-Name", HeadersFissionFunctionPrefix), meta.Name)
+	request.Header.Set(fmt.Sprintf("X-%s-Namespace", HeadersFissionFunctionPrefix), meta.Namespace)
+	request.Header.Set(fmt.Sprintf("X-%s-ResourceVersion", HeadersFissionFunctionPrefix), meta.ResourceVersion)
 }
 
 // setPathInfoToHeaders set URL path params and full URL path to request header


### PR DESCRIPTION

Adding requests recieved metric at Router and function uid label to all metrics of 

We can now find the the number of requests received at Router before any processing with fission_requests_received

 We can find out the number of pending/failed requests by querying Prometheus like this: sum(fission_requests_received{name="hello-1-15"}) - sum(fission_function_calls_total{name="hello-1-

We can differentiate between functions which were deleted and re-deployed with same name with help of function uid label

 Added a metric to measure specialization 

Added a metric to measure the time taken to get service URL from Executor

Fixed few golint warnings

To find average request duration, we can :
rate(fission_function_duration_seconds_sum [30m])/rate(fission_function_duration_seconds_count[30m])