### PR TITLE
feature: Apply commit label on resources created/updated when '--commitlabel' is passed

### DIFF
--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -128,7 +128,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 		if toSpec {
 
-			fr, err := spec.ReadSpecs(specDir, specIgnore)
+			fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 			}
@@ -169,7 +169,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 		if toSpec {
 
-			fr, err := spec.ReadSpecs(specDir, specIgnore)
+			fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 			}

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -135,7 +135,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if input.Bool(flagkey.SpecSave) {
 		specDir := util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore)
+		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 		}

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -67,7 +67,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if input.Bool(flagkey.SpecSave) {
 		specDir := util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore)
+		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 		}

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -128,7 +128,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if input.Bool(flagkey.SpecSave) {
 		specDir := util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore)
+		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 		}

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -87,7 +87,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	if input.Bool(flagkey.SpecSave) {
 		specDir = util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore)
+		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 		}
@@ -186,7 +186,7 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 
 	if input.Bool(flagkey.SpecSave) {
 		// if a package with the same spec exists, don't create a new spec file
-		fr, err := spec.ReadSpecs(util.GetSpecDir(input), util.GetSpecIgnore(input))
+		fr, err := spec.ReadSpecs(util.GetSpecDir(input), util.GetSpecIgnore(input), false)
 		if err != nil {
 			return nil, errors.Wrap(err, "error reading specs")
 		}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -162,7 +162,7 @@ func CreateArchive(client client.Interface, input cli.Input, includeFiles []stri
 		} else if input.Bool(flagkey.SpecSave) {
 			// check if this AUS exists in the specs; if so, don't create a new one
 			specIgnore := util.GetSpecIgnore(input)
-			fr, err := spec.ReadSpecs(specDir, specIgnore)
+			fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 			if err != nil {
 				return nil, errors.Wrap(err, "error reading specs")
 			}

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -48,7 +48,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Apply),
 	}
 	wrapper.SetFlags(applyCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation, flag.SpecApplyCommitLabel},
 	})
 
 	destroyCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -43,7 +43,7 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	specIgnore := util.GetSpecIgnore(input)
 
 	// read everything
-	fr, err := ReadSpecs(specDir, specIgnore)
+	fr, err := ReadSpecs(specDir, specIgnore, false)
 	if err != nil {
 		return errors.Wrap(err, "error reading specs")
 	}

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -53,7 +53,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		// get specdir, specignore and read the deployID
 		specDir := util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
-		fr, err := ReadSpecs(specDir, specIgnore)
+		fr, err := ReadSpecs(specDir, specIgnore, false)
 		if err != nil {
 			return errors.Wrap(err, "error reading specs")
 		}

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -78,7 +78,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if input.Bool(flagkey.SpecSave) {
 		specDir := util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore)
+		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 		if err != nil {
 			return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
 		}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -191,16 +191,17 @@ var (
 	PkgSrcChecksum    = Flag{Type: String, Name: flagkey.PkgSrcChecksum, Usage: "SHA256 checksum of source archive when providing URL"}
 	PkgInsecure       = Flag{Type: Bool, Name: flagkey.PkgInsecure, Usage: "Skip generating SHA256 checksum for file integrity validation"}
 
-	SpecSave       = Flag{Type: Bool, Name: flagkey.SpecSave, Usage: "Save to the spec directory instead of creating on cluster"}
-	SpecDir        = Flag{Type: String, Name: flagkey.SpecDir, Usage: "Directory to store specs, defaults to ./specs"}
-	SpecName       = Flag{Type: String, Name: flagkey.SpecName, Usage: "Name for the app, applied to resources as a Kubernetes annotation"}
-	SpecDeployID   = Flag{Type: String, Name: flagkey.SpecDeployID, Aliases: []string{"id"}, Usage: "Deployment ID for the spec deployment config"}
-	SpecWait       = Flag{Type: Bool, Name: flagkey.SpecWait, Usage: "Wait for package builds"}
-	SpecWatch      = Flag{Type: Bool, Name: flagkey.SpecWatch, Usage: "Watch local files for change, and re-apply specs as necessary"}
-	SpecDelete     = Flag{Type: Bool, Name: flagkey.SpecDelete, Usage: "Allow apply to delete resources that no longer exist in the specification"}
-	SpecDry        = Flag{Type: Bool, Name: flagkey.SpecDry, Usage: "View the generated specs"}
-	SpecValidation = Flag{Type: String, Name: flagkey.SpecValidate, Usage: "Turns server side validations of Fission objects on/off"}
-	SpecIgnore     = Flag{Type: String, Name: flagkey.SpecIgnore, Usage: fmt.Sprintf("File containing specs to be ignored inside --specdir, defaults to %v", util.SPEC_IGNORE_FILE)}
+	SpecSave             = Flag{Type: Bool, Name: flagkey.SpecSave, Usage: "Save to the spec directory instead of creating on cluster"}
+	SpecDir              = Flag{Type: String, Name: flagkey.SpecDir, Usage: "Directory to store specs, defaults to ./specs"}
+	SpecName             = Flag{Type: String, Name: flagkey.SpecName, Usage: "Name for the app, applied to resources as a Kubernetes annotation"}
+	SpecDeployID         = Flag{Type: String, Name: flagkey.SpecDeployID, Aliases: []string{"id"}, Usage: "Deployment ID for the spec deployment config"}
+	SpecWait             = Flag{Type: Bool, Name: flagkey.SpecWait, Usage: "Wait for package builds"}
+	SpecWatch            = Flag{Type: Bool, Name: flagkey.SpecWatch, Usage: "Watch local files for change, and re-apply specs as necessary"}
+	SpecDelete           = Flag{Type: Bool, Name: flagkey.SpecDelete, Usage: "Allow apply to delete resources that no longer exist in the specification"}
+	SpecDry              = Flag{Type: Bool, Name: flagkey.SpecDry, Usage: "View the generated specs"}
+	SpecValidation       = Flag{Type: String, Name: flagkey.SpecValidate, Usage: "Turns server side validations of Fission objects on/off"}
+	SpecIgnore           = Flag{Type: String, Name: flagkey.SpecIgnore, Usage: fmt.Sprintf("File containing specs to be ingored inside --specdir, defaults to %v", util.SPEC_IGNORE_FILE)}
+	SpecApplyCommitLabel = Flag{Type: Bool, Name: flagkey.SpecApplyCommitLabel, Usage: "Apply commit label to the resources"}
 
 	SupportOutput = Flag{Type: String, Name: flagkey.SupportOutput, Short: "o", Usage: "Output directory to save dump archive/files", DefaultValue: flagkey.DefaultSpecOutputDir}
 	SupportNoZip  = Flag{Type: Bool, Name: flagkey.SupportNoZip, Usage: "Save dump information into multiple files instead of single zip file"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -142,16 +142,17 @@ const (
 	PkgStatus         = "status"
 	PkgOrphan         = "orphan"
 
-	SpecSave     = "spec"
-	SpecDir      = "specdir"
-	SpecName     = resourceName
-	SpecDeployID = "deployid"
-	SpecWait     = "wait"
-	SpecWatch    = "watch"
-	SpecDelete   = "delete"
-	SpecDry      = "dry"
-	SpecValidate = "validation"
-	SpecIgnore   = "specignore"
+	SpecSave             = "spec"
+	SpecDir              = "specdir"
+	SpecName             = resourceName
+	SpecDeployID         = "deployid"
+	SpecWait             = "wait"
+	SpecWatch            = "watch"
+	SpecDelete           = "delete"
+	SpecDry              = "dry"
+	SpecValidate         = "validation"
+	SpecIgnore           = "specignore"
+	SpecApplyCommitLabel = "commitlabel"
 
 	SupportOutput = Output
 	SupportNoZip  = "nozip"

--- a/pkg/fission-cli/util/constants.go
+++ b/pkg/fission-cli/util/constants.go
@@ -19,4 +19,5 @@ package util
 // fission-cli options
 const (
 	SPEC_IGNORE_FILE = ".specignore"
+	COMMIT_LABEL     = "commit"
 )

--- a/pkg/utils/gitrepo/gitrepo.go
+++ b/pkg/utils/gitrepo/gitrepo.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitrepo
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/pkg/errors"
+)
+
+type GitRepo struct {
+	setupDone       bool
+	isGitRepo       bool
+	repo            *git.Repository
+	status          git.Status
+	dirPath         string
+	gitRepoRootPath string // absolute path of the root of the git repository
+	commitID        string // commit ID the HEAD of the repository is poitning to
+}
+
+// NewGitRepo creates new GitRepo struct
+// checks if the given directory path is part of git repository
+// accordingly updates the fields of GitRepo struct and returns it
+func NewGitRepo(dirPath string) *GitRepo {
+
+	var g *GitRepo = &GitRepo{}
+	var err error
+
+	g.dirPath = dirPath
+	g.setupDone = true
+
+	// check if directory is tracked by git repo
+	g.repo, err = git.PlainOpenWithOptions(dirPath, &git.PlainOpenOptions{DetectDotGit: true})
+	if err != nil {
+		return g
+	}
+
+	workTree, err := g.repo.Worktree()
+	if err != nil {
+		return g
+	}
+
+	g.status, err = workTree.Status()
+	if err != nil {
+		return g
+	}
+
+	if g.status == nil {
+		return g
+	}
+
+	plumbRef, err := g.repo.Head()
+	if err != nil {
+		return g
+	}
+
+	// extract short commit ID
+	g.commitID = plumbRef.Hash().String()[:7]
+
+	// get the root path of git repository
+	g.gitRepoRootPath = workTree.Filesystem.Root()
+
+	g.isGitRepo = true
+	return g
+}
+
+// IsGitRepo returns if the initialized directory path is tracked by git repo
+func (g *GitRepo) IsGitRepo() bool {
+	return g.setupDone && g.isGitRepo
+}
+
+// getFileCommitLabel returns the value of 'commit' label
+// for the resources present in the file
+/*
+The value of the `commit` label for different status of the file is as follows:
+| Git File Status                       | Label Value          |
+|---------------------------------------|----------------------|
+| New untracked file                    | untracked            |
+| New staged file                       | staged               |
+| Tracked file with changes in worktree | <commitID>-unstaged  |
+| Tracked file with changes staged      | <commitID>-staged    |
+| Tracked file with clean commit        | <commitID>           |
+*/
+func (g *GitRepo) GetFileCommitLabel(filePath string) (string, error) {
+
+	if !g.setupDone {
+		return "", errors.New(`GitRepo is not setup. It has to be created by calling 'NewGitRepo' function, 
+					then this function has to be called.`)
+	}
+
+	if !g.isGitRepo {
+		return "", errors.Errorf(`directory: %s doesn't belong to git repository.`, g.dirPath)
+	}
+
+	// filepath in the git repository
+	splitPathList := strings.Split(filePath, g.gitRepoRootPath+string(os.PathSeparator))
+	if len(splitPathList) != 2 {
+		return "", errors.Errorf("error finding the git repository path of %s", filePath)
+	}
+	gitFilePath := splitPathList[1]
+	gitFileStatus := g.status.File(gitFilePath)
+
+	// check if file is tracked
+	if !g.status.IsUntracked(gitFilePath) {
+
+		// unstaged file
+		if gitFileStatus.Worktree == git.Modified {
+			return fmt.Sprintf("%s-unstaged", g.commitID), nil
+		}
+
+		// newly staged file
+		if gitFileStatus.Staging == git.Added {
+			return "staged", nil
+		}
+
+		// staged file
+		if gitFileStatus.Staging == git.Modified {
+			return fmt.Sprintf("%s-staged", g.commitID), nil
+		}
+
+	}
+
+	// check if file is committed already
+	oc, err := g.repo.Log(&git.LogOptions{FileName: &gitFilePath})
+	if err != nil {
+		return "", nil
+	}
+
+	_, err = oc.Next()
+	defer oc.Close()
+
+	if err != nil {
+		// File not tracked by git and/or not committed
+		return "untracked", nil
+
+	}
+
+	// File tracked by git and has been committed
+	return g.commitID, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
When `--commitlabel` is passed to the `fission spec apply` command, the resources created will have `commit`
 label with value set depending upon the status of the spec file in the git repository. If the `specdir` is not part of git repository then despite passing the `--commitlabel` flag this label will not be applied on the resources created/updated.

The value of the `commit` label for different status of the file is as follows:
| Git File Status | Label Value |
| :--- | :---: |
| New untracked file | `untracked` |
| New staged file | `staged` |
| Tracked file with changes in worktree | `<commitID>-unstaged` |
| Tracked file with changes staged | `<commitID>-staged` |
| Tracked file with clean commit | `<commitID>` |

The value of `<commitID>` will be the short commit version of the commit the HEAD will be pointing to.

**P.S**: This PR also contains the changes to update resource if there is a difference in the `labels` and `annotations` of the reources in the spec file and the existing object. Prior to this only changes under `spec` were considered for updating the resource.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2208 

## Testing
<!--- Please describe in detail how you tested your changes. -->
Before changes
------------------------
4.59s user 0.71s system 92% cpu 5.749
3.83s user 0.70s system 85% cpu 5.281
4.14s user 0.71s system 88% cpu 5.492

After changes
----------------------
(gitrepo)
4.38s user 0.73s system 90% cpu 5.644
3.93s user 0.70s system 87% cpu 5.316  

(non-gitrepo)
3.83s user 0.67s system 84% cpu 5.302  
3.88s user 0.68s system 84% cpu 5.410

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
