### PR TITLE
Rbac resources per release

### DIFF
--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        - name: HELM_RELEASE_NAME
+          value: {{ .Release.Name | quote }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         {{- if .Values.terminationMessagePath }}

--- a/charts/fission-all/templates/common/clusterrole.yaml
+++ b/charts/fission-all/templates/common/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: fission-cr-admin
+  name: {{ .Release.Name }}-fission-cr-admin
 rules:
 - apiGroups:
   - ""

--- a/charts/fission-all/templates/common/clusterrolebinding.yaml
+++ b/charts/fission-all/templates/common/clusterrolebinding.yaml
@@ -1,12 +1,12 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: fission-cr-admin
+  name: {{ .Release.Name }}-fission-cr-admin
 subjects:
   - kind: ServiceAccount
     name: fission-svc
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: fission-cr-admin
+  name: {{ .Release.Name }}-fission-cr-admin
   apiGroup: rbac.authorization.k8s.io

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -54,6 +54,8 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        - name: HELM_RELEASE_NAME
+          value: {{ .Release.Name | quote }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         readinessProbe:

--- a/charts/fission-all/templates/misc-functions/clusterrole.yaml
+++ b/charts/fission-all/templates/misc-functions/clusterrole.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: secret-configmap-getter
+  name: {{ .Release.Name }}-secret-configmap-getter
 rules:
   - apiGroups:
       - "*"
@@ -17,7 +17,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: package-getter
+  name: {{ .Release.Name }}-package-getter
 rules:
   - apiGroups:
       - "*"

--- a/charts/fission-all/templates/misc-functions/role.yaml
+++ b/charts/fission-all/templates/misc-functions/role.yaml
@@ -60,7 +60,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .Values.functionNamespace }}
-  name: event-fetcher
+  name: {{ .Release.Name }}-event-fetcher
 rules:
   - apiGroups: [""] # "" indicates the core API group
     resources: ["pods"]

--- a/charts/fission-all/templates/misc-functions/role.yaml
+++ b/charts/fission-all/templates/misc-functions/role.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-fission-fetcher
-  namespace: default
+  namespace: {{ .Values.defaultNamespace }}
 rules:
   - apiGroups:
       - ""
@@ -39,7 +39,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ .Release.Name }}-fission-builder
-  namespace: default
+  namespace: {{ .Values.defaultNamespace }}
 rules:
   - apiGroups:
       - fission.io

--- a/charts/fission-all/templates/misc-functions/role.yaml
+++ b/charts/fission-all/templates/misc-functions/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: fission-fetcher
+  name: {{ .Release.Name }}-fission-fetcher
   namespace: default
 rules:
   - apiGroups:
@@ -38,7 +38,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: fission-builder
+  name: {{ .Release.Name }}-fission-builder
   namespace: default
 rules:
   - apiGroups:

--- a/charts/fission-all/templates/misc-functions/rolebinding.yaml
+++ b/charts/fission-all/templates/misc-functions/rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: fission-fetcher
+  name: {{ .Release.Name }}-fission-fetcher
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: fission-fetcher
+  name: {{ .Release.Name }}-fission-fetcher
 subjects:
   - kind: ServiceAccount
     name: fission-fetcher
@@ -16,12 +16,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: fission-builder
+  name: {{ .Release.Name }}-fission-builder
   namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: fission-builder
+  name: {{ .Release.Name }}-fission-builder
 subjects:
   - kind: ServiceAccount
     name: fission-builder

--- a/charts/fission-all/templates/misc-functions/rolebinding.yaml
+++ b/charts/fission-all/templates/misc-functions/rolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-fission-fetcher
-  namespace: default
+  namespace: {{ .Values.defaultNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-fission-builder
-  namespace: default
+  namespace: {{ .Values.defaultNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/fission-all/templates/misc-functions/rolebinding.yaml
+++ b/charts/fission-all/templates/misc-functions/rolebinding.yaml
@@ -31,12 +31,12 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: fission-fetcher-pod-reader
+  name: {{ .Release.Name }}-fission-fetcher-pod-reader
   namespace: {{ .Values.functionNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: event-fetcher
+  name: {{ .Release.Name }}-event-fetcher
 subjects:
   - kind: ServiceAccount
     name: fission-fetcher

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -68,6 +68,10 @@ functionNamespace: fission-function
 ##
 builderNamespace: fission-builder
 
+## defaultNamespace represents the default namespace in Kubernetes.
+##
+defaultNamespace: default
+
 ## createNamespace decides to create namespaces by the chart.
 ## If set to true, functionNamespace and builderNamespace namespaces mentioned above will be created by the chart.
 ## Set to false if you want to create the namespaces manually.

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -140,10 +140,8 @@ const (
 	FissionBuilderSA = "fission-builder"
 	FissionFetcherSA = "fission-fetcher"
 
-	SecretConfigMapGetterCR = "secret-configmap-getter"
 	SecretConfigMapGetterRB = "secret-configmap-getter-binding"
 
-	PackageGetterCR = "package-getter"
 	PackageGetterRB = "package-getter-binding"
 
 	ClusterRole = "ClusterRole"

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -167,7 +167,7 @@ func (pkgw *packageWatcher) build(ctx context.Context, srcpkg *fv1.Package) {
 			// Add the package getter rolebinding to builder sa
 			// we continue here if role binding was not setup successfully. this is because without this, the fetcher won't be able to fetch the source pkg into the container and
 			// the build will fail eventually
-			err := utils.SetupRoleBinding(ctx, pkgw.logger, pkgw.k8sClient, fv1.PackageGetterRB, pkg.ObjectMeta.Namespace, fv1.PackageGetterCR, fv1.ClusterRole, fv1.FissionBuilderSA, builderNs)
+			err := utils.SetupRoleBinding(ctx, pkgw.logger, pkgw.k8sClient, fv1.PackageGetterRB, pkg.ObjectMeta.Namespace, utils.GetPackageGetterCR(), fv1.ClusterRole, fv1.FissionBuilderSA, builderNs)
 			if err != nil {
 				pkgw.logger.Error("error setting up role binding for package",
 					zap.Error(err),

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -140,7 +140,7 @@ func (deploy *NewDeploy) setupRBACObjs(ctx context.Context, deployNamespace stri
 	}
 
 	// create a cluster role binding for the fetcher SA, if not already created, granting access to do a get on packages in any ns
-	err = utils.SetupRoleBinding(ctx, deploy.logger, deploy.kubernetesClient, fv1.PackageGetterRB, fn.Spec.Package.PackageRef.Namespace, fv1.PackageGetterCR, fv1.ClusterRole, fv1.FissionFetcherSA, deployNamespace)
+	err = utils.SetupRoleBinding(ctx, deploy.logger, deploy.kubernetesClient, fv1.PackageGetterRB, fn.Spec.Package.PackageRef.Namespace, utils.GetPackageGetterCR(), fv1.ClusterRole, fv1.FissionFetcherSA, deployNamespace)
 	if err != nil {
 		deploy.logger.Error("error creating role binding for function",
 			zap.Error(err),
@@ -151,7 +151,7 @@ func (deploy *NewDeploy) setupRBACObjs(ctx context.Context, deployNamespace stri
 	}
 
 	// create rolebinding in function namespace for fetcherSA.envNamespace to be able to get secrets and configmaps
-	err = utils.SetupRoleBinding(ctx, deploy.logger, deploy.kubernetesClient, fv1.SecretConfigMapGetterRB, fn.ObjectMeta.Namespace, fv1.SecretConfigMapGetterCR, fv1.ClusterRole, fv1.FissionFetcherSA, deployNamespace)
+	err = utils.SetupRoleBinding(ctx, deploy.logger, deploy.kubernetesClient, fv1.SecretConfigMapGetterRB, fn.ObjectMeta.Namespace, utils.GetSecretConfigMapGetterCR(), fv1.ClusterRole, fv1.FissionFetcherSA, deployNamespace)
 	if err != nil {
 		deploy.logger.Error("error creating role binding for function",
 			zap.Error(err),

--- a/pkg/executor/executortype/poolmgr/funchandlers.go
+++ b/pkg/executor/executortype/poolmgr/funchandlers.go
@@ -70,7 +70,7 @@ func FunctionEventHandlers(logger *zap.Logger, kubernetesClient *kubernetes.Clie
 			// setup rolebinding is tried, if it fails, we don't return. we just log an error and move on, because :
 			// 1. not all functions have secrets and/or configmaps, so things will work without this rolebinding in that case.
 			// 2. on the contrary, when the route is tried, the env fetcher logs will show a 403 forbidden message and same will be relayed to executor.
-			err := utils.SetupRoleBinding(ctx, logger, kubernetesClient, fv1.SecretConfigMapGetterRB, fn.ObjectMeta.Namespace, fv1.SecretConfigMapGetterCR, fv1.ClusterRole, fv1.FissionFetcherSA, envNs)
+			err := utils.SetupRoleBinding(ctx, logger, kubernetesClient, fv1.SecretConfigMapGetterRB, fn.ObjectMeta.Namespace, utils.GetSecretConfigMapGetterCR(), fv1.ClusterRole, fv1.FissionFetcherSA, envNs)
 			if err != nil {
 				logger.Error("error creating rolebinding", zap.Error(err), zap.String("role_binding", fv1.SecretConfigMapGetterRB))
 			} else {
@@ -185,7 +185,7 @@ func FunctionEventHandlers(logger *zap.Logger, kubernetesClient *kubernetes.Clie
 				}
 				ctx := context.Background()
 				err := utils.SetupRoleBinding(ctx, logger, kubernetesClient, fv1.SecretConfigMapGetterRB,
-					newFunc.ObjectMeta.Namespace, fv1.SecretConfigMapGetterCR, fv1.ClusterRole,
+					newFunc.ObjectMeta.Namespace, utils.GetSecretConfigMapGetterCR(), fv1.ClusterRole,
 					fv1.FissionFetcherSA, envNs)
 
 				if err != nil {

--- a/pkg/executor/executortype/poolmgr/packagehandlers.go
+++ b/pkg/executor/executortype/poolmgr/packagehandlers.go
@@ -47,7 +47,7 @@ func PackageEventHandlers(logger *zap.Logger, kubernetesClient *kubernetes.Clien
 			ctx := context.Background()
 			// here, we return if we hit an error during rolebinding setup. this is because this rolebinding is mandatory for
 			// every function's package to be loaded into its env. without that, there's no point to move forward.
-			err := utils.SetupRoleBinding(ctx, logger, kubernetesClient, fv1.PackageGetterRB, pkg.ObjectMeta.Namespace, fv1.PackageGetterCR, fv1.ClusterRole, fv1.FissionFetcherSA, envNs)
+			err := utils.SetupRoleBinding(ctx, logger, kubernetesClient, fv1.PackageGetterRB, pkg.ObjectMeta.Namespace, utils.GetPackageGetterCR(), fv1.ClusterRole, fv1.FissionFetcherSA, envNs)
 			if err != nil {
 				logger.Error("error creating rolebinding for package",
 					zap.Error(err),
@@ -83,7 +83,7 @@ func PackageEventHandlers(logger *zap.Logger, kubernetesClient *kubernetes.Clien
 
 				ctx := context.Background()
 				err := utils.SetupRoleBinding(ctx, logger, kubernetesClient, fv1.PackageGetterRB,
-					newPkg.ObjectMeta.Namespace, fv1.PackageGetterCR, fv1.ClusterRole,
+					newPkg.ObjectMeta.Namespace, utils.GetPackageGetterCR(), fv1.ClusterRole,
 					fv1.FissionFetcherSA, envNs)
 				if err != nil {
 					logger.Error("error updating rolebinding for package",

--- a/pkg/utils/rbacutils.go
+++ b/pkg/utils/rbacutils.go
@@ -19,6 +19,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 
@@ -294,4 +295,20 @@ func DeleteRoleBinding(ctx context.Context, k8sClient *kubernetes.Clientset, rol
 
 func MakeSAMapKey(saName, saNamespace string) string {
 	return fmt.Sprintf("%s-%s", saName, saNamespace)
+}
+
+func GetSecretConfigMapGetterCR() string {
+	releaseName := os.Getenv("HELM_RELEASE_NAME")
+	if len(releaseName) > 0 {
+		return fmt.Sprintf("%s-secret-configmap-getter", releaseName)
+	}
+	return "secret-configmap-getter"
+}
+
+func GetPackageGetterCR() string {
+	releaseName := os.Getenv("HELM_RELEASE_NAME")
+	if len(releaseName) > 0 {
+		return fmt.Sprintf("%s-package-getter", releaseName)
+	}
+	return "package-getter"
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Changes consider Helm Release name while creation of RBAC ClusterRole resources. This change allows users to have multiple Fission releases on the same cluster.

## Which issue(s) this PR fixes:

Fixes https://github.com/fission/fission/issues/2291

## Testing
Verified two Fission release install on same cluster.
On  creation of env and function both installations created deployment. 
Fission function could be tested by setting `FISSION_NAMESPACE` env variable.

```
FISSION_NAMESPACE=fission
fission fn test --name hello-world
FISSION_NAMESPACE=fisison-canary
fission fn test --name hello-world
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
