### PR TITLE
List fission resources in specific namespace instead of all namespace

### DIFF
--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -199,48 +199,46 @@ func (pkgw *packageWatcher) build(ctx context.Context, srcpkg *fv1.Package) {
 
 			pkgw.logger.Info("starting package info update", zap.String("package_name", pkg.ObjectMeta.Name))
 
-			for _, namespace := range utils.GetNamespaces() {
-				fnList, err := pkgw.fissionClient.CoreV1().
-					Functions(namespace).List(ctx, metav1.ListOptions{})
-				if err != nil {
-					e := "error getting function list"
-					pkgw.logger.Error(e, zap.Error(err))
-					buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-					_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-					if er != nil {
-						pkgw.logger.Error(
-							"error updating package",
-							zap.String("package_name", pkg.ObjectMeta.Name),
-							zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-							zap.Error(er),
-						)
-					}
+			fnList, err := pkgw.fissionClient.CoreV1().
+				Functions(pkg.Namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				e := "error getting function list"
+				pkgw.logger.Error(e, zap.Error(err))
+				buildLogs += fmt.Sprintf("%s: %v\n", e, err)
+				_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+				if er != nil {
+					pkgw.logger.Error(
+						"error updating package",
+						zap.String("package_name", pkg.ObjectMeta.Name),
+						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+						zap.Error(er),
+					)
 				}
+			}
 
-				// A package may be used by multiple functions. Update
-				// functions with old package resource version
-				for _, fn := range fnList.Items {
-					if fn.Spec.Package.PackageRef.Name == pkg.ObjectMeta.Name &&
-						fn.Spec.Package.PackageRef.Namespace == pkg.ObjectMeta.Namespace &&
-						fn.Spec.Package.PackageRef.ResourceVersion != pkg.ObjectMeta.ResourceVersion {
-						fn.Spec.Package.PackageRef.ResourceVersion = pkg.ObjectMeta.ResourceVersion
-						// update CRD
-						_, err = pkgw.fissionClient.CoreV1().Functions(fn.ObjectMeta.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
-						if err != nil {
-							e := "error updating function package resource version"
-							pkgw.logger.Error(e, zap.Error(err))
-							buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-							_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-							if er != nil {
-								pkgw.logger.Error(
-									"error updating package",
-									zap.String("package_name", pkg.ObjectMeta.Name),
-									zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-									zap.Error(er),
-								)
-							}
-							return
+			// A package may be used by multiple functions. Update
+			// functions with old package resource version
+			for _, fn := range fnList.Items {
+				if fn.Spec.Package.PackageRef.Name == pkg.ObjectMeta.Name &&
+					fn.Spec.Package.PackageRef.Namespace == pkg.ObjectMeta.Namespace &&
+					fn.Spec.Package.PackageRef.ResourceVersion != pkg.ObjectMeta.ResourceVersion {
+					fn.Spec.Package.PackageRef.ResourceVersion = pkg.ObjectMeta.ResourceVersion
+					// update CRD
+					_, err = pkgw.fissionClient.CoreV1().Functions(fn.ObjectMeta.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
+					if err != nil {
+						e := "error updating function package resource version"
+						pkgw.logger.Error(e, zap.Error(err))
+						buildLogs += fmt.Sprintf("%s: %v\n", e, err)
+						_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+						if er != nil {
+							pkgw.logger.Error(
+								"error updating package",
+								zap.String("package_name", pkg.ObjectMeta.Name),
+								zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+								zap.Error(er),
+							)
 						}
+						return
 					}
 				}
 			}

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -199,46 +199,48 @@ func (pkgw *packageWatcher) build(ctx context.Context, srcpkg *fv1.Package) {
 
 			pkgw.logger.Info("starting package info update", zap.String("package_name", pkg.ObjectMeta.Name))
 
-			fnList, err := pkgw.fissionClient.CoreV1().
-				Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				e := "error getting function list"
-				pkgw.logger.Error(e, zap.Error(err))
-				buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-				_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-				if er != nil {
-					pkgw.logger.Error(
-						"error updating package",
-						zap.String("package_name", pkg.ObjectMeta.Name),
-						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-						zap.Error(er),
-					)
+			for _, namespace := range utils.GetNamespaces() {
+				fnList, err := pkgw.fissionClient.CoreV1().
+					Functions(namespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					e := "error getting function list"
+					pkgw.logger.Error(e, zap.Error(err))
+					buildLogs += fmt.Sprintf("%s: %v\n", e, err)
+					_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+					if er != nil {
+						pkgw.logger.Error(
+							"error updating package",
+							zap.String("package_name", pkg.ObjectMeta.Name),
+							zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+							zap.Error(er),
+						)
+					}
 				}
-			}
 
-			// A package may be used by multiple functions. Update
-			// functions with old package resource version
-			for _, fn := range fnList.Items {
-				if fn.Spec.Package.PackageRef.Name == pkg.ObjectMeta.Name &&
-					fn.Spec.Package.PackageRef.Namespace == pkg.ObjectMeta.Namespace &&
-					fn.Spec.Package.PackageRef.ResourceVersion != pkg.ObjectMeta.ResourceVersion {
-					fn.Spec.Package.PackageRef.ResourceVersion = pkg.ObjectMeta.ResourceVersion
-					// update CRD
-					_, err = pkgw.fissionClient.CoreV1().Functions(fn.ObjectMeta.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
-					if err != nil {
-						e := "error updating function package resource version"
-						pkgw.logger.Error(e, zap.Error(err))
-						buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-						_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-						if er != nil {
-							pkgw.logger.Error(
-								"error updating package",
-								zap.String("package_name", pkg.ObjectMeta.Name),
-								zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-								zap.Error(er),
-							)
+				// A package may be used by multiple functions. Update
+				// functions with old package resource version
+				for _, fn := range fnList.Items {
+					if fn.Spec.Package.PackageRef.Name == pkg.ObjectMeta.Name &&
+						fn.Spec.Package.PackageRef.Namespace == pkg.ObjectMeta.Namespace &&
+						fn.Spec.Package.PackageRef.ResourceVersion != pkg.ObjectMeta.ResourceVersion {
+						fn.Spec.Package.PackageRef.ResourceVersion = pkg.ObjectMeta.ResourceVersion
+						// update CRD
+						_, err = pkgw.fissionClient.CoreV1().Functions(fn.ObjectMeta.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
+						if err != nil {
+							e := "error updating function package resource version"
+							pkgw.logger.Error(e, zap.Error(err))
+							buildLogs += fmt.Sprintf("%s: %v\n", e, err)
+							_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+							if er != nil {
+								pkgw.logger.Error(
+									"error updating package",
+									zap.String("package_name", pkg.ObjectMeta.Name),
+									zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+									zap.Error(er),
+								)
+							}
+							return
 						}
-						return
 					}
 				}
 			}

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -240,7 +240,7 @@ func (caaf *Container) RefreshFuncPods(ctx context.Context, logger *zap.Logger, 
 
 	funcLabels := caaf.getDeployLabels(f.ObjectMeta)
 
-	dep, err := caaf.kubernetesClient.AppsV1().Deployments(f.Namespace).List(ctx, metav1.ListOptions{
+	dep, err := caaf.kubernetesClient.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(funcLabels).AsSelector().String(),
 	})
 	if err != nil {

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -240,7 +240,7 @@ func (caaf *Container) RefreshFuncPods(ctx context.Context, logger *zap.Logger, 
 
 	funcLabels := caaf.getDeployLabels(f.ObjectMeta)
 
-	dep, err := caaf.kubernetesClient.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+	dep, err := caaf.kubernetesClient.AppsV1().Deployments(f.Spec.Environment.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(funcLabels).AsSelector().String(),
 	})
 	if err != nil {
@@ -269,28 +269,30 @@ func (caaf *Container) RefreshFuncPods(ctx context.Context, logger *zap.Logger, 
 
 // AdoptExistingResources attempts to adopt resources for functions in all namespaces.
 func (caaf *Container) AdoptExistingResources(ctx context.Context) {
-	fnList, err := caaf.fissionClient.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		caaf.logger.Error("error getting function list", zap.Error(err))
-		return
-	}
-
 	wg := &sync.WaitGroup{}
 
-	for i := range fnList.Items {
-		fn := &fnList.Items[i]
-		if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+	for _, namepsace := range utils.GetNamespaces() {
+		fnList, err := caaf.fissionClient.CoreV1().Functions(namepsace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			caaf.logger.Error("error getting function list", zap.Error(err))
+			return
+		}
 
-				_, err = caaf.fnCreate(ctx, fn)
-				if err != nil {
-					caaf.logger.Warn("failed to adopt resources for function", zap.Error(err))
-					return
-				}
-				caaf.logger.Info("adopt resources for function", zap.String("function", fn.ObjectMeta.Name))
-			}()
+		for i := range fnList.Items {
+			fn := &fnList.Items[i]
+			if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					_, err = caaf.fnCreate(ctx, fn)
+					if err != nil {
+						caaf.logger.Warn("failed to adopt resources for function", zap.Error(err))
+						return
+					}
+					caaf.logger.Info("adopt resources for function", zap.String("function", fn.ObjectMeta.Name))
+				}()
+			}
 		}
 	}
 

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -240,7 +240,7 @@ func (caaf *Container) RefreshFuncPods(ctx context.Context, logger *zap.Logger, 
 
 	funcLabels := caaf.getDeployLabels(f.ObjectMeta)
 
-	dep, err := caaf.kubernetesClient.AppsV1().Deployments(f.Spec.Environment.Namespace).List(ctx, metav1.ListOptions{
+	dep, err := caaf.kubernetesClient.AppsV1().Deployments(f.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(funcLabels).AsSelector().String(),
 	})
 	if err != nil {

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -260,7 +260,7 @@ func (deploy *NewDeploy) RefreshFuncPods(ctx context.Context, logger *zap.Logger
 		UID:       env.ObjectMeta.UID,
 	})
 
-	dep, err := deploy.kubernetesClient.AppsV1().Deployments(f.Spec.Environment.Namespace).List(ctx, metav1.ListOptions{
+	dep, err := deploy.kubernetesClient.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(funcLabels).AsSelector().String(),
 	})
 

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -263,7 +263,7 @@ func (p *PoolPodController) workerRun(ctx context.Context, name string, processF
 }
 
 func (p *PoolPodController) getEnvLister(namespace string) (flisterv1.EnvironmentLister, error) {
-	lister, ok := p.envLister[metav1.NamespaceAll]
+	lister, ok := p.envLister[namespace]
 	if ok {
 		return lister, nil
 	}

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -71,118 +71,114 @@ func CleanupKubeObject(ctx context.Context, logger *zap.Logger, kubeClient kuber
 
 // CleanupDeployments deletes deployment(s) for a given instanceID
 func CleanupDeployments(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	for _, namespace := range utils.GetNamespaces() {
-		deploymentList, err := client.AppsV1().Deployments(namespace).List(ctx, listOps)
-		if err != nil {
-			return err
+	deploymentList, err := client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, listOps)
+	if err != nil {
+		return err
+	}
+	for _, dep := range deploymentList.Items {
+		id, ok := dep.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if !ok {
+			// Backward compatibility with older label name
+			id, ok = dep.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		for _, dep := range deploymentList.Items {
-			id, ok := dep.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-			if !ok {
-				// Backward compatibility with older label name
-				id, ok = dep.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if ok && id != instanceID {
+			logger.Info("cleaning up deployment", zap.String("deployment", dep.ObjectMeta.Name))
+			err := client.AppsV1().Deployments(dep.ObjectMeta.Namespace).Delete(ctx, dep.ObjectMeta.Name, delOpt)
+			if err != nil {
+				logger.Error("error cleaning up deployment",
+					zap.Error(err),
+					zap.String("deployment_name", dep.ObjectMeta.Name),
+					zap.String("deployment_namespace", dep.ObjectMeta.Namespace))
 			}
-			if ok && id != instanceID {
-				logger.Info("cleaning up deployment", zap.String("deployment", dep.ObjectMeta.Name))
-				err := client.AppsV1().Deployments(dep.ObjectMeta.Namespace).Delete(ctx, dep.ObjectMeta.Name, delOpt)
-				if err != nil {
-					logger.Error("error cleaning up deployment",
-						zap.Error(err),
-						zap.String("deployment_name", dep.ObjectMeta.Name),
-						zap.String("deployment_namespace", dep.ObjectMeta.Namespace))
-				}
-				// ignore err
-			}
+			// ignore err
 		}
 	}
+
 	return nil
 }
 
 // CleanupPods deletes pod(s) for a given instanceID
 func CleanupPods(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	for _, namespace := range utils.GetNamespaces() {
-		podList, err := client.CoreV1().Pods(namespace).List(ctx, listOps)
-		if err != nil {
-			return err
+	podList, err := client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, listOps)
+	if err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		id, ok := pod.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if !ok {
+			// Backward compatibility with older label name
+			id, ok = pod.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		for _, pod := range podList.Items {
-			id, ok := pod.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-			if !ok {
-				// Backward compatibility with older label name
-				id, ok = pod.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if ok && id != instanceID {
+			logger.Info("cleaning up pod", zap.String("pod", pod.ObjectMeta.Name))
+			err := client.CoreV1().Pods(pod.ObjectMeta.Namespace).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
+			if err != nil {
+				logger.Error("error cleaning up pod",
+					zap.Error(err),
+					zap.String("pod_name", pod.ObjectMeta.Name),
+					zap.String("pod_namespace", pod.ObjectMeta.Namespace))
 			}
-			if ok && id != instanceID {
-				logger.Info("cleaning up pod", zap.String("pod", pod.ObjectMeta.Name))
-				err := client.CoreV1().Pods(pod.ObjectMeta.Namespace).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
-				if err != nil {
-					logger.Error("error cleaning up pod",
-						zap.Error(err),
-						zap.String("pod_name", pod.ObjectMeta.Name),
-						zap.String("pod_namespace", pod.ObjectMeta.Namespace))
-				}
-				// ignore err
-			}
+			// ignore err
 		}
 	}
+
 	return nil
 }
 
 // CleanupServices deletes service(s) for a given instanceID
 func CleanupServices(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	for _, namespace := range utils.GetNamespaces() {
-		svcList, err := client.CoreV1().Services(namespace).List(ctx, listOps)
-		if err != nil {
-			return err
+	svcList, err := client.CoreV1().Services(metav1.NamespaceAll).List(ctx, listOps)
+	if err != nil {
+		return err
+	}
+	for _, svc := range svcList.Items {
+		id, ok := svc.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if !ok {
+			// Backward compatibility with older label name
+			id, ok = svc.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 		}
-		for _, svc := range svcList.Items {
-			id, ok := svc.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-			if !ok {
-				// Backward compatibility with older label name
-				id, ok = svc.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if ok && id != instanceID {
+			logger.Info("cleaning up service", zap.String("service", svc.ObjectMeta.Name))
+			err := client.CoreV1().Services(svc.ObjectMeta.Namespace).Delete(ctx, svc.ObjectMeta.Name, metav1.DeleteOptions{})
+			if err != nil {
+				logger.Error("error cleaning up service",
+					zap.Error(err),
+					zap.String("service_name", svc.ObjectMeta.Name),
+					zap.String("service_namespace", svc.ObjectMeta.Namespace))
 			}
-			if ok && id != instanceID {
-				logger.Info("cleaning up service", zap.String("service", svc.ObjectMeta.Name))
-				err := client.CoreV1().Services(svc.ObjectMeta.Namespace).Delete(ctx, svc.ObjectMeta.Name, metav1.DeleteOptions{})
-				if err != nil {
-					logger.Error("error cleaning up service",
-						zap.Error(err),
-						zap.String("service_name", svc.ObjectMeta.Name),
-						zap.String("service_namespace", svc.ObjectMeta.Namespace))
-				}
-				// ignore err
-			}
+			// ignore err
 		}
 	}
+
 	return nil
 }
 
 // CleanupHpa deletes horizontal pod autoscaler(s) for a given instanceID
 func CleanupHpa(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	for _, namespace := range utils.GetNamespaces() {
-		hpaList, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(ctx, listOps)
-		if err != nil {
-			return err
-		}
+	hpaList, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(ctx, listOps)
+	if err != nil {
+		return err
+	}
 
-		for _, hpa := range hpaList.Items {
-			id, ok := hpa.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-			if !ok {
-				// Backward compatibility with older label name
-				id, ok = hpa.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+	for _, hpa := range hpaList.Items {
+		id, ok := hpa.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+		if !ok {
+			// Backward compatibility with older label name
+			id, ok = hpa.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+		}
+		if ok && id != instanceID {
+			logger.Info("cleaning up HPA", zap.String("hpa", hpa.ObjectMeta.Name))
+			err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(ctx, hpa.ObjectMeta.Name, metav1.DeleteOptions{})
+			if err != nil {
+				logger.Error("error cleaning up HPA",
+					zap.Error(err),
+					zap.String("hpa_name", hpa.ObjectMeta.Name),
+					zap.String("hpa_namespace", hpa.ObjectMeta.Namespace))
 			}
-			if ok && id != instanceID {
-				logger.Info("cleaning up HPA", zap.String("hpa", hpa.ObjectMeta.Name))
-				err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(ctx, hpa.ObjectMeta.Name, metav1.DeleteOptions{})
-				if err != nil {
-					logger.Error("error cleaning up HPA",
-						zap.Error(err),
-						zap.String("hpa_name", hpa.ObjectMeta.Name),
-						zap.String("hpa_namespace", hpa.ObjectMeta.Namespace))
-				}
-				// ignore err
-			}
+			// ignore err
 		}
 	}
+
 	return nil
 }
 
@@ -195,136 +191,134 @@ func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kuberne
 
 		logger.Debug("starting cleanupRoleBindings cycle")
 
-		for _, namespace := range utils.GetNamespaces() {
-			// get all rolebindings ( just to be efficient, one call to kubernetes )
-			rbList, err := client.RbacV1().RoleBindings(namespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				// something wrong, but next iteration hopefully succeeds
-				logger.Error("error listing role bindings in all namespaces", zap.Error(err))
+		// get all rolebindings ( just to be efficient, one call to kubernetes )
+		rbList, err := client.RbacV1().RoleBindings(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			// something wrong, but next iteration hopefully succeeds
+			logger.Error("error listing role bindings in all namespaces", zap.Error(err))
+			continue
+		}
+
+		// go through each role-binding object and do the cleanup necessary
+		for _, roleBinding := range rbList.Items {
+			// ignore role-bindings in kube-system namespace
+			if roleBinding.Namespace == "kube-system" {
 				continue
 			}
 
-			// go through each role-binding object and do the cleanup necessary
-			for _, roleBinding := range rbList.Items {
-				// ignore role-bindings in kube-system namespace
-				if roleBinding.Namespace == "kube-system" {
-					continue
+			// ignore role-bindings not created by fission
+			if roleBinding.Name != fv1.PackageGetterRB && roleBinding.Name != fv1.SecretConfigMapGetterRB {
+				continue
+			}
+
+			// in order to find out if there are any functions that need this role-binding in role-binding namespace,
+			// we can list the functions once per role-binding.
+			funcList, err := fissionClient.CoreV1().Functions(roleBinding.Namespace).List(ctx, metav1.ListOptions{})
+			if err != nil {
+				logger.Error("error fetching function list in namespace", zap.Error(err), zap.String("namespace", roleBinding.Namespace))
+				continue
+			}
+
+			// final map of service accounts that can be removed from this roleBinding object
+			// using a map here instead of a list so the code in RemoveSAFromRoleBindingWithRetries is efficient.
+			saToRemove := make(map[string]bool)
+
+			// the following flags are needed to decide if any of the service accounts can be removed from role-bindings depending on the functions that need them.
+			// ndmFunc denotes if there's at least one function that has executor type New deploy Manager
+			// funcEnvReference denotes if there's at least one function that has reference to an environment in the SA Namespace for the SA in question
+			var ndmFunc, funcEnvReference bool
+
+			// iterate through each subject in the role-binding and check if there are any references to them
+			for _, subj := range roleBinding.Subjects {
+				ndmFunc = false
+				funcEnvReference = false
+
+				// this is the reverse of what we're doing in setting up of role-bindings. if objects are created in default ns,
+				// the SA namespace will have the value of "fission-function"/"fission-builder" depending on the SA.
+				// so now we need to look for the objects in default namespace.
+				saNs := subj.Namespace
+				isInReservedNS := false
+				if subj.Namespace == functionNs ||
+					subj.Namespace == envBuilderNs {
+					saNs = metav1.NamespaceDefault
+					isInReservedNS = true
 				}
 
-				// ignore role-bindings not created by fission
-				if roleBinding.Name != fv1.PackageGetterRB && roleBinding.Name != fv1.SecretConfigMapGetterRB {
-					continue
-				}
-
-				// in order to find out if there are any functions that need this role-binding in role-binding namespace,
-				// we can list the functions once per role-binding.
-				funcList, err := fissionClient.CoreV1().Functions(roleBinding.Namespace).List(ctx, metav1.ListOptions{})
-				if err != nil {
-					logger.Error("error fetching function list in namespace", zap.Error(err), zap.String("namespace", roleBinding.Namespace))
-					continue
-				}
-
-				// final map of service accounts that can be removed from this roleBinding object
-				// using a map here instead of a list so the code in RemoveSAFromRoleBindingWithRetries is efficient.
-				saToRemove := make(map[string]bool)
-
-				// the following flags are needed to decide if any of the service accounts can be removed from role-bindings depending on the functions that need them.
-				// ndmFunc denotes if there's at least one function that has executor type New deploy Manager
-				// funcEnvReference denotes if there's at least one function that has reference to an environment in the SA Namespace for the SA in question
-				var ndmFunc, funcEnvReference bool
-
-				// iterate through each subject in the role-binding and check if there are any references to them
-				for _, subj := range roleBinding.Subjects {
-					ndmFunc = false
-					funcEnvReference = false
-
-					// this is the reverse of what we're doing in setting up of role-bindings. if objects are created in default ns,
-					// the SA namespace will have the value of "fission-function"/"fission-builder" depending on the SA.
-					// so now we need to look for the objects in default namespace.
-					saNs := subj.Namespace
-					isInReservedNS := false
-					if subj.Namespace == functionNs ||
-						subj.Namespace == envBuilderNs {
-						saNs = metav1.NamespaceDefault
-						isInReservedNS = true
+				// go through each function and find out if there's either at least one function with env reference in the same namespace as the Service Account in this iteration
+				// or at least one function using ndm executor in the role-binding namespace and set the corresponding flags
+				for _, fn := range funcList.Items {
+					if fn.Spec.Environment.Namespace == saNs ||
+						//  For the case that the environment is created in the reserved namespace.
+						(isInReservedNS && (fn.Spec.Environment.Namespace == functionNs || fn.Spec.Environment.Namespace == envBuilderNs)) {
+						funcEnvReference = true
+						break
 					}
 
-					// go through each function and find out if there's either at least one function with env reference in the same namespace as the Service Account in this iteration
-					// or at least one function using ndm executor in the role-binding namespace and set the corresponding flags
-					for _, fn := range funcList.Items {
-						if fn.Spec.Environment.Namespace == saNs ||
-							//  For the case that the environment is created in the reserved namespace.
-							(isInReservedNS && (fn.Spec.Environment.Namespace == functionNs || fn.Spec.Environment.Namespace == envBuilderNs)) {
-							funcEnvReference = true
-							break
-						}
+					if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy {
+						ndmFunc = true
+						break
+					}
+				}
 
-						if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy {
-							ndmFunc = true
-							break
-						}
+				// if its a package-getter-rb, we have 2 kinds of SAs and each of them is handled differently
+				// else if its a secret-configmap-rb, we have only one SA which is fission-fetcher
+				if roleBinding.Name == fv1.PackageGetterRB {
+					// check if there is an env obj in saNs
+					envList, err := fissionClient.CoreV1().Environments(saNs).List(ctx, metav1.ListOptions{})
+					if err != nil {
+						logger.Error("error fetching environment list in service account namespace", zap.Error(err), zap.String("namespace", saNs))
+						continue
 					}
 
-					// if its a package-getter-rb, we have 2 kinds of SAs and each of them is handled differently
-					// else if its a secret-configmap-rb, we have only one SA which is fission-fetcher
-					if roleBinding.Name == fv1.PackageGetterRB {
-						// check if there is an env obj in saNs
-						envList, err := fissionClient.CoreV1().Environments(saNs).List(ctx, metav1.ListOptions{})
-						if err != nil {
-							logger.Error("error fetching environment list in service account namespace", zap.Error(err), zap.String("namespace", saNs))
-							continue
-						}
-
-						// if the SA in this iteration is fission-builder, then we need to only check
-						// if either there's at least one env object in the SA's namespace, or,
-						// if there's at least one function in the role-binding namespace with env reference
-						// to the SA's namespace.
-						// if neither, then we can remove this SA from this role-binding
-						if subj.Name == fv1.FissionBuilderSA {
-							if len(envList.Items) == 0 && !funcEnvReference {
-								saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
-							}
-						}
-
-						// if the SA in this iteration is fission-fetcher, then in addition to above checks,
-						// we also need to check if there's at least one function with executor type New deploy
-						// in the rolebinding's namespace.
-						// if none of them are true, then remove this SA from this role-binding
-						if subj.Name == fv1.FissionFetcherSA {
-							if len(envList.Items) == 0 && !ndmFunc && !funcEnvReference {
-								// remove SA from rolebinding
-								saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
-							}
-						}
-					} else if roleBinding.Name == fv1.SecretConfigMapGetterRB {
-						// if there's not even one function in the role-binding's namespace and there's not even
-						// one function with env reference to the SA's namespace, then remove that SA
-						// from this role-binding
-						if !ndmFunc && !funcEnvReference {
+					// if the SA in this iteration is fission-builder, then we need to only check
+					// if either there's at least one env object in the SA's namespace, or,
+					// if there's at least one function in the role-binding namespace with env reference
+					// to the SA's namespace.
+					// if neither, then we can remove this SA from this role-binding
+					if subj.Name == fv1.FissionBuilderSA {
+						if len(envList.Items) == 0 && !funcEnvReference {
 							saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
 						}
 					}
-				}
 
-				// finally, make a call to RemoveSAFromRoleBindingWithRetries for all the service accounts that need to be removed
-				// for the role-binding in this iteration
-				if len(saToRemove) != 0 {
-					logger.Debug("removing service accounts from role binding",
+					// if the SA in this iteration is fission-fetcher, then in addition to above checks,
+					// we also need to check if there's at least one function with executor type New deploy
+					// in the rolebinding's namespace.
+					// if none of them are true, then remove this SA from this role-binding
+					if subj.Name == fv1.FissionFetcherSA {
+						if len(envList.Items) == 0 && !ndmFunc && !funcEnvReference {
+							// remove SA from rolebinding
+							saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
+						}
+					}
+				} else if roleBinding.Name == fv1.SecretConfigMapGetterRB {
+					// if there's not even one function in the role-binding's namespace and there's not even
+					// one function with env reference to the SA's namespace, then remove that SA
+					// from this role-binding
+					if !ndmFunc && !funcEnvReference {
+						saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
+					}
+				}
+			}
+
+			// finally, make a call to RemoveSAFromRoleBindingWithRetries for all the service accounts that need to be removed
+			// for the role-binding in this iteration
+			if len(saToRemove) != 0 {
+				logger.Debug("removing service accounts from role binding",
+					zap.Any("service_accounts", saToRemove),
+					zap.String("role_binding_name", roleBinding.Name),
+					zap.String("role_binding_namespace", roleBinding.Namespace))
+
+				// call this once in the end for each role-binding
+				err = utils.RemoveSAFromRoleBindingWithRetries(ctx, logger, client, roleBinding.Name, roleBinding.Namespace, saToRemove)
+				if err != nil {
+					// if there's an error, we just log it and proceed with the next role-binding, hoping that this role-binding
+					// will be processed in next iteration.
+					logger.Debug("error removing service account from role binding",
+						zap.Error(err),
 						zap.Any("service_accounts", saToRemove),
 						zap.String("role_binding_name", roleBinding.Name),
 						zap.String("role_binding_namespace", roleBinding.Namespace))
-
-					// call this once in the end for each role-binding
-					err = utils.RemoveSAFromRoleBindingWithRetries(ctx, logger, client, roleBinding.Name, roleBinding.Namespace, saToRemove)
-					if err != nil {
-						// if there's an error, we just log it and proceed with the next role-binding, hoping that this role-binding
-						// will be processed in next iteration.
-						logger.Debug("error removing service account from role binding",
-							zap.Error(err),
-							zap.Any("service_accounts", saToRemove),
-							zap.String("role_binding_name", roleBinding.Name),
-							zap.String("role_binding_namespace", roleBinding.Namespace))
-					}
 				}
 			}
 		}

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -71,26 +71,28 @@ func CleanupKubeObject(ctx context.Context, logger *zap.Logger, kubeClient kuber
 
 // CleanupDeployments deletes deployment(s) for a given instanceID
 func CleanupDeployments(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	deploymentList, err := client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, listOps)
-	if err != nil {
-		return err
-	}
-	for _, dep := range deploymentList.Items {
-		id, ok := dep.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-		if !ok {
-			// Backward compatibility with older label name
-			id, ok = dep.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+	for _, namespace := range utils.GetNamespaces() {
+		deploymentList, err := client.AppsV1().Deployments(namespace).List(ctx, listOps)
+		if err != nil {
+			return err
 		}
-		if ok && id != instanceID {
-			logger.Info("cleaning up deployment", zap.String("deployment", dep.ObjectMeta.Name))
-			err := client.AppsV1().Deployments(dep.ObjectMeta.Namespace).Delete(ctx, dep.ObjectMeta.Name, delOpt)
-			if err != nil {
-				logger.Error("error cleaning up deployment",
-					zap.Error(err),
-					zap.String("deployment_name", dep.ObjectMeta.Name),
-					zap.String("deployment_namespace", dep.ObjectMeta.Namespace))
+		for _, dep := range deploymentList.Items {
+			id, ok := dep.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+			if !ok {
+				// Backward compatibility with older label name
+				id, ok = dep.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 			}
-			// ignore err
+			if ok && id != instanceID {
+				logger.Info("cleaning up deployment", zap.String("deployment", dep.ObjectMeta.Name))
+				err := client.AppsV1().Deployments(dep.ObjectMeta.Namespace).Delete(ctx, dep.ObjectMeta.Name, delOpt)
+				if err != nil {
+					logger.Error("error cleaning up deployment",
+						zap.Error(err),
+						zap.String("deployment_name", dep.ObjectMeta.Name),
+						zap.String("deployment_namespace", dep.ObjectMeta.Namespace))
+				}
+				// ignore err
+			}
 		}
 	}
 	return nil
@@ -98,26 +100,28 @@ func CleanupDeployments(ctx context.Context, logger *zap.Logger, client kubernet
 
 // CleanupPods deletes pod(s) for a given instanceID
 func CleanupPods(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	podList, err := client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, listOps)
-	if err != nil {
-		return err
-	}
-	for _, pod := range podList.Items {
-		id, ok := pod.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-		if !ok {
-			// Backward compatibility with older label name
-			id, ok = pod.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+	for _, namespace := range utils.GetNamespaces() {
+		podList, err := client.CoreV1().Pods(namespace).List(ctx, listOps)
+		if err != nil {
+			return err
 		}
-		if ok && id != instanceID {
-			logger.Info("cleaning up pod", zap.String("pod", pod.ObjectMeta.Name))
-			err := client.CoreV1().Pods(pod.ObjectMeta.Namespace).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("error cleaning up pod",
-					zap.Error(err),
-					zap.String("pod_name", pod.ObjectMeta.Name),
-					zap.String("pod_namespace", pod.ObjectMeta.Namespace))
+		for _, pod := range podList.Items {
+			id, ok := pod.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+			if !ok {
+				// Backward compatibility with older label name
+				id, ok = pod.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 			}
-			// ignore err
+			if ok && id != instanceID {
+				logger.Info("cleaning up pod", zap.String("pod", pod.ObjectMeta.Name))
+				err := client.CoreV1().Pods(pod.ObjectMeta.Namespace).Delete(ctx, pod.ObjectMeta.Name, metav1.DeleteOptions{})
+				if err != nil {
+					logger.Error("error cleaning up pod",
+						zap.Error(err),
+						zap.String("pod_name", pod.ObjectMeta.Name),
+						zap.String("pod_namespace", pod.ObjectMeta.Namespace))
+				}
+				// ignore err
+			}
 		}
 	}
 	return nil
@@ -125,26 +129,28 @@ func CleanupPods(ctx context.Context, logger *zap.Logger, client kubernetes.Inte
 
 // CleanupServices deletes service(s) for a given instanceID
 func CleanupServices(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	svcList, err := client.CoreV1().Services(metav1.NamespaceAll).List(ctx, listOps)
-	if err != nil {
-		return err
-	}
-	for _, svc := range svcList.Items {
-		id, ok := svc.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-		if !ok {
-			// Backward compatibility with older label name
-			id, ok = svc.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+	for _, namespace := range utils.GetNamespaces() {
+		svcList, err := client.CoreV1().Services(namespace).List(ctx, listOps)
+		if err != nil {
+			return err
 		}
-		if ok && id != instanceID {
-			logger.Info("cleaning up service", zap.String("service", svc.ObjectMeta.Name))
-			err := client.CoreV1().Services(svc.ObjectMeta.Namespace).Delete(ctx, svc.ObjectMeta.Name, metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("error cleaning up service",
-					zap.Error(err),
-					zap.String("service_name", svc.ObjectMeta.Name),
-					zap.String("service_namespace", svc.ObjectMeta.Namespace))
+		for _, svc := range svcList.Items {
+			id, ok := svc.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+			if !ok {
+				// Backward compatibility with older label name
+				id, ok = svc.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 			}
-			// ignore err
+			if ok && id != instanceID {
+				logger.Info("cleaning up service", zap.String("service", svc.ObjectMeta.Name))
+				err := client.CoreV1().Services(svc.ObjectMeta.Namespace).Delete(ctx, svc.ObjectMeta.Name, metav1.DeleteOptions{})
+				if err != nil {
+					logger.Error("error cleaning up service",
+						zap.Error(err),
+						zap.String("service_name", svc.ObjectMeta.Name),
+						zap.String("service_namespace", svc.ObjectMeta.Namespace))
+				}
+				// ignore err
+			}
 		}
 	}
 	return nil
@@ -152,27 +158,29 @@ func CleanupServices(ctx context.Context, logger *zap.Logger, client kubernetes.
 
 // CleanupHpa deletes horizontal pod autoscaler(s) for a given instanceID
 func CleanupHpa(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
-	hpaList, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(ctx, listOps)
-	if err != nil {
-		return err
-	}
-
-	for _, hpa := range hpaList.Items {
-		id, ok := hpa.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
-		if !ok {
-			// Backward compatibility with older label name
-			id, ok = hpa.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
+	for _, namespace := range utils.GetNamespaces() {
+		hpaList, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(ctx, listOps)
+		if err != nil {
+			return err
 		}
-		if ok && id != instanceID {
-			logger.Info("cleaning up HPA", zap.String("hpa", hpa.ObjectMeta.Name))
-			err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(ctx, hpa.ObjectMeta.Name, metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("error cleaning up HPA",
-					zap.Error(err),
-					zap.String("hpa_name", hpa.ObjectMeta.Name),
-					zap.String("hpa_namespace", hpa.ObjectMeta.Namespace))
+
+		for _, hpa := range hpaList.Items {
+			id, ok := hpa.ObjectMeta.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+			if !ok {
+				// Backward compatibility with older label name
+				id, ok = hpa.ObjectMeta.Labels[fv1.EXECUTOR_INSTANCEID_LABEL]
 			}
-			// ignore err
+			if ok && id != instanceID {
+				logger.Info("cleaning up HPA", zap.String("hpa", hpa.ObjectMeta.Name))
+				err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(ctx, hpa.ObjectMeta.Name, metav1.DeleteOptions{})
+				if err != nil {
+					logger.Error("error cleaning up HPA",
+						zap.Error(err),
+						zap.String("hpa_name", hpa.ObjectMeta.Name),
+						zap.String("hpa_namespace", hpa.ObjectMeta.Namespace))
+				}
+				// ignore err
+			}
 		}
 	}
 	return nil
@@ -186,134 +194,137 @@ func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kuberne
 		time.Sleep(cleanupRoleBindingInterval)
 
 		logger.Debug("starting cleanupRoleBindings cycle")
-		// get all rolebindings ( just to be efficient, one call to kubernetes )
-		rbList, err := client.RbacV1().RoleBindings(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			// something wrong, but next iteration hopefully succeeds
-			logger.Error("error listing role bindings in all namespaces", zap.Error(err))
-			continue
-		}
 
-		// go through each role-binding object and do the cleanup necessary
-		for _, roleBinding := range rbList.Items {
-			// ignore role-bindings in kube-system namespace
-			if roleBinding.Namespace == "kube-system" {
-				continue
-			}
-
-			// ignore role-bindings not created by fission
-			if roleBinding.Name != fv1.PackageGetterRB && roleBinding.Name != fv1.SecretConfigMapGetterRB {
-				continue
-			}
-
-			// in order to find out if there are any functions that need this role-binding in role-binding namespace,
-			// we can list the functions once per role-binding.
-			funcList, err := fissionClient.CoreV1().Functions(roleBinding.Namespace).List(ctx, metav1.ListOptions{})
+		for _, namespace := range utils.GetNamespaces() {
+			// get all rolebindings ( just to be efficient, one call to kubernetes )
+			rbList, err := client.RbacV1().RoleBindings(namespace).List(ctx, metav1.ListOptions{})
 			if err != nil {
-				logger.Error("error fetching function list in namespace", zap.Error(err), zap.String("namespace", roleBinding.Namespace))
+				// something wrong, but next iteration hopefully succeeds
+				logger.Error("error listing role bindings in all namespaces", zap.Error(err))
 				continue
 			}
 
-			// final map of service accounts that can be removed from this roleBinding object
-			// using a map here instead of a list so the code in RemoveSAFromRoleBindingWithRetries is efficient.
-			saToRemove := make(map[string]bool)
-
-			// the following flags are needed to decide if any of the service accounts can be removed from role-bindings depending on the functions that need them.
-			// ndmFunc denotes if there's at least one function that has executor type New deploy Manager
-			// funcEnvReference denotes if there's at least one function that has reference to an environment in the SA Namespace for the SA in question
-			var ndmFunc, funcEnvReference bool
-
-			// iterate through each subject in the role-binding and check if there are any references to them
-			for _, subj := range roleBinding.Subjects {
-				ndmFunc = false
-				funcEnvReference = false
-
-				// this is the reverse of what we're doing in setting up of role-bindings. if objects are created in default ns,
-				// the SA namespace will have the value of "fission-function"/"fission-builder" depending on the SA.
-				// so now we need to look for the objects in default namespace.
-				saNs := subj.Namespace
-				isInReservedNS := false
-				if subj.Namespace == functionNs ||
-					subj.Namespace == envBuilderNs {
-					saNs = metav1.NamespaceDefault
-					isInReservedNS = true
+			// go through each role-binding object and do the cleanup necessary
+			for _, roleBinding := range rbList.Items {
+				// ignore role-bindings in kube-system namespace
+				if roleBinding.Namespace == "kube-system" {
+					continue
 				}
 
-				// go through each function and find out if there's either at least one function with env reference in the same namespace as the Service Account in this iteration
-				// or at least one function using ndm executor in the role-binding namespace and set the corresponding flags
-				for _, fn := range funcList.Items {
-					if fn.Spec.Environment.Namespace == saNs ||
-						//  For the case that the environment is created in the reserved namespace.
-						(isInReservedNS && (fn.Spec.Environment.Namespace == functionNs || fn.Spec.Environment.Namespace == envBuilderNs)) {
-						funcEnvReference = true
-						break
-					}
-
-					if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy {
-						ndmFunc = true
-						break
-					}
+				// ignore role-bindings not created by fission
+				if roleBinding.Name != fv1.PackageGetterRB && roleBinding.Name != fv1.SecretConfigMapGetterRB {
+					continue
 				}
 
-				// if its a package-getter-rb, we have 2 kinds of SAs and each of them is handled differently
-				// else if its a secret-configmap-rb, we have only one SA which is fission-fetcher
-				if roleBinding.Name == fv1.PackageGetterRB {
-					// check if there is an env obj in saNs
-					envList, err := fissionClient.CoreV1().Environments(saNs).List(ctx, metav1.ListOptions{})
-					if err != nil {
-						logger.Error("error fetching environment list in service account namespace", zap.Error(err), zap.String("namespace", saNs))
-						continue
-					}
-
-					// if the SA in this iteration is fission-builder, then we need to only check
-					// if either there's at least one env object in the SA's namespace, or,
-					// if there's at least one function in the role-binding namespace with env reference
-					// to the SA's namespace.
-					// if neither, then we can remove this SA from this role-binding
-					if subj.Name == fv1.FissionBuilderSA {
-						if len(envList.Items) == 0 && !funcEnvReference {
-							saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
-						}
-					}
-
-					// if the SA in this iteration is fission-fetcher, then in addition to above checks,
-					// we also need to check if there's at least one function with executor type New deploy
-					// in the rolebinding's namespace.
-					// if none of them are true, then remove this SA from this role-binding
-					if subj.Name == fv1.FissionFetcherSA {
-						if len(envList.Items) == 0 && !ndmFunc && !funcEnvReference {
-							// remove SA from rolebinding
-							saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
-						}
-					}
-				} else if roleBinding.Name == fv1.SecretConfigMapGetterRB {
-					// if there's not even one function in the role-binding's namespace and there's not even
-					// one function with env reference to the SA's namespace, then remove that SA
-					// from this role-binding
-					if !ndmFunc && !funcEnvReference {
-						saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
-					}
-				}
-			}
-
-			// finally, make a call to RemoveSAFromRoleBindingWithRetries for all the service accounts that need to be removed
-			// for the role-binding in this iteration
-			if len(saToRemove) != 0 {
-				logger.Debug("removing service accounts from role binding",
-					zap.Any("service_accounts", saToRemove),
-					zap.String("role_binding_name", roleBinding.Name),
-					zap.String("role_binding_namespace", roleBinding.Namespace))
-
-				// call this once in the end for each role-binding
-				err = utils.RemoveSAFromRoleBindingWithRetries(ctx, logger, client, roleBinding.Name, roleBinding.Namespace, saToRemove)
+				// in order to find out if there are any functions that need this role-binding in role-binding namespace,
+				// we can list the functions once per role-binding.
+				funcList, err := fissionClient.CoreV1().Functions(roleBinding.Namespace).List(ctx, metav1.ListOptions{})
 				if err != nil {
-					// if there's an error, we just log it and proceed with the next role-binding, hoping that this role-binding
-					// will be processed in next iteration.
-					logger.Debug("error removing service account from role binding",
-						zap.Error(err),
+					logger.Error("error fetching function list in namespace", zap.Error(err), zap.String("namespace", roleBinding.Namespace))
+					continue
+				}
+
+				// final map of service accounts that can be removed from this roleBinding object
+				// using a map here instead of a list so the code in RemoveSAFromRoleBindingWithRetries is efficient.
+				saToRemove := make(map[string]bool)
+
+				// the following flags are needed to decide if any of the service accounts can be removed from role-bindings depending on the functions that need them.
+				// ndmFunc denotes if there's at least one function that has executor type New deploy Manager
+				// funcEnvReference denotes if there's at least one function that has reference to an environment in the SA Namespace for the SA in question
+				var ndmFunc, funcEnvReference bool
+
+				// iterate through each subject in the role-binding and check if there are any references to them
+				for _, subj := range roleBinding.Subjects {
+					ndmFunc = false
+					funcEnvReference = false
+
+					// this is the reverse of what we're doing in setting up of role-bindings. if objects are created in default ns,
+					// the SA namespace will have the value of "fission-function"/"fission-builder" depending on the SA.
+					// so now we need to look for the objects in default namespace.
+					saNs := subj.Namespace
+					isInReservedNS := false
+					if subj.Namespace == functionNs ||
+						subj.Namespace == envBuilderNs {
+						saNs = metav1.NamespaceDefault
+						isInReservedNS = true
+					}
+
+					// go through each function and find out if there's either at least one function with env reference in the same namespace as the Service Account in this iteration
+					// or at least one function using ndm executor in the role-binding namespace and set the corresponding flags
+					for _, fn := range funcList.Items {
+						if fn.Spec.Environment.Namespace == saNs ||
+							//  For the case that the environment is created in the reserved namespace.
+							(isInReservedNS && (fn.Spec.Environment.Namespace == functionNs || fn.Spec.Environment.Namespace == envBuilderNs)) {
+							funcEnvReference = true
+							break
+						}
+
+						if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy {
+							ndmFunc = true
+							break
+						}
+					}
+
+					// if its a package-getter-rb, we have 2 kinds of SAs and each of them is handled differently
+					// else if its a secret-configmap-rb, we have only one SA which is fission-fetcher
+					if roleBinding.Name == fv1.PackageGetterRB {
+						// check if there is an env obj in saNs
+						envList, err := fissionClient.CoreV1().Environments(saNs).List(ctx, metav1.ListOptions{})
+						if err != nil {
+							logger.Error("error fetching environment list in service account namespace", zap.Error(err), zap.String("namespace", saNs))
+							continue
+						}
+
+						// if the SA in this iteration is fission-builder, then we need to only check
+						// if either there's at least one env object in the SA's namespace, or,
+						// if there's at least one function in the role-binding namespace with env reference
+						// to the SA's namespace.
+						// if neither, then we can remove this SA from this role-binding
+						if subj.Name == fv1.FissionBuilderSA {
+							if len(envList.Items) == 0 && !funcEnvReference {
+								saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
+							}
+						}
+
+						// if the SA in this iteration is fission-fetcher, then in addition to above checks,
+						// we also need to check if there's at least one function with executor type New deploy
+						// in the rolebinding's namespace.
+						// if none of them are true, then remove this SA from this role-binding
+						if subj.Name == fv1.FissionFetcherSA {
+							if len(envList.Items) == 0 && !ndmFunc && !funcEnvReference {
+								// remove SA from rolebinding
+								saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
+							}
+						}
+					} else if roleBinding.Name == fv1.SecretConfigMapGetterRB {
+						// if there's not even one function in the role-binding's namespace and there's not even
+						// one function with env reference to the SA's namespace, then remove that SA
+						// from this role-binding
+						if !ndmFunc && !funcEnvReference {
+							saToRemove[utils.MakeSAMapKey(subj.Name, subj.Namespace)] = true
+						}
+					}
+				}
+
+				// finally, make a call to RemoveSAFromRoleBindingWithRetries for all the service accounts that need to be removed
+				// for the role-binding in this iteration
+				if len(saToRemove) != 0 {
+					logger.Debug("removing service accounts from role binding",
 						zap.Any("service_accounts", saToRemove),
 						zap.String("role_binding_name", roleBinding.Name),
 						zap.String("role_binding_namespace", roleBinding.Namespace))
+
+					// call this once in the end for each role-binding
+					err = utils.RemoveSAFromRoleBindingWithRetries(ctx, logger, client, roleBinding.Name, roleBinding.Namespace, saToRemove)
+					if err != nil {
+						// if there's an error, we just log it and proceed with the next role-binding, hoping that this role-binding
+						// will be processed in next iteration.
+						logger.Debug("error removing service account from role binding",
+							zap.Error(err),
+							zap.Any("service_accounts", saToRemove),
+							zap.String("role_binding_name", roleBinding.Name),
+							zap.String("role_binding_namespace", roleBinding.Namespace))
+					}
 				}
 			}
 		}

--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -122,9 +122,6 @@ func (frr *functionReferenceResolver) resolve(trigger fv1.HTTPTrigger) (*resolve
 }
 
 func (frr *functionReferenceResolver) getInformerByNamespace(namespace string) (k8sCache.SharedIndexInformer, error) {
-	if informer, ok := frr.funcInformer[metav1.NamespaceAll]; ok {
-		return informer, nil
-	}
 	if informer, ok := frr.funcInformer[namespace]; ok {
 		return informer, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
Created two environment in go. One in default namespace and second in testns1 namespace.
Created 1 pool manager executor type function in each environment.
Verified that all the deployment, services etc for function created inside testns1 namespace, were created inside testns1 namespace.
Tested both functions individually and verified that idle object reaper is reaping pods in their respective namespaces.

Created 1 newdeploy executor type function in each environment.
Tested both functions individually and verified that idle object reaper is reaping pods in their respective namespaces according to their idletimeout .

Performed same steps for python environment as well,

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
