### PR TITLE
Add NATS streaming image tag

### DIFF
--- a/charts/fission-all/templates/mqt-fission-nats/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-nats/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccount: fission-nats-streaming
       containers:
       - name: nats-streaming
-        image: {{ .Values.nats.streamingserver.image | quote }}
+        image: "{{ .Values.nats.streamingserver.image }}:{{ .Values.nats.streamingserver.tag }}"
         imagePullPolicy: {{ .Values.pullPolicy }}
         args: [
           "--cluster_id", "{{ .Values.nats.clusterID }}",

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -168,6 +168,7 @@ nats:
   # The image to use for NATS streaming server
   streamingserver:
     image: nats-streaming
+    tag: "0.23.0"
 
 ## Port at which NATS streaming service should be exposed
 ## (only if nats enabled and not external)


### PR DESCRIPTION
Creates reproducible builds by locking NATS streaming to a specific version.

Closes #2230