### PR TITLE
removed unused reference of TRACING_SAMPLING_RATE

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -79,7 +79,7 @@ func router(ctx context.Context, logger *zap.Logger, httpTriggerSet *HTTPTrigger
 	return mr
 }
 
-func serve(ctx context.Context, logger *zap.Logger, port int, tracingSamplingRate float64,
+func serve(ctx context.Context, logger *zap.Logger, port int,
 	httpTriggerSet *HTTPTriggerSet, displayAccessLog bool) {
 	mr := router(ctx, logger, httpTriggerSet)
 	handler := otelUtils.GetHandlerWithOTEL(mr, "fission-router", otelUtils.UrlsToIgnore("/router-healthz"))
@@ -185,16 +185,6 @@ func Start(ctx context.Context, logger *zap.Logger, port int, executorURL string
 			zap.Duration("default", unTapServiceTimeout))
 	}
 
-	tracingSamplingRateStr := os.Getenv("TRACING_SAMPLING_RATE")
-	tracingSamplingRate, err := strconv.ParseFloat(tracingSamplingRateStr, 64)
-	if err != nil {
-		tracingSamplingRate = .5
-		logger.Error("failed to parse tracing sampling rate from 'TRACING_SAMPLING_RATE' - set to the default value",
-			zap.Error(err),
-			zap.String("value", tracingSamplingRateStr),
-			zap.Float64("default", tracingSamplingRate))
-	}
-
 	displayAccessLogStr := os.Getenv("DISPLAY_ACCESS_LOG")
 	displayAccessLog, err := strconv.ParseBool(displayAccessLogStr)
 	if err != nil {
@@ -222,5 +212,5 @@ func Start(ctx context.Context, logger *zap.Logger, port int, executorURL string
 	ctx, span := tracer.Start(ctx, "router/Start")
 	defer span.End()
 
-	serve(ctx, logger, port, tracingSamplingRate, triggers, displayAccessLog)
+	serve(ctx, logger, port, triggers, displayAccessLog)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Whenever github action workflow run then workflow show an error message "ERROR fission-bundle/main.go:52 failed to parse tracing sampling rate from 'TRACING_SAMPLING_RATE'". Since we are no more using TRACING_SAMPLING_RATE environment variable so it will be better to remove from the code.
This fix will remove the mentioned above error during github action workflow.

## Which issue(s) this PR fixes:
Fixes # https://github.com/fission/fission/issues/2496

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
