### PR TITLE
Fix validation for secret & configmap reference with function  

### DIFF
--- a/pkg/controller/client/v1/misc.go
+++ b/pkg/controller/client/v1/misc.go
@@ -23,7 +23,9 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/fission/fission/pkg/controller/client/rest"
 	"github.com/fission/fission/pkg/fission-cli/console"
@@ -60,6 +62,9 @@ func (c *Misc) SecretExists(m *metav1.ObjectMeta) error {
 	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode >= 400 {
+		return k8serrors.NewNotFound(schema.GroupResource{"", ""}, "")
 	}
 	defer resp.Body.Close()
 	return nil

--- a/pkg/controller/client/v1/misc.go
+++ b/pkg/controller/client/v1/misc.go
@@ -64,7 +64,7 @@ func (c *Misc) SecretExists(m *metav1.ObjectMeta) error {
 		return err
 	}
 	if resp.StatusCode >= 400 {
-		return k8serrors.NewNotFound(schema.GroupResource{}, "")
+		return k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secret"}, m.Name)
 	}
 	defer resp.Body.Close()
 	return nil
@@ -77,6 +77,9 @@ func (c *Misc) ConfigMapExists(m *metav1.ObjectMeta) error {
 	resp, err := c.client.Get(relativeUrl)
 	if err != nil {
 		return err
+	}
+	if resp.StatusCode >= 400 {
+		return k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmap"}, m.Name)
 	}
 	defer resp.Body.Close()
 	return nil

--- a/pkg/controller/client/v1/misc.go
+++ b/pkg/controller/client/v1/misc.go
@@ -64,7 +64,7 @@ func (c *Misc) SecretExists(m *metav1.ObjectMeta) error {
 		return err
 	}
 	if resp.StatusCode >= 400 {
-		return k8serrors.NewNotFound(schema.GroupResource{"", ""}, "")
+		return k8serrors.NewNotFound(schema.GroupResource{}, "")
 	}
 	defer resp.Body.Close()
 	return nil

--- a/pkg/controller/client/v1/misc.go
+++ b/pkg/controller/client/v1/misc.go
@@ -63,10 +63,10 @@ func (c *Misc) SecretExists(m *metav1.ObjectMeta) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		return k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "secret"}, m.Name)
 	}
-	defer resp.Body.Close()
 	return nil
 }
 
@@ -78,10 +78,10 @@ func (c *Misc) ConfigMapExists(m *metav1.ObjectMeta) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
 		return k8serrors.NewNotFound(schema.GroupResource{Group: "", Resource: "configmap"}, m.Name)
 	}
-	defer resp.Body.Close()
 	return nil
 }
 


### PR DESCRIPTION
## Description
Secret should be created in the same namespace as the function. Before this fix, SecretExists() didn't raise a warning but now it does.

## Which issue(s) this PR fixes:
Fixes #2304 

## Testing

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
