### PR TITLE
Added metrics for fission mqtrigger and optimizations in trigger subscriptions

### DIFF
--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         svc: mqtrigger
         messagequeue: kafka
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
     spec:
       containers:
       - name: mqtrigger

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -65,8 +65,8 @@ func runTimer(ctx context.Context, logger *zap.Logger, routerUrl string) error {
 	return timer.Start(ctx, logger, routerUrl)
 }
 
-func runMessageQueueMgr(logger *zap.Logger, routerUrl string) error {
-	return mqtrigger.Start(logger, routerUrl)
+func runMessageQueueMgr(ctx context.Context, logger *zap.Logger, routerUrl string) error {
+	return mqtrigger.Start(ctx, logger, routerUrl)
 }
 
 // KEDA based MessageQueue Trigger Manager
@@ -276,7 +276,7 @@ Options:
 	}
 
 	if arguments["--mqt"] == true {
-		err = runMessageQueueMgr(logger, routerUrl)
+		err = runMessageQueueMgr(ctx, logger, routerUrl)
 		if err != nil {
 			logger.Error("message queue manager exited", zap.Error(err))
 			return

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mqtrigger
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -35,7 +36,7 @@ import (
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/nats"
 )
 
-func Start(logger *zap.Logger, routerUrl string) error {
+func Start(ctx context.Context, logger *zap.Logger, routerUrl string) error {
 	fissionClient, _, _, _, err := crd.MakeFissionClient()
 
 	if err != nil {
@@ -74,9 +75,7 @@ func Start(logger *zap.Logger, routerUrl string) error {
 	if err != nil {
 		logger.Fatal("failed to connect to remote message queue server", zap.Error(err))
 	}
-
-	mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, mq).Run()
-
+	mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, mq).Run(ctx)
 	return nil
 }
 

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -75,7 +75,8 @@ func Start(ctx context.Context, logger *zap.Logger, routerUrl string) error {
 	if err != nil {
 		logger.Fatal("failed to connect to remote message queue server", zap.Error(err))
 	}
-	mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, mq).Run(ctx)
+	mqtMgr := mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, mq)
+	mqtMgr.Run(ctx)
 	return nil
 }
 

--- a/pkg/mqtrigger/messageQueue/kafka/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka/kafka.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/zap"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/mqtrigger/factory"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	"github.com/fission/fission/pkg/mqtrigger/validator"
@@ -120,6 +121,7 @@ func (ch MqtConsumerGroupHandler) Cleanup(sarama.ConsumerGroupSession) error {
 func (ch MqtConsumerGroupHandler) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
 	for msg := range claim.Messages() {
 		ch.kafkaMsgHandler(session, msg)
+		mqtrigger.IncreaseMessageCount(ch.trigger.Name, ch.trigger.Namespace)
 	}
 	return nil
 }

--- a/pkg/mqtrigger/messageQueue/kafka/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka/kafka.go
@@ -409,6 +409,7 @@ func (kafka Kafka) getTLSConfig() (*tls.Config, error) {
 func (kafka Kafka) Unsubscribe(subscription messageQueue.Subscription) error {
 	mqtConsumer := subscription.(MqtConsumer)
 	mqtConsumer.cancel()
+	kafka.logger.Info("Working or no")
 	return mqtConsumer.consumer.Close()
 }
 

--- a/pkg/mqtrigger/messageQueue/kafka/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka/kafka.go
@@ -337,6 +337,8 @@ func (kafka Kafka) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Sub
 		return nil, err
 	}
 
+	kafka.logger.Info("Consumer", zap.Any("consumer: ", consumer))
+
 	producer, err := sarama.NewSyncProducer(kafka.brokers, producerConfig)
 	kafka.logger.Info("created a new producer", zap.Strings("brokers", kafka.brokers),
 		zap.String("input topic", trigger.Spec.Topic),
@@ -358,10 +360,12 @@ func (kafka Kafka) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Sub
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
+	kafka.logger.Info("context", zap.Any("Context", ctx), zap.Any("cancel", cancel))
 
 	ch := NewMqtConsumerGroupHandler(kafka.version, kafka.logger, trigger, producer, kafka.routerUrl)
 
 	// consume messages
+	kafka.logger.Info("Till here its ok")
 	go func() {
 		topic := []string{trigger.Spec.Topic}
 		err = consumer.Consume(ctx, topic, ch)
@@ -379,6 +383,7 @@ func (kafka Kafka) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Sub
 		cancel:   cancel,
 		consumer: consumer,
 	}
+	kafka.logger.Info("Before returning", zap.Any("mqtConsumer", mqtConsumer))
 	return mqtConsumer, nil
 }
 

--- a/pkg/mqtrigger/messageQueue/kafka/kafka.go
+++ b/pkg/mqtrigger/messageQueue/kafka/kafka.go
@@ -337,8 +337,6 @@ func (kafka Kafka) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Sub
 		return nil, err
 	}
 
-	kafka.logger.Info("Consumer", zap.Any("consumer: ", consumer))
-
 	producer, err := sarama.NewSyncProducer(kafka.brokers, producerConfig)
 	kafka.logger.Info("created a new producer", zap.Strings("brokers", kafka.brokers),
 		zap.String("input topic", trigger.Spec.Topic),
@@ -360,12 +358,9 @@ func (kafka Kafka) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Sub
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())
-	kafka.logger.Info("context", zap.Any("Context", ctx), zap.Any("cancel", cancel))
-
 	ch := NewMqtConsumerGroupHandler(kafka.version, kafka.logger, trigger, producer, kafka.routerUrl)
 
 	// consume messages
-	kafka.logger.Info("Till here its ok")
 	go func() {
 		topic := []string{trigger.Spec.Topic}
 		err = consumer.Consume(ctx, topic, ch)
@@ -383,7 +378,6 @@ func (kafka Kafka) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Sub
 		cancel:   cancel,
 		consumer: consumer,
 	}
-	kafka.logger.Info("Before returning", zap.Any("mqtConsumer", mqtConsumer))
 	return mqtConsumer, nil
 }
 
@@ -414,7 +408,6 @@ func (kafka Kafka) getTLSConfig() (*tls.Config, error) {
 func (kafka Kafka) Unsubscribe(subscription messageQueue.Subscription) error {
 	mqtConsumer := subscription.(MqtConsumer)
 	mqtConsumer.cancel()
-	kafka.logger.Info("Working or no")
 	return mqtConsumer.consumer.Close()
 }
 

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -1,0 +1,3 @@
+package mqtrigger
+
+var metricsAddr = ":8080"

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -13,7 +13,7 @@ var (
 			Name: "fission_mqt_subscriptions_total",
 			Help: "Total number of subscriptions to mq currently",
 		},
-		labels,
+		[]string{},
 	)
 	messageCount = promauto.NewCounterVec(
 		prometheus.CounterOpts{
@@ -24,14 +24,14 @@ var (
 	)
 )
 
-func IncreaseSubscriptionCount(trigname, trignamespace string) {
-	subscriptionCount.WithLabelValues(trigname, trignamespace).Inc()
+func IncreaseSubscriptionCount() {
+	subscriptionCount.WithLabelValues().Inc()
 }
 
-func DecreaseSubscriptionCount(trigname, trignamespace string) {
-	subscriptionCount.WithLabelValues(trigname, trignamespace).Dec()
+func DecreaseSubscriptionCount() {
+	subscriptionCount.WithLabelValues().Dec()
 }
 
 func IncreaseMessageCount(trigname, trignamespace string) {
-	subscriptionCount.WithLabelValues(trigname, trignamespace).Inc()
+	messageCount.WithLabelValues(trigname, trignamespace).Inc()
 }

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mqtrigger
 
 import (

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -10,7 +10,7 @@ var (
 	labels            = []string{"trigger_name", "trigger_namespace"}
 	subscriptionCount = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "fission_mqt_subscriptions_total",
+			Name: "fission_mqt_subscriptions",
 			Help: "Total number of subscriptions to mq currently",
 		},
 		[]string{},

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -1,3 +1,37 @@
 package mqtrigger
 
-var metricsAddr = ":8080"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	metricsAddr       = ":8080"
+	labels            = []string{"trigger_name", "trigger_namespace"}
+	subscriptionCount = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "fission_mqt_subscriptions_total",
+			Help: "Total number of subscriptions to mq currently",
+		},
+		labels,
+	)
+	messageCount = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fission_mqt_messages_processed_total",
+			Help: "Total number of messages processed",
+		},
+		labels,
+	)
+)
+
+func IncreaseSubscriptionCount(trigname, trignamespace string) {
+	subscriptionCount.WithLabelValues(trigname, trignamespace).Inc()
+}
+
+func DecreaseSubscriptionCount(trigname, trignamespace string) {
+	subscriptionCount.WithLabelValues(trigname, trignamespace).Dec()
+}
+
+func IncreaseMessageCount(trigname, trignamespace string) {
+	subscriptionCount.WithLabelValues(trigname, trignamespace).Inc()
+}

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -214,6 +214,6 @@ func (mqt *MessageQueueTriggerManager) syncTriggers() {
 		}
 
 		// TODO replace with a watch
-		time.Sleep(3 * time.Second)
+		time.Sleep(time.Second)
 	}
 }

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	"github.com/fission/fission/pkg/utils"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 const (

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -109,11 +109,10 @@ func (mqt *MessageQueueTriggerManager) service() {
 			} else {
 				mqt.triggers[k] = req.triggerSub
 				mqt.logger.Debug("set trigger subscription", zap.String("key", k))
+				IncreaseSubscriptionCount(req.triggerSub.trigger.Name, req.triggerSub.trigger.Namespace)
 			}
 			req.respChan <- resp
 		case GET_TRIGGER_SUBSCRIPTION:
-			_, exists := mqt.triggers[k]
-			mqt.logger.Debug("looking up trigger", zap.String("key", k), zap.Bool("exists", exists))
 			if _, ok := mqt.triggers[k]; !ok {
 				resp.err = errors.New("trigger does not exist")
 			} else {
@@ -123,6 +122,7 @@ func (mqt *MessageQueueTriggerManager) service() {
 		case DELETE_TRIGGER:
 			delete(mqt.triggers, k)
 			mqt.logger.Debug("delete trigger", zap.String("key", k))
+			DecreaseSubscriptionCount(req.triggerSub.trigger.Name, req.triggerSub.trigger.Namespace)
 			req.respChan <- resp
 		}
 	}

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -169,7 +169,6 @@ func (mqt *MessageQueueTriggerManager) delTrigger(m *metav1.ObjectMeta) {
 }
 
 func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueueTrigger) {
-	mqt.logger.Info("Inside register trigger")
 	isPresent := mqt.checkTrigger(&trigger.ObjectMeta)
 	if isPresent {
 		mqt.logger.Info("message queue trigger already registered", zap.String("trigger_name", trigger.ObjectMeta.Name))
@@ -177,7 +176,6 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 	}
 
 	// actually subscribe using the message queue client impl
-	mqt.logger.Info("Trigger", zap.Any("kafka: ", trigger.ObjectMeta))
 	sub, err := mqt.messageQueue.Subscribe(trigger)
 	if err != nil {
 		mqt.logger.Warn("failed to subscribe to message queue trigger", zap.Error(err), zap.String("trigger_name", trigger.ObjectMeta.Name))

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -175,28 +175,11 @@ func (mqt *MessageQueueTriggerManager) delTrigger(m *metav1.ObjectMeta) {
 func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueueTrigger) {
 	mqt.logger.Info("Inside register trigger")
 	isPresent := mqt.checkTrigger(&trigger.ObjectMeta)
-	if !isPresent {
-		// actually subscribe using the message queue client impl
-		sub, err := mqt.messageQueue.Subscribe(trigger)
-		if err != nil {
-			mqt.logger.Warn("failed to subscribe to message queue trigger", zap.Error(err), zap.String("trigger_name", trigger.ObjectMeta.Name))
-			return
-		}
-		triggerSub := triggerSubscription{
-			trigger:      *trigger,
-			subscription: sub,
-		}
-		mqt.logger.Info("Subscription successful")
-		// add to our list
-		err = mqt.addTrigger(&triggerSub)
-		if err != nil {
-			mqt.logger.Fatal("adding message queue trigger failed", zap.Error(err), zap.String("trigger_name", trigger.ObjectMeta.Name))
-		}
-		mqt.logger.Info("message queue trigger created", zap.String("trigger_name", trigger.ObjectMeta.Name))
-	} else {
+	if isPresent {
 		mqt.logger.Info("message queue trigger already registered", zap.String("trigger_name", trigger.ObjectMeta.Name))
 		return
 	}
+
 	// actually subscribe using the message queue client impl
 	sub, err := mqt.messageQueue.Subscribe(trigger)
 	if err != nil {
@@ -207,6 +190,7 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 		trigger:      *trigger,
 		subscription: sub,
 	}
+	mqt.logger.Info("Subscription successful")
 	// add to our list
 	err = mqt.addTrigger(&triggerSub)
 	if err != nil {

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -135,6 +135,7 @@ func (mqt *MessageQueueTriggerManager) addTrigger(triggerSub *triggerSubscriptio
 		triggerSub:  triggerSub,
 		respChan:    respChan,
 	}
+	mqt.logger.Info("respchan struct: ", zap.Any("sub: ", triggerSub))
 	r := <-respChan
 	return r.err
 }
@@ -181,6 +182,7 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 	}
 
 	// actually subscribe using the message queue client impl
+	mqt.logger.Info("Trigger", zap.Any("kafka: ", trigger.ObjectMeta))
 	sub, err := mqt.messageQueue.Subscribe(trigger)
 	if err != nil {
 		mqt.logger.Warn("failed to subscribe to message queue trigger", zap.Error(err), zap.String("trigger_name", trigger.ObjectMeta.Name))
@@ -190,7 +192,7 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 		trigger:      *trigger,
 		subscription: sub,
 	}
-	mqt.logger.Info("Subscription successful")
+	mqt.logger.Info("Subscription successful", zap.Any("Sub: ", sub))
 	// add to our list
 	err = mqt.addTrigger(&triggerSub)
 	if err != nil {

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -109,7 +109,7 @@ func (mqt *MessageQueueTriggerManager) service() {
 			} else {
 				mqt.triggers[k] = req.triggerSub
 				mqt.logger.Debug("set trigger subscription", zap.String("key", k))
-				IncreaseSubscriptionCount(req.triggerSub.trigger.Name, req.triggerSub.trigger.Namespace)
+				IncreaseSubscriptionCount()
 			}
 			req.respChan <- resp
 		case GET_TRIGGER_SUBSCRIPTION:
@@ -122,7 +122,7 @@ func (mqt *MessageQueueTriggerManager) service() {
 		case DELETE_TRIGGER:
 			delete(mqt.triggers, k)
 			mqt.logger.Debug("delete trigger", zap.String("key", k))
-			DecreaseSubscriptionCount(req.triggerSub.trigger.Name, req.triggerSub.trigger.Namespace)
+			DecreaseSubscriptionCount()
 			req.respChan <- resp
 		}
 	}

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -214,6 +214,6 @@ func (mqt *MessageQueueTriggerManager) syncTriggers() {
 		}
 
 		// TODO replace with a watch
-		time.Sleep(time.Second)
+		time.Sleep(3 * time.Second)
 	}
 }

--- a/pkg/mqtrigger/mqtmanager_test.go
+++ b/pkg/mqtrigger/mqtmanager_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mqtrigger
+
+import (
+	"context"
+	"testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type mqtConsumer struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type fakeMessageQueue struct {
+}
+
+func (f fakeMessageQueue) Subscribe(trigger *fv1.MessageQueueTrigger) (messageQueue.Subscription, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mqtConsumer := mqtConsumer{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	return mqtConsumer, nil
+}
+
+func (f fakeMessageQueue) Unsubscribe(triggerSub messageQueue.Subscription) error {
+	sub := triggerSub.(mqtConsumer)
+	sub.cancel()
+	return nil
+}
+
+func TestMqtManager(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	defer logger.Sync()
+	msgQueue := fakeMessageQueue{}
+	mgr := MakeMessageQueueTriggerManager(logger, nil, fv1.MessageQueueTypeKafka, msgQueue)
+	go mgr.service()
+	trigger := fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+	}
+	if mgr.checkTrigger(&trigger.ObjectMeta) {
+		t.Errorf("checkTrigger should return false")
+	}
+	sub, err := msgQueue.Subscribe(&trigger)
+	if err != nil {
+		t.Errorf("Subscribe should not return error")
+	}
+	triggerSub := triggerSubscription{
+		trigger:      trigger,
+		subscription: sub,
+	}
+	err = mgr.addTrigger(&triggerSub)
+	if err != nil {
+		t.Errorf("addTrigger should not return error")
+	}
+	if !mgr.checkTrigger(&trigger.ObjectMeta) {
+		t.Errorf("checkTrigger should return true")
+	}
+	getSub := mgr.getTriggerSubscription(&trigger.ObjectMeta)
+	if getSub == nil {
+		t.Errorf("getTriggerSubscription should return triggerSub")
+	}
+	if getSub.trigger.ObjectMeta.Name != trigger.ObjectMeta.Name {
+		t.Errorf("getTriggerSubscription should return triggerSub with trigger name %s", trigger.ObjectMeta.Name)
+	}
+	getSub.subscription.(mqtConsumer).cancel()
+	mgr.delTrigger(&trigger.ObjectMeta)
+	if mgr.checkTrigger(&trigger.ObjectMeta) {
+		t.Errorf("checkTrigger should return false")
+	}
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,6 +49,9 @@ deploy:
         pruneInterval: "60"
         repository: index.docker.io
         routerServiceType: LoadBalancer
+        kafka.enabled: true
+        kafka.brokers: 'my-cluster-kafka-bootstrap.kafka.svc:9092'
+        kafka.version: '3.0.0'
         openTracing.enabled: false
         openTelemetry.otlpCollectorEndpoint: ""
         openTelemetry.otlpInsecure: true

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -49,9 +49,6 @@ deploy:
         pruneInterval: "60"
         repository: index.docker.io
         routerServiceType: LoadBalancer
-        kafka.enabled: true
-        kafka.brokers: 'my-cluster-kafka-bootstrap.kafka.svc:9092'
-        kafka.version: '3.0.0'
         openTracing.enabled: false
         openTelemetry.otlpCollectorEndpoint: ""
         openTelemetry.otlpInsecure: true


### PR DESCRIPTION
## Description

- Use mqtrigger watch instead of polling mqtrigger every 5 seconds
- Added metrics to monitor no of subscriptions, and no of messages per subscription
- Add standard go metrics exported by prometheus
- Enable prometheus discovery for mqtrigger pod
- Optimized mqtrigger manager cache

## Which issue(s) this PR fixes:
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
