### PR TITLE
Generate package within 63 character limit when creating function

### DIFF
--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -326,11 +326,19 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 // generatePackgeName => will return package name by appending id in function name and will make sure that package name will never be more than length of 63 characters.
 func generatePackageName(fnName string, id string) string {
-	if len(fnName) <= 26 {
+	var (
+		lenFnName       int = len(fnName)
+		lenId           int = len(id)
+		lastIndexOfChar int
+	)
+	if lenFnName+lenId <= 62 {
 		return fmt.Sprintf("%v-%v", fnName, id)
 	}
-	console.Info("Package name is more than 63 characters, hence trimming to 63 characters")
-	return fmt.Sprintf("%v-%v", fnName[:26], id)
+
+	lastIndexOfChar = lenFnName - (lenFnName + lenId - 62)
+	pkgName := fmt.Sprintf("%v-%v", fnName[:lastIndexOfChar], id)
+	console.Info(fmt.Sprintf("Generated package %v from function to acceptable character limit", pkgName))
+	return pkgName
 }
 
 // run write the resource to a spec file or create a fission CRD with remote fission server.

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -221,7 +221,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		if err != nil {
 			return errors.Wrap(err, "error generating uuid")
 		}
-		pkgName := fmt.Sprintf("%v-%v", fnName, id.String())
+		pkgName := generatePackageName(fnName, id.String())
 
 		// create new package in the same namespace as the function.
 		pkgMetadata, err = _package.CreatePackage(input, opts.Client(), pkgName, fnNamespace, envName, envNamespace,
@@ -322,6 +322,15 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 
 	return nil
+}
+
+// generatePackgeName => will return package name by appending id in function name and will make sure that package name will never be more than length of 63 characters.
+func generatePackageName(fnName string, id string) string {
+	if len(fnName) <= 26 {
+		return fmt.Sprintf("%v-%v", fnName, id)
+	}
+	console.Info("Package name is more than 63 characters, hence trimming to 63 characters")
+	return fmt.Sprintf("%v-%v", fnName[:26], id)
 }
 
 // run write the resource to a spec file or create a fission CRD with remote fission server.

--- a/pkg/fission-cli/cmd/function/create_test.go
+++ b/pkg/fission-cli/cmd/function/create_test.go
@@ -1,0 +1,40 @@
+package function
+
+import "testing"
+
+type pkgRequest struct {
+	uid    string
+	fnName string
+}
+
+func TestGeneratePackageName(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		request  *pkgRequest
+		expected int
+	}{
+		{
+			name: "name of package should be less than or equal to 63 characters, if function name is less than or equal to 26 characters",
+			request: &pkgRequest{
+				uid:    "35764439-0676-48bf-bb61-c3cdcc82b801",
+				fnName: "testfunctionwith26character",
+			},
+			expected: 63,
+		},
+		{
+			name: "name of package should be less than or equal to 63 characters, if function name is more than 26 characters",
+			request: &pkgRequest{
+				uid:    "cea48e99-cd94-4ee0-bd9d-a249fa8d70a0",
+				fnName: "testfunctionwithmorethan26character",
+			},
+			expected: 63,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			pkgName := generatePackageName(test.request.fnName, test.request.uid)
+			if len(pkgName) > test.expected {
+				t.Errorf("expected len of package to be %v, got %v", test.expected, len(pkgName))
+			}
+		})
+	}
+}

--- a/pkg/fission-cli/cmd/function/create_test.go
+++ b/pkg/fission-cli/cmd/function/create_test.go
@@ -1,6 +1,10 @@
 package function
 
-import "testing"
+import (
+	"testing"
+
+	uuid "github.com/satori/go.uuid"
+)
 
 type pkgRequest struct {
 	uid    string
@@ -10,28 +14,31 @@ type pkgRequest struct {
 func TestGeneratePackageName(t *testing.T) {
 	for _, test := range []struct {
 		name     string
-		request  *pkgRequest
+		fnName   string
 		expected int
 	}{
 		{
-			name: "name of package should be less than or equal to 63 characters, if function name is less than or equal to 26 characters",
-			request: &pkgRequest{
-				uid:    "35764439-0676-48bf-bb61-c3cdcc82b801",
-				fnName: "testfunctionwith26character",
-			},
+			name:     "name of package should be less than or equal to 63 characters, if function name is equal to 26 characters",
+			fnName:   "test-function-with-26-char",
 			expected: 63,
 		},
 		{
-			name: "name of package should be less than or equal to 63 characters, if function name is more than 26 characters",
-			request: &pkgRequest{
-				uid:    "cea48e99-cd94-4ee0-bd9d-a249fa8d70a0",
-				fnName: "testfunctionwithmorethan26character",
-			},
+			name:     "name of package should be less than or equal to 63 characters, if function name is more than 26 characters",
+			fnName:   "testfunctionwithmorethan26character",
+			expected: 63,
+		},
+		{
+			name:     "name of package should be less than or equal to 63 characters, if function name is less than 26 characters",
+			fnName:   "fission-function",
 			expected: 63,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			pkgName := generatePackageName(test.request.fnName, test.request.uid)
+			id, err := uuid.NewV4()
+			if err != nil {
+				t.Fatal(err)
+			}
+			pkgName := generatePackageName(test.fnName, id.String())
 			if len(pkgName) > test.expected {
 				t.Errorf("expected len of package to be %v, got %v", test.expected, len(pkgName))
 			}

--- a/pkg/fission-cli/cmd/function/create_test.go
+++ b/pkg/fission-cli/cmd/function/create_test.go
@@ -6,11 +6,6 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-type pkgRequest struct {
-	uid    string
-	fnName string
-}
-
 func TestGeneratePackageName(t *testing.T) {
 	for _, test := range []struct {
 		name     string

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -62,6 +62,12 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 			console.Warn(fmt.Sprintf("--%v will be soon marked as required flag, see 'help' for details", flagkey.HtName))
 		}
 	}
+
+	if len(pkgName) > 63 {
+		console.Info("Package name is more than 63 characters, hence trimming to 63 characters")
+		pkgName = pkgName[:63]
+	}
+
 	pkgNamespace := input.String(flagkey.NamespacePackage)
 	envName := input.String(flagkey.PkgEnvironment)
 	envNamespace := input.String(flagkey.NamespaceEnvironment)

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -63,11 +63,6 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		}
 	}
 
-	if len(pkgName) > 63 {
-		console.Info("Package name is more than 63 characters, hence trimming to 63 characters")
-		pkgName = pkgName[:63]
-	}
-
 	pkgNamespace := input.String(flagkey.NamespacePackage)
 	envName := input.String(flagkey.PkgEnvironment)
 	envNamespace := input.String(flagkey.NamespaceEnvironment)
@@ -91,6 +86,11 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	var specDir, specFile string
 
 	if input.Bool(flagkey.SpecSave) {
+		// since package CRD created using --spec, not validate by k8s. So we need to validate it and make sure package name is not more than 63 characters.
+		if len(pkgName) > 63 {
+			return errors.Errorf("error creating package: package name %v, must be no more than 63 characters", pkgName)
+		}
+
 		specDir = util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
 		fr, err := spec.ReadSpecs(specDir, specIgnore, false)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
While creating a package if package name is more than 63 characters, then package get failed.
This fix will allow to create a package even if package name is more than 63 characters by taking first 26 characters as package name and appending unique id to it, and will trim rest of the characters of package name.

## Which issue(s) this PR fixes:

Fixes # https://fissionio.slack.com/archives/C3LUX6BBP/p1657148131481119

## Testing
Created a simple function with function name less than 63 characters.
Created a function with function name more than 63 characters.
Created a function using spec with function name less than 63 characters.
Created a function using spec with function name more than 63 characters.
Created a package manually with package name less than 63 characters.
Created a package manually with package name more than 63 characters.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
