### PR TITLE
Check package resource version from fetch request with fetched package

### DIFF
--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -125,8 +125,9 @@ func (cfg *Config) NewSpecializeRequest(fn *fv1.Function, env *fv1.Environment) 
 		FetchReq: fetcher.FunctionFetchRequest{
 			FetchType: fv1.FETCH_DEPLOYMENT,
 			Package: metav1.ObjectMeta{
-				Namespace: fn.Spec.Package.PackageRef.Namespace,
-				Name:      fn.Spec.Package.PackageRef.Name,
+				Namespace:       fn.Spec.Package.PackageRef.Namespace,
+				Name:            fn.Spec.Package.PackageRef.Name,
+				ResourceVersion: fn.Spec.Package.PackageRef.ResourceVersion,
 			},
 			Filename:    targetFilename,
 			Secrets:     fn.Spec.Secrets,

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -602,8 +602,12 @@ func (fetcher *Fetcher) unarchive(src string, dst string) error {
 func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetchRequest) (pkg *fv1.Package, err error) {
 	maxRetries := 5
 	for i := 0; i < maxRetries; i++ {
+		// TODO: pass resource version in the GetOptions, added warning for now
 		pkg, err = fetcher.fissionClient.CoreV1().Packages(req.Package.Namespace).Get(ctx, req.Package.Name, metav1.GetOptions{})
 		if err == nil {
+			if req.Package.ResourceVersion != pkg.ResourceVersion {
+				fetcher.logger.Warn("package resource version mismatch", zap.String("pkgName", req.Package.Name), zap.String("pkgNamespace", req.Package.Namespace), zap.String("pkgResourceVersion", req.Package.ResourceVersion), zap.String("fetchedResourceVersion", pkg.ResourceVersion))
+			}
 			return pkg, nil
 		}
 		if i < maxRetries-1 {


### PR DESCRIPTION
When fetch request is received by fetcher, it fetches
package information. Adding resource version also in fetch request
so that we ensure package resource version mentioned in fetch req
matches with one received.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>