### PR TITLE
Update alpine base image to 3.14.3 and security fixes

### DIFF
--- a/cmd/builder/Dockerfile.fission-builder
+++ b/cmd/builder/Dockerfile.fission-builder
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.3
 RUN apk add --update ca-certificates
 COPY builder /builder
 ENTRYPOINT ["/builder"]

--- a/cmd/fetcher/Dockerfile.fission-fetcher
+++ b/cmd/fetcher/Dockerfile.fission-fetcher
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.3
 RUN apk add --update ca-certificates
 COPY fetcher /
 ENTRYPOINT ["/fetcher"]

--- a/cmd/fission-bundle/Dockerfile.fission-bundle
+++ b/cmd/fission-bundle/Dockerfile.fission-bundle
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.3
 RUN apk add --update ca-certificates
 COPY fission-bundle /
 ENTRYPOINT ["/fission-bundle"]

--- a/cmd/preupgradechecks/Dockerfile.fission-preupgradechecks
+++ b/cmd/preupgradechecks/Dockerfile.fission-preupgradechecks
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.3
 RUN apk add --update ca-certificates
 COPY pre-upgrade-checks /
 ENTRYPOINT ["/pre-upgrade-checks"]

--- a/cmd/reporter/Dockerfile.reporter
+++ b/cmd/reporter/Dockerfile.reporter
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.3
 RUN apk add --update ca-certificates
 COPY reporter /
 ENTRYPOINT ["/reporter"]

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/nats-io/nats.go v1.13.0
 	github.com/nats-io/stan.go v0.10.0
 	github.com/nwaples/rardecode v1.1.2 // indirect
-	github.com/opencontainers/image-spec v1.0.1 // indirect
+	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/opencontainers/runc v1.0.2 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -969,8 +969,8 @@ github.com/onsi/gomega v1.15.0/go.mod h1:cIuvLEne0aoVhAgh/O6ac0Op8WWw9H6eYCriF+t
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
-github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
+github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v1.0.2 h1:opHZMaswlyxz1OuGpBE53Dwe4/xF7EZTY0A2L/FpCOg=
 github.com/opencontainers/runc v1.0.2/go.mod h1:aTaHFFwQXuA71CiyxOdFFIorAoemI04suvGRQFzWTD0=
 github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

- Update alpine base image to 3.14.3
- Update github.com/opencontainers/image-spec to v1.0.2