### PR TITLE
Added service monitors for components whose metrics are exposed

### DIFF
--- a/charts/fission-all/templates/controller/servicemonitor.yaml
+++ b/charts/fission-all/templates/controller/servicemonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: controller-service-app
+spec:
+  selector:
+    matchLabels:
+      svc: controller
+  endpoints:
+  - targetPort: 8080

--- a/charts/fission-all/templates/controller/servicemonitor.yaml
+++ b/charts/fission-all/templates/controller/servicemonitor.yaml
@@ -1,11 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: controller-monitor
-  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       svc: controller
   endpoints:
   - targetPort: 8080
+{{- end -}}

--- a/charts/fission-all/templates/controller/servicemonitor.yaml
+++ b/charts/fission-all/templates/controller/servicemonitor.yaml
@@ -1,7 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: controller-service-app
+  name: controller-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/fission-all/templates/executor/servicemonitor.yaml
+++ b/charts/fission-all/templates/executor/servicemonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: executor-service-app
+spec:
+  selector:
+    matchLabels:
+      svc: executor
+  endpoints:
+  - targetPort: 8080

--- a/charts/fission-all/templates/executor/servicemonitor.yaml
+++ b/charts/fission-all/templates/executor/servicemonitor.yaml
@@ -1,7 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: executor-service-app
+  name: executor-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/fission-all/templates/executor/servicemonitor.yaml
+++ b/charts/fission-all/templates/executor/servicemonitor.yaml
@@ -1,11 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: executor-monitor
-  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       svc: executor
   endpoints:
   - targetPort: 8080
+{{- end -}}

--- a/charts/fission-all/templates/router/servicemonitor.yaml
+++ b/charts/fission-all/templates/router/servicemonitor.yaml
@@ -1,11 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: router-monitor
-  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       svc: router
   endpoints:
   - targetPort: 8080
+{{- end -}}

--- a/charts/fission-all/templates/router/servicemonitor.yaml
+++ b/charts/fission-all/templates/router/servicemonitor.yaml
@@ -1,7 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: router-service-app
+  name: router-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/fission-all/templates/router/servicemonitor.yaml
+++ b/charts/fission-all/templates/router/servicemonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: router-service-app
+spec:
+  selector:
+    matchLabels:
+      svc: router
+  endpoints:
+  - targetPort: 8080

--- a/charts/fission-all/templates/storagesvc/servicemonitor.yaml
+++ b/charts/fission-all/templates/storagesvc/servicemonitor.yaml
@@ -1,11 +1,18 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: storagesvc-monitor
-  namespace: {{ .Release.Namespace }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}  
 spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   selector:
     matchLabels:
       svc: storagesvc
   endpoints:
   - targetPort: 8080
+{{- end -}}

--- a/charts/fission-all/templates/storagesvc/servicemonitor.yaml
+++ b/charts/fission-all/templates/storagesvc/servicemonitor.yaml
@@ -1,7 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: storagesvc-service-app
+  name: storagesvc-monitor
+  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:

--- a/charts/fission-all/templates/storagesvc/servicemonitor.yaml
+++ b/charts/fission-all/templates/storagesvc/servicemonitor.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: storagesvc-service-app
+spec:
+  selector:
+    matchLabels:
+      svc: storagesvc
+  endpoints:
+  - targetPort: 8080

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -364,8 +364,9 @@ kafka:
 
 serviceMonitor:
   enabled: false
-##namespace in which you want to deploy servicemonitor
-  namespace: fission
+  ##namespace in which you want to deploy servicemonitor
+  ##
+  namespace: ""
 
 ## Persist data to a persistent volume.
 ##

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -362,6 +362,11 @@ kafka:
   ##
   # version: "0.11.2.0"
 
+serviceMonitor:
+  enabled: false
+##namespace in which you want to deploy servicemonitor
+  namespace: fission
+
 ## Persist data to a persistent volume.
 ##
 persistence:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,8 +56,6 @@ deploy:
         # Use /var/log directory for kind logs export
         terminationMessagePath: /var/log/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
-        serviceMonitor.enabled: true
-        serviceMonitor.namespace: monitoring
       wait: true
     flags:
       install:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,6 +56,8 @@ deploy:
         # Use /var/log directory for kind logs export
         terminationMessagePath: /var/log/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
+        serviceMonitor.enabled: true
+        serviceMonitor.namespace: monitoring
       wait: true
     flags:
       install:


### PR DESCRIPTION
## Description
Initially the user had to implement the service monitors kube-prometheus-stack. Now it would be implemented with helm.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
