### PR TITLE
Disable nats test as we deprecate Fission Nats Integration

### DIFF
--- a/charts/fission-all/Chart.yaml
+++ b/charts/fission-all/Chart.yaml
@@ -11,6 +11,10 @@ sources:
 keywords:
   - fission
   - serverless
+  - platform
+  - faas
+  - functions
+  - Integration & Delivery
 maintainers:
   - name: Vishal Biyani
     email: vishal@infracloud.io

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -102,9 +102,6 @@ profiles:
     path: /deploy/helm/releases/0/setValues/prometheus.enabled
     value: true
   - op: replace
-    path: /deploy/helm/releases/0/setValues/nats.enabled
-    value: true
-  - op: replace
     path: /deploy/helm/releases/0/setValues/influxdb.enabled
     value: true
   - op: replace

--- a/test/tests/mqtrigger/nats/test_mqtrigger.sh
+++ b/test/tests/mqtrigger/nats/test_mqtrigger.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#test:disabled
 
 #
 # Create a function and trigger it using NATS

--- a/test/tests/mqtrigger/nats/test_mqtrigger_error.sh
+++ b/test/tests/mqtrigger/nats/test_mqtrigger_error.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#test:disabled
 
 #
 # Create a function and trigger it using NATS


### PR DESCRIPTION
We would like to deprecate Fission Nats Integration and recommend
user to use Fission Keda Nats connector to handle Keda events.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>