### PR TITLE
Inject open telemetry(OTEL) transport in executor

### DIFF
--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -55,6 +56,7 @@ type (
 // MakeClient initializes and returns a Client instance.
 func MakeClient(logger *zap.Logger, executorURL string) *Client {
 	hc := retryablehttp.NewClient()
+	hc.HTTPClient.Transport = otelhttp.NewTransport(hc.HTTPClient.Transport)
 	c := &Client{
 		logger:      logger.Named("executor_client"),
 		executorURL: strings.TrimSuffix(executorURL, "/"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Span for executor and fetcher was missing from router tracing.
We have injected otelhttp transport in executor, After this fix user will be able to see all the traces from router itself.

## Which issue(s) this PR fixes:
Fixes https://github.com/fission/fission/issues/2545

## Testing
Attached is the image before and after making changes.

Before changes
![Screenshot from 2022-09-21 12-30-14](https://user-images.githubusercontent.com/62992590/191551833-b4491751-b1aa-4ef6-a5fd-05ef8b7858e5.png)

After changes
![Screenshot from 2022-09-21 19-13-25](https://user-images.githubusercontent.com/62992590/191551850-460e2e7f-8f14-4dc6-84c7-421ed591dd2c.png)


## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
