### PR TITLE
add namespace param for fn and env

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - name: Kind Clutser
+      - name: Kind Cluster
         uses: engineerd/setup-kind@v0.5.0
         with:
           image: kindest/node:${{ matrix.kindversion }}
@@ -67,6 +67,9 @@ jobs:
           kubectl cluster-info --context kind-kind
           kubectl get nodes
           sudo apt-get install -y apache2-utils
+          kubectl config use-context kind-kind
+          kubectl config set-context --current --namespace=default
+          kubectl config view
 
       - name: Helm chart lint
         run: |

--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -64,6 +64,9 @@ jobs:
           kubectl cluster-info --context kind-kind
           kubectl get nodes
           kubectl get storageclasses.storage.k8s.io
+          kubectl config use-context kind-kind
+          kubectl config set-context --current --namespace=default
+          kubectl config view
 
       - name: Dump system info
         run: |

--- a/cmd/fission-cli/app/app.go
+++ b/cmd/fission-cli/app/app.go
@@ -87,7 +87,7 @@ func App() *cobra.Command {
 	})
 
 	wrapper.SetFlags(rootCmd, flag.FlagSet{
-		Global: []flag.Flag{flag.GlobalServer, flag.GlobalVerbosity, flag.KubeContext},
+		Global: []flag.Flag{flag.GlobalServer, flag.GlobalVerbosity, flag.KubeContext, flag.Namespace},
 	})
 
 	groups := helptemplate.CommandGroups{}
@@ -101,7 +101,7 @@ func App() *cobra.Command {
 
 	flagExposer := helptemplate.ActsAsRootCommand(rootCmd, nil, groups...)
 	// show global options in usage
-	flagExposer.ExposeFlags(rootCmd, flagkey.Server, flagkey.Verbosity, flagkey.KubeContext)
+	flagExposer.ExposeFlags(rootCmd, flagkey.Server, flagkey.Verbosity, flagkey.KubeContext, flagkey.Namespace)
 
 	return rootCmd
 }

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -163,8 +163,8 @@ func ValidateKubeReference(refName string, name string, namespace string) error 
 	result := &multierror.Error{}
 
 	result = multierror.Append(result,
-		ValidateKubeName(fmt.Sprintf("%v.Name", refName), name),
-		validateNS(fmt.Sprintf("%v.Namespace", refName), namespace))
+		ValidateKubeName(fmt.Sprintf("%s.Name", refName), name),
+		validateNS(fmt.Sprintf("%s.Namespace", refName), namespace))
 
 	return result.ErrorOrNil()
 }

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -150,12 +150,21 @@ func ValidateKubeName(field string, val string) error {
 	return result.ErrorOrNil()
 }
 
+// validateNS is to match the k8s behaviour. Where it is not mandatory to provide a NS. And so we validate it if user has provided one.
+// Or we skip the validation on namespace.
+func validateNS(refName string, namespace string) error {
+	if namespace != "" {
+		return ValidateKubeName(refName, namespace)
+	}
+	return nil
+}
+
 func ValidateKubeReference(refName string, name string, namespace string) error {
 	result := &multierror.Error{}
 
 	result = multierror.Append(result,
 		ValidateKubeName(fmt.Sprintf("%v.Name", refName), name),
-		ValidateKubeName(fmt.Sprintf("%v.Namespace", refName), namespace))
+		validateNS(fmt.Sprintf("%v.Namespace", refName), namespace))
 
 	return result.ErrorOrNil()
 }

--- a/pkg/controller/client/v1/mqtrigger.go
+++ b/pkg/controller/client/v1/mqtrigger.go
@@ -142,10 +142,10 @@ func (c *MessageQueueTrigger) Delete(m *metav1.ObjectMeta) error {
 }
 
 func (c *MessageQueueTrigger) List(mqType string, ns string) ([]fv1.MessageQueueTrigger, error) {
-	relativeUrl := "triggers/messagequeue"
+	relativeUrl := fmt.Sprintf("triggers/messagequeue?namespace=%v", ns)
 	if len(mqType) > 0 {
 		// TODO remove this, replace with field selector
-		relativeUrl += fmt.Sprintf("?mqtype=%v&namespace=%v", mqType, ns)
+		relativeUrl += fmt.Sprintf("&mqtype=%v", mqType)
 	}
 
 	resp, err := c.client.Get(relativeUrl)

--- a/pkg/controller/client/v1/mqtrigger.go
+++ b/pkg/controller/client/v1/mqtrigger.go
@@ -136,16 +136,16 @@ func (c *MessageQueueTrigger) Update(mqTrigger *fv1.MessageQueueTrigger) (*metav
 }
 
 func (c *MessageQueueTrigger) Delete(m *metav1.ObjectMeta) error {
-	relativeUrl := fmt.Sprintf("triggers/messagequeue/%v", m.Name)
-	relativeUrl += fmt.Sprintf("?namespace=%v", m.Namespace)
+	relativeUrl := fmt.Sprintf("triggers/messagequeue/%s", m.Name)
+	relativeUrl += fmt.Sprintf("?namespace=%s", m.Namespace)
 	return c.client.Delete(relativeUrl)
 }
 
 func (c *MessageQueueTrigger) List(mqType string, ns string) ([]fv1.MessageQueueTrigger, error) {
-	relativeUrl := fmt.Sprintf("triggers/messagequeue?namespace=%v", ns)
+	relativeUrl := fmt.Sprintf("triggers/messagequeue?namespace=%s", ns)
 	if len(mqType) > 0 {
 		// TODO remove this, replace with field selector
-		relativeUrl += fmt.Sprintf("&mqtype=%v", mqType)
+		relativeUrl += fmt.Sprintf("&mqtype=%s", mqType)
 	}
 
 	resp, err := c.client.Get(relativeUrl)

--- a/pkg/controller/httpTriggerApi.go
+++ b/pkg/controller/httpTriggerApi.go
@@ -103,7 +103,6 @@ func RegisterHTTPTriggerRoute(ws *restful.WebService) {
 
 func (a *API) HTTPTriggerApiList(w http.ResponseWriter, r *http.Request) {
 	ns := a.extractQueryParamFromRequest(r, "namespace")
-	// TODO: TBD do we want this behaviour
 	if len(ns) == 0 {
 		ns = metav1.NamespaceAll
 	}

--- a/pkg/controller/httpTriggerApi.go
+++ b/pkg/controller/httpTriggerApi.go
@@ -103,6 +103,7 @@ func RegisterHTTPTriggerRoute(ws *restful.WebService) {
 
 func (a *API) HTTPTriggerApiList(w http.ResponseWriter, r *http.Request) {
 	ns := a.extractQueryParamFromRequest(r, "namespace")
+	// TODO: TBD do we want this behaviour
 	if len(ns) == 0 {
 		ns = metav1.NamespaceAll
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/command.go
+++ b/pkg/fission-cli/cmd/canaryconfig/command.go
@@ -32,7 +32,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName, flag.CanaryTriggerName, flag.CanaryNewFunc, flag.CanaryOldFunc},
-		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceFunction, flag.Namespace},
+		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceFunction},
 	})
 
 	getCmd := &cobra.Command{
@@ -43,7 +43,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceCanary},
 	})
 
 	updateCmd := &cobra.Command{
@@ -54,7 +54,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(updateCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceCanary, flag.Namespace},
+		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceCanary},
 	})
 
 	deleteCmd := &cobra.Command{
@@ -65,7 +65,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/canaryconfig/command.go
+++ b/pkg/fission-cli/cmd/canaryconfig/command.go
@@ -32,7 +32,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName, flag.CanaryTriggerName, flag.CanaryNewFunc, flag.CanaryOldFunc},
-		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceFunction, flag.Namespace},
 	})
 
 	getCmd := &cobra.Command{
@@ -43,7 +43,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace},
 	})
 
 	updateCmd := &cobra.Command{
@@ -54,7 +54,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(updateCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceCanary},
+		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceCanary, flag.Namespace},
 	})
 
 	deleteCmd := &cobra.Command{
@@ -65,7 +65,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -76,7 +76,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceCanary},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/canaryconfig/command.go
+++ b/pkg/fission-cli/cmd/canaryconfig/command.go
@@ -76,7 +76,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.Namespace, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/canaryconfig/create.go
+++ b/pkg/fission-cli/cmd/canaryconfig/create.go
@@ -47,20 +47,23 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *CreateSubCommand) complete(input cli.Input) error {
+func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 	// canary configs can be created for functions in the same namespace
 
 	name := input.String(flagkey.CanaryName)
 	ht := input.String(flagkey.CanaryHTTPTriggerName)
 	newFunc := input.String(flagkey.CanaryNewFunc)
 	oldFunc := input.String(flagkey.CanaryOldFunc)
-	fnNs := input.String(flagkey.NamespaceFunction)
+	_, fnNs, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, "error in creating canaryconfig")
+	}
 	incrementStep := input.Int(flagkey.CanaryWeightIncrement)
 	failureThreshold := input.Int(flagkey.CanaryFailureThreshold)
 	incrementInterval := input.String(flagkey.CanaryIncrementInterval)
 
 	// check for time parsing
-	_, err := time.ParseDuration(incrementInterval)
+	_, err = time.ParseDuration(incrementInterval)
 	if err != nil {
 		return errors.Wrap(err, "error parsing time duration")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/delete.go
+++ b/pkg/fission-cli/cmd/canaryconfig/delete.go
@@ -36,13 +36,17 @@ func Delete(input cli.Input) error {
 	return (&DeleteSubCommand{}).run(input)
 }
 
-func (opts *DeleteSubCommand) run(input cli.Input) error {
+func (opts *DeleteSubCommand) run(input cli.Input) (err error) {
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting canaryConfig ")
+	}
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.CanaryName),
-		Namespace: input.String(flagkey.NamespaceCanary),
+		Namespace: namespace,
 	}
 
-	err := opts.Client().V1().CanaryConfig().Delete(m)
+	err = opts.Client().V1().CanaryConfig().Delete(m)
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -37,10 +38,16 @@ func Get(input cli.Input) error {
 	return (&GetSubCommand{}).run(input)
 }
 
-func (opts *GetSubCommand) run(input cli.Input) error {
+func (opts *GetSubCommand) run(input cli.Input) (err error) {
+
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	if err != nil {
+		return errors.Wrap(err, "error getting canary config")
+	}
+
 	canaryCfg, err := opts.Client().V1().CanaryConfig().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.CanaryName),
-		Namespace: input.String(flagkey.NamespaceCanary),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting canary config")

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -45,8 +46,11 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *ListSubCommand) complete(input cli.Input) error {
-	opts.namespace = input.String(flagkey.NamespaceCanary)
+func (opts *ListSubCommand) complete(input cli.Input) (err error) {
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	if err != nil {
+		return errors.Wrap(err, "error in listing canary config ")
+	}
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -54,8 +55,14 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	return nil
 }
 
-func (opts *ListSubCommand) run(input cli.Input) error {
-	canaryCfgs, err := opts.Client().V1().CanaryConfig().List(opts.namespace)
+func (opts *ListSubCommand) run(input cli.Input) (err error) {
+
+	var canaryCfgs []v1.CanaryConfig
+	if input.Bool(flagkey.AllNamespaces) {
+		canaryCfgs, err = opts.Client().V1().CanaryConfig().List("")
+	} else {
+		canaryCfgs, err = opts.Client().V1().CanaryConfig().List(opts.namespace)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error listing canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
@@ -46,16 +47,19 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *UpdateSubCommand) complete(input cli.Input) error {
+func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	// get the current config
 	name := input.String(flagkey.CanaryName)
-	ns := input.String(flagkey.NamespaceCanary)
+	_, ns, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	if err != nil {
+		return errors.Wrap(err, "error updating canary config")
+	}
 	incrementStep := input.Int(flagkey.CanaryWeightIncrement)
 	failureThreshold := input.Int(flagkey.CanaryFailureThreshold)
 	incrementInterval := input.String(flagkey.CanaryIncrementInterval)
 
 	// check for time parsing
-	_, err := time.ParseDuration(incrementInterval)
+	_, err = time.ParseDuration(incrementInterval)
 	if err != nil {
 		return errors.Wrap(err, "error parsing time duration")
 	}

--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -35,7 +35,7 @@ func Commands() *cobra.Command {
 			flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret, flag.EnvKeepArchive,
-			flag.NamespaceEnvironment, flag.EnvExternalNetwork, flag.Labels, flag.Annotation,
+			flag.NamespaceEnvironment, flag.Namespace, flag.EnvExternalNetwork, flag.Labels, flag.Annotation,
 			flag.SpecSave, flag.SpecDry, flag.EnvBuilder, flag.EnvRuntime},
 	})
 
@@ -46,7 +46,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace},
 	})
 
 	updateCmd := &cobra.Command{
@@ -60,7 +60,7 @@ func Commands() *cobra.Command {
 			flag.EnvBuilderImage, flag.EnvBuildCmd, flag.EnvImagePullSecret,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvKeepArchive, flag.EnvRuntime,
-			flag.NamespaceEnvironment, flag.EnvExternalNetwork,
+			flag.NamespaceEnvironment, flag.Namespace, flag.EnvExternalNetwork,
 			flag.Labels, flag.Annotation},
 	})
 
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.IgnoreNotFound, flag.EnvForce},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace, flag.IgnoreNotFound, flag.EnvForce},
 	})
 
 	listCmd := &cobra.Command{
@@ -81,7 +81,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceEnvironment},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace},
 	})
 
 	listPodsCmd := &cobra.Command{
@@ -93,7 +93,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(listPodsCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.EnvExecutorType},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace, flag.EnvExecutorType},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -35,7 +35,7 @@ func Commands() *cobra.Command {
 			flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret, flag.EnvKeepArchive,
-			flag.NamespaceEnvironment, flag.Namespace, flag.EnvExternalNetwork, flag.Labels, flag.Annotation,
+			flag.NamespaceEnvironment, flag.EnvExternalNetwork, flag.Labels, flag.Annotation,
 			flag.SpecSave, flag.SpecDry, flag.EnvBuilder, flag.EnvRuntime},
 	})
 
@@ -46,7 +46,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceEnvironment},
 	})
 
 	updateCmd := &cobra.Command{
@@ -60,7 +60,7 @@ func Commands() *cobra.Command {
 			flag.EnvBuilderImage, flag.EnvBuildCmd, flag.EnvImagePullSecret,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvKeepArchive, flag.EnvRuntime,
-			flag.NamespaceEnvironment, flag.Namespace, flag.EnvExternalNetwork,
+			flag.NamespaceEnvironment, flag.EnvExternalNetwork,
 			flag.Labels, flag.Annotation},
 	})
 
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace, flag.IgnoreNotFound, flag.EnvForce},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.IgnoreNotFound, flag.EnvForce},
 	})
 
 	listCmd := &cobra.Command{
@@ -81,7 +81,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.AllNamespaces},
 	})
 
 	listPodsCmd := &cobra.Command{
@@ -93,7 +93,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(listPodsCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace, flag.EnvExecutorType},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.EnvExecutorType},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -81,7 +81,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.Namespace, flag.AllNamespaces},
 	})
 
 	listPodsCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -79,7 +79,7 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
-	// we user only user provided NS in spec. While creating actual record we use the current context's NS.
+	// we use user provided NS in spec. While creating actual record we use the current context's NS.
 	opts.env.ObjectMeta.Namespace = userDefinedNS
 
 	// if we're writing a spec, don't call the API
@@ -189,7 +189,6 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: envName,
-			// Namespace: envNamespace,
 		},
 		Spec: fv1.EnvironmentSpec{
 			Version: envVersion,

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -105,11 +105,8 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 
 	envName := input.String(flagkey.EnvName)
 	envImg := input.String(flagkey.EnvImage)
-	envNamespace := input.String(flagkey.NamespaceEnvironment)
-	// will overide the envNamespace value because the flagkey.NamespaceEnvironment flag is deprecated.
-	if input.String(flagkey.Namespace) != "default" {
-		envNamespace = input.String(flagkey.Namespace)
-	}
+
+	envNamespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	envBuildCmd := input.String(flagkey.EnvBuildcommand)
 	envExternalNetwork := input.Bool(flagkey.EnvExternalNetwork)
 	keepArchive := input.Bool(flagkey.EnvKeeparchive)

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -63,7 +63,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
-func (opts *CreateSubCommand) run(input cli.Input) error {
+func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 	m := opts.env.ObjectMeta
 
 	envList, err := opts.Client().V1().Environment().List(m.Namespace)
@@ -78,16 +78,37 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	// if we're writing a spec, don't call the API
 	// save to spec file or display the spec to console
 	if input.Bool(flagkey.SpecDry) {
+		err = opts.env.Validate()
+		if err != nil {
+			return fv1.AggregateValidationErrors("Environment", err)
+		}
+
 		return spec.SpecDry(*opts.env)
 	}
 
 	if input.Bool(flagkey.SpecSave) {
+		err = opts.env.Validate()
+		if err != nil {
+			return fv1.AggregateValidationErrors("Environment", err)
+		}
+
 		specFile := fmt.Sprintf("env-%v.yaml", m.Name)
 		err = spec.SpecSave(*opts.env, specFile)
 		if err != nil {
 			return errors.Wrap(err, "error saving environment spec")
 		}
 		return nil
+	}
+
+	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+
+	opts.env.ObjectMeta.Namespace = currentNS
+	err = opts.env.Validate()
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
 	}
 
 	_, err = opts.Client().V1().Environment().Create(opts.env)
@@ -106,7 +127,6 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 	envName := input.String(flagkey.EnvName)
 	envImg := input.String(flagkey.EnvImage)
 
-	envNamespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	envBuildCmd := input.String(flagkey.EnvBuildcommand)
 	envExternalNetwork := input.Bool(flagkey.EnvExternalNetwork)
 	keepArchive := input.Bool(flagkey.EnvKeeparchive)
@@ -166,8 +186,8 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 			APIVersion: fv1.CRD_VERSION,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      envName,
-			Namespace: envNamespace,
+			Name: envName,
+			// Namespace: envNamespace,
 		},
 		Spec: fv1.EnvironmentSpec{
 			Version: envVersion,
@@ -193,13 +213,19 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 		},
 	}
 
+	// if !(input.Bool(flagkey.SpecDry) || input.Bool(flagkey.SpecSave)) || namespace != "" {
+
+	// }
+	// else {
+	// 	err = env.Validate()
+	// 	if err != nil {
+	// 		return nil, fv1.AggregateValidationErrors("Environment", err)
+	// 	}
+	// }
+
 	err = util.ApplyLabelsAndAnnotations(input, &env.ObjectMeta)
 	if err != nil {
 		return nil, err
-	}
-	err = env.Validate()
-	if err != nil {
-		return nil, fv1.AggregateValidationErrors("Environment", err)
 	}
 
 	return env, nil

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -106,6 +106,10 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 	envName := input.String(flagkey.EnvName)
 	envImg := input.String(flagkey.EnvImage)
 	envNamespace := input.String(flagkey.NamespaceEnvironment)
+	// will overide the envNamespace value because the flagkey.NamespaceEnvironment flag is deprecated.
+	if input.String(flagkey.Namespace) != "default" {
+		envNamespace = input.String(flagkey.Namespace)
+	}
 	envBuildCmd := input.String(flagkey.EnvBuildcommand)
 	envExternalNetwork := input.Bool(flagkey.EnvExternalNetwork)
 	keepArchive := input.Bool(flagkey.EnvKeeparchive)

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -75,6 +75,13 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 			len(envList), m.Namespace)
 	}
 
+	userDefinedNS, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+	// we user only user provided NS in spec. While creating actual record we use the current context's NS.
+	opts.env.ObjectMeta.Namespace = userDefinedNS
+
 	// if we're writing a spec, don't call the API
 	// save to spec file or display the spec to console
 	if input.Bool(flagkey.SpecDry) {
@@ -98,11 +105,6 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 			return errors.Wrap(err, "error saving environment spec")
 		}
 		return nil
-	}
-
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
-	if err != nil {
-		return fv1.AggregateValidationErrors("Environment", err)
 	}
 
 	opts.env.ObjectMeta.Namespace = currentNS
@@ -212,16 +214,6 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 			ImagePullSecret:              pullSecret,
 		},
 	}
-
-	// if !(input.Bool(flagkey.SpecDry) || input.Bool(flagkey.SpecSave)) || namespace != "" {
-
-	// }
-	// else {
-	// 	err = env.Validate()
-	// 	if err != nil {
-	// 		return nil, fv1.AggregateValidationErrors("Environment", err)
-	// 	}
-	// }
 
 	err = util.ApplyLabelsAndAnnotations(input, &env.ObjectMeta)
 	if err != nil {

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -41,13 +41,9 @@ func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
 	_, currentContextNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	console.Verbose(2, "Namespace before not set %v ", currentContextNS)
-	// if namespace == "" {
-	// 	kubeContext := "" //TODO: get correct value here
-	// 	namespace, err = util.GetKubernetesCurrentNamespace(kubeContext)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}
-	// }
 	console.Verbose(2, "Namespace after set %v ", currentContextNS)
 
 	m := &metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -40,11 +40,10 @@ func Delete(input cli.Input) error {
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
 	_, currentContextNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
-	console.Verbose(2, "Namespace before not set %v ", currentContextNS)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}
-	console.Verbose(2, "Namespace after set %v ", currentContextNS)
+	console.Verbose(2, "Namespace used to delete resource: %s ", currentContextNS)
 
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -38,13 +38,11 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = flagkey.Namespace
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: input.String(namespace),
+		Namespace: namespace,
 	}
 
 	if !input.Bool(flagkey.EnvForce) {

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -37,9 +37,14 @@ func Delete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
+
+	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = flagkey.Namespace
+	}
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: input.String(flagkey.NamespaceEnvironment),
+		Namespace: input.String(namespace),
 	}
 
 	if !input.Bool(flagkey.EnvForce) {

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -38,13 +38,16 @@ func Get(input cli.Input) error {
 	return (&GetSubCommand{}).do(input)
 }
 
-func (opts *GetSubCommand) do(input cli.Input) error {
+func (opts *GetSubCommand) do(input cli.Input) (err error) {
 
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	if err != nil {
+		return errors.Wrap(err, "error creating environment")
+	}
 
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: namespace,
+		Namespace: currentNS,
 	}
 
 	env, err := opts.Client().V1().Environment().Get(m)

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -39,14 +40,11 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) do(input cli.Input) error {
 
-	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = flagkey.Namespace
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: input.String(namespace),
+		Namespace: namespace,
 	}
 
 	env, err := opts.Client().V1().Environment().Get(m)

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -38,9 +38,15 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
+
+	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = flagkey.Namespace
+	}
+
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: input.String(flagkey.NamespaceEnvironment),
+		Namespace: input.String(namespace),
 	}
 
 	env, err := opts.Client().V1().Environment().Get(m)

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -38,11 +39,9 @@ func List(input cli.Input) error {
 
 func (opts *ListSubCommand) do(input cli.Input) error {
 
-	namespace := flagkey.NamespaceEnvironment
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = flagkey.Namespace
-	}
-	envs, err := opts.Client().V1().Environment().List(input.String(namespace))
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+
+	envs, err := opts.Client().V1().Environment().List(namespace)
 	if err != nil {
 		return errors.Wrap(err, "error listing environments")
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -44,7 +45,13 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 		return errors.Wrap(err, "error creating environment")
 	}
 
-	envs, err := opts.Client().V1().Environment().List(currentNS)
+	var envs []v1.Environment
+	if input.Bool(flagkey.AllNamespaces) {
+		envs, err = opts.Client().V1().Environment().List("")
+	} else {
+		envs, err = opts.Client().V1().Environment().List(currentNS)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "error listing environments")
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -37,7 +37,12 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	envs, err := opts.Client().V1().Environment().List(input.String(flagkey.NamespaceEnvironment))
+
+	namespace := flagkey.NamespaceEnvironment
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = flagkey.Namespace
+	}
+	envs, err := opts.Client().V1().Environment().List(input.String(namespace))
 	if err != nil {
 		return errors.Wrap(err, "error listing environments")
 	}

--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -41,16 +42,13 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
-	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = flagkey.Namespace
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 
 	// validate environment
 	_, err := opts.Client().V1().Environment().Get(
 		&metav1.ObjectMeta{
 			Name:      input.String(flagkey.EnvName),
-			Namespace: input.String(namespace),
+			Namespace: namespace,
 		})
 	if err != nil {
 		return errors.Wrap(err, "error getting environment")
@@ -59,7 +57,7 @@ func (opts *ListPodsSubCommand) do(input cli.Input) error {
 	m := &metav1.ObjectMeta{
 		Name: input.String(flagkey.EnvName),
 		Labels: map[string]string{
-			v1.ENVIRONMENT_NAMESPACE: input.String(namespace),
+			v1.ENVIRONMENT_NAMESPACE: namespace,
 			v1.EXECUTOR_TYPE:         input.String(flagkey.EnvExecutorType),
 		},
 	}

--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -41,11 +41,16 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
+	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = flagkey.Namespace
+	}
+
 	// validate environment
 	_, err := opts.Client().V1().Environment().Get(
 		&metav1.ObjectMeta{
 			Name:      input.String(flagkey.EnvName),
-			Namespace: input.String(flagkey.NamespaceEnvironment),
+			Namespace: input.String(namespace),
 		})
 	if err != nil {
 		return errors.Wrap(err, "error getting environment")
@@ -54,7 +59,7 @@ func (opts *ListPodsSubCommand) do(input cli.Input) error {
 	m := &metav1.ObjectMeta{
 		Name: input.String(flagkey.EnvName),
 		Labels: map[string]string{
-			v1.ENVIRONMENT_NAMESPACE: input.String(flagkey.NamespaceEnvironment),
+			v1.ENVIRONMENT_NAMESPACE: input.String(namespace),
 			v1.EXECUTOR_TYPE:         input.String(flagkey.EnvExecutorType),
 		},
 	}

--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -40,15 +40,18 @@ func ListPods(input cli.Input) error {
 	return (&ListPodsSubCommand{}).do(input)
 }
 
-func (opts *ListPodsSubCommand) do(input cli.Input) error {
+func (opts *ListPodsSubCommand) do(input cli.Input) (err error) {
 
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	if err != nil {
+		return errors.Wrap(err, "error creating environment")
+	}
 
 	// validate environment
-	_, err := opts.Client().V1().Environment().Get(
+	_, err = opts.Client().V1().Environment().Get(
 		&metav1.ObjectMeta{
 			Name:      input.String(flagkey.EnvName),
-			Namespace: namespace,
+			Namespace: currentNS,
 		})
 	if err != nil {
 		return errors.Wrap(err, "error getting environment")
@@ -57,7 +60,7 @@ func (opts *ListPodsSubCommand) do(input cli.Input) error {
 	m := &metav1.ObjectMeta{
 		Name: input.String(flagkey.EnvName),
 		Labels: map[string]string{
-			v1.ENVIRONMENT_NAMESPACE: namespace,
+			v1.ENVIRONMENT_NAMESPACE: currentNS,
 			v1.EXECUTOR_TYPE:         input.String(flagkey.EnvExecutorType),
 		},
 	}

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -54,14 +54,11 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
-	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = flagkey.Namespace
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 
 	env, err := opts.Client().V1().Environment().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: input.String(namespace),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error finding environment")

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -53,9 +53,15 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
+
+	namespace := flagkey.NamespaceEnvironment // Once deprecated we can remove the if condition
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = flagkey.Namespace
+	}
+
 	env, err := opts.Client().V1().Environment().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: input.String(flagkey.NamespaceEnvironment),
+		Namespace: input.String(namespace),
 	})
 	if err != nil {
 		return errors.Wrap(err, "error finding environment")
@@ -126,6 +132,9 @@ func updateExistingEnvironmentWithCmd(env *fv1.Environment, input cli.Input) (*f
 	if input.IsSet(flagkey.EnvImagePullSecret) {
 		env.Spec.ImagePullSecret = input.String(flagkey.EnvImagePullSecret)
 	}
+
+	env.Spec.Resources.Requests = make(v1.ResourceList)
+	env.Spec.Resources.Limits = make(v1.ResourceList)
 
 	if input.IsSet(flagkey.RuntimeMincpu) {
 		mincpu := input.Int(flagkey.RuntimeMincpu)

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -52,13 +52,15 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *UpdateSubCommand) complete(input cli.Input) error {
+func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
-
+	_, currentContextNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	if err != nil {
+		return errors.Wrap(err, "error creating environment")
+	}
 	env, err := opts.Client().V1().Environment().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),
-		Namespace: namespace,
+		Namespace: currentContextNS,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error finding environment")

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory,
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
-			flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry},
+			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{
@@ -60,7 +60,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceFunction},
 	})
 
 	getmetaCmd := &cobra.Command{
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getmetaCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceFunction},
 	})
 
 	updateCmd := &cobra.Command{
@@ -97,7 +97,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.Namespace, flag.NamespaceEnvironment, flag.SpecSave,
+			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave,
 		},
 	})
 
@@ -109,7 +109,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -120,7 +120,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.AllNamespaces},
 	})
 
 	logsCmd := &cobra.Command{
@@ -133,7 +133,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{
 			flag.FnLogFollow, flag.FnLogReverseQuery, flag.FnLogCount,
-			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.Namespace, flag.FnLogDBType},
+			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.FnLogDBType},
 	})
 
 	testCmd := &cobra.Command{
@@ -145,7 +145,7 @@ func Commands() *cobra.Command {
 	wrapper.SetFlags(testCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{flag.HtMethod, flag.FnTestHeader, flag.FnTestBody,
-			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction, flag.Namespace,
+			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction,
 			// for getting log from log database if
 			// we failed to get logs from function pod.
 			flag.FnLogDBType,
@@ -174,7 +174,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry,
+			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
 		},
 	})
 
@@ -197,7 +197,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.Namespace, flag.SpecSave,
+			flag.NamespaceFunction, flag.SpecSave,
 		},
 	})
 
@@ -210,7 +210,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(listPodsCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceFunction},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory,
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
-			flag.NamespaceFunction, flag.Namespace, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
+			flag.NamespaceFunction, flag.Namespace, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry}, // TODO: do we need flag.NamespaceEnvironment flag
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory,
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
-			flag.NamespaceFunction, flag.Namespace, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry}, // TODO: do we need flag.NamespaceEnvironment flag
+			flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -120,7 +120,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace, flag.AllNamespaces},
 	})
 
 	logsCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -49,8 +49,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory,
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
-
-			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
+			flag.NamespaceFunction, flag.Namespace, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := &cobra.Command{
@@ -61,7 +60,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
 	})
 
 	getmetaCmd := &cobra.Command{
@@ -72,7 +71,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getmetaCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
 	})
 
 	updateCmd := &cobra.Command{
@@ -98,7 +97,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave,
+			flag.NamespaceFunction, flag.Namespace, flag.NamespaceEnvironment, flag.SpecSave,
 		},
 	})
 
@@ -110,7 +109,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -121,7 +120,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
 	})
 
 	logsCmd := &cobra.Command{
@@ -134,7 +133,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{
 			flag.FnLogFollow, flag.FnLogReverseQuery, flag.FnLogCount,
-			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.FnLogDBType},
+			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.Namespace, flag.FnLogDBType},
 	})
 
 	testCmd := &cobra.Command{
@@ -146,7 +145,7 @@ func Commands() *cobra.Command {
 	wrapper.SetFlags(testCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{flag.HtMethod, flag.FnTestHeader, flag.FnTestBody,
-			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction,
+			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction, flag.Namespace,
 			// for getting log from log database if
 			// we failed to get logs from function pod.
 			flag.FnLogDBType,
@@ -175,7 +174,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
+			flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry,
 		},
 	})
 
@@ -198,7 +197,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.SpecSave,
+			flag.NamespaceFunction, flag.Namespace, flag.SpecSave,
 		},
 	})
 
@@ -211,7 +210,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(listPodsCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Namespace},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -65,11 +65,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	fnNamespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		fnNamespace = input.String(flagkey.Namespace)
-	}
-
+	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	envNamespace := input.String(flagkey.NamespaceEnvironment)
 
 	// user wants a spec, create a yaml file with package and function

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -74,7 +74,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	toSpec := false
 	if input.Bool(flagkey.SpecSave) {
 		toSpec = true
-		opts.specFile = fmt.Sprintf("function-%v.yaml", fnName)
+		opts.specFile = fmt.Sprintf("function-%s.yaml", fnName)
 	}
 	specDir := util.GetSpecDir(input)
 	specIgnore := util.GetSpecIgnore(input)
@@ -138,7 +138,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 			fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
+				return errors.Wrap(err, fmt.Sprintf("error reading spec in '%s'", specDir))
 			}
 
 			obj := fr.SpecExists(&fv1.Package{ // In case of spec I might or might not have the `fnNamespace`, how will I get pkg objectMeta here.
@@ -160,7 +160,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 				Name:      pkgName,
 			})
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("read package in '%v' in Namespace: %s. Package needs to be present in the same namespace as function", pkgName, fnNamespace))
+				return errors.Wrap(err, fmt.Sprintf("read package in '%s' in Namespace: %s. Package needs to be present in the same namespace as function", pkgName, fnNamespace))
 			}
 			pkgMetadata = &pkg.ObjectMeta
 		}
@@ -180,7 +180,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 			fr, err := spec.ReadSpecs(specDir, specIgnore, false)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("error reading spec in '%v'", specDir))
+				return errors.Wrap(err, fmt.Sprintf("error reading spec in '%s'", specDir))
 			}
 			exists, err := fr.ExistsInSpecs(fv1.Environment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -192,7 +192,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 				return err
 			}
 			if !exists {
-				console.Warn(fmt.Sprintf("Function '%v' references unknown Environment '%v', please create it before applying spec",
+				console.Warn(fmt.Sprintf("Function '%s' references unknown Environment '%s', please create it before applying spec",
 					fnName, envName))
 			}
 		} else {
@@ -359,12 +359,12 @@ func generatePackageName(fnName string, id string) string {
 		lastIndexOfChar int
 	)
 	if lenFnName+lenId <= 62 {
-		return fmt.Sprintf("%v-%v", fnName, id)
+		return fmt.Sprintf("%s-%s", fnName, id)
 	}
 
 	lastIndexOfChar = lenFnName - (lenFnName + lenId - 62)
-	pkgName := fmt.Sprintf("%v-%v", fnName[:lastIndexOfChar], id)
-	console.Info(fmt.Sprintf("Generated package %v from function to acceptable character limit", pkgName))
+	pkgName := fmt.Sprintf("%v-%s", fnName[:lastIndexOfChar], id)
+	console.Info(fmt.Sprintf("Generated package %s from function to acceptable character limit", pkgName))
 	return pkgName
 }
 
@@ -390,7 +390,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return errors.Wrap(err, "error creating function")
 	}
 
-	fmt.Printf("function '%v' created\n", opts.function.ObjectMeta.Name)
+	fmt.Printf("function '%s' created\n", opts.function.ObjectMeta.Name)
 
 	// Allow the user to specify an HTTP trigger while creating a function.
 	triggerUrl := input.String(flagkey.HtUrl)
@@ -439,7 +439,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return errors.Wrap(err, "error creating HTTP trigger")
 	}
 
-	fmt.Printf("route created: %v %v -> %v\n", methods, triggerUrl, opts.function.ObjectMeta.Name)
+	fmt.Printf("route created: %s %s -> %s\n", methods, triggerUrl, opts.function.ObjectMeta.Name)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -62,8 +62,6 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-// 249
-
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -69,7 +69,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "error retrieving namespace information")
 	}
-	//envNamespace := input.String(flagkey.NamespaceEnvironment)
 
 	// user wants a spec, create a yaml file with package and function
 	toSpec := false
@@ -170,7 +169,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		if envName != input.String(flagkey.FnEnvironmentName) {
 			console.Warn("Function's environment is different than package's environment, package's environment will be used for creating function")
 		}
-		// envNamespace = pkg.Spec.Environment.Namespace
 	} else {
 		// need to specify environment for creating new package
 		envName = input.String(flagkey.FnEnvironmentName)

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -148,7 +148,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 				},
 			}, true, false)
 			if obj == nil {
-				return errors.Errorf("please create package %v spec file with namespace %v before referencing it", pkgName, userProvidedNS)
+				return errors.Errorf("please create package %s spec file with namespace %s before referencing it", pkgName, userProvidedNS)
 			}
 
 			pkg = obj.(*fv1.Package)
@@ -202,7 +202,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			})
 			if err != nil {
 				if e, ok := err.(ferror.Error); ok && e.Code == ferror.ErrorNotFound {
-					console.Warn(fmt.Sprintf("Environment \"%v\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %v --envns %v --image <image>`\n", envName, envName, fnNamespace))
+					console.Warn(fmt.Sprintf("Environment \"%s\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %s --envns %s --image <image>`\n", envName, envName, fnNamespace))
 				} else {
 					return errors.Wrap(err, "error retrieving environment information")
 				}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -65,7 +65,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	envNamespace := input.String(flagkey.NamespaceEnvironment)
 
 	// user wants a spec, create a yaml file with package and function

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -64,7 +64,12 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
+
 	fnNamespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		fnNamespace = input.String(flagkey.Namespace)
+	}
+
 	envNamespace := input.String(flagkey.NamespaceEnvironment)
 
 	// user wants a spec, create a yaml file with package and function
@@ -80,7 +85,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		// check for unique function names within a namespace
 		fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 			Name:      input.String(flagkey.FnName),
-			Namespace: input.String(flagkey.NamespaceFunction),
+			Namespace: fnNamespace,
 		})
 		if err != nil && !ferror.IsNotFound(err) {
 			return err

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -37,9 +37,14 @@ func Delete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
+
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	}
 
 	err := opts.Client().V1().Function().Delete(m)

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -52,9 +52,9 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil
 		}
-		return errors.Wrap(err, fmt.Sprintf("delete function '%v'", m.Name))
+		return errors.Wrap(err, fmt.Sprintf("delete function '%s'", m.Name))
 	}
 
-	fmt.Printf("function '%v' deleted\n", m.Name)
+	fmt.Printf("function '%s' deleted\n", m.Name)
 	return nil
 }

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -40,7 +40,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in deleting function ")
 	}
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -38,13 +38,16 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: namespace,
 	}
 
-	err := opts.Client().V1().Function().Delete(m)
+	err = opts.Client().V1().Function().Delete(m)
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -38,10 +38,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: namespace,

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -36,9 +36,14 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
+
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -17,7 +17,6 @@ limitations under the License.
 package function
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -40,7 +39,7 @@ func Get(input cli.Input) error {
 func (opts *GetSubCommand) do(input cli.Input) error {
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in get function ")
 	}
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -36,10 +37,7 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -17,6 +17,7 @@ limitations under the License.
 package function
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pkg/errors"
@@ -37,8 +38,10 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
-
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: namespace,

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -39,7 +39,7 @@ func GetMeta(input cli.Input) error {
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in getting meta function ")
 	}
 
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetMetaSubCommand struct {
@@ -36,10 +37,7 @@ func GetMeta(input cli.Input) error {
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -36,9 +36,14 @@ func GetMeta(input cli.Input) error {
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
+
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -37,7 +37,10 @@ func GetMeta(input cli.Input) error {
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -38,16 +38,19 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	ns := input.String(flagkey.NamespaceFunction)
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
 
-	fns, err := opts.Client().V1().Function().List(ns)
+	fns, err := opts.Client().V1().Function().List(namespace)
 	if err != nil {
 		return errors.Wrap(err, "error listing functions")
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS", "NAMESPACE")
 	for _, f := range fns {
 		secrets := f.Spec.Secrets
 		configMaps := f.Spec.ConfigMaps
@@ -59,7 +62,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 			configMapList = append(configMapList, configMap.Name)
 		}
 
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 			f.ObjectMeta.Name, f.Spec.Environment.Name,
 			f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType,
 			f.Spec.InvokeStrategy.ExecutionStrategy.MinScale,
@@ -69,7 +72,8 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 			f.Spec.Resources.Requests.Memory().String(),
 			f.Spec.Resources.Limits.Memory().String(),
 			strings.Join(secretsList, ","),
-			strings.Join(configMapList, ","))
+			strings.Join(configMapList, ","),
+			f.ObjectMeta.Namespace)
 	}
 	w.Flush()
 

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -44,7 +45,12 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error in listing function ")
 	}
 
-	fns, err := opts.Client().V1().Function().List(namespace)
+	var fns []v1.Function
+	if input.Bool(flagkey.AllNamespaces) {
+		fns, err = opts.Client().V1().Function().List("")
+	} else {
+		fns, err = opts.Client().V1().Function().List(namespace)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error listing functions")
 	}

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -39,7 +39,10 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	fns, err := opts.Client().V1().Function().List(namespace)
 	if err != nil {

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -41,7 +41,7 @@ func List(input cli.Input) error {
 func (opts *ListSubCommand) do(input cli.Input) error {
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in listing function ")
 	}
 
 	fns, err := opts.Client().V1().Function().List(namespace)

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -38,10 +39,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	fns, err := opts.Client().V1().Function().List(namespace)
 	if err != nil {

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -40,10 +40,7 @@ func Log(input cli.Input) error {
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	dbType := input.String(flagkey.FnLogDBType)
 	fnPod := input.String(flagkey.FnLogPod)

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -40,7 +40,10 @@ func Log(input cli.Input) error {
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	dbType := input.String(flagkey.FnLogDBType)
 	fnPod := input.String(flagkey.FnLogPod)

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -40,6 +40,11 @@ func Log(input cli.Input) error {
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
+
 	dbType := input.String(flagkey.FnLogDBType)
 	fnPod := input.String(flagkey.FnLogPod)
 	kubeContext := input.String(flagkey.KubeContext)
@@ -53,7 +58,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 
 	f, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -42,7 +42,7 @@ func Log(input cli.Input) error {
 func (opts *LogSubCommand) do(input cli.Input) error {
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in logs for function ")
 	}
 
 	dbType := input.String(flagkey.FnLogDBType)

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -41,10 +42,7 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	// validate function
 	_, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -41,10 +41,15 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
+
 	// validate function
 	_, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")
@@ -53,7 +58,7 @@ func (opts *ListPodsSubCommand) do(input cli.Input) error {
 	m := &metav1.ObjectMeta{
 		Name: input.String(flagkey.FnName),
 		Labels: map[string]string{
-			v1.FUNCTION_NAMESPACE: input.String(flagkey.NamespaceFunction),
+			v1.FUNCTION_NAMESPACE: namespace,
 		},
 	}
 

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -45,7 +45,7 @@ func (opts *ListPodsSubCommand) do(input cli.Input) error {
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in finding pod for function ")
 	}
 	// validate function
 	_, err = opts.Client().V1().Function().Get(&metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -42,10 +42,13 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 	// validate function
-	_, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
+	_, err = opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
 		Namespace: namespace,
 	})

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -58,7 +58,7 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 
 	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in running container for function ")
 	}
 
 	// user wants a spec, create a yaml file with package and function

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -55,7 +55,11 @@ func (opts *RunContainerSubCommand) do(input cli.Input) error {
 
 func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
+
 	fnNamespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		fnNamespace = input.String(flagkey.Namespace)
+	}
 
 	// user wants a spec, create a yaml file with package and function
 	toSpec := false
@@ -68,7 +72,7 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 		// check for unique function names within a namespace
 		fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 			Name:      input.String(flagkey.FnName),
-			Namespace: input.String(flagkey.NamespaceFunction),
+			Namespace: fnNamespace,
 		})
 		if err != nil && !ferror.IsNotFound(err) {
 			return err

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -56,7 +56,10 @@ func (opts *RunContainerSubCommand) do(input cli.Input) error {
 func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	// user wants a spec, create a yaml file with package and function
 	toSpec := false

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -56,10 +56,7 @@ func (opts *RunContainerSubCommand) do(input cli.Input) error {
 func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	fnNamespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		fnNamespace = input.String(flagkey.Namespace)
-	}
+	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	// user wants a spec, create a yaml file with package and function
 	toSpec := false

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -52,7 +52,10 @@ func Test(input cli.Input) error {
 
 func (opts *TestSubCommand) do(input cli.Input) error {
 
-	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -52,10 +52,7 @@ func Test(input cli.Input) error {
 
 func (opts *TestSubCommand) do(input cli.Input) error {
 
-	namespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		namespace = input.String(flagkey.Namespace)
-	}
+	namespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -51,9 +51,15 @@ func Test(input cli.Input) error {
 }
 
 func (opts *TestSubCommand) do(input cli.Input) error {
+
+	namespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
+
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	}
 	kubeContext := input.String(flagkey.KubeContext)
 	routerURL := os.Getenv("FISSION_ROUTER")

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -54,7 +54,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in testing function ")
 	}
 
 	m := &metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -53,7 +53,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in updating function ")
 	}
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -51,7 +51,10 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
-	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -52,10 +52,13 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 	fnNamespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		fnNamespace = input.String(flagkey.Namespace)
+	}
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: fnNamespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("read function '%v'", fnName))

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -51,10 +51,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
-	fnNamespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		fnNamespace = input.String(flagkey.Namespace)
-	}
+	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -52,11 +52,15 @@ func (opts *UpdateContainerSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
+
 	fnNamespace := input.String(flagkey.NamespaceFunction)
+	if input.String(flagkey.Namespace) != "default" {
+		fnNamespace = input.String(flagkey.Namespace)
+	}
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: input.String(fnNamespace),
 	})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("read function '%v'", fnName))

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -53,7 +53,10 @@ func (opts *UpdateContainerSubCommand) do(input cli.Input) error {
 func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+	}
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -55,7 +55,7 @@ func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 
 	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("error in deleting function "))
+		return errors.Wrap(err, "error in updating container for function ")
 	}
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -53,14 +53,11 @@ func (opts *UpdateContainerSubCommand) do(input cli.Input) error {
 func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	fnNamespace := input.String(flagkey.NamespaceFunction)
-	if input.String(flagkey.Namespace) != "default" {
-		fnNamespace = input.String(flagkey.Namespace)
-	}
+	fnNamespace := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	function, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.FnName),
-		Namespace: input.String(fnNamespace),
+		Namespace: fnNamespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("read function '%v'", fnName))

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.HtFnName},
 		Optional: []flag.Flag{flag.HtUrl, flag.HtName, flag.HtMethod, flag.HtIngress,
 			flag.HtIngressRule, flag.HtIngressAnnotation, flag.HtIngressTLS,
-			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry,
+			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
 			flag.HtPrefix, flag.HtKeepPrefix},
 	})
 
@@ -57,7 +57,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.HtName},
 		Optional: []flag.Flag{flag.HtUrl, flag.HtFnName,
 			flag.HtMethod, flag.HtIngress, flag.HtIngressRule, flag.HtIngressAnnotation,
-			flag.HtIngressTLS, flag.HtFnWeight, flag.HtHost, flag.NamespaceTrigger, flag.Namespace,
+			flag.HtIngressTLS, flag.HtFnWeight, flag.HtHost, flag.NamespaceTrigger,
 			flag.HtPrefix, flag.HtKeepPrefix},
 	})
 
@@ -68,7 +68,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(Delete),
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.HtName, flag.HtFnFilter, flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.HtName, flag.HtFnFilter, flag.NamespaceTrigger, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -79,7 +79,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.HtFnFilter, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.HtFnFilter, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.HtFnName},
 		Optional: []flag.Flag{flag.HtUrl, flag.HtName, flag.HtMethod, flag.HtIngress,
 			flag.HtIngressRule, flag.HtIngressAnnotation, flag.HtIngressTLS,
-			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
+			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry,
 			flag.HtPrefix, flag.HtKeepPrefix},
 	})
 
@@ -57,7 +57,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.HtName},
 		Optional: []flag.Flag{flag.HtUrl, flag.HtFnName,
 			flag.HtMethod, flag.HtIngress, flag.HtIngressRule, flag.HtIngressAnnotation,
-			flag.HtIngressTLS, flag.HtFnWeight, flag.HtHost, flag.NamespaceTrigger,
+			flag.HtIngressTLS, flag.HtFnWeight, flag.HtHost, flag.NamespaceTrigger, flag.Namespace,
 			flag.HtPrefix, flag.HtKeepPrefix},
 	})
 
@@ -68,7 +68,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(Delete),
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.HtName, flag.HtFnFilter, flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.HtName, flag.HtFnFilter, flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -79,7 +79,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.HtFnFilter},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.HtFnFilter},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -79,7 +79,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.HtFnFilter},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.HtFnFilter, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -81,7 +81,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	// fnNamespace := input.String(flagkey.NamespaceFunction)
 
 	triggerUrl := input.String(flagkey.HtUrl)
 	prefix := input.String(flagkey.HtPrefix)
@@ -194,10 +193,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 	opts.trigger = &fv1.HTTPTrigger{
 		ObjectMeta: m,
-		// metav1.ObjectMeta{
-		// 	Name:      triggerName,
-		// 	Namespace: fnNamespace,
-		// },
 		Spec: fv1.HTTPTriggerSpec{
 			Host:              host,
 			RelativeURL:       triggerUrl,

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -76,20 +76,12 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		}
 		triggerName = id.String()
 	}
-	fnNamespace := input.String(flagkey.NamespaceFunction)
 
-	m := &metav1.ObjectMeta{
-		Name:      triggerName,
-		Namespace: fnNamespace,
+	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
 	}
-
-	htTrigger, err := opts.Client().V1().HTTPTrigger().Get(m)
-	if err != nil && !ferror.IsNotFound(err) {
-		return err
-	}
-	if htTrigger != nil {
-		return errors.New("duplicate trigger exists, choose a different name or leave it empty for fission to auto-generate it")
-	}
+	// fnNamespace := input.String(flagkey.NamespaceFunction)
 
 	triggerUrl := input.String(flagkey.HtUrl)
 	prefix := input.String(flagkey.HtPrefix)
@@ -130,9 +122,24 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			return err
 		}
 	}
+	m := metav1.ObjectMeta{
+		Name:      triggerName,
+		Namespace: userProvidedNS,
+	}
+
+	console.Warn(fmt.Sprintf("Ns: %v", userProvidedNS))
 
 	// For Specs, the spec validate checks for function reference
 	if input.Bool(flagkey.SpecSave) {
+
+		htTrigger, err := opts.Client().V1().HTTPTrigger().Get(&m)
+		if err != nil && !ferror.IsNotFound(err) {
+			return err
+		}
+		if htTrigger != nil {
+			return errors.New("duplicate trigger exists, choose a different name or leave it empty for fission to auto-generate it")
+		}
+
 		specDir := util.GetSpecDir(input)
 		specIgnore := util.GetSpecIgnore(input)
 		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
@@ -143,7 +150,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			exists, err := fr.ExistsInSpecs(fv1.Function{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      fn,
-					Namespace: fnNamespace,
+					Namespace: userProvidedNS,
 				},
 			})
 			if err != nil {
@@ -155,6 +162,20 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			}
 		}
 	} else {
+
+		m = metav1.ObjectMeta{
+			Name:      triggerName,
+			Namespace: fnNamespace,
+		}
+
+		htTrigger, err := opts.Client().V1().HTTPTrigger().Get(&m)
+		if err != nil && !ferror.IsNotFound(err) {
+			return err
+		}
+		if htTrigger != nil {
+			return errors.New("duplicate trigger exists, choose a different name or leave it empty for fission to auto-generate it")
+		}
+
 		err = util.CheckFunctionExistence(opts.Client(), functionList, fnNamespace)
 		if err != nil {
 			console.Warn(err.Error())
@@ -172,10 +193,11 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	host := input.String(flagkey.HtHost)
 
 	opts.trigger = &fv1.HTTPTrigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      triggerName,
-			Namespace: fnNamespace,
-		},
+		ObjectMeta: m,
+		// metav1.ObjectMeta{
+		// 	Name:      triggerName,
+		// 	Namespace: fnNamespace,
+		// },
 		Spec: fv1.HTTPTriggerSpec{
 			Host:              host,
 			RelativeURL:       triggerUrl,

--- a/pkg/fission-cli/cmd/httptrigger/delete.go
+++ b/pkg/fission-cli/cmd/httptrigger/delete.go
@@ -49,7 +49,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *DeleteSubCommand) complete(input cli.Input) error {
+func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.triggerName = input.String(flagkey.HtName)
 	opts.functionName = input.String(flagkey.HtFnName)
 	if len(opts.triggerName) == 0 && len(opts.functionName) == 0 {
@@ -57,7 +57,12 @@ func (opts *DeleteSubCommand) complete(input cli.Input) error {
 	} else if len(opts.triggerName) > 0 && len(opts.functionName) > 0 {
 		return errors.Errorf("need either of --%v or --%v and not both arguments", flagkey.HtName, flagkey.HtFnName)
 	}
-	opts.namespace = input.String(flagkey.NamespaceTrigger)
+
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+	// opts.namespace = input.String(flagkey.NamespaceTrigger)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/httptrigger/delete.go
+++ b/pkg/fission-cli/cmd/httptrigger/delete.go
@@ -62,7 +62,6 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	// opts.namespace = input.String(flagkey.NamespaceTrigger)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -66,7 +66,7 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 
 func printHtSummary(triggers []fv1.HTTPTrigger) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "METHOD", "URL", "FUNCTION(s)", "INGRESS", "HOST", "PATH", "TLS", "ANNOTATIONS")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "METHOD", "URL", "FUNCTION(s)", "INGRESS", "HOST", "PATH", "TLS", "ANNOTATIONS", "NAMESPACE")
 	for _, trigger := range triggers {
 		function := ""
 		if trigger.Spec.FunctionReference.Type == fv1.FunctionReferenceTypeFunctionName {
@@ -99,8 +99,8 @@ func printHtSummary(triggers []fv1.HTTPTrigger) {
 		if len(trigger.Spec.Methods) > 0 {
 			methods = trigger.Spec.Methods
 		}
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			trigger.ObjectMeta.Name, methods, trigger.Spec.RelativeURL, function, trigger.Spec.CreateIngress, host, path, trigger.Spec.IngressConfig.TLS, ann)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+			trigger.ObjectMeta.Name, methods, trigger.Spec.RelativeURL, function, trigger.Spec.CreateIngress, host, path, trigger.Spec.IngressConfig.TLS, ann, trigger.ObjectMeta.Namespace)
 	}
 	w.Flush()
 }

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -43,10 +44,15 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *GetSubCommand) run(input cli.Input) error {
+func (opts *GetSubCommand) run(input cli.Input) (err error) {
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.HtName),
-		Namespace: input.String(flagkey.NamespaceFunction),
+		Namespace: namespace,
 	}
 	ht, err := opts.Client().V1().HTTPTrigger().Get(m)
 	if err != nil {

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -45,7 +45,13 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	hts, err := opts.Client().V1().HTTPTrigger().List(namespace)
+	var hts []fv1.HTTPTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		hts, err = opts.Client().V1().HTTPTrigger().List("")
+	} else {
+		hts, err = opts.Client().V1().HTTPTrigger().List(namespace)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "error listing HTTP triggers")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -37,8 +38,14 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *ListSubCommand) run(input cli.Input) error {
-	hts, err := opts.Client().V1().HTTPTrigger().List(input.String(flagkey.NamespaceTrigger))
+func (opts *ListSubCommand) run(input cli.Input) (err error) {
+
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+
+	hts, err := opts.Client().V1().HTTPTrigger().List(namespace)
 	if err != nil {
 		return errors.Wrap(err, "error listing HTTP triggers")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -56,8 +56,6 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	// triggerNamespace := input.String(flagkey.NamespaceTrigger)
-
 	ht, err := opts.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
 		Name:      htName,
 		Namespace: triggerNamespace,

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -48,9 +48,15 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *UpdateSubCommand) complete(input cli.Input) error {
+func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	htName := input.String(flagkey.HtName)
-	triggerNamespace := input.String(flagkey.NamespaceTrigger)
+
+	_, triggerNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+
+	// triggerNamespace := input.String(flagkey.NamespaceTrigger)
 
 	ht, err := opts.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
 		Name:      htName,

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -44,7 +44,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.KwFnName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -55,7 +55,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -44,7 +44,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.KwFnName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -55,7 +55,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -55,7 +55,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -61,8 +61,14 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		watchName = id.String()
 	}
 	fnName := input.String(flagkey.KwFnName)
-	fnNamespace := input.String(flagkey.NamespaceFunction) // TODO: we want watch to be created in same namespace or different
-	namespace := input.String(flagkey.KwNamespace)
+	// Don't need this. Will use single namespace
+	// fnNamespace := input.String(flagkey.NamespaceFunction) // TODO: we want watch to be created in same namespace or different
+
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.KwNamespace)
+	if err != nil {
+		return errors.Wrap(err, "error in listing function ")
+	}
+
 	objType := input.String(flagkey.KwObjType)
 
 	if input.Bool(flagkey.SpecSave) {
@@ -76,7 +82,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		exists, err := fr.ExistsInSpecs(fv1.Function{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fnName,
-				Namespace: fnNamespace,
+				Namespace: namespace,
 			},
 		})
 		if err != nil {
@@ -91,7 +97,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	opts.watcher = &fv1.KubernetesWatchTrigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      watchName,
-			Namespace: fnNamespace,
+			Namespace: namespace,
 		},
 		Spec: fv1.KubernetesWatchTriggerSpec{
 			Namespace: namespace,

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: need some input here
 package kubewatch
 
 import (
@@ -61,8 +60,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		watchName = id.String()
 	}
 	fnName := input.String(flagkey.KwFnName)
-	// Don't need this. Will use single namespace
-	// fnNamespace := input.String(flagkey.NamespaceFunction) // TODO: we want watch to be created in same namespace or different
 
 	_, namespace, err := util.GetResourceNamespace(input, flagkey.KwNamespace)
 	if err != nil {

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: need some input here
 package kubewatch
 
 import (
@@ -60,7 +61,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		watchName = id.String()
 	}
 	fnName := input.String(flagkey.KwFnName)
-	fnNamespace := input.String(flagkey.NamespaceFunction)
+	fnNamespace := input.String(flagkey.NamespaceFunction) // TODO: we want watch to be created in same namespace or different
 	namespace := input.String(flagkey.KwNamespace)
 	objType := input.String(flagkey.KwObjType)
 

--- a/pkg/fission-cli/cmd/kubewatch/delete.go
+++ b/pkg/fission-cli/cmd/kubewatch/delete.go
@@ -46,9 +46,12 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *DeleteSubCommand) complete(input cli.Input) error {
+func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.KwName)
-	opts.namespace = input.String(flagkey.NamespaceTrigger)
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting kubewatch")
+	}
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -45,8 +46,11 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *ListSubCommand) complete(input cli.Input) error {
-	opts.namespace = input.String(flagkey.NamespaceTrigger)
+func (opts *ListSubCommand) complete(input cli.Input) (err error) {
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error listing kubewatchers")
+	}
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -54,8 +55,13 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	return nil
 }
 
-func (opts *ListSubCommand) run(input cli.Input) error {
-	ws, err := opts.Client().V1().KubeWatcher().List(opts.namespace)
+func (opts *ListSubCommand) run(input cli.Input) (err error) {
+	var ws []v1.KubernetesWatchTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		ws, err = opts.Client().V1().KubeWatcher().List("")
+	} else {
+		ws, err = opts.Client().V1().KubeWatcher().List(opts.namespace)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error listing kubewatchers")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.MqtFnName, flag.MqtTopic},
 		Optional: []flag.Flag{flag.MqtName, flag.MqtMQType, flag.MqtRespTopic,
 			flag.MqtErrorTopic, flag.MqtMaxRetries, flag.MqtMsgContentType,
-			flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry, flag.MqtPollingInterval,
+			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtSecret,
 			flag.MqtMetadata, flag.MqtKind},
 	})
@@ -47,7 +47,7 @@ func Commands() *cobra.Command {
 	wrapper.SetFlags(updateCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName},
 		Optional: []flag.Flag{flag.MqtFnName, flag.MqtTopic, flag.MqtRespTopic, flag.MqtErrorTopic,
-			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.NamespaceTrigger, flag.Namespace, flag.MqtPollingInterval,
+			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.NamespaceTrigger, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtMetadata,
 			flag.MqtSecret, flag.MqtKind},
 	})
@@ -60,7 +60,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.MqtFnName, flag.MqtTopic},
 		Optional: []flag.Flag{flag.MqtName, flag.MqtMQType, flag.MqtRespTopic,
 			flag.MqtErrorTopic, flag.MqtMaxRetries, flag.MqtMsgContentType,
-			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry, flag.MqtPollingInterval,
+			flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtSecret,
 			flag.MqtMetadata, flag.MqtKind},
 	})
@@ -47,7 +47,7 @@ func Commands() *cobra.Command {
 	wrapper.SetFlags(updateCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName},
 		Optional: []flag.Flag{flag.MqtFnName, flag.MqtTopic, flag.MqtRespTopic, flag.MqtErrorTopic,
-			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.NamespaceTrigger, flag.MqtPollingInterval,
+			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.NamespaceTrigger, flag.Namespace, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtMetadata,
 			flag.MqtSecret, flag.MqtKind},
 	})
@@ -60,7 +60,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -66,7 +66,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	// fnNamespace := input.String(flagkey.NamespaceFunction)
 
 	mqtKind := input.String(flagkey.MqtKind)
 

--- a/pkg/fission-cli/cmd/mqtrigger/delete.go
+++ b/pkg/fission-cli/cmd/mqtrigger/delete.go
@@ -45,10 +45,16 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *DeleteSubCommand) complete(input cli.Input) error {
+func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
+
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+
 	opts.metadata = &metav1.ObjectMeta{
 		Name:      input.String(flagkey.MqtName),
-		Namespace: input.String(flagkey.NamespaceTrigger),
+		Namespace: namespace,
 	}
 	return nil
 }

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -51,7 +51,6 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	// opts.namespace = input.String(flagkey.NamespaceTrigger)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -45,8 +46,12 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *ListSubCommand) complete(input cli.Input) error {
-	opts.namespace = input.String(flagkey.NamespaceTrigger)
+func (opts *ListSubCommand) complete(input cli.Input) (err error) {
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+	// opts.namespace = input.String(flagkey.NamespaceTrigger)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -26,7 +26,6 @@ import (
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
-	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
@@ -59,14 +58,11 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
 	var mqts []v1.MessageQueueTrigger
-	var namespace string
 	if input.Bool(flagkey.AllNamespaces) {
 		mqts, err = opts.Client().V1().MessageQueueTrigger().List(input.String(flagkey.MqtMQType), "")
 	} else {
-		console.Warn(fmt.Sprintf("Namespace we got: %s", opts.namespace))
 		mqts, err = opts.Client().V1().MessageQueueTrigger().List(input.String(flagkey.MqtMQType), opts.namespace)
 	}
-	console.Warn(fmt.Sprintf("Namespace we got from API: %s", namespace))
 	if err != nil {
 		return errors.Wrap(err, "error listing message queue triggers")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -46,10 +46,15 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *UpdateSubCommand) complete(input cli.Input) error {
+func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+
 	mqt, err := opts.Client().V1().MessageQueueTrigger().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.MqtName),
-		Namespace: input.String(flagkey.NamespaceTrigger),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting message queue trigger")

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -25,6 +25,7 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
@@ -98,6 +99,12 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 		updated = true
 	}
 	if len(fnName) > 0 {
+		functionList := []string{fnName}
+		err := util.CheckFunctionExistence(opts.Client(), functionList, namespace)
+		if err != nil {
+			console.Warn(err.Error())
+		}
+
 		mqt.Spec.FunctionReference.Name = fnName
 		updated = true
 	}

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd,
-			flag.NamespacePackage, flag.NamespaceEnvironment, flag.SpecSave, flag.SpecDry},
+			flag.NamespacePackage, flag.Namespace, flag.SpecSave, flag.SpecDry}, //flag.NamespaceEnvironment- we don't want env and pkg NS to be different
 	})
 
 	getSrcCmd := &cobra.Command{
@@ -43,7 +43,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getSrcCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.PkgOutput},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace, flag.PkgOutput},
 	})
 
 	getDeployCmd := &cobra.Command{
@@ -53,7 +53,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getDeployCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.PkgOutput},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace, flag.PkgOutput},
 	})
 
 	updateCmd := &cobra.Command{
@@ -65,7 +65,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgName},
 		Optional: []flag.Flag{flag.PkgEnvironment, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd, flag.PkgForce,
-			flag.NamespacePackage, flag.NamespaceEnvironment},
+			flag.NamespacePackage, flag.Namespace, flag.NamespaceEnvironment}, //, flag.NamespaceEnvironment
 	})
 
 	deleteCmd := &cobra.Command{
@@ -74,7 +74,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Delete),
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgName, flag.PkgForce, flag.PkgOrphan, flag.NamespacePackage, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.PkgName, flag.PkgForce, flag.PkgOrphan, flag.NamespacePackage, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -84,7 +84,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage},
+		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.Namespace},
 	})
 
 	infoCmd := &cobra.Command{
@@ -94,7 +94,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(infoCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace},
 	})
 
 	rebuildCmd := &cobra.Command{
@@ -104,7 +104,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(rebuildCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -84,7 +84,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.Namespace},
+		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.Namespace, flag.AllNamespaces},
 	})
 
 	infoCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd,
-			flag.NamespacePackage, flag.Namespace, flag.SpecSave, flag.SpecDry}, //flag.NamespaceEnvironment- we don't want env and pkg NS to be different
+			flag.NamespacePackage, flag.SpecSave, flag.SpecDry},
 	})
 
 	getSrcCmd := &cobra.Command{
@@ -43,7 +43,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getSrcCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace, flag.PkgOutput},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.PkgOutput},
 	})
 
 	getDeployCmd := &cobra.Command{
@@ -53,7 +53,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(getDeployCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace, flag.PkgOutput},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.PkgOutput},
 	})
 
 	updateCmd := &cobra.Command{
@@ -65,7 +65,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgName},
 		Optional: []flag.Flag{flag.PkgEnvironment, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd, flag.PkgForce,
-			flag.NamespacePackage, flag.Namespace, flag.NamespaceEnvironment}, //, flag.NamespaceEnvironment
+			flag.NamespacePackage, flag.NamespaceEnvironment},
 	})
 
 	deleteCmd := &cobra.Command{
@@ -74,7 +74,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Delete),
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgName, flag.PkgForce, flag.PkgOrphan, flag.NamespacePackage, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.PkgName, flag.PkgForce, flag.PkgOrphan, flag.NamespacePackage, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -84,7 +84,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.AllNamespaces},
 	})
 
 	infoCmd := &cobra.Command{
@@ -94,7 +94,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(infoCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespacePackage},
 	})
 
 	rebuildCmd := &cobra.Command{
@@ -104,7 +104,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(rebuildCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespacePackage},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -63,7 +63,6 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		}
 	}
 
-	// pkgNamespace := input.String(flagkey.NamespacePackage)
 	envName := input.String(flagkey.PkgEnvironment)
 
 	userProvidedNS, pkgNamespace, err := util.GetResourceNamespace(input, flagkey.NamespacePackage)
@@ -71,7 +70,6 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
 
-	// envNamespace := input.String(flagkey.NamespaceEnvironment)
 	srcArchiveFiles := input.StringSlice(flagkey.PkgSrcArchive)
 	deployArchiveFiles := input.StringSlice(flagkey.PkgDeployArchive)
 	buildcmd := input.String(flagkey.PkgBuildCmd)

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -111,12 +111,12 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 			return err
 		}
 		if !exists {
-			console.Warn(fmt.Sprintf("Package '%v' references unknown Environment '%v' in Namespace '%v', please create it before applying spec",
+			console.Warn(fmt.Sprintf("Package '%s' references unknown Environment '%s' in Namespace '%s', please create it before applying spec",
 				pkgName, envName, userProvidedNS))
 		}
 
 		specDir = util.GetSpecDir(input)
-		specFile = fmt.Sprintf("package-%v.yaml", pkgName)
+		specFile = fmt.Sprintf("package-%s.yaml", pkgName)
 	}
 
 	_, err = CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName,

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -63,9 +63,15 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		}
 	}
 
-	pkgNamespace := input.String(flagkey.NamespacePackage)
+	// pkgNamespace := input.String(flagkey.NamespacePackage)
 	envName := input.String(flagkey.PkgEnvironment)
-	envNamespace := input.String(flagkey.NamespaceEnvironment)
+
+	userProvidedNS, pkgNamespace, err := util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+
+	// envNamespace := input.String(flagkey.NamespaceEnvironment)
 	srcArchiveFiles := input.StringSlice(flagkey.PkgSrcArchive)
 	deployArchiveFiles := input.StringSlice(flagkey.PkgDeployArchive)
 	buildcmd := input.String(flagkey.PkgBuildCmd)
@@ -100,30 +106,30 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		exists, err := fr.ExistsInSpecs(fv1.Environment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      envName,
-				Namespace: envNamespace,
+				Namespace: userProvidedNS,
 			},
 		})
 		if err != nil {
 			return err
 		}
 		if !exists {
-			console.Warn(fmt.Sprintf("Package '%v' references unknown Environment '%v', please create it before applying spec",
-				pkgName, envName))
+			console.Warn(fmt.Sprintf("Package '%v' references unknown Environment '%v' in Namespace '%v', please create it before applying spec",
+				pkgName, envName, userProvidedNS))
 		}
 
 		specDir = util.GetSpecDir(input)
 		specFile = fmt.Sprintf("package-%v.yaml", pkgName)
 	}
 
-	_, err := CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName, envNamespace,
-		srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip)
+	_, err = CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName, pkgNamespace,
+		srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip, userProvidedNS)
 
 	return err
 }
 
 // TODO: get all necessary value from CLI input directly
 func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkgNamespace string, envName string, envNamespace string,
-	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, specDir string, specFile string, noZip bool) (*metav1.ObjectMeta, error) {
+	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, specDir string, specFile string, noZip bool, userProvidedNS string) (*metav1.ObjectMeta, error) {
 
 	insecure := input.Bool(flagkey.PkgInsecure)
 	deployChecksum := input.String(flagkey.PkgDeployChecksum)
@@ -131,10 +137,19 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 
 	pkgSpec := fv1.PackageSpec{
 		Environment: fv1.EnvironmentReference{
-			Namespace: envNamespace,
+			Namespace: pkgNamespace,
 			Name:      envName,
 		},
 	}
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
+		pkgSpec = fv1.PackageSpec{
+			Environment: fv1.EnvironmentReference{
+				Namespace: userProvidedNS,
+				Name:      envName,
+			},
+		}
+	}
+
 	var pkgStatus fv1.BuildStatus = fv1.BuildStatusSucceeded
 
 	if len(deployArchiveFiles) > 0 {
@@ -177,7 +192,7 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 	pkg := &fv1.Package{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      pkgName,
-			Namespace: pkgNamespace,
+			Namespace: userProvidedNS,
 		},
 		Spec: pkgSpec,
 		Status: fv1.PackageStatus{
@@ -210,6 +225,7 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 		}
 		return &pkg.ObjectMeta, nil
 	} else {
+		pkg.ObjectMeta.Namespace = pkgNamespace
 		pkgMetadata, err := client.V1().Package().Create(pkg)
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating package")

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -121,14 +121,14 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		specFile = fmt.Sprintf("package-%v.yaml", pkgName)
 	}
 
-	_, err = CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName, pkgNamespace,
+	_, err = CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName,
 		srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip, userProvidedNS)
 
 	return err
 }
 
 // TODO: get all necessary value from CLI input directly
-func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkgNamespace string, envName string, envNamespace string,
+func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkgNamespace string, envName string,
 	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, specDir string, specFile string, noZip bool, userProvidedNS string) (*metav1.ObjectMeta, error) {
 
 	insecure := input.Bool(flagkey.PkgInsecure)

--- a/pkg/fission-cli/cmd/package/delete.go
+++ b/pkg/fission-cli/cmd/package/delete.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
@@ -49,9 +50,14 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *DeleteSubCommand) complete(input cli.Input) error {
+func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	opts.namespace = input.String(flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+
+	// opts.namespace = input.String(flagkey.NamespacePackage)
 	opts.deleteOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.force = input.Bool(flagkey.PkgForce)
 

--- a/pkg/fission-cli/cmd/package/delete.go
+++ b/pkg/fission-cli/cmd/package/delete.go
@@ -57,7 +57,6 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
 
-	// opts.namespace = input.String(flagkey.NamespacePackage)
 	opts.deleteOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.force = input.Bool(flagkey.PkgForce)
 

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -28,6 +28,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 const (
@@ -58,9 +59,13 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *GetSubCommand) complete(input cli.Input) error {
+func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	opts.namespace = input.String(flagkey.NamespacePackage)
+	// opts.namespace = input.String(flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
 	opts.output = input.String(flagkey.PkgOutput)
 	return nil
 }

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -61,7 +61,6 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 
 func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	// opts.namespace = input.String(flagkey.NamespacePackage)
 	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -55,7 +55,6 @@ func (opts *InfoSubCommand) complete(input cli.Input) (err error) {
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
-	// opts.namespace = input.String(flagkey.NamespacePackage)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -22,10 +22,12 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type InfoSubCommand struct {
@@ -46,9 +48,14 @@ func (opts *InfoSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *InfoSubCommand) complete(input cli.Input) error {
+func (opts *InfoSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	opts.namespace = input.String(flagkey.NamespacePackage)
+
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+	// opts.namespace = input.String(flagkey.NamespacePackage)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -25,9 +25,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -49,11 +51,15 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *ListSubCommand) complete(input cli.Input) error {
+func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	// option for the user to list all orphan packages (not referenced by any function)
 	opts.listOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.status = input.String(flagkey.PkgStatus)
-	opts.pkgNamespace = input.String(flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+	// opts.pkgNamespace = input.String(flagkey.NamespacePackage)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -62,8 +62,14 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	return nil
 }
 
-func (opts *ListSubCommand) run(input cli.Input) error {
-	pkgList, err := opts.Client().V1().Package().List(opts.pkgNamespace)
+func (opts *ListSubCommand) run(input cli.Input) (err error) {
+
+	var pkgList []fv1.Package
+	if input.Bool(flagkey.AllNamespaces) {
+		pkgList, err = opts.Client().V1().Package().List("")
+	} else {
+		pkgList, err = opts.Client().V1().Package().List(opts.pkgNamespace)
+	}
 	if err != nil {
 		return err
 	}
@@ -74,7 +80,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT")
+	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT", "NAMESPACE")
 
 	for _, pkg := range pkgList {
 		show := true
@@ -92,7 +98,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 			show = false
 		}
 		if show {
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", pkg.ObjectMeta.Name, pkg.Status.BuildStatus, pkg.Spec.Environment.Name, pkg.Status.LastUpdateTimestamp.Format(time.RFC822))
+			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", pkg.ObjectMeta.Name, pkg.Status.BuildStatus, pkg.Spec.Environment.Name, pkg.Status.LastUpdateTimestamp.Format(time.RFC822), pkg.ObjectMeta.Namespace)
 		}
 	}
 

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -59,7 +59,6 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
-	// opts.pkgNamespace = input.String(flagkey.NamespacePackage)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -49,7 +49,6 @@ func (opts *RebuildSubCommand) do(input cli.Input) error {
 
 func (opts *RebuildSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	// opts.namespace = input.String(flagkey.NamespacePackage)
 	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type RebuildSubCommand struct {
@@ -46,9 +47,13 @@ func (opts *RebuildSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *RebuildSubCommand) complete(input cli.Input) error {
+func (opts *RebuildSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	opts.namespace = input.String(flagkey.NamespacePackage)
+	// opts.namespace = input.String(flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
@@ -50,9 +51,13 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *UpdateSubCommand) complete(input cli.Input) error {
+func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	opts.pkgName = input.String(flagkey.PkgName)
-	opts.pkgNamespace = input.String(flagkey.NamespacePackage)
+	// opts.pkgNamespace = input.String(flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
 	opts.force = input.Bool(flagkey.PkgForce)
 	return nil
 }
@@ -94,7 +99,7 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 
 func UpdatePackage(input cli.Input, client client.Interface, pkg *fv1.Package) (*metav1.ObjectMeta, error) {
 	envName := input.String(flagkey.PkgEnvironment)
-	envNamespace := input.String(flagkey.NamespaceEnvironment)
+	// envNamespace := input.String(flagkey.NamespaceEnvironment)
 	srcArchiveFiles := input.StringSlice(flagkey.PkgSrcArchive)
 	deployArchiveFiles := input.StringSlice(flagkey.PkgDeployArchive)
 	buildcmd := input.String(flagkey.PkgBuildCmd)
@@ -119,11 +124,11 @@ func UpdatePackage(input cli.Input, client client.Interface, pkg *fv1.Package) (
 		needToUpdate = true
 	}
 
-	if input.IsSet(flagkey.NamespaceEnvironment) {
-		pkg.Spec.Environment.Namespace = envNamespace
-		needToRebuild = true
-		needToUpdate = true
-	}
+	// if input.IsSet(flagkey.NamespaceEnvironment) {
+	// 	pkg.Spec.Environment.Namespace = envNamespace
+	// 	needToRebuild = true
+	// 	needToUpdate = true
+	// }
 
 	if input.IsSet(flagkey.PkgBuildCmd) {
 		pkg.Spec.BuildCommand = buildcmd

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -53,7 +53,6 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	opts.pkgName = input.String(flagkey.PkgName)
-	// opts.pkgNamespace = input.String(flagkey.NamespacePackage)
 	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
@@ -123,12 +122,6 @@ func UpdatePackage(input cli.Input, client client.Interface, pkg *fv1.Package) (
 		needToRebuild = true
 		needToUpdate = true
 	}
-
-	// if input.IsSet(flagkey.NamespaceEnvironment) {
-	// 	pkg.Spec.Environment.Namespace = envNamespace
-	// 	needToRebuild = true
-	// 	needToUpdate = true
-	// }
 
 	if input.IsSet(flagkey.PkgBuildCmd) {
 		pkg.Spec.BuildCommand = buildcmd

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -98,7 +98,6 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 
 func UpdatePackage(input cli.Input, client client.Interface, pkg *fv1.Package) (*metav1.ObjectMeta, error) {
 	envName := input.String(flagkey.PkgEnvironment)
-	// envNamespace := input.String(flagkey.NamespaceEnvironment)
 	srcArchiveFiles := input.StringSlice(flagkey.PkgSrcArchive)
 	deployArchiveFiles := input.StringSlice(flagkey.PkgDeployArchive)
 	buildcmd := input.String(flagkey.PkgBuildCmd)

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -81,6 +81,12 @@ func (opts *ApplySubCommand) insertNamespace(input cli.Input, fr *FissionResourc
 			fr.Functions[i].Namespace = currentNS
 			fr.Functions[i].Spec.Package.PackageRef.Namespace = currentNS
 			fr.Functions[i].Spec.Environment.Namespace = currentNS
+			for j := range fr.Functions[i].Spec.ConfigMaps {
+				fr.Functions[i].Spec.ConfigMaps[j].Namespace = currentNS
+			}
+			for j := range fr.Functions[i].Spec.Secrets {
+				fr.Functions[i].Spec.Secrets[j].Namespace = currentNS
+			}
 		}
 	}
 	for i := range fr.Environments {

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -77,42 +77,42 @@ func (opts *ApplySubCommand) insertNamespace(input cli.Input, fr *FissionResourc
 	}
 
 	for i := range fr.Functions {
-		if fr.Functions[i].Namespace == "" {
+		if fr.Functions[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.Functions[i].Namespace = currentNS
 			fr.Functions[i].Spec.Package.PackageRef.Namespace = currentNS
 			fr.Functions[i].Spec.Environment.Namespace = currentNS
 		}
 	}
 	for i := range fr.Environments {
-		if fr.Environments[i].Namespace == "" {
+		if fr.Environments[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.Environments[i].Namespace = currentNS
 		}
 	}
 	for i := range fr.Packages {
-		if fr.Packages[i].Namespace == "" {
+		if fr.Packages[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.Packages[i].Namespace = currentNS
 			fr.Packages[i].Spec.Environment.Namespace = currentNS
 			fr.Packages[i].ObjectMeta.Namespace = currentNS
 		}
 	}
 	for i := range fr.HttpTriggers {
-		if fr.HttpTriggers[i].Namespace == "" {
+		if fr.HttpTriggers[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.HttpTriggers[i].Namespace = currentNS
 			// sObj.Spec.FunctionReference. TODO: it doesn't have namespace info
 		}
 	}
 	for i := range fr.MessageQueueTriggers {
-		if fr.MessageQueueTriggers[i].Namespace == "" {
+		if fr.MessageQueueTriggers[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.MessageQueueTriggers[i].Namespace = currentNS
 		}
 	}
 	for i := range fr.TimeTriggers {
-		if fr.TimeTriggers[i].Namespace == "" {
+		if fr.TimeTriggers[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.TimeTriggers[i].Namespace = currentNS
 		}
 	}
 	for i := range fr.KubernetesWatchTriggers {
-		if fr.KubernetesWatchTriggers[i].Namespace == "" {
+		if fr.KubernetesWatchTriggers[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.KubernetesWatchTriggers[i].Namespace = currentNS
 		}
 	}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -185,9 +185,6 @@ func (opts *ApplySubCommand) run(input cli.Input) error {
 			}
 		}
 
-		console.Infof("Resources:\n *%+v \n %v NS \n * %v ENV \n %v Packages \n * \n",
-			fr.Packages[0], fr.Packages[0].Namespace, fr.Functions[0].Spec.Environment.Namespace, fr.Functions[0].Spec.Package.PackageRef.Namespace)
-
 		err = warnIfDirtyWorkTree(filepath.Clean(specDir + "/.."))
 		if err != nil {
 			console.Warn(err.Error())

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -852,7 +852,7 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 
 func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().Environment().List(metav1.NamespaceAll) // TBD: this can be conflicting with the multi-tenancy but check if we have valid use case for this
+	allObjs, err := fclient.V1().Environment().List(metav1.NamespaceAll)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -104,7 +104,6 @@ func (opts *ApplySubCommand) insertNamespace(input cli.Input, fr *FissionResourc
 	for i := range fr.HttpTriggers {
 		if fr.HttpTriggers[i].Namespace == "" || input.Bool(flagkey.ForceNamespace) {
 			fr.HttpTriggers[i].Namespace = currentNS
-			// sObj.Spec.FunctionReference. TODO: it doesn't have namespace info
 		}
 	}
 	for i := range fr.MessageQueueTriggers {

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -58,7 +58,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Destroy),
 	}
 	wrapper.SetFlags(destroyCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.Namespace, flag.ForceDelete},
 	})
 
 	listCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -67,7 +67,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDeployID, flag.SpecDir, flag.SpecIgnore, flag.Namespace},
+		Optional: []flag.Flag{flag.SpecDeployID, flag.SpecDir, flag.SpecIgnore, flag.Namespace, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(applyCmd, flag.FlagSet{
 		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch,
-			flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.Namespace, flag.ForceNamespace},
+			flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.ForceNamespace},
 	})
 
 	destroyCmd := &cobra.Command{
@@ -58,7 +58,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Destroy),
 	}
 	wrapper.SetFlags(destroyCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.Namespace, flag.ForceDelete},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.ForceDelete},
 	})
 
 	listCmd := &cobra.Command{
@@ -67,7 +67,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDeployID, flag.SpecDir, flag.SpecIgnore, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.SpecDeployID, flag.SpecDir, flag.SpecIgnore, flag.AllNamespaces},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -39,7 +39,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Validate),
 	}
 	wrapper.SetFlags(validateCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecAllowConflicts},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecAllowConflicts, flag.Namespace},
 	})
 
 	applyCmd := &cobra.Command{
@@ -48,7 +48,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Apply),
 	}
 	wrapper.SetFlags(applyCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.Namespace},
 	})
 
 	destroyCmd := &cobra.Command{
@@ -66,7 +66,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDeployID, flag.SpecDir, flag.SpecIgnore},
+		Optional: []flag.Flag{flag.SpecDeployID, flag.SpecDir, flag.SpecIgnore, flag.Namespace},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -39,7 +39,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Validate),
 	}
 	wrapper.SetFlags(validateCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecAllowConflicts, flag.Namespace},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecAllowConflicts},
 	})
 
 	applyCmd := &cobra.Command{
@@ -48,7 +48,8 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(Apply),
 	}
 	wrapper.SetFlags(applyCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch, flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.Namespace},
+		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch,
+			flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.Namespace, flag.ForceNamespace},
 	})
 
 	destroyCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -218,36 +218,34 @@ func deleteResources(fclient client.Interface, fr *FissionResources, forceDelete
 }
 
 func destroyHTTPTriggers(fclient client.Interface, fr *FissionResources) error {
-	// objs is already filtered with our UID
 	for _, o := range fr.HttpTriggers {
 		err := fclient.V1().HTTPTrigger().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete httptrigger: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete httptrigger: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 	return nil
 }
 
 func destroyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources) error {
 
-	// objs is already filtered with our UID
 	for _, o := range fr.KubernetesWatchTriggers {
 		err := fclient.V1().KubeWatcher().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete watch: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete watch: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil
@@ -255,18 +253,17 @@ func destroyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResourc
 
 func destroyTimeTriggers(fclient client.Interface, fr *FissionResources) error {
 
-	// objs is already filtered with our UID
 	for _, o := range fr.TimeTriggers {
 		err := fclient.V1().TimeTrigger().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete Time trigger: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete Time trigger: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil
@@ -274,18 +271,17 @@ func destroyTimeTriggers(fclient client.Interface, fr *FissionResources) error {
 
 func destroyMessageQueueTriggers(fclient client.Interface, fr *FissionResources) error {
 
-	// objs is already filtered with our UID
 	for _, o := range fr.MessageQueueTriggers {
 		err := fclient.V1().MessageQueueTrigger().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete Message trigger: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete Message trigger: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil
@@ -293,18 +289,17 @@ func destroyMessageQueueTriggers(fclient client.Interface, fr *FissionResources)
 
 func destroyFunctions(fclient client.Interface, fr *FissionResources) error {
 
-	// objs is already filtered with our UID
 	for _, o := range fr.Functions {
 		err := fclient.V1().Function().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete Functions: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete Functions: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil
@@ -312,18 +307,17 @@ func destroyFunctions(fclient client.Interface, fr *FissionResources) error {
 
 func destroyPackages(fclient client.Interface, fr *FissionResources) error {
 
-	// objs is already filtered with our UID
 	for _, o := range fr.Packages {
 		err := fclient.V1().Package().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete Package: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete Package: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil
@@ -331,18 +325,17 @@ func destroyPackages(fclient client.Interface, fr *FissionResources) error {
 
 func destroyEnvironments(fclient client.Interface, fr *FissionResources) error {
 
-	// objs is already filtered with our UID
 	for _, o := range fr.Environments {
 		err := fclient.V1().Environment().Delete(&o.ObjectMeta)
 		if err != nil && strings.Contains(err.Error(), "not found") {
-			console.Verbose(2, fmt.Sprintf("could not delete Env: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			console.Verbose(2, fmt.Sprintf("could not delete Env: %s Namespace: %s", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
 			err = nil
 			continue
 
 		} else if err != nil {
 			return err
 		}
-		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+		fmt.Printf("Deleted %s %s/%s\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -62,6 +62,7 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	return nil
 }
 
+// TODO: we don't have namespace here. It uses UUID. Do we need to add namespace here
 func deleteResources(fclient client.Interface, fr *FissionResources) error {
 
 	var err error

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -17,12 +17,19 @@ limitations under the License.
 package spec
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/pkg/errors"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/console"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
+	"github.com/fission/fission/pkg/utils"
 )
 
 type DestroySubCommand struct {
@@ -49,12 +56,26 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 		return errors.Wrap(err, "error reading specs")
 	}
 
-	// set desired state to nothing, but keep the UID so "apply" can find it
-	emptyFr := FissionResources{}
-	emptyFr.DeploymentConfig = fr.DeploymentConfig
+	if !input.Bool(flagkey.ForceDelete) {
+		err = opts.insertNSToResource(input, fr)
+		if err != nil {
+			return errors.Wrap(err, "error adding namespace")
+		}
+	} else {
+		// if force delete set to true we fetch all resources with our deployment ID and delete them
+		// set desired state to nothing, but keep the UID so "apply" can find it
+		emptyFr := FissionResources{}
+		emptyFr.DeploymentConfig = fr.DeploymentConfig
 
-	// "apply" the empty state
-	err = deleteResources(opts.Client(), &emptyFr)
+		// "apply" the empty state
+		err = forceDeleteResources(opts.Client(), &emptyFr)
+		if err != nil {
+			return errors.Wrap(err, "error deleting resources")
+		}
+		return nil
+	}
+	forceDelete := input.Bool(flagkey.ForceDelete)
+	err = deleteResources(opts.Client(), fr, forceDelete)
 	if err != nil {
 		return errors.Wrap(err, "error deleting resources")
 	}
@@ -62,8 +83,7 @@ func (opts *DestroySubCommand) run(input cli.Input) error {
 	return nil
 }
 
-// TODO: we don't have namespace here. It uses UUID. Do we need to add namespace here
-func deleteResources(fclient client.Interface, fr *FissionResources) error {
+func forceDeleteResources(fclient client.Interface, fr *FissionResources) error {
 
 	var err error
 
@@ -100,6 +120,229 @@ func deleteResources(fclient client.Interface, fr *FissionResources) error {
 	_, _, err = applyEnvironments(fclient, fr, true, false)
 	if err != nil {
 		return errors.Wrap(err, "environment delete failed")
+	}
+
+	return nil
+}
+
+// insertNSToResource provides a namespace to all resource which don't have a namespace specified
+// in resource
+func (opts *DestroySubCommand) insertNSToResource(input cli.Input, fr *FissionResources) error {
+
+	result := utils.MultiErrorWithFormat()
+
+	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	if err != nil {
+		return fv1.AggregateValidationErrors("Environment", err)
+	}
+
+	for i := range fr.Functions {
+		if fr.Functions[i].Namespace == "" {
+			fr.Functions[i].Namespace = currentNS
+		}
+	}
+	for i := range fr.Environments {
+		if fr.Environments[i].Namespace == "" {
+			fr.Environments[i].Namespace = currentNS
+		}
+	}
+	for i := range fr.Packages {
+		if fr.Packages[i].Namespace == "" {
+			fr.Packages[i].Namespace = currentNS
+		}
+	}
+	for i := range fr.HttpTriggers {
+		if fr.HttpTriggers[i].Namespace == "" {
+			fr.HttpTriggers[i].Namespace = currentNS
+		}
+	}
+	for i := range fr.MessageQueueTriggers {
+		if fr.MessageQueueTriggers[i].Namespace == "" {
+			fr.MessageQueueTriggers[i].Namespace = currentNS
+		}
+	}
+	for i := range fr.TimeTriggers {
+		if fr.TimeTriggers[i].Namespace == "" {
+			fr.TimeTriggers[i].Namespace = currentNS
+		}
+	}
+	for i := range fr.KubernetesWatchTriggers {
+		if fr.KubernetesWatchTriggers[i].Namespace == "" {
+			fr.KubernetesWatchTriggers[i].Namespace = currentNS
+		}
+	}
+
+	return result.ErrorOrNil()
+}
+
+func deleteResources(fclient client.Interface, fr *FissionResources, forceDelete bool) error {
+
+	var err error
+
+	err = destroyHTTPTriggers(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "HTTPTrigger delete failed")
+	}
+
+	err = destroyKubernetesWatchTriggers(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "KubernetesWatchTrigger delete failed")
+	}
+
+	err = destroyTimeTriggers(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "TimeTrigger delete failed")
+	}
+
+	err = destroyMessageQueueTriggers(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "MessageQueueTrigger delete failed")
+	}
+
+	err = destroyFunctions(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "function delete failed")
+	}
+
+	err = destroyPackages(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "package delete failed")
+	}
+
+	err = destroyEnvironments(fclient, fr)
+	if err != nil {
+		return errors.Wrap(err, "environment delete failed")
+	}
+
+	return nil
+}
+
+func destroyHTTPTriggers(fclient client.Interface, fr *FissionResources) error {
+	// objs is already filtered with our UID
+	for _, o := range fr.HttpTriggers {
+		err := fclient.V1().HTTPTrigger().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete httptrigger: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+	}
+	return nil
+}
+
+func destroyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources) error {
+
+	// objs is already filtered with our UID
+	for _, o := range fr.KubernetesWatchTriggers {
+		err := fclient.V1().KubeWatcher().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete watch: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+	}
+
+	return nil
+}
+
+func destroyTimeTriggers(fclient client.Interface, fr *FissionResources) error {
+
+	// objs is already filtered with our UID
+	for _, o := range fr.TimeTriggers {
+		err := fclient.V1().TimeTrigger().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete Time trigger: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+	}
+
+	return nil
+}
+
+func destroyMessageQueueTriggers(fclient client.Interface, fr *FissionResources) error {
+
+	// objs is already filtered with our UID
+	for _, o := range fr.MessageQueueTriggers {
+		err := fclient.V1().MessageQueueTrigger().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete Message trigger: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+	}
+
+	return nil
+}
+
+func destroyFunctions(fclient client.Interface, fr *FissionResources) error {
+
+	// objs is already filtered with our UID
+	for _, o := range fr.Functions {
+		err := fclient.V1().Function().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete Functions: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+	}
+
+	return nil
+}
+
+func destroyPackages(fclient client.Interface, fr *FissionResources) error {
+
+	// objs is already filtered with our UID
+	for _, o := range fr.Packages {
+		err := fclient.V1().Package().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete Package: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
+	}
+
+	return nil
+}
+
+func destroyEnvironments(fclient client.Interface, fr *FissionResources) error {
+
+	// objs is already filtered with our UID
+	for _, o := range fr.Environments {
+		err := fclient.V1().Environment().Delete(&o.ObjectMeta)
+		if err != nil && strings.Contains(err.Error(), "not found") {
+			console.Verbose(2, fmt.Sprintf("could not delete Env: %v Namespace: %v", o.ObjectMeta.Name, o.ObjectMeta.Namespace))
+			err = nil
+			continue
+
+		} else if err != nil {
+			return err
+		}
+		fmt.Printf("Deleted %v %v/%v\n", o.TypeMeta.Kind, o.ObjectMeta.Namespace, o.ObjectMeta.Name)
 	}
 
 	return nil

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -80,7 +80,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 		printNS = "all"
 	}
 
-	allfn, err = getAllFunctions(opts.Client(), "")
+	allfn, err = getAllFunctions(opts.Client(), namespace)
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("error getting Functions from %s namespaces", printNS))
 	}

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -65,103 +65,85 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
 
-	var allfn []fv1.Function
 	if input.Bool(flagkey.AllNamespaces) {
-		allfn, err = getAllFunctions(opts.Client(), "")
+		return opts.getResource(input, "", deployID)
 	} else {
-		allfn, err = getAllFunctions(opts.Client(), currentNS)
+		return opts.getResource(input, currentNS, deployID)
 	}
+
+}
+
+func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deployID string) (err error) {
+	var allfn []fv1.Function
+	printNS := namespace
+	if printNS == "" {
+		printNS = "all"
+	}
+
+	allfn, err = getAllFunctions(opts.Client(), "")
 	if err != nil {
-		return errors.Wrap(err, "error getting Functions from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting Functions from %s namespaces", printNS))
 	}
 	specfns := getAppliedFunctions(allfn, deployID)
 	ShowFunctions(specfns)
 
 	var allenvs []fv1.Environment
-	if input.Bool(flagkey.AllNamespaces) {
-		allenvs, err = getAllEnvironments(opts.Client(), "")
-	} else {
-		allenvs, err = getAllEnvironments(opts.Client(), currentNS)
-	}
+	allenvs, err = getAllEnvironments(opts.Client(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting Environments from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting Environments from  %s namespaces", printNS))
 	}
 	specenvs := getAppliedEnvironments(allenvs, deployID)
 	ShowEnvironments(specenvs)
 
 	var pkglists []fv1.Package
-	if input.Bool(flagkey.AllNamespaces) {
-		pkglists, err = getAllPackages(opts.Client(), "")
-	} else {
-		pkglists, err = getAllPackages(opts.Client(), currentNS)
-	}
+	pkglists, err = getAllPackages(opts.Client(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting Packages from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting Packages from  %s namespaces", printNS))
 	}
 	specPkgs := getAppliedPackages(pkglists, deployID)
 	ShowPackages(specPkgs)
 
 	var canaryCfgs []fv1.CanaryConfig
-	if input.Bool(flagkey.AllNamespaces) {
-		canaryCfgs, err = getAllCanaryConfigs(opts.Client(), "")
-	} else {
-		canaryCfgs, err = getAllCanaryConfigs(opts.Client(), currentNS)
-	}
+	canaryCfgs, err = getAllCanaryConfigs(opts.Client(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting Canary Config from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting Canary Config from  %s namespaces", printNS))
 	}
 	specCanaryCfgs := getAppliedCanaryConfigs(canaryCfgs, deployID)
 	ShowCanaryConfigs(specCanaryCfgs)
 
 	var hts []fv1.HTTPTrigger
-	if input.Bool(flagkey.AllNamespaces) {
-		hts, err = getAllHTTPTriggers(opts.Client(), "")
-	} else {
-		hts, err = getAllHTTPTriggers(opts.Client(), currentNS)
-	}
+	hts, err = getAllHTTPTriggers(opts.Client(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting HTTP Triggers from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting HTTP Triggers from  %s namespaces", printNS))
 	}
 	specHTTPTriggers := getAppliedHTTPTriggers(hts, deployID)
 	ShowHTTPTriggers(specHTTPTriggers)
 
 	var mqts []fv1.MessageQueueTrigger
-	if input.Bool(flagkey.AllNamespaces) {
-		mqts, err = getAllMessageQueueTriggers(opts.Client(), input.String(flagkey.MqtMQType), "")
-	} else {
-		mqts, err = getAllMessageQueueTriggers(opts.Client(), input.String(flagkey.MqtMQType), currentNS)
-	}
+	mqts, err = getAllMessageQueueTriggers(opts.Client(), input.String(flagkey.MqtMQType), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting MessageQueue Triggers from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting MessageQueue Triggers from  %s namespaces", printNS))
 	}
 	specMessageQueueTriggers := getAppliedMessageQueueTriggers(mqts, deployID)
 	ShowMQTriggers(specMessageQueueTriggers)
 
 	var tts []fv1.TimeTrigger
-	if input.Bool(flagkey.AllNamespaces) {
-		tts, err = getAllTimeTriggers(opts.Client(), "")
-	} else {
-		tts, err = getAllTimeTriggers(opts.Client(), currentNS)
-	}
+	tts, err = getAllTimeTriggers(opts.Client(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting Time Triggers from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting Time Triggers from  %s namespaces", printNS))
 	}
 	specTimeTriggers := getAppliedTimeTriggers(tts, deployID)
 	ShowTimeTriggers(specTimeTriggers)
 
 	var kws []fv1.KubernetesWatchTrigger
-	if input.Bool(flagkey.AllNamespaces) {
-		kws, err = getAllKubeWatchTriggers(opts.Client(), "")
-	} else {
-		kws, err = getAllKubeWatchTriggers(opts.Client(), currentNS)
-	}
+	kws, err = getAllKubeWatchTriggers(opts.Client(), namespace)
 	if err != nil {
-		return errors.Wrap(err, "error getting Kube Watchers from all namespaces")
+		return errors.Wrap(err, fmt.Sprintf("error getting Kube Watchers from  %s namespaces", printNS))
 	}
 	specKubeWatchers := getSpecKubeWatchers(kws, deployID)
 	ShowAppliedKubeWatchers(specKubeWatchers)
 
-	return nil
+	return err
 }
 
 func getAppliedFunctions(fns []fv1.Function, deployID string) []fv1.Function {

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -397,8 +397,8 @@ func ShowAppliedKubeWatchers(ws []fv1.KubernetesWatchTrigger) {
 	}
 }
 
-// getAllFunctions get lists of functions in all namespaces
-func getAllFunctions(client client.Interface, namespace string) ([]fv1.Function, error) { // TODO: do we want this to be ns specific now
+// getAllFunctions get lists of functions in provided namespaces
+func getAllFunctions(client client.Interface, namespace string) ([]fv1.Function, error) {
 	fns, err := client.V1().Function().List(namespace)
 	if err != nil {
 		return nil, errors.Errorf("Unable to get Functions %v", err.Error())

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -65,56 +65,96 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
 
-	allfn, err := getAllFunctions(opts.Client(), currentNS)
+	var allfn []fv1.Function
+	if input.Bool(flagkey.AllNamespaces) {
+		allfn, err = getAllFunctions(opts.Client(), "")
+	} else {
+		allfn, err = getAllFunctions(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting Functions from all namespaces")
 	}
 	specfns := getAppliedFunctions(allfn, deployID)
 	ShowFunctions(specfns)
 
-	allenvs, err := getAllEnvironments(opts.Client(), currentNS)
+	var allenvs []fv1.Environment
+	if input.Bool(flagkey.AllNamespaces) {
+		allenvs, err = getAllEnvironments(opts.Client(), "")
+	} else {
+		allenvs, err = getAllEnvironments(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting Environments from all namespaces")
 	}
 	specenvs := getAppliedEnvironments(allenvs, deployID)
 	ShowEnvironments(specenvs)
 
-	pkglists, err := getAllPackages(opts.Client(), currentNS)
+	var pkglists []fv1.Package
+	if input.Bool(flagkey.AllNamespaces) {
+		pkglists, err = getAllPackages(opts.Client(), "")
+	} else {
+		pkglists, err = getAllPackages(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting Packages from all namespaces")
 	}
 	specPkgs := getAppliedPackages(pkglists, deployID)
 	ShowPackages(specPkgs)
 
-	canaryCfgs, err := getAllCanaryConfigs(opts.Client(), currentNS)
+	var canaryCfgs []fv1.CanaryConfig
+	if input.Bool(flagkey.AllNamespaces) {
+		canaryCfgs, err = getAllCanaryConfigs(opts.Client(), "")
+	} else {
+		canaryCfgs, err = getAllCanaryConfigs(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting Canary Config from all namespaces")
 	}
 	specCanaryCfgs := getAppliedCanaryConfigs(canaryCfgs, deployID)
 	ShowCanaryConfigs(specCanaryCfgs)
 
-	hts, err := getAllHTTPTriggers(opts.Client(), currentNS)
+	var hts []fv1.HTTPTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		hts, err = getAllHTTPTriggers(opts.Client(), "")
+	} else {
+		hts, err = getAllHTTPTriggers(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting HTTP Triggers from all namespaces")
 	}
 	specHTTPTriggers := getAppliedHTTPTriggers(hts, deployID)
 	ShowHTTPTriggers(specHTTPTriggers)
 
-	mqts, err := getAllMessageQueueTriggers(opts.Client(), input.String(flagkey.MqtMQType), currentNS)
+	var mqts []fv1.MessageQueueTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		mqts, err = getAllMessageQueueTriggers(opts.Client(), input.String(flagkey.MqtMQType), "")
+	} else {
+		mqts, err = getAllMessageQueueTriggers(opts.Client(), input.String(flagkey.MqtMQType), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting MessageQueue Triggers from all namespaces")
 	}
 	specMessageQueueTriggers := getAppliedMessageQueueTriggers(mqts, deployID)
 	ShowMQTriggers(specMessageQueueTriggers)
 
-	tts, err := getAllTimeTriggers(opts.Client(), currentNS)
+	var tts []fv1.TimeTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		tts, err = getAllTimeTriggers(opts.Client(), "")
+	} else {
+		tts, err = getAllTimeTriggers(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting Time Triggers from all namespaces")
 	}
 	specTimeTriggers := getAppliedTimeTriggers(tts, deployID)
 	ShowTimeTriggers(specTimeTriggers)
 
-	kws, err := getAllKubeWatchTriggers(opts.Client(), currentNS)
+	var kws []fv1.KubernetesWatchTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		kws, err = getAllKubeWatchTriggers(opts.Client(), "")
+	} else {
+		kws, err = getAllKubeWatchTriggers(opts.Client(), currentNS)
+	}
 	if err != nil {
 		return errors.Wrap(err, "error getting Kube Watchers from all namespaces")
 	}

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -491,7 +491,7 @@ func (fr *FissionResources) Validate(input cli.Input) ([]string, error) {
 
 	for _, f := range fr.Functions {
 		if _, ok := environments[fmt.Sprintf("%s:%s", f.Spec.Environment.Name, f.Spec.Environment.Namespace)]; !ok {
-			warnings = append(warnings, "Environment %s is referenced in function %s but not declared in specs", f.Spec.Environment.Name, f.ObjectMeta.Name)
+			warnings = append(warnings, fmt.Sprintf("Environment %s is referenced in function %s but not declared in specs", f.Spec.Environment.Name, f.ObjectMeta.Name))
 		}
 		strategy := f.Spec.InvokeStrategy.ExecutionStrategy
 		if strategy.ExecutorType == fv1.ExecutorTypeNewdeploy && strategy.SpecializationTimeout < fv1.DefaultSpecializationTimeOut {

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Optional: []flag.Flag{flag.TtName, flag.TtFnName,
-			flag.TtCron, flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry},
+			flag.TtCron, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 	})
 
 	updateCmd := &cobra.Command{
@@ -42,7 +42,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(updateCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName},
-		Optional: []flag.Flag{flag.TtFnName, flag.TtCron, flag.NamespaceTrigger, flag.Namespace},
+		Optional: []flag.Flag{flag.TtFnName, flag.TtCron, flag.NamespaceTrigger},
 	})
 
 	deleteCmd := &cobra.Command{
@@ -53,7 +53,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -64,7 +64,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces},
 	})
 
 	showCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Optional: []flag.Flag{flag.TtName, flag.TtFnName,
-			flag.TtCron, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
+			flag.TtCron, flag.NamespaceFunction, flag.Namespace, flag.SpecSave, flag.SpecDry},
 	})
 
 	updateCmd := &cobra.Command{
@@ -42,7 +42,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(updateCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName},
-		Optional: []flag.Flag{flag.TtFnName, flag.TtCron, flag.NamespaceTrigger},
+		Optional: []flag.Flag{flag.TtFnName, flag.TtCron, flag.NamespaceTrigger, flag.Namespace},
 	})
 
 	deleteCmd := &cobra.Command{
@@ -53,7 +53,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(deleteCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.IgnoreNotFound},
 	})
 
 	listCmd := &cobra.Command{
@@ -64,7 +64,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace},
 	})
 
 	showCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -64,7 +64,7 @@ func Commands() *cobra.Command {
 		RunE:    wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Namespace, flag.AllNamespaces},
 	})
 
 	showCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -68,8 +68,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 		return errors.New("Need a function name to create a trigger, use --function")
 	}
 
-	// fnNamespace := input.String(flagkey.NamespaceFunction)
-
 	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -53,7 +53,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	return opts.run(input)
 }
 
-func (opts *CreateSubCommand) complete(input cli.Input) error {
+func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 	name := input.String(flagkey.TtName)
 	if len(name) == 0 {
 		id, err := uuid.NewV4()
@@ -68,7 +68,12 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		return errors.New("Need a function name to create a trigger, use --function")
 	}
 
-	fnNamespace := input.String(flagkey.NamespaceFunction)
+	// fnNamespace := input.String(flagkey.NamespaceFunction)
+
+	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
 
 	cronSpec := input.String(flagkey.TtCron)
 	if len(cronSpec) == 0 {
@@ -86,7 +91,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		exists, err := fr.ExistsInSpecs(fv1.Function{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fnName,
-				Namespace: fnNamespace,
+				Namespace: userProvidedNS,
 			},
 		})
 		if err != nil {
@@ -98,11 +103,20 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		}
 	}
 
-	opts.trigger = &fv1.TimeTrigger{
-		ObjectMeta: metav1.ObjectMeta{
+	m := metav1.ObjectMeta{
+		Name:      name,
+		Namespace: fnNamespace,
+	}
+
+	if input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry) {
+		m = metav1.ObjectMeta{
 			Name:      name,
-			Namespace: fnNamespace,
-		},
+			Namespace: userProvidedNS,
+		}
+	}
+
+	opts.trigger = &fv1.TimeTrigger{
+		ObjectMeta: m,
 		Spec: fv1.TimeTriggerSpec{
 			Cron: cronSpec,
 			FunctionReference: fv1.FunctionReference{

--- a/pkg/fission-cli/cmd/timetrigger/delete.go
+++ b/pkg/fission-cli/cmd/timetrigger/delete.go
@@ -36,13 +36,18 @@ func Delete(input cli.Input) error {
 	return (&DeleteSubCommand{}).do(input)
 }
 
-func (opts *DeleteSubCommand) do(input cli.Input) error {
+func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
+
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.TtName),
-		Namespace: input.String(flagkey.NamespaceTrigger),
+		Namespace: namespace,
 	}
 
-	err := opts.Client().V1().TimeTrigger().Delete(m)
+	err = opts.Client().V1().TimeTrigger().Delete(m)
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -37,13 +38,20 @@ func List(input cli.Input) error {
 	return (&ListSubCommand{}).do(input)
 }
 
-func (opts *ListSubCommand) do(input cli.Input) error {
+func (opts *ListSubCommand) do(input cli.Input) (err error) {
 	_, ttNs, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 	// ttNs := input.String(flagkey.NamespaceTrigger)
-	tts, err := opts.Client().V1().TimeTrigger().List(ttNs)
+
+	var tts []v1.TimeTrigger
+	if input.Bool(flagkey.AllNamespaces) {
+		tts, err = opts.Client().V1().TimeTrigger().List("")
+	} else {
+		tts, err = opts.Client().V1().TimeTrigger().List(ttNs)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "list Time triggers")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -37,7 +38,11 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	ttNs := input.String(flagkey.NamespaceTrigger)
+	_, ttNs, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
+	// ttNs := input.String(flagkey.NamespaceTrigger)
 	tts, err := opts.Client().V1().TimeTrigger().List(ttNs)
 	if err != nil {
 		return errors.Wrap(err, "list Time triggers")

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -43,7 +43,6 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	// ttNs := input.String(flagkey.NamespaceTrigger)
 
 	var tts []v1.TimeTrigger
 	if input.Bool(flagkey.AllNamespaces) {

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -26,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
@@ -46,9 +47,13 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
+	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return errors.Wrap(err, "error in deleting function ")
+	}
 	tt, err := opts.Client().V1().TimeTrigger().Get(&metav1.ObjectMeta{
 		Name:      input.String(flagkey.TtName),
-		Namespace: input.String(flagkey.NamespaceTrigger),
+		Namespace: namespace,
 	})
 	if err != nil {
 		return errors.Wrap(err, "error getting time trigger")

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -25,6 +25,7 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
@@ -66,11 +67,13 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 		updated = true
 	}
 
-	// TODO : During update, function has to be in the same ns as the trigger object
-	// but since we are not checking this for other triggers too, not sure if we need a check here.
-
 	fnName := input.String("function")
 	if len(fnName) > 0 {
+		functionList := []string{fnName}
+		err := util.CheckFunctionExistence(opts.Client(), functionList, namespace)
+		if err != nil {
+			console.Warn(err.Error())
+		}
 		tt.Spec.FunctionReference.Name = fnName
 		updated = true
 	}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -87,14 +87,13 @@ var (
 	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", Deprecated: true, Substitute: flagkey.Namespace}
 	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
-	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"ns"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace"}
-	AllNamespace         = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
-
-	RunTimeMinCPU    = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
-	RunTimeMaxCPU    = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
-	RunTimeTargetCPU = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}
-	RunTimeMinMemory = Flag{Type: Int, Name: flagkey.RuntimeMinmemory, Usage: "Minimum memory to be assigned to pod (In megabyte)"}
-	RunTimeMaxMemory = Flag{Type: Int, Name: flagkey.RuntimeMaxmemory, Usage: "Maximum memory to be assigned to pod (In megabyte)"}
+	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"force"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace", DefaultValue: false}
+	ForceDelete          = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
+	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
+	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
+	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}
+	RunTimeMinMemory     = Flag{Type: Int, Name: flagkey.RuntimeMinmemory, Usage: "Minimum memory to be assigned to pod (In megabyte)"}
+	RunTimeMaxMemory     = Flag{Type: Int, Name: flagkey.RuntimeMaxmemory, Usage: "Maximum memory to be assigned to pod (In megabyte)"}
 
 	ReplicasMin = Flag{Type: Int, Name: flagkey.ReplicasMinscale, Usage: "Minimum number of pods (Uses resource inputs to configure HPA)", DefaultValue: 1}
 	ReplicasMax = Flag{Type: Int, Name: flagkey.ReplicasMaxscale, Usage: "Maximum number of pods (Uses resource inputs to configure HPA)", DefaultValue: 1}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -21,8 +21,6 @@ import (
 	"net/http"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
@@ -87,8 +85,9 @@ var (
 	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", Deprecated: true, Substitute: flagkey.Namespace}
-	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", DefaultValue: metav1.NamespaceDefault}
+	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", Deprecated: true, Substitute: flagkey.Namespace}
 	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
+	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"ns"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace"}
 	AllNamespace         = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
 
 	RunTimeMinCPU    = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -89,6 +89,7 @@ var (
 	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
 	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"force"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace", DefaultValue: false}
 	ForceDelete          = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
+	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Aliases: []string{"all"}, Usage: "Fetch resources from all namespaces"}
 	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -83,10 +83,10 @@ var (
 	Labels     = Flag{Type: String, Name: flagkey.Labels, Usage: "Comma separated labels to apply to the function. E.g. --labels=\"environment=dev,application=analytics\""}
 	Annotation = Flag{Type: StringSlice, Name: flagkey.Annotation, Usage: "Annotation to apply to the function. To mention multiple annotations --annotation=\"abc.com/team=dev\" --annotation=\"foo=bar\""}
 
-	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault, Deprecated: true, Substitute: flagkey.Namespace}
+	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", Deprecated: true, Substitute: flagkey.Namespace}
-	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", DefaultValue: metav1.NamespaceDefault}
-	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", DefaultValue: metav1.NamespaceDefault}
+	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", Deprecated: true, Substitute: flagkey.Namespace}
+	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", DefaultValue: metav1.NamespaceDefault}
 	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
 	AllNamespace         = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -84,12 +84,12 @@ var (
 	Annotation = Flag{Type: StringSlice, Name: flagkey.Annotation, Usage: "Annotation to apply to the function. To mention multiple annotations --annotation=\"abc.com/team=dev\" --annotation=\"foo=bar\""}
 
 	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault, Deprecated: true, Substitute: flagkey.Namespace}
-	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", DefaultValue: metav1.NamespaceDefault, Deprecated: true, Substitute: flagkey.Namespace}
+	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", DefaultValue: metav1.NamespaceDefault}
-	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource", DefaultValue: metav1.NamespaceDefault}
-	AllNamespace         = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource", DefaultValue: metav1.NamespaceDefault}
+	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
+	AllNamespace         = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
 
 	RunTimeMinCPU    = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU    = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -89,6 +89,7 @@ var (
 	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", DefaultValue: metav1.NamespaceDefault}
 	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource", DefaultValue: metav1.NamespaceDefault}
+	AllNamespace         = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource", DefaultValue: metav1.NamespaceDefault}
 
 	RunTimeMinCPU    = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU    = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -83,11 +83,12 @@ var (
 	Labels     = Flag{Type: String, Name: flagkey.Labels, Usage: "Comma separated labels to apply to the function. E.g. --labels=\"environment=dev,application=analytics\""}
 	Annotation = Flag{Type: StringSlice, Name: flagkey.Annotation, Usage: "Annotation to apply to the function. To mention multiple annotations --annotation=\"abc.com/team=dev\" --annotation=\"foo=bar\""}
 
-	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault}
-	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", DefaultValue: metav1.NamespaceDefault}
+	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", DefaultValue: metav1.NamespaceDefault, Deprecated: true, Substitute: flagkey.Namespace}
+	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", DefaultValue: metav1.NamespaceDefault, Deprecated: true, Substitute: flagkey.Namespace}
 	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", DefaultValue: metav1.NamespaceDefault}
 	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", DefaultValue: metav1.NamespaceDefault}
+	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource", DefaultValue: metav1.NamespaceDefault}
 
 	RunTimeMinCPU    = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU    = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -188,7 +188,7 @@ var (
 
 	KwName      = Flag{Type: String, Name: flagkey.KwName, Usage: "Watch name"}
 	KwFnName    = Flag{Type: String, Name: flagkey.KwFnName, Usage: "Function name"}
-	KwNamespace = Flag{Type: String, Name: flagkey.KwNamespace, Aliases: []string{"ns"}, Usage: "Namespace of resource to watch", DefaultValue: metav1.NamespaceDefault}
+	KwNamespace = Flag{Type: String, Name: flagkey.KwNamespace, Aliases: []string{"ns"}, Usage: "Namespace of resource to watch"}
 	KwObjType   = Flag{Type: String, Name: flagkey.KwObjType, Usage: "Type of resource to watch (Pod, Service, etc.)", DefaultValue: "pod"}
 	KwLabels    = Flag{Type: String, Name: flagkey.KwLabels, Usage: "Label selector of the form a=b,c=d"}
 

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -81,15 +81,16 @@ var (
 	Labels     = Flag{Type: String, Name: flagkey.Labels, Usage: "Comma separated labels to apply to the function. E.g. --labels=\"environment=dev,application=analytics\""}
 	Annotation = Flag{Type: StringSlice, Name: flagkey.Annotation, Usage: "Annotation to apply to the function. To mention multiple annotations --annotation=\"abc.com/team=dev\" --annotation=\"foo=bar\""}
 
+	Namespace = Flag{Type: String, Name: flagkey.Namespace, Short: "n", Usage: "If present, the namespace scope for this CLI request"}
+
 	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", Deprecated: true, Substitute: flagkey.Namespace}
 	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", Deprecated: true, Substitute: flagkey.Namespace}
-	Namespace            = Flag{Type: String, Name: flagkey.Namespace, Aliases: []string{"ns"}, Usage: "Namespace for resource"}
 	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"force"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace", DefaultValue: false}
 	ForceDelete          = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
-	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Aliases: []string{"all"}, Usage: "Fetch resources from all namespaces"}
+	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Short: "A", Usage: "Fetch resources from all namespaces"}
 	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -39,8 +39,8 @@ const (
 	NamespaceTrigger     = "triggerNamespace"
 	NamespaceCanary      = "canaryNamespace"
 	Namespace            = "namespace"
-	ForceNamespace       = "forcenamespace"
-	AllNamespaces        = "allNamespaces"
+	ForceNamespace       = "force-namespace"
+	AllNamespaces        = "all-namespaces"
 	ForceDelete          = "force"
 
 	RuntimeMincpu    = "mincpu"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -39,6 +39,7 @@ const (
 	NamespaceTrigger     = "triggerNamespace"
 	NamespaceCanary      = "canaryNamespace"
 	Namespace            = "namespace"
+	ForceNamespace       = "forcenamespace"
 	AllNamespaces        = "allNamespaces"
 
 	RuntimeMincpu    = "mincpu"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -38,6 +38,8 @@ const (
 	NamespacePackage     = "pkgNamespace"
 	NamespaceTrigger     = "triggerNamespace"
 	NamespaceCanary      = "canaryNamespace"
+	// using "namespaces" because "namespace" already used
+	Namespace = "namespaces"
 
 	RuntimeMincpu    = "mincpu"
 	RuntimeMaxcpu    = "maxcpu"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -38,8 +38,8 @@ const (
 	NamespacePackage     = "pkgNamespace"
 	NamespaceTrigger     = "triggerNamespace"
 	NamespaceCanary      = "canaryNamespace"
-	// using "namespaces" because "namespace" already used
-	Namespace = "namespaces"
+	Namespace            = "namespace"
+	AllNamespaces        = "allNamespaces"
 
 	RuntimeMincpu    = "mincpu"
 	RuntimeMaxcpu    = "maxcpu"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -41,6 +41,7 @@ const (
 	Namespace            = "namespace"
 	ForceNamespace       = "forcenamespace"
 	AllNamespaces        = "allNamespaces"
+	ForceDelete          = "force"
 
 	RuntimeMincpu    = "mincpu"
 	RuntimeMaxcpu    = "maxcpu"

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -157,10 +157,10 @@ func GetKubernetesClient(kubeContext string) (*restclient.Config, kubernetes.Int
 	return config, clientset, nil
 }
 
-// GetKubernetesCurrentNamespace builds a new kubernetes client. If the KUBECONFIG
+// GetKubernetesNamespace builds a new kubernetes client. If the KUBECONFIG
 // environment variable is empty or doesn't exist, ~/.kube/config is used for
 // the kube config path
-func GetKubernetesCurrentNamespace(kubeContext string) (currentNS string, err error) {
+func GetKubernetesNamespace(kubeContext string) (currentNS string, err error) {
 	loadingRules, err := getLoadingRules()
 	if err != nil {
 		return "", err
@@ -489,19 +489,21 @@ func GetStorageURL(ctx context.Context, kubeContext string) (*url.URL, error) {
 
 func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, currentNS string, err error) {
 	namespace = input.String(deprecatedFlag)
+	currentNS = namespace
 
 	if input.String(flagkey.Namespace) != "" {
 		namespace = input.String(flagkey.Namespace)
+		currentNS = namespace
+		return namespace, currentNS, err
 	}
-	console.Verbose(2, "Namespace from user %v ", namespace)
-	currentNS = namespace
+	console.Verbose(2, "Namespace from user %s ", namespace)
 
 	if namespace == "" {
-		if os.Getenv("NAMESPACE") != "" {
-			currentNS = os.Getenv("NAMESPACE")
+		if os.Getenv("FISSION_DEFAULT_NAMESPACE") != "" {
+			currentNS = os.Getenv("FISSION_DEFAULT_NAMESPACE")
 		} else {
 			kubeContext := input.String(flagkey.KubeContext)
-			currentNS, err = GetKubernetesCurrentNamespace(kubeContext)
+			currentNS, err = GetKubernetesNamespace(kubeContext)
 			if err != nil {
 				return namespace, currentNS, err
 			}
@@ -511,7 +513,7 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 		}
 	}
 
-	console.Verbose(2, "Namespace final %v ", currentNS)
+	console.Verbose(2, "Namespace final %s ", currentNS)
 
 	return namespace, currentNS, nil
 }

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -459,3 +459,12 @@ func GetStorageURL(ctx context.Context, kubeContext string) (*url.URL, error) {
 
 	return serverURL, nil
 }
+
+func GetResourceNamespace(input cli.Input, deprecatedFlag string) string {
+	namespace := input.String(deprecatedFlag)
+
+	if input.String(flagkey.Namespace) != "default" {
+		namespace = input.String(flagkey.Namespace)
+	}
+	return namespace
+}

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -495,18 +495,23 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 	}
 	console.Verbose(2, "Namespace from user %v ", namespace)
 	currentNS = namespace
+
 	if namespace == "" {
-		kubeContext := input.String(flagkey.KubeContext)
-		currentNS, err = GetKubernetesCurrentNamespace(kubeContext)
-		if err != nil {
-			return namespace, currentNS, err
+		if os.Getenv("NAMESPACE") != "" {
+			currentNS = os.Getenv("NAMESPACE")
+		} else {
+			kubeContext := input.String(flagkey.KubeContext)
+			currentNS, err = GetKubernetesCurrentNamespace(kubeContext)
+			if err != nil {
+				return namespace, currentNS, err
+			}
 		}
 		if currentNS == "" {
 			return namespace, currentNS, errors.Errorf("either set current-context or provide namespace with --namespace flag")
 		}
 	}
 
-	console.Verbose(2, "Namespace final %v ", namespace)
+	console.Verbose(2, "Namespace final %v ", currentNS)
 
 	return namespace, currentNS, nil
 }

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -501,6 +501,9 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 		if err != nil {
 			return namespace, currentNS, err
 		}
+		if currentNS == "" {
+			return namespace, currentNS, errors.Errorf("either set current-context or provide namespace with --namespace flag")
+		}
 	}
 
 	console.Verbose(2, "Namespace final %v ", namespace)

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -496,7 +496,7 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 	console.Verbose(2, "Namespace from user %v ", namespace)
 	currentNS = namespace
 	if namespace == "" {
-		kubeContext := "" //TODO: get correct value here
+		kubeContext := input.String(flagkey.KubeContext)
 		currentNS, err = GetKubernetesCurrentNamespace(kubeContext)
 		if err != nil {
 			return namespace, currentNS, err

--- a/pkg/fission-cli/util/util_test.go
+++ b/pkg/fission-cli/util/util_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -67,9 +66,9 @@ func TestGetEnvVarFromStringSlice(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	response, err := GetKubernetesCurrentNamespace("")
+	response, err := GetKubernetesNamespace("")
 	if err != nil {
-		fmt.Println(err)
+		t.Log(err)
 	}
-	fmt.Println("Current NS: ", response)
+	t.Log("Current NS: ", response)
 }

--- a/pkg/fission-cli/util/util_test.go
+++ b/pkg/fission-cli/util/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -63,4 +64,12 @@ func TestGetEnvVarFromStringSlice(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetConfig(t *testing.T) {
+	response, err := GetKubernetesCurrentNamespace("")
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println("Current NS: ", response)
 }

--- a/test/kind_CI.sh
+++ b/test/kind_CI.sh
@@ -101,6 +101,10 @@ main() {
         $ROOT/test/tests/test_fn_update/test_secret_update.sh \
         $ROOT/test/tests/test_fn_update/test_nd_pkg_update.sh \
         $ROOT/test/tests/test_fn_update/test_poolmgr_nd.sh  
+        $ROOT/test/tests/test_namespace/test_ns_current_context.sh
+        $ROOT/test/tests/test_namespace/test_ns_flag.sh
+        $ROOT/test/tests/test_namespace/test_ns_env.sh
+        $ROOT/test/tests/test_namespace/test_ns_deprecated_flag.sh
 
     set -e
 

--- a/test/tests/test_fn_update/test_configmap_update.sh
+++ b/test/tests/test_fn_update/test_configmap_update.sh
@@ -54,7 +54,7 @@ log "Waiting for router to catch up"
 sleep 5
 
 log "Testing function"
-timeout 120 bash -c "test_fn $fn_name 'TESTVALUE'"
+timeout 60 bash -c "test_fn $fn_name 'TESTVALUE'"
 
 log "Creating a new cfgmap"
 kubectl create configmap ${new_cfgmap} --from-literal=TEST_KEY="TESTVALUE_NEW" -n default

--- a/test/tests/test_fn_update/test_configmap_update.sh
+++ b/test/tests/test_fn_update/test_configmap_update.sh
@@ -54,7 +54,7 @@ log "Waiting for router to catch up"
 sleep 5
 
 log "Testing function"
-timeout 60 bash -c "test_fn $fn_name 'TESTVALUE'"
+timeout 120 bash -c "test_fn $fn_name 'TESTVALUE'"
 
 log "Creating a new cfgmap"
 kubectl create configmap ${new_cfgmap} --from-literal=TEST_KEY="TESTVALUE_NEW" -n default

--- a/test/tests/test_fn_update/test_secret_update.sh
+++ b/test/tests/test_fn_update/test_secret_update.sh
@@ -54,7 +54,7 @@ log "Waiting for router to catch up"
 sleep 5
 
 log "Testing function"
-timeout 60 bash -c "test_fn $fn_name 'TESTVALUE'"
+timeout 120 bash -c "test_fn $fn_name 'TESTVALUE'"
 
 log "Creating a new secret"
 kubectl create secret generic ${new_secret} --from-literal=TEST_KEY="TESTVALUE_NEW" -n default

--- a/test/tests/test_fn_update/test_secret_update.sh
+++ b/test/tests/test_fn_update/test_secret_update.sh
@@ -54,7 +54,7 @@ log "Waiting for router to catch up"
 sleep 5
 
 log "Testing function"
-timeout 120 bash -c "test_fn $fn_name 'TESTVALUE'"
+timeout 60 bash -c "test_fn $fn_name 'TESTVALUE'"
 
 log "Creating a new secret"
 kubectl create secret generic ${new_secret} --from-literal=TEST_KEY="TESTVALUE_NEW" -n default

--- a/test/tests/test_namespace/test_ns_current_context.sh
+++ b/test/tests/test_namespace/test_ns_current_context.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -euo pipefail
+source $(dirname $0)/../../utils.sh
+
+TEST_ID=$(generate_test_id)
+echo "TEST_ID = $TEST_ID"
+
+tmp_dir="/tmp/test-$TEST_ID"
+mkdir -p $tmp_dir
+
+ROOT=$(dirname $0)/../../..
+
+cleanup() {
+    echo "previous response" $?
+    log "Cleaning up..."
+    clean_resource_by_id $TEST_ID
+    rm -rf $tmp_dir
+}
+
+if [ -z "${TEST_NOCLEANUP:-}" ]; then
+    trap cleanup EXIT
+else
+    log "TEST_NOCLEANUP is set; not cleaning up test artifacts afterwards."
+fi
+
+httptrigger=http-$TEST_ID
+httptriggerurl=/url-$TEST_ID
+fn_n=nbuilderhello-$TEST_ID
+
+cd $ROOT/examples/go/hello-world
+
+log "Creating httptrigger using default namespace"
+fission  httptrigger create --function $fn_n --url /$httptriggerurl --name $httptrigger
+
+log "verify trigger exists"
+fission httptrigger list --namespace default | grep $httptrigger
+
+log "Test PASSED"

--- a/test/tests/test_namespace/test_ns_deprecated_flag.sh
+++ b/test/tests/test_namespace/test_ns_deprecated_flag.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+source $(dirname $0)/../../utils.sh
+
+TEST_ID=$(generate_test_id)
+echo "TEST_ID = $TEST_ID"
+
+tmp_dir="/tmp/test-$TEST_ID"
+mkdir -p $tmp_dir
+
+TEST_NS=ns-$TEST_ID
+
+ROOT=$(dirname $0)/../../..
+
+cleanup() {
+    echo "previous response" $?
+    log "Cleaning up..."
+    clean_resource_by_id_for_namespace $TEST_ID $TEST_NS
+    rm -rf $tmp_dir
+}
+
+if [ -z "${TEST_NOCLEANUP:-}" ]; then
+    trap cleanup EXIT
+else
+    log "TEST_NOCLEANUP is set; not cleaning up test artifacts afterwards."
+fi
+
+httptrigger=http-$TEST_ID
+httptriggerurl=/url-$TEST_ID
+fn_n=nbuilderhello-$TEST_ID
+
+cd $ROOT/examples/go/hello-world
+
+kubectl create namespace $TEST_NS
+
+log "Creating httptrigger using deprecating flag"
+fission  httptrigger create --function $fn_n --url /$httptriggerurl --name $httptrigger --fnNamespace $TEST_NS
+
+log "verify trigger exists"
+fission httptrigger list --namespace $TEST_NS | grep $httptrigger
+
+log "Test PASSED"

--- a/test/tests/test_namespace/test_ns_env.sh
+++ b/test/tests/test_namespace/test_ns_env.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -euo pipefail
+source $(dirname $0)/../../utils.sh
+
+TEST_ID=$(generate_test_id)
+echo "TEST_ID = $TEST_ID"
+
+tmp_dir="/tmp/test-$TEST_ID"
+mkdir -p $tmp_dir
+
+TEST_NS=ns-$TEST_ID
+
+export FISSION_DEFAULT_NAMESPACE=$TEST_NS
+
+ROOT=$(dirname $0)/../../..
+
+cleanup() {
+    echo "previous response" $?
+    log "Cleaning up..."
+    clean_resource_by_id_for_namespace $TEST_ID $TEST_NS
+    rm -rf $tmp_dir
+}
+
+if [ -z "${TEST_NOCLEANUP:-}" ]; then
+    trap cleanup EXIT
+else
+    log "TEST_NOCLEANUP is set; not cleaning up test artifacts afterwards."
+fi
+
+httptrigger=http-$TEST_ID
+httptriggerurl=/url-$TEST_ID
+fn_n=nbuilderhello-$TEST_ID
+
+cd $ROOT/examples/go/hello-world
+
+kubectl create namespace $TEST_NS
+
+log "Creating httptrigger in namespace using env var"
+fission  httptrigger create --function $fn_n --url /$httptriggerurl --name $httptrigger 
+
+log "verify trigger exists"
+fission httptrigger list --namespace $TEST_NS | grep $httptrigger
+
+log "Test PASSED"

--- a/test/tests/test_namespace/test_ns_flag.sh
+++ b/test/tests/test_namespace/test_ns_flag.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+source $(dirname $0)/../../utils.sh
+
+TEST_ID=$(generate_test_id)
+echo "TEST_ID = $TEST_ID"
+
+tmp_dir="/tmp/test-$TEST_ID"
+mkdir -p $tmp_dir
+
+TEST_NS=ns-$TEST_ID
+
+ROOT=$(dirname $0)/../../..
+
+cleanup() {
+    echo "previous response" $?
+    log "Cleaning up..."
+    clean_resource_by_id_for_namespace $TEST_ID $TEST_NS
+    rm -rf $tmp_dir
+}
+
+if [ -z "${TEST_NOCLEANUP:-}" ]; then
+    trap cleanup EXIT
+else
+    log "TEST_NOCLEANUP is set; not cleaning up test artifacts afterwards."
+fi
+
+httptrigger=http-$TEST_ID
+httptriggerurl=/url-$TEST_ID
+fn_n=nbuilderhello-$TEST_ID
+
+cd $ROOT/examples/go/hello-world
+
+kubectl create namespace $TEST_NS
+
+log "Creating httptrigger in namespace provided by flag"
+fission  httptrigger create --function $fn_n --url /$httptriggerurl --name $httptrigger --namespace $TEST_NS
+
+log "verify trigger exists"
+fission httptrigger list --namespace $TEST_NS | grep $httptrigger
+
+log "Test PASSED"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
add 'namespace'  param/tag in CLI for functions and env. This will give us records filtered by a namespace.Deprecated `fnNamespace` and `envNamespace`

### Principals

- Act similar to kubectl behavior as possible
- No cross namespace resource creation
- If the user passes namespace explicitly, consider if for resource creation or for spec.
- If user does not pass namespace explicitly 
- For spec generation keep it empty and decide it at the time of spec apply.
- For actual resource creation use the current namespace from kubernetes context(kubeconfig).

**NOTE:** spec file’s NS always takes precedence unless specified by - “–forcenamespace” flag
Implementation Details

**NOTE:** CurrentNS is determined by
- value of environment variable `FISSION_DEFAULT_NAMESPACE` Or,
- Namespace set as default namespace in currently used context. 
### Env creation
- If no NS provided by user
Create env in CurrentNS
- If NS provided by user
Create env in user provided NS
- If no NS provided by user for `SPEC`
Create spec without any NS
- If NS provided by user for `SPEC`
Create env spec with user provided NS

### Pkg creation
We need to remove `envNamespace`. Because we no longer want “env” and “pkg” to be created in different NSs
- If no NS provided 
Create in pkg with CurrentNS and env’s NS as CurrentNS
- If NS provided 
Create pkg with user provided NS. And env’s NS as CurrentNS 
- If no NS provided for Spec
   Search for “ENV” with no Namespace(“ ” or blank), 
    - if it’s found with blank NS we give a warning “No namespace provided ” and create the spec.
- If  NS provided for Spec
  Find env with provided NS. And send a warning if not found. Create with provided ns
   - If env with same ns found create pkg with provided ns

### Function creation
- If no NS provided 
Search for pkg in  CurrentNS and create function in same NS
- If NS provided
Search for pkg in provided NS and create function in provided NS
- If no NS provided in spec
 Search for pkg with no namespace(blank “ ”) ns and
  - if it’s found with blank NS we give a warning “No namespace provided ” and create the spec.
  - No record with blank NS found we fail saying “No pkg spec found. Provide NS if pkg present in different NS“
- If NS provided in spec
  Search it and use it for function creation

### Spec apply
- Spec file doesn’t have namespace for resource
   - Use NS provided by `–ns` flag
   - If flag not provided use current context NS
- Spec files have namespace for resource
   - Use ns provided by `–forcenamespace` flag
   - If `–forcenamespace` flag not provided use NS provided in file
- Spec files have namespace for partial resource
   - Use ns provided by `–forcenamespace` flag
   - If `–forcenamespace` flag not provided,
       - And resource does have NS provided in spec file, Use that NS
       - And resource does not have any NS provided in spec file use NS provided by `–namespace` flag and if flag not provided use current context NS
   
### Spec Destroy
- `–forcedelete` flag provided-
  Delete all resource in spec
- `–namespace` provided-
  Delete all resource with ns in the spec and also delete all resource where ns is present in the spec file
- No flag provided
  Delete all resource in current context namespace and all resource where ns is specified in the spec file  

**NOTE:** if a resource was not created by spec. But it is present in the spec file. And we do a spec destroy, it will delete the resource. This is to match k8s behaviour.
*ns=namespace in above description

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

https://github.com/fission/fission/issues/2294
https://github.com/fission/fission/issues/2177
https://github.com/fission/fission/issues/924

## Testing
try running any env and fn command using --namespaces tag

## Checklist:
<!-- Please tick following check-boxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
