### PR TITLE
[Feature] Force spec apply even if conflicting resources exist with different deployment ID

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -733,7 +733,7 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) || !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -839,10 +839,9 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 			newmeta, err := fclient.V1().Environment().Create(&o)
 			if err != nil {
 				return nil, nil, err
-			} else {
-				ras.Created = append(ras.Created, newmeta)
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
 			}
+			ras.Created = append(ras.Created, newmeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
 		}
 	}
 

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -630,8 +630,7 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 				keep = true
 			}
 
-			if keep && isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && existingObj.Status.BuildStatus == fv1.BuildStatusSucceeded &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if keep && isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && existingObj.Status.BuildStatus == fv1.BuildStatusSucceeded {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -734,8 +733,7 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -822,8 +820,7 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -911,8 +908,7 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -999,8 +995,7 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -1087,8 +1082,7 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -1175,8 +1169,7 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
-				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -1221,25 +1214,5 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 }
 
 func isObjectMetaEqual(existingObj, newObj metav1.ObjectMeta) bool {
-
-	if !reflect.DeepEqual(existingObj.Labels, newObj.Labels) {
-		return false
-	}
-
-	existingAnnotations := make(map[string]string)
-	newAnnotations := make(map[string]string)
-
-	for existingObjKey, existingObjVal := range existingObj.Annotations {
-		if existingObjKey != FISSION_DEPLOYMENT_NAME_KEY && existingObjKey != FISSION_DEPLOYMENT_UID_KEY {
-			existingAnnotations[existingObjKey] = existingObjVal
-		}
-	}
-
-	for newObjKey, newObjVal := range newObj.Annotations {
-		if newObjKey != FISSION_DEPLOYMENT_NAME_KEY && newObjKey != FISSION_DEPLOYMENT_UID_KEY {
-			newAnnotations[newObjKey] = newObjVal
-		}
-	}
-
-	return reflect.DeepEqual(existingAnnotations, newAnnotations)
+	return reflect.DeepEqual(existingObj.Labels, newObj.Labels) && reflect.DeepEqual(existingObj.Annotations, newObj.Annotations)
 }

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -630,7 +630,8 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 				keep = true
 			}
 
-			if keep && isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && existingObj.Status.BuildStatus == fv1.BuildStatusSucceeded && !specAllowConflicts {
+			if keep && isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && existingObj.Status.BuildStatus == fv1.BuildStatusSucceeded &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -733,7 +734,8 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -820,7 +822,8 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -908,7 +911,8 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -995,7 +999,8 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -1082,7 +1087,8 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
@@ -1169,7 +1175,8 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 		existingObj, ok := existent[mapKey(&o.ObjectMeta)]
 		if ok {
 			// ok, a resource with the same name exists, is it the same?
-			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) && !specAllowConflicts {
+			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) &&
+				existingObj.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] == o.ObjectMeta.Annotations[FISSION_DEPLOYMENT_UID_KEY] {
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -632,11 +632,26 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 
 			if keep && isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && existingObj.Status.BuildStatus == fv1.BuildStatusSucceeded {
 				// nothing to do on the server
+				if specAllowConflicts {
+					o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+					pkg, err := waitForPackageBuild(fclient, &o)
+					if err != nil {
+						console.Warn(fmt.Sprintf("Error waiting for package '%v' build, ignoring", o.ObjectMeta.Name))
+						pkg = &o
+					}
+
+					if pkg.Status.BuildStatus == fv1.BuildStatusFailed {
+						pkg.Status.BuildStatus = fv1.BuildStatusPending
+					}
+					_, err = fclient.V1().Package().Update(pkg)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
 				// update
 				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-
 				// We may be racing against the package builder to update the
 				// package (a previous version might have been getting built).  So,
 				// wait for the package to have a non-running build status.
@@ -823,6 +838,14 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 			// ok, a resource with the same name exists, is it the same?
 			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
+				//Update is necessary to update the UID incase of conflict
+				if specAllowConflicts {
+					o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+					_, err := fclient.V1().Environment().Update(&o)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
 				// update
@@ -911,6 +934,13 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 			// ok, a resource with the same name exists, is it the same?
 			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
+				if specAllowConflicts {
+					o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+					_, err := fclient.V1().HTTPTrigger().Update(&o)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
 				// update
@@ -998,6 +1028,13 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 			// ok, a resource with the same name exists, is it the same?
 			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
+				if specAllowConflicts {
+					o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+					_, err := fclient.V1().KubeWatcher().Update(&o)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
 				// update
@@ -1085,6 +1122,13 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 			// ok, a resource with the same name exists, is it the same?
 			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
+				if specAllowConflicts {
+					o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+					_, err := fclient.V1().TimeTrigger().Update(&o)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
 				// update
@@ -1172,6 +1216,13 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 			// ok, a resource with the same name exists, is it the same?
 			if isObjectMetaEqual(existingObj.ObjectMeta, o.ObjectMeta) && reflect.DeepEqual(existingObj.Spec, o.Spec) {
 				// nothing to do on the server
+				if specAllowConflicts {
+					o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+					_, err := fclient.V1().MessageQueueTrigger().Update(&o)
+					if err != nil {
+						return nil, nil, err
+					}
+				}
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
 				// update

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -39,7 +39,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Validate),
 	}
 	wrapper.SetFlags(validateCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecAllowConflicts},
 	})
 
 	applyCmd := &cobra.Command{
@@ -48,7 +48,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Apply),
 	}
 	wrapper.SetFlags(applyCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation, flag.SpecApplyCommitLabel},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts},
 	})
 
 	destroyCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -53,7 +53,7 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	emptyFr.DeploymentConfig = fr.DeploymentConfig
 
 	// "apply" the empty state
-	_, _, err = applyResources(opts.Client(), specDir, &emptyFr, true)
+	_, _, err = applyResources(opts.Client(), specDir, &emptyFr, true, input)
 	if err != nil {
 		return errors.Wrap(err, "error deleting resources")
 	}

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -53,7 +53,7 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	emptyFr.DeploymentConfig = fr.DeploymentConfig
 
 	// "apply" the empty state
-	_, _, err = applyResources(opts.Client(), specDir, &emptyFr, true, input)
+	_, _, err = applyResources(opts.Client(), specDir, &emptyFr, true, false)
 	if err != nil {
 		return errors.Wrap(err, "error deleting resources")
 	}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -210,7 +210,7 @@ var (
 	SpecValidation       = Flag{Type: String, Name: flagkey.SpecValidate, Usage: "Turns server side validations of Fission objects on/off"}
 	SpecIgnore           = Flag{Type: String, Name: flagkey.SpecIgnore, Usage: fmt.Sprintf("File containing specs to be ingored inside --specdir, defaults to %v", util.SPEC_IGNORE_FILE)}
 	SpecApplyCommitLabel = Flag{Type: Bool, Name: flagkey.SpecApplyCommitLabel, Usage: "Apply commit label to the resources"}
-	SpecAllowConflicts   = Flag{Type: Bool, Name: flagkey.SpecAllowConflicts, Usage: "If true, spec apply will be forced even if resources are already deployed", DefaultValue: false}
+	SpecAllowConflicts   = Flag{Type: Bool, Name: flagkey.SpecAllowConflicts, Usage: "If true, spec apply will be forced even if conflicting resources exist", DefaultValue: false}
 
 	SupportOutput = Flag{Type: String, Name: flagkey.SupportOutput, Short: "o", Usage: "Output directory to save dump archive/files", DefaultValue: flagkey.DefaultSpecOutputDir}
 	SupportNoZip  = Flag{Type: Bool, Name: flagkey.SupportNoZip, Usage: "Save dump information into multiple files instead of single zip file"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -210,6 +210,7 @@ var (
 	SpecValidation       = Flag{Type: String, Name: flagkey.SpecValidate, Usage: "Turns server side validations of Fission objects on/off"}
 	SpecIgnore           = Flag{Type: String, Name: flagkey.SpecIgnore, Usage: fmt.Sprintf("File containing specs to be ingored inside --specdir, defaults to %v", util.SPEC_IGNORE_FILE)}
 	SpecApplyCommitLabel = Flag{Type: Bool, Name: flagkey.SpecApplyCommitLabel, Usage: "Apply commit label to the resources"}
+	SpecAllowConflicts   = Flag{Type: Bool, Name: flagkey.SpecAllowConflicts, Usage: "If true, server-side apply will force the changes against conflicts.", DefaultValue: false}
 
 	SupportOutput = Flag{Type: String, Name: flagkey.SupportOutput, Short: "o", Usage: "Output directory to save dump archive/files", DefaultValue: flagkey.DefaultSpecOutputDir}
 	SupportNoZip  = Flag{Type: Bool, Name: flagkey.SupportNoZip, Usage: "Save dump information into multiple files instead of single zip file"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -210,7 +210,7 @@ var (
 	SpecValidation       = Flag{Type: String, Name: flagkey.SpecValidate, Usage: "Turns server side validations of Fission objects on/off"}
 	SpecIgnore           = Flag{Type: String, Name: flagkey.SpecIgnore, Usage: fmt.Sprintf("File containing specs to be ingored inside --specdir, defaults to %v", util.SPEC_IGNORE_FILE)}
 	SpecApplyCommitLabel = Flag{Type: Bool, Name: flagkey.SpecApplyCommitLabel, Usage: "Apply commit label to the resources"}
-	SpecAllowConflicts   = Flag{Type: Bool, Name: flagkey.SpecAllowConflicts, Usage: "If true, server-side apply will force the changes against conflicts.", DefaultValue: false}
+	SpecAllowConflicts   = Flag{Type: Bool, Name: flagkey.SpecAllowConflicts, Usage: "If true, spec apply will be forced even if resources are already deployed", DefaultValue: false}
 
 	SupportOutput = Flag{Type: String, Name: flagkey.SupportOutput, Short: "o", Usage: "Output directory to save dump archive/files", DefaultValue: flagkey.DefaultSpecOutputDir}
 	SupportNoZip  = Flag{Type: Bool, Name: flagkey.SupportNoZip, Usage: "Save dump information into multiple files instead of single zip file"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -160,6 +160,7 @@ const (
 	SpecValidate         = "validation"
 	SpecIgnore           = "specignore"
 	SpecApplyCommitLabel = "commitlabel"
+	SpecAllowConflicts   = "allowconflicts"
 
 	SupportOutput = Output
 	SupportNoZip  = "nozip"


### PR DESCRIPTION
## Description
Added allowconflicts flag to specs.

## Which issue(s) this PR fixes:
Fixes #2109 

## Testing
Rebuilt the fission-cli and tested the command.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
