### PR TITLE
Avoid tapservice call to executor with empty URL

### DIFF
--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -160,7 +160,7 @@ func (c *Client) service() {
 }
 
 // TapService sends a TapServiceRequest over the request channel.
-func (c *Client) TapService(fnMeta metav1.ObjectMeta, executorType fv1.ExecutorType, serviceURL *url.URL) {
+func (c *Client) TapService(fnMeta metav1.ObjectMeta, executorType fv1.ExecutorType, serviceURL url.URL) {
 	c.requestChan <- TapServiceRequest{
 		FnMetadata: metav1.ObjectMeta{
 			Name:            fnMeta.Name,

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -455,10 +455,10 @@ func (roundTripper *RetryingRoundTripper) closeContext() {
 }
 
 func (fh *functionHandler) tapService(fn *fv1.Function, serviceURL *url.URL) {
-	if fh.executor == nil {
+	if fh.executor == nil || serviceURL == nil {
 		return
 	}
-	fh.executor.TapService(fn.ObjectMeta, fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType, serviceURL)
+	fh.executor.TapService(fn.ObjectMeta, fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType, *serviceURL)
 }
 
 func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
We should avoid tap service call to executor if service
URL retrieved from executor is empty.
Added sanity checks to ensure that.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
