### PR TITLE
Capture error from schema check in preupgrade verification

### DIFF
--- a/cmd/preupgradechecks/checks.go
+++ b/cmd/preupgradechecks/checks.go
@@ -96,21 +96,21 @@ func (client *PreUpgradeTaskClient) LatestSchemaApplied(ctx context.Context) err
 	client.logger.Info("Checking if user has applied the latest CRDs")
 	funcCRD := client.GetFunctionCRD(ctx)
 	if funcCRD == nil {
-		return errors.New("Could not get the Function CRD")
+		return fmt.Errorf("could not get the Function CRD")
 	}
 	// Any new field added in Function spec can be checked here provided the substring matches the description in CRD Validation of the field
 	if !strings.Contains(funcCRD.Spec.String(), "RequestsPerPod") || !strings.Contains(funcCRD.Spec.String(), "OnceOnly") || !strings.Contains(funcCRD.Spec.String(), "PodSpec") {
-		return errors.New("Apply the newer CRDs before upgrading")
+		return fmt.Errorf("could not find RequestPerPod/OnceOnly/PodSpec in Function CRD")
 	}
 
 	mqtCRD := client.GetMqtCRD(ctx)
 	if mqtCRD == nil {
-		return errors.New("Could not get the MQT CRD")
+		return fmt.Errorf("could not get the MQT CRD")
 	}
 
 	// Any new field added in MQT spec can be checked here provided the substring matches the description in CRD Validation of the field
 	if !strings.Contains(mqtCRD.Spec.String(), "PodSpec") {
-		return errors.New("Apply the newer CRDs before upgrading")
+		return fmt.Errorf("could not find PodSpec field in MQT CRD")
 	}
 
 	return nil

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -67,7 +67,7 @@ Options:
 
 	err = crdBackedClient.LatestSchemaApplied(ctx)
 	if err != nil {
-		logger.Fatal("New CRDs are not applied")
+		logger.Fatal("New CRDs are not applied", zap.Error(err))
 	}
 	crdBackedClient.VerifyFunctionSpecReferences(ctx)
 }


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

## Description

Added error logs that capture if any missing fields in CRDs.
These were identified as missing error capture logs during one of the debugging sessions.

## Which issue(s) this PR fixes:

Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
Test image : tripples/pre-upgrade-checks:sanket-dev

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
