### PR TITLE
Allow user to use existing bucket with same name via fission storage service

### DIFF
--- a/pkg/storagesvc/stowClient.go
+++ b/pkg/storagesvc/stowClient.go
@@ -80,7 +80,10 @@ func getContainer(loc stow.Location, containerName string, cursor string) (stow.
 		}
 	}
 	if con == nil && !stow.IsCursorEnd(cursorNew) {
-		getContainer(loc, containerName, cursorNew)
+		_, err := getContainer(loc, containerName, cursorNew)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return con, nil
 }

--- a/pkg/storagesvc/stowClient.go
+++ b/pkg/storagesvc/stowClient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package storagesvc
 
 import (
+	"fmt"
 	"io"
 	"mime/multipart"
 	"os"
@@ -93,8 +94,8 @@ func getOrCreateContainer(loc stow.Location, containerName string, cursor string
 	if err != nil && (os.IsExist(err) || strings.Contains(err.Error(), "BucketAlreadyOwnedByYou")) {
 		con, err = getContainer(loc, containerName, stow.CursorStart)
 	}
-	if con == nil {
-		err = errors.New("Storage container not found")
+	if con == nil && err == nil {
+		err = fmt.Errorf("Storage container %s not found", containerName)
 	}
 	return con, err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
If a bucket name passed by a user already exists on the cloud, allow the user to use that one as storage and do not throw an error. So users don't really have to create a bucket always and no need to give create buckets privileges to access keys.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/fission/fission/issues/2199

## Testing
Created multiple buckets on S3 having the same prefix, and the code picked the right bucket (with exact match) 

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
