### PR TITLE
Prevent creating function of executor type container via fn create command

### DIFF
--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -112,6 +112,10 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	secretNames := input.StringSlice(flagkey.FnSecret)
 	cfgMapNames := input.StringSlice(flagkey.FnCfgMap)
 
+	if input.String(flagkey.FnExecutorType) == string(fv1.ExecutorTypeContainer) {
+		return errors.Errorf("this command does not support creating function of executor type container. Check `fission function run-container --help`")
+	}
+
 	invokeStrategy, err := getInvokeStrategy(input, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
1. add check to ensure proper error message is shown when user is trying to create function with executor type container
2. add hint to the actual command
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2463 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
