### PR TITLE
Use pool pod controller with env informer 

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -85,6 +85,7 @@ rules:
   resources:
   - deployments
   - deployments/scale
+  - replicasets
   verbs:
   - '*'
 - apiGroups:

--- a/pkg/crd/key.go
+++ b/pkg/crd/key.go
@@ -31,3 +31,10 @@ import (
 func CacheKey(metadata *metav1.ObjectMeta) string {
 	return fmt.Sprintf("%v_%v", metadata.UID, metadata.ResourceVersion)
 }
+
+// CacheKeyForUID create a key that uniquely identifies the
+// of the object. Since resourceVersion changes on every update and
+// UIDs are unique, we don't use resource version here
+func CacheKeyUID(metadata *metav1.ObjectMeta) string {
+	return fmt.Sprintf("%v", metadata.UID)
+}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -285,7 +285,7 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 		logger,
 		fissionClient, kubernetesClient, metricsClient,
 		functionNamespace, fetcherConfig, executorInstanceID,
-		funcInformer, pkgInformer,
+		funcInformer, pkgInformer, envInformer,
 	)
 	if err != nil {
 		return errors.Wrap(err, "pool manager creation faied")
@@ -345,7 +345,6 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 	if err != nil {
 		return err
 	}
-
 	go reaper.CleanupRoleBindings(logger, kubernetesClient, fissionClient, functionNamespace, envBuilderNamespace, time.Minute*30)
 	go api.Serve(port, openTracingEnabled)
 	go serveMetric(logger)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -287,13 +287,13 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 		return err
 	}
 	gpmPodInformer := gpmInformerFactory.Core().V1().Pods()
+	gpmRsInformer := gpmInformerFactory.Apps().V1().ReplicaSets()
 	gpm, err := poolmgr.MakeGenericPoolManager(
 		logger,
 		fissionClient, kubernetesClient, metricsClient,
 		functionNamespace, fetcherConfig, executorInstanceID,
 		funcInformer, pkgInformer, envInformer,
-		gpmPodInformer,
-	)
+		gpmPodInformer, gpmRsInformer)
 	if err != nil {
 		return errors.Wrap(err, "pool manager creation faied")
 	}
@@ -309,8 +309,7 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 		fissionClient, kubernetesClient,
 		functionNamespace, fetcherConfig, executorInstanceID,
 		funcInformer, envInformer,
-		ndmDeplInformer, ndmSvcInformer,
-	)
+		ndmDeplInformer, ndmSvcInformer)
 	if err != nil {
 		return errors.Wrap(err, "new deploy manager creation faied")
 	}
@@ -323,8 +322,7 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 	cnmSvcInformer := cnmInformerFactory.Core().V1().Services()
 	ctx := context.Background()
 	cnm, err := container.MakeContainer(
-		ctx,
-		logger,
+		ctx, logger,
 		fissionClient, kubernetesClient,
 		functionNamespace, executorInstanceID, funcInformer,
 		cnmDeplInformer, cnmSvcInformer)
@@ -368,6 +366,7 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 			configmapInformer.Informer(),
 			secretInformer.Informer(),
 			gpmPodInformer.Informer(),
+			gpmRsInformer.Informer(),
 			ndmDeplInformer.Informer(),
 			ndmSvcInformer.Informer(),
 			cnmDeplInformer.Informer(),

--- a/pkg/executor/executortype/poolmgr/common.go
+++ b/pkg/executor/executortype/poolmgr/common.go
@@ -27,3 +27,13 @@ func getEnvPoolSize(env *fv1.Environment) int32 {
 	}
 	return poolsize
 }
+
+func getSpecializedPodLabels(env *fv1.Environment) map[string]string {
+	specialPodLabels := make(map[string]string)
+	specialPodLabels[fv1.EXECUTOR_TYPE] = string(fv1.ExecutorTypePoolmgr)
+	specialPodLabels[fv1.ENVIRONMENT_NAME] = env.ObjectMeta.Name
+	specialPodLabels[fv1.ENVIRONMENT_NAMESPACE] = env.ObjectMeta.Namespace
+	specialPodLabels[fv1.ENVIRONMENT_UID] = string(env.ObjectMeta.UID)
+	specialPodLabels["managed"] = "false"
+	return specialPodLabels
+}

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -205,14 +205,15 @@ func (gp *GenericPool) createPoolDeployment(ctx context.Context, env *fv1.Enviro
 }
 
 func (gp *GenericPool) updatePoolDeployment(ctx context.Context, env *fv1.Environment) error {
+	logger := gp.logger.With(zap.String("env", env.Name), zap.String("namespace", env.Namespace))
 	if gp.env.ObjectMeta.ResourceVersion == env.ObjectMeta.ResourceVersion {
-		gp.logger.Debug("env resource version matching with pool env", zap.String("env", gp.env.ObjectMeta.Name))
+		logger.Debug("env resource version matching with pool env")
 		return nil
 	}
 	newDeployment := gp.deployment.DeepCopy()
 	spec, err := gp.genDeploymentSpec(env)
 	if err != nil {
-		gp.logger.Error("error generating deployment spec", zap.Error(err))
+		logger.Error("error generating deployment spec", zap.Error(err))
 		return err
 	}
 	newDeployment.Spec = *spec
@@ -229,7 +230,7 @@ func (gp *GenericPool) updatePoolDeployment(ctx context.Context, env *fv1.Enviro
 
 	depl, err := gp.kubernetesClient.AppsV1().Deployments(gp.namespace).Update(ctx, newDeployment, metav1.UpdateOptions{})
 	if err != nil {
-		gp.logger.Error("error updating deployment in kubernetes", zap.Error(err), zap.String("deployment", gp.deployment.Name))
+		logger.Error("error updating deployment in kubernetes", zap.Error(err), zap.String("deployment", depl.Name))
 		return err
 	}
 	// possible concurrency issue here as
@@ -237,6 +238,6 @@ func (gp *GenericPool) updatePoolDeployment(ctx context.Context, env *fv1.Enviro
 	// we can move update pool to gpm.service if required
 	gp.env = env
 	gp.deployment = depl
-	gp.logger.Info("Updated deployment for pool")
+	logger.Info("Updated deployment for pool", zap.String("deployment", depl.Name))
 	return nil
 }

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -522,6 +522,7 @@ func (gpm *GenericPoolManager) getPool(ctx context.Context, env *fv1.Environment
 
 func (gpm *GenericPoolManager) cleanupPool(ctx context.Context, env *fv1.Environment) {
 	gpm.requestChannel <- &request{
+		ctx:         ctx,
 		requestType: CLEANUP_POOL,
 		env:         env,
 	}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -35,10 +35,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	appsinformers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
-
 	k8sCache "k8s.io/client-go/tools/cache"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 
@@ -115,6 +115,7 @@ func MakeGenericPoolManager(
 	pkgInformer finformerv1.PackageInformer,
 	envInformer finformerv1.EnvironmentInformer,
 	podInformer coreinformers.PodInformer,
+	rsInformer appsinformers.ReplicaSetInformer,
 ) (executortype.ExecutorType, error) {
 
 	gpmLogger := logger.Named("generic_pool_manager")
@@ -129,7 +130,7 @@ func MakeGenericPoolManager(
 	}
 
 	poolPodC := NewPoolPodController(gpmLogger, kubernetesClient, functionNamespace,
-		enableIstio, funcInformer, pkgInformer, envInformer)
+		enableIstio, funcInformer, pkgInformer, envInformer, rsInformer)
 
 	gpm := &GenericPoolManager{
 		logger:                 gpmLogger,

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2021 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package poolmgr
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	k8sCache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
+	flisterv1 "github.com/fission/fission/pkg/generated/listers/core/v1"
+)
+
+type (
+	PoolPodController struct {
+		logger           *zap.Logger
+		kubernetesClient *kubernetes.Clientset
+		namespace        string
+		enableIstio      bool
+
+		envLister       flisterv1.EnvironmentLister
+		envListerSynced cache.InformerSynced
+
+		envCreateUpdateQueue workqueue.RateLimitingInterface
+		envDeleteQueue       workqueue.RateLimitingInterface
+
+		gpm *GenericPoolManager
+	}
+)
+
+func NewPoolPodController(logger *zap.Logger,
+	kubernetesClient *kubernetes.Clientset,
+	namespace string,
+	enableIstio bool,
+	funcInformer finformerv1.FunctionInformer,
+	pkgInformer finformerv1.PackageInformer,
+	envInformer finformerv1.EnvironmentInformer) *PoolPodController {
+	p := &PoolPodController{
+		logger:           logger,
+		kubernetesClient: kubernetesClient,
+		namespace:        namespace,
+		enableIstio:      enableIstio,
+
+		envCreateUpdateQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EnvAddUpdateQueue"),
+		envDeleteQueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EnvDeleteQueue"),
+	}
+	funcInformer.Informer().AddEventHandler(FunctionEventHandlers(p.logger, p.kubernetesClient, p.namespace, p.enableIstio))
+	pkgInformer.Informer().AddEventHandler(PackageEventHandlers(p.logger, p.kubernetesClient, p.namespace))
+	envInformer.Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+		AddFunc:    p.enqueueEnvAdd,
+		UpdateFunc: p.enqueueEnvUpdate,
+		DeleteFunc: p.enqueueEnvDelete,
+	})
+	p.envLister = envInformer.Lister()
+	p.envListerSynced = envInformer.Informer().HasSynced
+	p.logger.Info("pool pod controller handlers registered")
+	return p
+}
+
+func (p *PoolPodController) InjectGpm(gpm *GenericPoolManager) {
+	p.gpm = gpm
+}
+
+func (p *PoolPodController) enqueueEnvAdd(obj interface{}) {
+	key, err := k8sCache.MetaNamespaceKeyFunc(obj)
+	if err != nil {
+		p.logger.Error("error retrieving key from object in poolPodController", zap.Any("obj", obj))
+		return
+	}
+	p.logger.Debug("enqueue env add", zap.String("key", key))
+	p.envCreateUpdateQueue.Add(key)
+}
+
+func (p *PoolPodController) enqueueEnvUpdate(oldObj, newObj interface{}) {
+	key, err := k8sCache.MetaNamespaceKeyFunc(newObj)
+	if err != nil {
+		p.logger.Error("error retrieving key from object in poolPodController", zap.Any("obj", key))
+		return
+	}
+	p.logger.Debug("enqueue env update", zap.String("key", key))
+	p.envCreateUpdateQueue.Add(key)
+}
+
+func (p *PoolPodController) enqueueEnvDelete(obj interface{}) {
+	env, ok := obj.(*fv1.Environment)
+	if !ok {
+		p.logger.Error("unexpected type when deleting env to pool pod controller", zap.Any("obj", obj))
+		return
+	}
+	p.logger.Debug("enqueue env delete", zap.Any("env", env))
+	p.envDeleteQueue.Add(env)
+}
+
+func (p *PoolPodController) Run(stopCh <-chan struct{}) {
+	defer utilruntime.HandleCrash()
+	defer p.envCreateUpdateQueue.ShutDown()
+	defer p.envDeleteQueue.ShutDown()
+
+	// Wait for the caches to be synced before starting workers
+	p.logger.Info("Waiting for informer caches to sync")
+	if ok := k8sCache.WaitForCacheSync(stopCh, p.envListerSynced); !ok {
+		p.logger.Fatal("failed to wait for caches to sync")
+	}
+	for i := 0; i < 4; i++ {
+		go wait.Until(p.runEnvCreateUpdateWorker, time.Second, stopCh)
+	}
+	go wait.Until(p.runEnvDeleteWorker, time.Second, stopCh)
+	p.logger.Info("Started workers for poolPodController")
+	<-stopCh
+	p.logger.Info("Shutting down workers for poolPodController")
+}
+
+func (p *PoolPodController) runEnvCreateUpdateWorker() {
+	p.logger.Debug("Starting runEnvCreateUpdateWorker worker")
+	maxRetries := 3
+	handleEnv := func(env *fv1.Environment) error {
+		log := p.logger.With(zap.String("env", env.ObjectMeta.Name), zap.String("namespace", env.ObjectMeta.Namespace))
+		log.Debug("env reconsile request processing")
+		pool, created, err := p.gpm.getPool(env)
+		if err != nil {
+			log.Error("error getting pool", zap.Error(err))
+			return err
+		}
+		if created {
+			log.Info("created pool for the environment")
+			return nil
+		}
+		poolsize := getEnvPoolSize(env)
+		if poolsize == 0 {
+			log.Info("pool size is zero")
+			p.gpm.cleanupPool(env)
+			return nil
+		}
+		err = pool.updatePoolDeployment(context.Background(), env)
+		if err != nil {
+			log.Error("error updating pool", zap.Error(err))
+			return err
+		}
+		p.deleteSpecializedPods(env)
+		return nil
+	}
+	processItem := func() bool {
+		obj, quit := p.envCreateUpdateQueue.Get()
+		if quit {
+			return true
+		}
+		key := obj.(string)
+		defer p.envCreateUpdateQueue.Done(key)
+
+		namespace, name, err := k8sCache.SplitMetaNamespaceKey(key)
+		if err != nil {
+			p.logger.Error("error splitting key", zap.Error(err))
+			return false
+		}
+		env, err := p.envLister.Environments(namespace).Get(name)
+		if apierrors.IsNotFound(err) {
+			p.logger.Info("env not found", zap.String("key", key))
+			p.envCreateUpdateQueue.Forget(key)
+			return false
+		}
+
+		if err != nil {
+			if p.envCreateUpdateQueue.NumRequeues(key) < maxRetries {
+				p.envCreateUpdateQueue.AddRateLimited(key)
+				p.logger.Error("error getting env, retrying", zap.Error(err))
+			} else {
+				p.envCreateUpdateQueue.Forget(key)
+				p.logger.Error("error getting env, retrying, max retries reached", zap.Error(err))
+			}
+			return false
+		}
+
+		err = handleEnv(env)
+		if err != nil {
+			if p.envCreateUpdateQueue.NumRequeues(key) < maxRetries {
+				p.envCreateUpdateQueue.AddRateLimited(key)
+				p.logger.Error("error handling env from envInformer, retrying", zap.String("key", key), zap.Error(err))
+			} else {
+				p.envCreateUpdateQueue.Forget(key)
+				p.logger.Error("error handling env from envInformer, max retries reached", zap.String("key", key), zap.Error(err))
+			}
+			return false
+		}
+		p.envCreateUpdateQueue.Forget(key)
+		return false
+	}
+	for {
+		if quit := processItem(); quit {
+			p.logger.Info("Shutting down create/update worker")
+			return
+		}
+	}
+}
+
+func (p *PoolPodController) runEnvDeleteWorker() {
+	p.logger.Debug("Starting runEnvDeleteWorker worker")
+	processItem := func() bool {
+		obj, quit := p.envDeleteQueue.Get()
+		if quit {
+			return true
+		}
+		defer p.envDeleteQueue.Done(obj)
+		env, ok := obj.(*fv1.Environment)
+		if !ok {
+			p.logger.Error("unexpected type when deleting env to pool pod controller", zap.Any("obj", obj))
+			p.envDeleteQueue.Forget(obj)
+			return false
+		}
+		p.logger.Debug("env delete request processing")
+		p.gpm.cleanupPool(env)
+		p.deleteSpecializedPods(env)
+		p.envDeleteQueue.Forget(obj)
+		return false
+	}
+	for {
+		if quit := processItem(); quit {
+			p.logger.Info("Shutting down delete worker")
+			return
+		}
+	}
+}
+
+func (p *PoolPodController) deleteSpecializedPods(env *fv1.Environment) {
+	log := p.logger.With(zap.String("env", env.ObjectMeta.Name), zap.String("namespace", env.ObjectMeta.Namespace))
+	log.Debug("environment delete")
+	selectorLabels := getSpecializedPodLabels(env)
+	listOptions := metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(selectorLabels).String(),
+	}
+	ctx := context.Background()
+	podList, err := p.kubernetesClient.CoreV1().Pods(p.namespace).List(ctx, listOptions)
+	if err != nil {
+		log.Error("failed to list pods", zap.Error(err))
+		return
+	}
+	if len(podList.Items) == 0 {
+		log.Debug("no pods identified for cleanup after env delete")
+		return
+	}
+	log.Info("specialized pods identified for cleanup after env delete", zap.Int("numPods", len(podList.Items)))
+	for _, pod := range podList.Items {
+		podName := strings.SplitAfter(pod.GetName(), ".")
+		if fsvc, ok := p.gpm.fsCache.PodToFsvc.Load(strings.TrimSuffix(podName[0], ".")); ok {
+			fsvc, ok := fsvc.(*fscache.FuncSvc)
+			if !ok {
+				log.Error("could not covert item from PodToFsvc")
+			}
+			p.gpm.fsCache.DeleteFunctionSvc(fsvc)
+			p.gpm.fsCache.DeleteEntry(fsvc)
+		}
+		err = p.kubernetesClient.CoreV1().Pods(p.namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			log.Error("failed to delete pod", zap.Error(err))
+			continue
+		}
+		log.Info("cleaned specialized pod as environment deleted",
+			zap.String("pod", pod.ObjectMeta.Name), zap.String("pod_namespace", pod.ObjectMeta.Namespace),
+			zap.String("address", pod.Status.PodIP))
+	}
+}

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -1,28 +1,26 @@
 package utils
 
 import (
-	"fmt"
+	"time"
 
-	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	k8sInformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	k8sCache "k8s.io/client-go/tools/cache"
 	metricsapi "k8s.io/metrics/pkg/apis/metrics"
 
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
-func GetInformerFactoryByExecutor(client *kubernetes.Clientset, executorType v1.ExecutorType) (k8sInformers.SharedInformerFactory, error) {
+func GetInformerFactoryByExecutor(client *kubernetes.Clientset, executorType v1.ExecutorType, defaultResync time.Duration) (k8sInformers.SharedInformerFactory, error) {
 	executorLabel, err := labels.NewRequirement(v1.EXECUTOR_TYPE, selection.DoubleEquals, []string{string(executorType)})
 	if err != nil {
 		return nil, err
 	}
 	labelSelector := labels.NewSelector()
 	labelSelector.Add(*executorLabel)
-	informerFactory := k8sInformers.NewSharedInformerFactoryWithOptions(client, 0,
+	informerFactory := k8sInformers.NewSharedInformerFactoryWithOptions(client, defaultResync,
 		k8sInformers.WithTweakListOptions(func(options *metav1.ListOptions) {
 			options.LabelSelector = labelSelector.String()
 		}))
@@ -46,15 +44,4 @@ func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupLis
 		}
 	}
 	return false
-}
-
-func GetCachedItem(obj apiv1.ObjectReference, informer k8sCache.SharedIndexInformer) (item interface{}, exists bool, err error) {
-	store := informer.GetStore()
-
-	item, exists, err = store.Get(obj)
-	if err != nil || !exists {
-		item, exists, err = store.GetByKey(fmt.Sprintf("%s/%s", obj.Namespace, obj.Name))
-	}
-
-	return item, exists, err
 }


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

- Use informers and listers in executors 
- Passing context properly in pool manager executor
- Environment updates in pool manager would not cause updates in the deployment
- Environment update minimizing downtime
- Use replicaset controller and environment delete triggers to cleanup specialized pods
