### PR TITLE
Update keda-jetstream to v0.3

### DIFF
--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -751,7 +751,7 @@ mqt_keda:
       tag: v0.12
     nats_jetstream:
       image: fission/keda-nats-jetstream-http-connector
-      tag: v0.2
+      tag: v0.3
     gcp_pubsub:
       image: fission/keda-gcp-pubsub-http-connector
       tag: v0.5


### PR DESCRIPTION
To pull in ackwait change from
https://github.com/fission/keda-connectors/pull/115

## Description
Just update the chart to pull in v0.3 of the keda-jetstream connector. This adds one new flag to configure ackwait.

## Testing
Deployed image on my staging cluster to prove it works.

## Checklist:
The changes are not to code here, so none of these are done.
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
