### PR TITLE
Increase time for port forwarding

### DIFF
--- a/pkg/fission-cli/util/portforward.go
+++ b/pkg/fission-cli/util/portforward.go
@@ -50,16 +50,20 @@ func SetupPortForward(namespace, labelSelector string, kubeContext string) (stri
 		return "", errors.Wrap(err, "error finding unused port")
 	}
 
-	var duration time.Duration = 50
+	var (
+		defaultDuration time.Duration = 50
+		maxDuration     time.Duration = 2000
+	)
+
 	console.Verbose(2, "Waiting for local port %v", localPort)
 	for {
 		conn, _ := net.DialTimeout("tcp",
-			net.JoinHostPort("", localPort), time.Millisecond*duration)
+			net.JoinHostPort("", localPort), time.Millisecond*defaultDuration)
 		if conn != nil {
 			conn.Close()
-			duration *= 2
-			if duration > 2000 {
-				duration = 2000
+			defaultDuration *= 2
+			if defaultDuration > maxDuration {
+				defaultDuration = maxDuration
 			}
 		} else {
 			break
@@ -78,15 +82,15 @@ func SetupPortForward(namespace, labelSelector string, kubeContext string) (stri
 
 	console.Verbose(2, "Waiting for port forward %v to start...", localPort)
 
-	duration = 50
+	defaultDuration = 50
 	for {
 		conn, err := net.DialTimeout("tcp",
-			net.JoinHostPort("", localPort), time.Millisecond*duration)
+			net.JoinHostPort("", localPort), time.Millisecond*defaultDuration)
 		if err != nil {
 			console.Verbose(2, "Error dialing on local port %v: %s", localPort, err.Error())
-			duration *= 2
-			if duration > 2000 {
-				duration = 2000
+			defaultDuration *= 2
+			if defaultDuration > maxDuration {
+				defaultDuration = maxDuration
 			}
 		} else {
 			conn.Close()

--- a/pkg/fission-cli/util/portforward.go
+++ b/pkg/fission-cli/util/portforward.go
@@ -50,14 +50,17 @@ func SetupPortForward(namespace, labelSelector string, kubeContext string) (stri
 		return "", errors.Wrap(err, "error finding unused port")
 	}
 
-	var duration time.Duration = 5
+	var duration time.Duration = 50
 	console.Verbose(2, "Waiting for local port %v", localPort)
 	for {
 		conn, _ := net.DialTimeout("tcp",
-			net.JoinHostPort("", localPort), time.Second*duration)
+			net.JoinHostPort("", localPort), time.Millisecond*duration)
 		if conn != nil {
 			conn.Close()
 			duration *= 2
+			if duration > 2000 {
+				duration = 2000
+			}
 		} else {
 			break
 		}
@@ -75,13 +78,16 @@ func SetupPortForward(namespace, labelSelector string, kubeContext string) (stri
 
 	console.Verbose(2, "Waiting for port forward %v to start...", localPort)
 
-	duration = 5
+	duration = 50
 	for {
 		conn, err := net.DialTimeout("tcp",
-			net.JoinHostPort("", localPort), time.Second*duration)
+			net.JoinHostPort("", localPort), time.Millisecond*duration)
 		if err != nil {
 			console.Verbose(2, "Error dialing on local port %v: %s", localPort, err.Error())
 			duration *= 2
+			if duration > 2000 {
+				duration = 2000
+			}
 		} else {
 			conn.Close()
 			break


### PR DESCRIPTION
## Description
Fission CLI get time out in port forwarding, currently the timeout for port forwarding is 1 ms.
This fix will increase the port forwarding time initially to 5 sec, and then time will increase exponentially like 10, 20, 40 and so on.

## Which issue(s) this PR fixes:

Fixes # https://github.com/fission/fission/issues/2462

## Testing
forward the port of controller and test changes for the same.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
