### PR TITLE
Fixing gcp connector name typo

### DIFF
--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -40,8 +40,8 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.aws_sqs.image }}:{{ .Values.mqt_keda.connector_images.aws_sqs.tag }}"
         - name: STAN_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.nats_steaming.image }}:{{ .Values.mqt_keda.connector_images.nats_steaming.tag }}"
-        - name: GCP-PUB-SUB_IMAGE
-          value: "{{ .Values.mqt_keda.connector_images.gcp_pub_sub.image }}:{{ .Values.mqt_keda.connector_images.gcp_pub_sub.tag }}"
+        - name: GCP-PUBSUB_IMAGE
+          value: "{{ .Values.mqt_keda.connector_images.gcp_pubsub.image }}:{{ .Values.mqt_keda.connector_images.gcp_pubsub.tag }}"
         - name: REDIS_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.redis.image }}:{{ .Values.mqt_keda.connector_images.redis.tag }}"
         {{- include "opentracing.envs" . | indent 8 }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -676,7 +676,7 @@ mqt_keda:
     nats_steaming:
       image: fission/keda-nats-streaming-http-connector
       tag: v0.9
-    gcp_pub_sub:
+    gcp_pubsub:
       image: fission/keda-gcp-pubsub-http-connector
       tag: v0.3
     redis:


### PR DESCRIPTION
## Description
Typo in gcp-pubsub connector causes error in creating mqtrigger
## Which issue(s) this PR fixes:
Fixes #2392 

## Testing
Successfully created mqtrigger after fixing typo.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
