### PR TITLE
Add API for listing storage service archives

### DIFF
--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -67,6 +67,32 @@ func getStorageLocation(config *storageConfig) (stow.Location, error) {
 	return config.storage.dial()
 }
 
+func (ss *StorageService) listItems(w http.ResponseWriter, r *http.Request) {
+	// get all archives on storage
+	// out of them, there may be some just created but not referenced by packages yet.
+	// need to filter them out.
+	archivesInStorage, err := ss.storageClient.getItemIDsWithFilter(ss.storageClient.filterAllItems, false)
+	if err != nil {
+		ss.logger.Error("error getting items from storage", zap.Error(err))
+		return
+	}
+	ss.logger.Debug("archives in storage", zap.Strings("archives", archivesInStorage))
+
+	// respond with the list of items
+	resp, err := json.Marshal(archivesInStorage)
+	if err != nil {
+		http.Error(w, "error marshaling item list", http.StatusInternalServerError)
+		return
+	}
+	_, err = w.Write(resp)
+	if err != nil {
+		ss.logger.Error(
+			"error writing HTTP response",
+			zap.Error(err),
+		)
+	}
+}
+
 // Handle multipart file uploads.
 func (ss *StorageService) uploadHandler(w http.ResponseWriter, r *http.Request) {
 	// handle upload
@@ -219,7 +245,8 @@ func (ss *StorageService) Start(ctx context.Context, port int, openTracingEnable
 	r := mux.NewRouter()
 	r.Use(metrics.HTTPMetricMiddleware)
 	r.HandleFunc("/v1/archive", ss.uploadHandler).Methods("POST")
-	r.HandleFunc("/v1/archive", ss.downloadHandler).Methods("GET")
+	r.HandleFunc("/v1/archive", ss.downloadHandler).Queries("id", "{id}").Methods("GET")
+	r.HandleFunc("/v1/archive", ss.listItems).Methods("GET")
 	r.HandleFunc("/v1/archive", ss.deleteHandler).Methods("DELETE")
 	r.HandleFunc("/healthz", ss.healthHandler).Methods("GET")
 

--- a/pkg/storagesvc/stowClient.go
+++ b/pkg/storagesvc/stowClient.go
@@ -240,3 +240,12 @@ func (client StowClient) filterItemCreatedAMinuteAgo(item stow.Item, currentTime
 	}
 	return false
 }
+
+func (client StowClient) filterAllItems(item stow.Item, _ interface{}) bool {
+	itemLastModTime, _ := item.LastMod()
+	client.logger.Debug("item info",
+		zap.String("item", item.ID()),
+		zap.Time("last_modified_time", itemLastModTime))
+	return false
+
+}


### PR DESCRIPTION
Add listing for storage service archives API.
This change modifies current GET /v1/archive API
and breaks into two parts.
If id is mentioned we allow user to download specific
archive. If id is not mentioned we list all archives
present with storage service.
This will allow us to build CLI with storage service
and help users to debug storage service.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
