### PR TITLE
Prevent env deletion if any function exists

### DIFF
--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -72,7 +72,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.IgnoreNotFound, flag.EnvForce},
 	})
 
 	listCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -42,16 +42,6 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceEnvironment),
 	}
 
-	err := opts.Client().V1().Environment().Delete(m)
-	if err != nil {
-		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
-			return nil
-		}
-		return errors.Wrap(err, "error deleting environment")
-	}
-
-	fmt.Printf("environment '%v' deleted\n", m.Name)
-
 	fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
 	if err != nil {
 		return errors.Wrap(err, "Error getting functions wrt environment.")
@@ -63,5 +53,16 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 			return errors.New("Environment is used by atleast one function.")
 		}
 	}
+
+	err = opts.Client().V1().Environment().Delete(m)
+	if err != nil {
+		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
+			return nil
+		}
+		return errors.Wrap(err, "error deleting environment")
+	}
+
+	fmt.Printf("environment '%v' deleted\n", m.Name)
+
 	return nil
 }

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -51,5 +52,24 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 	}
 
 	fmt.Printf("environment '%v' deleted\n", m.Name)
+
+	fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
+	if err != nil {
+		return errors.Wrap(err, "Error updating function environment")
+	}
+
+	for _, fn := range fns {
+		if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy &&
+			fn.Spec.Environment.Name == m.Name {
+			funcm := &metav1.ObjectMeta{
+				Name:      fn.Name,
+				Namespace: fn.Namespace,
+			}
+			err := opts.Client().V1().Function().Delete(funcm)
+			if err != nil {
+				return errors.Wrap(err, "error deleting functions associated with env")
+			}
+		}
+	}
 	return nil
 }

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -22,7 +22,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -55,20 +54,13 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 	fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
 	if err != nil {
-		return errors.Wrap(err, "Error updating function environment")
+		return errors.Wrap(err, "Error getting functions wrt environment.")
 	}
 
 	for _, fn := range fns {
-		if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy &&
-			fn.Spec.Environment.Name == m.Name {
-			funcm := &metav1.ObjectMeta{
-				Name:      fn.Name,
-				Namespace: fn.Namespace,
-			}
-			err := opts.Client().V1().Function().Delete(funcm)
-			if err != nil {
-				return errors.Wrap(err, "error deleting functions associated with env")
-			}
+		if fn.Spec.Environment.Name == m.Name &&
+			fn.Spec.Environment.Namespace == m.Namespace {
+			return errors.New("Environment is used by atleast one function.")
 		}
 	}
 	return nil

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -42,19 +42,21 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		Namespace: input.String(flagkey.NamespaceEnvironment),
 	}
 
-	fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
-	if err != nil {
-		return errors.Wrap(err, "Error getting functions wrt environment.")
-	}
+	if !input.Bool(flagkey.EnvForce) {
+		fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
+		if err != nil {
+			return errors.Wrap(err, "Error getting functions wrt environment.")
+		}
 
-	for _, fn := range fns {
-		if fn.Spec.Environment.Name == m.Name &&
-			fn.Spec.Environment.Namespace == m.Namespace {
-			return errors.New("Environment is used by atleast one function.")
+		for _, fn := range fns {
+			if fn.Spec.Environment.Name == m.Name &&
+				fn.Spec.Environment.Namespace == m.Namespace {
+				return errors.New("Environment is used by atleast one function.")
+			}
 		}
 	}
 
-	err = opts.Client().V1().Environment().Delete(m)
+	err := opts.Client().V1().Environment().Delete(m)
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -178,6 +178,7 @@ var (
 	EnvVersion                = Flag{Type: Int, Name: flagkey.EnvVersion, Usage: "Environment API version (1 means v1 interface)", DefaultValue: 1}
 	EnvImagePullSecret        = Flag{Type: String, Name: flagkey.EnvImagePullSecret, Usage: "Secret for Kubernetes to pull an image from a private registry"}
 	EnvExecutorType           = Flag{Type: String, Name: flagkey.EnvExecutorType, Usage: "Executor type of pod in environment; one of 'poolmgr', 'newdeploy', 'container'"}
+	EnvForce                  = Flag{Type: Bool, Name: flagkey.EnvForce, Short: "f", Usage: "Force delete env even if one or more functions exist", DefaultValue: false}
 
 	KwName      = Flag{Type: String, Name: flagkey.KwName, Usage: "Watch name"}
 	KwFnName    = Flag{Type: String, Name: flagkey.KwFnName, Usage: "Function name"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -128,6 +128,7 @@ const (
 	EnvVersion         = "version"
 	EnvImagePullSecret = "imagepullsecret"
 	EnvExecutorType    = "executortype"
+	EnvForce           = force
 
 	KwName      = resourceName
 	KwFnName    = "function"


### PR DESCRIPTION
## Description
Prevents deletion of environment even if one function is using it.

### Sample Outputs
```
fission env create --name nodeenv --image fission/node-env
fission fn create --name consumer --env nodeenv --code consumer.js
```

- `fission env delete --name nodeenv`
```
Options:
  --name=''                           Environment name
  --envNamespace='default' (--envns)  Namespace for environment object
  --ignorenotfound=false              Treat "resource not found" as a successful delete.
  --force=false (-f)                  Force delete env even if one or more functions exist

Global Options:
  --server=''         Server URL
  --verbosity=1 (-v)  CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)
  --kube-context=''   Kubernetes context to be used for the execution of Fission commands

Usage:
  fission environment delete [options]

Error: Environment is used by atleast one function.
```
- `fission env delete --name nodeenv --force`
```
environment 'nodeenv' deleted
```
- `fission env delete --name nodeenv -f`
```
environment 'nodeenv' deleted
```
- `fission env delete --name nodeenv -f fission env create --name nodeenv --image fission/node-env
fission env delete --name nodeenv
`
```
Options:
  --name=''                           Environment name
  --envNamespace='default' (--envns)  Namespace for environment object
  --ignorenotfound=false              Treat "resource not found" as a successful delete.
  --force=false (-f)                  Force delete env even if one or more functions exist

Global Options:
  --server=''         Server URL
  --verbosity=1 (-v)  CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)
  --kube-context=''   Kubernetes context to be used for the execution of Fission commands

Usage:
  fission environment delete [options]

Error: Environment is used by atleast one function.
```

## Which issue(s) this PR fixes: 

## Testing

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
