### PR TITLE
Ensure poolmanager fn address validation even if pod has active connections

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -77,7 +77,7 @@ func (executor *Executor) getServiceForFunctionAPI(w http.ResponseWriter, r *htt
 		if err == nil {
 			// if a pod is already serving request then it already exists else validated
 			logger.Debug("from cache", zap.Int("active", active))
-			if active > 1 || et.IsValid(ctx, fsvc) {
+			if et.IsValid(ctx, fsvc) {
 				// Cached, return svc address
 				logger.Debug("served from cache", zap.String("name", fsvc.Name), zap.String("address", fsvc.Address))
 				executor.writeResponse(w, fsvc.Address, fn.ObjectMeta.Name)


### PR DESCRIPTION
## Description
Executor sending invalid ips because validation function is getting skipped as the active number of requests allow it to pass the condition. 
This error occurs when a pod is killed but the untap function is not called which influences the value of active variable.

## Which issue(s) this PR fixes:
Fixes #2438

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
