### PR TITLE
Fix namespace used in speciallized pod cleanup

### DIFF
--- a/pkg/executor/executortype/poolmgr/funchandlers.go
+++ b/pkg/executor/executortype/poolmgr/funchandlers.go
@@ -41,7 +41,7 @@ func getIstioServiceLabels(fnName string) map[string]string {
 // Based on function create/update/delete event, we create role binding
 // for the secret/configmap access which is used by fetcher component.
 // If istio is enabled, we create a service for the function.
-func FunctionEventHandlers(logger *zap.Logger, kubernetesClient *kubernetes.Clientset, fissionfnNamespace string, istioEnabled bool) k8sCache.ResourceEventHandlerFuncs {
+func FunctionEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Interface, fissionfnNamespace string, istioEnabled bool) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			ctx := context.Background()

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -50,6 +50,7 @@ import (
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/reaper"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
 	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
 	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -69,11 +70,11 @@ type (
 		logger *zap.Logger
 
 		pools            map[string]*GenericPool
-		kubernetesClient *kubernetes.Clientset
-		metricsClient    *metricsclient.Clientset
+		kubernetesClient kubernetes.Interface
+		metricsClient    metricsclient.Interface
 		namespace        string
 
-		fissionClient  *crd.FissionClient
+		fissionClient  versioned.Interface
 		functionEnv    *cache.Cache
 		fsCache        *fscache.FunctionServiceCache
 		instanceID     string
@@ -107,9 +108,9 @@ type (
 
 func MakeGenericPoolManager(
 	logger *zap.Logger,
-	fissionClient *crd.FissionClient,
-	kubernetesClient *kubernetes.Clientset,
-	metricsClient *metricsclient.Clientset,
+	fissionClient versioned.Interface,
+	kubernetesClient kubernetes.Interface,
+	metricsClient metricsclient.Interface,
 	functionNamespace string,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
@@ -657,7 +658,7 @@ func (gpm *GenericPoolManager) idleObjectReaper() {
 }
 
 // WebsocketStartEventChecker checks if the pod has emitted a websocket connection start event
-func (gpm *GenericPoolManager) WebsocketStartEventChecker(kubeClient *kubernetes.Clientset) {
+func (gpm *GenericPoolManager) WebsocketStartEventChecker(kubeClient kubernetes.Interface) {
 
 	informer := k8sCache.NewSharedInformer(
 		&k8sCache.ListWatch{
@@ -698,7 +699,7 @@ func (gpm *GenericPoolManager) WebsocketStartEventChecker(kubeClient *kubernetes
 }
 
 // NoActiveConnectionEventChecker checks if the pod has emitted an inactive event
-func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(kubeClient *kubernetes.Clientset) {
+func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(kubeClient kubernetes.Interface) {
 
 	informer := k8sCache.NewSharedInformer(
 		&k8sCache.ListWatch{

--- a/pkg/executor/executortype/poolmgr/packagehandlers.go
+++ b/pkg/executor/executortype/poolmgr/packagehandlers.go
@@ -31,7 +31,7 @@ import (
 // PackageEventHandlers provides handlers for package events.
 // Based on package create/update event, we create role binding
 // for the package which is used by fetcher component.
-func PackageEventHandlers(logger *zap.Logger, kubernetesClient *kubernetes.Clientset, fissionfnNamespace string) k8sCache.ResourceEventHandlerFuncs {
+func PackageEventHandlers(logger *zap.Logger, kubernetesClient kubernetes.Interface, fissionfnNamespace string) k8sCache.ResourceEventHandlerFuncs {
 	return k8sCache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			pkg := obj.(*fv1.Package)

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package poolmgr
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dchest/uniuri"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	k8sCache "k8s.io/client-go/tools/cache"
+	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
+	fClient "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
+	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+func runInformers(ctx context.Context, informers []k8sCache.SharedIndexInformer) {
+	// Run all informers
+	for _, informer := range informers {
+		go informer.Run(ctx.Done())
+	}
+}
+
+func TestPoolPodControllerPodCleanup(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	kubernetesClient := fake.NewSimpleClientset()
+	fissionClient := fClient.NewSimpleClientset()
+	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
+	funcInformer := informerFactory.Core().V1().Functions()
+	pkgInformer := informerFactory.Core().V1().Packages()
+	envInformer := informerFactory.Core().V1().Environments()
+
+	gpmInformerFactory, err := utils.GetInformerFactoryByExecutor(kubernetesClient, fv1.ExecutorTypePoolmgr, time.Minute*30)
+	if err != nil {
+		t.Fatalf("Error creating informer factory: %v", err)
+	}
+	gpmPodInformer := gpmInformerFactory.Core().V1().Pods()
+	gpmRsInformer := gpmInformerFactory.Apps().V1().ReplicaSets()
+
+	fnNamespace := "fission-function"
+	ppc := NewPoolPodController(logger, kubernetesClient, fnNamespace, false,
+		funcInformer,
+		pkgInformer,
+		envInformer,
+		gpmRsInformer,
+		gpmPodInformer)
+
+	executorInstanceID := strings.ToLower(uniuri.NewLen(8))
+	metricsClient := metricsclient.NewSimpleClientset()
+	fetcherConfig, err := fetcherConfig.MakeFetcherConfig("/userfunc")
+	if err != nil {
+		t.Fatalf("Error creating fetcher config: %v", err)
+	}
+	executor, err := MakeGenericPoolManager(
+		logger,
+		fissionClient, kubernetesClient, metricsClient,
+		fnNamespace, fetcherConfig, executorInstanceID,
+		funcInformer, pkgInformer, envInformer,
+		gpmPodInformer, gpmRsInformer)
+	if err != nil {
+		t.Fatalf("Error creating generic pool manager: %v", err)
+	}
+	gpm := executor.(*GenericPoolManager)
+	ppc.InjectGpm(gpm)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go ppc.Run(ctx.Done())
+
+	podInformer := gpmPodInformer.Informer()
+
+	runInformers(ctx, []k8sCache.SharedIndexInformer{
+		funcInformer.Informer(),
+		pkgInformer.Informer(),
+		envInformer.Informer(),
+		podInformer,
+		gpmRsInformer.Informer(),
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-different-namespace",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+	_, err = kubernetesClient.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Error creating pod: %v", err)
+	}
+
+	// Wait for pod to be added to informer
+	start := time.Now()
+	found := false
+	for found == false && time.Since(start) < time.Second*5 {
+		t.Log("Waiting for pod to be added to pool")
+		pod, err := ppc.podLister.Pods(pod.Namespace).Get(pod.Name)
+		if err == nil {
+			found = true
+			t.Logf("Found pod %#v", pod.ObjectMeta)
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+	t.Log("Pod added to pool")
+
+	// Ask the controller to clean up the pod
+	key, err := k8sCache.MetaNamespaceKeyFunc(pod)
+	if err != nil {
+		t.Fatalf("Error creating key: %v", err)
+	}
+	ppc.spCleanupPodQueue.Add(key)
+	start = time.Now()
+	for ppc.spCleanupPodQueue.Len() > 0 && time.Since(start) < time.Second*5 {
+		time.Sleep(time.Millisecond * 100)
+		t.Log("Waiting for pod cleanup to complete")
+	}
+	t.Log("Cleanup pod queue is empty")
+
+	// Ensure pod is gone
+	getPod, err := kubernetesClient.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	if err == nil {
+		t.Fatalf("Pod %v still exists", getPod.ObjectMeta)
+	}
+}

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -37,7 +37,7 @@ var (
 )
 
 // CleanupKubeObject deletes given kubernetes object
-func CleanupKubeObject(ctx context.Context, logger *zap.Logger, kubeClient *kubernetes.Clientset, kubeobj *apiv1.ObjectReference) {
+func CleanupKubeObject(ctx context.Context, logger *zap.Logger, kubeClient kubernetes.Interface, kubeobj *apiv1.ObjectReference) {
 	switch strings.ToLower(kubeobj.Kind) {
 	case "pod":
 		err := kubeClient.CoreV1().Pods(kubeobj.Namespace).Delete(ctx, kubeobj.Name, meta_v1.DeleteOptions{})
@@ -70,7 +70,7 @@ func CleanupKubeObject(ctx context.Context, logger *zap.Logger, kubeClient *kube
 }
 
 // CleanupDeployments deletes deployment(s) for a given instanceID
-func CleanupDeployments(ctx context.Context, logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
+func CleanupDeployments(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps meta_v1.ListOptions) error {
 	deploymentList, err := client.AppsV1().Deployments(meta_v1.NamespaceAll).List(ctx, listOps)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func CleanupDeployments(ctx context.Context, logger *zap.Logger, client *kuberne
 }
 
 // CleanupPods deletes pod(s) for a given instanceID
-func CleanupPods(ctx context.Context, logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
+func CleanupPods(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps meta_v1.ListOptions) error {
 	podList, err := client.CoreV1().Pods(meta_v1.NamespaceAll).List(ctx, listOps)
 	if err != nil {
 		return err
@@ -124,7 +124,7 @@ func CleanupPods(ctx context.Context, logger *zap.Logger, client *kubernetes.Cli
 }
 
 // CleanupServices deletes service(s) for a given instanceID
-func CleanupServices(ctx context.Context, logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
+func CleanupServices(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps meta_v1.ListOptions) error {
 	svcList, err := client.CoreV1().Services(meta_v1.NamespaceAll).List(ctx, listOps)
 	if err != nil {
 		return err
@@ -151,7 +151,7 @@ func CleanupServices(ctx context.Context, logger *zap.Logger, client *kubernetes
 }
 
 // CleanupHpa deletes horizontal pod autoscaler(s) for a given instanceID
-func CleanupHpa(ctx context.Context, logger *zap.Logger, client *kubernetes.Clientset, instanceID string, listOps meta_v1.ListOptions) error {
+func CleanupHpa(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps meta_v1.ListOptions) error {
 	hpaList, err := client.AutoscalingV1().HorizontalPodAutoscalers(meta_v1.NamespaceAll).List(ctx, listOps)
 	if err != nil {
 		return err
@@ -180,7 +180,7 @@ func CleanupHpa(ctx context.Context, logger *zap.Logger, client *kubernetes.Clie
 
 // CleanupRoleBindings periodically lists rolebindings across all namespaces and removes Service Accounts from them or
 // deletes the rolebindings completely if there are no Service Accounts in a rolebinding object.
-func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client *kubernetes.Clientset, fissionClient *crd.FissionClient, functionNs, envBuilderNs string, cleanupRoleBindingInterval time.Duration) {
+func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, fissionClient *crd.FissionClient, functionNs, envBuilderNs string, cleanupRoleBindingInterval time.Duration) {
 	for {
 		// some sleep before the next reaper iteration
 		time.Sleep(cleanupRoleBindingInterval)

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -93,7 +93,7 @@ func MakeFetcherConfig(sharedMountPath string) (*Config, error) {
 	}, nil
 }
 
-func (cfg *Config) SetupServiceAccount(kubernetesClient *kubernetes.Clientset, namespace string, context interface{}) error {
+func (cfg *Config) SetupServiceAccount(kubernetesClient kubernetes.Interface, namespace string, context interface{}) error {
 	_, err := utils.SetupSA(kubernetesClient, fv1.FissionFetcherSA, namespace)
 	if err != nil {
 		log.Printf("Error : %v creating %s in ns : %s for: %#v", err, fv1.FissionFetcherSA, namespace, context)

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -13,7 +13,7 @@ import (
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
-func GetInformerFactoryByReadyPod(client *kubernetes.Clientset, namespace string, labelSelector *metav1.LabelSelector) (k8sInformers.SharedInformerFactory, error) {
+func GetInformerFactoryByReadyPod(client kubernetes.Interface, namespace string, labelSelector *metav1.LabelSelector) (k8sInformers.SharedInformerFactory, error) {
 	informerFactory := k8sInformers.NewSharedInformerFactoryWithOptions(client, 0,
 		k8sInformers.WithNamespace(namespace),
 		k8sInformers.WithTweakListOptions(func(options *metav1.ListOptions) {
@@ -23,7 +23,7 @@ func GetInformerFactoryByReadyPod(client *kubernetes.Clientset, namespace string
 	return informerFactory, nil
 }
 
-func GetInformerFactoryByExecutor(client *kubernetes.Clientset, executorType v1.ExecutorType, defaultResync time.Duration) (k8sInformers.SharedInformerFactory, error) {
+func GetInformerFactoryByExecutor(client kubernetes.Interface, executorType v1.ExecutorType, defaultResync time.Duration) (k8sInformers.SharedInformerFactory, error) {
 	executorLabel, err := labels.NewRequirement(v1.EXECUTOR_TYPE, selection.DoubleEquals, []string{string(executorType)})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In pool pod controller we were using pool namespace
rather than pod namespace in cleanup which was causing
issue in few scenarios. Using pod namespace now instead.
Also add unit test for scenario which was failing.
Using kubernetes client interface now across instead of
kubernetes ClientSet for testing.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2373

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
