### PR TITLE
Pods immediately terminate for idletimeout in new deployment and container executer type

### DIFF
--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
 	"k8s.io/client-go/kubernetes"
@@ -62,6 +63,7 @@ var _ executortype.ExecutorType = &NewDeploy{}
 type (
 	// NewDeploy represents an ExecutorType
 	NewDeploy struct {
+		ctx    context.Context
 		logger *zap.Logger
 
 		kubernetesClient kubernetes.Interface
@@ -169,7 +171,7 @@ func (deploy *NewDeploy) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fsc
 // GetFuncSvcFromCache returns a function service from cache; error otherwise.
 func (deploy *NewDeploy) GetFuncSvcFromCache(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	otelUtils.SpanTrackEvent(ctx, "GetFuncSvcFromCache")
-	return deploy.fsCache.GetByFunction(&fn.ObjectMeta)
+	return deploy.fsCache.GetByFunctionUID(fn.UID)
 }
 
 // DeleteFuncSvcFromCache deletes a function service from cache.
@@ -592,8 +594,7 @@ func (deploy *NewDeploy) updateFunction(ctx context.Context, oldFn *fv1.Function
 
 	if oldFn.Spec.Environment != newFn.Spec.Environment ||
 		oldFn.Spec.Package.PackageRef != newFn.Spec.Package.PackageRef ||
-		oldFn.Spec.Package.FunctionName != newFn.Spec.Package.FunctionName ||
-		newFn.Spec.IdleTimeout != nil && (*oldFn.Spec.IdleTimeout != *newFn.Spec.IdleTimeout) {
+		oldFn.Spec.Package.FunctionName != newFn.Spec.Package.FunctionName {
 		deploy.logger.Info("deployment changed", zap.String("msg", "deployment changed"))
 		deployChanged = true
 	}
@@ -769,93 +770,89 @@ func (deploy *NewDeploy) updateStatus(fn *fv1.Function, err error, message strin
 // idleObjectReaper reaps objects after certain idle time
 func (deploy *NewDeploy) idleObjectReaper(ctx context.Context) {
 	deploy.logger.Info("idleObjectReaper function invoked", zap.String("function", "idleObjectReaper"))
-	pollSleep := 5 * time.Second
-	for {
-		time.Sleep(pollSleep)
+	deploy.ctx = ctx
 
-		envs, err := deploy.fissionClient.CoreV1().Environments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			deploy.logger.Fatal("failed to get environment list", zap.Error(err))
-		}
+	// calling function doIdleObjectReaper() repeatedly at given interval of time
+	wait.Forever(deploy.doIdleObjectReaper, time.Second*5)
+}
 
-		envList := make(map[k8sTypes.UID]struct{})
-		for _, env := range envs.Items {
-			envList[env.ObjectMeta.UID] = struct{}{}
-		}
+func (deploy *NewDeploy) doIdleObjectReaper() {
+	envs, err := deploy.fissionClient.CoreV1().Environments(metav1.NamespaceAll).List(deploy.ctx, metav1.ListOptions{})
+	if err != nil {
+		deploy.logger.Fatal("failed to get environment list", zap.Error(err))
+	}
 
-		funcSvcs, err := deploy.fsCache.ListOld(pollSleep)
-		if err != nil {
-			deploy.logger.Error("error reaping idle pods", zap.Error(err))
+	envList := make(map[k8sTypes.UID]struct{})
+	for _, env := range envs.Items {
+		envList[env.ObjectMeta.UID] = struct{}{}
+	}
+
+	funcSvcs, err := deploy.fsCache.ListOld(time.Second * 5)
+	if err != nil {
+		deploy.logger.Error("error reaping idle pods", zap.Error(err))
+		return
+	}
+
+	for i := range funcSvcs {
+		fsvc := funcSvcs[i]
+		if fsvc.Executor != fv1.ExecutorTypeNewdeploy {
 			continue
 		}
-		count := 0
-		for i := range funcSvcs {
-			count++
-			deploy.logger.Info("funcSvcs", zap.Int("counter", count), zap.Any("functionSvcs", funcSvcs))
-			fsvc := funcSvcs[i]
-			if fsvc.Executor != fv1.ExecutorTypeNewdeploy {
-				continue
-			}
 
-			// For function with the environment that no longer exists, executor
-			// scales down the deployment as usual and prints log to notify user.
-			if _, ok := envList[fsvc.Environment.ObjectMeta.UID]; !ok {
-				deploy.logger.Warn("function environment no longer exists",
-					zap.String("environment", fsvc.Environment.ObjectMeta.Name),
-					zap.String("function", fsvc.Name))
-			}
-
-			fn, err := deploy.fissionClient.CoreV1().Functions(fsvc.Function.Namespace).Get(ctx, fsvc.Function.Name, metav1.GetOptions{})
-			if err != nil {
-				// Newdeploy manager handles the function delete event and clean cache/kubeobjs itself,
-				// so we ignore the not found error for functions with newdeploy executor type here.
-				if k8sErrs.IsNotFound(err) && fsvc.Executor == fv1.ExecutorTypeNewdeploy {
-					continue
-				}
-				deploy.logger.Error("error getting function", zap.Error(err), zap.String("function", fsvc.Function.Name))
-				continue
-			}
-
-			idlePodReapTime := deploy.defaultIdlePodReapTime
-			if fn.Spec.IdleTimeout != nil {
-				idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
-			}
-
-			if time.Since(fsvc.Atime) < idlePodReapTime {
-				deploy.logger.Info("function last access timeout and function name", zap.String("access time", time.Since(fsvc.Atime).String()), zap.String("function", fsvc.Function.Name))
-				continue
-			}
-
-			func() {
-
-				deploy.logger.Info("self execute function last access timeout and function name", zap.String("access time", time.Since(fsvc.Atime).String()), zap.String("function", fsvc.Function.Name))
-				deployObj := getDeploymentObj(fsvc.KubernetesObjects)
-				if deployObj == nil {
-					deploy.logger.Error("error finding function deployment", zap.Error(err), zap.String("function", fsvc.Function.Name))
-					return
-				}
-
-				currentDeploy, err := deploy.kubernetesClient.AppsV1().
-					Deployments(deployObj.Namespace).Get(ctx, deployObj.Name, metav1.GetOptions{})
-				if err != nil {
-					deploy.logger.Error("error getting function deployment", zap.Error(err), zap.String("function", fsvc.Function.Name))
-					return
-				}
-
-				minScale := int32(fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale)
-
-				// do nothing if the current replicas is already lower than minScale
-				if *currentDeploy.Spec.Replicas <= minScale {
-					return
-				}
-
-				err = deploy.scaleDeployment(ctx, deployObj.Namespace, deployObj.Name, minScale)
-				if err != nil {
-					deploy.logger.Error("error scaling down function deployment", zap.Error(err), zap.String("function", fsvc.Function.Name))
-				}
-			}()
-
+		// For function with the environment that no longer exists, executor
+		// scales down the deployment as usual and prints log to notify user.
+		if _, ok := envList[fsvc.Environment.ObjectMeta.UID]; !ok {
+			deploy.logger.Warn("function environment no longer exists",
+				zap.String("environment", fsvc.Environment.ObjectMeta.Name),
+				zap.String("function", fsvc.Name))
 		}
+
+		fn, err := deploy.fissionClient.CoreV1().Functions(fsvc.Function.Namespace).Get(deploy.ctx, fsvc.Function.Name, metav1.GetOptions{})
+		if err != nil {
+			// Newdeploy manager handles the function delete event and clean cache/kubeobjs itself,
+			// so we ignore the not found error for functions with newdeploy executor type here.
+			if k8sErrs.IsNotFound(err) && fsvc.Executor == fv1.ExecutorTypeNewdeploy {
+				continue
+			}
+			deploy.logger.Error("error getting function", zap.Error(err), zap.String("function", fsvc.Function.Name))
+			continue
+		}
+
+		idlePodReapTime := deploy.defaultIdlePodReapTime
+		if fn.Spec.IdleTimeout != nil {
+			idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
+		}
+
+		if time.Since(fsvc.Atime) < idlePodReapTime {
+			continue
+		}
+
+		go func() {
+			deployObj := getDeploymentObj(fsvc.KubernetesObjects)
+			if deployObj == nil {
+				deploy.logger.Error("error finding function deployment", zap.Error(err), zap.String("function", fsvc.Function.Name))
+				return
+			}
+
+			currentDeploy, err := deploy.kubernetesClient.AppsV1().
+				Deployments(deployObj.Namespace).Get(deploy.ctx, deployObj.Name, metav1.GetOptions{})
+			if err != nil {
+				deploy.logger.Error("error getting function deployment", zap.Error(err), zap.String("function", fsvc.Function.Name))
+				return
+			}
+
+			minScale := int32(fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale)
+
+			// do nothing if the current replicas is already lower than minScale
+			if *currentDeploy.Spec.Replicas <= minScale {
+				return
+			}
+
+			err = deploy.scaleDeployment(deploy.ctx, deployObj.Namespace, deployObj.Name, minScale)
+			if err != nil {
+				deploy.logger.Error("error scaling down function deployment", zap.Error(err), zap.String("function", fsvc.Function.Name))
+			}
+		}()
 	}
 }
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	appsinformers "k8s.io/client-go/informers/apps/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -67,6 +68,7 @@ const (
 
 type (
 	GenericPoolManager struct {
+		ctx    context.Context
 		logger *zap.Logger
 
 		pools            map[string]*GenericPool
@@ -570,94 +572,94 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 
 // idleObjectReaper reaps objects after certain idle time
 func (gpm *GenericPoolManager) idleObjectReaper() {
-	ctx := context.Background()
-	pollSleep := 5 * time.Second
+	gpm.ctx = context.Background()
 
-	for {
-		time.Sleep(pollSleep)
+	// calling function doIdleObjectReaper() repeatedly at given interval of time
+	wait.Forever(gpm.doIdleObjectReaper, time.Second*5)
+}
 
-		envs, err := gpm.fissionClient.CoreV1().Environments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			gpm.logger.Error("failed to get environment list", zap.Error(err))
+func (gpm *GenericPoolManager) doIdleObjectReaper() {
+	envs, err := gpm.fissionClient.CoreV1().Environments(metav1.NamespaceAll).List(gpm.ctx, metav1.ListOptions{})
+	if err != nil {
+		gpm.logger.Error("failed to get environment list", zap.Error(err))
+		return
+	}
+
+	envList := make(map[k8sTypes.UID]struct{})
+	for _, env := range envs.Items {
+		envList[env.ObjectMeta.UID] = struct{}{}
+	}
+
+	fns, err := gpm.fissionClient.CoreV1().Functions(metav1.NamespaceAll).List(gpm.ctx, metav1.ListOptions{})
+	if err != nil {
+		gpm.logger.Error("failed to get environment list", zap.Error(err))
+		return
+	}
+
+	fnList := make(map[k8sTypes.UID]fv1.Function)
+	for i, fn := range fns.Items {
+		fnList[fn.ObjectMeta.UID] = fns.Items[i]
+	}
+
+	funcSvcs, err := gpm.fsCache.ListOldForPool(time.Second * 5)
+	if err != nil {
+		gpm.logger.Error("error reaping idle pods", zap.Error(err))
+		return
+	}
+
+	for i := range funcSvcs {
+		fsvc := funcSvcs[i]
+
+		if fsvc.Executor != fv1.ExecutorTypePoolmgr {
 			continue
 		}
 
-		envList := make(map[k8sTypes.UID]struct{})
-		for _, env := range envs.Items {
-			envList[env.ObjectMeta.UID] = struct{}{}
+		if _, ok := gpm.fsCache.WebsocketFsvc.Load(fsvc.Name); ok {
+			continue
+		}
+		// For function with the environment that no longer exists, executor
+		// cleanups the idle pod as usual and prints log to notify user.
+		if _, ok := envList[fsvc.Environment.ObjectMeta.UID]; !ok {
+			gpm.logger.Warn("function environment no longer exists",
+				zap.String("environment", fsvc.Environment.ObjectMeta.Name),
+				zap.String("function", fsvc.Name))
 		}
 
-		fns, err := gpm.fissionClient.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			gpm.logger.Error("failed to get environment list", zap.Error(err))
+		if fsvc.Environment.Spec.AllowedFunctionsPerContainer == fv1.AllowedFunctionsPerContainerInfinite {
 			continue
 		}
 
-		fnList := make(map[k8sTypes.UID]fv1.Function)
-		for i, fn := range fns.Items {
-			fnList[fn.ObjectMeta.UID] = fns.Items[i]
+		idlePodReapTime := gpm.defaultIdlePodReapTime
+		if fn, ok := fnList[fsvc.Function.UID]; ok {
+			if fn.Spec.IdleTimeout != nil {
+				idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
+			}
 		}
 
-		funcSvcs, err := gpm.fsCache.ListOldForPool(pollSleep)
-		if err != nil {
-			gpm.logger.Error("error reaping idle pods", zap.Error(err))
+		if time.Since(fsvc.Atime) < idlePodReapTime {
 			continue
 		}
 
-		for i := range funcSvcs {
-			fsvc := funcSvcs[i]
-
-			if fsvc.Executor != fv1.ExecutorTypePoolmgr {
-				continue
+		go func() {
+			deleted, err := gpm.fsCache.DeleteOldPoolCache(gpm.ctx, fsvc, idlePodReapTime)
+			if err != nil {
+				gpm.logger.Error("error deleting Kubernetes objects for function service",
+					zap.Error(err),
+					zap.Any("service", fsvc))
 			}
-
-			if _, ok := gpm.fsCache.WebsocketFsvc.Load(fsvc.Name); ok {
-				continue
-			}
-			// For function with the environment that no longer exists, executor
-			// cleanups the idle pod as usual and prints log to notify user.
-			if _, ok := envList[fsvc.Environment.ObjectMeta.UID]; !ok {
-				gpm.logger.Warn("function environment no longer exists",
-					zap.String("environment", fsvc.Environment.ObjectMeta.Name),
-					zap.String("function", fsvc.Name))
-			}
-
-			if fsvc.Environment.Spec.AllowedFunctionsPerContainer == fv1.AllowedFunctionsPerContainerInfinite {
-				continue
-			}
-
-			idlePodReapTime := gpm.defaultIdlePodReapTime
-			if fn, ok := fnList[fsvc.Function.UID]; ok {
-				if fn.Spec.IdleTimeout != nil {
-					idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
+			if deleted {
+				for i := range fsvc.KubernetesObjects {
+					gpm.logger.Info("release idle function resources",
+						zap.String("function", fsvc.Function.Name),
+						zap.String("address", fsvc.Address),
+						zap.String("executor", string(fsvc.Executor)),
+						zap.String("pod", fsvc.Name),
+					)
+					reaper.CleanupKubeObject(gpm.ctx, gpm.logger, gpm.kubernetesClient, &fsvc.KubernetesObjects[i])
+					time.Sleep(50 * time.Millisecond)
 				}
 			}
-
-			if time.Since(fsvc.Atime) < idlePodReapTime {
-				continue
-			}
-
-			go func() {
-				deleted, err := gpm.fsCache.DeleteOldPoolCache(ctx, fsvc, idlePodReapTime)
-				if err != nil {
-					gpm.logger.Error("error deleting Kubernetes objects for function service",
-						zap.Error(err),
-						zap.Any("service", fsvc))
-				}
-				if deleted {
-					for i := range fsvc.KubernetesObjects {
-						gpm.logger.Info("release idle function resources",
-							zap.String("function", fsvc.Function.Name),
-							zap.String("address", fsvc.Address),
-							zap.String("executor", string(fsvc.Executor)),
-							zap.String("pod", fsvc.Name),
-						)
-						reaper.CleanupKubeObject(ctx, gpm.logger, gpm.kubernetesClient, &fsvc.KubernetesObjects[i])
-						time.Sleep(50 * time.Millisecond)
-					}
-				}
-			}()
-		}
+		}()
 	}
 }
 

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -136,7 +136,6 @@ func (fsc *FunctionServiceCache) service() {
 				mI := funcSvc.(metav1.ObjectMeta)
 				fsvcI, err := fsc.byFunction.Get(crd.CacheKey(&mI))
 				if err != nil {
-					// resp.error = err
 					fsc.logger.Error("error while getting service", zap.Any("error", err))
 					return
 				}

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -130,10 +130,17 @@ func (fsc *FunctionServiceCache) service() {
 			resp.error = fsc._touchByAddress(req.address)
 		case LISTOLD:
 			// get svcs idle for > req.age
-			fscs := fsc.byFunction.Copy()
+			fscs := fsc.byFunctionUID.Copy()
 			funcObjects := make([]*FuncSvc, 0)
 			for _, funcSvc := range fscs {
-				fsvc := funcSvc.(*FuncSvc)
+				mI := funcSvc.(metav1.ObjectMeta)
+				fsvcI, err := fsc.byFunction.Get(crd.CacheKey(&mI))
+				if err != nil {
+					// resp.error = err
+					fsc.logger.Error("error while getting service", zap.Any("error", err))
+					return
+				}
+				fsvc := fsvcI.(*FuncSvc)
 				if time.Since(fsvc.Atime) > req.age {
 					funcObjects = append(funcObjects, fsvc)
 				}


### PR DESCRIPTION
## Description
Function pod immediately terminates once user change the idle timeout in case of new deployment and container executor type. 
This fix will prevent to immediate termination of pods and user will no more face any error for the same. Pod will get terminate as per the idle timeout provided by user.

## Which issue(s) this PR fixes:

Fixes #2451

## Testing
1. Created a simple function for executor type as pool manager, just to check my changes didn't broke the existing functionality.

2. Created a function for executor type as new deployment with idle timeout of 60 sec, and then tested the function.

3. Created a function for executor type as new deployment with idle timeout of 60 sec, and then wait to terminate the pods, once the pod get terminated, now updated the function idle timeout to something else like 50 sec, and then test the function. Now Pods were not terminated immediately. Pods got terminated after 50 sec(same as given by user).

4. Created few more functions as new deployment type and check them all together by changing their idle timeout and few other spec like minscale, maxscale etc, Everything was working as expected.

5. Created a function for executor type as new container and repeat the same steps as mentioned on point 2,3 and 4.
 
## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
