### PR TITLE
[helm chart] fission deployments resources

### DIFF
--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -50,6 +50,8 @@ spec:
           value: {{ .Release.Name | quote }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.buildermgr.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -37,6 +37,8 @@ spec:
               fieldPath: metadata.namespace
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.controller.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -58,6 +58,8 @@ spec:
           value: {{ .Release.Name | quote }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.executor.resources | nindent 10 }}
         readinessProbe:
           httpGet:
             path: "/healthz"

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.kubewatcher.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.redis.image }}:{{ .Values.mqt_keda.connector_images.redis.tag }}"
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.mqt_keda.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -83,7 +83,7 @@ spec:
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
-          {{- toYaml .Values.router.resources | indent 10 }}
+          {{- toYaml .Values.router.resources | nindent 10 }}
         readinessProbe:
           httpGet:
             path: "/router-healthz"

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -51,6 +51,8 @@ spec:
         {{- end }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.storagesvc.resources | nindent 10 }}
         {{- if ne (.Values.persistence.storageType | default "local") "s3" }}
         volumeMounts:
         - name: fission-storage

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        resources:
+          {{- toYaml .Values.timer.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -128,6 +128,17 @@ executor:
   ## This is applicable to Pool Manager executor type only.
   ##
   podReadyTimeout: 300s
+  
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
 
 ## router is responsible for routing function calls to the appropriate function.
 ##
@@ -223,6 +234,78 @@ router:
   #  tolerations:
   #  nodeSelector:
 
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
+
+## The builder manager watches the package & environments CRD changes and manages the builds of function source code.
+## 
+buildermgr:
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
+
+## controller is the component that the client talks to.
+## It contains CRUD APIs for functions, triggers, environments, Kubernetes event watches, etc. and proxy APIs to internal 3rd-party services.
+##
+controller:
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
+
+## kubewatcher watches the Kubernetes API and invokes functions associated with watches, sending the watch event to the function.
+##
+kubewatcher:
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
+
+## The storage service is the home for all archives of packages with sizes larger than 256KB.
+##
+storagesvc:
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
+
+## The timer works like kubernetes CronJob but instead of creating a pod to do the task
+## It sends a request to router to invoke the function.
+##
+timer:
   ## Pod resources as:
   ##  resources:
   ##    limits:
@@ -599,6 +682,17 @@ mqt_keda:
     redis:
       image: fission/keda-redis-http-connector
       tag: v0.1
+
+  ## Pod resources as:
+  ##  resources:
+  ##    limits:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##    requests:
+  ##      cpu: <tbd>
+  ##      memory: <tbd>
+  ##
+  resources: {}
 
 ## Enable Pprof based profiling used mostly by Fission developers
 ##


### PR DESCRIPTION
Fix helm templating on `resources:` of router deployment and add `resources:` attribute to other fission deployments
