### PR TITLE
Improve warning/verbose messages around namespace in Fission CLI

### DIFF
--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -43,7 +43,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}
-	console.Verbose(2, "Namespace used to delete resource: %s ", currentContextNS)
+	console.Verbose(2, "Searching for resource in  %s Namespace", currentContextNS)
 
 	m := &metav1.ObjectMeta{
 		Name:      input.String(flagkey.EnvName),

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -126,8 +126,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		Namespace: userProvidedNS,
 	}
 
-	console.Warn(fmt.Sprintf("Ns: %v", userProvidedNS))
-
 	// For Specs, the spec validate checks for function reference
 	if input.Bool(flagkey.SpecSave) {
 

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -494,9 +494,9 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 	if input.String(flagkey.Namespace) != "" {
 		namespace = input.String(flagkey.Namespace)
 		currentNS = namespace
+		console.Verbose(2, "Namespace for resource %s ", currentNS)
 		return namespace, currentNS, err
 	}
-	console.Verbose(2, "Namespace from user %s ", namespace)
 
 	if namespace == "" {
 		if os.Getenv("FISSION_DEFAULT_NAMESPACE") != "" {
@@ -513,7 +513,7 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 		}
 	}
 
-	console.Verbose(2, "Namespace final %s ", currentNS)
+	console.Verbose(2, "Namespace for resource %s ", currentNS)
 
 	return namespace, currentNS, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Removed extra warning message while creating HTTP trigger. And updated some verbose logs to show info related to namespace.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

## Testing
Create httptrigger and check logs 

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
