### PR TITLE
Newdeploy/container function service names should fit in 63 characters 

### DIFF
--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -672,7 +672,16 @@ func (caaf *Container) fnDelete(fn *fv1.Function) error {
 func (caaf *Container) getObjName(fn *fv1.Function) string {
 	// use meta uuid of function, this ensure we always get the same name for the same function.
 	uid := fn.ObjectMeta.UID[len(fn.ObjectMeta.UID)-17:]
-	return strings.ToLower(fmt.Sprintf("Container-%v-%v-%v", fn.ObjectMeta.Name, fn.ObjectMeta.Namespace, uid))
+	var functionMetadata string
+	if len(fn.ObjectMeta.Name)+len(fn.ObjectMeta.Namespace) < 35 {
+		functionMetadata = fn.ObjectMeta.Name + "-" + fn.ObjectMeta.Namespace
+	} else {
+		functionMetadata = fn.ObjectMeta.Name[:17] + "-" + fn.ObjectMeta.Namespace[:17]
+	}
+	// contructed name should be 63 characters long, as it is a valid k8s name
+	// functionMetadata should be 35 characters long, as we take 17 characters from functionUid
+	// with newdeploy 10 character prefix
+	return strings.ToLower(fmt.Sprintf("container-%s-%s", functionMetadata, uid))
 }
 
 func (caaf *Container) getDeployLabels(fnMeta metav1.ObjectMeta) map[string]string {

--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -123,7 +123,9 @@ func (cn *Container) deleteDeployment(ns string, name string) error {
 	})
 }
 
-func (cn *Container) waitForDeploy(depl *appsv1.Deployment, replicas int32, specializationTimeout int) (*appsv1.Deployment, error) {
+func (cn *Container) waitForDeploy(depl *appsv1.Deployment, replicas int32, specializationTimeout int) (latestDepl *appsv1.Deployment, err error) {
+	oldStatus := depl.Status
+
 	// if no specializationTimeout is set, use default value
 	if specializationTimeout < fv1.DefaultSpecializationTimeOut {
 		specializationTimeout = fv1.DefaultSpecializationTimeOut
@@ -142,6 +144,10 @@ func (cn *Container) waitForDeploy(depl *appsv1.Deployment, replicas int32, spec
 		}
 		time.Sleep(time.Second)
 	}
+
+	cn.logger.Error("Deployment provision failed within timeout window",
+		zap.String("name", latestDepl.ObjectMeta.Name), zap.Any("old_status", oldStatus),
+		zap.Any("current_status", latestDepl.Status), zap.Int("timeout", specializationTimeout))
 
 	// this error appears in the executor pod logs
 	timeoutError := fmt.Errorf("failed to create deployment within the timeout window of %d seconds", specializationTimeout)


### PR DESCRIPTION
- Newdeploy/container function service names should fit in 63 characters 
- Added error message to dump deployment status before and after update in case of failure
- Dump if any error in case of newdeploy cleanup