### PR TITLE
[issue-2401] Added pod security context for Fission Components

### DIFF
--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      {{- if .Values.buildermgr.securityContext.enabled }}
+      securityContext: {{- omit .Values.buildermgr.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: buildermgr
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      {{- if .Values.controller.securityContext.enabled }}
+      securityContext: {{- omit .Values.controller.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: controller
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -19,6 +19,9 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      {{- if .Values.executor.securityContext.enabled }}
+      securityContext: {{- omit .Values.executor.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: executor
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         svc: kubewatcher
     spec:
+      {{- if .Values.kubewatcher.securityContext.enabled }}
+      securityContext: {{- omit .Values.kubewatcher.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: kubewatcher
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -28,6 +28,9 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      {{- if .Values.router.securityContext.enabled }}
+      securityContext: {{- omit .Values.router.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: router
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         prometheus.io/path: "/metrics"
         prometheus.io/port: "8080"
     spec:
+      {{- if .Values.storagesvc.securityContext.enabled }}
+      securityContext: {{- omit .Values.storagesvc.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: storagesvc
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -15,6 +15,9 @@ spec:
       labels:
         svc: timer
     spec:
+      {{- if .Values.timer.securityContext.enabled }}
+      securityContext: {{- omit .Values.timer.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
       - name: timer
         image: {{ include "fission-bundleImage" . | quote }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -110,6 +110,18 @@ fetcher:
       requests: "16Mi"
       limits: ""
 
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
+
 ## executor is responsible for providing resources to your functions.
 ##
 executor:
@@ -142,6 +154,18 @@ executor:
   ##      memory: <tbd>
   ##
   resources: {}
+
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
 
 ## router is responsible for routing function calls to the appropriate function.
 ##
@@ -248,6 +272,18 @@ router:
   ##
   resources: {}
 
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
+
 ## The builder manager watches the package & environments CRD changes and manages the builds of function source code.
 ## 
 buildermgr:
@@ -261,6 +297,18 @@ buildermgr:
   ##      memory: <tbd>
   ##
   resources: {}
+
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
 
 ## controller is the component that the client talks to.
 ## It contains CRUD APIs for functions, triggers, environments, Kubernetes event watches, etc. and proxy APIs to internal 3rd-party services.
@@ -277,6 +325,18 @@ controller:
   ##
   resources: {}
 
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
+
 ## kubewatcher watches the Kubernetes API and invokes functions associated with watches, sending the watch event to the function.
 ##
 kubewatcher:
@@ -290,6 +350,18 @@ kubewatcher:
   ##      memory: <tbd>
   ##
   resources: {}
+
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
 
 ## The storage service is the home for all archives of packages with sizes larger than 256KB.
 ##
@@ -305,6 +377,18 @@ storagesvc:
   ##
   resources: {}
 
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
+
 ## The timer works like kubernetes CronJob but instead of creating a pod to do the task
 ## It sends a request to router to invoke the function.
 ##
@@ -319,6 +403,18 @@ timer:
   ##      memory: <tbd>
   ##
   resources: {}
+
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This section is experimental, and enabling it may introduce new challenges.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: false
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
 
 ## Kafka: enable and configure the details
 ##

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -110,18 +110,6 @@ fetcher:
       requests: "16Mi"
       limits: ""
 
-  ## Security Context
-  ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
-  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
-  securityContext:
-    enabled: false
-    ## Mark it false, if you want to stop the non root user validation
-    runAsNonRoot: true
-    fsGroup: 10001
-    runAsUser: 10001
-    runAsGroup: 10001
-
 ## executor is responsible for providing resources to your functions.
 ##
 executor:
@@ -157,7 +145,7 @@ executor:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false
@@ -274,7 +262,7 @@ router:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false
@@ -300,7 +288,7 @@ buildermgr:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false
@@ -327,7 +315,7 @@ controller:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false
@@ -353,7 +341,7 @@ kubewatcher:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false
@@ -379,7 +367,7 @@ storagesvc:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false
@@ -406,7 +394,7 @@ timer:
 
   ## Security Context
   ## It holds pod-level and container level security configuration.
-  ## This section is experimental, and enabling it may introduce new challenges.
+  ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
     enabled: false

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,6 +56,13 @@ deploy:
         # Use /var/log directory for kind logs export
         terminationMessagePath: /var/log/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
+        fetcher.securityContext.enabled: true
+        executor.securityContext.enabled: true
+        router.securityContext.enabled: true
+        buildermgr.securityContext.enabled: true
+        controller.securityContext.enabled: true
+        kubewatcher.securityContext.enabled: true
+        storagesvc.securityContext.enabled: true
       wait: true
     flags:
       install:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -56,7 +56,6 @@ deploy:
         # Use /var/log directory for kind logs export
         terminationMessagePath: /var/log/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
-        fetcher.securityContext.enabled: true
         executor.securityContext.enabled: true
         router.securityContext.enabled: true
         buildermgr.securityContext.enabled: true


### PR DESCRIPTION
## Description
- I have added `securityContext` in the following fission components -

1. buildermgr
2. controller
3. executor
4. kubewatcher
5. router
6. timer
7. storagesvc

- By default, I kept the `component.securityContext.enabled: false`; however, I made it `true` in the Fission CI.

## Which issue(s) this PR fixes:
Fixes https://github.com/fission/fission/issues/2401

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [X] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
