### PR TITLE
Env deletion deletes function pods

### DIFF
--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -51,5 +52,24 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 	}
 
 	fmt.Printf("environment '%v' deleted\n", m.Name)
+
+	fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
+	if err != nil {
+		return errors.Wrap(err, "Error updating function environment")
+	}
+
+	for _, fn := range fns {
+		if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy &&
+			fn.Spec.Environment.Name == m.Name {
+			funcm := &metav1.ObjectMeta{
+				Name:      fn.Name,
+				Namespace: fn.Namespace,
+			}
+			err := opts.Client().V1().Function().Delete(funcm)
+			if err != nil {
+				return errors.Wrap(err, "error deleting functions associated with env")
+			}
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
## Description
Whenever an environment is deleted, it deletes the new deploy function pods too.

## Which issue(s) this PR fixes:
Fixes #1848 

## Testing
Created new deploy pods and then deleted environment.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
