### PR TITLE
feature: Basic auth support with fission router

### DIFF
--- a/charts/fission-all/templates/NOTES.txt
+++ b/charts/fission-all/templates/NOTES.txt
@@ -20,6 +20,15 @@ Windows:
   # Register this function with Fission
   $ fission function create --name hello --env nodejs --code hello.js
 
+{{- if .Values.authentication.enabled }}
+
+  # Create token
+  $ FISSION_USERNAME=$(kubectl get secrets/router --template={{`{{.data.username}}`}} -n fission | base64 -d)
+  $ FISSION_PASSWORD=$(kubectl get secrets/router --template={{`{{.data.password}}`}} -n fission | base64 -d)
+  $ export FISSION_AUTH_TOKEN=$(fission token create --username $FISSION_USERNAME --password $FISSION_PASSWORD)
+{{- end }}
+
   # Run this function
   $ fission function test --name hello
   Hello, world!
+

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -31,6 +31,13 @@ canary:
   prometheusSvc: {{ .Values.prometheus.serviceEndpoint | default "" | quote }}
   {{- end }}
   {{- printf "\n" -}}
+auth:
+  enabled: {{ .Values.authentication.enabled | default false }}
+  {{- if .Values.authentication.enabled }}
+  authUriPath: {{ .Values.authentication.authUriPath | default "/auth/login" | quote}}
+  jwtExpiryTime: {{ .Values.authentication.jwtExpiryTime | default 120 }}
+  jwtIssuer: {{ .Values.authentication.jwtIssuer | default "fission" | quote }}
+  {{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -35,6 +35,23 @@ spec:
         command: ["/fission-bundle"]
         args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}"]
         env:
+        {{- if .Values.authentication.enabled }}
+        - name: AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: router
+              key: username
+        - name: AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: router
+              key: password
+        - name: JWT_SIGNING_KEY
+          valueFrom:
+            secretKeyRef:
+              name: router
+              key: jwtSigningKey
+        {{- end }}      
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:
@@ -80,6 +97,10 @@ spec:
             port: 8888
           initialDelaySeconds: 35
           periodSeconds: 5
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/config/config.yaml
+          subPath: config.yaml
         ports:
         - containerPort: 8080
           name: metrics
@@ -100,6 +121,10 @@ spec:
         terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
       serviceAccountName: fission-svc
+      volumes:
+      - name: config-volume
+        configMap:
+          name: feature-config
 {{- if .Values.router.priorityClassName }}
       priorityClassName: {{ .Values.router.priorityClassName }}
 {{- else if .Values.priorityClassName }}

--- a/charts/fission-all/templates/router/secret.yaml
+++ b/charts/fission-all/templates/router/secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.authentication.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: router
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    "helm.sh/hook": pre-install
+data:
+  username: {{ .Values.authentication.authUsername | b64enc | quote }}
+  password: {{ randAlphaNum 20 | b64enc | quote }}
+  jwtSigningKey: {{ .Values.authentication.jwtSigningKey | b64enc | quote }}
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -161,7 +161,6 @@ router:
   ## router resource utilization when under heavy workloads.
   ##
   displayAccessLog: false
-
   ## svcAnnotations is the annotations to be added to the service resource created for router.
   ##
   # svcAnnotations:
@@ -482,6 +481,37 @@ prometheus:
 ##
 canaryDeployment:
   enabled: false
+
+## Enable authentication for fission function invocation via Fission router
+##
+authentication:
+  ## set this flag to true if you need authentication
+  ## for all function invocations
+  ## default 'false'
+  ##
+  enabled: false
+  ## authUriPath defines authentication endpoint path
+  ## via router
+  ## default '/auth/login'
+  ##
+  authUriPath:
+  ## authUsername is used as a username for authentication
+  ## default 'admin'
+  ##
+  authUsername: admin
+  ## jwtSigningKey is the signing key used for
+  ## signing the JWT token
+  ##
+  jwtSigningKey: serverless
+  ## jwtExpiryTime is the JWT expiry time
+  ## in seconds
+  ## default '120'
+  ##
+  jwtExpiryTime: 
+  ## jwtIssuer is the issuer of JWT
+  ## default 'fission'
+  ##
+  jwtIssuer: fission
 
 ## Use the following flags to enable OpenTracing.
 ## Note: OpenTracing support will be removed in an upcoming release.

--- a/cmd/fission-cli/app/app.go
+++ b/cmd/fission-cli/app/app.go
@@ -19,6 +19,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/cmd/support"
 	"github.com/fission/fission/pkg/fission-cli/cmd/timetrigger"
+	"github.com/fission/fission/pkg/fission-cli/cmd/token"
 	"github.com/fission/fission/pkg/fission-cli/cmd/version"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	"github.com/fission/fission/pkg/fission-cli/flag"
@@ -77,6 +78,7 @@ func App() *cobra.Command {
 	})
 
 	groups := helptemplate.CommandGroups{}
+	groups = append(groups, helptemplate.CreateCmdGroup("Auth Commands(Note: Authentication should be enabled to use a command in this group.)", token.Commands()))
 	groups = append(groups, helptemplate.CreateCmdGroup("Basic Commands", environment.Commands(), _package.Commands(), function.Commands()))
 	groups = append(groups, helptemplate.CreateCmdGroup("Trigger Commands", httptrigger.Commands(), mqtrigger.Commands(), timetrigger.Commands(), kubewatch.Commands()))
 	groups = append(groups, helptemplate.CreateCmdGroup("Deploy Strategies Commands", canaryconfig.Commands()))

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-ini/ini v1.63.2 // indirect
 	github.com/go-openapi/spec v0.20.4
+	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/graymeta/stow v0.2.7

--- a/go.sum
+++ b/go.sum
@@ -492,7 +492,10 @@ github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt v3.2.1+incompatible h1:73Z+4BJcrTC+KczS6WvTPvRGOp1WmfEP4Q1lOd9Z/+c=
 github.com/golang-jwt/jwt v3.2.1+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v4 v4.2.0 h1:besgBTC8w8HjP6NzQdxwKH9Z5oQMZ24ThTrHp3cZ8eU=
+github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 h1:DACJavvAHhabrF08vX0COfcOBJRhZ8lUbR+ZWIs0Y5g=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -854,6 +854,18 @@ type (
 		GetObjectKind() schema.ObjectKind
 		GetObjectMeta() metav1.Object
 	}
+
+	// AuthLogin defines the body for router login
+	AuthLogin struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	// RouterAuthToken defines the authorization token for accessing router
+	RouterAuthToken struct {
+		AccessToken string `json:"accesstoken"`
+		TokenType   string `json:"tokentype"`
+	}
 )
 
 //IsEmpty checks if the archive byte and litreal are of length 0

--- a/pkg/error/httperror.go
+++ b/pkg/error/httperror.go
@@ -60,6 +60,8 @@ func MakeErrorFromHTTP(resp *http.Response) error {
 		errCode = ErrorRequestTimeout
 	case http.StatusTooManyRequests:
 		errCode = ErrorTooManyRequests
+	case http.StatusUnauthorized:
+		errCode = ErrorNotAuthorized
 	default:
 		errCode = ErrorInternal
 	}

--- a/pkg/featureconfig/types.go
+++ b/pkg/featureconfig/types.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package featureconfig
 
+import "time"
+
 const (
 	FeatureConfigFile = "/etc/config/config.yaml"
 	CanaryFeature     = "canary"
@@ -31,11 +33,19 @@ type (
 	FeatureConfig struct {
 		// In the future more such feature configs can be added here for each optional feature
 		CanaryConfig CanaryFeatureConfig `json:"canary"`
+		AuthConfig   AuthFeatureConfig   `json:"auth"`
 	}
 
 	// specific feature config
 	CanaryFeatureConfig struct {
 		IsEnabled     bool   `json:"enabled"`
 		PrometheusSvc string `json:"prometheusSvc"`
+	}
+
+	AuthFeatureConfig struct {
+		IsEnabled     bool          `json:"enabled"`
+		AuthUriPath   string        `json:"authUriPath"`
+		JWTExpiryTime time.Duration `json:"jwtExpiryTime"`
+		JWTIssuer     string        `json:"jwtIssuer"`
 	}
 )

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -18,6 +18,7 @@ package function
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -178,6 +179,11 @@ func doHTTPRequest(ctx context.Context, url string, headers []string, method, bo
 		return nil, errors.Wrap(err, "error creating HTTP request")
 	}
 
+	accesstoken, ok := os.LookupEnv(util.FISSION_AUTH_TOKEN)
+	if ok && len(accesstoken) != 0 {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %v", accesstoken))
+	}
+
 	for _, header := range headers {
 		headerKeyValue := strings.SplitN(header, ":", 2)
 		if len(headerKeyValue) != 2 {
@@ -185,6 +191,7 @@ func doHTTPRequest(ctx context.Context, url string, headers []string, method, bo
 		}
 		req.Header.Set(headerKeyValue[0], headerKeyValue[1])
 	}
+
 	hc := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 	resp, err := hc.Do(req.WithContext(ctx))
 	if err != nil {

--- a/pkg/fission-cli/cmd/token/command.go
+++ b/pkg/fission-cli/cmd/token/command.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package token
+
+import (
+	"github.com/spf13/cobra"
+
+	wrapper "github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra"
+	"github.com/fission/fission/pkg/fission-cli/flag"
+)
+
+func Commands() *cobra.Command {
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a JWT token for function invocation",
+		RunE:  wrapper.Wrapper(Create),
+	}
+	wrapper.SetFlags(createCmd, flag.FlagSet{
+		Required: []flag.Flag{flag.TokUsername, flag.TokPassword},
+		Optional: []flag.Flag{flag.TokAuthURI},
+	})
+
+	command := &cobra.Command{
+		Use:   "token",
+		Short: "Create a JWT token for function invocation",
+	}
+
+	command.AddCommand(createCmd)
+
+	return command
+}

--- a/pkg/fission-cli/cmd/token/create.go
+++ b/pkg/fission-cli/cmd/token/create.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/pkg/errors"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type CreateSubCommand struct {
+	cmd.CommandActioner
+}
+
+func Create(input cli.Input) error {
+	return (&CreateSubCommand{}).do(input)
+}
+
+func (opts *CreateSubCommand) do(input cli.Input) error {
+	return opts.run(input)
+}
+
+func (opts *CreateSubCommand) run(input cli.Input) error {
+
+	lb := &fv1.AuthLogin{}
+
+	username := input.String(flagkey.TokUsername)
+	if len(username) != 0 {
+		lb.Username = username
+	}
+
+	password := input.String(flagkey.TokPassword)
+	if len(password) != 0 {
+		lb.Password = password
+	}
+
+	values := map[string]string{"username": username, "password": password}
+
+	jsonValue, _ := json.Marshal(values)
+
+	kubeContext := input.String(flagkey.KubeContext)
+	// Portforward to the fission router
+	localRouterPort, err := util.SetupPortForward(util.GetFissionNamespace(), "application=fission-router", kubeContext)
+	if err != nil {
+		return err
+	}
+
+	authURI, _ := os.LookupEnv("FISSION_AUTH_URI")
+
+	if input.IsSet(flagkey.TokAuthURI) {
+		authURI = input.String(flagkey.TokAuthURI)
+	}
+
+	if len(authURI) == 0 {
+		authURI = util.FISSION_AUTH_URI
+	}
+
+	relativeURL, _ := url.Parse(authURI)
+	serverURL, _ := url.Parse("http://127.0.0.1:" + localRouterPort)
+	authAuthenticatorUrl := serverURL.ResolveReference(relativeURL)
+
+	resp, err := http.Post(authAuthenticatorUrl.String(), "application/json", bytes.NewBuffer(jsonValue))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "error creating token")
+	}
+
+	if resp.StatusCode == http.StatusCreated {
+		var rat fv1.RouterAuthToken
+		err = json.Unmarshal(body, &rat)
+		if err != nil {
+			return err
+		}
+		fmt.Println(rat.AccessToken)
+	} else if resp.StatusCode == http.StatusNotFound {
+		fmt.Printf("%s. Please check if authentication is enabled and correct auth URI is mentioned via --authuri or FISSION_AUTH_URI.\n", resp.Status)
+	} else {
+		fmt.Println(resp.Status)
+	}
+
+	return nil
+}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -142,6 +142,10 @@ var (
 	HtPrefix            = Flag{Type: String, Name: flagkey.HtPrefix, Usage: "Prefix with which functions are exposed. NOTE: Prefix takes precedence over URL/RelativeURL [DEPRECATED for 'fn create', use 'route create' instead]"}
 	HtKeepPrefix        = Flag{Type: Bool, Name: flagkey.HtKeepPrefix, Usage: "Keep the prefix in the URL while forwarding request to the function"}
 
+	TokUsername = Flag{Type: String, Name: flagkey.TokUsername, Usage: "Username to generate token for function invocation"}
+	TokPassword = Flag{Type: String, Name: flagkey.TokPassword, Usage: "Password to generate token for function invocation"}
+	TokAuthURI  = Flag{Type: String, Name: flagkey.TokAuthURI, Usage: "Relative URI path to generate token"}
+
 	TtName   = Flag{Type: String, Name: flagkey.TtName, Usage: "Time Trigger name"}
 	TtCron   = Flag{Type: String, Name: flagkey.TtCron, Usage: "Time trigger cron spec with each asterisk representing respectively second, minute, hour, the day of the month, month and day of the week. Also supports readable formats like '@every 5m', '@hourly'"}
 	TtFnName = Flag{Type: String, Name: flagkey.TtFnName, Usage: "Function name"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -92,6 +92,10 @@ const (
 	HtPrefix            = "prefix"
 	HtKeepPrefix        = "keepprefix"
 
+	TokUsername = "username"
+	TokPassword = "password"
+	TokAuthURI  = "authuri"
+
 	TtName   = resourceName
 	TtCron   = "cron"
 	TtFnName = "function"

--- a/pkg/fission-cli/util/constants.go
+++ b/pkg/fission-cli/util/constants.go
@@ -18,6 +18,8 @@ package util
 
 // fission-cli options
 const (
-	SPEC_IGNORE_FILE = ".specignore"
-	COMMIT_LABEL     = "commit"
+	SPEC_IGNORE_FILE   = ".specignore"
+	COMMIT_LABEL       = "commit"
+	FISSION_AUTH_URI   = "/auth/login"
+	FISSION_AUTH_TOKEN = "FISSION_AUTH_TOKEN"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

This PR adds new feature to enable authentication for fission routers. 
This is **a optional feature** which can be enabled/disabled as per the needs of the user. 
On enabling this feature, an endpoint for authentication will be registered in the router and all function API calls with be routed via authentication middleware. 
The user has to first create auth token by passing credentials. 
The token generated has to be then passed in the authorization header for all susbequent API calls to access the function.

This feature can be turned on by setting the key `authentication.enabled` in `charts/fission-all/values.yaml ` to `true` during the time of deployment. 
Along with this there are other keys like 
- `authUrlPath`
-  `authUsername`
- `jwtSigningKey`
- `jwtExpiryTime` 
- `jwtIssuer` 

The description for these parameters are provided in the same file as comments.

On enabling this feature a secret by name `router` will be created in the `fission` namespace with `username`, randomly generated `password` and `jwtSigningKey`. 
This secret will be mounted as volume on the router pod.
Also the other values mentioned above will be added to the existing `feature-config` configmap and will be mounted as volume on the router pod.

fission function test command:
---------------------------------
-  If default `authUrlPath` is not used, then the custom path has to be exported to the environment variable `FISSION_AUTH_URI`

  ```bash
  export FISSION_USERNAME=$(kubectl get secrets/router --template={{.data.username}} -n fission | base64 -d)
  export FISSION_PASSWORD=$(kubectl get secrets/router --template={{.data.password}} -n fission | base64 -d)
  export FISSION_AUTH_TOKEN=$(fi token create --username $FISSION_USERNAME --password $FISSION_PASSWORD)
  ```

-  For testing function token is picked from the env variable `FISSION_AUTH_TOKEN`, 
  
  ```bash
  fission function --name <functionName>
  ```

-  If env variable is not set then token has to be passed in the header 

  ```bash
  fission function test --name <functionName> --header "Authorization:Bearer <token>" 
  ```

fission function API:
----------------------------------------------
-  Router port has to be port-forwarded to one of the port. ex: 3000
  
  ```bash
  export FISSION_USERNAME=$(kubectl get secrets/router --template={{.data.username}} -n fission | base64 -d)
  export FISSION_PASSWORD=$(kubectl get secrets/router --template={{.data.password}} -n fission | base64 -d)
  curl -v http://localhost:3000/auth/login -d '{"username":"'$FISSION_USERNAME'", "password":"'$FISSION_PASSWORD'"}'
  export FISSION_AUTH_TOKEN=<token>
  curl http://localhost:3000/<path> -H "Authorization: Bearer ${FISSION_AUTH_TOKEN}"
  ```


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2277

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
