### PR TITLE
Fission failed to list resources if namespace flag is not provided

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -69,7 +69,6 @@ jobs:
           kubectl get nodes
           sudo apt-get install -y apache2-utils
           kubectl config use-context kind-kind
-          kubectl config set-context --current --namespace=default
           kubectl config view
 
       - name: Helm chart lint

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -509,7 +509,8 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 			}
 		}
 		if currentNS == "" {
-			return namespace, currentNS, errors.Errorf("either set current-context or provide namespace with --namespace flag")
+			// if no namespace is available then set default namespace as current namespace
+			currentNS = metav1.NamespaceDefault
 		}
 	}
 

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -166,14 +166,13 @@ func GetKubernetesNamespace(kubeContext string) (currentNS string, err error) {
 		return "", err
 	}
 
-	config1, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		loadingRules, &clientcmd.ConfigOverrides{CurrentContext: kubeContext}).RawConfig()
+	namespace, _, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		loadingRules, &clientcmd.ConfigOverrides{CurrentContext: kubeContext}).Namespace()
 	if err != nil {
 		return "", errors.Wrap(err, "Failed to build Kubernetes config")
 	}
-	currentNS = config1.Contexts[config1.CurrentContext].Namespace
 
-	return currentNS, nil
+	return namespace, nil
 }
 
 // given a list of functions, this checks if the functions actually exist on the cluster
@@ -507,10 +506,6 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 			if err != nil {
 				return namespace, currentNS, err
 			}
-		}
-		if currentNS == "" {
-			// if no namespace is available then set default namespace as current namespace
-			currentNS = metav1.NamespaceDefault
 		}
 	}
 


### PR DESCRIPTION
## Description
Fission falied to list resources in default or all-namespaces, if namespace flag is not provided and current-context namespace is not set **OR** namespace flag is not provided and FISSION_DEFAULT_NAMESPACE environment variable not set.

These changes will set namespace as default in case of no namespace is available and will list resources in the default or all namespace if namespace flag is not provided.

Fixes https://github.com/fission/fission/issues/2578

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
