### PR TITLE
Added variable to enable or disable archivePruner

### DIFF
--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -36,8 +36,12 @@ spec:
         args: ["--storageServicePort", "8000", "--storageType", "local"]
         {{- end }}
         env:
+        - name: PRUNE_ENABLED
+          value: "{{.Values.archivePruner.enabled}}"
+        {{- if .Values.archivePruner.enabled }}
         - name: PRUNE_INTERVAL
-          value: "{{.Values.pruneInterval}}"
+          value: "{{.Values.archivePruner.interval}}"
+        {{- end }}
         - name: DEBUG_ENV
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -37,10 +37,10 @@ spec:
         {{- end }}
         env:
         - name: PRUNE_ENABLED
-          value: "{{.Values.archivePruner.enabled}}"
-        {{- if .Values.archivePruner.enabled }}
+          value: "{{.Values.storagesvc.archivePruner.enabled}}"
+        {{- if .Values.storagesvc.archivePruner.enabled }}
         - name: PRUNE_INTERVAL
-          value: "{{.Values.archivePruner.interval}}"
+          value: "{{.Values.storagesvc.archivePruner.interval}}"
         {{- end }}
         - name: DEBUG_ENV
           value: {{ .Values.debugEnv | quote }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -365,6 +365,12 @@ storagesvc:
   ##
   resources: {}
 
+  ##ArchivePruner removes archives from storage after every interval(in mins).
+  archivePruner:
+    enabled: true
+    interval: 60
+
+
   ## Security Context
   ## It holds pod-level and container level security configuration.
   ## This is an experimental section, please verify before enabling in production.
@@ -567,10 +573,6 @@ busyboxImage: busybox
 ## This interval configures the frequency at which it runs inside the storagesvc pod.
 ## The value is in minutes.
 ##
-archivePruner:
-  enabled: true
-
-  interval: 60
 
 preUpgradeChecks:
   ## Run pre-install/pre-upgrade checks if true

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -567,7 +567,10 @@ busyboxImage: busybox
 ## This interval configures the frequency at which it runs inside the storagesvc pod.
 ## The value is in minutes.
 ##
-pruneInterval: 60
+archivePruner:
+  enabled: true
+
+  interval: 60
 
 preUpgradeChecks:
   ## Run pre-install/pre-upgrade checks if true

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -365,11 +365,11 @@ storagesvc:
   ##
   resources: {}
 
-  ##ArchivePruner removes archives from storage after every interval(in mins).
+  ## Archive pruner removes archives from storage which are not referenced by any package.
   archivePruner:
     enabled: true
+    ## Run prune routine at interval (in minutes)
     interval: 60
-
 
   ## Security Context
   ## It holds pod-level and container level security configuration.

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -236,7 +236,10 @@ func (ss *StorageService) Start(ctx context.Context, port int, openTracingEnable
 
 // Start runs storage service
 func Start(ctx context.Context, logger *zap.Logger, storage Storage, port int, openTracingEnabled bool) error {
-	enablePruner := true
+	enablePruner, err := strconv.ParseBool(os.Getenv("PRUNE_ENABLED"))
+	if err != nil {
+		enablePruner = true
+	}
 	// create a storage client
 	storageClient, err := MakeStowClient(logger, storage)
 	if err != nil {

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -238,6 +238,7 @@ func (ss *StorageService) Start(ctx context.Context, port int, openTracingEnable
 func Start(ctx context.Context, logger *zap.Logger, storage Storage, port int, openTracingEnabled bool) error {
 	enablePruner, err := strconv.ParseBool(os.Getenv("PRUNE_ENABLED"))
 	if err != nil {
+		logger.Warn("PRUNE_ENABLED value not set. Enabling archive pruner by default.", zap.Error(err))
 		enablePruner = true
 	}
 	// create a storage client

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -45,8 +45,8 @@ deploy:
         pprof.enabled: false
         canaryDeployment.enabled: false
         influxdb.enabled: false
-        archivePruner.enabled: true
-        archivePruner.interval: "60"
+        storagesvc.archivePruner.enabled: true
+        storagesvc.archivePruner.interval: "60"
         repository: index.docker.io
         routerServiceType: LoadBalancer
         openTracing.enabled: false
@@ -103,7 +103,7 @@ profiles:
     path: /deploy/helm/releases/0/setValues/repository
     value: ""
   - op: replace
-    path: /deploy/helm/releases/0/setValues/archivePruner.interval
+    path: /deploy/helm/releases/0/setValues/storagesvc.archivePruner.interval
     value: 1
   - op: replace
     path: /deploy/helm/releases/0/setValues/routerServiceType

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -45,7 +45,8 @@ deploy:
         pprof.enabled: false
         canaryDeployment.enabled: false
         influxdb.enabled: false
-        pruneInterval: "60"
+        archivePruner.enabled: true
+        archivePruner.interval: "60"
         repository: index.docker.io
         routerServiceType: LoadBalancer
         openTracing.enabled: false
@@ -102,7 +103,7 @@ profiles:
     path: /deploy/helm/releases/0/setValues/repository
     value: ""
   - op: replace
-    path: /deploy/helm/releases/0/setValues/pruneInterval
+    path: /deploy/helm/releases/0/setValues/archivePruner.interval
     value: 1
   - op: replace
     path: /deploy/helm/releases/0/setValues/routerServiceType


### PR DESCRIPTION
## Description
Earlier the archivePruner was always enabled with an interval. Now the users can disable it if they want to.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
