### PR TITLE
Added support to set builder and fn pod specs via helm chart

### DIFF
--- a/charts/fission-all/templates/buildermgr/configmap.yaml
+++ b/charts/fission-all/templates/buildermgr/configmap.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.builderPodSpec.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: builder-podspec-patch
+data: 
+  spec: |
+    {{- toYaml .Values.builderPodSpec.podSpec | nindent 4 }}
+{{- end -}}

--- a/charts/fission-all/templates/executor/configmap.yaml
+++ b/charts/fission-all/templates/executor/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: podspecpatch
+  namespace: {{ .Release.Namespace }}
+data:
+  spec: |
+    securityContext:
+      fsGroup: 10001
+      runAsGroup: 10001
+      runAsNonRoot: true
+      runAsUser: 10001

--- a/charts/fission-all/templates/executor/configmap.yaml
+++ b/charts/fission-all/templates/executor/configmap.yaml
@@ -1,8 +1,9 @@
+{{- if .Values.runtimePodSpec.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: runtime-podspec-patch
-  namespace: {{ .Release.Namespace }}
 data: 
   spec: |
-    {{- toYaml .Values.podSpec | nindent 4 }}
+    {{- toYaml .Values.runtimePodSpec.podSpec | nindent 4 }}
+{{- end -}}

--- a/charts/fission-all/templates/executor/configmap.yaml
+++ b/charts/fission-all/templates/executor/configmap.yaml
@@ -1,12 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: podspecpatch
+  name: runtime-podspec-patch
   namespace: {{ .Release.Namespace }}
-data:
+data: 
   spec: |
-    securityContext:
-      fsGroup: 10001
-      runAsGroup: 10001
-      runAsNonRoot: true
-      runAsUser: 10001
+    {{- toYaml .Values.podSpec | nindent 4 }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -59,6 +59,8 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
+        - name: FISSION_NAMESPACE
+          value: {{ .Release.Namespace }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -59,8 +59,6 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
-        - name: FISSION_NAMESPACE
-          value: {{ .Release.Namespace }}
         {{- include "opentracing.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -745,13 +745,17 @@ pprof:
 ## Enable runtimePodSpec and add spec to your poolmgr or newdeploy pods
 ##
 runtimePodSpec:
-  enabled: true
+
+  ## Setting it false by default so that integration tests pass
+  ##
+  enabled: false
+  
   ## Checkout PodSpec in https://fission.io/docs/reference/crd-reference/#runtime
   ##
-  
   podSpec:
-  ## Default podspec to improve security of the pods
-  ##
+
+    ## Default podspec to improve security of the pods
+    ##
     securityContext:
       fsGroup: 10001
       runAsGroup: 10001
@@ -761,13 +765,17 @@ runtimePodSpec:
 ## Enable builderPodSpec and add spec to your env builder pods
 ##
 builderPodSpec:
-  enabled: true
+
+  ## Setting it false by default so that integration tests pass
+  ##
+  enabled: false
+
   ## Checkout PodSpec in https://fission.io/docs/reference/crd-reference/#builder
   ##
-  
   podSpec:
-  ## Default podspec to improve security of the pods
-  ##
+
+    ## Default podspec to improve security of the pods
+    ##
     securityContext:
       fsGroup: 10001
       runAsGroup: 10001

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -743,14 +743,34 @@ pprof:
   enabled: false
 
 ## Enable runtimePodSpec and add spec to your poolmgr or newdeploy pods
+##
 runtimePodSpec:
   enabled: true
-## Refer https://doc.crds.dev/github.com/fission/fission/fission.io/Environment/v1@v1.16.0#spec-runtime-podspec
-## To write podspec
+  ## Checkout PodSpec in https://fission.io/docs/reference/crd-reference/#runtime
+  ##
+  
   podSpec:
-## Default podspec to improve security of the pods
+  ## Default podspec to improve security of the pods
+  ##
     securityContext:
       fsGroup: 10001
       runAsGroup: 10001
       runAsNonRoot: true
       runAsUser: 10001
+
+## Enable builderPodSpec and add spec to your env builder pods
+##
+builderPodSpec:
+  enabled: true
+  ## Checkout PodSpec in https://fission.io/docs/reference/crd-reference/#builder
+  ##
+  
+  podSpec:
+  ## Default podspec to improve security of the pods
+  ##
+    securityContext:
+      fsGroup: 10001
+      runAsGroup: 10001
+      runAsNonRoot: true
+      runAsUser: 10001
+

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -742,9 +742,11 @@ mqt_keda:
 pprof:
   enabled: false
 
-podSpec:
-  securityContext:
-    fsGroup: 10001
-    runAsGroup: 10001
-    runAsNonRoot: true
-    runAsUser: 10001
+runtimePodSpec:
+  enabled: false
+  podSpec:
+    securityContext:
+      fsGroup: 10001
+      runAsGroup: 10001
+      runAsNonRoot: true
+      runAsUser: 10001

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -741,3 +741,10 @@ mqt_keda:
 ##
 pprof:
   enabled: false
+
+podSpec:
+  securityContext:
+    fsGroup: 10001
+    runAsGroup: 10001
+    runAsNonRoot: true
+    runAsUser: 10001

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -742,9 +742,13 @@ mqt_keda:
 pprof:
   enabled: false
 
+## Enable runtimePodSpec and add spec to your poolmgr or newdeploy pods
 runtimePodSpec:
-  enabled: false
+  enabled: true
+## Refer https://doc.crds.dev/github.com/fission/fission/fission.io/Environment/v1@v1.16.0#spec-runtime-podspec
+## To write podspec
   podSpec:
+## Default podspec to improve security of the pods
     securityContext:
       fsGroup: 10001
       runAsGroup: 10001

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	k8s.io/client-go v0.23.4
 	k8s.io/metrics v0.23.4
 	sigs.k8s.io/controller-runtime v0.10.2
+	sigs.k8s.io/yaml v1.2.0
 )
 
 require (
@@ -181,5 +182,4 @@ require (
 	k8s.io/utils v0.0.0-20211116205334-6203023598ed // indirect
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.2.0 // indirect
 )

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -67,6 +67,10 @@ const (
 )
 
 const (
+	RuntimePodSpecConfigmap = "runtime-podspec-patch"
+)
+
+const (
 	SharedVolumeUserfunc   = "userfunc"
 	SharedVolumePackages   = "packages"
 	SharedVolumeSecrets    = "secrets"

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -68,6 +68,7 @@ const (
 
 const (
 	RuntimePodSpecConfigmap = "runtime-podspec-patch"
+	BuilderPodSpecConfigmap = "builder-podspec-patch"
 )
 
 const (

--- a/pkg/buildermgr/envwatcher.go
+++ b/pkg/buildermgr/envwatcher.go
@@ -87,7 +87,7 @@ type (
 		fetcherConfig          *fetcherConfig.Config
 		builderImagePullPolicy apiv1.PullPolicy
 		useIstio               bool
-		podSpec                *apiv1.PodSpec
+		podSpecPatch           *apiv1.PodSpec
 	}
 )
 
@@ -97,7 +97,7 @@ func makeEnvironmentWatcher(
 	kubernetesClient kubernetes.Interface,
 	fetcherConfig *fetcherConfig.Config,
 	builderNamespace string,
-	podSpec *apiv1.PodSpec) *environmentWatcher {
+	podSpecPatch *apiv1.PodSpec) *environmentWatcher {
 
 	useIstio := false
 	enableIstio := os.Getenv("ENABLE_ISTIO")
@@ -121,7 +121,7 @@ func makeEnvironmentWatcher(
 		builderImagePullPolicy: builderImagePullPolicy,
 		useIstio:               useIstio,
 		fetcherConfig:          fetcherConfig,
-		podSpec:                podSpec,
+		podSpecPatch:           podSpecPatch,
 	}
 
 	go envWatcher.service()
@@ -506,9 +506,9 @@ func (envw *environmentWatcher) createBuilderDeployment(env *fv1.Environment, ns
 		},
 	}
 
-	if envw.podSpec != nil {
+	if envw.podSpecPatch != nil {
 
-		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, envw.podSpec)
+		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, envw.podSpecPatch)
 		if err == nil {
 			pod.Spec = *updatedPodSpec
 		} else {

--- a/pkg/buildermgr/envwatcher.go
+++ b/pkg/buildermgr/envwatcher.go
@@ -87,6 +87,7 @@ type (
 		fetcherConfig          *fetcherConfig.Config
 		builderImagePullPolicy apiv1.PullPolicy
 		useIstio               bool
+		podSpec                *apiv1.PodSpec
 	}
 )
 
@@ -95,7 +96,8 @@ func makeEnvironmentWatcher(
 	fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface,
 	fetcherConfig *fetcherConfig.Config,
-	builderNamespace string) *environmentWatcher {
+	builderNamespace string,
+	podSpec *apiv1.PodSpec) *environmentWatcher {
 
 	useIstio := false
 	enableIstio := os.Getenv("ENABLE_ISTIO")
@@ -119,6 +121,7 @@ func makeEnvironmentWatcher(
 		builderImagePullPolicy: builderImagePullPolicy,
 		useIstio:               useIstio,
 		fetcherConfig:          fetcherConfig,
+		podSpec:                podSpec,
 	}
 
 	go envWatcher.service()
@@ -501,6 +504,16 @@ func (envw *environmentWatcher) createBuilderDeployment(env *fv1.Environment, ns
 			Containers:         []apiv1.Container{*container},
 			ServiceAccountName: "fission-builder",
 		},
+	}
+
+	if envw.podSpec != nil {
+
+		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, envw.podSpec)
+		if err == nil {
+			pod.Spec = *updatedPodSpec
+		} else {
+			envw.logger.Warn("Failed to merge the specs: %v", zap.Error(err))
+		}
 	}
 
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -274,7 +274,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	var podSpecPatch *apiv1.PodSpec
 	namespace, err := utils.GetCurrentNamespace()
 	if err != nil {
-		logger.Warn("Current namespace not found %v", zap.Error(err))
+		logger.Warn("Current namespace not found %s", zap.Error(err))
 	} else {
 		podSpecPatch, err = util.GetSpecFromConfigMap(ctx, kubernetesClient, fv1.RuntimePodSpecConfigmap, namespace)
 		if err != nil {

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dchest/uniuri"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	apiv1 "k8s.io/api/core/v1"
 	k8sInformers "k8s.io/client-go/informers"
 	k8sCache "k8s.io/client-go/tools/cache"
 
@@ -270,14 +271,15 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 
 	executorInstanceID := strings.ToLower(uniuri.NewLen(8))
 
+	var podSpecPatch *apiv1.PodSpec
 	namespace, err := utils.GetCurrentNamespace()
 	if err != nil {
 		logger.Warn("Current namespace not found %v", zap.Error(err))
-	}
-
-	podSpecPatch, err := util.GetSpecFromConfigMap(ctx, kubernetesClient, fv1.RuntimePodSpecConfigmap, namespace)
-	if err != nil {
-		logger.Warn("Either configmap is not found or error reading data %v", zap.Error(err))
+	} else {
+		podSpecPatch, err = util.GetSpecFromConfigMap(ctx, kubernetesClient, fv1.RuntimePodSpecConfigmap, namespace)
+		if err != nil {
+			logger.Warn("Either configmap is not found or error reading data %v", zap.Error(err))
+		}
 	}
 
 	logger.Info("Starting executor", zap.String("instanceID", executorInstanceID))

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -19,6 +19,7 @@ package executor
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"github.com/dchest/uniuri"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sInformers "k8s.io/client-go/informers"
 	k8sCache "k8s.io/client-go/tools/cache"
 
@@ -270,6 +272,16 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 
 	executorInstanceID := strings.ToLower(uniuri.NewLen(8))
 
+	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		logger.Warn("Failed to read namespace file: %v", zap.Error(err))
+	}
+
+	podSpecPatch, err := kubernetesClient.CoreV1().ConfigMaps(string(body)).Get(ctx, fv1.RuntimePodSpecConfigmap, metav1.GetOptions{})
+	if err != nil {
+		logger.Warn("No configmap for pod spec found %v", zap.Error(err))
+	}
+
 	logger.Info("Starting executor", zap.String("instanceID", executorInstanceID))
 
 	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
@@ -288,7 +300,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 		fissionClient, kubernetesClient, metricsClient,
 		functionNamespace, fetcherConfig, executorInstanceID,
 		funcInformer, pkgInformer, envInformer,
-		gpmPodInformer, gpmRsInformer)
+		gpmPodInformer, gpmRsInformer, podSpecPatch)
 	if err != nil {
 		return errors.Wrap(err, "pool manager creation failed")
 	}
@@ -304,7 +316,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 		fissionClient, kubernetesClient,
 		functionNamespace, fetcherConfig, executorInstanceID,
 		funcInformer, envInformer,
-		ndmDeplInformer, ndmSvcInformer)
+		ndmDeplInformer, ndmSvcInformer, podSpecPatch)
 	if err != nil {
 		return errors.Wrap(err, "new deploy manager creation failed")
 	}

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -19,9 +19,11 @@ package newdeploy
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
+	"github.com/ghodss/yaml"
 	multierror "github.com/hashicorp/go-multierror"
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -277,6 +279,24 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 			TerminationGracePeriodSeconds: &gracePeriodSeconds,
 		},
 	}
+
+	var additionalSpec apiv1.PodSpec
+	podSpecPatch, err := deploy.kubernetesClient.CoreV1().ConfigMaps(os.Getenv("FISSION_NAMESPACE")).Get(context.Background(), "podspecpatch", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = yaml.Unmarshal([]byte(podSpecPatch.Data["spec"]), &additionalSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedPodSpec, err := util.MergePodSpec(&pod.Spec, &additionalSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	pod.Spec = *updatedPodSpec
 
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))
 

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -278,9 +278,9 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		},
 	}
 
-	if deploy.podSpec != nil {
+	if deploy.podSpecPatch != nil {
 
-		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, deploy.podSpec)
+		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, deploy.podSpecPatch)
 		if err == nil {
 			pod.Spec = *updatedPodSpec
 		} else {

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -278,13 +278,14 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		},
 	}
 
-	updatedPodSpec, err := util.CheckAndMergeSpec(pod.Spec, deploy.podSpec)
-	if err != nil {
-		return nil, err
-	}
+	if deploy.podSpec != nil {
 
-	if updatedPodSpec != nil {
-		pod.Spec = *updatedPodSpec
+		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, deploy.podSpec)
+		if err == nil {
+			pod.Spec = *updatedPodSpec
+		} else {
+			deploy.logger.Warn("Failed to merge the specs: %v", zap.Error(err))
+		}
 	}
 
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -278,7 +278,7 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		},
 	}
 
-	updatedPodSpec, err := util.GetSpecConfigMap(ctx, deploy.kubernetesClient, pod.Spec, deploy.podSpecConfigMap)
+	updatedPodSpec, err := util.CheckAndMergeSpec(pod.Spec, deploy.podSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -278,11 +278,14 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		},
 	}
 
-	updatedPodSpec, err := util.GetSpecConfigMap(ctx, deploy.kubernetesClient, pod.Spec)
+	updatedPodSpec, err := util.GetSpecConfigMap(ctx, deploy.kubernetesClient, pod.Spec, deploy.podSpecConfigMap)
 	if err != nil {
 		return nil, err
 	}
-	pod.Spec = *updatedPodSpec
+
+	if updatedPodSpec != nil {
+		pod.Spec = *updatedPodSpec
+	}
 
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -87,7 +87,7 @@ type (
 
 		hpaops *hpautils.HpaOperations
 
-		podSpecConfigMap *apiv1.ConfigMap
+		podSpec *apiv1.PodSpec
 	}
 )
 
@@ -103,7 +103,7 @@ func MakeNewDeploy(
 	envInformer finformerv1.EnvironmentInformer,
 	deplInformer appsinformers.DeploymentInformer,
 	svcInformer coreinformers.ServiceInformer,
-	podSpecConfigMap *apiv1.ConfigMap,
+	podSpec *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
 	enableIstio := false
 	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
@@ -133,7 +133,7 @@ func MakeNewDeploy(
 
 		hpaops: hpautils.NewHpaOperations(logger, kubernetesClient, instanceID),
 
-		podSpecConfigMap: podSpecConfigMap,
+		podSpec: podSpec,
 	}
 
 	nd.deplLister = deplInformer.Lister()

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -87,7 +87,7 @@ type (
 
 		hpaops *hpautils.HpaOperations
 
-		podSpec *apiv1.PodSpec
+		podSpecPatch *apiv1.PodSpec
 	}
 )
 
@@ -103,7 +103,7 @@ func MakeNewDeploy(
 	envInformer finformerv1.EnvironmentInformer,
 	deplInformer appsinformers.DeploymentInformer,
 	svcInformer coreinformers.ServiceInformer,
-	podSpec *apiv1.PodSpec,
+	podSpecPatch *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
 	enableIstio := false
 	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
@@ -133,7 +133,7 @@ func MakeNewDeploy(
 
 		hpaops: hpautils.NewHpaOperations(logger, kubernetesClient, instanceID),
 
-		podSpec: podSpec,
+		podSpecPatch: podSpecPatch,
 	}
 
 	nd.deplLister = deplInformer.Lister()

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -86,6 +86,8 @@ type (
 		svcListerSynced  k8sCache.InformerSynced
 
 		hpaops *hpautils.HpaOperations
+
+		podSpecConfigMap *apiv1.ConfigMap
 	}
 )
 
@@ -101,6 +103,7 @@ func MakeNewDeploy(
 	envInformer finformerv1.EnvironmentInformer,
 	deplInformer appsinformers.DeploymentInformer,
 	svcInformer coreinformers.ServiceInformer,
+	podSpecConfigMap *apiv1.ConfigMap,
 ) (executortype.ExecutorType, error) {
 	enableIstio := false
 	if len(os.Getenv("ENABLE_ISTIO")) > 0 {
@@ -129,6 +132,8 @@ func MakeNewDeploy(
 		defaultIdlePodReapTime: 2 * time.Minute,
 
 		hpaops: hpautils.NewHpaOperations(logger, kubernetesClient, instanceID),
+
+		podSpecConfigMap: podSpecConfigMap,
 	}
 
 	nd.deplLister = deplInformer.Lister()

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -78,7 +78,7 @@ type (
 		readyPodQueue            workqueue.DelayingInterface
 		poolInstanceID           string // small random string to uniquify pod names
 		instanceID               string // poolmgr instance id
-		podSpec                  *apiv1.PodSpec
+		podSpecPatch             *apiv1.PodSpec
 		// TODO: move this field into fsCache
 		podFSVCMap sync.Map
 	}
@@ -97,7 +97,7 @@ func MakeGenericPool(
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
 	enableIstio bool,
-	podSpec *apiv1.PodSpec) *GenericPool {
+	podSpecPatch *apiv1.PodSpec) *GenericPool {
 
 	gpLogger := logger.Named("generic_pool")
 
@@ -132,7 +132,7 @@ func MakeGenericPool(
 		poolInstanceID:           uniuri.NewLen(8),
 		instanceID:               instanceID,
 		podFSVCMap:               sync.Map{},
-		podSpec:                  podSpec,
+		podSpecPatch:             podSpecPatch,
 	}
 
 	gp.runtimeImagePullPolicy = utils.GetImagePullPolicy(os.Getenv("RUNTIME_IMAGE_PULL_POLICY"))

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -78,6 +78,7 @@ type (
 		readyPodQueue            workqueue.DelayingInterface
 		poolInstanceID           string // small random string to uniquify pod names
 		instanceID               string // poolmgr instance id
+		podSpecConfigMap         *apiv1.ConfigMap
 		// TODO: move this field into fsCache
 		podFSVCMap sync.Map
 	}
@@ -95,7 +96,8 @@ func MakeGenericPool(
 	fsCache *fscache.FunctionServiceCache,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	enableIstio bool) *GenericPool {
+	enableIstio bool,
+	podSpecConfigMap *apiv1.ConfigMap) *GenericPool {
 
 	gpLogger := logger.Named("generic_pool")
 
@@ -130,6 +132,7 @@ func MakeGenericPool(
 		poolInstanceID:           uniuri.NewLen(8),
 		instanceID:               instanceID,
 		podFSVCMap:               sync.Map{},
+		podSpecConfigMap:         podSpecConfigMap,
 	}
 
 	gp.runtimeImagePullPolicy = utils.GetImagePullPolicy(os.Getenv("RUNTIME_IMAGE_PULL_POLICY"))

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -78,7 +78,7 @@ type (
 		readyPodQueue            workqueue.DelayingInterface
 		poolInstanceID           string // small random string to uniquify pod names
 		instanceID               string // poolmgr instance id
-		podSpecConfigMap         *apiv1.ConfigMap
+		podSpec                  *apiv1.PodSpec
 		// TODO: move this field into fsCache
 		podFSVCMap sync.Map
 	}
@@ -97,7 +97,7 @@ func MakeGenericPool(
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
 	enableIstio bool,
-	podSpecConfigMap *apiv1.ConfigMap) *GenericPool {
+	podSpec *apiv1.PodSpec) *GenericPool {
 
 	gpLogger := logger.Named("generic_pool")
 
@@ -132,7 +132,7 @@ func MakeGenericPool(
 		poolInstanceID:           uniuri.NewLen(8),
 		instanceID:               instanceID,
 		podFSVCMap:               sync.Map{},
-		podSpecConfigMap:         podSpecConfigMap,
+		podSpec:                  podSpec,
 	}
 
 	gp.runtimeImagePullPolicy = utils.GetImagePullPolicy(os.Getenv("RUNTIME_IMAGE_PULL_POLICY"))

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -150,9 +150,9 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 		},
 	}
 
-	if gp.podSpec != nil {
+	if gp.podSpecPatch != nil {
 
-		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, gp.podSpec)
+		updatedPodSpec, err := util.MergePodSpec(&pod.Spec, gp.podSpecPatch)
 		if err == nil {
 			pod.Spec = *updatedPodSpec
 		} else {

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -150,7 +150,7 @@ func (gp *GenericPool) genDeploymentSpec(ctx context.Context, env *fv1.Environme
 		},
 	}
 
-	updatedPodSpec, err := util.GetSpecConfigMap(ctx, gp.kubernetesClient, pod.Spec, gp.podSpecConfigMap)
+	updatedPodSpec, err := util.CheckAndMergeSpec(pod.Spec, gp.podSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -150,11 +150,14 @@ func (gp *GenericPool) genDeploymentSpec(ctx context.Context, env *fv1.Environme
 		},
 	}
 
-	updatedPodSpec, err := util.GetSpecConfigMap(ctx, gp.kubernetesClient, pod.Spec)
+	updatedPodSpec, err := util.GetSpecConfigMap(ctx, gp.kubernetesClient, pod.Spec, gp.podSpecConfigMap)
 	if err != nil {
 		return nil, err
 	}
-	pod.Spec = *updatedPodSpec
+
+	if updatedPodSpec != nil {
+		pod.Spec = *updatedPodSpec
+	}
 
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -93,7 +93,7 @@ type (
 
 		poolPodC *PoolPodController
 
-		podSpecConfigMap *apiv1.ConfigMap
+		podSpec *apiv1.PodSpec
 	}
 	request struct {
 		requestType
@@ -121,7 +121,7 @@ func MakeGenericPoolManager(
 	envInformer finformerv1.EnvironmentInformer,
 	podInformer coreinformers.PodInformer,
 	rsInformer appsinformers.ReplicaSetInformer,
-	podSpecConfigMap *apiv1.ConfigMap,
+	podSpec *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
 
 	gpmLogger := logger.Named("generic_pool_manager")
@@ -153,7 +153,7 @@ func MakeGenericPoolManager(
 		fetcherConfig:          fetcherConfig,
 		enableIstio:            enableIstio,
 		poolPodC:               poolPodC,
-		podSpecConfigMap:       podSpecConfigMap,
+		podSpec:                podSpec,
 	}
 	gpm.podLister = podInformer.Lister()
 	gpm.podListerSynced = podInformer.Informer().HasSynced
@@ -480,7 +480,7 @@ func (gpm *GenericPoolManager) service() {
 				}
 				pool = MakeGenericPool(gpm.logger, gpm.fissionClient, gpm.kubernetesClient,
 					gpm.metricsClient, req.env, ns, gpm.namespace, gpm.fsCache,
-					gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio, gpm.podSpecConfigMap)
+					gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio, gpm.podSpec)
 				err = pool.setup(req.ctx)
 				if err != nil {
 					req.responseChannel <- &response{error: err}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -92,6 +92,8 @@ type (
 		defaultIdlePodReapTime time.Duration
 
 		poolPodC *PoolPodController
+
+		podSpecConfigMap *apiv1.ConfigMap
 	}
 	request struct {
 		requestType
@@ -119,6 +121,7 @@ func MakeGenericPoolManager(
 	envInformer finformerv1.EnvironmentInformer,
 	podInformer coreinformers.PodInformer,
 	rsInformer appsinformers.ReplicaSetInformer,
+	podSpecConfigMap *apiv1.ConfigMap,
 ) (executortype.ExecutorType, error) {
 
 	gpmLogger := logger.Named("generic_pool_manager")
@@ -150,6 +153,7 @@ func MakeGenericPoolManager(
 		fetcherConfig:          fetcherConfig,
 		enableIstio:            enableIstio,
 		poolPodC:               poolPodC,
+		podSpecConfigMap:       podSpecConfigMap,
 	}
 	gpm.podLister = podInformer.Lister()
 	gpm.podListerSynced = podInformer.Informer().HasSynced
@@ -476,7 +480,7 @@ func (gpm *GenericPoolManager) service() {
 				}
 				pool = MakeGenericPool(gpm.logger, gpm.fissionClient, gpm.kubernetesClient,
 					gpm.metricsClient, req.env, ns, gpm.namespace, gpm.fsCache,
-					gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio)
+					gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio, gpm.podSpecConfigMap)
 				err = pool.setup(req.ctx)
 				if err != nil {
 					req.responseChannel <- &response{error: err}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -93,7 +93,7 @@ type (
 
 		poolPodC *PoolPodController
 
-		podSpec *apiv1.PodSpec
+		podSpecPatch *apiv1.PodSpec
 	}
 	request struct {
 		requestType
@@ -121,7 +121,7 @@ func MakeGenericPoolManager(
 	envInformer finformerv1.EnvironmentInformer,
 	podInformer coreinformers.PodInformer,
 	rsInformer appsinformers.ReplicaSetInformer,
-	podSpec *apiv1.PodSpec,
+	podSpecPatch *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
 
 	gpmLogger := logger.Named("generic_pool_manager")
@@ -153,7 +153,7 @@ func MakeGenericPoolManager(
 		fetcherConfig:          fetcherConfig,
 		enableIstio:            enableIstio,
 		poolPodC:               poolPodC,
-		podSpec:                podSpec,
+		podSpecPatch:           podSpecPatch,
 	}
 	gpm.podLister = podInformer.Lister()
 	gpm.podListerSynced = podInformer.Informer().HasSynced
@@ -480,7 +480,7 @@ func (gpm *GenericPoolManager) service() {
 				}
 				pool = MakeGenericPool(gpm.logger, gpm.fissionClient, gpm.kubernetesClient,
 					gpm.metricsClient, req.env, ns, gpm.namespace, gpm.fsCache,
-					gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio, gpm.podSpec)
+					gpm.fetcherConfig, gpm.instanceID, gpm.enableIstio, gpm.podSpecPatch)
 				err = pool.setup(req.ctx)
 				if err != nil {
 					req.responseChannel <- &response{error: err}

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
@@ -78,7 +78,7 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 		fissionClient, kubernetesClient, metricsClient,
 		fnNamespace, fetcherConfig, executorInstanceID,
 		funcInformer, pkgInformer, envInformer,
-		gpmPodInformer, gpmRsInformer)
+		gpmPodInformer, gpmRsInformer, nil)
 	if err != nil {
 		t.Fatalf("Error creating generic pool manager: %v", err)
 	}

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -115,20 +115,6 @@ func ConvertConfigSecrets(ctx context.Context, fn *fv1.Function, kc kubernetes.I
 	return envFromSources, nil
 }
 
-func CheckAndMergeSpec(podSpec apiv1.PodSpec, additionalSpec *apiv1.PodSpec) (*apiv1.PodSpec, error) {
-
-	if additionalSpec == nil {
-		return nil, nil
-	}
-
-	updatedPodSpec, err := MergePodSpec(&podSpec, additionalSpec)
-	if err != nil {
-		return nil, err
-	}
-
-	return updatedPodSpec, nil
-}
-
 func GetSpecFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface, cm string, cmns string) (*apiv1.PodSpec, error) {
 
 	podSpecPatch, err := kubeClient.CoreV1().ConfigMaps(cmns).Get(ctx, cm, metav1.GetOptions{})

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -125,9 +125,6 @@ func GetSpecFromConfigMap(ctx context.Context, kubeClient kubernetes.Interface, 
 	var additionalSpec apiv1.PodSpec
 
 	err = yaml.Unmarshal([]byte(podSpecPatch.Data["spec"]), &additionalSpec)
-	if err != nil {
-		return nil, err
-	}
 
-	return &additionalSpec, nil
+	return &additionalSpec, err
 }

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -19,7 +19,6 @@ package util
 import (
 	"context"
 	"errors"
-	"os"
 	"sync"
 	"time"
 
@@ -116,15 +115,15 @@ func ConvertConfigSecrets(ctx context.Context, fn *fv1.Function, kc kubernetes.I
 	return envFromSources, nil
 }
 
-func GetSpecConfigMap(ctx context.Context, kubeClient kubernetes.Interface, podSpec apiv1.PodSpec) (*apiv1.PodSpec, error) {
-	var additionalSpec apiv1.PodSpec
+func GetSpecConfigMap(ctx context.Context, kubeClient kubernetes.Interface, podSpec apiv1.PodSpec, podSpecConfigMap *apiv1.ConfigMap) (*apiv1.PodSpec, error) {
 
-	podSpecPatch, err := kubeClient.CoreV1().ConfigMaps(os.Getenv("FISSION_NAMESPACE")).Get(ctx, "runtime-podspec-patch", metav1.GetOptions{})
-	if err != nil {
-		return nil, err
+	if podSpecConfigMap == nil {
+		return nil, nil
 	}
 
-	err = yaml.Unmarshal([]byte(podSpecPatch.Data["spec"]), &additionalSpec)
+	var additionalSpec apiv1.PodSpec
+
+	err := yaml.Unmarshal([]byte(podSpecConfigMap.Data["spec"]), &additionalSpec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/util/util_test.go
+++ b/pkg/executor/util/util_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestGetSpecFromConfigMap(t *testing.T) {
+
+	kubeClient := fake.NewSimpleClientset()
+
+	var permissionNum int64 = 10001
+	var runAsNonRoot bool = true
+
+	configMapData := make(map[string]string, 0)
+	specPatch := `
+securityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001`
+
+	configMapData["spec"] = specPatch
+
+	testConfigMap := apiv1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ConfigMap",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-config-map",
+			Namespace: "fission",
+		},
+		Data: configMapData,
+	}
+
+	configmap, err := kubeClient.CoreV1().ConfigMaps("fission").Create(context.Background(), &testConfigMap, metav1.CreateOptions{})
+	if err != nil {
+		t.Errorf("Error creating configmap %v", err)
+	}
+
+	t.Logf("Configmap: %v", configmap.Data)
+
+	testSpecPatch := apiv1.PodSpec{
+		SecurityContext: &apiv1.PodSecurityContext{
+			FSGroup:      &permissionNum,
+			RunAsGroup:   &permissionNum,
+			RunAsNonRoot: &runAsNonRoot,
+			RunAsUser:    &permissionNum,
+		},
+	}
+	tests := []struct {
+		name    string
+		cm      string
+		cmns    string
+		want    *apiv1.PodSpec
+		wantErr bool
+	}{
+		{
+			name:    "Configmap exists",
+			cm:      "test-config-map",
+			cmns:    "fission",
+			want:    &testSpecPatch,
+			wantErr: false,
+		},
+		{
+			name:    "Configmap does not exists",
+			cm:      "wrongname",
+			cmns:    "fission",
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetSpecFromConfigMap(context.Background(), kubeClient, tt.cm, tt.cmns)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetSpecFromConfigMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetSpecFromConfigMap() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/executor/util/util_test.go
+++ b/pkg/executor/util/util_test.go
@@ -91,6 +91,13 @@ securityContext:
 			want:    nil,
 			wantErr: true,
 		},
+		{
+			name:    "Wrong namespace",
+			cm:      "test-config-map",
+			cmns:    "fissio",
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -213,4 +214,12 @@ func IsZip(filename string) (bool, error) {
 	}
 	defer f.Close()
 	return archiver.DefaultZip.Match(f)
+}
+
+func GetCurrentNamespace() (string, error) {
+	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -216,7 +216,10 @@ func IsZip(filename string) (bool, error) {
 	return archiver.DefaultZip.Match(f)
 }
 
+//Returns namespace where fission is deployed.
 func GetCurrentNamespace() (string, error) {
+
+	//This file contains the namespace and can be found in each container.
 	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", err

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -216,10 +216,10 @@ func IsZip(filename string) (bool, error) {
 	return archiver.DefaultZip.Match(f)
 }
 
-//Returns namespace where fission is deployed.
+// GetCurrentNamespace returns Kubernetes namespace of current Pod
 func GetCurrentNamespace() (string, error) {
 
-	//This file contains the namespace and can be found in each container.
+	// This file contains the namespace and can be found in each container.
 	body, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err != nil {
 		return "", err

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -47,8 +47,8 @@ deploy:
         influxdb.enabled: false
         storagesvc.archivePruner.enabled: true
         storagesvc.archivePruner.interval: "60"
-        runtimePodSpec.enabled: true
-        builderPodSpec.enabled: true
+        runtimePodSpec.enabled: false
+        builderPodSpec.enabled: false
         repository: index.docker.io
         routerServiceType: LoadBalancer
         openTracing.enabled: false

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -47,6 +47,8 @@ deploy:
         influxdb.enabled: false
         storagesvc.archivePruner.enabled: true
         storagesvc.archivePruner.interval: "60"
+        runtimePodSpec.enabled: true
+        builderPodSpec.enabled: true
         repository: index.docker.io
         routerServiceType: LoadBalancer
         openTracing.enabled: false


### PR DESCRIPTION
## Description
The users can now set the pod spec for builder and fn pods via helm chart.
Currently we have set some default securitycontext for the pods. Before there were no permissions set and the user would by default enter root when `kubectl exec` into pod. Now the permissions have been set and the user will not be able to access root directory in poolmgr and newdeploy pods.

## Which issue(s) this PR fixes:
Fixes #2401
Fixes #1820 

## Testing
Added unit tests and did some manual testing.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
