### PR TITLE
Remove `--force` option from upgrade strategy in skaffold.yaml - fix #2362

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -73,7 +73,6 @@ deploy:
       upgrade:
       - --timeout=3m
       - --install
-      - --force
       - --debug
 profiles:
 - name: kind


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
we are using the `--force` flag on upgrade. This essentially means calling `helm upgrade --force` which will make helm force resource updates through a replacement strategy. This is resulting in errors as dynamically provisioned PVCs cannot be replaces as certain values are immutable

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2362 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
