### PR TITLE
refactor: Use workqueue in package watcher and pod lister in builder manager

### DIFF
--- a/charts/fission-all/templates/deployment.yaml
+++ b/charts/fission-all/templates/deployment.yaml
@@ -109,6 +109,7 @@ rules:
   - kuberneteswatchtriggers
   - messagequeuetriggers
   - packages
+  - packages/status
   - timetriggers
   verbs:
   - '*'

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -121,7 +121,7 @@ func buildPackage(ctx context.Context, logger *zap.Logger, fissionClient *crd.Fi
 	return uploadResp, buildResp.BuildLogs, nil
 }
 
-func updatePackage(logger *zap.Logger, fissionClient *crd.FissionClient,
+func updatePackage(ctx context.Context, logger *zap.Logger, fissionClient *crd.FissionClient,
 	pkg *fv1.Package, status fv1.BuildStatus, buildLogs string,
 	uploadResp *fetcher.ArchiveUploadResponse) (*fv1.Package, error) {
 
@@ -140,7 +140,7 @@ func updatePackage(logger *zap.Logger, fissionClient *crd.FissionClient,
 	}
 
 	// update package spec
-	pkg, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(context.TODO(), pkg, metav1.UpdateOptions{})
+	pkg, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
 	if err != nil {
 		e := "error updating package"
 		logger.Error(e, zap.Error(err))


### PR DESCRIPTION
Use pod lister synced for listing pods

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>