### PR TITLE
Refactoring prometheus metrics and labels

### DIFF
--- a/pkg/executor/fscache/metrics.go
+++ b/pkg/executor/fscache/metrics.go
@@ -5,53 +5,56 @@ import (
 )
 
 var (
-	// funcname: the function's name
-	// funcuid: the function's version id
-	coldStarts = prometheus.NewCounterVec(
+	// function_name: the function's name
+	// function_uid: the function's version id
+	// function_address: the address of the pod from which the function was called
+	functionLabels    = []string{"function_name", "function_uid"}
+	functionPodLabels = []string{"function_name", "function_address"}
+	coldStarts        = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Name: "fission_cold_starts_total",
-			Help: "How many cold starts are made by funcname, funcuid.",
+			Name: "fission_function_cold_starts_total",
+			Help: "How many cold starts are made by function_name, function_uid.",
 		},
-		[]string{"funcname", "funcuid"},
+		functionLabels,
 	)
 	funcRunningSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name:       "fission_func_running_seconds_summary",
+			Name:       "fission_function_running_seconds",
 			Help:       "The running time (last access - create) in seconds of the function.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"funcname", "funcuid"},
+		functionLabels,
 	)
 	funcAliveSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name:       "fission_func_alive_seconds_summary",
+			Name:       "fission_function_alive_seconds",
 			Help:       "The alive time in seconds of the function.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"funcname", "funcuid"},
+		functionLabels,
 	)
 	funcIsAlive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "fission_func_is_alive",
-			Help: "A binary value indicating is the funcname, funcuid alive",
+			Name: "fission_function_is_alive",
+			Help: "A binary value indicating is the function_name, function_uid alive",
 		},
-		[]string{"funcname", "funcuid"},
+		functionLabels,
 	)
 	funcReapTime = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name:       "fission_pod_reaptime_seconds",
+			Name:       "fission_function_pod_reaptime_seconds",
 			Help:       "Amount of seconds to reap a pod",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"funcname", "funcaddress"},
+		functionPodLabels,
 	)
 	idleTime = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Name:       "fission_idle_pod_time",
+			Name:       "fission_function_idle_pod_time",
 			Help:       "Number of seconds it took for Reaper to detect the pod was idle",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 		},
-		[]string{"funcname", "funcaddress"},
+		functionPodLabels,
 	)
 )
 

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -43,12 +43,12 @@ var (
 	metricAddr = ":8080"
 
 	// function + http labels as strings
-	labelsStrings = []string{"cached", "namespace", "name", "host", "path", "method", "code"}
+	labelsStrings = []string{"cached", "function_namespace", "function_name", "host", "path", "method", "code"}
 
 	// Function http calls count
 	// cached: true | false, is this function service address cached locally
-	// namespace: function namespace
-	// name: function name
+	// function_namespace: function namespace
+	// function_name: function name
 	// code: http status code
 	// path: the client call the function on which http path
 	// method: the function's http method


### PR DESCRIPTION
This change mainly fixes few things around router and executor
exposed metrices.
1. We are trying to follow standard in metric names.
2. Lables such as namespace are colliding with kube-prometheus standards
so they are getting relabled to exported_namespace. Added function prefix
to resolve this.
3. Also made required changes in canary config Prometheus queries.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

### Router 

- Labels changed 
  - `name` to `function_name`
  - `namespace` to `function_namespace`
- Changes affects following metrics exposed by router
  - `fission_function_calls_total`
  - `fission_function_errors_total`
  - `fission_function_duration_seconds`
  - `fission_function_overhead_seconds`
  - `fission_function_response_size_bytes`
  
## Executor

- Labels 
  - `funcname` -> `function_name`
  - `funcuid` -> `function_uid` 
  - `funcaddress` -> `function_address`
- Metrics
  -  `fission_cold_starts_total` -> `fission_function_cold_starts_total`
  - `fission_func_running_seconds_summary` -> `fission_function_running_seconds`
  - `fission_func_alive_seconds_summary` -> `fission_function_alive_seconds`
  - `fission_func_is_alive` -> `fission_function_is_alive`
  - `fission_pod_reaptime_seconds` -> `fission_function_pod_reaptime_seconds`
  - `fission_idle_pod_time` -> `fission_function_idle_pod_time`

## Reference
https://github.com/prometheus/prometheus/pull/9832

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
