### PR TITLE
Changed spec deletion order according to dependency

### DIFF
--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -19,6 +19,7 @@ package spec
 import (
 	"github.com/pkg/errors"
 
+	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
@@ -53,9 +54,51 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	emptyFr.DeploymentConfig = fr.DeploymentConfig
 
 	// "apply" the empty state
-	_, _, err = applyResources(opts.Client(), specDir, &emptyFr, true, false)
+	err = deleteResources(opts.Client(), &emptyFr)
 	if err != nil {
 		return errors.Wrap(err, "error deleting resources")
+	}
+
+	return nil
+}
+
+func deleteResources(fclient client.Interface, fr *FissionResources) error {
+
+	var err error
+
+	_, _, err = applyHTTPTriggers(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "HTTPTrigger delete failed")
+	}
+
+	_, _, err = applyKubernetesWatchTriggers(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "KubernetesWatchTrigger delete failed")
+	}
+
+	_, _, err = applyTimeTriggers(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "TimeTrigger delete failed")
+	}
+
+	_, _, err = applyMessageQueueTriggers(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "MessageQueueTrigger delete failed")
+	}
+
+	_, _, err = applyFunctions(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "function delete failed")
+	}
+
+	_, _, err = applyPackages(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "package delete failed")
+	}
+
+	_, _, err = applyEnvironments(fclient, fr, true, false)
+	if err != nil {
+		return errors.Wrap(err, "environment delete failed")
 	}
 
 	return nil


### PR DESCRIPTION
## Description
Changed spec deletion order according to dependency.

## Which issue(s) this PR fixes:

## Testing
Tested using this example. [https://github.com/fission/examples/tree/master/spec-example/hello-spec-exmaple](url)

Sample Output:
- `fission spec destroy`
```
Deleted Function default/hello
Deleted Package default/hello-pkg
Deleted Environment default/python-27
```
## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
