### PR TITLE
show error while creating mqtrigger if given function is not present

### DIFF
--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -146,6 +146,11 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			console.Warn(fmt.Sprintf("MessageQueueTrigger '%v' references unknown Function '%v', please create it before applying spec",
 				mqtName, fnName))
 		}
+	} else {
+		err = util.CheckFunctionExistence(opts.Client(), []string{fnName}, fnNamespace)
+		if err != nil {
+			return err
+		}
 	}
 
 	opts.trigger = &fv1.MessageQueueTrigger{


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
The terminal throws error while creating mqtrigger if the given function is not present. Previously, nothing was displayed by the terminal. Please let me know if you want to show just a warning like in the case of httptrigger.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2300

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
