### PR TITLE
Fixed poolmgr pod naming error

### DIFF
--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -39,9 +39,8 @@ func getPoolName(env *fv1.Environment) string {
 	min := func(a, b int) int {
 		if a > b {
 			return b
-		} else {
-			return a
 		}
+		return a
 	}
 
 	//To fit the 63 character limit

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -19,6 +19,7 @@ package poolmgr
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 
 	"go.uber.org/zap"
@@ -34,7 +35,18 @@ import (
 // getPoolName returns a unique name of an environment
 func (gp *GenericPool) getPoolName(env *fv1.Environment) string {
 	// TODO: get rid of resource version here
-	return strings.ToLower(fmt.Sprintf("poolmgr-%v-%v-%v", env.ObjectMeta.Name, env.ObjectMeta.Namespace, env.ObjectMeta.ResourceVersion))
+	var envPodName string
+
+	//To fit the 63 character limit
+	if len(env.ObjectMeta.Name)+len(env.ObjectMeta.Namespace) < 37 {
+		envPodName = env.ObjectMeta.Name + "-" + env.ObjectMeta.Namespace
+	} else {
+		nameLength := int(math.Min(float64(len(env.ObjectMeta.Name)), 18))
+		namespaceLength := int(math.Min(float64(len(env.ObjectMeta.Namespace)), 18))
+		envPodName = env.ObjectMeta.Name[:nameLength] + "-" + env.ObjectMeta.Namespace[:namespaceLength]
+	}
+
+	return strings.ToLower(fmt.Sprintf("poolmgr-%v-%v", envPodName, env.ResourceVersion))
 }
 
 func (gp *GenericPool) genDeploymentMeta(env *fv1.Environment) metav1.ObjectMeta {

--- a/pkg/executor/executortype/poolmgr/gp_deployment_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package poolmgr
+
+import (
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+func TestGetPoolName(t *testing.T) {
+	tests := []struct {
+		name string
+		env  *fv1.Environment
+		want string
+	}{
+		{
+			"Under character limit",
+			&fv1.Environment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       fv1.CRD_NAME_ENVIRONMENT,
+					APIVersion: fv1.CRD_VERSION,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "testns",
+				},
+			},
+			"poolmgr-test-testns-",
+		},
+		{
+			"Over character limit",
+			&fv1.Environment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       fv1.CRD_NAME_ENVIRONMENT,
+					APIVersion: fv1.CRD_VERSION,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "justtryingtoincreasethenumberofcharactersinthisstring",
+					Namespace: "checkingifthegetpoolfunctionworkswithcharactersmorethan18",
+				},
+			},
+			"poolmgr-justtryingtoincrea-checkingifthegetpo-",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getPoolName(tt.env); got != tt.want {
+				t.Errorf("getPoolName() = %v, want %v", got, tt.want)
+			} else {
+				fmt.Print(got)
+			}
+		})
+	}
+}

--- a/pkg/executor/executortype/poolmgr/gp_deployment_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment_test.go
@@ -39,11 +39,12 @@ func TestGetPoolName(t *testing.T) {
 					APIVersion: fv1.CRD_VERSION,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "testns",
+					Name:            "test",
+					Namespace:       "testns",
+					ResourceVersion: "2517",
 				},
 			},
-			"poolmgr-test-testns-",
+			"poolmgr-test-testns-2517",
 		},
 		{
 			"Over character limit",
@@ -53,19 +54,20 @@ func TestGetPoolName(t *testing.T) {
 					APIVersion: fv1.CRD_VERSION,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "justtryingtoincreasethenumberofcharactersinthisstring",
-					Namespace: "checkingifthegetpoolfunctionworkswithcharactersmorethan18",
+					Name:            "justtryingtoincreasethenumberofcharactersinthisstring",
+					Namespace:       "checkingifthegetpoolfunctionworkswithcharactersmorethan18",
+					ResourceVersion: "2518",
 				},
 			},
-			"poolmgr-justtryingtoincrea-checkingifthegetpo-",
+			"poolmgr-justtryingtoincrea-checkingifthegetpo-2518",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := getPoolName(tt.env); got != tt.want {
-				t.Errorf("getPoolName() = %v, want %v", got, tt.want)
+				t.Errorf("getPoolName() = %s, want = %s len(getPoolName()) = %x len(want) = %x", got, tt.want, len(got), len(tt.want))
 			} else {
-				fmt.Print(got)
+				fmt.Printf("getPoolName() = %s,length of string = %x", got, len(got))
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Poolmgr pod naming convention changed

## Which issue(s) this PR fixes:
Fixes #2379 

## Testing

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
