### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -18,7 +18,6 @@ package mqtrigger
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -87,7 +86,7 @@ func readSecrets(logger *zap.Logger, secretsPath string) (map[string][]byte, err
 		return nil, err
 	}
 
-	secretFiles, err := ioutil.ReadDir(secretsPath)
+	secretFiles, err := os.ReadDir(secretsPath)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +101,7 @@ func readSecrets(logger *zap.Logger, secretsPath string) (map[string][]byte, err
 			logger.Info(fmt.Sprintf("Reading secret from %s", fileName))
 
 			filePath := path.Join(secretsPath, fileName)
-			secret, fileReadErr := ioutil.ReadFile(filePath)
+			secret, fileReadErr := os.ReadFile(filePath)
 			if fileReadErr != nil {
 				return nil, fileReadErr
 			}

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -98,7 +97,7 @@ func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	// parse request
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		e := "error reading request body"
 		builder.logger.Error(e, zap.Error(err))

--- a/pkg/builder/client/client.go
+++ b/pkg/builder/client/client.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -31,7 +31,7 @@ import (
 	"go.uber.org/zap"
 	"golang.org/x/net/context/ctxhttp"
 
-	builder "github.com/fission/fission/pkg/builder"
+	"github.com/fission/fission/pkg/builder"
 	ferror "github.com/fission/fission/pkg/error"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 	"github.com/fission/fission/pkg/utils/tracing"
@@ -91,7 +91,7 @@ func (c *Client) Build(ctx context.Context, req *builder.PackageBuildRequest) (*
 
 	defer resp.Body.Close()
 
-	rBody, err := ioutil.ReadAll(resp.Body)
+	rBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		logger.Error("error reading resp body", zap.Error(err))
 		return nil, err

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -396,7 +396,7 @@ func TestMain(m *testing.M) {
 	}
 	assert(found, "incorrect response content type")
 
-	_, err = ioutil.ReadAll(resp.Body)
+	_, err = io.ReadAll(resp.Body)
 	panicIf(err)
 
 	os.Exit(m.Run())

--- a/pkg/controller/canaryConfigApi.go
+++ b/pkg/controller/canaryConfigApi.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -108,7 +108,7 @@ func (a *API) CanaryConfigApiCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -202,7 +202,7 @@ func (a *API) CanaryConfigApiUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/client/rest/client.go
+++ b/pkg/controller/client/rest/client.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 
@@ -78,7 +77,7 @@ func (c *RESTClient) Delete(relativeUrl string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return errors.Wrap(err, "error deleting")
 		} else {

--- a/pkg/controller/client/v1/misc.go
+++ b/pkg/controller/client/v1/misc.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -88,7 +87,7 @@ func (c *Misc) GetSvcURL(label string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}
@@ -105,7 +104,7 @@ func (c *Misc) ServerInfo() (*info.ServerInfo, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/v1/v1.go
+++ b/pkg/controller/client/v1/v1.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	ferror "github.com/fission/fission/pkg/error"
@@ -87,7 +87,7 @@ func handleResponse(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode != 200 {
 		return nil, ferror.MakeErrorFromHTTP(resp)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	return body, err
 }
 
@@ -95,6 +95,6 @@ func handleCreateResponse(resp *http.Response) ([]byte, error) {
 	if resp.StatusCode != 201 {
 		return nil, ferror.MakeErrorFromHTTP(resp)
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	return body, err
 }

--- a/pkg/controller/environmentApi.go
+++ b/pkg/controller/environmentApi.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -123,7 +123,7 @@ func (a *API) EnvironmentApiList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) EnvironmentApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -188,7 +188,7 @@ func (a *API) EnvironmentApiUpdate(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["environment"]
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/functionApi.go
+++ b/pkg/controller/functionApi.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -134,7 +133,7 @@ func (a *API) FunctionApiList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) FunctionApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -196,7 +195,7 @@ func (a *API) FunctionApiUpdate(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["function"]
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/httpTriggerApi.go
+++ b/pkg/controller/httpTriggerApi.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 
@@ -158,7 +158,7 @@ func (a *API) checkHTTPTriggerDuplicates(ctx context.Context, t *fv1.HTTPTrigger
 }
 
 func (a *API) HTTPTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -228,7 +228,7 @@ func (a *API) HTTPTriggerApiUpdate(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["httpTrigger"]
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/mqTriggerApi.go
+++ b/pkg/controller/mqTriggerApi.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -119,7 +119,7 @@ func (a *API) MessageQueueTriggerApiList(w http.ResponseWriter, r *http.Request)
 }
 
 func (a *API) MessageQueueTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -179,7 +179,7 @@ func (a *API) MessageQueueTriggerApiUpdate(w http.ResponseWriter, r *http.Reques
 	vars := mux.Vars(r)
 	name := vars["mqTrigger"]
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/packageApi.go
+++ b/pkg/controller/packageApi.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/dustin/go-humanize"
@@ -121,7 +121,7 @@ func (a *API) PackageApiList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) PackageApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -203,7 +203,7 @@ func (a *API) PackageApiUpdate(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["package"]
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/timeTriggerApi.go
+++ b/pkg/controller/timeTriggerApi.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -121,7 +121,7 @@ func (a *API) TimeTriggerApiList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) TimeTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return
@@ -192,7 +192,7 @@ func (a *API) TimeTriggerApiUpdate(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["timeTrigger"]
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/controller/watchApi.go
+++ b/pkg/controller/watchApi.go
@@ -18,7 +18,7 @@ package controller
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/emicklei/go-restful"
@@ -120,7 +120,7 @@ func (a *API) WatchApiList(w http.ResponseWriter, r *http.Request) {
 }
 
 func (a *API) WatchApiCreate(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		a.respondWithError(w, err)
 		return

--- a/pkg/error/httperror.go
+++ b/pkg/error/httperror.go
@@ -18,7 +18,7 @@ package error
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -66,7 +66,7 @@ func MakeErrorFromHTTP(resp *http.Response) error {
 
 	msg := resp.Status
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err == nil && len(body) > 0 {
 		msg = strings.TrimSpace(string(body))
 	}

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -21,7 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"html"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -39,7 +39,7 @@ import (
 
 func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request", http.StatusInternalServerError)
 		return
@@ -170,7 +170,7 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := otelUtils.LoggerWithTraceID(ctx, executor.logger)
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		logger.Error("failed to read tap service request", zap.Error(err))
 		http.Error(w, "Failed to read request", http.StatusInternalServerError)
@@ -222,7 +222,7 @@ func (executor *Executor) healthHandler(w http.ResponseWriter, r *http.Request) 
 
 func (executor *Executor) unTapService(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "Failed to read request", http.StatusInternalServerError)
 		return

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -95,7 +95,7 @@ func (c *Client) GetServiceForFunction(ctx context.Context, fn *fv1.Function) (s
 		return "", ferror.MakeErrorFromHTTP(resp)
 	}
 
-	svcName, err := ioutil.ReadAll(resp.Body)
+	svcName, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", errors.Wrap(err, "error reading response body from getting service for function")
 	}

--- a/pkg/featureconfig/config.go
+++ b/pkg/featureconfig/config.go
@@ -19,7 +19,7 @@ package featureconfig
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/ghodss/yaml"
 )
@@ -27,7 +27,7 @@ import (
 // GetFeatureConfig reads the configMap file and unmarshals the config into a feature config struct
 func GetFeatureConfig() (*FeatureConfig, error) {
 	// read the file
-	b64EncodedContent, err := ioutil.ReadFile(FeatureConfigFile)
+	b64EncodedContent, err := os.ReadFile(FeatureConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("error reading YAML file %s: %v", FeatureConfigFile, err)
 	}

--- a/pkg/fetcher/client/client.go
+++ b/pkg/fetcher/client/client.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -94,7 +94,7 @@ func sendRequest(logger *zap.Logger, ctx context.Context, httpClient *http.Clien
 
 		if err == nil {
 			if resp.StatusCode == 200 {
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				if err != nil {
 					logger.Error("error reading response body", zap.Error(err))
 				}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -18,7 +18,7 @@ package function
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -131,7 +131,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "error reading response from function")
 	}
@@ -201,7 +201,7 @@ func printPodLogs(client client.Interface, fnMeta *metav1.ObjectMeta) (string, e
 	}
 	defer reader.Close()
 
-	body, err := ioutil.ReadAll(reader)
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return "", errors.Wrap(err, "error reading the response body")
 	}

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -86,7 +85,7 @@ func UploadArchiveFile(ctx context.Context, client client.Interface, fileName st
 }
 
 func GetContents(filePath string) ([]byte, error) {
-	code, err := ioutil.ReadFile(filePath)
+	code, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error reading %v", filePath)
 	}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -19,7 +19,6 @@ package spec
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -487,7 +486,7 @@ func localArchiveFromSpec(specDir string, aus *spectypes.ArchiveUploadSpec) (*fv
 
 	if len(files) > 1 || !isSingleFile {
 		// zip up the file list
-		archiveFile, err := ioutil.TempFile("", fmt.Sprintf("fission-archive-%v", aus.Name))
+		archiveFile, err := os.CreateTemp("", fmt.Sprintf("fission-archive-%v", aus.Name))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fission-cli/cmd/spec/init.go
+++ b/pkg/fission-cli/cmd/spec/init.go
@@ -18,7 +18,6 @@ package spec
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -110,7 +109,7 @@ func (opts *InitSubCommand) run(input cli.Input) error {
 	}
 
 	// Add a bit of documentation to the spec dir here
-	err := ioutil.WriteFile(readme, []byte(SPEC_README), 0644)
+	err := os.WriteFile(readme, []byte(SPEC_README), 0644)
 	if err != nil {
 		return err
 	}
@@ -138,7 +137,7 @@ func writeDeploymentConfig(file string, dc *spectypes.DeploymentConfig) error {
 		"# See the README in this directory for background and usage information.\n" +
 		"# Do not edit the UID below: that will break 'fission spec apply'\n")
 
-	err = ioutil.WriteFile(file, append(msg, y...), 0644)
+	err = os.WriteFile(file, append(msg, y...), 0644)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/spec/validate.go
+++ b/pkg/fission-cli/cmd/spec/validate.go
@@ -19,7 +19,6 @@ package spec
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -234,7 +233,7 @@ func ReadSpecs(specDir string) (*FissionResources, error) {
 			return nil
 		}
 		// read
-		b, err := ioutil.ReadFile(path)
+		b, err := os.ReadFile(path)
 		if err != nil {
 			result = multierror.Append(result, err)
 			return nil

--- a/pkg/fission-cli/cmd/support/resources/resource.go
+++ b/pkg/fission-cli/cmd/support/resources/resource.go
@@ -18,7 +18,7 @@ package resources
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/ghodss/yaml"
@@ -55,7 +55,7 @@ func writeToFile(file string, obj interface{}) {
 	// remove the empty byte from string.
 	file = string(utils.RemoveZeroBytes([]byte(file)))
 
-	err = ioutil.WriteFile(file, bs, 0644)
+	err = os.WriteFile(file, bs, 0644)
 	if err != nil {
 		console.Error(fmt.Sprintf("Error writing file %v: %v", file, err))
 	}

--- a/pkg/mqtrigger/messageQueue/azurequeuestorage/asq.go
+++ b/pkg/mqtrigger/messageQueue/azurequeuestorage/asq.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
@@ -354,7 +354,7 @@ func invokeTriggeredFunction(conn AzureStorageConnection, sub *AzureQueueSubscri
 		}
 		defer response.Body.Close()
 
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		if err != nil {
 			conn.logger.Error("failed to read response body from function invocation", zap.Error(err), zap.String("function_url", sub.functionURL))
 			continue

--- a/pkg/mqtrigger/messageQueue/azurequeuestorage/asq_test.go
+++ b/pkg/mqtrigger/messageQueue/azurequeuestorage/asq_test.go
@@ -17,7 +17,7 @@ package azurequeuestorage
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -197,7 +197,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 	).Return(
 		&http.Response{
 			StatusCode: http.StatusInternalServerError,
-			Body:       ioutil.NopCloser(strings.NewReader("server error")),
+			Body:       io.NopCloser(strings.NewReader("server error")),
 		},
 		nil,
 	).Once()
@@ -207,7 +207,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 	).Return(
 		&http.Response{
 			StatusCode: http.StatusNotFound,
-			Body:       ioutil.NopCloser(strings.NewReader("not found")),
+			Body:       io.NopCloser(strings.NewReader("not found")),
 		},
 		nil,
 	).Once()
@@ -217,7 +217,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 	).Return(
 		&http.Response{
 			StatusCode: http.StatusBadRequest,
-			Body:       ioutil.NopCloser(strings.NewReader("bad request")),
+			Body:       io.NopCloser(strings.NewReader("bad request")),
 		},
 		nil,
 	).Once()
@@ -227,7 +227,7 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 	).Return(
 		&http.Response{
 			StatusCode: http.StatusForbidden,
-			Body:       ioutil.NopCloser(strings.NewReader("not authorized")),
+			Body:       io.NopCloser(strings.NewReader("not authorized")),
 		},
 		nil,
 	).Once()
@@ -339,10 +339,10 @@ func TestAzureStorageQueuePoisonMessage(t *testing.T) {
 func httpRequestMatcher(t *testing.T, queue string, responseQueue string, retry string, contentType string, functionName string, body string) func(*http.Request) bool {
 	expectedURL := fmt.Sprintf("%s/fission-function/%s", DummyRouterURL, functionName)
 	return func(req *http.Request) bool {
-		requestBody, err := ioutil.ReadAll(req.Body)
+		requestBody, err := io.ReadAll(req.Body)
 		require.NoError(t, err)
 
-		req.Body = ioutil.NopCloser(strings.NewReader(string(requestBody)))
+		req.Body = io.NopCloser(strings.NewReader(string(requestBody)))
 
 		return queue == req.Header.Get("X-Fission-MQTrigger-Topic") &&
 			responseQueue == req.Header.Get("X-Fission-MQTrigger-RespTopic") &&
@@ -372,7 +372,7 @@ func runAzureStorageQueueTest(t *testing.T, count int, output bool) {
 	// Mock a HTTP client that returns http.StatusOK with "output" for the body
 	httpClient := new(azureHTTPClientMock)
 	httpClient.bodyHandler = func(res *http.Response) {
-		res.Body = ioutil.NopCloser(strings.NewReader(FunctionResponse))
+		res.Body = io.NopCloser(strings.NewReader(FunctionResponse))
 	}
 	httpClient.On(
 		"Do",

--- a/pkg/mqtrigger/messageQueue/kafka/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka/kafka.go
@@ -20,14 +20,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
 
-	sarama "github.com/Shopify/sarama"
+	"github.com/Shopify/sarama"
 	cluster "github.com/bsm/sarama-cluster"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
@@ -307,7 +307,7 @@ func kafkaMsgHandler(kafka *Kafka, producer sarama.SyncProducer, trigger *fv1.Me
 		return
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	kafka.logger.Debug("got response from function invocation",
 		zap.String("function_url", url),

--- a/pkg/mqtrigger/messageQueue/nats/nats.go
+++ b/pkg/mqtrigger/messageQueue/nats/nats.go
@@ -19,7 +19,7 @@ package nats
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -192,7 +192,7 @@ func msgHandler(nats *Nats, trigger *fv1.MessageQueueTrigger) func(*ns.Msg) {
 
 		defer resp.Body.Close()
 
-		body, bodyErr := ioutil.ReadAll(resp.Body)
+		body, bodyErr := io.ReadAll(resp.Body)
 		if bodyErr != nil {
 			nats.logger.Error("error reading function invocation response",
 				zap.Error(err),

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -108,7 +107,7 @@ func FindAll() map[string]*Metadata {
 
 	dirs := strings.Split(os.Getenv("PATH"), ":")
 	for _, dir := range dirs {
-		fs, err := ioutil.ReadDir(dir)
+		fs, err := os.ReadDir(dir)
 		if err != nil {
 			continue
 		}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -19,7 +19,6 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -47,7 +46,7 @@ func TestFind(t *testing.T) {
 	if err != nil {
 		t.FailNow()
 	}
-	err = ioutil.WriteFile(testBinary, []byte(fmt.Sprintf("#!/bin/sh\necho '%v'", string(jsonMd))), os.ModePerm)
+	err = os.WriteFile(testBinary, []byte(fmt.Sprintf("#!/bin/sh\necho '%v'", string(jsonMd))), os.ModePerm)
 	if err != nil {
 		t.FailNow()
 	}
@@ -89,7 +88,7 @@ func TestExec(t *testing.T) {
 	if err != nil {
 		t.FailNow()
 	}
-	err = ioutil.WriteFile(testBinary, []byte(fmt.Sprintf("#!/bin/sh\necho '%v'", string(jsonMd))), os.ModePerm)
+	err = os.WriteFile(testBinary, []byte(fmt.Sprintf("#!/bin/sh\necho '%v'", string(jsonMd))), os.ModePerm)
 	if err != nil {
 		t.FailNow()
 	}

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -18,7 +18,7 @@ package publisher
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -112,7 +112,7 @@ func (p *WebhookPublisher) makeHTTPRequest(r *publishRequest) {
 		fields = append(fields, zap.Error(err), zap.Any("request", r))
 	} else {
 		var body []byte
-		body, err = ioutil.ReadAll(resp.Body)
+		body, err = io.ReadAll(resp.Body)
 		if err != nil {
 			fields = append(fields, zap.Error(err), zap.Any("request", r))
 			msg = "read response body error"

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -242,7 +241,7 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 						Proto:         req.Proto,
 						ProtoMajor:    req.ProtoMajor,
 						ProtoMinor:    req.ProtoMinor,
-						Body:          ioutil.NopCloser(bytes.NewBufferString(errMsg)),
+						Body:          io.NopCloser(bytes.NewBufferString(errMsg)),
 						ContentLength: int64(len(errMsg)),
 						Request:       req,
 						Header:        make(http.Header),

--- a/pkg/router/util_test.go
+++ b/pkg/router/util_test.go
@@ -1,7 +1,7 @@
 package router
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 )
@@ -17,7 +17,7 @@ func testRequest(targetURL string, expectedResponse string) {
 		log.Panicf("response status: %v", resp.StatusCode)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Panic("failed to read response")
 	}

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -101,7 +100,7 @@ func (c *Client) Upload(ctx context.Context, filePath string, metadata *map[stri
 		return "", err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/storagesvc/client/storagesvc_test.go
+++ b/pkg/storagesvc/client/storagesvc_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"testing"
@@ -50,7 +49,7 @@ func panicIf(err error) {
 }
 
 func MakeTestFile(size int) *os.File {
-	f, err := ioutil.TempFile("", "storagesvc_test_")
+	f, err := os.CreateTemp("", "storagesvc_test_")
 	panicIf(err)
 
 	_, err = f.Write(bytes.Repeat([]byte("."), size))
@@ -158,7 +157,7 @@ func TestS3StorageService(t *testing.T) {
 	panicIf(err)
 	defer reader.Close()
 
-	retThroughMinio, err := ioutil.TempFile("", "storagesvc_verify_minio_")
+	retThroughMinio, err := os.CreateTemp("", "storagesvc_verify_minio_")
 	panicIf(err)
 	defer os.Remove(retThroughMinio.Name())
 
@@ -170,7 +169,7 @@ func TestS3StorageService(t *testing.T) {
 	}
 
 	// Retrieve file through API
-	retThroughAPI, err := ioutil.TempFile("", "storagesvc_verify_")
+	retThroughAPI, err := os.CreateTemp("", "storagesvc_verify_")
 	panicIf(err)
 	os.Remove(retThroughAPI.Name())
 
@@ -179,9 +178,9 @@ func TestS3StorageService(t *testing.T) {
 	defer os.Remove(retThroughAPI.Name())
 
 	// compare contents
-	contentsMinio, err := ioutil.ReadFile(retThroughMinio.Name())
+	contentsMinio, err := os.ReadFile(retThroughMinio.Name())
 	panicIf(err)
-	contentsAPI, err := ioutil.ReadFile(retThroughAPI.Name())
+	contentsAPI, err := os.ReadFile(retThroughAPI.Name())
 	panicIf(err)
 	if !bytes.Equal(contentsMinio, contentsAPI) {
 		log.Panic("Contents don't match")
@@ -228,7 +227,7 @@ func TestLocalStorageService(t *testing.T) {
 	panicIf(err)
 
 	// make a temp file for verification
-	retrievedfile, err := ioutil.TempFile("", "storagesvc_verify_")
+	retrievedfile, err := os.CreateTemp("", "storagesvc_verify_")
 	panicIf(err)
 	os.Remove(retrievedfile.Name())
 
@@ -238,9 +237,9 @@ func TestLocalStorageService(t *testing.T) {
 	defer os.Remove(retrievedfile.Name())
 
 	// compare contents
-	contents1, err := ioutil.ReadFile(tmpfile.Name())
+	contents1, err := os.ReadFile(tmpfile.Name())
 	panicIf(err)
-	contents2, err := ioutil.ReadFile(retrievedfile.Name())
+	contents2, err := os.ReadFile(retrievedfile.Name())
 	panicIf(err)
 	if !bytes.Equal(contents1, contents2) {
 		log.Panic("Contents don't match")

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -65,7 +64,7 @@ func GetTempDir() (string, error) {
 		return "", err
 	}
 	tmpDir := id.String()
-	dir, err := ioutil.TempDir("", tmpDir)
+	dir, err := os.MkdirTemp("", tmpDir)
 	return dir, err
 }
 

--- a/test/benchmark/picasso.go
+++ b/test/benchmark/picasso.go
@@ -8,7 +8,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -163,7 +162,7 @@ func generateChart(title string, file string, format chart.RendererProvider, ser
 		return err
 	}
 
-	err = ioutil.WriteFile(file, buffer.Bytes(), 0644)
+	err = os.WriteFile(file, buffer.Bytes(), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.