### PR TITLE
Adding validations for env/fn before listing pods

### DIFF
--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -41,6 +41,16 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
+	// validate environment
+	_, err := opts.Client().V1().Environment().Get(
+		&metav1.ObjectMeta{
+			Name:      input.String(flagkey.EnvName),
+			Namespace: input.String(flagkey.NamespaceEnvironment),
+		})
+	if err != nil {
+		return errors.Wrap(err, "error getting environment")
+	}
+
 	m := &metav1.ObjectMeta{
 		Name: input.String(flagkey.EnvName),
 		Labels: map[string]string{

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -41,6 +41,15 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
+	// validate function
+	_, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
+		Name:      input.String(flagkey.FnName),
+		Namespace: input.String(flagkey.NamespaceFunction),
+	})
+	if err != nil {
+		return errors.Wrap(err, "error getting function")
+	}
+
 	m := &metav1.ObjectMeta{
 		Name: input.String(flagkey.FnName),
 		Labels: map[string]string{


### PR DESCRIPTION
Before listing pods for a function/enviornment,a validation has been added to check it's existence.

```
 fission env po --name notexist

Aliases:
  pods, pod, po

Options:
  --name=''                           Environment name
  --envNamespace='default' (--envns)  Namespace for environment object
  --executortype=''                   Executor type of pod in environment; one of 'poolmgr',
                                      'newdeploy', 'container'

Global Options:
  --server=''         Server URL
  --verbosity=1 (-v)  CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)
  --kube-context=''   Kubernetes context to be used for the execution of Fission commands

Usage:
  fission environment pods [options]

Error: error getting environment: Resource not found - environments.fission.io "notexist" not found

```


```
fi fn po --name notfound

Aliases:
  pods, pod, po

Options:
  --name=''                        Function name
  --fnNamespace='default' (--fns)  Namespace for function object

Global Options:
  --server=''         Server URL
  --verbosity=1 (-v)  CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)
  --kube-context=''   Kubernetes context to be used for the execution of Fission commands

Usage:
  fission function pods [options]

Error: error getting function: Resource not found - functions.fission.io "notfound" not found

```