### PR TITLE
Package resource get stuck in Pending state when created without Fission CLI

### DIFF
--- a/crds/v1/fission.io_packages.yaml
+++ b/crds/v1/fission.io_packages.yaml
@@ -122,7 +122,7 @@ spec:
                 description: BuildLog stores build log during the compilation.
                 type: string
               buildstatus:
-                default: Pending
+                default: pending
                 description: BuildStatus is the package build status.
                 type: string
               lastUpdateTimestamp:

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -304,7 +304,7 @@ type (
 		//   is ready for deploy instead of setting "none" in build status.
 
 		// BuildStatus is the package build status.
-		// +kubebuilder:default:="Pending"
+		// +kubebuilder:default:="pending"
 		BuildStatus BuildStatus `json:"buildstatus,omitempty"`
 
 		// BuildLog stores build log during the compilation.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Package resource get stuck in Pending state if package resource is being created without fission CLI. For fission CLI it's working fine.
This issue is occurring because of ambiguous value of BuildStatus in CRD. This fix will change the value of BuildStatus and use the same value everywhere.  

## Which issue(s) this PR fixes:

Fixes #2488

## Testing

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
