### PR TITLE
Change default informer resync period to 30 minutes

### DIFF
--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -50,8 +50,8 @@ func Start(logger *zap.Logger, storageSvcUrl string, envBuilderNamespace string)
 	envWatcher := makeEnvironmentWatcher(bmLogger, fissionClient, kubernetesClient, fetcherConfig, envBuilderNamespace)
 	go envWatcher.watchEnvironments()
 
-	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Second*30)
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, 60*time.Minute)
+	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
+	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
 	podInformer := k8sInformerFactory.Core().V1().Pods().Informer()
 	pkgInformer := informerFactory.Core().V1().Packages().Informer()
 	pkgWatcher := makePackageWatcher(bmLogger, fissionClient,

--- a/pkg/canaryconfigmgr/canaryConfigMgr.go
+++ b/pkg/canaryconfigmgr/canaryConfigMgr.go
@@ -93,7 +93,7 @@ func MakeCanaryConfigMgr(logger *zap.Logger, fissionClient *crd.FissionClient, k
 		canaryCfgCancelFuncMap: makecanaryConfigCancelFuncMap(),
 	}
 
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Second*30)
+	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
 	informer := informerFactory.Core().V1().CanaryConfigs().Informer()
 	configMgr.canaryConfigInformer = &informer
 	configMgr.CanaryConfigEventHandlers()

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -275,7 +275,7 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 
 	logger.Info("Starting executor", zap.String("instanceID", executorInstanceID))
 
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Second*30)
+	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
 	funcInformer := informerFactory.Core().V1().Functions().Informer()
 	pkgInformer := informerFactory.Core().V1().Packages().Informer()
 	envInformer := informerFactory.Core().V1().Environments().Informer()
@@ -330,7 +330,7 @@ func StartExecutor(logger *zap.Logger, functionNamespace string, envBuilderNames
 	// TODO: use context to control the waiting time once kubernetes client supports it.
 	util.WaitTimeout(wg, 30*time.Second)
 
-	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Second*30)
+	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
 	configmapInformer := k8sInformerFactory.Core().V1().ConfigMaps().Informer()
 	secretInformer := k8sInformerFactory.Core().V1().Secrets().Informer()
 

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -185,7 +185,7 @@ func Start() {
 	if err != nil {
 		log.Fatalf("Error starting pod watcher: %v", err)
 	}
-	informerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, 30*time.Second)
+	informerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	podInformer.AddEventHandler(podInformerHandlers(zapLogger))
 	podInformer.Run(make(chan struct{}))

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -158,7 +158,7 @@ func StartScalerManager(logger *zap.Logger, routerURL string) error {
 	if err != nil {
 		return errors.Wrap(err, "error waiting for CRDs")
 	}
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, 30*time.Second)
+	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
 	mqTriggerInformer := informerFactory.Core().V1().MessageQueueTriggers().Informer()
 	mqTriggerInformer.AddEventHandler(mqTriggerEventHandlers(logger, kubeClient, routerURL))
 	mqTriggerInformer.Run(context.Background().Done())

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -76,7 +76,7 @@ func makeHTTPTriggerSet(logger *zap.Logger, fmap *functionServiceMap, fissionCli
 		unTapServiceTimeout:        unTapServiceTimeout,
 	}
 
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Second*30)
+	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
 	httpTriggerSet.triggerInformer = informerFactory.Core().V1().HTTPTriggers().Informer()
 	httpTriggerSet.funcInformer = informerFactory.Core().V1().Functions().Informer()
 


### PR DESCRIPTION
Currently most of informers used in Fission are using resync
period of 30sec which is quite low and causes lot of disturbances
in overall system. Since informers already have watchers which would
be delivering events to the handlers. If any handlers require lower
sync period they should register handler with `AddEventHandlersWithResyncPeriod`
instead of we generaling informer.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>