### PR TITLE
security: Chart dependency update: prometheus, fluentd, influxdb

### DIFF
--- a/charts/fission-all/Chart.lock
+++ b/charts/fission-all/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: prometheus
   repository: https://prometheus-community.github.io/helm-charts
-  version: 13.2.1
-digest: sha256:136360a97bdc11f1933d75bab77728acc75dd9583257b973cb3336b6d136c9b6
-generated: "2021-05-27T18:51:04.509283+05:30"
+  version: 14.11.0
+digest: sha256:1404b25cbdba70279240fead15b765d6945097fed5afc7e184da02dabfaa577a
+generated: "2021-10-19T17:20:08.919609+05:30"

--- a/charts/fission-all/Chart.yaml
+++ b/charts/fission-all/Chart.yaml
@@ -20,6 +20,6 @@ engine: gotpl
 type: application
 dependencies:
   - name: prometheus
-    version: 13.2.1
+    version: 14.11.0
     repository: https://prometheus-community.github.io/helm-charts
     condition: prometheus.enabled

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -284,7 +284,7 @@ logger:
   influxdbAdmin: "admin"
   fluentdImageRepository: index.docker.io
   fluentdImage: fluent/fluent-bit
-  fluentdImageTag: 1.5.1
+  fluentdImageTag: 1.8.8
 
   ## Fluent-bit writes/reads it’s own sqlite database to record a history of tracked
   ## files and a state of offsets, this is very useful to resume a state if the ser-
@@ -307,7 +307,7 @@ logger:
 ## Enable InfluxDB
 influxdb:
   enabled: false
-  image: influxdb:1.7
+  image: influxdb:1.8
 
 # Allow user to override busybox image used in fluent-bit init container
 busyboxImage: busybox


### PR DESCRIPTION
- Updated prometheus chart to 14.11.0
- Fluentd image to 1.8.8
- Influxdb to 1.8

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>