### PR TITLE
Add yaml manifest generation for CI releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,6 +62,12 @@ jobs:
         env:
           KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
 
+      - name: Generate yaml for manifest, Minikube and Openshift installation
+        run: ${GITHUB_WORKSPACE}/hack/build-yaml.sh $VERSION
+        env:
+          VERSION: ${{ steps.get_version.outputs.VERSION }}
+        shell: bash
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:

--- a/hack/build-yaml.sh
+++ b/hack/build-yaml.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+set -e
+set -x
+
+DIR=${GITHUB_WORKSPACE}
+MANIFESTDIR=${GITHUB_WORKSPACE}/manifest
+CHARTPATH=${GITHUB_WORKSPACE}/charts/fission-all
+
+source $(realpath "${DIR}"/test/init_tools.sh)
+doit() {
+    echo "! $*"
+    "$@"
+}
+
+build_yamls() {
+    local version=$1
+
+    mkdir -p "${MANIFESTDIR}"/yamls
+    releaseName=fission-$(echo "${version}" | sed 's/\./-/g')
+
+    cd $CHARTPATH
+    doit helm dependency update
+    cd $GITHUB_WORKSPACE
+
+    echo "Release name", "$releaseName"
+    cmdprefix="helm template ${releaseName} ${CHARTPATH} --namespace fission --validate"
+
+    # for minikube and other environments that don't support LoadBalancer
+    command="$cmdprefix --set analytics=false,analyticsNonHelmInstall=true,serviceType=NodePort,routerServiceType=NodePort"
+    echo "$command"
+    $command >"$MANIFESTDIR/yamls/fission-all-${version}"-minikube.yaml
+
+    # for environments that support LoadBalancer
+    command="$cmdprefix --set analytics=false,analyticsNonHelmInstall=true"
+    echo "$command"
+    $command >"$MANIFESTDIR/yamls/fission-all-${version}".yaml
+
+    # for OpenShift
+    command="$cmdprefix --set analytics=false,analyticsNonHelmInstall=true,logger.enableSecurityContext=true"
+    echo "$command"
+    $command >"$MANIFESTDIR/yamls/fission-all-${version}"-openshift.yaml
+
+}
+
+
+version=$1
+if [ -z "$version" ]; then
+    echo "Release version not mentioned"
+    exit 1
+fi
+
+echo "Current version for release: $version"
+
+build_yamls "$version"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Adds yaml manifests for direct install, Minikube and OpenShift to the releases generated by Github Actions

## Testing
Tested on my fork [github.com/kanuahs/fission](https://github.com/kanuahs/fission/actions/workflows/release.yaml) by running multiple times. 

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
