### PR TITLE
[helm chart] Remove prometheus chart dependency from Fission

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -74,9 +74,6 @@ jobs:
         run: |
           helm lint charts/fission-all/
 
-      - name: Helm update
-        run: helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-
       - name: Install Skaffold
         run: |
           curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64
@@ -87,6 +84,13 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           install-only: true
+
+      - name: Setup Prometheus Stack
+        run: |
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+          kubectl create ns monitoring
+          helm install monitoring prometheus-community/prometheus -n monitoring
 
       - name: Build and Install Fission
         run: |

--- a/charts/fission-all/Chart.lock
+++ b/charts/fission-all/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: prometheus
-  repository: https://prometheus-community.github.io/helm-charts
-  version: 14.11.0
-digest: sha256:1404b25cbdba70279240fead15b765d6945097fed5afc7e184da02dabfaa577a
-generated: "2021-10-19T17:20:08.919609+05:30"

--- a/charts/fission-all/Chart.yaml
+++ b/charts/fission-all/Chart.yaml
@@ -22,8 +22,3 @@ maintainers:
     email: sanket@infracloud.io
 engine: gotpl
 type: application
-dependencies:
-  - name: prometheus
-    version: 14.11.0
-    repository: https://prometheus-community.github.io/helm-charts
-    condition: prometheus.enabled

--- a/charts/fission-all/README.md
+++ b/charts/fission-all/README.md
@@ -93,6 +93,12 @@ _See [helm upgrade](https://helm.sh/docs/helm/helm_upgrade/) for command documen
 
 A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an incompatible breaking change needing manual actions.
 
+### Upgrade from 1.15.x to 1.16.x
+
+If you have been using `prometheus.enabled=true` in your fission-all chart, you will need to deploy the prometheus using prometheus community supported chart.
+We have removed prometheus dependency from fission-all chart.
+We would recommend [prometheus-community/kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) chart.
+
 ### Upgrade from 1.14.x to 1.15.x
 
 With 1.15.x release, following changes are made:
@@ -129,4 +135,4 @@ You may also `helm show values` on this chart's [dependencies](#dependencies) fo
 
 ### Multiple releases
 
-The same chart can be used to run multiple Fission instances in the same cluster if required. To disable a dependency during installation, set `prometheus.enabled` to `false`.
+The same chart can be used to run multiple Fission instances in the same cluster if required.

--- a/charts/fission-all/README.md
+++ b/charts/fission-all/README.md
@@ -97,7 +97,7 @@ A major chart version change (like v1.2.3 -> v2.0.0) indicates that there is an 
 
 If you have been using `prometheus.enabled=true` in your fission-all chart, you will need to deploy the prometheus using prometheus community supported chart.
 We have removed prometheus dependency from fission-all chart.
-We would recommend [prometheus-community/kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) chart.
+We would recommend [prometheus-community/prometheus](https://artifacthub.io/packages/helm/prometheus-community/prometheus) or [prometheus-community/kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) chart.
 
 ### Upgrade from 1.14.x to 1.15.x
 

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -25,11 +25,7 @@ controller/config.go
 {{- define "config" -}}
 canary:
   enabled: {{ .Values.canaryDeployment.enabled }}
-  {{- if .Values.prometheus.enabled }}
-  prometheusSvc: "http://{{ .Release.Name }}-prometheus-server.{{ .Release.Namespace }}"
-  {{- else }}
   prometheusSvc: {{ .Values.prometheus.serviceEndpoint | default "" | quote }}
-  {{- end }}
   {{- printf "\n" -}}
 auth:
   enabled: {{ .Values.authentication.enabled | default false }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -551,15 +551,12 @@ postInstallReportImage: fission/reporter
 ##
 debugEnv: false
 
-## Prometheus for scrapping service metrics
+## Prometheus related configuration to query metrics
 ##
 prometheus:
-  ## set this flag to true if prometheus needs to be deployed along with fission
-  ##
-  enabled: false
-
-  ## If enabled is false, please assign the prometheus service URL
-  ## that is accessible by components.
+  ## please assign the prometheus service URL
+  ## that is accessible by Fission components.
+  ## This is mainly used to enable canary deployment.
   ##
   serviceEndpoint: ""
 

--- a/hack/generate-helm-manifest.sh
+++ b/hack/generate-helm-manifest.sh
@@ -86,7 +86,7 @@ build_yamls() {
         $command >${c}-"${version}".yaml
 
         # for OpenShift
-        command="$cmdprefix --set analytics=false,analyticsNonHelmInstall=true,logger.enableSecurityContext=true,prometheus.enabled=false"
+        command="$cmdprefix --set analytics=false,analyticsNonHelmInstall=true,logger.enableSecurityContext=true"
         echo "$command"
         $command >${c}-"${version}"-openshift.yaml
 

--- a/pkg/canaryconfigmgr/prometheusClient.go
+++ b/pkg/canaryconfigmgr/prometheusClient.go
@@ -138,8 +138,7 @@ func (promApiClient *PrometheusApiClient) GetTotalFailedRequestsToFuncInWindow(f
 }
 
 func (promApiClient *PrometheusApiClient) executeQuery(queryString string) (float64, error) {
-	// TODO: Change to debug level once we have a better understanding of what is happening
-	promApiClient.logger.Info("prometheus executing query", zap.String("query", queryString))
+	promApiClient.logger.Debug("executing prometheus query", zap.String("query", queryString))
 
 	val, warn, err := promApiClient.client.Query(context.Background(), queryString, time.Now())
 	if err != nil {

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -110,7 +110,7 @@ profiles:
     value: true
   - op: replace
     path: /deploy/helm/releases/0/setValues/prometheus.serviceEndpoint
-    value: "monitoring-prometheus-server.monitoring.svc.cluster.local"
+    value: "http://monitoring-prometheus-server.monitoring.svc.cluster.local"
 - name: kind-opentelemetry
   patches:
   - op: replace

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -52,6 +52,7 @@ deploy:
         openTracing.enabled: false
         openTelemetry.otlpCollectorEndpoint: ""
         openTelemetry.otlpInsecure: true
+        prometheus.serviceEndpoint: ""
         priorityClassName: system-cluster-critical
         # Use /var/log directory for kind logs export
         terminationMessagePath: /var/log/termination-log
@@ -107,6 +108,9 @@ profiles:
   - op: replace
     path: /deploy/helm/releases/0/setValues/canaryDeployment.enabled
     value: true
+  - op: replace
+    path: /deploy/helm/releases/0/setValues/prometheus.serviceEndpoint
+    value: "monitoring-prometheus-server.monitoring.svc.cluster.local"
 - name: kind-opentelemetry
   patches:
   - op: replace

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -43,7 +43,6 @@ deploy:
         preUpgradeChecks.imageTag: ""
         namespace: fission
         pprof.enabled: false
-        prometheus.enabled: false
         canaryDeployment.enabled: false
         nats.enabled: false
         influxdb.enabled: false
@@ -102,9 +101,6 @@ profiles:
   - op: replace
     path: /deploy/helm/releases/0/setValues/routerServiceType
     value: NodePort
-  - op: replace
-    path: /deploy/helm/releases/0/setValues/prometheus.enabled
-    value: true
   - op: replace
     path: /deploy/helm/releases/0/setValues/influxdb.enabled
     value: true


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

Removing prometheus dependency from Fission chart and request user to have their own prometheus deployment.
We would recommend [kube-prometheus-stack](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack) helm chart from prometheus-community and link it with fission installation.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
