### PR TITLE
Fix for preupgrade checks of CRDs during fission upgrade

### DIFF
--- a/cmd/preupgradechecks/checks.go
+++ b/cmd/preupgradechecks/checks.go
@@ -100,7 +100,7 @@ func (client *PreUpgradeTaskClient) LatestSchemaApplied(ctx context.Context) err
 		return fmt.Errorf("could not get the Function CRD")
 	}
 	// Any new field added in Function spec can be checked here provided the substring matches the description in CRD Validation of the field
-	if !strings.Contains(funcCRD.Spec.String(), "RequestsPerPod") || !strings.Contains(funcCRD.Spec.String(), "OnceOnly") || !strings.Contains(funcCRD.Spec.String(), "PodSpec") {
+	if !strings.Contains(funcCRD.Spec.String(), "requestsPerPod") || !strings.Contains(funcCRD.Spec.String(), "onceOnly") || !strings.Contains(funcCRD.Spec.String(), "podSpec") {
 		return fmt.Errorf("could not find RequestPerPod/OnceOnly/PodSpec in Function CRD")
 	}
 
@@ -110,7 +110,7 @@ func (client *PreUpgradeTaskClient) LatestSchemaApplied(ctx context.Context) err
 	}
 
 	// Any new field added in MQT spec can be checked here provided the substring matches the description in CRD Validation of the field
-	if !strings.Contains(mqtCRD.Spec.String(), "PodSpec") {
+	if !strings.Contains(mqtCRD.Spec.String(), "podSpec") {
 		return fmt.Errorf("could not find PodSpec field in MQT CRD")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
Fission fails to upgrade because of preupgrade check of CRDs. Fission has a logic of pre-upgrade checks of CRD and this logic works while upgrading fission, In case of fresh install of fission, it works fine.

Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
