### PR TITLE
Allow namespace configuration for different CRD resources in Fission

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -71,3 +71,12 @@ This template generates the image name for the deployment depending on the value
 - name: OTEL_PROPAGATORS
   value: "{{ .Values.openTelemetry.propagators }}"
 {{- end }}
+
+{{- define "additional-namespace.envs" }}
+- name: FISSION_RESOURCE_NAMESPACES
+{{- if not .Values.singleDefaultNamespace }}
+  value: "{{ .Values.defaultNamespace }},{{ join "," .Values.additionalFissionNamespaces }}"
+{{- else }}
+  value: {{ .Values.defaultNamespace }}  
+{{- end }}
+{{- end }}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -72,7 +72,7 @@ This template generates the image name for the deployment depending on the value
   value: "{{ .Values.openTelemetry.propagators }}"
 {{- end }}
 
-{{- define "additional-namespace.envs" }}
+{{- define "fission-resource-namespace.envs" }}
 - name: FISSION_RESOURCE_NAMESPACES
 {{- if not .Values.singleDefaultNamespace }}
   value: "{{ .Values.defaultNamespace }},{{ join "," .Values.additionalFissionNamespaces }}"

--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -55,6 +55,10 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         ports:
           - containerPort: 8080

--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
-        {{- include "additional-namespace.envs" . | indent 8 }}  
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         ports:
           - containerPort: 8080

--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -55,10 +55,7 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}  
+        {{- include "additional-namespace.envs" . | indent 8 }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         ports:
           - containerPort: 8080

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -38,10 +38,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}  
+        {{- include "additional-namespace.envs" . | indent 8 }} 
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- include "additional-namespace.envs" . | indent 8 }} 
+        {{- include "fission-resource-namespace.envs" . | indent 8 }} 
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -38,6 +38,10 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}  
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -71,6 +71,18 @@ spec:
         - name: CONTAINER_OBJECT_REAPER_INTERVAL
           value: {{ .Values.executor.container.objectReaperInterval | quote }}
         {{- end}}
+        {{- if .Values.informerNamespace.function }}
+        - name: FUNCTION_INFORMER_NS
+          value: {{ .Values.informerNamespace.function | quote }}
+        {{- end}}
+        {{- if .Values.informerNamespace.environment }}
+        - name: ENVIRONMENT_INFORMER_NS
+          value: {{ .Values.informerNamespace.environment | quote }}
+        {{- end}}
+        {{- if .Values.informerNamespace.packages }}
+        - name: PACKAGE_INFORMER_NS
+          value: {{ .Values.informerNamespace.packages | quote }}
+        {{- end}}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -71,10 +71,7 @@ spec:
         - name: CONTAINER_OBJECT_REAPER_INTERVAL
           value: {{ .Values.executor.container.objectReaperInterval | quote }}
         {{- end}}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}
+        {{- include "additional-namespace.envs" . | indent 8 }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -71,18 +71,6 @@ spec:
         - name: CONTAINER_OBJECT_REAPER_INTERVAL
           value: {{ .Values.executor.container.objectReaperInterval | quote }}
         {{- end}}
-        {{- if .Values.informerNamespace.function }}
-        - name: FUNCTION_INFORMER_NS
-          value: {{ .Values.informerNamespace.function | quote }}
-        {{- end}}
-        {{- if .Values.informerNamespace.environment }}
-        - name: ENVIRONMENT_INFORMER_NS
-          value: {{ .Values.informerNamespace.environment | quote }}
-        {{- end}}
-        {{- if .Values.informerNamespace.packages }}
-        - name: PACKAGE_INFORMER_NS
-          value: {{ .Values.informerNamespace.packages | quote }}
-        {{- end}}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -71,7 +71,7 @@ spec:
         - name: CONTAINER_OBJECT_REAPER_INTERVAL
           value: {{ .Values.executor.container.objectReaperInterval | quote }}
         {{- end}}
-        {{- include "additional-namespace.envs" . | indent 8 }}
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -71,6 +71,10 @@ spec:
         - name: CONTAINER_OBJECT_REAPER_INTERVAL
           value: {{ .Values.executor.container.objectReaperInterval | quote }}
         {{- end}}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}
         - name: HELM_RELEASE_NAME
           value: {{ .Release.Name | quote }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- include "additional-namespace.envs" . | indent 8 }}  
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.kubewatcher.resources | nindent 10 }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -32,10 +32,6 @@ spec:
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.kubewatcher.resources | nindent 10 }}
-        {{- if .Values.informerNamespace.kubernetesWatch }}
-        - name: KUBERNETES_WATCH_INFORMER_NS
-          value: {{ .Values.informerNamespace.kubernetesWatch | quote }}
-        {{- end}}  
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -38,6 +38,10 @@ spec:
         {{- if .Values.terminationMessagePolicy }}
         terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}
       serviceAccountName: fission-kubewatcher
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -29,6 +29,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        {{- include "additional-namespace.envs" . | indent 8 }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.kubewatcher.resources | nindent 10 }}
@@ -37,10 +38,6 @@ spec:
         {{- end }}
         {{- if .Values.terminationMessagePolicy }}
         terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
-        {{- end }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
         {{- end }}
       serviceAccountName: fission-kubewatcher
 {{- if .Values.priorityClassName }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -32,6 +32,10 @@ spec:
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.kubewatcher.resources | nindent 10 }}
+        {{- if .Values.informerNamespace.kubernetesWatch }}
+        - name: KUBERNETES_WATCH_INFORMER_NS
+          value: {{ .Values.informerNamespace.kubernetesWatch | quote }}
+        {{- end}}  
         {{- if .Values.terminationMessagePath }}
         terminationMessagePath: {{ .Values.terminationMessagePath }}
         {{- end }}

--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- include "additional-namespace.envs" . | indent 8 }} 
+        {{- include "fission-resource-namespace.envs" . | indent 8 }} 
         {{- include "opentelemtry.envs" . | indent 8 }}
         # TLS authentication is TLS with authentication (2 way)
         # More info: https://docs.confluent.io/current/kafka/authentication_ssl.html#ssl-overview

--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -47,6 +47,10 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         # TLS authentication is TLS with authentication (2 way)
         # More info: https://docs.confluent.io/current/kafka/authentication_ssl.html#ssl-overview

--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -47,10 +47,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}  
+        {{- include "additional-namespace.envs" . | indent 8 }} 
         {{- include "opentelemtry.envs" . | indent 8 }}
         # TLS authentication is TLS with authentication (2 way)
         # More info: https://docs.confluent.io/current/kafka/authentication_ssl.html#ssl-overview

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -46,6 +46,10 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.gcp_pubsub.image }}:{{ .Values.mqt_keda.connector_images.gcp_pubsub.tag }}"
         - name: REDIS_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.redis.image }}:{{ .Values.mqt_keda.connector_images.redis.tag }}"
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.mqt_keda.resources | nindent 10 }}

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.gcp_pubsub.image }}:{{ .Values.mqt_keda.connector_images.gcp_pubsub.tag }}"
         - name: REDIS_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.redis.image }}:{{ .Values.mqt_keda.connector_images.redis.tag }}"
-        {{- include "additional-namespace.envs" . | indent 8 }}
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.mqt_keda.resources | nindent 10 }}

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -46,10 +46,7 @@ spec:
           value: "{{ .Values.mqt_keda.connector_images.gcp_pubsub.image }}:{{ .Values.mqt_keda.connector_images.gcp_pubsub.tag }}"
         - name: REDIS_IMAGE
           value: "{{ .Values.mqt_keda.connector_images.redis.image }}:{{ .Values.mqt_keda.connector_images.redis.tag }}"
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}  
+        {{- include "additional-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.mqt_keda.resources | nindent 10 }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -83,7 +83,7 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: DISPLAY_ACCESS_LOG
           value: {{ .Values.router.displayAccessLog | default false | quote }}
-        {{- include "additional-namespace.envs" . | indent 8 }}  
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.router.resources | nindent 10 }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -83,6 +83,10 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: DISPLAY_ACCESS_LOG
           value: {{ .Values.router.displayAccessLog | default false | quote }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.router.resources | nindent 10 }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -83,10 +83,7 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: DISPLAY_ACCESS_LOG
           value: {{ .Values.router.displayAccessLog | default false | quote }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}  
+        {{- include "additional-namespace.envs" . | indent 8 }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.router.resources | nindent 10 }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -83,10 +83,6 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: DISPLAY_ACCESS_LOG
           value: {{ .Values.router.displayAccessLog | default false | quote }}
-        {{- if .Values.informerNamespace.httpTrigger }}
-        - name: HTTP_TRIGGER_INFORMER_NS
-          value: {{ .Values.informerNamespace.httpTrigger | quote }}
-        {{- end}}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.router.resources | nindent 10 }}

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -83,6 +83,10 @@ spec:
           value: {{ .Values.pprof.enabled | quote }}
         - name: DISPLAY_ACCESS_LOG
           value: {{ .Values.router.displayAccessLog | default false | quote }}
+        {{- if .Values.informerNamespace.httpTrigger }}
+        - name: HTTP_TRIGGER_INFORMER_NS
+          value: {{ .Values.informerNamespace.httpTrigger | quote }}
+        {{- end}}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.router.resources | nindent 10 }}

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -60,10 +60,7 @@ spec:
         - name: STORAGE_S3_REGION
           value: {{ .Values.persistence.s3.region }}
         {{- end }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}
+        {{- include "additional-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.storagesvc.resources | nindent 10 }}

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -60,7 +60,7 @@ spec:
         - name: STORAGE_S3_REGION
           value: {{ .Values.persistence.s3.region }}
         {{- end }}
-        {{- include "additional-namespace.envs" . | indent 8 }}
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.storagesvc.resources | nindent 10 }}

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -60,6 +60,10 @@ spec:
         - name: STORAGE_S3_REGION
           value: {{ .Values.persistence.s3.region }}
         {{- end }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.storagesvc.resources | nindent 10 }}

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -29,7 +29,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- include "additional-namespace.envs" . | indent 8 }}
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.timer.resources | nindent 10 }}

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -29,6 +29,10 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        {{- if not .Values.singleDefaultNamespace }}
+        - name: ADDITIONAL_NAMESPACES
+          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
+        {{- end }}  
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.timer.resources | nindent 10 }}

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -29,10 +29,7 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- if not .Values.singleDefaultNamespace }}
-        - name: ADDITIONAL_NAMESPACES
-          value: {{ join "," .Values.additionalFissionNamespaces | quote }}
-        {{- end }}  
+        {{- include "additional-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.timer.resources | nindent 10 }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -75,6 +75,15 @@ builderNamespace: fission-builder
 ##
 defaultNamespace: default
 
+## If true, fission will only watch for fission components created in the `defaultNamespace` above
+##
+singleDefaultNamespace: true
+
+## Fission will watch the following namespaces along with the `defaultNamespace` for fission components.
+## Only works if `singleDefaultNamespace` is false.
+##
+additionalFissionNamespaces: []
+
 ## createNamespace decides to create namespaces by the chart.
 ## If set to true, functionNamespace and builderNamespace namespaces mentioned above will be created by the chart.
 ## Set to false if you want to create the namespaces manually.

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -110,27 +110,6 @@ fetcher:
       requests: "16Mi"
       limits: ""
 
-# informerNamespace to watch informers in specific namespaces.
-informerNamespace:
-  # User can provide comma seperated values for each resources
-  ##
-  # informer namspace for canary config resource
-  canaryConfig: ""
-  # informer namspace for environment resource
-  environment: ""
-  # informer namspace for function resource
-  function: ""
-  # informer namspace for http trigger resource
-  httpTrigger: ""
-  # informer namspace for kubernetes watch trigger resource
-  kubernetesWatch: ""
-  # informer namspace for message queue trigger resource
-  messageQueue: ""
-  # informer namspace for packages resource
-  packages: ""
-  # informer namspace for time trigger resource
-  timeTrigger: ""
-
 ## executor is responsible for providing resources to your functions.
 ##
 executor:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -72,6 +72,7 @@ functionNamespace: fission-function
 builderNamespace: fission-builder
 
 ## defaultNamespace represents the default namespace in Kubernetes.
+## Fission will watch the defaultNamespace only if `singleDefaultNamespace` is true.
 ##
 defaultNamespace: default
 
@@ -81,6 +82,11 @@ singleDefaultNamespace: true
 
 ## Fission will watch the following namespaces along with the `defaultNamespace` for fission components.
 ## Only works if `singleDefaultNamespace` is false.
+## Example for additionalFissionNamespaces
+## additionalFissionNamespaces: 
+  # - namespace1
+  # - namespace2
+  # - namespace3
 ##
 additionalFissionNamespaces: []
 

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -110,6 +110,27 @@ fetcher:
       requests: "16Mi"
       limits: ""
 
+# informerNamespace to watch informers in specific namespaces.
+informerNamespace:
+  # User can provide comma seperated values for each resources
+  ##
+  # informer namspace for canary config resource
+  canaryConfig: ""
+  # informer namspace for environment resource
+  environment: ""
+  # informer namspace for function resource
+  function: ""
+  # informer namspace for http trigger resource
+  httpTrigger: ""
+  # informer namspace for kubernetes watch trigger resource
+  kubernetesWatch: ""
+  # informer namspace for message queue trigger resource
+  messageQueue: ""
+  # informer namspace for packages resource
+  packages: ""
+  # informer namspace for time trigger resource
+  timeTrigger: ""
+
 ## executor is responsible for providing resources to your functions.
 ##
 executor:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -71,23 +71,24 @@ functionNamespace: fission-function
 ##
 builderNamespace: fission-builder
 
-## defaultNamespace represents the default namespace in Kubernetes.
+## defaultNamespace represents the namespace in which Fission custom resources will be created by the Fission user.
+## This is different from the release namespace.
+## Please consider setting `singleDefaultNamespace` and `additionalFissionNamespaces` if you want
+## more than one namespace to be used for Fission custom resources.
 ## Fission will watch the defaultNamespace only if `singleDefaultNamespace` is true.
 ##
 defaultNamespace: default
 
-## If true, fission will only watch for fission components created in the `defaultNamespace` above
+## If true, fission will only watch for fission custom resources created in the `defaultNamespace` above.
 ##
 singleDefaultNamespace: true
 
-## Fission will watch the following namespaces along with the `defaultNamespace` for fission components.
+## Fission will watch the following namespaces along with the `defaultNamespace` for fission custom resources.
 ## Only works if `singleDefaultNamespace` is false.
-## Example for additionalFissionNamespaces
 ## additionalFissionNamespaces: 
-  # - namespace1
-  # - namespace2
-  # - namespace3
-##
+## - namespace1
+## - namespace2
+## - namespace3
 additionalFissionNamespaces: []
 
 ## createNamespace decides to create namespaces by the chart.
@@ -266,7 +267,7 @@ router:
     maxRetries: 10
 
   ## Extend the container specs for the core fission pods.
-  ## Can be used to add things like affinty/tolerations/nodeSelectors/etc.
+  ## Can be used to add things like affinity/tolerations/nodeSelectors/etc.
   ## For example:
   ## extraCoreComponentPodConfig:
   ##   affinity:
@@ -494,8 +495,8 @@ serviceMonitor:
   ##namespace in which you want to deploy servicemonitor
   ##
   namespace: ""
-  ## Map of additional lables to add to the ServiceMonitor resources
-  #  to allow selecting sepcific ServiceMonitors
+  ## Map of additional labels to add to the ServiceMonitor resources
+  #  to allow selecting specific ServiceMonitors
   #  in case of multiple prometheus deployments
   additionalServiceMonitorLabels: {}
   #  release: "monitoring"
@@ -508,8 +509,8 @@ podMonitor:
   ##namespace in which you want to deploy podmonitor
   ##
   namespace: ""
-  ## Map of additional lables to add to the PodMonitor resources
-  #  to allow selecting sepcific PodMonitor
+  ## Map of additional labels to add to the PodMonitor resources
+  #  to allow selecting specific PodMonitor
   #  in case of multiple prometheus deployments
   additionalPodMonitorLabels: {}
   #  release: "monitoring"
@@ -557,7 +558,7 @@ persistence:
   size: 8Gi
 
 ## Extend the container specs for the core fission pods.
-## Can be used to add things like affinty/tolerations/nodeSelectors/etc.
+## Can be used to add things like affinity/tolerations/nodeSelectors/etc.
 ## For example:
 ## extraCoreComponentPodConfig:
 ##   affinity:

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -164,3 +164,15 @@ const (
 	PackagesResource        = "packages"
 	TimeTriggerResource     = "timetriggers"
 )
+
+// These env variables is used to watch informers in specific namespace
+const (
+	CanaryConfigInformerNS    = "CANARY_INFORMER_NS"
+	EnvironmentInformerNS     = "ENVIRONMENT_INFORMER_NS"
+	FunctionInformerNS        = "FUNCTION_INFORMER_NS"
+	HttpTriggerInformerNS     = "HTTP_TRIGGER_INFORMER_NS"
+	KubernetesWatchInformerNS = "KUBERNETES_WATCH_INFORMER_NS"
+	MessageQueueInformerNS    = "MESSAGE_QUEUE_INFORMER_NS"
+	PackagesInformerNS        = "PACKAGE_INFORMER_NS"
+	TimeTriggerInformerNS     = "TIME_TRIGGER_INFORMER_NS"
+)

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -164,15 +164,3 @@ const (
 	PackagesResource        = "packages"
 	TimeTriggerResource     = "timetriggers"
 )
-
-// These env variables is used to watch informers in specific namespace
-const (
-	CanaryConfigInformerNS    = "CANARY_INFORMER_NS"
-	EnvironmentInformerNS     = "ENVIRONMENT_INFORMER_NS"
-	FunctionInformerNS        = "FUNCTION_INFORMER_NS"
-	HttpTriggerInformerNS     = "HTTP_TRIGGER_INFORMER_NS"
-	KubernetesWatchInformerNS = "KUBERNETES_WATCH_INFORMER_NS"
-	MessageQueueInformerNS    = "MESSAGE_QUEUE_INFORMER_NS"
-	PackagesInformerNS        = "PACKAGE_INFORMER_NS"
-	TimeTriggerInformerNS     = "TIME_TRIGGER_INFORMER_NS"
-)

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -153,3 +153,14 @@ const (
 
 	ClusterRole = "ClusterRole"
 )
+
+const (
+	CanaryConfigResource    = "canaryconfigs"
+	EnvironmentResource     = "environments"
+	FunctionResource        = "functions"
+	HttpTriggerResource     = "httptriggers"
+	KubernetesWatchResource = "kuberneteswatchtriggers"
+	MessageQueueResource    = "messagequeuetriggers"
+	PackagesResource        = "packages"
+	TimeTriggerResource     = "timetriggers"
+)

--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -24,7 +24,6 @@ import (
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
 	k8sInformers "k8s.io/client-go/informers"
-	"k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
@@ -68,12 +67,9 @@ func Start(ctx context.Context, logger *zap.Logger, storageSvcUrl string, envBui
 
 	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
 	podInformer := k8sInformerFactory.Core().V1().Pods().Informer()
-	pkgInformers := make([]cache.SharedIndexInformer, 0)
-	for _, pkgInformer := range utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.PackagesResource) {
-		pkgInformers = append(pkgInformers, pkgInformer)
-	}
 	pkgWatcher := makePackageWatcher(bmLogger, fissionClient,
-		kubernetesClient, envBuilderNamespace, storageSvcUrl, podInformer, pkgInformers)
+		kubernetesClient, envBuilderNamespace, storageSvcUrl, podInformer,
+		utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.PackagesResource))
 	pkgWatcher.Run(ctx)
 	return nil
 }

--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
 	k8sInformers "k8s.io/client-go/informers"
+	"k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
@@ -71,7 +72,7 @@ func Start(ctx context.Context, logger *zap.Logger, storageSvcUrl string, envBui
 	podInformer := k8sInformerFactory.Core().V1().Pods().Informer()
 	pkgInformer := informerFactory.Core().V1().Packages().Informer()
 	pkgWatcher := makePackageWatcher(bmLogger, fissionClient,
-		kubernetesClient, envBuilderNamespace, storageSvcUrl, &podInformer, &pkgInformer)
+		kubernetesClient, envBuilderNamespace, storageSvcUrl, podInformer, []cache.SharedIndexInformer{pkgInformer})
 	pkgWatcher.Run(ctx)
 	return nil
 }

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -41,7 +41,7 @@ type (
 		fissionClient    versioned.Interface
 		k8sClient        kubernetes.Interface
 		podInformer      k8sCache.SharedIndexInformer
-		pkgInformer      []k8sCache.SharedIndexInformer
+		pkgInformer      map[string]k8sCache.SharedIndexInformer
 		builderNamespace string
 		storageSvcUrl    string
 		buildCache       *cache.Cache
@@ -50,7 +50,7 @@ type (
 
 func makePackageWatcher(logger *zap.Logger, fissionClient versioned.Interface, k8sClientSet kubernetes.Interface,
 	builderNamespace string, storageSvcUrl string, podInformer k8sCache.SharedIndexInformer,
-	pkgInformer []k8sCache.SharedIndexInformer) *packageWatcher {
+	pkgInformer map[string]k8sCache.SharedIndexInformer) *packageWatcher {
 	pkgw := &packageWatcher{
 		logger:           logger.Named("package_watcher"),
 		fissionClient:    fissionClient,

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -325,7 +325,7 @@ func (pkgw *packageWatcher) Run(ctx context.Context) {
 	go metrics.ServeMetrics(ctx, pkgw.logger)
 	go pkgw.podInformer.Run(ctx.Done())
 	for _, pkgInformer := range pkgw.pkgInformer {
-		pkgInformer.AddEventHandler(pkgw.packageInformerHandler())
+		pkgInformer.AddEventHandler(pkgw.packageInformerHandler(ctx))
 		pkgInformer.Run(ctx.Done())
 	}
 }

--- a/pkg/canaryconfigmgr/canaryConfigMgr.go
+++ b/pkg/canaryconfigmgr/canaryConfigMgr.go
@@ -44,7 +44,7 @@ type canaryConfigMgr struct {
 	logger                 *zap.Logger
 	fissionClient          versioned.Interface
 	kubeClient             kubernetes.Interface
-	canaryConfigInformer   []k8sCache.SharedIndexInformer
+	canaryConfigInformer   map[string]k8sCache.SharedIndexInformer
 	promClient             *PrometheusApiClient
 	canaryCfgCancelFuncMap *canaryConfigCancelFuncMap
 }
@@ -92,11 +92,7 @@ func MakeCanaryConfigMgr(ctx context.Context, logger *zap.Logger, fissionClient 
 		promClient:             promClient,
 		canaryCfgCancelFuncMap: makecanaryConfigCancelFuncMap(),
 	}
-	canaryInformers := make([]k8sCache.SharedIndexInformer, 0)
-	for _, informer := range utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.CanaryConfigResource) {
-		canaryInformers = append(canaryInformers, informer)
-	}
-	configMgr.canaryConfigInformer = canaryInformers
+	configMgr.canaryConfigInformer = utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.CanaryConfigResource)
 	configMgr.CanaryConfigEventHandlers(ctx)
 	return configMgr, nil
 }

--- a/pkg/canaryconfigmgr/canaryConfigMgr.go
+++ b/pkg/canaryconfigmgr/canaryConfigMgr.go
@@ -33,7 +33,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
+	"github.com/fission/fission/pkg/utils"
 )
 
 const (
@@ -44,7 +44,7 @@ type canaryConfigMgr struct {
 	logger                 *zap.Logger
 	fissionClient          versioned.Interface
 	kubeClient             kubernetes.Interface
-	canaryConfigInformer   *k8sCache.SharedIndexInformer
+	canaryConfigInformer   []k8sCache.SharedIndexInformer
 	promClient             *PrometheusApiClient
 	canaryCfgCancelFuncMap *canaryConfigCancelFuncMap
 }
@@ -92,45 +92,50 @@ func MakeCanaryConfigMgr(ctx context.Context, logger *zap.Logger, fissionClient 
 		promClient:             promClient,
 		canaryCfgCancelFuncMap: makecanaryConfigCancelFuncMap(),
 	}
-
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
-	informer := informerFactory.Core().V1().CanaryConfigs().Informer()
-	configMgr.canaryConfigInformer = &informer
+	canaryInformers := make([]k8sCache.SharedIndexInformer, 0)
+	for _, informer := range utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.CanaryConfigResource) {
+		canaryInformers = append(canaryInformers, informer)
+	}
+	configMgr.canaryConfigInformer = canaryInformers
 	configMgr.CanaryConfigEventHandlers(ctx)
 	return configMgr, nil
 }
 
 func (canaryCfgMgr *canaryConfigMgr) CanaryConfigEventHandlers(ctx context.Context) {
-	(*canaryCfgMgr.canaryConfigInformer).AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			canaryConfig := obj.(*fv1.CanaryConfig)
-			if canaryConfig.Status.Status == fv1.CanaryConfigStatusPending {
-				go canaryCfgMgr.addCanaryConfig(ctx, canaryConfig)
-			}
-		},
-		DeleteFunc: func(obj interface{}) {
-			canaryConfig := obj.(*fv1.CanaryConfig)
-			go canaryCfgMgr.deleteCanaryConfig(canaryConfig)
-		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-			oldConfig := oldObj.(*fv1.CanaryConfig)
-			newConfig := newObj.(*fv1.CanaryConfig)
-			if oldConfig.ObjectMeta.ResourceVersion != newConfig.ObjectMeta.ResourceVersion &&
-				newConfig.Status.Status == fv1.CanaryConfigStatusPending {
-				canaryCfgMgr.logger.Info("update canary config invoked",
-					zap.String("name", newConfig.ObjectMeta.Name),
-					zap.String("namespace", newConfig.ObjectMeta.Namespace),
-					zap.String("version", newConfig.ObjectMeta.ResourceVersion))
-				go canaryCfgMgr.updateCanaryConfig(ctx, oldConfig, newConfig)
-			}
-			go canaryCfgMgr.reSyncCanaryConfigs(ctx)
+	for _, informer := range canaryCfgMgr.canaryConfigInformer {
+		informer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				canaryConfig := obj.(*fv1.CanaryConfig)
+				if canaryConfig.Status.Status == fv1.CanaryConfigStatusPending {
+					go canaryCfgMgr.addCanaryConfig(ctx, canaryConfig)
+				}
+			},
+			DeleteFunc: func(obj interface{}) {
+				canaryConfig := obj.(*fv1.CanaryConfig)
+				go canaryCfgMgr.deleteCanaryConfig(canaryConfig)
+			},
+			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+				oldConfig := oldObj.(*fv1.CanaryConfig)
+				newConfig := newObj.(*fv1.CanaryConfig)
+				if oldConfig.ObjectMeta.ResourceVersion != newConfig.ObjectMeta.ResourceVersion &&
+					newConfig.Status.Status == fv1.CanaryConfigStatusPending {
+					canaryCfgMgr.logger.Info("update canary config invoked",
+						zap.String("name", newConfig.ObjectMeta.Name),
+						zap.String("namespace", newConfig.ObjectMeta.Namespace),
+						zap.String("version", newConfig.ObjectMeta.ResourceVersion))
+					go canaryCfgMgr.updateCanaryConfig(ctx, oldConfig, newConfig)
+				}
+				go canaryCfgMgr.reSyncCanaryConfigs(ctx)
 
-		},
-	})
+			},
+		})
+	}
 }
 
 func (canaryCfgMgr *canaryConfigMgr) Run(ctx context.Context) {
-	go (*canaryCfgMgr.canaryConfigInformer).Run(ctx.Done())
+	for _, informer := range canaryCfgMgr.canaryConfigInformer {
+		go informer.Run(ctx.Done())
+	}
 	canaryCfgMgr.logger.Info("started canary configmgr controller")
 }
 
@@ -492,17 +497,19 @@ func (canaryCfgMgr *canaryConfigMgr) rollForward(ctx context.Context, canaryConf
 }
 
 func (canaryCfgMgr *canaryConfigMgr) reSyncCanaryConfigs(ctx context.Context) {
-	for _, obj := range (*canaryCfgMgr.canaryConfigInformer).GetStore().List() {
-		canaryConfig := obj.(*fv1.CanaryConfig)
-		_, err := canaryCfgMgr.canaryCfgCancelFuncMap.lookup(&canaryConfig.ObjectMeta)
-		if err != nil && canaryConfig.Status.Status == fv1.CanaryConfigStatusPending {
-			canaryCfgMgr.logger.Debug("adding canary config from resync loop",
-				zap.String("name", canaryConfig.ObjectMeta.Name),
-				zap.String("namespace", canaryConfig.ObjectMeta.Namespace),
-				zap.String("version", canaryConfig.ObjectMeta.ResourceVersion))
+	for _, informer := range canaryCfgMgr.canaryConfigInformer {
+		for _, obj := range informer.GetStore().List() {
+			canaryConfig := obj.(*fv1.CanaryConfig)
+			_, err := canaryCfgMgr.canaryCfgCancelFuncMap.lookup(&canaryConfig.ObjectMeta)
+			if err != nil && canaryConfig.Status.Status == fv1.CanaryConfigStatusPending {
+				canaryCfgMgr.logger.Debug("adding canary config from resync loop",
+					zap.String("name", canaryConfig.ObjectMeta.Name),
+					zap.String("namespace", canaryConfig.ObjectMeta.Namespace),
+					zap.String("version", canaryConfig.ObjectMeta.ResourceVersion))
 
-			// new canaryConfig detected, add it to our cache and start processing it
-			go canaryCfgMgr.addCanaryConfig(ctx, canaryConfig)
+				// new canaryConfig detected, add it to our cache and start processing it
+				go canaryCfgMgr.addCanaryConfig(ctx, canaryConfig)
+			}
 		}
 	}
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -289,17 +289,17 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	envInformer := make(map[string]finformerv1.EnvironmentInformer, 0)
 	pkgInformer := make(map[string]finformerv1.PackageInformer, 0)
 
-	for _, ns := range utils.GetNamespaces(fv1.FunctionResource) {
+	for _, ns := range utils.GetNamespaces() {
 		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
 		funcInformer[ns] = factory.Core().V1().Functions()
 	}
 
-	for _, ns := range utils.GetNamespaces(fv1.EnvironmentResource) {
+	for _, ns := range utils.GetNamespaces() {
 		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
 		envInformer[ns] = factory.Core().V1().Environments()
 	}
 
-	for _, ns := range utils.GetNamespaces(fv1.PackagesResource) {
+	for _, ns := range utils.GetNamespaces() {
 		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
 		pkgInformer[ns] = factory.Core().V1().Packages()
 	}

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -45,6 +45,7 @@ import (
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
+	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/metrics"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -79,7 +80,7 @@ type (
 // MakeExecutor returns an Executor for given ExecutorType(s).
 func MakeExecutor(ctx context.Context, logger *zap.Logger, cms *cms.ConfigSecretController,
 	fissionClient versioned.Interface, types map[fv1.ExecutorType]executortype.ExecutorType,
-	informers []k8sCache.SharedIndexInformer) (*Executor, error) {
+	informers ...k8sCache.SharedIndexInformer) (*Executor, error) {
 	executor := &Executor{
 		logger:        logger.Named("executor"),
 		cms:           cms,
@@ -284,10 +285,24 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 
 	logger.Info("Starting executor", zap.String("instanceID", executorInstanceID))
 
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
-	funcInformer := informerFactory.Core().V1().Functions()
-	pkgInformer := informerFactory.Core().V1().Packages()
-	envInformer := informerFactory.Core().V1().Environments()
+	funcInformer := make(map[string]finformerv1.FunctionInformer, 0)
+	envInformer := make(map[string]finformerv1.EnvironmentInformer, 0)
+	pkgInformer := make(map[string]finformerv1.PackageInformer, 0)
+
+	for _, ns := range utils.GetNamespaces(fv1.FunctionResource) {
+		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
+		funcInformer[ns] = factory.Core().V1().Functions()
+	}
+
+	for _, ns := range utils.GetNamespaces(fv1.EnvironmentResource) {
+		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
+		envInformer[ns] = factory.Core().V1().Environments()
+	}
+
+	for _, ns := range utils.GetNamespaces(fv1.PackagesResource) {
+		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
+		pkgInformer[ns] = factory.Core().V1().Packages()
+	}
 
 	gpmInformerFactory, err := utils.GetInformerFactoryByExecutor(kubernetesClient, fv1.ExecutorTypePoolmgr, time.Minute*30)
 	if err != nil {
@@ -364,20 +379,29 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 
 	cms := cms.MakeConfigSecretController(ctx, logger, fissionClient, kubernetesClient, executorTypes, configmapInformer, secretInformer)
 
+	fissionInformers := make([]k8sCache.SharedIndexInformer, 0)
+	for _, informer := range funcInformer {
+		fissionInformers = append(fissionInformers, informer.Informer())
+	}
+	for _, informer := range envInformer {
+		fissionInformers = append(fissionInformers, informer.Informer())
+	}
+	for _, informer := range pkgInformer {
+		fissionInformers = append(fissionInformers, informer.Informer())
+	}
+	fissionInformers = append(fissionInformers,
+		configmapInformer.Informer(),
+		secretInformer.Informer(),
+		gpmPodInformer.Informer(),
+		gpmRsInformer.Informer(),
+		ndmDeplInformer.Informer(),
+		ndmSvcInformer.Informer(),
+		cnmDeplInformer.Informer(),
+		cnmSvcInformer.Informer(),
+	)
 	api, err := MakeExecutor(ctx, logger, cms, fissionClient, executorTypes,
-		[]k8sCache.SharedIndexInformer{
-			funcInformer.Informer(),
-			pkgInformer.Informer(),
-			envInformer.Informer(),
-			configmapInformer.Informer(),
-			secretInformer.Informer(),
-			gpmPodInformer.Informer(),
-			gpmRsInformer.Informer(),
-			ndmDeplInformer.Informer(),
-			ndmSvcInformer.Informer(),
-			cnmDeplInformer.Informer(),
-			cnmSvcInformer.Informer(),
-		})
+		fissionInformers...,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -98,7 +98,7 @@ func MakeContainer(
 	kubernetesClient kubernetes.Interface,
 	namespace string,
 	instanceID string,
-	funcInformer finformerv1.FunctionInformer,
+	funcInformer map[string]finformerv1.FunctionInformer,
 	deplInformer appsinformers.DeploymentInformer,
 	svcInformer coreinformers.ServiceInformer,
 ) (executortype.ExecutorType, error) {
@@ -135,7 +135,9 @@ func MakeContainer(
 	caaf.svcLister = svcInformer.Lister()
 	caaf.svcListerSynced = svcInformer.Informer().HasSynced
 
-	funcInformer.Informer().AddEventHandler(caaf.FuncInformerHandler(ctx))
+	for _, informer := range funcInformer {
+		informer.Informer().AddEventHandler(caaf.FuncInformerHandler(ctx))
+	}
 	return caaf, nil
 }
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -103,8 +103,8 @@ func MakeNewDeploy(
 	namespace string,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	funcInformer finformerv1.FunctionInformer,
-	envInformer finformerv1.EnvironmentInformer,
+	funcInformer map[string]finformerv1.FunctionInformer,
+	envInformer map[string]finformerv1.EnvironmentInformer,
 	deplInformer appsinformers.DeploymentInformer,
 	svcInformer coreinformers.ServiceInformer,
 	podSpecPatch *apiv1.PodSpec,
@@ -146,9 +146,12 @@ func MakeNewDeploy(
 	nd.svcLister = svcInformer.Lister()
 	nd.svcListerSynced = svcInformer.Informer().HasSynced
 
-	funcInformer.Informer().AddEventHandler(nd.FunctionEventHandlers(ctx))
-	envInformer.Informer().AddEventHandler(nd.EnvEventHandlers(ctx))
-
+	for _, fnInformer := range funcInformer {
+		fnInformer.Informer().AddEventHandler(nd.FunctionEventHandlers(ctx))
+	}
+	for _, envInformer := range envInformer {
+		envInformer.Informer().AddEventHandler(nd.EnvEventHandlers(ctx))
+	}
 	return nd, nil
 }
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -119,9 +119,9 @@ func MakeGenericPoolManager(ctx context.Context,
 	functionNamespace string,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	funcInformer finformerv1.FunctionInformer,
-	pkgInformer finformerv1.PackageInformer,
-	envInformer finformerv1.EnvironmentInformer,
+	funcInformer map[string]finformerv1.FunctionInformer,
+	pkgInformer map[string]finformerv1.PackageInformer,
+	envInformer map[string]finformerv1.EnvironmentInformer,
 	podInformer coreinformers.PodInformer,
 	rsInformer appsinformers.ReplicaSetInformer,
 	podSpecPatch *apiv1.PodSpec,
@@ -554,7 +554,11 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 	}
 
 	// Get env from controller
-	env, err = gpm.poolPodC.envLister.Environments(fn.Spec.Environment.Namespace).Get(fn.Spec.Environment.Name)
+	envLister, err := gpm.poolPodC.getEnvLister(fn.Spec.Environment.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	env, err = envLister.Environments(fn.Spec.Environment.Namespace).Get(fn.Spec.Environment.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -272,6 +272,7 @@ func (p *PoolPodController) getEnvLister(namespace string) (flisterv1.Environmen
 			return lister, nil
 		}
 	}
+	p.logger.Error("no environment lister found for namespace", zap.String("namespace", namespace))
 	return nil, fmt.Errorf("no environment lister found for namespace %s", namespace)
 }
 

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -80,8 +80,7 @@ func MakeMessageQueueTriggerManager(logger *zap.Logger,
 
 func (mqt *MessageQueueTriggerManager) Run(ctx context.Context) {
 	go mqt.service()
-	informers := utils.GetInformersForNamespaces(mqt.fissionClient, time.Minute*30, fv1.MessageQueueResource)
-	for _, informer := range informers {
+	for _, informer := range utils.GetInformersForNamespaces(mqt.fissionClient, time.Minute*30, fv1.MessageQueueResource) {
 		informer.AddEventHandler(mqt.mqtInformerHandlers())
 		go informer.Run(ctx.Done())
 		if ok := k8sCache.WaitForCacheSync(ctx.Done(), informer.HasSynced); !ok {

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -158,8 +158,7 @@ func StartScalerManager(ctx context.Context, logger *zap.Logger, routerURL strin
 		return errors.Wrap(err, "error waiting for CRDs")
 	}
 
-	informers := utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.MessageQueueResource)
-	for _, informer := range informers {
+	for _, informer := range utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.MessageQueueResource) {
 		informer.AddEventHandler(mqTriggerEventHandlers(ctx, logger, kubeClient, routerURL))
 		go informer.Run(ctx.Done())
 		if ok := k8sCache.WaitForCacheSync(ctx.Done(), informer.HasSynced); !ok {

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -24,7 +24,6 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/executor/util"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -158,10 +157,15 @@ func StartScalerManager(ctx context.Context, logger *zap.Logger, routerURL strin
 	if err != nil {
 		return errors.Wrap(err, "error waiting for CRDs")
 	}
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
-	mqTriggerInformer := informerFactory.Core().V1().MessageQueueTriggers().Informer()
-	mqTriggerInformer.AddEventHandler(mqTriggerEventHandlers(ctx, logger, kubeClient, routerURL))
-	mqTriggerInformer.Run(ctx.Done())
+
+	informers := utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.MessageQueueResource)
+	for _, informer := range informers {
+		informer.AddEventHandler(mqTriggerEventHandlers(ctx, logger, kubeClient, routerURL))
+		go informer.Run(ctx.Done())
+		if ok := k8sCache.WaitForCacheSync(ctx.Done(), informer.HasSynced); !ok {
+			logger.Fatal("failed to wait for caches to sync")
+		}
+	}
 	return nil
 }
 

--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -35,7 +35,7 @@ type (
 	functionReferenceResolver struct {
 		// FunctionReference -> function metadata
 		refCache     *cache.Cache
-		funcInformer []k8sCache.SharedIndexInformer
+		funcInformer map[string]k8sCache.SharedIndexInformer
 		logger       *zap.Logger
 		// store    k8sCache.Store
 	}
@@ -71,7 +71,7 @@ const (
 	resolveResultMultipleFunctions
 )
 
-func makeFunctionReferenceResolver(logger *zap.Logger, funcInformer []k8sCache.SharedIndexInformer) *functionReferenceResolver {
+func makeFunctionReferenceResolver(logger *zap.Logger, funcInformer map[string]k8sCache.SharedIndexInformer) *functionReferenceResolver {
 	frr := &functionReferenceResolver{
 		refCache:     cache.MakeCache(time.Minute, 0),
 		funcInformer: funcInformer,

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -89,7 +89,7 @@ func makeHTTPTriggerSet(logger *zap.Logger, fmap *functionServiceMap, fissionCli
 }
 
 func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mr *mutableRouter) {
-	resolver := makeFunctionReferenceResolver(ts.funcInformer)
+	resolver := makeFunctionReferenceResolver(ts.logger, ts.funcInformer)
 	ts.resolver = resolver
 	ts.mutableRouter = mr
 

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -32,7 +32,6 @@ import (
 	executorClient "github.com/fission/fission/pkg/executor/client"
 	config "github.com/fission/fission/pkg/featureconfig"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/metrics"
@@ -50,9 +49,9 @@ type HTTPTriggerSet struct {
 	executor                   *executorClient.Client
 	resolver                   *functionReferenceResolver
 	triggers                   []fv1.HTTPTrigger
-	triggerInformer            k8sCache.SharedIndexInformer
+	triggerInformer            []k8sCache.SharedIndexInformer
 	functions                  []fv1.Function
-	funcInformer               k8sCache.SharedIndexInformer
+	funcInformer               []k8sCache.SharedIndexInformer
 	updateRouterRequestChannel chan struct{}
 	tsRoundTripperParams       *tsRoundTripperParams
 	isDebugEnv                 bool
@@ -76,18 +75,21 @@ func makeHTTPTriggerSet(logger *zap.Logger, fmap *functionServiceMap, fissionCli
 		svcAddrUpdateThrottler:     actionThrottler,
 		unTapServiceTimeout:        unTapServiceTimeout,
 	}
-
-	informerFactory := genInformer.NewSharedInformerFactory(fissionClient, time.Minute*30)
-	httpTriggerSet.triggerInformer = informerFactory.Core().V1().HTTPTriggers().Informer()
-	httpTriggerSet.funcInformer = informerFactory.Core().V1().Functions().Informer()
-
+	httpTriggerSet.triggerInformer = make([]k8sCache.SharedIndexInformer, 0)
+	for _, informer := range utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.HttpTriggerResource) {
+		httpTriggerSet.triggerInformer = append(httpTriggerSet.triggerInformer, informer)
+	}
+	httpTriggerSet.funcInformer = make([]k8sCache.SharedIndexInformer, 0)
+	for _, informer := range utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.FunctionResource) {
+		httpTriggerSet.funcInformer = append(httpTriggerSet.funcInformer, informer)
+	}
 	httpTriggerSet.addTriggerHandlers()
 	httpTriggerSet.addFunctionHandlers()
 	return httpTriggerSet
 }
 
 func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mr *mutableRouter) {
-	resolver := makeFunctionReferenceResolver(&ts.funcInformer)
+	resolver := makeFunctionReferenceResolver(ts.funcInformer)
 	ts.resolver = resolver
 	ts.mutableRouter = mr
 
@@ -280,70 +282,75 @@ func (ts *HTTPTriggerSet) updateTriggerStatusFailed(ht *fv1.HTTPTrigger, err err
 }
 
 func (ts *HTTPTriggerSet) addTriggerHandlers() {
-	ts.triggerInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			trigger := obj.(*fv1.HTTPTrigger)
-			go createIngress(context.Background(), ts.logger, trigger, ts.kubeClient)
-			ts.syncTriggers()
-		},
-		DeleteFunc: func(obj interface{}) {
-			ts.syncTriggers()
-			trigger := obj.(*fv1.HTTPTrigger)
-			go deleteIngress(context.Background(), ts.logger, trigger, ts.kubeClient)
-		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-			oldTrigger := oldObj.(*fv1.HTTPTrigger)
-			newTrigger := newObj.(*fv1.HTTPTrigger)
+	for _, triggerInformer := range ts.triggerInformer {
+		triggerInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				trigger := obj.(*fv1.HTTPTrigger)
+				go createIngress(context.Background(), ts.logger, trigger, ts.kubeClient)
+				ts.syncTriggers()
+			},
+			DeleteFunc: func(obj interface{}) {
+				ts.syncTriggers()
+				trigger := obj.(*fv1.HTTPTrigger)
+				go deleteIngress(context.Background(), ts.logger, trigger, ts.kubeClient)
+			},
+			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+				oldTrigger := oldObj.(*fv1.HTTPTrigger)
+				newTrigger := newObj.(*fv1.HTTPTrigger)
 
-			if oldTrigger.ObjectMeta.ResourceVersion == newTrigger.ObjectMeta.ResourceVersion {
-				return
-			}
+				if oldTrigger.ObjectMeta.ResourceVersion == newTrigger.ObjectMeta.ResourceVersion {
+					return
+				}
 
-			go updateIngress(context.Background(), ts.logger, oldTrigger, newTrigger, ts.kubeClient)
-			ts.syncTriggers()
-		},
-	})
+				go updateIngress(context.Background(), ts.logger, oldTrigger, newTrigger, ts.kubeClient)
+				ts.syncTriggers()
+			},
+		})
+	}
 }
 
 func (ts *HTTPTriggerSet) addFunctionHandlers() {
-	ts.funcInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
-			ts.syncTriggers()
-		},
-		DeleteFunc: func(obj interface{}) {
-			ts.syncTriggers()
-		},
-		UpdateFunc: func(oldObj interface{}, newObj interface{}) {
-			oldFn := oldObj.(*fv1.Function)
-			fn := newObj.(*fv1.Function)
+	for _, funcInformer := range ts.funcInformer {
 
-			if oldFn.ObjectMeta.ResourceVersion == fn.ObjectMeta.ResourceVersion {
-				return
-			}
+		funcInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+			AddFunc: func(obj interface{}) {
+				ts.syncTriggers()
+			},
+			DeleteFunc: func(obj interface{}) {
+				ts.syncTriggers()
+			},
+			UpdateFunc: func(oldObj interface{}, newObj interface{}) {
+				oldFn := oldObj.(*fv1.Function)
+				fn := newObj.(*fv1.Function)
 
-			// update resolver function reference cache
-			for key, rr := range ts.resolver.copy() {
-				if key.namespace == fn.ObjectMeta.Namespace &&
-					rr.functionMap[fn.ObjectMeta.Name] != nil &&
-					rr.functionMap[fn.ObjectMeta.Name].ObjectMeta.ResourceVersion != fn.ObjectMeta.ResourceVersion {
-					// invalidate resolver cache
-					ts.logger.Debug("invalidating resolver cache")
-					err := ts.resolver.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
-					if err != nil {
-						ts.logger.Error("error deleting functionReferenceResolver cache", zap.Error(err))
-					}
-					break
+				if oldFn.ObjectMeta.ResourceVersion == fn.ObjectMeta.ResourceVersion {
+					return
 				}
-			}
-			ts.syncTriggers()
-		},
-	})
+
+				// update resolver function reference cache
+				for key, rr := range ts.resolver.copy() {
+					if key.namespace == fn.ObjectMeta.Namespace &&
+						rr.functionMap[fn.ObjectMeta.Name] != nil &&
+						rr.functionMap[fn.ObjectMeta.Name].ObjectMeta.ResourceVersion != fn.ObjectMeta.ResourceVersion {
+						// invalidate resolver cache
+						ts.logger.Debug("invalidating resolver cache")
+						err := ts.resolver.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
+						if err != nil {
+							ts.logger.Error("error deleting functionReferenceResolver cache", zap.Error(err))
+						}
+						break
+					}
+				}
+				ts.syncTriggers()
+			},
+		})
+	}
 }
 
-func (ts *HTTPTriggerSet) runInformer(ctx context.Context, informer k8sCache.SharedIndexInformer) {
-	go func() {
-		informer.Run(ctx.Done())
-	}()
+func (ts *HTTPTriggerSet) runInformer(ctx context.Context, informer []k8sCache.SharedIndexInformer) {
+	for _, inf := range informer {
+		go inf.Run(ctx.Done())
+	}
 }
 
 func (ts *HTTPTriggerSet) syncTriggers() {
@@ -353,23 +360,27 @@ func (ts *HTTPTriggerSet) syncTriggers() {
 func (ts *HTTPTriggerSet) updateRouter() {
 	for range ts.updateRouterRequestChannel {
 		// get triggers
-		latestTriggers := ts.triggerInformer.GetStore().List()
-		triggers := make([]fv1.HTTPTrigger, len(latestTriggers))
-		for _, t := range latestTriggers {
-			triggers = append(triggers, *t.(*fv1.HTTPTrigger))
+		alltriggers := make([]fv1.HTTPTrigger, 0)
+		for _, triggerInformer := range ts.triggerInformer {
+			latestTriggers := triggerInformer.GetStore().List()
+			for _, t := range latestTriggers {
+				alltriggers = append(alltriggers, *t.(*fv1.HTTPTrigger))
+			}
 		}
-		ts.triggers = triggers
+		ts.triggers = alltriggers
 
 		// get functions
-		latestFunctions := ts.funcInformer.GetStore().List()
-		functionTimeout := make(map[types.UID]int, len(latestFunctions))
-		functions := make([]fv1.Function, len(latestFunctions))
-		for _, f := range latestFunctions {
-			fn := *f.(*fv1.Function)
-			functionTimeout[fn.ObjectMeta.UID] = fn.Spec.FunctionTimeout
-			functions = append(functions, *f.(*fv1.Function))
+		allfunctions := make([]fv1.Function, 0)
+		functionTimeout := make(map[types.UID]int, 0)
+		for _, funcInformer := range ts.funcInformer {
+			latestFunctions := funcInformer.GetStore().List()
+			for _, f := range latestFunctions {
+				fn := *f.(*fv1.Function)
+				functionTimeout[fn.ObjectMeta.UID] = fn.Spec.FunctionTimeout
+				allfunctions = append(allfunctions, *f.(*fv1.Function))
+			}
 		}
-		ts.functions = functions
+		ts.functions = allfunctions
 
 		// make a new router and use it
 		ts.mutableRouter.updateRouter(ts.getRouter(functionTimeout))

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -20,7 +20,7 @@ import (
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 )
 
-const additionalNamespaces string = "ADDITIONAL_NAMESPACES"
+const additionalNamespaces string = "FISSION_RESOURCE_NAMESPACES"
 
 func GetNamespaces() []string {
 	envValue := os.Getenv(additionalNamespaces)

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -13,6 +13,12 @@ import (
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
+func GetNamespaces() []string {
+	return []string{
+		metav1.NamespaceAll,
+	}
+}
+
 func GetInformerFactoryByReadyPod(client kubernetes.Interface, namespace string, labelSelector *metav1.LabelSelector) (k8sInformers.SharedInformerFactory, error) {
 	informerFactory := k8sInformers.NewSharedInformerFactoryWithOptions(client, 0,
 		k8sInformers.WithNamespace(namespace),

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"os"
-	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,48 +18,10 @@ import (
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 )
 
-func getEnvVal(name string) []string {
-	envValue := os.Getenv(name)
-	if len(envValue) == 0 {
-		return []string{
-			metav1.NamespaceAll,
-		}
-	}
-
-	informerNS := make([]string, 0)
-	lstNamespaces := strings.Split(envValue, ",")
-	for _, namespace := range lstNamespaces {
-		//check to handle string with additional comma at the end of string. eg- ns1,ns2,
-		if namespace != "" {
-			informerNS = append(informerNS, namespace)
-		}
-	}
-	return informerNS
-}
-
 func GetNamespaces(kind string) []string {
-	var namespaces []string
-	switch kind {
-	case fv1.CanaryConfigResource:
-		namespaces = getEnvVal(fv1.CanaryConfigInformerNS)
-	case fv1.EnvironmentResource:
-		namespaces = getEnvVal(fv1.EnvironmentInformerNS)
-	case fv1.FunctionResource:
-		namespaces = getEnvVal(fv1.FunctionInformerNS)
-	case fv1.HttpTriggerResource:
-		namespaces = getEnvVal(fv1.HttpTriggerInformerNS)
-	case fv1.KubernetesWatchResource:
-		namespaces = getEnvVal(fv1.KubernetesWatchInformerNS)
-	case fv1.MessageQueueResource:
-		namespaces = getEnvVal(fv1.MessageQueueInformerNS)
-	case fv1.PackagesResource:
-		namespaces = getEnvVal(fv1.PackagesInformerNS)
-	case fv1.TimeTriggerResource:
-		namespaces = getEnvVal(fv1.TimeTriggerInformerNS)
-	default:
-		panic("Unknown kind: " + kind)
+	return []string{
+		metav1.NamespaceAll,
 	}
-	return namespaces
 }
 
 func GetInformersForNamespaces(client versioned.Interface, defaultSync time.Duration, kind string) map[string]cache.SharedIndexInformer {

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"os"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,15 +20,30 @@ import (
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 )
 
-func GetNamespaces(kind string) []string {
-	return []string{
-		metav1.NamespaceAll,
+const additionalNamespaces string = "ADDITIONAL_NAMESPACES"
+
+func GetNamespaces() []string {
+	envValue := os.Getenv(additionalNamespaces)
+	if len(envValue) == 0 {
+		return []string{
+			metav1.NamespaceAll,
+		}
 	}
+
+	informerNS := make([]string, 0)
+	lstNamespaces := strings.Split(envValue, ",")
+	for _, namespace := range lstNamespaces {
+		//check to handle string with additional comma at the end of string. eg- ns1,ns2,
+		if namespace != "" {
+			informerNS = append(informerNS, namespace)
+		}
+	}
+	return informerNS
 }
 
 func GetInformersForNamespaces(client versioned.Interface, defaultSync time.Duration, kind string) map[string]cache.SharedIndexInformer {
 	informers := make(map[string]cache.SharedIndexInformer)
-	for _, ns := range GetNamespaces(kind) {
+	for _, ns := range GetNamespaces() {
 		factory := genInformer.NewFilteredSharedInformerFactory(client, defaultSync, ns, nil).Core().V1()
 		switch kind {
 		case fv1.CanaryConfigResource:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
These changes will allow to configure CRD resources according to namespaces. Previously CRD could have only be configured in default namespace provided by user in values.yaml file under defaultNamespace field.

Helm Changes
We have added two new field in helm.
1. additionalFissionNamespaces: [] - This will be a type of array, where user can provide multiple namespaces.
    eg-
   ```
    additionalFissionNamespaces: 
     - namespace1
     - namespace2
     - namespace3
      ```
2. singleDefaultNamespace: boolean - This will be a boolean value and default value will be true. If this field sets to true then fission will always use only default namespace provided by user under defaultNamespace field. If this set to false then fission will use namespaces defined in additionalFissionNamespaces field along with defaultNamespace.

For example - if values in helm defined something like this, then fission will use default, namespace1, namespace2 and namespace3.
```
defaultNamespace: default
singleDefaultNamespace: false
additionalFissionNamespaces: 
 - namespace1
 - namespace2
 - namespace3
 ``` 
## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
