### PR TITLE
Use common httpserver across fission

### DIFF
--- a/cmd/builder/app/server.go
+++ b/cmd/builder/app/server.go
@@ -17,15 +17,17 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"net/http"
 
 	"go.uber.org/zap"
 
 	builder "github.com/fission/fission/pkg/builder"
+	"github.com/fission/fission/pkg/utils/httpserver"
 )
 
 // Usage: builder <shared volume path>
-func Run(logger *zap.Logger, shareVolume string) error {
+func Run(ctx context.Context, logger *zap.Logger, shareVolume string) {
 	builder := builder.MakeBuilder(logger, shareVolume)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", builder.Handler)
@@ -33,5 +35,5 @@ func Run(logger *zap.Logger, shareVolume string) error {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	return http.ListenAndServe(":8001", mux)
+	httpserver.StartServer(ctx, logger, "builder", "8001", mux)
 }

--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -24,15 +24,15 @@ import (
 	"github.com/fission/fission/cmd/builder/app"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 	"github.com/fission/fission/pkg/utils/profile"
+	"github.com/fission/fission/pkg/utils/signals"
 )
 
 // Usage: builder <shared volume path>
 func main() {
 	logger := loggerfactory.GetLogger()
 	defer logger.Sync()
-
-	profile.ProfileIfEnabled(logger)
-
+	ctx := signals.SetupSignalHandlerWithContext(logger)
+	profile.ProfileIfEnabled(ctx, logger)
 	shareVolume := os.Args[1]
 	if _, err := os.Stat(shareVolume); err != nil {
 		if os.IsNotExist(err) {
@@ -42,7 +42,5 @@ func main() {
 			}
 		}
 	}
-
-	err := app.Run(logger, shareVolume)
-	logger.Error("error running builder", zap.Error(err))
+	app.Run(ctx, logger, shareVolume)
 }

--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"sync/atomic"
@@ -31,6 +30,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/fission/fission/pkg/fetcher"
+	"github.com/fission/fission/pkg/utils/httpserver"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 	"github.com/fission/fission/pkg/utils/tracing"
 )
@@ -135,9 +135,7 @@ func Run(ctx context.Context, logger *zap.Logger) {
 	} else {
 		handler = otelUtils.GetHandlerWithOTEL(mux, "fission-fetcher", otelUtils.UrlsToIgnore("/healthz", "/readiness-healthz"))
 	}
-	if err = http.ListenAndServe(":8000", handler); err != nil {
-		log.Fatal(err)
-	}
+	httpserver.StartServer(ctx, logger, "fetcher", "8000", handler)
 }
 
 func fetcherUsage() {

--- a/cmd/fetcher/main.go
+++ b/cmd/fetcher/main.go
@@ -28,8 +28,7 @@ func main() {
 	logger := loggerfactory.GetLogger()
 	defer logger.Sync()
 
-	profile.ProfileIfEnabled(logger)
-
 	ctx := signals.SetupSignalHandlerWithContext(logger)
+	profile.ProfileIfEnabled(ctx, logger)
 	app.Run(ctx, logger)
 }

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -200,7 +200,8 @@ Options:
 	logger := loggerfactory.GetLogger()
 	defer exitWithSync(logger)
 
-	profile.ProfileIfEnabled(logger)
+	ctx := signals.SetupSignalHandlerWithContext(logger)
+	profile.ProfileIfEnabled(ctx, logger)
 
 	version := fmt.Sprintf("Fission Bundle Version: %v", info.BuildInfo().String())
 	arguments, err := docopt.ParseArgs(usage, nil, version)
@@ -208,8 +209,6 @@ Options:
 		logger.Error("failed to parse arguments", zap.Error(err))
 		return
 	}
-
-	ctx := signals.SetupSignalHandlerWithContext(logger)
 
 	openTracingEnabled := tracing.TracingEnabled(logger)
 	if openTracingEnabled {

--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -35,6 +35,7 @@ import (
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/logdb"
 	"github.com/fission/fission/pkg/info"
+	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/metrics"
 	"github.com/fission/fission/pkg/utils/otel"
 )
@@ -270,9 +271,6 @@ func (api *API) GetHandler() http.Handler {
 }
 
 func (api *API) Serve(ctx context.Context, port int, openTracingEnabled bool) {
-	address := fmt.Sprintf(":%v", port)
-	api.logger.Info("server started", zap.Int("port", port))
-
 	var handler http.Handler
 	if openTracingEnabled {
 		handler = &ochttp.Handler{Handler: api.GetHandler()}
@@ -281,6 +279,5 @@ func (api *API) Serve(ctx context.Context, port int, openTracingEnabled bool) {
 	}
 
 	go metrics.ServeMetrics(ctx, api.logger)
-	err := http.ListenAndServe(address, handler)
-	api.logger.Fatal("done listening", zap.Error(err))
+	httpserver.StartServer(ctx, api.logger, "controller", fmt.Sprintf("%d", port), handler)
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -370,7 +370,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	}
 	go reaper.CleanupRoleBindings(ctx, logger, kubernetesClient, fissionClient, functionNamespace, envBuilderNamespace, time.Minute*30)
 	go metrics.ServeMetrics(ctx, logger)
-	go api.Serve(port, openTracingEnabled)
+	go api.Serve(ctx, port, openTracingEnabled)
 
 	return nil
 }

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -22,7 +22,6 @@ import (
 )
 
 var (
-	metricsAddr       = ":8080"
 	labels            = []string{"trigger_name", "trigger_namespace"}
 	subscriptionCount = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/pkg/router/mutablemux_test.go
+++ b/pkg/router/mutablemux_test.go
@@ -97,7 +97,7 @@ func TestMutableMux(t *testing.T) {
 	// change the muxer
 	log.Print("Change mux router")
 	newMuxRouter := mux.NewRouter()
-	muxRouter.Use(metrics.HTTPMetricMiddleware())
+	newMuxRouter.Use(metrics.HTTPMetricMiddleware())
 	newMuxRouter.HandleFunc("/", NewHandler)
 	mr.updateRouter(newMuxRouter)
 

--- a/pkg/storagesvc/client/storagesvc_test.go
+++ b/pkg/storagesvc/client/storagesvc_test.go
@@ -209,7 +209,7 @@ func TestLocalStorageService(t *testing.T) {
 	storage := storagesvc.NewLocalStorage(localPath)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	os.Setenv("METRICS_ADDR", ":8083")
+	os.Setenv("METRICS_ADDR", "8083")
 	_ = storagesvc.Start(ctx, logger, storage, port, true)
 
 	time.Sleep(time.Second)

--- a/pkg/utils/httpserver/server.go
+++ b/pkg/utils/httpserver/server.go
@@ -1,0 +1,32 @@
+package httpserver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+func StartServer(ctx context.Context, log *zap.Logger, svc string, port string, handler http.Handler) {
+	server := http.Server{
+		Addr:    fmt.Sprintf(":%s", port),
+		Handler: handler,
+	}
+	l := log.With(zap.String("service", svc), zap.String("addr", server.Addr))
+	l.Info("starting server")
+	go func() {
+		if err := server.ListenAndServe(); err != nil {
+			if err != http.ErrServerClosed {
+				l.Error("server error", zap.Error(err))
+			}
+		}
+	}()
+	<-ctx.Done()
+	l.Info("shutting down server")
+	if err := server.Shutdown(ctx); err != nil {
+		if err != context.Canceled && err != context.DeadlineExceeded {
+			l.Error("server shutdown error", zap.Error(err))
+		}
+	}
+}

--- a/pkg/utils/httpserver/server_test.go
+++ b/pkg/utils/httpserver/server_test.go
@@ -1,0 +1,62 @@
+package httpserver
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+func TestStartServer(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := loggerfactory.GetLogger()
+	m := mux.NewRouter()
+	m.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("test handler"))
+		if err != nil {
+			logger.Error("failed to write response", zap.Error(err))
+		}
+	}))
+	go StartServer(ctx, logger, "test", "8999", m)
+
+	tests := []struct {
+		URL        string
+		StatusCode int
+		Body       string
+	}{
+		{
+			URL:        "http://localhost:8999",
+			StatusCode: http.StatusOK,
+			Body:       "test handler",
+		},
+		{
+			URL:        "http://localhost:8999/notfound",
+			StatusCode: http.StatusNotFound,
+			Body:       "404 page not found\n",
+		},
+	}
+	for _, test := range tests {
+		resp, err := http.Get(test.URL)
+		if err != nil {
+			t.Errorf("failed to make get request %v: %v", test.URL, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != test.StatusCode {
+			t.Errorf("expected status code %v, got %v", test.StatusCode, resp.StatusCode)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("failed to read response body: %v", err)
+		}
+		if string(body) != test.Body {
+			t.Errorf("expected body \"%v\", got \"%v\"", test.Body, string(body))
+		}
+	}
+}

--- a/pkg/utils/metrics/server.go
+++ b/pkg/utils/metrics/server.go
@@ -23,34 +23,16 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
+
+	"github.com/fission/fission/pkg/utils/httpserver"
 )
 
 func ServeMetrics(ctx context.Context, logger *zap.Logger) {
 	metricsAddr := os.Getenv("METRICS_ADDR")
 	if metricsAddr == "" {
-		metricsAddr = ":8080"
+		metricsAddr = "8080"
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
-	s := &http.Server{
-		Addr:    metricsAddr,
-		Handler: mux,
-	}
-	logger.Info("Starting metrics server", zap.String("address", metricsAddr))
-	go func() {
-		if err := s.ListenAndServe(); err != nil {
-			if err != http.ErrServerClosed {
-				logger.Error("Metrics server error", zap.Error(err))
-			}
-		}
-	}()
-	<-ctx.Done()
-	logger.Info("Shutting down metrics server")
-	err := s.Shutdown(ctx)
-	if err == context.DeadlineExceeded || err == context.Canceled {
-		return
-	}
-	if err != nil {
-		logger.Error("Failed to shutdown metrics server", zap.Error(err))
-	}
+	httpserver.StartServer(ctx, logger, "metrics", metricsAddr, mux)
 }


### PR DESCRIPTION
Defining httpserver package capture httpserver shutdown and
introduces uniform running of http server across codebase.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
