### PR TITLE
Monitor specific namespaces for configmap/secret updates

### DIFF
--- a/pkg/executor/cms/cmhandler.go
+++ b/pkg/executor/cms/cmhandler.go
@@ -29,8 +29,9 @@ import (
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
 )
 
+// getConfigmapRelatedFuncs returns functions related to configmap in the same namespace
 func getConfigmapRelatedFuncs(ctx context.Context, logger *zap.Logger, m *metav1.ObjectMeta, fissionClient versioned.Interface) ([]fv1.Function, error) {
-	funcList, err := fissionClient.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	funcList, err := fissionClient.CoreV1().Functions(m.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -57,11 +58,9 @@ func ConfigMapEventHandlers(ctx context.Context, logger *zap.Logger, fissionClie
 			oldCm := oldObj.(*apiv1.ConfigMap)
 			newCm := newObj.(*apiv1.ConfigMap)
 			if oldCm.ObjectMeta.ResourceVersion != newCm.ObjectMeta.ResourceVersion {
-				if newCm.ObjectMeta.Namespace != "kube-system" {
-					logger.Debug("Configmap changed",
-						zap.String("configmap_name", newCm.ObjectMeta.Name),
-						zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))
-				}
+				logger.Debug("Configmap changed",
+					zap.String("configmap_name", newCm.ObjectMeta.Name),
+					zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))
 				funcs, err := getConfigmapRelatedFuncs(ctx, logger, &newCm.ObjectMeta, fissionClient)
 				if err != nil {
 					logger.Error("Failed to get functions related to configmap", zap.String("configmap_name", newCm.ObjectMeta.Name), zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))

--- a/pkg/executor/cms/cmscontroller.go
+++ b/pkg/executor/cms/cmscontroller.go
@@ -41,15 +41,19 @@ type (
 // MakeConfigSecretController makes a controller for configmaps and secrets which changes related functions
 func MakeConfigSecretController(ctx context.Context, logger *zap.Logger, fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface, types map[fv1.ExecutorType]executortype.ExecutorType,
-	configmapInformer informerv1.ConfigMapInformer,
-	secretInformer informerv1.SecretInformer) *ConfigSecretController {
+	configmapInformer map[string]informerv1.ConfigMapInformer,
+	secretInformer map[string]informerv1.SecretInformer) *ConfigSecretController {
 	logger.Debug("Creating ConfigMap & Secret Controller")
 	cmsController := &ConfigSecretController{
 		logger:        logger,
 		fissionClient: fissionClient,
 	}
-	configmapInformer.Informer().AddEventHandler(ConfigMapEventHandlers(ctx, logger, fissionClient, kubernetesClient, types))
-	secretInformer.Informer().AddEventHandler(SecretEventHandlers(ctx, logger, fissionClient, kubernetesClient, types))
+	for _, informer := range configmapInformer {
+		informer.Informer().AddEventHandler(ConfigMapEventHandlers(ctx, logger, fissionClient, kubernetesClient, types))
+	}
+	for _, informer := range secretInformer {
+		informer.Informer().AddEventHandler(SecretEventHandlers(ctx, logger, fissionClient, kubernetesClient, types))
+	}
 
 	return cmsController
 }

--- a/pkg/executor/cms/secrethandler.go
+++ b/pkg/executor/cms/secrethandler.go
@@ -29,8 +29,9 @@ import (
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
 )
 
+// getSecretRelatedFuncs returns functions that are related to the secret in the same namespace
 func getSecretRelatedFuncs(ctx context.Context, logger *zap.Logger, m *metav1.ObjectMeta, fissionClient versioned.Interface) ([]fv1.Function, error) {
-	funcList, err := fissionClient.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	funcList, err := fissionClient.CoreV1().Functions(m.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -56,11 +57,9 @@ func SecretEventHandlers(ctx context.Context, logger *zap.Logger, fissionClient 
 			oldS := oldObj.(*apiv1.Secret)
 			newS := newObj.(*apiv1.Secret)
 			if oldS.ObjectMeta.ResourceVersion != newS.ObjectMeta.ResourceVersion {
-				if newS.ObjectMeta.Namespace != "kube-system" {
-					logger.Debug("Secret changed",
-						zap.String("configmap_name", newS.ObjectMeta.Name),
-						zap.String("configmap_namespace", newS.ObjectMeta.Namespace))
-				}
+				logger.Debug("Secret changed",
+					zap.String("configmap_name", newS.ObjectMeta.Name),
+					zap.String("configmap_namespace", newS.ObjectMeta.Namespace))
 				funcs, err := getSecretRelatedFuncs(ctx, logger, &newS.ObjectMeta, fissionClient)
 				if err != nil {
 					logger.Error("Failed to get functions related to secret", zap.String("secret_name", newS.ObjectMeta.Name), zap.String("secret_namespace", newS.ObjectMeta.Namespace))

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
 	k8sInformers "k8s.io/client-go/informers"
+	k8sInformersv1 "k8s.io/client-go/informers/core/v1"
 	k8sCache "k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -292,15 +293,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	for _, ns := range utils.GetNamespaces() {
 		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
 		funcInformer[ns] = factory.Core().V1().Functions()
-	}
-
-	for _, ns := range utils.GetNamespaces() {
-		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
 		envInformer[ns] = factory.Core().V1().Environments()
-	}
-
-	for _, ns := range utils.GetNamespaces() {
-		factory := genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
 		pkgInformer[ns] = factory.Core().V1().Packages()
 	}
 
@@ -373,11 +366,16 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	// TODO: use context to control the waiting time once kubernetes client supports it.
 	util.WaitTimeout(wg, 30*time.Second)
 
-	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
-	configmapInformer := k8sInformerFactory.Core().V1().ConfigMaps()
-	secretInformer := k8sInformerFactory.Core().V1().Secrets()
+	configMapInformer := make(map[string]k8sInformersv1.ConfigMapInformer, 0)
+	secretInformer := make(map[string]k8sInformersv1.SecretInformer, 0)
 
-	cms := cms.MakeConfigSecretController(ctx, logger, fissionClient, kubernetesClient, executorTypes, configmapInformer, secretInformer)
+	for _, ns := range utils.GetNamespaces() {
+		factory := k8sInformers.NewFilteredSharedInformerFactory(kubernetesClient, time.Minute*30, ns, nil)
+		configMapInformer[ns] = factory.Core().V1().ConfigMaps()
+		secretInformer[ns] = factory.Core().V1().Secrets()
+	}
+
+	cms := cms.MakeConfigSecretController(ctx, logger, fissionClient, kubernetesClient, executorTypes, configMapInformer, secretInformer)
 
 	fissionInformers := make([]k8sCache.SharedIndexInformer, 0)
 	for _, informer := range funcInformer {
@@ -389,9 +387,14 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	for _, informer := range pkgInformer {
 		fissionInformers = append(fissionInformers, informer.Informer())
 	}
+	for _, informer := range configMapInformer {
+		fissionInformers = append(fissionInformers, informer.Informer())
+	}
+	for _, informer := range secretInformer {
+		fissionInformers = append(fissionInformers, informer.Informer())
+	}
+
 	fissionInformers = append(fissionInformers,
-		configmapInformer.Informer(),
-		secretInformer.Informer(),
 		gpmPodInformer.Informer(),
 		gpmRsInformer.Informer(),
 		ndmDeplInformer.Informer(),


### PR DESCRIPTION
We allow functions to refer configmap/secrets. We are monitoring all namespaces for configmaps and secrets and also allow cross-namespace references.
This fix monitors configmaps/secret updates in specific namespaces. Also, we ignore cross-namespace references for configmap/secret updates.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide a detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
