### PR TITLE
feature: Capture important events with span in fission and add trace id in logs

### DIFF
--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -131,7 +131,7 @@ func Run(logger *zap.Logger) {
 	logger.Info("fetcher ready to receive requests")
 
 	var handler http.Handler
-	if tracing.TracingEnabled(logger) {
+	if openTracingEnabled {
 		handler = &ochttp.Handler{Handler: mux}
 	} else {
 		handler = otelUtils.GetHandlerWithOTEL(mux, "fission-fetcher", otelUtils.UrlsToIgnore("/healthz", "/readiness-healthz"))

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -225,11 +225,7 @@ Options:
 		logger.Fatal("Could not parse command line arguments", zap.Error(err))
 	}
 
-	openTracingEnabled, err := strconv.ParseBool(os.Getenv("OPENTRACING_ENABLED"))
-	if err != nil {
-		logger.Fatal("error parsing OPENTRACING_ENABLED", zap.Error(err))
-	}
-
+	openTracingEnabled := tracing.TracingEnabled(logger)
 	if openTracingEnabled {
 		err = tracing.RegisterTraceExporter(logger, os.Getenv("TRACE_JAEGER_COLLECTOR_ENDPOINT"), getServiceName(arguments))
 		if err != nil {

--- a/pkg/builder/client/client.go
+++ b/pkg/builder/client/client.go
@@ -69,7 +69,7 @@ func (c *Client) Build(ctx context.Context, req *builder.PackageBuildRequest) (*
 	var resp *http.Response
 
 	for i := 0; i < maxRetries; i++ {
-		resp, err := ctxhttp.Post(ctx, c.httpClient, c.url, "application/json", bytes.NewReader(body))
+		resp, err = ctxhttp.Post(ctx, c.httpClient, c.url, "application/json", bytes.NewReader(body))
 		if err == nil {
 			if resp.StatusCode == 200 {
 				break

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -88,7 +88,7 @@ func buildPackage(ctx context.Context, logger *zap.Logger, fissionClient *crd.Fi
 
 	logger.Info("started building with source package", zap.String("source_package", srcPkgFilename))
 	// send build request to builder
-	buildResp, err := builderC.Build(pkgBuildReq)
+	buildResp, err := builderC.Build(ctx, pkgBuildReq)
 	if err != nil {
 		e := fmt.Sprintf("Error building deployment package: %v", err)
 		var buildLogs string

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -55,9 +55,10 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 
 	t := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
 	et := executor.executorTypes[t]
+	logger := otelUtils.LoggerWithTraceID(ctx, executor.logger)
 
 	// Check function -> svc cache
-	executor.logger.Debug("checking for cached function service",
+	logger.Debug("checking for cached function service",
 		zap.String("function_name", fn.ObjectMeta.Name),
 		zap.String("function_namespace", fn.ObjectMeta.Namespace))
 	if t == fv1.ExecutorTypePoolmgr && !fn.Spec.OnceOnly {
@@ -73,14 +74,14 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 		// check if its a cache hit (check if there is already specialized function pod that can serve another request)
 		if err == nil {
 			// if a pod is already serving request then it already exists else validated
-			executor.logger.Debug("from cache", zap.Int("active", active))
+			logger.Debug("from cache", zap.Int("active", active))
 			if active > 1 || et.IsValid(ctx, fsvc) {
 				// Cached, return svc address
-				executor.logger.Debug("served from cache", zap.String("name", fsvc.Name), zap.String("address", fsvc.Address))
+				logger.Debug("served from cache", zap.String("name", fsvc.Name), zap.String("address", fsvc.Address))
 				executor.writeResponse(w, fsvc.Address, fn.ObjectMeta.Name)
 				return
 			}
-			executor.logger.Debug("deleting cache entry for invalid address",
+			logger.Debug("deleting cache entry for invalid address",
 				zap.String("function_name", fn.ObjectMeta.Name),
 				zap.String("function_namespace", fn.ObjectMeta.Namespace),
 				zap.String("address", fsvc.Address))
@@ -90,7 +91,7 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 
 		if active >= concurrency {
 			errMsg := fmt.Sprintf("max concurrency reached for %v. All %v instance are active", fn.ObjectMeta.Name, concurrency)
-			executor.logger.Error("error occurred", zap.String("error", errMsg))
+			logger.Error("error occurred", zap.String("error", errMsg))
 			http.Error(w, html.EscapeString(errMsg), http.StatusTooManyRequests)
 			return
 		}
@@ -102,7 +103,7 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 				executor.writeResponse(w, fsvc.Address, fn.ObjectMeta.Name)
 				return
 			}
-			executor.logger.Debug("deleting cache entry for invalid address",
+			logger.Debug("deleting cache entry for invalid address",
 				zap.String("function_name", fn.ObjectMeta.Name),
 				zap.String("function_namespace", fn.ObjectMeta.Namespace),
 				zap.String("address", fsvc.Address))
@@ -113,7 +114,7 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 	serviceName, err := executor.getServiceForFunction(ctx, fn)
 	if err != nil {
 		code, msg := ferror.GetHTTPError(err)
-		executor.logger.Error("error getting service for function",
+		logger.Error("error getting service for function",
 			zap.Error(err),
 			zap.String("function", fn.ObjectMeta.Name),
 			zap.String("fission_http_error", msg))
@@ -167,10 +168,11 @@ func (executor *Executor) tapService(w http.ResponseWriter, r *http.Request) {
 // find funcSvc and update its atime
 func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := otelUtils.LoggerWithTraceID(ctx, executor.logger)
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		executor.logger.Error("failed to read tap service request", zap.Error(err))
+		logger.Error("failed to read tap service request", zap.Error(err))
 		http.Error(w, "Failed to read request", http.StatusInternalServerError)
 		return
 	}
@@ -178,7 +180,7 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 	tapSvcReqs := []client.TapServiceRequest{}
 	err = json.Unmarshal(body, &tapSvcReqs)
 	if err != nil {
-		executor.logger.Error("failed to decode tap service request",
+		logger.Error("failed to decode tap service request",
 			zap.Error(err),
 			zap.String("request-payload", string(body)))
 		http.Error(w, "Failed to decode tap service request", http.StatusBadRequest)
@@ -206,7 +208,7 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if errs.ErrorOrNil() != nil {
-		executor.logger.Error("error tapping function service", zap.Error(errs))
+		logger.Error("error tapping function service", zap.Error(errs))
 		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -34,7 +34,7 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/client"
-	"github.com/fission/fission/pkg/utils/otel"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *http.Request) {
@@ -220,7 +220,6 @@ func (executor *Executor) healthHandler(w http.ResponseWriter, r *http.Request) 
 
 func (executor *Executor) unTapService(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request", http.StatusInternalServerError)
@@ -267,7 +266,7 @@ func (executor *Executor) Serve(port int, openTracingEnabled bool) {
 	if openTracingEnabled {
 		handler = &ochttp.Handler{Handler: executor.GetHandler()}
 	} else {
-		handler = otel.GetHandlerWithOTEL(executor.GetHandler(), "fission-executor", otel.UrlsToIgnore("/healthz"))
+		handler = otelUtils.GetHandlerWithOTEL(executor.GetHandler(), "fission-executor", otelUtils.UrlsToIgnore("/healthz"))
 	}
 
 	err := http.ListenAndServe(address, handler)

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -150,8 +150,7 @@ func (c *Client) service() {
 					svcReqs = append(svcReqs, req)
 				}
 				c.logger.Debug("tapped services in batch", zap.Int("service_count", len(urls)))
-
-				err := c._tapService(svcReqs)
+				err := c._tapService(context.TODO(), svcReqs)
 				if err != nil {
 					c.logger.Error("error tapping function service address", zap.Error(err))
 				}
@@ -176,7 +175,7 @@ func (c *Client) TapService(fnMeta metav1.ObjectMeta, executorType fv1.ExecutorT
 	}
 }
 
-func (c *Client) _tapService(tapSvcReqs []TapServiceRequest) error {
+func (c *Client) _tapService(ctx context.Context, tapSvcReqs []TapServiceRequest) error {
 	executorURL := c.executorURL + "/v2/tapServices"
 
 	body, err := json.Marshal(tapSvcReqs)
@@ -184,7 +183,7 @@ func (c *Client) _tapService(tapSvcReqs []TapServiceRequest) error {
 		return err
 	}
 
-	resp, err := http.Post(executorURL, "application/json", bytes.NewReader(body))
+	resp, err := ctxhttp.Post(ctx, c.httpClient, executorURL, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -23,8 +23,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +35,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	ferror "github.com/fission/fission/pkg/error"
+	"github.com/fission/fission/pkg/utils/tracing"
 )
 
 type (
@@ -59,13 +58,8 @@ type (
 
 // MakeClient initializes and returns a Client instance.
 func MakeClient(logger *zap.Logger, executorURL string) *Client {
-	openTracingEnabled, err := strconv.ParseBool(os.Getenv("OPENTRACING_ENABLED"))
-	if err != nil {
-		logger.Fatal("error parsing OPENTRACING_ENABLED", zap.Error(err))
-	}
-
 	var hc *http.Client
-	if openTracingEnabled {
+	if tracing.TracingEnabled(logger) {
 		hc = &http.Client{Transport: &ochttp.Transport{}}
 	} else {
 		hc = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -46,6 +46,7 @@ import (
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 type (
@@ -214,6 +215,7 @@ func (executor *Executor) serveCreateFuncServices() {
 }
 
 func (executor *Executor) createServiceForFunction(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	otelUtils.SpanTrackEvent(ctx, "createServiceForFunction", otelUtils.GetAttributesForFunction(fn)...)
 	executor.logger.Debug("no cached function service found, creating one",
 		zap.String("function_name", fn.ObjectMeta.Name),
 		zap.String("function_namespace", fn.ObjectMeta.Namespace))
@@ -238,6 +240,7 @@ func (executor *Executor) createServiceForFunction(ctx context.Context, fn *fv1.
 }
 
 func (executor *Executor) getFunctionServiceFromCache(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	otelUtils.SpanTrackEvent(ctx, "getFunctionServiceFromCache", otelUtils.GetAttributesForFunction(fn)...)
 	t := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
 	e, ok := executor.executorTypes[t]
 	if !ok {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -170,7 +170,7 @@ func (executor *Executor) serveCreateFuncServices() {
 					specializationTimeout = fv1.DefaultSpecializationTimeOut
 				}
 
-				fnSpecializationTimeoutContext, cancel := context.WithTimeout(context.Background(),
+				fnSpecializationTimeoutContext, cancel := context.WithTimeout(req.context,
 					time.Duration(specializationTimeout+buffer)*time.Second)
 				defer cancel()
 

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -215,8 +215,9 @@ func (executor *Executor) serveCreateFuncServices() {
 }
 
 func (executor *Executor) createServiceForFunction(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	logger := otelUtils.LoggerWithTraceID(ctx, executor.logger)
 	otelUtils.SpanTrackEvent(ctx, "createServiceForFunction", otelUtils.GetAttributesForFunction(fn)...)
-	executor.logger.Debug("no cached function service found, creating one",
+	logger.Debug("no cached function service found, creating one",
 		zap.String("function_name", fn.ObjectMeta.Name),
 		zap.String("function_namespace", fn.ObjectMeta.Namespace))
 
@@ -229,7 +230,7 @@ func (executor *Executor) createServiceForFunction(ctx context.Context, fn *fv1.
 	fsvc, fsvcErr := e.GetFuncSvc(ctx, fn)
 	if fsvcErr != nil {
 		e := "error creating service for function"
-		executor.logger.Error(e,
+		logger.Error(e,
 			zap.Error(fsvcErr),
 			zap.String("function_name", fn.ObjectMeta.Name),
 			zap.String("function_namespace", fn.ObjectMeta.Namespace))

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -50,6 +50,7 @@ import (
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/maps"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 var _ executortype.ExecutorType = &Container{}
@@ -160,6 +161,7 @@ func (caaf *Container) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 
 // GetFuncSvcFromCache returns a function service from cache; error otherwise.
 func (caaf *Container) GetFuncSvcFromCache(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	otelUtils.SpanTrackEvent(ctx, "GetFuncSvcFromCache", otelUtils.GetAttributesForFunction(fn)...)
 	return caaf.fsCache.GetByFunction(&fn.ObjectMeta)
 }
 
@@ -187,6 +189,7 @@ func (caaf *Container) TapService(ctx context.Context, svcHost string) error {
 // scale deployment to 1 replica if there are no available replicas for function.
 // Return true if no error occurs, return false otherwise.
 func (caaf *Container) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) bool {
+	otelUtils.SpanTrackEvent(ctx, "IsValid", otelUtils.GetAttributesForFuncSvc(fsvc)...)
 	if len(strings.Split(fsvc.Address, ".")) == 0 {
 		caaf.logger.Error("address not found in function service")
 		return false

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -189,13 +189,14 @@ func (caaf *Container) TapService(ctx context.Context, svcHost string) error {
 // scale deployment to 1 replica if there are no available replicas for function.
 // Return true if no error occurs, return false otherwise.
 func (caaf *Container) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) bool {
+	logger := otelUtils.LoggerWithTraceID(ctx, caaf.logger)
 	otelUtils.SpanTrackEvent(ctx, "IsValid", otelUtils.GetAttributesForFuncSvc(fsvc)...)
 	if len(strings.Split(fsvc.Address, ".")) == 0 {
-		caaf.logger.Error("address not found in function service")
+		logger.Error("address not found in function service")
 		return false
 	}
 	if len(fsvc.KubernetesObjects) == 0 {
-		caaf.logger.Error("no kubernetes object related to function", zap.String("function", fsvc.Function.Name))
+		logger.Error("no kubernetes object related to function", zap.String("function", fsvc.Function.Name))
 		return false
 	}
 	for _, obj := range fsvc.KubernetesObjects {
@@ -203,7 +204,7 @@ func (caaf *Container) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) bool 
 			_, err := caaf.svcLister.Services(obj.Namespace).Get(obj.Name)
 			if err != nil {
 				if !k8sErrs.IsNotFound(err) {
-					caaf.logger.Error("error validating function service", zap.String("function", fsvc.Function.Name), zap.Error(err))
+					logger.Error("error validating function service", zap.String("function", fsvc.Function.Name), zap.Error(err))
 				}
 				return false
 			}
@@ -211,7 +212,7 @@ func (caaf *Container) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) bool 
 			currentDeploy, err := caaf.deplLister.Deployments(obj.Namespace).Get(obj.Name)
 			if err != nil {
 				if !k8sErrs.IsNotFound(err) {
-					caaf.logger.Error("error validating function deployment", zap.String("function", fsvc.Function.Name), zap.Error(err))
+					logger.Error("error validating function deployment", zap.String("function", fsvc.Function.Name), zap.Error(err))
 				}
 				return false
 			}

--- a/pkg/executor/executortype/container/hpa.go
+++ b/pkg/executor/executortype/container/hpa.go
@@ -42,6 +42,7 @@ func (cn *Container) createOrGetHpa(ctx context.Context, hpaName string, execStr
 		return nil, errors.New("failed to create HPA, found empty deployment")
 	}
 
+	logger := otelUtils.LoggerWithTraceID(ctx, cn.logger)
 	minRepl := int32(execStrategy.MinScale)
 	if minRepl == 0 {
 		minRepl = 1
@@ -79,7 +80,7 @@ func (cn *Container) createOrGetHpa(ctx context.Context, hpaName string, execStr
 			existingHpa.Spec = hpa.Spec
 			existingHpa, err = cn.kubernetesClient.AutoscalingV1().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Update(ctx, existingHpa, metav1.UpdateOptions{})
 			if err != nil {
-				cn.logger.Warn("error adopting HPA", zap.Error(err),
+				logger.Warn("error adopting HPA", zap.Error(err),
 					zap.String("HPA", hpaName), zap.String("ns", depl.ObjectMeta.Namespace))
 				return nil, err
 			}

--- a/pkg/executor/executortype/container/hpa.go
+++ b/pkg/executor/executortype/container/hpa.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 const (
@@ -94,6 +95,7 @@ func (cn *Container) createOrGetHpa(ctx context.Context, hpaName string, execStr
 				return nil, err
 			}
 		}
+		otelUtils.SpanTrackEvent(ctx, "hpaCreated", otelUtils.GetAttributesForHPA(cHpa)...)
 		return cHpa, nil
 	}
 	return nil, err

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -48,6 +48,7 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 	if err != nil {
 		return nil, err
 	}
+	logger := otelUtils.LoggerWithTraceID(ctx, cn.logger)
 	service := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        svcName,
@@ -78,7 +79,7 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 			existingSvc.Spec.Type = service.Spec.Type
 			existingSvc, err = cn.kubernetesClient.CoreV1().Services(svcNamespace).Update(ctx, existingSvc, metav1.UpdateOptions{})
 			if err != nil {
-				cn.logger.Warn("error adopting service", zap.Error(err),
+				logger.Warn("error adopting service", zap.Error(err),
 					zap.String("service", svcName), zap.String("ns", svcNamespace))
 				return nil, err
 			}

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 func (cn *Container) getSvPort(fn *fv1.Function) (port int32, err error) {
@@ -93,6 +94,7 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 				return nil, err
 			}
 		}
+		otelUtils.SpanTrackEvent(ctx, "svcCreated", otelUtils.GetAttributesForSvc(svc)...)
 		return svc, nil
 	}
 	return nil, err

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -174,8 +174,9 @@ func (gpm *GenericPoolManager) GetTypeName(ctx context.Context) fv1.ExecutorType
 
 func (gpm *GenericPoolManager) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	otelUtils.SpanTrackEvent(ctx, "GetFuncSvc", otelUtils.GetAttributesForFunction(fn)...)
+	logger := otelUtils.LoggerWithTraceID(ctx, gpm.logger)
 	// from Func -> get Env
-	gpm.logger.Debug("getting environment for function", zap.String("function", fn.ObjectMeta.Name))
+	logger.Debug("getting environment for function", zap.String("function", fn.ObjectMeta.Name))
 	env, err := gpm.getFunctionEnv(ctx, fn)
 	if err != nil {
 		return nil, err
@@ -187,12 +188,12 @@ func (gpm *GenericPoolManager) GetFuncSvc(ctx context.Context, fn *fv1.Function)
 	}
 
 	if created {
-		gpm.logger.Info("created pool for the environment", zap.String("env", env.ObjectMeta.Name), zap.String("namespace", gpm.namespace))
+		logger.Info("created pool for the environment", zap.String("env", env.ObjectMeta.Name), zap.String("namespace", gpm.namespace))
 	}
 
 	// from GenericPool -> get one function container
 	// (this also adds to the cache)
-	gpm.logger.Debug("getting function service from pool", zap.String("function", fn.ObjectMeta.Name))
+	logger.Debug("getting function service from pool", zap.String("function", fn.ObjectMeta.Name))
 	return pool.getFuncSvc(ctx, fn)
 }
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-multierror"
+	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -51,6 +52,7 @@ import (
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
 	"github.com/fission/fission/pkg/utils"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 var _ executortype.ExecutorType = &GenericPoolManager{}
@@ -171,6 +173,7 @@ func (gpm *GenericPoolManager) GetTypeName(ctx context.Context) fv1.ExecutorType
 }
 
 func (gpm *GenericPoolManager) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	otelUtils.SpanTrackEvent(ctx, "GetFuncSvc", otelUtils.GetAttributesForFunction(fn)...)
 	// from Func -> get Env
 	gpm.logger.Debug("getting environment for function", zap.String("function", fn.ObjectMeta.Name))
 	env, err := gpm.getFunctionEnv(ctx, fn)
@@ -198,18 +201,25 @@ func (gpm *GenericPoolManager) GetFuncSvcFromCache(ctx context.Context, fn *fv1.
 }
 
 func (gpm *GenericPoolManager) GetFuncSvcFromPoolCache(ctx context.Context, fn *fv1.Function, requestsPerPod int) (*fscache.FuncSvc, int, error) {
+	otelUtils.SpanTrackEvent(ctx, "GetFuncSvcFromPoolCache", otelUtils.GetAttributesForFunction(fn)...)
 	return gpm.fsCache.GetFuncSvc(&fn.ObjectMeta, requestsPerPod)
 }
 
 func (gpm *GenericPoolManager) DeleteFuncSvcFromCache(ctx context.Context, fsvc *fscache.FuncSvc) {
+	otelUtils.SpanTrackEvent(ctx, "DeleteFuncSvcFromCache", otelUtils.GetAttributesForFuncSvc(fsvc)...)
 	gpm.fsCache.DeleteFunctionSvc(fsvc)
 }
 
 func (gpm *GenericPoolManager) UnTapService(ctx context.Context, key string, svcHost string) {
+	otelUtils.SpanTrackEvent(ctx, "UnTapService",
+		attribute.KeyValue{Key: "key", Value: attribute.StringValue(key)},
+		attribute.KeyValue{Key: "svcHost", Value: attribute.StringValue(svcHost)})
 	gpm.fsCache.MarkAvailable(key, svcHost)
 }
 
 func (gpm *GenericPoolManager) TapService(ctx context.Context, svcHost string) error {
+	otelUtils.SpanTrackEvent(ctx, "UnTapService",
+		attribute.KeyValue{Key: "svcHost", Value: attribute.StringValue(svcHost)})
 	err := gpm.fsCache.TouchByAddress(svcHost)
 	if err != nil {
 		return err
@@ -220,6 +230,7 @@ func (gpm *GenericPoolManager) TapService(ctx context.Context, svcHost string) e
 // IsValid checks if pod is not deleted and that it has the address passed as the argument. Also checks that all the
 // containers in it are reporting a ready status for the healthCheck.
 func (gpm *GenericPoolManager) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) bool {
+	otelUtils.SpanTrackEvent(ctx, "IsValid", otelUtils.GetAttributesForFuncSvc(fsvc)...)
 	for _, obj := range fsvc.KubernetesObjects {
 		if strings.ToLower(obj.Kind) == "pod" {
 			pod, err := gpm.podLister.Pods(obj.Namespace).Get(obj.Name)
@@ -499,6 +510,7 @@ func (gpm *GenericPoolManager) service() {
 }
 
 func (gpm *GenericPoolManager) getPool(ctx context.Context, env *fv1.Environment) (*GenericPool, bool, error) {
+	otelUtils.SpanTrackEvent(ctx, "getPool", otelUtils.GetAttributesForEnv(env)...)
 	c := make(chan *response)
 	gpm.requestChannel <- &request{
 		ctx:             ctx,
@@ -511,6 +523,7 @@ func (gpm *GenericPoolManager) getPool(ctx context.Context, env *fv1.Environment
 }
 
 func (gpm *GenericPoolManager) cleanupPool(ctx context.Context, env *fv1.Environment) {
+	otelUtils.SpanTrackEvent(ctx, "cleanupPool", otelUtils.GetAttributesForEnv(env)...)
 	gpm.requestChannel <- &request{
 		ctx:         ctx,
 		requestType: CLEANUP_POOL,
@@ -520,6 +533,7 @@ func (gpm *GenericPoolManager) cleanupPool(ctx context.Context, env *fv1.Environ
 
 func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Function) (*fv1.Environment, error) {
 	var env *fv1.Environment
+	otelUtils.SpanTrackEvent(ctx, "getFunctionEnv", otelUtils.GetAttributesForFunction(fn)...)
 
 	// Cached ?
 	// TODO: the cache should be able to search by <env name, fn namespace> instead of function metadata.
@@ -530,7 +544,7 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 	}
 
 	// Get env from controller
-	env, err = gpm.fissionClient.CoreV1().Environments(fn.Spec.Environment.Namespace).Get(ctx, fn.Spec.Environment.Name, metav1.GetOptions{})
+	env, err = gpm.poolPodC.envLister.Environments(fn.Spec.Environment.Namespace).Get(fn.Spec.Environment.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fetcher/client/client.go
+++ b/pkg/fetcher/client/client.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -19,6 +17,7 @@ import (
 
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fetcher"
+	"github.com/fission/fission/pkg/utils/tracing"
 )
 
 type (
@@ -30,13 +29,8 @@ type (
 )
 
 func MakeClient(logger *zap.Logger, fetcherUrl string) *Client {
-	openTracingEnabled, err := strconv.ParseBool(os.Getenv("OPENTRACING_ENABLED"))
-	if err != nil {
-		logger.Fatal("error parsing OPENTRACING_ENABLED", zap.Error(err))
-	}
-
 	var hc *http.Client
-	if openTracingEnabled {
+	if tracing.TracingEnabled(logger) {
 		hc = &http.Client{Transport: &ochttp.Transport{}}
 	} else {
 		hc = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -34,6 +34,7 @@ import (
 	"go.opencensus.io/plugin/ochttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
+	"golang.org/x/net/context/ctxhttp"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -709,7 +710,7 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		otelUtils.SpanTrackEvent(ctx, "specializeCall", otelUtils.MapToAttributes(map[string]string{
 			"url": specializeURL,
 		})...)
-		resp, err := http.Post(specializeURL, contentType, reader)
+		resp, err := ctxhttp.Post(ctx, fetcher.httpClient, specializeURL, contentType, reader)
 		if err == nil && resp.StatusCode < 300 {
 			// Success
 			resp.Body.Close()

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -166,50 +166,52 @@ func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
+
 	startTime := time.Now()
 	defer func() {
 		elapsed := time.Since(startTime)
-		fetcher.logger.Info("fetch request done", zap.Duration("elapsed_time", elapsed))
+		logger.Info("fetch request done", zap.Duration("elapsed_time", elapsed))
 	}()
 
 	// parse request
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		fetcher.logger.Error("error reading request body", zap.Error(err))
+		logger.Error("error reading request body", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	var req FunctionFetchRequest
 	err = json.Unmarshal(body, &req)
 	if err != nil {
-		fetcher.logger.Error("error parsing request body", zap.Error(err))
+		logger.Error("error parsing request body", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	pkg, err := fetcher.getPkgInformation(ctx, req)
 	if err != nil {
-		fetcher.logger.Error("error getting package information", zap.Error(err))
+		logger.Error("error getting package information", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
 	code, err := fetcher.Fetch(ctx, pkg, req)
 	if err != nil {
-		fetcher.logger.Error("error fetching", zap.Error(err))
+		logger.Error("error fetching", zap.Error(err))
 		http.Error(w, err.Error(), code)
 		return
 	}
 
-	fetcher.logger.Info("checking secrets/cfgmaps")
+	logger.Info("checking secrets/cfgmaps")
 	code, err = fetcher.FetchSecretsAndCfgMaps(ctx, req.Secrets, req.ConfigMaps)
 	if err != nil {
-		fetcher.logger.Error("error fetching secrets and config maps", zap.Error(err))
+		logger.Error("error fetching secrets and config maps", zap.Error(err))
 		http.Error(w, err.Error(), code)
 		return
 	}
 
-	fetcher.logger.Info("completed fetch request")
+	logger.Info("completed fetch request")
 	// all done
 	w.WriteHeader(http.StatusOK)
 }
@@ -221,25 +223,26 @@ func (fetcher *Fetcher) SpecializeHandler(w http.ResponseWriter, r *http.Request
 		http.Error(w, fmt.Sprintf("only POST is supported on this endpoint, %v received", r.Method), http.StatusMethodNotAllowed)
 		return
 	}
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
 
 	// parse request
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		fetcher.logger.Error("error reading request body", zap.Error(err))
+		logger.Error("error reading request body", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	var req FunctionSpecializeRequest
 	err = json.Unmarshal(body, &req)
 	if err != nil {
-		fetcher.logger.Error("error parsing request body", zap.Error(err))
+		logger.Error("error parsing request body", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
 	err = fetcher.SpecializePod(ctx, req.FetchReq, req.LoadReq)
 	if err != nil {
-		fetcher.logger.Error("error specializing pod", zap.Error(err))
+		logger.Error("error specializing pod", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -251,16 +254,18 @@ func (fetcher *Fetcher) SpecializeHandler(w http.ResponseWriter, r *http.Request
 // Fetch takes FetchRequest and makes the fetch call
 // It returns the HTTP code and error if any
 func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req FunctionFetchRequest) (int, error) {
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
+
 	// check that the requested filename is not an empty string and error out if so
 	if len(req.Filename) == 0 {
 		e := "fetch request received for an empty file name"
-		fetcher.logger.Error(e, zap.Any("request", req))
+		logger.Error(e, zap.Any("request", req))
 		return http.StatusBadRequest, errors.New(fmt.Sprintf("%s, request: %v", e, req))
 	}
 
 	// verify first if the file already exists.
 	if _, err := os.Stat(filepath.Join(fetcher.sharedVolumePath, req.Filename)); err == nil {
-		fetcher.logger.Info("requested file already exists at shared volume - skipping fetch",
+		logger.Info("requested file already exists at shared volume - skipping fetch",
 			zap.String("requested_file", req.Filename),
 			zap.String("shared_volume_path", fetcher.sharedVolumePath))
 		otelUtils.SpanTrackEvent(ctx, "packageAlreadyExists", otelUtils.GetAttributesForPackage(pkg)...)
@@ -280,7 +285,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 		err := utils.DownloadUrl(ctx, fetcher.httpClient, req.Url, tmpPath)
 		if err != nil {
 			e := "failed to download url"
-			fetcher.logger.Error(e, zap.Error(err), zap.String("url", req.Url))
+			logger.Error(e, zap.Error(err), zap.String("url", req.Url))
 			return http.StatusBadRequest, errors.Wrapf(err, "%s: %s", e, req.Url)
 		}
 	} else {
@@ -294,7 +299,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 			// it may be useful to the user if we can send a more meaningful error in such a scenario.
 			if pkg.Status.BuildStatus != fv1.BuildStatusSucceeded && pkg.Status.BuildStatus != fv1.BuildStatusNone {
 				e := fmt.Sprintf("cannot fetch deployment: package build status was not %q", fv1.BuildStatusSucceeded)
-				fetcher.logger.Error(e,
+				logger.Error(e,
 					zap.String("package_name", pkg.ObjectMeta.Name),
 					zap.String("package_namespace", pkg.ObjectMeta.Namespace),
 					zap.Any("package_build_status", pkg.Status.BuildStatus))
@@ -311,7 +316,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 			err := ioutil.WriteFile(tmpPath, archive.Literal, 0600)
 			if err != nil {
 				e := "failed to write file"
-				fetcher.logger.Error(e, zap.Error(err), zap.String("location", tmpPath))
+				logger.Error(e, zap.Error(err), zap.String("location", tmpPath))
 				return http.StatusInternalServerError, errors.Wrapf(err, "%s %s", e, tmpPath)
 			}
 			otelUtils.SpanTrackEvent(ctx, "archiveLiteral", otelUtils.GetAttributesForPackage(pkg)...)
@@ -325,7 +330,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 			err := utils.DownloadUrl(ctx, fetcher.httpClient, archive.URL, tmpPath)
 			if err != nil {
 				e := "failed to download url"
-				fetcher.logger.Error(e, zap.Error(err), zap.String("url", req.Url))
+				logger.Error(e, zap.Error(err), zap.String("url", req.Url))
 				return http.StatusBadRequest, errors.Wrapf(err, "%s %s", e, req.Url)
 			}
 
@@ -334,13 +339,13 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 				checksum, err := utils.GetFileChecksum(tmpPath)
 				if err != nil {
 					e := "failed to get checksum"
-					fetcher.logger.Error(e, zap.Error(err))
+					logger.Error(e, zap.Error(err))
 					return http.StatusBadRequest, errors.Wrap(err, e)
 				}
 				err = verifyChecksum(checksum, &archive.Checksum)
 				if err != nil {
 					e := "failed to verify checksum"
-					fetcher.logger.Error(e, zap.Error(err))
+					logger.Error(e, zap.Error(err))
 					return http.StatusBadRequest, errors.Wrap(err, e)
 				}
 			}
@@ -352,7 +357,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 		tmpUnarchivePath := filepath.Join(fetcher.sharedVolumePath, uuid.NewV4().String())
 		err := fetcher.unarchive(tmpPath, tmpUnarchivePath)
 		if err != nil {
-			fetcher.logger.Error("error unarchive",
+			logger.Error("error unarchive",
 				zap.Error(err),
 				zap.String("archive_location", tmpPath),
 				zap.String("target_location", tmpUnarchivePath))
@@ -366,7 +371,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 	renamePath := filepath.Join(fetcher.sharedVolumePath, req.Filename)
 	err := fetcher.rename(tmpPath, renamePath)
 	if err != nil {
-		fetcher.logger.Error("error renaming file",
+		logger.Error("error renaming file",
 			zap.Error(err),
 			zap.String("original_path", tmpPath),
 			zap.String("rename_path", renamePath))
@@ -374,13 +379,15 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 	}
 
 	otelUtils.SpanTrackEvent(ctx, "packageFetched", otelUtils.GetAttributesForPackage(pkg)...)
-	fetcher.logger.Info("successfully placed", zap.String("location", renamePath))
+	logger.Info("successfully placed", zap.String("location", renamePath))
 	return http.StatusOK, nil
 }
 
 // FetchSecretsAndCfgMaps fetches secrets and configmaps specified by user
 // It returns the HTTP code and error if any
 func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv1.SecretReference, cfgmaps []fv1.ConfigMapReference) (int, error) {
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
+
 	if len(secrets) > 0 {
 		for _, secret := range secrets {
 			data, err := fetcher.kubeClient.CoreV1().Secrets(secret.Namespace).Get(ctx, secret.Name, metav1.GetOptions{})
@@ -393,7 +400,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 					httpCode = http.StatusNotFound
 					e = "secret was not found in kubeapi"
 				}
-				fetcher.logger.Error(e,
+				logger.Error(e,
 					zap.Error(err),
 					zap.String("secret_name", secret.Name),
 					zap.String("secret_namespace", secret.Namespace))
@@ -406,7 +413,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 			err = os.MkdirAll(secretDir, os.ModeDir|0750)
 			if err != nil {
 				e := "failed to create directory for secret"
-				fetcher.logger.Error(e,
+				logger.Error(e,
 					zap.Error(err),
 					zap.String("directory", secretDir),
 					zap.String("secret_name", secret.Name),
@@ -415,7 +422,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 			}
 			err = writeSecretOrConfigMap(data.Data, secretDir)
 			if err != nil {
-				fetcher.logger.Error("failed to write secret to file location",
+				logger.Error("failed to write secret to file location",
 					zap.Error(err),
 					zap.String("location", secretDir),
 					zap.String("secret_name", secret.Name),
@@ -441,7 +448,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 					httpCode = http.StatusNotFound
 					e = "configmap was not found in kubeapi"
 				}
-				fetcher.logger.Error(e,
+				logger.Error(e,
 					zap.Error(err),
 					zap.String("config_map_name", config.Name),
 					zap.String("config_map_namespace", config.Namespace))
@@ -454,7 +461,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 			err = os.MkdirAll(configDir, os.ModeDir|0750)
 			if err != nil {
 				e := "failed to create directory for configmap"
-				fetcher.logger.Error(e,
+				logger.Error(e,
 					zap.Error(err),
 					zap.String("directory", configDir),
 					zap.String("config_map_name", config.Name),
@@ -467,7 +474,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 			}
 			err = writeSecretOrConfigMap(configMap, configDir)
 			if err != nil {
-				fetcher.logger.Error("failed to write configmap to file location",
+				logger.Error("failed to write configmap to file location",
 					zap.Error(err),
 					zap.String("location", configDir),
 					zap.String("config_map_name", config.Name),
@@ -486,6 +493,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 
 func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
 
 	if r.Method != "POST" {
 		http.Error(w, "only POST is supported on this endpoint", http.StatusMethodNotAllowed)
@@ -495,13 +503,13 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
 	defer func() {
 		elapsed := time.Since(startTime)
-		fetcher.logger.Info("upload request done", zap.Duration("elapsed_time", elapsed))
+		logger.Info("upload request done", zap.Duration("elapsed_time", elapsed))
 	}()
 
 	// parse request
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		fetcher.logger.Error("error reading request body", zap.Error(err))
+		logger.Error("error reading request body", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -509,11 +517,11 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	var req ArchiveUploadRequest
 	err = json.Unmarshal(body, &req)
 	if err != nil {
-		fetcher.logger.Error("error parsing request body", zap.Error(err))
+		logger.Error("error parsing request body", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	fetcher.logger.Info("fetcher received upload request", zap.Any("request", req))
+	logger.Info("fetcher received upload request", zap.Any("request", req))
 
 	zipFilename := req.Filename + ".zip"
 	srcFilepath := filepath.Join(fetcher.sharedVolumePath, req.Filename)
@@ -523,7 +531,7 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 		err = fetcher.archive(srcFilepath, dstFilepath)
 		if err != nil {
 			e := "error archiving zip file"
-			fetcher.logger.Error(e, zap.Error(err), zap.String("source", srcFilepath), zap.String("destination", dstFilepath))
+			logger.Error(e, zap.Error(err), zap.String("source", srcFilepath), zap.String("destination", dstFilepath))
 			http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 			return
 		}
@@ -531,19 +539,19 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 		err = os.Rename(srcFilepath, dstFilepath)
 		if err != nil {
 			e := "error renaming the archive"
-			fetcher.logger.Error(e, zap.Error(err), zap.String("source", srcFilepath), zap.String("destination", dstFilepath))
+			logger.Error(e, zap.Error(err), zap.String("source", srcFilepath), zap.String("destination", dstFilepath))
 			http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 			return
 		}
 	}
 
-	fetcher.logger.Info("starting upload...")
+	logger.Info("starting upload...")
 	ssClient := storageSvcClient.MakeClient(req.StorageSvcUrl)
 
 	fileID, err := ssClient.Upload(ctx, dstFilepath, nil)
 	if err != nil {
 		e := "error uploading zip file"
-		fetcher.logger.Error(e, zap.Error(err), zap.String("file", dstFilepath))
+		logger.Error(e, zap.Error(err), zap.String("file", dstFilepath))
 		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 		return
 	}
@@ -551,7 +559,7 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	sum, err := utils.GetFileChecksum(dstFilepath)
 	if err != nil {
 		e := "error calculating checksum of zip file"
-		fetcher.logger.Error(e, zap.Error(err), zap.String("file", dstFilepath))
+		logger.Error(e, zap.Error(err), zap.String("file", dstFilepath))
 		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 		return
 	}
@@ -564,18 +572,18 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	rBody, err := json.Marshal(resp)
 	if err != nil {
 		e := "error encoding upload response"
-		fetcher.logger.Error(e, zap.Error(err))
+		logger.Error(e, zap.Error(err))
 		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 		return
 	}
 
-	fetcher.logger.Info("completed upload request")
+	logger.Info("completed upload request")
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(rBody)
 	if err != nil {
 		e := "error writing response"
-		fetcher.logger.Error(e, zap.Error(err))
+		logger.Error(e, zap.Error(err))
 		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 	}
 }
@@ -619,6 +627,7 @@ func (fetcher *Fetcher) unarchive(src string, dst string) error {
 
 // getPkgInformation gets package information from k8s api server.
 func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetchRequest) (pkg *fv1.Package, err error) {
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
 	maxRetries := 5
 	for i := 0; i < maxRetries; i++ {
 		otelUtils.SpanTrackEvent(ctx, "fetchPkgInfo", otelUtils.MapToAttributes(map[string]string{
@@ -630,7 +639,7 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 		pkg, err = fetcher.fissionClient.CoreV1().Packages(req.Package.Namespace).Get(ctx, req.Package.Name, metav1.GetOptions{})
 		if err == nil {
 			if req.Package.ResourceVersion != pkg.ResourceVersion {
-				fetcher.logger.Warn("package resource version mismatch", zap.String("pkgName", req.Package.Name), zap.String("pkgNamespace", req.Package.Namespace), zap.String("pkgResourceVersion", req.Package.ResourceVersion), zap.String("fetchedResourceVersion", pkg.ResourceVersion))
+				logger.Warn("package resource version mismatch", zap.String("pkgName", req.Package.Name), zap.String("pkgNamespace", req.Package.Namespace), zap.String("pkgResourceVersion", req.Package.ResourceVersion), zap.String("fetchedResourceVersion", pkg.ResourceVersion))
 			}
 			return pkg, nil
 		}
@@ -658,10 +667,11 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 }
 
 func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetchRequest, loadReq FunctionLoadRequest) error {
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
 	startTime := time.Now()
 	defer func() {
 		elapsed := time.Since(startTime)
-		fetcher.logger.Info("specialize request done", zap.Duration("elapsed_time", elapsed))
+		logger.Info("specialize request done", zap.Duration("elapsed_time", elapsed))
 	}()
 
 	pkg, err := fetcher.getPkgInformation(ctx, fetchReq)
@@ -698,12 +708,12 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		contentType = "application/json"
 		specializeURL = "http://127.0.0.1:8888/v2/specialize"
 		reader = bytes.NewReader(loadPayload)
-		fetcher.logger.Info("calling environment v2 specialization endpoint")
+		logger.Info("calling environment v2 specialization endpoint")
 	} else {
 		contentType = "text/plain"
 		specializeURL = "http://127.0.0.1:8888/specialize"
 		reader = bytes.NewReader([]byte{})
-		fetcher.logger.Info("calling environment v1 specialization endpoint")
+		logger.Info("calling environment v1 specialization endpoint")
 	}
 
 	for i := 0; i < maxRetries; i++ {
@@ -722,7 +732,7 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		if netErr != nil && (netErr.IsConnRefusedError() || netErr.IsDialError()) {
 			if i < maxRetries-1 {
 				time.Sleep(500 * time.Duration(2*i) * time.Millisecond)
-				fetcher.logger.Error("error connecting to function environment pod for specialization request, retrying", zap.Error(netErr))
+				logger.Error("error connecting to function environment pod for specialization request, retrying", zap.Error(netErr))
 				continue
 			}
 		}
@@ -741,7 +751,7 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 // WsStartHandler is used to generate websocket events in Kubernetes
 func (fetcher *Fetcher) WsStartHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
 	if r.Method != "GET" {
 		http.Error(w, "only GET is supported on this endpoint", http.StatusMethodNotAllowed)
 		return
@@ -755,17 +765,17 @@ func (fetcher *Fetcher) WsStartHandler(w http.ResponseWriter, r *http.Request) {
 		FieldSelector: "metadata.name=" + fetcher.Info.Name,
 	})
 	if err != nil {
-		fetcher.logger.Error("Failed to get the pod", zap.Error(err))
+		logger.Error("Failed to get the pod", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	for _, pod := range pods.Items {
 		ref, err := reference.GetReference(scheme.Scheme, &pod)
 		if err != nil {
-			fetcher.logger.Error("Could not get reference for pod", zap.Error(err))
+			logger.Error("Could not get reference for pod", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		rec.Event(ref, corev1.EventTypeNormal, "WsConnectionStarted", "Websocket connection has been formed on this pod")
-		fetcher.logger.Info("Sent websocket initiation event")
+		logger.Info("Sent websocket initiation event")
 	}
 	w.WriteHeader(http.StatusOK)
 }
@@ -774,6 +784,8 @@ func (fetcher *Fetcher) WsStartHandler(w http.ResponseWriter, r *http.Request) {
 func (fetcher *Fetcher) WsEndHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
+
 	if r.Method != "GET" {
 		http.Error(w, "only GET is supported on this endpoint", http.StatusMethodNotAllowed)
 		return
@@ -787,19 +799,19 @@ func (fetcher *Fetcher) WsEndHandler(w http.ResponseWriter, r *http.Request) {
 		FieldSelector: "metadata.name=" + fetcher.Info.Name,
 	})
 	if err != nil {
-		fetcher.logger.Error("Failed to get the pod", zap.Error(err))
+		logger.Error("Failed to get the pod", zap.Error(err))
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 	for _, pod := range pods.Items {
 		// There will only be one time since we've used field selector
 		ref, err := reference.GetReference(scheme.Scheme, &pod)
 		if err != nil {
-			fetcher.logger.Error("Could not get reference for pod", zap.Error(err))
+			logger.Error("Could not get reference for pod", zap.Error(err))
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		// We could use Eventf and supply the amount of time the connection was inactive although, in case of multiple connections, it doesn't make sense
 		rec.Event(ref, corev1.EventTypeNormal, "NoActiveConnections", "Connection has been inactive")
-		fetcher.logger.Info("Sent no active connections event")
+		logger.Info("Sent no active connections event")
 	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -19,8 +19,6 @@ package router
 import (
 	"context"
 	"net/http"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -37,6 +35,7 @@ import (
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/otel"
+	"github.com/fission/fission/pkg/utils/tracing"
 )
 
 // HTTPTriggerSet represents an HTTP trigger set
@@ -114,10 +113,7 @@ func routerHealthHandler(w http.ResponseWriter, r *http.Request) {
 func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router {
 	muxRouter := mux.NewRouter()
 
-	openTracingEnabled, err := strconv.ParseBool(os.Getenv("OPENTRACING_ENABLED"))
-	if err != nil {
-		ts.logger.Fatal("error parsing OPENTRACING_ENABLED", zap.Error(err))
-	}
+	openTracingEnabled := tracing.TracingEnabled(ts.logger)
 
 	// HTTP triggers setup by the user
 	homeHandled := false

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -27,16 +27,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-	"go.uber.org/zap"
 	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/fission/fission/pkg/storagesvc"
+	"github.com/fission/fission/pkg/utils/tracing"
 )
 
 type (
@@ -48,13 +47,8 @@ type (
 
 // Client creates a storage service client.
 func MakeClient(url string) *Client {
-	openTracingEnabled, err := strconv.ParseBool(os.Getenv("OPENTRACING_ENABLED"))
-	if err != nil {
-		fmt.Printf("error parsing OPENTRACING_ENABLED: %v\n", zap.Error(err))
-	}
-
 	var hc *http.Client
-	if openTracingEnabled {
+	if tracing.TracingEnabled(nil) {
 		hc = &http.Client{Transport: &ochttp.Transport{}}
 	} else {
 		hc = &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}

--- a/pkg/utils/otel/attributes.go
+++ b/pkg/utils/otel/attributes.go
@@ -1,9 +1,16 @@
 package otel
 
 import (
+	"context"
+
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	appsv1 "k8s.io/api/apps/v1"
+	asv1 "k8s.io/api/autoscaling/v1"
+	apiv1 "k8s.io/api/core/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
 )
 
 /* GetAttributesForFunction returns a set of attributes for a function. Attributes returned:
@@ -11,14 +18,112 @@ import (
     function-namespace
     environment-name
     environment-namespace
-
 These attributes are tags that can be used to filter traces.
 */
 func GetAttributesForFunction(fn *fv1.Function) []attribute.KeyValue {
-	return []attribute.KeyValue{
+	if fn == nil {
+		return []attribute.KeyValue{}
+	}
+	attrs := []attribute.KeyValue{
 		{Key: "function-name", Value: attribute.StringValue(fn.Name)},
 		{Key: "function-namespace", Value: attribute.StringValue(fn.Namespace)},
-		{Key: "environment-name", Value: attribute.StringValue(fn.Spec.Environment.Name)},
-		{Key: "environment-namespace", Value: attribute.StringValue(fn.Spec.Environment.Namespace)},
 	}
+	if fn.Spec.Environment.Name != "" {
+		attrs = append(attrs,
+			attribute.KeyValue{Key: "environment-name", Value: attribute.StringValue(fn.Spec.Environment.Name)},
+			attribute.KeyValue{Key: "environment-namespace", Value: attribute.StringValue(fn.Spec.Environment.Namespace)})
+	}
+	return attrs
+}
+
+func GetAttributesForEnv(env *fv1.Environment) []attribute.KeyValue {
+	if env == nil {
+		return []attribute.KeyValue{}
+	}
+	return []attribute.KeyValue{
+		{Key: "environment-name", Value: attribute.StringValue(env.Name)},
+		{Key: "environment-namespace", Value: attribute.StringValue(env.Namespace)}}
+}
+
+func GetAttributesForPackage(pkg *fv1.Package) []attribute.KeyValue {
+	if pkg == nil {
+		return []attribute.KeyValue{}
+	}
+	return []attribute.KeyValue{
+		{Key: "package-name", Value: attribute.StringValue(pkg.Name)},
+		{Key: "package-namespace", Value: attribute.StringValue(pkg.Namespace)}}
+}
+
+func GetAttributesForFuncSvc(fsvc *fscache.FuncSvc) []attribute.KeyValue {
+	if fsvc == nil {
+		return []attribute.KeyValue{}
+	}
+	var attrs []attribute.KeyValue
+	if fsvc.Function != nil {
+		attrs = append(attrs,
+			attribute.KeyValue{Key: "function-name", Value: attribute.StringValue(fsvc.Function.Name)},
+			attribute.KeyValue{Key: "function-namespace", Value: attribute.StringValue(fsvc.Function.Namespace)})
+	}
+	if fsvc.Environment != nil {
+		attrs = append(attrs,
+			attribute.KeyValue{Key: "environment-name", Value: attribute.StringValue(fsvc.Environment.Name)},
+			attribute.KeyValue{Key: "environment-namespace", Value: attribute.StringValue(fsvc.Environment.Namespace)})
+	}
+	if fsvc.Address != "" {
+		attrs = append(attrs, attribute.KeyValue{Key: "address", Value: attribute.StringValue(fsvc.Address)})
+	}
+	return attrs
+}
+
+func GetAttributesForPod(pod *apiv1.Pod) []attribute.KeyValue {
+	if pod == nil {
+		return []attribute.KeyValue{}
+	}
+	return []attribute.KeyValue{
+		{Key: "pod-name", Value: attribute.StringValue(pod.Name)},
+		{Key: "pod-namespace", Value: attribute.StringValue(pod.Namespace)},
+		{Key: "pod-ip", Value: attribute.StringValue(pod.Status.PodIP)},
+	}
+}
+
+func GetAttributesForDeployment(deployment *appsv1.Deployment) []attribute.KeyValue {
+	if deployment == nil {
+		return []attribute.KeyValue{}
+	}
+	return []attribute.KeyValue{
+		{Key: "deployment-name", Value: attribute.StringValue(deployment.Name)},
+		{Key: "deployment-namespace", Value: attribute.StringValue(deployment.Namespace)},
+	}
+}
+
+func GetAttributesForHPA(hpa *asv1.HorizontalPodAutoscaler) []attribute.KeyValue {
+	if hpa == nil {
+		return []attribute.KeyValue{}
+	}
+	return []attribute.KeyValue{
+		{Key: "hpa-name", Value: attribute.StringValue(hpa.Name)},
+		{Key: "hpa-namespace", Value: attribute.StringValue(hpa.Namespace)},
+	}
+}
+
+func GetAttributesForSvc(svc *apiv1.Service) []attribute.KeyValue {
+	if svc == nil {
+		return []attribute.KeyValue{}
+	}
+	return []attribute.KeyValue{
+		{Key: "svc-name", Value: attribute.StringValue(svc.Name)},
+		{Key: "svc-namespace", Value: attribute.StringValue(svc.Namespace)},
+	}
+}
+
+func MapToAttributes(m map[string]string) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(m))
+	for k, v := range m {
+		attrs = append(attrs, attribute.KeyValue{Key: attribute.Key(k), Value: attribute.StringValue(v)})
+	}
+	return attrs
+}
+
+func SpanTrackEvent(ctx context.Context, event string, attributes ...attribute.KeyValue) {
+	trace.SpanFromContext(ctx).AddEvent(event, trace.WithAttributes(attributes...))
 }

--- a/pkg/utils/otel/log.go
+++ b/pkg/utils/otel/log.go
@@ -26,5 +26,5 @@ func LoggerWithTraceID(context context.Context, logger *zap.Logger) *zap.Logger 
 	if span := trace.SpanContextFromContext(context); span.TraceID().IsValid() {
 		return logger.With(zap.String("trace_id", span.TraceID().String()))
 	}
-	return logger.With(zap.String("trace_id", "unknown"))
+	return logger
 }

--- a/pkg/utils/otel/log.go
+++ b/pkg/utils/otel/log.go
@@ -18,13 +18,13 @@ package otel
 import (
 	"context"
 
-	"go.opencensus.io/trace"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
 
 func LoggerWithTraceID(context context.Context, logger *zap.Logger) *zap.Logger {
-	if span := trace.FromContext(context); span != nil {
-		return logger.With(zap.String("trace_id", span.SpanContext().TraceID.String()))
+	if span := trace.SpanContextFromContext(context); span.TraceID().IsValid() {
+		return logger.With(zap.String("trace_id", span.TraceID().String()))
 	}
 	return logger.With(zap.String("trace_id", "unknown"))
 }

--- a/pkg/utils/otel/log.go
+++ b/pkg/utils/otel/log.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package otel
+
+import (
+	"context"
+
+	"go.opencensus.io/trace"
+	"go.uber.org/zap"
+)
+
+func LoggerWithTraceID(context context.Context, logger *zap.Logger) *zap.Logger {
+	if span := trace.FromContext(context); span != nil {
+		return logger.With(zap.String("trace_id", span.SpanContext().TraceID.String()))
+	}
+	return logger.With(zap.String("trace_id", "unknown"))
+}

--- a/pkg/utils/tracing/tracing.go
+++ b/pkg/utils/tracing/tracing.go
@@ -10,6 +10,17 @@ import (
 	"go.uber.org/zap"
 )
 
+func TracingEnabled(logger *zap.Logger) bool {
+	openTracingEnabled, err := strconv.ParseBool(os.Getenv("OPENTRACING_ENABLED"))
+	if err != nil {
+		if logger != nil {
+			logger.Error("Error parsing OpenTracing enabled flag", zap.Error(err))
+		}
+		return false
+	}
+	return openTracingEnabled
+}
+
 func RegisterTraceExporter(logger *zap.Logger, collectorEndpoint, serviceName string) error {
 	if len(collectorEndpoint) == 0 {
 		logger.Info("skipping trace exporter registration")


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

1. We capture all spans from router to function pod
![image](https://user-images.githubusercontent.com/1511975/133258882-7c96493c-966c-452e-b264-bf42a3c5d014.png)

2. Within a span different events are captured
![image](https://user-images.githubusercontent.com/1511975/133259366-227a7dc4-639c-4c42-a599-6b6f74f1bc04.png)

3. Logs with context should have traceID, so by trace ID we can travel all logs. Logs with trace ID are enabled even if opentelemtry collector not mentioned.
```text
executor-7758b648f6-2tsgn executor {"level":"info","ts":"2021-09-14T11:32:01.971Z","logger":"generic_pool_manager.generic_pool","caller":"poolmgr/gp.go:480","msg":"chose pod","trace_id":"26394b2c0739b896b5dada41d2bba00e","labels":{"environmentName":"go","environmentNamespace":"default","environmentUid":"97e63265-4846-4b19-8035-d6d862164409","executorType":"poolmgr","functionName":"go-otel-func","functionNamespace":"default","functionUid":"53c273ec-842c-4071-bd62-13d944a251cf","managed":"false"},"pod":"poolmgr-go-default-2129733-8f85f8f65-kpg82","elapsed_time":0.0274459}
executor-7758b648f6-2tsgn executor {"level":"info","ts":"2021-09-14T11:32:01.971Z","logger":"generic_pool_manager.generic_pool","caller":"poolmgr/gp.go:485","msg":"calling fetcher to copy function","trace_id":"26394b2c0739b896b5dada41d2bba00e","function":"go-otel-func","url":"http://10.244.0.73:8000/"}
executor-7758b648f6-2tsgn executor {"level":"info","ts":"2021-09-14T11:32:01.971Z","logger":"generic_pool_manager.generic_pool","caller":"poolmgr/gp.go:485","msg":"specializing pod","trace_id":"26394b2c0739b896b5dada41d2bba00e","function":"go-otel-func"}
executor-7758b648f6-2tsgn executor {"level":"info","ts":"2021-09-14T11:32:02.184Z","logger":"generic_pool_manager.generic_pool","caller":"poolmgr/gpm.go:197","msg":"specialized pod","trace_id":"26394b2c0739b896b5dada41d2bba00e","function":"go-otel-func","functionNamespace":"default","env":"go","envNamespace":"default","pod":"poolmgr-go-default-2129733-8f85f8f65-kpg82","podNamespace":"fission-function","podIP":"10.244.0.73"}
executor-7758b648f6-2tsgn executor {"level":"info","ts":"2021-09-14T11:32:02.220Z","logger":"generic_pool_manager.generic_pool","caller":"poolmgr/gpm.go:197","msg":"added function service","trace_id":"26394b2c0739b896b5dada41d2bba00e","function":"go-otel-func","functionNamespace":"default","env":"go","envNamespace":"default","pod":"poolmgr-go-default-2129733-8f85f8f65-kpg82","podNamespace":"fission-function","serviceHost":"10.244.0.73:8888","podIP":"10.244.0.73"}
executor-7758b648f6-2tsgn executor {"level":"info","ts":"2021-09-14T11:34:04.971Z","logger":"generic_pool_manager","caller":"runtime/asm_amd64.s:1371","msg":"release idle function resources","function":"go-otel-func","address":"10.244.0.73:8888","executor":"poolmgr","pod":"poolmgr-go-default-2129733-8f85f8f65-kpg82"}
```