### PR TITLE
Add support to mention priorityClassName for Fission components

### DIFF
--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -49,6 +49,9 @@ spec:
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
       serviceAccountName: fission-svc
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -66,6 +66,9 @@ spec:
       - name: config-volume
         configMap:
           name: feature-config
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -79,6 +79,11 @@ spec:
           name: pprof
         {{- end }}
       serviceAccountName: fission-svc
+{{- if .Values.executor.priorityClassName }}
+      priorityClassName: {{ .Values.executor.priorityClassName }}
+{{- else if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
       serviceAccountName: fission-svc
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -47,6 +47,9 @@ spec:
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
       serviceAccountName: fission-svc
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -90,6 +90,11 @@ spec:
           name: pprof
         {{- end }}
       serviceAccountName: fission-svc
+{{- if .Values.router.priorityClassName }}
+      priorityClassName: {{ .Values.router.priorityClassName }}
+{{- else if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.router.extraCoreComponentPodConfig }}
 {{ toYaml .Values.router.extraCoreComponentPodConfig | indent 6 -}}
 {{- else }}

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -87,6 +87,9 @@ spec:
       - name: fission-storage
         emptyDir: {}
       {{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
       serviceAccountName: fission-svc
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -31,6 +31,13 @@ imageTag: v1.15.0-rc2
 ##
 pullPolicy: IfNotPresent
 
+## priorityClassName represents the priority class name to use for Fission components.
+## Refer to https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+## executor.priorityClassName takes precedence over this value for executor.
+## router.priorityClassName takes precedence over this value for router.
+##
+priorityClassName: ""
+
 ## controllerPort represents the port at which the Fission controller service should be exposed.
 ##
 controllerPort: 31313
@@ -87,6 +94,11 @@ fetcher:
 ## executor is responsible for providing resources to your functions.
 ##
 executor:
+  ## executor priorityClassName
+  ## Ref. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  ## Recommended to use system-cluster-critical for executor pods.
+  ##
+  priorityClassName: ""
   ## adoptExistingResources decides whether to adopt existing resources when executor restarts or Fission is redeployed.
   ##
   adoptExistingResources: false
@@ -98,6 +110,11 @@ executor:
 ## router is responsible for routing function calls to the appropriate function.
 ##
 router:
+  ## router priorityClassName
+  ## Ref. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
+  ## Recommended to use system-cluster-critical for router pods.
+  ##
+  priorityClassName: ""
   ## deployAsDaemonSet decides whether to deploy router as a DaemonSet or a Deployment.
   ##
   deployAsDaemonSet: false

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -53,6 +53,7 @@ deploy:
         openTracing.enabled: false
         openTelemetry.otlpCollectorEndpoint: ""
         openTelemetry.otlpInsecure: true
+        priorityClassName: "system-cluster-critical"
       wait: true
     flags:
       install:


### PR DESCRIPTION
In Fission CI as well in couple of scenarios, noticed Fission pods
getting preempted when Function pods are getting created. As both
Fission components and function pods have same priority class
fission component pods might get preempted. It to be recommended to
set higher priority class for components such as Fission router, executor,
controller so that Fission functioning doesnt get disrupted.
Most of Fission components work fine with restart except executor. So
user should set priorityClass for Fission executor.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>