### PR TITLE
Fix for archivepruner to delete files only from subdir

### DIFF
--- a/pkg/storagesvc/localstorage.go
+++ b/pkg/storagesvc/localstorage.go
@@ -42,6 +42,10 @@ func (ls localStorage) getUploadFileName() (string, error) {
 	return id.String(), err
 }
 
+func (ls localStorage) getSubDir() string {
+	return ""
+}
+
 func (ls localStorage) getContainerName() string {
 	return ls.containerName
 }

--- a/pkg/storagesvc/s3storage.go
+++ b/pkg/storagesvc/s3storage.go
@@ -49,6 +49,10 @@ func (ss s3Storage) getContainerName() string {
 	return ss.bucketName
 }
 
+func (ss s3Storage) getSubDir() string {
+	return ss.subDir
+}
+
 func (ss s3Storage) getUploadFileName() (string, error) {
 	id, err := uuid.NewV4()
 	if err != nil {

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -41,7 +41,7 @@ type (
 	Storage interface {
 		getStorageType() StorageType
 		dial() (stow.Location, error)
-		// getSubDir() string
+		getSubDir() string
 		getContainerName() string
 		getUploadFileName() (string, error)
 	}

--- a/pkg/storagesvc/stowClient.go
+++ b/pkg/storagesvc/stowClient.go
@@ -206,7 +206,7 @@ func (client *StowClient) getItemIDsWithFilter(filterFunc filter, filterFuncPara
 	archiveIDList := make([]string, 0)
 
 	for {
-		items, cursor, err = client.container.Items(stow.NoPrefix, cursor, PaginationSize)
+		items, cursor, err = client.container.Items(client.config.storage.getSubDir(), cursor, PaginationSize)
 		if err != nil {
 			return nil, errors.Wrap(err, "error getting items from container")
 		}


### PR DESCRIPTION
## Description
Earlier archivepruner used to delete all files in S3 bucket irrespective of the subdir mentioned. Now the scope of archivepruner has been reduced to the subdir mentioned if any.

## Which issue(s) this PR fixes:
Fixes #2397 

## Testing
Tested manually by uploading files outside subdir in S3 bucket.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
