### PR TITLE
Labels and annotation support for functions and environments

### DIFF
--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -50,6 +50,7 @@ import (
 	fetcherClient "github.com/fission/fission/pkg/fetcher/client"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/maps"
 )
 
 type (
@@ -155,19 +156,19 @@ func MakeGenericPool(
 }
 
 func (gp *GenericPool) getEnvironmentPoolLabels() map[string]string {
-	return map[string]string{
-		fv1.EXECUTOR_TYPE:         string(fv1.ExecutorTypePoolmgr),
-		fv1.ENVIRONMENT_NAME:      gp.env.ObjectMeta.Name,
-		fv1.ENVIRONMENT_NAMESPACE: gp.env.ObjectMeta.Namespace,
-		fv1.ENVIRONMENT_UID:       string(gp.env.ObjectMeta.UID),
-		"managed":                 "true", // this allows us to easily find pods managed by the deployment
-	}
+	envLabels := maps.CopyStringMap(gp.env.ObjectMeta.Labels)
+	envLabels[fv1.EXECUTOR_TYPE] = string(fv1.ExecutorTypePoolmgr)
+	envLabels[fv1.ENVIRONMENT_NAME] = gp.env.ObjectMeta.Name
+	envLabels[fv1.ENVIRONMENT_NAMESPACE] = gp.env.ObjectMeta.Namespace
+	envLabels[fv1.ENVIRONMENT_UID] = string(gp.env.ObjectMeta.UID)
+	envLabels["managed"] = "true" // this allows us to easily find pods managed by the deployment
+	return envLabels
 }
 
 func (gp *GenericPool) getDeployAnnotations() map[string]string {
-	return map[string]string{
-		fv1.EXECUTOR_INSTANCEID_LABEL: gp.instanceID,
-	}
+	deployAnnotations := maps.CopyStringMap(gp.env.Annotations)
+	deployAnnotations[fv1.EXECUTOR_INSTANCEID_LABEL] = gp.instanceID
+	return deployAnnotations
 }
 
 func (gp *GenericPool) checkMetricsApi() bool {

--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -31,10 +31,13 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName, flag.EnvImage},
-		Optional: []flag.Flag{flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
+		Optional: []flag.Flag{
+			flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
-			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret,
-			flag.EnvExternalNetwork, flag.EnvKeepArchive, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
+			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret, flag.EnvKeepArchive,
+			flag.NamespaceEnvironment, flag.EnvExternalNetwork,
+			flag.Labels, flag.Annotation,
+			flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{
@@ -57,7 +60,9 @@ func Commands() *cobra.Command {
 		Optional: []flag.Flag{flag.EnvImage, flag.EnvPoolsize,
 			flag.EnvBuilderImage, flag.EnvBuildCmd, flag.EnvImagePullSecret,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
-			flag.EnvTerminationGracePeriod, flag.EnvKeepArchive, flag.NamespaceEnvironment, flag.EnvExternalNetwork},
+			flag.EnvTerminationGracePeriod, flag.EnvKeepArchive,
+			flag.NamespaceEnvironment, flag.EnvExternalNetwork,
+			flag.Labels, flag.Annotation},
 	})
 
 	deleteCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -179,6 +179,10 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 		},
 	}
 
+	err = util.ApplyLabelsAndAnnotations(input, &env.ObjectMeta)
+	if err != nil {
+		return nil, err
+	}
 	err = env.Validate()
 	if err != nil {
 		return nil, fv1.AggregateValidationErrors("Environment", err)

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -66,6 +67,11 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	}
 
 	opts.env = env
+
+	err = util.ApplyLabelsAndAnnotations(input, &opts.env.ObjectMeta)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -36,7 +36,7 @@ func Commands() *cobra.Command {
 			flag.FnExecutorType, flag.FnCfgMap, flag.FnSecret,
 			flag.FnSpecializationTimeout, flag.FnExecutionTimeout,
 			flag.FnIdleTimeout, flag.FnConcurrency, flag.FnRequestsPerPod,
-			flag.FnOnceOnly,
+			flag.FnOnceOnly, flag.Labels, flag.Annotation,
 
 			// TODO retired pkg & trigger related flags from function cmd
 			flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
@@ -88,7 +88,7 @@ func Commands() *cobra.Command {
 			flag.FnExecutorType, flag.FnSecret, flag.FnCfgMap,
 			flag.FnSpecializationTimeout, flag.FnExecutionTimeout,
 			flag.FnIdleTimeout, flag.FnConcurrency, flag.FnRequestsPerPod,
-			flag.FnOnceOnly,
+			flag.FnOnceOnly, flag.Labels, flag.Annotation,
 
 			flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure,

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -309,6 +309,11 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		},
 	}
 
+	err = util.ApplyLabelsAndAnnotations(input, &opts.function.ObjectMeta)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -243,6 +243,11 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	opts.function = function
 
+	err = util.ApplyLabelsAndAnnotations(input, &opts.function.ObjectMeta)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -74,6 +74,9 @@ var (
 
 	KubeContext = Flag{Type: String, Name: flagkey.KubeContext, Usage: "Kubernetes context to be used for the execution of Fission commands", DefaultValue: ""}
 
+	Labels     = Flag{Type: String, Name: flagkey.Labels, Usage: "Comma separated labels to apply to the function. Eg. --labels=\"environment=dev,application=analytics\""}
+	Annotation = Flag{Type: StringSlice, Name: flagkey.Annotation, Usage: "Annotation to apply to the function. To mention multiple annotations --annotation=\"abc.com/team=dev\" --annotation=\"foo=bar\""}
+
 	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", DefaultValue: metav1.NamespaceDefault}
 	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", DefaultValue: metav1.NamespaceDefault}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -26,6 +26,9 @@ const (
 	force        = "force"
 	Output       = "output"
 
+	Labels     = "labels"
+	Annotation = "annotation"
+
 	NamespaceFunction    = "fnNamespace"
 	NamespaceEnvironment = "envNamespace"
 	NamespacePackage     = "pkgNamespace"

--- a/pkg/utils/maps/map.go
+++ b/pkg/utils/maps/map.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package maps
+
+func CopyStringMap(m map[string]string) map[string]string {
+	n := make(map[string]string)
+	for k, v := range m {
+		n[k] = v
+	}
+	return n
+}


### PR DESCRIPTION
This PR adds,

1. Support for adding labels and annotations to fuctions & environment via fission CLI thrrough create & update command.

2. Change ensures labels and annotations assigned to environment would reflect on pods created via executortype poolmanager and newdeploy.

Usage:

```sh

fission env create --name nodejs --image fission/node-env --poolsize 1 --labels="env=node,author=sanket" \
   --annotation "abc.com/foo=bar" --annotation "secret-inject: my-secret"

fission env update --name nodejs --labels="env=node,author=sanket,another-label=value"

```

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>