### PR TITLE
make graceperiod configurable for container functions

### DIFF
--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -172,6 +172,9 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 	}
 
 	gracePeriodSeconds := int64(6 * 60)
+	if *fn.Spec.PodSpec.TerminationGracePeriodSeconds >= 0 {
+		gracePeriodSeconds = *fn.Spec.PodSpec.TerminationGracePeriodSeconds
+	}
 
 	podAnnotations := make(map[string]string)
 

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -167,6 +167,7 @@ func Commands() *cobra.Command {
 			flag.FnCfgMap, flag.FnSecret,
 			flag.FnExecutionTimeout,
 			flag.FnIdleTimeout,
+			flag.FnTerminationGracePeriod,
 			flag.Labels, flag.Annotation,
 
 			// flag for newdeploy to use.

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -100,6 +100,11 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 		return err
 	}
 
+	fnGracePeriod := input.Int64(flagkey.FnGracePeriod)
+	if fnGracePeriod < 0 {
+		console.Warn("grace period must be a non-negative integer, using default value (6 mins)")
+	}
+
 	var imageName string
 	var port int
 	var command, args string
@@ -205,7 +210,8 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	}
 
 	opts.function.Spec.PodSpec = &apiv1.PodSpec{
-		Containers: []apiv1.Container{*container},
+		Containers:                    []apiv1.Container{*container},
+		TerminationGracePeriodSeconds: &fnGracePeriod,
 	}
 
 	return nil

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -125,6 +125,8 @@ var (
 	FnRequestsPerPod        = Flag{Type: Int, Name: flagkey.FnRequestsPerPod, Aliases: []string{"rpp"}, Usage: "Maximum number of concurrent requests that can be served by a specialized pod", DefaultValue: 1}
 	FnOnceOnly              = Flag{Type: Bool, Name: flagkey.FnOnceOnly, Aliases: []string{"yolo"}, Usage: "Specifies if specialized pod will serve exactly one request in its lifetime"}
 	FnSubPath               = Flag{Type: String, Name: flagkey.FnSubPath, Usage: "Sub Path to check if function internally supports routing"}
+	// Termination Grace Period configurable at function creation/update only for container functions
+	FnTerminationGracePeriod = Flag{Type: Int64, Name: flagkey.FnGracePeriod, Usage: "Grace time (in seconds) for pod to perform connection draining before termination (default value will be used if negative value is given)", DefaultValue: 360}
 
 	HtName              = Flag{Type: String, Name: flagkey.HtName, Usage: "HTTP trigger name"}
 	HtMethod            = Flag{Type: StringSlice, Name: flagkey.HtMethod, Usage: "HTTP Methods: GET,POST,PUT,DELETE,HEAD. To mention single method: --method GET and for multiple methods --method GET --method POST. [DEPRECATED for 'fn create', use 'route create' instead]", DefaultValue: []string{http.MethodGet}}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -76,6 +76,7 @@ const (
 	FnRequestsPerPod        = "requestsperpod"
 	FnOnceOnly              = "onceonly"
 	FnSubPath               = "subpath"
+	FnGracePeriod           = "graceperiod"
 
 	HtName              = resourceName
 	HtMethod            = "method"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
Added flag to configure grace period while creating container functions.
For negative input I've given a warning. Let me know if you want to throw an error instead. 0 is a valid input according to this - https://doc.crds.dev/github.com/fission/fission/fission.io/Function/v1@v1.15.0#spec-podspec-terminationGracePeriodSeconds. Also in the same doc it says default is 30 seconds. I believe it is a typo mistake. Shouldn't it be 360 seconds?

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2284 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
