### PR TITLE
Use Kubernetes Client instead of Controller APIs from CLI

### DIFF
--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -261,7 +261,7 @@ func (api *API) GetHandler() http.Handler {
 	r.HandleFunc("/proxy/{dbType}", api.FunctionLogsApiPost).Methods("POST")
 	r.HandleFunc("/proxy/storage/v1/archive", api.StorageServiceProxy)
 	r.HandleFunc("/proxy/logs/{function}", api.FunctionPodLogs).Methods("POST")
-	r.HandleFunc("/proxy/workflows-apiserver/{path:.*}", api.WorkflowApiserverProxy)
+	r.HandleFunc("/proxy/workflows-apiserver/{path:.*}", api.WorkflowApiserverProxy) // Deprecated
 	r.HandleFunc("/proxy/svcname", api.GetSvcName).Queries("application", "").Methods("GET")
 
 	r.Handle("/v2/apidocs.json", openAPI()).Methods("GET")

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -521,10 +521,10 @@ func TestMain(m *testing.M) {
 
 	time.Sleep(5 * time.Second)
 
-	fissionClient, kubernetesClient, _, _, err := crd.MakeFissionClient()
+	client, err := cmd.NewClient(cmd.ClientOptions{})
 	panicIf(err)
 	// TODO: use fake rest client for offline spec generation
-	cmd.SetClientset(fissionClient, kubernetesClient)
+	cmd.SetClientset(*client)
 
 	resp, err := http.Get("http://localhost:8888/")
 	panicIf(err)

--- a/pkg/controller/api_test.go
+++ b/pkg/controller/api_test.go
@@ -44,9 +44,9 @@ import (
 )
 
 var (
-	g struct {
-		cmd.CommandActioner
-	}
+	// g struct {
+	// 	cmd.CommandActioner
+	// }
 	testNS = metav1.NamespaceDefault
 )
 
@@ -105,41 +105,45 @@ func TestFunctionApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.Client().V1().Function().Get(&metav1.ObjectMeta{
+
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+
+	_, err := dClient.V1().Function().Get(&metav1.ObjectMeta{
 		Name:      testFunc.ObjectMeta.Name,
 		Namespace: testNS,
 	})
 	assertNotFoundFailure(err, "function")
 
-	m, err := g.Client().V1().Function().Create(testFunc)
+	m, err := dClient.V1().Function().Create(testFunc)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().Function().Delete(m)
+		err := dClient.V1().Function().Delete(m)
 		panicIf(err)
 	}()
 
-	_, err = g.Client().V1().Function().Create(testFunc)
+	_, err = dClient.V1().Function().Create(testFunc)
 	assertNameReuseFailure(err, "function")
 
 	testFunc.ObjectMeta.ResourceVersion = m.ResourceVersion
 	testFunc.Spec.Package.FunctionName = "yyy"
-	_, err = g.Client().V1().Function().Update(testFunc)
+	_, err = dClient.V1().Function().Update(testFunc)
 	panicIf(err)
 
 	testFunc.ObjectMeta.ResourceVersion = ""
 	testFunc.ObjectMeta.Name = "bar"
-	m2, err := g.Client().V1().Function().Create(testFunc)
+	m2, err := dClient.V1().Function().Create(testFunc)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().Function().Delete(m2)
+		err := dClient.V1().Function().Delete(m2)
 		panicIf(err)
 	}()
 
-	funcs, err := g.Client().V1().Function().List(testNS)
+	funcs, err := dClient.V1().Function().List(testNS)
 	panicIf(err)
 	assert(len(funcs) == 2, fmt.Sprintf("created two functions, but found %v", len(funcs)))
 
-	funcs_url := g.Client().ServerURL() + "/v2/functions"
+	funcs_url := dClient.ServerURL() + "/v2/functions"
 	resp, err := http.Get(funcs_url)
 	panicIf(err)
 	defer resp.Body.Close()
@@ -169,23 +173,27 @@ func TestHTTPTriggerApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
+
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+
+	_, err := dClient.V1().HTTPTrigger().Get(&metav1.ObjectMeta{
 		Name:      testTrigger.ObjectMeta.Name,
 		Namespace: testNS,
 	})
 	assertNotFoundFailure(err, "httptrigger")
 
-	m, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
+	m, err := dClient.V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().HTTPTrigger().Delete(m)
+		err := dClient.V1().HTTPTrigger().Delete(m)
 		panicIf(err)
 	}()
 
-	_, err = g.Client().V1().HTTPTrigger().Create(testTrigger)
+	_, err = dClient.V1().HTTPTrigger().Create(testTrigger)
 	assertNameReuseFailure(err, "httptrigger")
 
-	tr, err := g.Client().V1().HTTPTrigger().Get(m)
+	tr, err := dClient.V1().HTTPTrigger().Get(m)
 	panicIf(err)
 	assert(len(testTrigger.Spec.Methods) == len(tr.Spec.Methods) &&
 		testTrigger.Spec.RelativeURL == tr.Spec.RelativeURL &&
@@ -194,23 +202,23 @@ func TestHTTPTriggerApi(t *testing.T) {
 
 	testTrigger.ObjectMeta.ResourceVersion = m.ResourceVersion
 	testTrigger.Spec.RelativeURL = "/hi"
-	_, err = g.Client().V1().HTTPTrigger().Update(testTrigger)
+	_, err = dClient.V1().HTTPTrigger().Update(testTrigger)
 	panicIf(err)
 
 	testTrigger.ObjectMeta.ResourceVersion = ""
 	testTrigger.ObjectMeta.Name = "yyy"
-	_, err = g.Client().V1().HTTPTrigger().Create(testTrigger)
+	_, err = dClient.V1().HTTPTrigger().Create(testTrigger)
 	assert(err != nil, "duplicate trigger should not be allowed")
 
 	testTrigger.Spec.RelativeURL = "/hi2"
-	m2, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
+	m2, err := dClient.V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
 	defer func() {
-		err = g.Client().V1().HTTPTrigger().Delete(m2)
+		err = dClient.V1().HTTPTrigger().Delete(m2)
 		panicIf(err)
 	}()
 
-	ts, err := g.Client().V1().HTTPTrigger().List(testNS)
+	ts, err := dClient.V1().HTTPTrigger().List(testNS)
 	panicIf(err)
 	assert(len(ts) == 2, fmt.Sprintf("created two triggers, but found %v", len(ts)))
 }
@@ -237,7 +245,9 @@ func createFissionFnForMultipleTrigger() {
 		},
 	}
 
-	_, err := g.Client().V1().Function().Create(testFunc)
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+	_, err := dClient.V1().Function().Create(testFunc)
 	panicIf(err)
 	defer func() {
 		panicIf(err)
@@ -245,7 +255,7 @@ func createFissionFnForMultipleTrigger() {
 
 	testFunc.Name = "foo2"
 
-	_, err = g.Client().V1().Function().Create(testFunc)
+	_, err = dClient.V1().Function().Create(testFunc)
 	panicIf(err)
 	defer func() {
 		panicIf(err)
@@ -272,9 +282,11 @@ func TestHTTPTriggerCreateMultipleTrigger(t *testing.T) {
 		},
 	}
 
-	m, err := g.Client().V1().HTTPTrigger().Create(testTrigger)
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+	m, err := dClient.V1().HTTPTrigger().Create(testTrigger)
 	panicIf(err)
-	defer panicIf(g.Client().V1().HTTPTrigger().Delete(m))
+	defer panicIf(dClient.V1().HTTPTrigger().Delete(m))
 
 	prefix_2 := "url_another"
 	testTrigger2 := &fv1.HTTPTrigger{
@@ -293,7 +305,7 @@ func TestHTTPTriggerCreateMultipleTrigger(t *testing.T) {
 		},
 	}
 
-	m2, err := g.Client().V1().HTTPTrigger().Create(testTrigger2)
+	m2, err := dClient.V1().HTTPTrigger().Create(testTrigger2)
 
 	if err != nil {
 		t.Fatal()
@@ -301,7 +313,7 @@ func TestHTTPTriggerCreateMultipleTrigger(t *testing.T) {
 
 	defer func() {
 		if m2 != nil {
-			err := g.Client().V1().HTTPTrigger().Delete(m2)
+			err := dClient.V1().HTTPTrigger().Delete(m2)
 			if err != nil {
 				logger.Error("Error deleting http trigger", zap.String("name", m2.Name), zap.Error(err))
 			}
@@ -324,42 +336,46 @@ func TestEnvironmentApi(t *testing.T) {
 			Resources: v1.ResourceRequirements{},
 		},
 	}
-	_, err := g.Client().V1().Environment().Get(&metav1.ObjectMeta{
+
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+
+	_, err := dClient.V1().Environment().Get(&metav1.ObjectMeta{
 		Name:      testEnv.ObjectMeta.Name,
 		Namespace: testNS,
 	})
 	assertNotFoundFailure(err, "environment")
 
-	m, err := g.Client().V1().Environment().Create(testEnv)
+	m, err := dClient.V1().Environment().Create(testEnv)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().Environment().Delete(m)
+		err := dClient.V1().Environment().Delete(m)
 		panicIf(err)
 	}()
 
-	_, err = g.Client().V1().Environment().Create(testEnv)
+	_, err = dClient.V1().Environment().Create(testEnv)
 	assertNameReuseFailure(err, "environment")
 
-	e, err := g.Client().V1().Environment().Get(m)
+	e, err := dClient.V1().Environment().Get(m)
 	panicIf(err)
 	assert(reflect.DeepEqual(testEnv.Spec, e.Spec), "env should match after reading")
 
 	testEnv.ObjectMeta.ResourceVersion = m.ResourceVersion
 	testEnv.Spec.Runtime.Image = "another-img"
-	_, err = g.Client().V1().Environment().Update(testEnv)
+	_, err = dClient.V1().Environment().Update(testEnv)
 	panicIf(err)
 
 	testEnv.ObjectMeta.ResourceVersion = ""
 	testEnv.ObjectMeta.Name = "bar"
 
-	m2, err := g.Client().V1().Environment().Create(testEnv)
+	m2, err := dClient.V1().Environment().Create(testEnv)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().Environment().Delete(m2)
+		err := dClient.V1().Environment().Delete(m2)
 		panicIf(err)
 	}()
 
-	ts, err := g.Client().V1().Environment().List(testNS)
+	ts, err := dClient.V1().Environment().List(testNS)
 	panicIf(err)
 	assert(len(ts) == 2, fmt.Sprintf("created two envs, but found %v", len(ts)))
 }
@@ -379,23 +395,27 @@ func TestWatchApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.Client().V1().KubeWatcher().Get(&metav1.ObjectMeta{
+
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+
+	_, err := dClient.V1().KubeWatcher().Get(&metav1.ObjectMeta{
 		Name:      testWatch.ObjectMeta.Name,
 		Namespace: testNS,
 	})
 	assertNotFoundFailure(err, "watch")
 
-	m, err := g.Client().V1().KubeWatcher().Create(testWatch)
+	m, err := dClient.V1().KubeWatcher().Create(testWatch)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().KubeWatcher().Delete(m)
+		err := dClient.V1().KubeWatcher().Delete(m)
 		panicIf(err)
 	}()
 
-	_, err = g.Client().V1().KubeWatcher().Create(testWatch)
+	_, err = dClient.V1().KubeWatcher().Create(testWatch)
 	assertNameReuseFailure(err, "watch")
 
-	w, err := g.Client().V1().KubeWatcher().Get(m)
+	w, err := dClient.V1().KubeWatcher().Get(m)
 	panicIf(err)
 	assert(testWatch.Spec.Namespace == w.Spec.Namespace &&
 		testWatch.Spec.Type == w.Spec.Type &&
@@ -403,14 +423,14 @@ func TestWatchApi(t *testing.T) {
 		testWatch.Spec.FunctionReference.Name == w.Spec.FunctionReference.Name, "watch should match after reading")
 
 	testWatch.ObjectMeta.Name = "yyy"
-	m2, err := g.Client().V1().KubeWatcher().Create(testWatch)
+	m2, err := dClient.V1().KubeWatcher().Create(testWatch)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().KubeWatcher().Delete(m2)
+		err := dClient.V1().KubeWatcher().Delete(m2)
 		panicIf(err)
 	}()
 
-	ws, err := g.Client().V1().KubeWatcher().List(testNS)
+	ws, err := dClient.V1().KubeWatcher().List(testNS)
 	panicIf(err)
 	assert(len(ws) == 2, fmt.Sprintf("created two watches, but found %v", len(ws)))
 }
@@ -429,20 +449,24 @@ func TestTimeTriggerApi(t *testing.T) {
 			},
 		},
 	}
-	_, err := g.Client().V1().TimeTrigger().Get(&metav1.ObjectMeta{Name: testTrigger.ObjectMeta.Name})
+
+	restClient := rest.NewRESTClient("http://localhost:8888")
+	dClient := client.MakeClientset(restClient)
+
+	_, err := dClient.V1().TimeTrigger().Get(&metav1.ObjectMeta{Name: testTrigger.ObjectMeta.Name})
 	assertNotFoundFailure(err, "trigger")
 
-	m, err := g.Client().V1().TimeTrigger().Create(testTrigger)
+	m, err := dClient.V1().TimeTrigger().Create(testTrigger)
 	panicIf(err)
 	defer func() {
-		err := g.Client().V1().TimeTrigger().Delete(m)
+		err := dClient.V1().TimeTrigger().Delete(m)
 		panicIf(err)
 	}()
 
-	_, err = g.Client().V1().TimeTrigger().Create(testTrigger)
+	_, err = dClient.V1().TimeTrigger().Create(testTrigger)
 	assertNameReuseFailure(err, "trigger")
 
-	tr, err := g.Client().V1().TimeTrigger().Get(m)
+	tr, err := dClient.V1().TimeTrigger().Get(m)
 	panicIf(err)
 	assert(testTrigger.Spec.Cron == tr.Spec.Cron &&
 		testTrigger.Spec.FunctionReference.Type == tr.Spec.FunctionReference.Type &&
@@ -450,16 +474,16 @@ func TestTimeTriggerApi(t *testing.T) {
 
 	testTrigger.ObjectMeta.ResourceVersion = m.ResourceVersion
 	testTrigger.Spec.Cron = "@hourly"
-	_, err = g.Client().V1().TimeTrigger().Update(testTrigger)
+	_, err = dClient.V1().TimeTrigger().Update(testTrigger)
 	panicIf(err)
 
 	testTrigger.ObjectMeta.ResourceVersion = ""
 	testTrigger.ObjectMeta.Name = "yyy"
 	testTrigger.Spec.Cron = "Not valid cron spec"
-	_, err = g.Client().V1().TimeTrigger().Create(testTrigger)
+	_, err = dClient.V1().TimeTrigger().Create(testTrigger)
 	assertCronSpecFails(err)
 
-	ts, err := g.Client().V1().TimeTrigger().List(testNS)
+	ts, err := dClient.V1().TimeTrigger().List(testNS)
 	panicIf(err)
 	assert(len(ts) == 1, fmt.Sprintf("created two time triggers, but found %v", len(ts)))
 }
@@ -497,9 +521,10 @@ func TestMain(m *testing.M) {
 
 	time.Sleep(5 * time.Second)
 
-	restClient := rest.NewRESTClient("http://localhost:8888")
+	fissionClient, kubernetesClient, _, _, err := crd.MakeFissionClient()
+	panicIf(err)
 	// TODO: use fake rest client for offline spec generation
-	cmd.SetClientset(client.MakeClientset(restClient))
+	cmd.SetClientset(fissionClient, kubernetesClient)
 
 	resp, err := http.Get("http://localhost:8888/")
 	panicIf(err)

--- a/pkg/controller/client/v1/canaryconfig.go
+++ b/pkg/controller/client/v1/canaryconfig.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fission/fission/pkg/controller/client/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
 )
 
 type (

--- a/pkg/controller/client/v1/fake/fake_package.go
+++ b/pkg/controller/client/v1/fake/fake_package.go
@@ -17,11 +17,10 @@ limitations under the License.
 package fake
 
 import (
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (

--- a/pkg/controller/client/v1/fake/fake_timetrigger.go
+++ b/pkg/controller/client/v1/fake/fake_timetrigger.go
@@ -17,11 +17,10 @@ limitations under the License.
 package fake
 
 import (
-	v1 "github.com/fission/fission/pkg/controller/client/v1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	v1 "github.com/fission/fission/pkg/controller/client/v1"
 )
 
 type (

--- a/pkg/controller/client/v1/httptrigger.go
+++ b/pkg/controller/client/v1/httptrigger.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fission/fission/pkg/controller/client/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
 )
 
 type (

--- a/pkg/controller/client/v1/kuberneteswatchtrigger.go
+++ b/pkg/controller/client/v1/kuberneteswatchtrigger.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fission/fission/pkg/controller/client/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
 	ferror "github.com/fission/fission/pkg/error"
 )
 

--- a/pkg/controller/client/v1/mqtrigger.go
+++ b/pkg/controller/client/v1/mqtrigger.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fission/fission/pkg/controller/client/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
 )
 
 type (

--- a/pkg/controller/client/v1/package.go
+++ b/pkg/controller/client/v1/package.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fission/fission/pkg/controller/client/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
 )
 
 type (

--- a/pkg/controller/client/v1/timetrigger.go
+++ b/pkg/controller/client/v1/timetrigger.go
@@ -20,11 +20,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/fission/fission/pkg/controller/client/rest"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller/client/rest"
 )
 
 type (

--- a/pkg/controller/client/v1/v1.go
+++ b/pkg/controller/client/v1/v1.go
@@ -20,9 +20,8 @@ import (
 	"io"
 	"net/http"
 
-	ferror "github.com/fission/fission/pkg/error"
-
 	"github.com/fission/fission/pkg/controller/client/rest"
+	ferror "github.com/fission/fission/pkg/error"
 )
 
 type (

--- a/pkg/fission-cli/cmd/archive/command.go
+++ b/pkg/fission-cli/cmd/archive/command.go
@@ -32,7 +32,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(uploadCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.ArchiveName},
-		Optional: []flag.Flag{flag.KubeContext},
+		Optional: []flag.Flag{},
 	})
 
 	listCmd := &cobra.Command{
@@ -41,7 +41,7 @@ func Commands() *cobra.Command {
 		RunE:  wrapper.Wrapper(List),
 	}
 	wrapper.SetFlags(listCmd, flag.FlagSet{
-		Optional: []flag.Flag{flag.KubeContext},
+		Optional: []flag.Flag{},
 	})
 
 	deleteCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(geturlCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.ArchiveID},
-		Optional: []flag.Flag{flag.KubeContext},
+		Optional: []flag.Flag{},
 	})
 
 	downloadCmd := &cobra.Command{
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(downloadCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.ArchiveID},
-		Optional: []flag.Flag{flag.KubeContext, flag.ArchiveOutput},
+		Optional: []flag.Flag{flag.ArchiveOutput},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/archive/delete.go
+++ b/pkg/fission-cli/cmd/archive/delete.go
@@ -36,10 +36,9 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	kubeContext := input.String(flagkey.KubeContext)
 	archiveID := input.String(flagkey.ArchiveID)
 
-	storagesvcURL, err := util.GetStorageURL(input.Context(), kubeContext)
+	storagesvcURL, err := util.GetStorageURL(input.Context(), opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/archive/download.go
+++ b/pkg/fission-cli/cmd/archive/download.go
@@ -37,7 +37,6 @@ func Download(input cli.Input) error {
 
 func (opts *DownloadSubCommand) do(input cli.Input) error {
 
-	kubeContext := input.String(flagkey.KubeContext)
 	archiveID := input.String(flagkey.ArchiveID)
 	archiveOutput := input.String(flagkey.ArchiveOutput)
 
@@ -45,7 +44,7 @@ func (opts *DownloadSubCommand) do(input cli.Input) error {
 		archiveOutput = strings.TrimPrefix(archiveID, "/fission/fission-functions/")
 	}
 
-	storageAccessURL, err := util.GetStorageURL(input.Context(), kubeContext)
+	storageAccessURL, err := util.GetStorageURL(input.Context(), opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/archive/geturl.go
+++ b/pkg/fission-cli/cmd/archive/geturl.go
@@ -67,7 +67,8 @@ func (opts *GetURLSubCommand) do(input cli.Input) error {
 	storageType := resp.Header.Get("X-FISSION-STORAGETYPE")
 
 	if storageType == "local" {
-		storageSvc, err := opts.Client().V1().Misc().GetSvcURL("application=fission-storage")
+		// TODO: testing required here
+		storageSvc, err := util.GetSvcName(input.Context(), opts.Client().KubernetesClient, "fission-storage")
 		if err != nil {
 			return err
 		}

--- a/pkg/fission-cli/cmd/archive/geturl.go
+++ b/pkg/fission-cli/cmd/archive/geturl.go
@@ -38,10 +38,9 @@ func GetURL(input cli.Input) error {
 
 func (opts *GetURLSubCommand) do(input cli.Input) error {
 
-	kubeContext := input.String(flagkey.KubeContext)
 	archiveID := input.String(flagkey.ArchiveID)
 
-	serverURL, err := util.GetStorageURL(input.Context(), kubeContext)
+	serverURL, err := util.GetStorageURL(input.Context(), opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/archive/geturl.go
+++ b/pkg/fission-cli/cmd/archive/geturl.go
@@ -66,7 +66,6 @@ func (opts *GetURLSubCommand) do(input cli.Input) error {
 	storageType := resp.Header.Get("X-FISSION-STORAGETYPE")
 
 	if storageType == "local" {
-		// TODO: testing required here
 		storageSvc, err := util.GetSvcName(input.Context(), opts.Client().KubernetesClient, "fission-storage")
 		if err != nil {
 			return err

--- a/pkg/fission-cli/cmd/archive/list.go
+++ b/pkg/fission-cli/cmd/archive/list.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
-	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
 )
@@ -36,9 +35,7 @@ func List(input cli.Input) error {
 
 func (opts *ListSubCommand) do(input cli.Input) error {
 
-	kubeContext := input.String(flagkey.KubeContext)
-
-	storageAccessURL, err := util.GetStorageURL(input.Context(), kubeContext)
+	storageAccessURL, err := util.GetStorageURL(input.Context(), opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/archive/upload.go
+++ b/pkg/fission-cli/cmd/archive/upload.go
@@ -36,10 +36,9 @@ func Upload(input cli.Input) error {
 
 func (opts *UploadSubCommand) do(input cli.Input) error {
 
-	kubeContext := input.String(flagkey.KubeContext)
 	archiveName := input.String(flagkey.ArchiveName)
 
-	storagesvcURL, err := util.GetStorageURL(input.Context(), kubeContext)
+	storagesvcURL, err := util.GetStorageURL(input.Context(), opts.Client())
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/create.go
+++ b/pkg/fission-cli/cmd/canaryconfig/create.go
@@ -69,10 +69,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 	}
 
 	// check that the trigger exists in the same namespace.
-	htTrigger, err := opts.Client().V1().HTTPTrigger().Get(&metav1.ObjectMeta{
-		Name:      ht,
-		Namespace: fnNs,
-	})
+	htTrigger, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(fnNs).Get(input.Context(), ht, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error finding http trigger referenced in the canary config")
 	}
@@ -95,7 +92,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 
 	// check that the functions exist in the same namespace
 	fnList := []string{newFunc, oldFunc}
-	err = util.CheckFunctionExistence(opts.Client(), fnList, fnNs)
+	err = util.CheckFunctionExistence(input.Context(), opts.Client(), fnList, fnNs)
 	if err != nil {
 		return errors.Wrap(err, "error checking functions existence")
 	}
@@ -124,7 +121,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().V1().CanaryConfig().Create(opts.canary)
+	_, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.canary.ObjectMeta.Namespace).Create(input.Context(), opts.canary, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error creating canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/create.go
+++ b/pkg/fission-cli/cmd/canaryconfig/create.go
@@ -54,7 +54,8 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 	ht := input.String(flagkey.CanaryHTTPTriggerName)
 	newFunc := input.String(flagkey.CanaryNewFunc)
 	oldFunc := input.String(flagkey.CanaryOldFunc)
-	_, fnNs, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+
+	_, fnNs, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in creating canaryconfig")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/create.go
+++ b/pkg/fission-cli/cmd/canaryconfig/create.go
@@ -54,7 +54,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 	ht := input.String(flagkey.CanaryHTTPTriggerName)
 	newFunc := input.String(flagkey.CanaryNewFunc)
 	oldFunc := input.String(flagkey.CanaryOldFunc)
-	_, fnNs, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNs, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in creating canaryconfig")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/delete.go
+++ b/pkg/fission-cli/cmd/canaryconfig/delete.go
@@ -41,12 +41,8 @@ func (opts *DeleteSubCommand) run(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting canaryConfig ")
 	}
-	m := &metav1.ObjectMeta{
-		Name:      input.String(flagkey.CanaryName),
-		Namespace: namespace,
-	}
 
-	err = opts.Client().V1().CanaryConfig().Delete(m)
+	err = opts.Client().FissionClientSet.CoreV1().CanaryConfigs(namespace).Delete(input.Context(), input.String(flagkey.CanaryName), metav1.DeleteOptions{})
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil
@@ -54,6 +50,6 @@ func (opts *DeleteSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error deleting canary config")
 	}
 
-	fmt.Printf("canaryconfig '%v.%v' deleted\n", m.Name, m.Namespace)
+	fmt.Printf("canaryconfig '%v.%v' deleted\n", input.String(flagkey.CanaryName), namespace)
 	return nil
 }

--- a/pkg/fission-cli/cmd/canaryconfig/delete.go
+++ b/pkg/fission-cli/cmd/canaryconfig/delete.go
@@ -37,7 +37,7 @@ func Delete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting canaryConfig ")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/delete.go
+++ b/pkg/fission-cli/cmd/canaryconfig/delete.go
@@ -37,7 +37,7 @@ func Delete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting canaryConfig ")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -45,10 +45,7 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error getting canary config")
 	}
 
-	canaryCfg, err := opts.Client().V1().CanaryConfig().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.CanaryName),
-		Namespace: namespace,
-	})
+	canaryCfg, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(namespace).Get(input.Context(), input.String(flagkey.CanaryName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -40,7 +40,7 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error getting canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -40,7 +39,7 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error getting canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -22,6 +22,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -57,11 +58,11 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	var canaryCfgs []v1.CanaryConfig
+	var canaryCfgs *v1.CanaryConfigList
 	if input.Bool(flagkey.AllNamespaces) {
-		canaryCfgs, err = opts.Client().V1().CanaryConfig().List("")
+		canaryCfgs, err = opts.Client().FissionClientSet.CoreV1().CanaryConfigs(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 	} else {
-		canaryCfgs, err = opts.Client().V1().CanaryConfig().List(opts.namespace)
+		canaryCfgs, err = opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.namespace).List(input.Context(), metav1.ListOptions{})
 	}
 	if err != nil {
 		return errors.Wrap(err, "error listing canary config")
@@ -69,7 +70,7 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS")
-	for _, canaryCfg := range canaryCfgs {
+	for _, canaryCfg := range canaryCfgs.Items {
 		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
 			canaryCfg.ObjectMeta.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction, canaryCfg.Spec.WeightIncrement, canaryCfg.Spec.WeightIncrementDuration,
 			canaryCfg.Spec.FailureThreshold, canaryCfg.Spec.FailureType, canaryCfg.Status.Status)

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -57,12 +56,11 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	var canaryCfgs *v1.CanaryConfigList
 	if input.Bool(flagkey.AllNamespaces) {
-		canaryCfgs, err = opts.Client().FissionClientSet.CoreV1().CanaryConfigs(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	} else {
-		canaryCfgs, err = opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.namespace).List(input.Context(), metav1.ListOptions{})
+		opts.namespace = metav1.NamespaceAll
 	}
+	canaryCfgs, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.namespace).List(input.Context(), metav1.ListOptions{})
+
 	if err != nil {
 		return errors.Wrap(err, "error listing canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -49,7 +48,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error in listing canary config ")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -49,7 +49,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error in listing canary config ")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -49,7 +49,6 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	// get the current config
-	name := input.String(flagkey.CanaryName)
 	_, ns, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error updating canary config")
@@ -64,10 +63,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 		return errors.Wrap(err, "error parsing time duration")
 	}
 
-	canaryCfg, err := opts.Client().V1().CanaryConfig().Get(&metav1.ObjectMeta{
-		Name:      name,
-		Namespace: ns,
-	})
+	canaryCfg, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(ns).Get(input.Context(), input.String(flagkey.CanaryName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting canary config")
 	}
@@ -96,7 +92,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().V1().CanaryConfig().Update(opts.canary)
+	_, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.canary.ObjectMeta.Namespace).Update(input.Context(), opts.canary, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error updating canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
@@ -49,7 +48,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	// get the current config
-	_, ns, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
+	_, ns, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error updating canary config")
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -49,7 +49,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	// get the current config
-	_, ns, err := util.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, ns, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceCanary)
 	if err != nil {
 		return errors.Wrap(err, "error updating canary config")
 	}

--- a/pkg/fission-cli/cmd/check/check.go
+++ b/pkg/fission-cli/cmd/check/check.go
@@ -30,8 +30,6 @@ func Check(input cli.Input) error {
 
 func (opts *CheckSubCommand) do(input cli.Input) error {
 
-	kubeContext := input.String(flagkey.KubeContext)
-
 	checks := []healthcheck.CategoryID{}
 
 	if input.IsSet(flagkey.PreCheckOnly) {
@@ -40,10 +38,7 @@ func (opts *CheckSubCommand) do(input cli.Input) error {
 		checks = append(checks, healthcheck.FissionServices, healthcheck.FissionVersion)
 	}
 
-	hc := healthcheck.NewHealthChecker(checks, &healthcheck.Options{
-		KubeContext:   kubeContext,
-		FissionClient: opts.Client(),
-	})
+	hc := healthcheck.NewHealthChecker(opts.Client(), checks)
 
 	healthcheck.RunChecks(input.Context(), hc)
 	return nil

--- a/pkg/fission-cli/cmd/check/check.go
+++ b/pkg/fission-cli/cmd/check/check.go
@@ -40,6 +40,6 @@ func (opts *CheckSubCommand) do(input cli.Input) error {
 
 	hc := healthcheck.NewHealthChecker(opts.Client(), checks)
 
-	healthcheck.RunChecks(input.Context(), hc)
+	healthcheck.RunChecks(input.Context(), input, opts.Client(), hc)
 	return nil
 }

--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -90,6 +90,7 @@ func GetClientConfig(kubeContext string) (clientcmd.ClientConfig, error) {
 	}
 	overrides := &clientcmd.ConfigOverrides{}
 	if len(kubeContext) > 0 {
+		console.Verbose(2, "Using kubeconfig context %q", kubeContext)
 		overrides.CurrentContext = kubeContext
 	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides), nil
@@ -110,6 +111,7 @@ func NewClient(opts ClientOptions) (*Client, error) {
 		return nil, err
 	}
 	client.Namespace = namespace
+	console.Verbose(2, "Kubeconfig default namespace %q", namespace)
 
 	restConfig, err := cmdConfig.ClientConfig()
 	if err != nil {

--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2022 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/fission/fission/pkg/fission-cli/console"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
+)
+
+type (
+	ClientOptions struct {
+		KubeContext string
+	}
+	Client struct {
+		Options          ClientOptions
+		ClientConfig     clientcmd.ClientConfig
+		RestConfig       *rest.Config
+		FissionClientSet versioned.Interface
+		KubernetesClient kubernetes.Interface
+		Namespace        string
+	}
+)
+
+func (c *Client) SetFissionClientset(fissionClientSet versioned.Interface) {
+	c.FissionClientSet = fissionClientSet
+}
+
+func (c *Client) SetKubernetesClient(kubernetesClient kubernetes.Interface) {
+	c.KubernetesClient = kubernetesClient
+}
+
+func getLoadingRules() (loadingRules *clientcmd.ClientConfigLoadingRules, err error) {
+	loadingRules = clientcmd.NewDefaultClientConfigLoadingRules()
+
+	kubeConfigPath := os.Getenv("KUBECONFIG")
+	if len(kubeConfigPath) == 0 {
+		var homeDir string
+		usr, err := user.Current()
+		if err != nil {
+			// In case that user.Current() may be unable to work under some circumstances and return errors like
+			// "user: Current not implemented on darwin/amd64" due to cross-compilation problem. (https://github.com/golang/go/issues/6376).
+			// Instead of doing fatal here, we fallback to get home directory from the environment $HOME.
+			console.Warn(fmt.Sprintf("Could not get the current user's directory (%s), fallback to get it from env $HOME", err))
+			homeDir = os.Getenv("HOME")
+		} else {
+			homeDir = usr.HomeDir
+		}
+		kubeConfigPath = filepath.Join(homeDir, ".kube", "config")
+
+		if _, err := os.Stat(kubeConfigPath); os.IsNotExist(err) {
+			return nil, errors.New("couldn't find kubeconfig file. " +
+				"Set the KUBECONFIG environment variable to your kubeconfig's path.")
+		}
+		loadingRules.ExplicitPath = kubeConfigPath
+		console.Verbose(2, "Using kubeconfig from %q", kubeConfigPath)
+	} else {
+		console.Verbose(2, "Using kubeconfig from environment %q", kubeConfigPath)
+	}
+	return loadingRules, nil
+}
+
+func GetClientConfig(kubeContext string) (clientcmd.ClientConfig, error) {
+	loadingRules, err := getLoadingRules()
+	if err != nil {
+		return nil, err
+	}
+	overrides := &clientcmd.ConfigOverrides{}
+	if len(kubeContext) > 0 {
+		overrides.CurrentContext = kubeContext
+	}
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides), nil
+}
+
+func NewClient(opts ClientOptions) (*Client, error) {
+	client := &Client{
+		Options: opts,
+	}
+	cmdConfig, err := GetClientConfig(opts.KubeContext)
+	if err != nil {
+		return nil, err
+	}
+	client.ClientConfig = cmdConfig
+
+	namespace, _, err := cmdConfig.Namespace()
+	if err != nil {
+		return nil, err
+	}
+	client.Namespace = namespace
+
+	restConfig, err := cmdConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	client.RestConfig = restConfig
+	clientset, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	client.KubernetesClient = clientset
+
+	fissionClientset, err := versioned.NewForConfig(restConfig)
+	if err != nil {
+		return nil, err
+	}
+	client.FissionClientSet = fissionClientset
+
+	return client, nil
+}

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -19,26 +19,36 @@ package cmd
 import (
 	"sync"
 
-	"github.com/fission/fission/pkg/controller/client"
+	"k8s.io/client-go/kubernetes"
+
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
 )
 
 type (
 	CommandAction   func(input cli.Input) error
 	CommandActioner struct{}
+	Client          struct {
+		FissionClientSet versioned.Interface
+		KubernetesClient kubernetes.Interface
+	}
 )
 
 var (
-	once             = sync.Once{}
-	defaultClientset client.Interface
+	once          = sync.Once{}
+	defaultClient Client
 )
 
-func SetClientset(clientset client.Interface) {
+func SetClientset(fClientSet versioned.Interface, kClient kubernetes.Interface) {
 	once.Do(func() {
-		defaultClientset = clientset
+		defaultClient = Client{
+			FissionClientSet: fClientSet,
+			KubernetesClient: kClient,
+		}
+
 	})
 }
 
-func (c *CommandActioner) Client() client.Interface {
-	return defaultClientset
+func (c *CommandActioner) Client() Client {
+	return defaultClient
 }

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -17,9 +17,12 @@ limitations under the License.
 package cmd
 
 import (
+	"os"
 	"sync"
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/console"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 )
 
 type (
@@ -40,4 +43,28 @@ func SetClientset(client Client) {
 
 func (c *CommandActioner) Client() Client {
 	return defaultClient
+}
+
+func (c *CommandActioner) GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, currentNS string, err error) {
+	namespace = input.String(deprecatedFlag)
+	currentNS = namespace
+
+	if input.String(flagkey.Namespace) != "" {
+		namespace = input.String(flagkey.Namespace)
+		currentNS = namespace
+		console.Verbose(2, "Namespace for resource %s ", currentNS)
+		return namespace, currentNS, err
+	}
+
+	if namespace == "" {
+		if os.Getenv("FISSION_DEFAULT_NAMESPACE") != "" {
+			currentNS = os.Getenv("FISSION_DEFAULT_NAMESPACE")
+		} else {
+			currentNS = c.Client().Namespace
+			return namespace, currentNS, err
+		}
+	}
+
+	console.Verbose(2, "Namespace for resource %s ", currentNS)
+	return namespace, currentNS, nil
 }

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -19,19 +19,12 @@ package cmd
 import (
 	"sync"
 
-	"k8s.io/client-go/kubernetes"
-
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
-	"github.com/fission/fission/pkg/generated/clientset/versioned"
 )
 
 type (
 	CommandAction   func(input cli.Input) error
 	CommandActioner struct{}
-	Client          struct {
-		FissionClientSet versioned.Interface
-		KubernetesClient kubernetes.Interface
-	}
 )
 
 var (
@@ -39,13 +32,9 @@ var (
 	defaultClient Client
 )
 
-func SetClientset(fClientSet versioned.Interface, kClient kubernetes.Interface) {
+func SetClientset(client Client) {
 	once.Do(func() {
-		defaultClient = Client{
-			FissionClientSet: fClientSet,
-			KubernetesClient: kClient,
-		}
-
+		defaultClient = client
 	})
 }
 

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -75,7 +75,7 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 			len(envList.Items), m.Namespace)
 	}
 
-	userDefinedNS, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	userDefinedNS, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -75,7 +75,7 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 			len(envList.Items), m.Namespace)
 	}
 
-	userDefinedNS, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	userDefinedNS, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -40,7 +40,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
-	_, currentContextNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentContextNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
@@ -40,7 +39,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
-	_, currentContextNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentContextNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -44,35 +45,31 @@ func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 		return errors.Wrap(err, "error creating environment")
 	}
 	console.Verbose(2, "Searching for resource in  %s Namespace", currentContextNS)
-
-	m := &metav1.ObjectMeta{
-		Name:      input.String(flagkey.EnvName),
-		Namespace: currentContextNS,
-	}
+	envName := input.String(flagkey.EnvName)
 
 	if !input.Bool(flagkey.EnvForce) {
-		fns, err := opts.Client().V1().Function().List(metav1.NamespaceAll)
+		fns, err := opts.Client().FissionClientSet.CoreV1().Functions(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 		if err != nil {
 			return errors.Wrap(err, "Error getting functions wrt environment.")
 		}
 
-		for _, fn := range fns {
-			if fn.Spec.Environment.Name == m.Name &&
-				fn.Spec.Environment.Namespace == m.Namespace {
+		for _, fn := range fns.Items {
+			if fn.Spec.Environment.Name == envName &&
+				fn.Spec.Environment.Namespace == currentContextNS {
 				return errors.New("Environment is used by at least one function.")
 			}
 		}
 	}
 
-	err = opts.Client().V1().Environment().Delete(m)
+	err = opts.Client().FissionClientSet.CoreV1().Environments(currentContextNS).Delete(input.Context(), envName, metav1.DeleteOptions{})
 	if err != nil {
-		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
+		if input.Bool(flagkey.IgnoreNotFound) && kerrors.IsNotFound(err) {
 			return nil
 		}
 		return errors.Wrap(err, "error deleting environment")
 	}
 
-	fmt.Printf("environment '%v' deleted\n", m.Name)
+	fmt.Printf("environment '%s' deleted\n", envName)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -45,12 +45,7 @@ func (opts *GetSubCommand) do(input cli.Input) (err error) {
 		return errors.Wrap(err, "error creating environment")
 	}
 
-	m := &metav1.ObjectMeta{
-		Name:      input.String(flagkey.EnvName),
-		Namespace: currentNS,
-	}
-
-	env, err := opts.Client().V1().Environment().Get(m)
+	env, err := opts.Client().FissionClientSet.CoreV1().Environments(currentNS).Get(input.Context(), input.String(flagkey.EnvName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting environment")
 	}

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -40,7 +40,7 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -40,7 +39,7 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -45,12 +44,11 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 		return errors.Wrap(err, "error creating environment")
 	}
 
-	var response *v1.EnvironmentList
 	if input.Bool(flagkey.AllNamespaces) {
-		response, err = opts.Client().FissionClientSet.CoreV1().Environments(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	} else {
-		response, err = opts.Client().FissionClientSet.CoreV1().Environments(currentNS).List(input.Context(), metav1.ListOptions{})
+		currentNS = metav1.NamespaceAll
 	}
+
+	response, err := opts.Client().FissionClientSet.CoreV1().Environments(currentNS).List(input.Context(), metav1.ListOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error listing environments")
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -41,7 +40,7 @@ func List(input cli.Input) error {
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -41,7 +41,7 @@ func List(input cli.Input) error {
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -43,7 +43,7 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -43,7 +42,7 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -58,10 +58,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}
-	env, err := opts.Client().V1().Environment().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.EnvName),
-		Namespace: currentContextNS,
-	})
+	env, err := opts.Client().FissionClientSet.CoreV1().Environments(currentContextNS).Get(input.Context(), input.String(flagkey.EnvName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error finding environment")
 	}
@@ -81,12 +78,16 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().V1().Environment().Update(opts.env)
+
+	enew, err := opts.Client().FissionClientSet.CoreV1().Environments(opts.env.ObjectMeta.Namespace).Update(input.Context(), opts.env, metav1.UpdateOptions{})
+	if err != nil {
+		return errors.Wrap(err, "error updating environment")
+	}
 	if err != nil {
 		return errors.Wrap(err, "error updating environment")
 	}
 
-	fmt.Printf("environment '%v' updated\n", opts.env.ObjectMeta.Name)
+	fmt.Printf("environment '%v' updated\n", enew.ObjectMeta.Name)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -54,7 +54,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 
-	_, currentContextNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentContextNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -54,7 +54,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 
-	_, currentContextNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentContextNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return errors.Wrap(err, "error creating environment")
 	}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -65,7 +65,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving namespace information")
 	}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -65,7 +65,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error retrieving namespace information")
 	}

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -47,7 +47,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 		Namespace: namespace,
 	}
 
-	err = opts.Client().V1().Function().Delete(m)
+	err = opts.Client().FissionClientSet.CoreV1().Functions(namespace).Delete(input.Context(), input.String(flagkey.FnName), metav1.DeleteOptions{})
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -38,7 +38,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -38,7 +38,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -41,18 +41,12 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "error in get function ")
 	}
-	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.FnName),
-		Namespace: namespace,
-	})
+	fn, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(input.Context(), input.String(flagkey.FnName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")
 	}
 
-	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
-		Name:      fn.Spec.Package.PackageRef.Name,
-		Namespace: fn.Spec.Package.PackageRef.Namespace,
-	})
+	pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(fn.Spec.Package.PackageRef.Namespace).Get(input.Context(), fn.Spec.Package.PackageRef.Name, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting package")
 	}

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -37,7 +37,7 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in get function ")
 	}

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -25,7 +25,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -37,7 +36,7 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in get function ")
 	}

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -42,10 +42,7 @@ func (opts *GetMetaSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error in getting meta function ")
 	}
 
-	fn, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.FnName),
-		Namespace: namespace,
-	})
+	fn, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(input.Context(), input.String(flagkey.FnName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")
 	}

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -25,7 +25,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetMetaSubCommand struct {
@@ -37,7 +36,7 @@ func GetMeta(input cli.Input) error {
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in getting meta function ")
 	}

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -37,7 +37,7 @@ func GetMeta(input cli.Input) error {
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in getting meta function ")
 	}

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -23,6 +23,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -45,11 +46,11 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error in listing function ")
 	}
 
-	var fns []v1.Function
+	var fns *v1.FunctionList
 	if input.Bool(flagkey.AllNamespaces) {
-		fns, err = opts.Client().V1().Function().List("")
+		fns, err = opts.Client().FissionClientSet.CoreV1().Functions(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 	} else {
-		fns, err = opts.Client().V1().Function().List(namespace)
+		fns, err = opts.Client().FissionClientSet.CoreV1().Functions(namespace).List(input.Context(), metav1.ListOptions{})
 	}
 	if err != nil {
 		return errors.Wrap(err, "error listing functions")
@@ -58,7 +59,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS", "NAMESPACE")
-	for _, f := range fns {
+	for _, f := range fns.Items {
 		secrets := f.Spec.Secrets
 		configMaps := f.Spec.ConfigMaps
 		var secretsList, configMapList []string

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -45,12 +44,11 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error in listing function ")
 	}
 
-	var fns *v1.FunctionList
 	if input.Bool(flagkey.AllNamespaces) {
-		fns, err = opts.Client().FissionClientSet.CoreV1().Functions(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	} else {
-		fns, err = opts.Client().FissionClientSet.CoreV1().Functions(namespace).List(input.Context(), metav1.ListOptions{})
+		namespace = metav1.NamespaceAll
 	}
+	fns, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).List(input.Context(), metav1.ListOptions{})
+
 	if err != nil {
 		return errors.Wrap(err, "error listing functions")
 	}

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -41,7 +40,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in listing function ")
 	}

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -41,7 +41,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in listing function ")
 	}

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -56,10 +56,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 		recordLimit = 1000
 	}
 
-	f, err := opts.Client().V1().Function().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.FnName),
-		Namespace: namespace,
-	})
+	f, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(input.Context(), input.String(flagkey.FnName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting function")
 	}

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -40,7 +40,7 @@ func Log(input cli.Input) error {
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in logs for function ")
 	}

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -40,14 +40,13 @@ func Log(input cli.Input) error {
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in logs for function ")
 	}
 
 	dbType := input.String(flagkey.FnLogDBType)
 	fnPod := input.String(flagkey.FnLogPod)
-	kubeContext := input.String(flagkey.KubeContext)
 
 	logReverseQuery := !input.Bool(flagkey.FnLogFollow) && input.Bool(flagkey.FnLogReverseQuery)
 
@@ -61,7 +60,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error getting function")
 	}
 
-	server, err := util.GetApplicationUrl(input.Context(), "application=fission-api", kubeContext)
+	server, err := util.GetApplicationUrl(input.Context(), opts.Client(), "application=fission-api")
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -43,7 +43,7 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 
 	if err != nil {
 		return errors.Wrap(err, "error in finding pod for function ")

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -43,7 +42,7 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 
 	if err != nil {
 		return errors.Wrap(err, "error in finding pod for function ")

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -125,7 +125,6 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 		// check the referenced secret is in the same ns as the function, if not give a warning.
 		if !toSpec { // TODO: workaround in order not to block users from creating function spec, remove it.
 			for _, secretName := range secretNames {
-				// TODO: discuss if this is fine or should we have a wrapper over kclient interface
 				err := util.SecretExists(input.Context(), &metav1.ObjectMeta{Namespace: fnNamespace, Name: secretName}, opts.Client().KubernetesClient)
 				if err != nil {
 					if kerrors.IsNotFound(err) {

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -55,7 +55,7 @@ func (opts *RunContainerSubCommand) do(input cli.Input) error {
 func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in running container for function ")
 	}

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -55,7 +55,7 @@ func (opts *RunContainerSubCommand) do(input cli.Input) error {
 func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	_, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in running container for function ")
 	}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -148,7 +148,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 	}
 
 	console.Errorf("Error calling function %s: %d; Please try again or fix the error: %s\n", m.Name, resp.StatusCode, string(body))
-	err = printPodLogs(opts.Client(), m)
+	err = printPodLogs(input.Context(), opts.Client(), m)
 	if err != nil {
 		console.Errorf("Error getting function logs from controller: %v. Try to get logs from log database.", err)
 		err = Log(input)
@@ -220,8 +220,8 @@ func doHTTPRequest(ctx context.Context, url string, headers []string, method, bo
 	return resp, nil
 }
 
-func printPodLogs(client cmd.Client, fnMeta *metav1.ObjectMeta) error {
-	err := util.FunctionPodLogs(context.Background(), fnMeta.Name, fnMeta.Namespace, client)
+func printPodLogs(ctx context.Context, client cmd.Client, fnMeta *metav1.ObjectMeta) error {
+	err := util.FunctionPodLogs(ctx, fnMeta.Name, fnMeta.Namespace, client)
 
 	if err != nil {
 		return errors.Wrap(err, "error executing get logs request")

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -51,7 +51,7 @@ func Test(input cli.Input) error {
 
 func (opts *TestSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in testing function ")
 	}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -156,9 +156,6 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 			return errors.Wrapf(err, "error retrieving function log from log database")
 		}
 	}
-	// else {
-	// 	console.Info(log)
-	// }
 	return errors.New("error getting function response")
 }
 

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -51,7 +51,7 @@ func Test(input cli.Input) error {
 
 func (opts *TestSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in testing function ")
 	}
@@ -60,14 +60,13 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 		Name:      input.String(flagkey.FnName),
 		Namespace: namespace,
 	}
-	kubeContext := input.String(flagkey.KubeContext)
 	routerURL := os.Getenv("FISSION_ROUTER")
 	if len(routerURL) != 0 {
 		console.Warn("The environment variable FISSION_ROUTER is no longer supported for this command")
 	}
 
 	// Portforward to the fission router
-	localRouterPort, err := util.SetupPortForward(input.Context(), util.GetFissionNamespace(), "application=fission-router", kubeContext)
+	localRouterPort, err := util.SetupPortForward(input.Context(), opts.Client(), util.GetFissionNamespace(), "application=fission-router")
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -51,7 +51,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
-	_, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in updating function ")
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -51,7 +51,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
-	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in updating function ")
 	}

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -53,7 +53,7 @@ func (opts *UpdateContainerSubCommand) do(input cli.Input) error {
 func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	_, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in updating container for function ")
 	}

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -53,7 +53,7 @@ func (opts *UpdateContainerSubCommand) do(input cli.Input) error {
 func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	_, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in updating container for function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
@@ -129,11 +129,11 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	// For Specs, the spec validate checks for function reference
 	if input.Bool(flagkey.SpecSave) {
 
-		htTrigger, err := opts.Client().V1().HTTPTrigger().Get(&m)
-		if err != nil && !ferror.IsNotFound(err) {
+		htTrigger, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(m.Namespace).Get(input.Context(), m.Name, metav1.GetOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
 			return err
 		}
-		if htTrigger != nil {
+		if htTrigger.Name != "" && htTrigger.Namespace != "" {
 			return errors.New("duplicate trigger exists, choose a different name or leave it empty for fission to auto-generate it")
 		}
 
@@ -164,16 +164,16 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			Name:      triggerName,
 			Namespace: fnNamespace,
 		}
+		htTrigger, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(m.Namespace).Get(input.Context(), m.Name, metav1.GetOptions{})
 
-		htTrigger, err := opts.Client().V1().HTTPTrigger().Get(&m)
-		if err != nil && !ferror.IsNotFound(err) {
+		if err != nil && !kerrors.IsNotFound(err) {
 			return err
 		}
-		if htTrigger != nil {
+		if htTrigger != nil && htTrigger.Namespace != "" {
 			return errors.New("duplicate trigger exists, choose a different name or leave it empty for fission to auto-generate it")
 		}
 
-		err = util.CheckFunctionExistence(opts.Client(), functionList, fnNamespace)
+		err = util.CheckFunctionExistence(input.Context(), opts.Client(), functionList, fnNamespace)
 		if err != nil {
 			console.Warn(err.Error())
 		}
@@ -226,7 +226,13 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.Client().V1().HTTPTrigger().Create(opts.trigger)
+	// Ensure we don't have a duplicate HTTP route defined (same URL and method)
+	err := util.CheckHTTPTriggerDuplicates(input.Context(), opts.Client(), opts.trigger)
+	if err != nil {
+		return errors.Wrap(err, "Error while creating HTTP Trigger")
+	}
+
+	_, err = opts.Client().FissionClientSet.CoreV1().HTTPTriggers(opts.trigger.Namespace).Create(input.Context(), opts.trigger, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "create HTTP trigger")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -77,7 +77,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		triggerName = id.String()
 	}
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -77,7 +77,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		triggerName = id.String()
 	}
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/delete.go
+++ b/pkg/fission-cli/cmd/httptrigger/delete.go
@@ -58,7 +58,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 		return errors.Errorf("need either of --%v or --%v and not both arguments", flagkey.HtName, flagkey.HtFnName)
 	}
 
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/delete.go
+++ b/pkg/fission-cli/cmd/httptrigger/delete.go
@@ -58,7 +58,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 		return errors.Errorf("need either of --%v or --%v and not both arguments", flagkey.HtName, flagkey.HtFnName)
 	}
 
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -50,11 +50,7 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	m := &metav1.ObjectMeta{
-		Name:      input.String(flagkey.HtName),
-		Namespace: namespace,
-	}
-	ht, err := opts.Client().V1().HTTPTrigger().Get(m)
+	ht, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).Get(input.Context(), input.String(flagkey.HtName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting http trigger")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -45,7 +44,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -45,7 +45,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -18,6 +18,7 @@ package httptrigger
 
 import (
 	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -45,11 +46,11 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	var hts []fv1.HTTPTrigger
+	var hts *fv1.HTTPTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		hts, err = opts.Client().V1().HTTPTrigger().List("")
+		hts, err = opts.Client().FissionClientSet.CoreV1().HTTPTriggers(v1.NamespaceAll).List(input.Context(), v1.ListOptions{})
 	} else {
-		hts, err = opts.Client().V1().HTTPTrigger().List(namespace)
+		hts, err = opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).List(input.Context(), v1.ListOptions{})
 	}
 
 	if err != nil {
@@ -59,7 +60,7 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 	filterFunctionName := input.String(flagkey.HtFnName)
 
 	var triggers []fv1.HTTPTrigger
-	for _, ht := range hts {
+	for _, ht := range hts.Items {
 		// TODO: list canary http triggers as well.
 		if len(filterFunctionName) == 0 ||
 			(len(filterFunctionName) > 0 && filterFunctionName == ht.Spec.FunctionReference.Name) {

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -45,12 +45,10 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	var hts *fv1.HTTPTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		hts, err = opts.Client().FissionClientSet.CoreV1().HTTPTriggers(v1.NamespaceAll).List(input.Context(), v1.ListOptions{})
-	} else {
-		hts, err = opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).List(input.Context(), v1.ListOptions{})
+		namespace = v1.NamespaceAll
 	}
+	hts, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).List(input.Context(), v1.ListOptions{})
 
 	if err != nil {
 		return errors.Wrap(err, "error listing HTTP triggers")

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -24,7 +24,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -41,7 +40,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -41,7 +41,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -51,7 +51,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	htName := input.String(flagkey.HtName)
 
-	_, triggerNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, triggerNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -51,7 +51,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	htName := input.String(flagkey.HtName)
 
-	_, triggerNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, triggerNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -126,7 +126,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.Client().V1().KubeWatcher().Create(opts.watcher)
+	_, err := opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.watcher.ObjectMeta.Namespace).Create(input.Context(), opts.watcher, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error creating kubewatch")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -61,7 +61,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 	fnName := input.String(flagkey.KwFnName)
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.KwNamespace)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.KwNamespace)
 	if err != nil {
 		return errors.Wrap(err, "error in listing function ")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -61,7 +61,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 	fnName := input.String(flagkey.KwFnName)
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.KwNamespace)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.KwNamespace)
 	if err != nil {
 		return errors.Wrap(err, "error in listing function ")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/delete.go
+++ b/pkg/fission-cli/cmd/kubewatch/delete.go
@@ -56,10 +56,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
-	err := opts.Client().V1().KubeWatcher().Delete(&metav1.ObjectMeta{
-		Name:      opts.name,
-		Namespace: opts.namespace,
-	})
+	err := opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.namespace).Delete(input.Context(), opts.name, metav1.DeleteOptions{})
 	if err != nil {
 		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
 			return nil

--- a/pkg/fission-cli/cmd/kubewatch/delete.go
+++ b/pkg/fission-cli/cmd/kubewatch/delete.go
@@ -48,7 +48,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.KwName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting kubewatch")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/delete.go
+++ b/pkg/fission-cli/cmd/kubewatch/delete.go
@@ -48,7 +48,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.KwName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting kubewatch")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -22,6 +22,7 @@ import (
 	"text/tabwriter"
 
 	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -56,11 +57,11 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-	var ws []v1.KubernetesWatchTrigger
+	var ws *v1.KubernetesWatchTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		ws, err = opts.Client().V1().KubeWatcher().List("")
+		ws, err = opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 	} else {
-		ws, err = opts.Client().V1().KubeWatcher().List(opts.namespace)
+		ws, err = opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
 	}
 	if err != nil {
 		return errors.Wrap(err, "error listing kubewatchers")
@@ -70,7 +71,7 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
 		"NAME", "NAMESPACE", "OBJTYPE", "LABELS", "FUNCTION_NAME")
-	for _, wa := range ws {
+	for _, wa := range ws.Items {
 		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
 			wa.ObjectMeta.Name, wa.Spec.Namespace, wa.Spec.Type, wa.Spec.LabelSelector, wa.Spec.FunctionReference.Name)
 	}

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -49,7 +48,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error listing kubewatchers")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -58,10 +58,10 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 	var ws *v1.KubernetesWatchTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		ws, err = opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	} else {
-		ws, err = opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
+		opts.namespace = metav1.NamespaceAll
 	}
+	ws, err = opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
+
 	if err != nil {
 		return errors.Wrap(err, "error listing kubewatchers")
 	}

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -49,7 +49,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error listing kubewatchers")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -151,7 +151,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 				mqtName, fnName))
 		}
 	} else {
-		err = util.CheckFunctionExistence(opts.Client(), []string{fnName}, fnNamespace)
+		err = util.CheckFunctionExistence(input.Context(), opts.Client(), []string{fnName}, fnNamespace)
 		if err != nil {
 			return err
 		}
@@ -210,7 +210,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		return nil
 	}
 
-	_, err := opts.Client().V1().MessageQueueTrigger().Create(opts.trigger)
+	_, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.trigger.ObjectMeta.Namespace).Create(input.Context(), opts.trigger, metav1.CreateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "create message queue trigger")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -62,7 +62,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 	fnName := input.String(flagkey.MqtFnName)
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -62,7 +62,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 	fnName := input.String(flagkey.MqtFnName)
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/delete.go
+++ b/pkg/fission-cli/cmd/mqtrigger/delete.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -60,9 +61,9 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) error {
-	err := opts.Client().V1().MessageQueueTrigger().Delete(opts.metadata)
+	err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.metadata.Namespace).Delete(input.Context(), opts.metadata.Name, metav1.DeleteOptions{})
 	if err != nil {
-		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
+		if input.Bool(flagkey.IgnoreNotFound) && kerrors.IsNotFound(err) {
 			return nil
 		}
 		return errors.Wrap(err, "error deleting message queue trigger")

--- a/pkg/fission-cli/cmd/mqtrigger/delete.go
+++ b/pkg/fission-cli/cmd/mqtrigger/delete.go
@@ -26,7 +26,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
@@ -48,7 +47,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/delete.go
+++ b/pkg/fission-cli/cmd/mqtrigger/delete.go
@@ -48,7 +48,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -59,7 +59,6 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
 	var mqts *v1.MessageQueueTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		// TODO: mqtype is ignored as of now in the controller server. I am ignoring it too. This won't create conflict with current implementation.
 		mqts, err = opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 	} else {
 		mqts, err = opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -49,7 +49,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -49,7 +48,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -57,12 +56,11 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	var mqts *v1.MessageQueueTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		mqts, err = opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	} else {
-		mqts, err = opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
+		opts.namespace = metav1.NamespaceAll
 	}
+	mqts, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
+
 	if err != nil {
 		return errors.Wrap(err, "error listing message queue triggers")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -53,10 +53,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	mqt, err := opts.Client().V1().MessageQueueTrigger().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.MqtName),
-		Namespace: namespace,
-	})
+	mqt, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(namespace).Get(input.Context(), input.String(flagkey.MqtName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting message queue trigger")
 	}
@@ -100,7 +97,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	}
 	if len(fnName) > 0 {
 		functionList := []string{fnName}
-		err := util.CheckFunctionExistence(opts.Client(), functionList, namespace)
+		err := util.CheckFunctionExistence(input.Context(), opts.Client(), functionList, namespace)
 		if err != nil {
 			console.Warn(err.Error())
 		}
@@ -151,7 +148,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().V1().MessageQueueTrigger().Update(opts.trigger)
+	_, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.trigger.ObjectMeta.Namespace).Update(input.Context(), opts.trigger, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error updating message queue trigger")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -48,7 +48,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -48,7 +48,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
@@ -126,7 +125,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 }
 
 // TODO: get all necessary value from CLI input directly
-func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkgNamespace string, envName string,
+func CreatePackage(input cli.Input, client cmd.Client, pkgName string, pkgNamespace string, envName string,
 	srcArchiveFiles []string, deployArchiveFiles []string, buildcmd string, specDir string, specFile string, noZip bool, userProvidedNS string) (*metav1.ObjectMeta, error) {
 
 	insecure := input.Bool(flagkey.PkgInsecure)
@@ -224,11 +223,12 @@ func CreatePackage(input cli.Input, client client.Interface, pkgName string, pkg
 		return &pkg.ObjectMeta, nil
 	} else {
 		pkg.ObjectMeta.Namespace = pkgNamespace
-		pkgMetadata, err := client.V1().Package().Create(pkg)
+
+		pkgMetadata, err := client.FissionClientSet.CoreV1().Packages(pkgNamespace).Create(input.Context(), pkg, metav1.CreateOptions{})
 		if err != nil {
 			return nil, errors.Wrap(err, "error creating package")
 		}
 		fmt.Printf("Package '%v' created\n", pkgMetadata.GetName())
-		return pkgMetadata, nil
+		return &pkgMetadata.ObjectMeta, nil
 	}
 }

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -64,7 +64,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 
 	envName := input.String(flagkey.PkgEnvironment)
 
-	userProvidedNS, pkgNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	userProvidedNS, pkgNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -64,7 +64,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 
 	envName := input.String(flagkey.PkgEnvironment)
 
-	userProvidedNS, pkgNamespace, err := util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	userProvidedNS, pkgNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/delete.go
+++ b/pkg/fission-cli/cmd/package/delete.go
@@ -53,7 +53,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/delete.go
+++ b/pkg/fission-cli/cmd/package/delete.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
@@ -53,7 +52,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -76,13 +76,6 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 		return err
 	}
 
-	// TODO: this is not used currently. Do we need to keep this behaviour
-	// raw := r.FormValue("raw")
-	// var resp []byte
-	// if raw != "" {
-	// 	resp = pkg.Spec.Deployment.Literal
-	// }
-
 	var reader io.Reader
 	archive := pkg.Spec.Source
 	if opts.archiveType == deployArchive {
@@ -93,22 +86,6 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 		reader = bytes.NewReader(archive.Literal)
 	} else if pkg.Spec.Deployment.Type == fv1.ArchiveTypeUrl {
 
-		// readCloser, err := pkgutil.DownloadStoragesvcURL(opts.Client().DefaultClientset, archive.URL)
-		// if err != nil {
-		// 	return err
-		// }
-
-		// TODO: check its working
-		// storageSvc, err := util.GetSvcName(input.Context(), opts.Client().KubernetesClient, "fission-storage")
-		// if err != nil {
-		// 	return err
-		// }
-
-		// storagesvcURL := "http://" + storageSvc
-		// ssClient := storagesvcClient.MakeClient(storagesvcURL)
-
-		// TODO: this is not required I suppose S3 not handled here
-		// fileDownloadUrl := ssClient.GetUrl(archive.URL)
 		readCloser, err := pkgutil.DownloadURL(archive.URL)
 		if err != nil {
 			return errors.Wrapf(err, "error downloading from storage service url: %s", archive.URL)

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -62,7 +62,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 
 func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 const (
@@ -62,7 +61,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 
 func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -70,13 +71,18 @@ func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) error {
-	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
-		Namespace: opts.namespace,
-		Name:      opts.name,
-	})
+
+	pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.namespace).Get(input.Context(), opts.name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
+
+	// TODO: this is not used currently. Do we need to keep this behaviour
+	// raw := r.FormValue("raw")
+	// var resp []byte
+	// if raw != "" {
+	// 	resp = pkg.Spec.Deployment.Literal
+	// }
 
 	var reader io.Reader
 	archive := pkg.Spec.Source
@@ -87,10 +93,28 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 	if pkg.Spec.Deployment.Type == fv1.ArchiveTypeLiteral {
 		reader = bytes.NewReader(archive.Literal)
 	} else if pkg.Spec.Deployment.Type == fv1.ArchiveTypeUrl {
-		readCloser, err := pkgutil.DownloadStoragesvcURL(opts.Client(), archive.URL)
+
+		// readCloser, err := pkgutil.DownloadStoragesvcURL(opts.Client().DefaultClientset, archive.URL)
+		// if err != nil {
+		// 	return err
+		// }
+
+		// TODO: check its working
+		// storageSvc, err := util.GetSvcName(input.Context(), opts.Client().KubernetesClient, "fission-storage")
+		// if err != nil {
+		// 	return err
+		// }
+
+		// storagesvcURL := "http://" + storageSvc
+		// ssClient := storagesvcClient.MakeClient(storagesvcURL)
+
+		// TODO: this is not required I suppose S3 not handled here
+		// fileDownloadUrl := ssClient.GetUrl(archive.URL)
+		readCloser, err := pkgutil.DownloadURL(archive.URL)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "error downloading from storage service url: %s", archive.URL)
 		}
+
 		defer readCloser.Close()
 		reader = readCloser
 	}

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -86,7 +86,7 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 		reader = bytes.NewReader(archive.Literal)
 	} else if pkg.Spec.Deployment.Type == fv1.ArchiveTypeUrl {
 
-		readCloser, err := pkgutil.DownloadURL(archive.URL)
+		readCloser, err := pkgutil.DownloadStrorageURL(input.Context(), opts.Client(), archive.URL)
 		if err != nil {
 			return errors.Wrapf(err, "error downloading from storage service url: %s", archive.URL)
 		}

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -59,10 +59,11 @@ func (opts *InfoSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *InfoSubCommand) run(input cli.Input) error {
-	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
-		Namespace: opts.namespace,
-		Name:      opts.name,
-	})
+	pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.namespace).Get(input.Context(), opts.name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
 	if err != nil {
 		return errors.Wrapf(err, "error finding package %s", opts.name)
 	}

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -27,7 +27,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type InfoSubCommand struct {
@@ -51,7 +50,7 @@ func (opts *InfoSubCommand) do(input cli.Input) error {
 func (opts *InfoSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
 
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -51,7 +51,7 @@ func (opts *InfoSubCommand) do(input cli.Input) error {
 func (opts *InfoSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
 
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -64,12 +64,11 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	var pkgList *fv1.PackageList
 	if input.Bool(flagkey.AllNamespaces) {
-		pkgList, err = opts.Client().FissionClientSet.CoreV1().Packages(v1.NamespaceAll).List(input.Context(), v1.ListOptions{})
-	} else {
-		pkgList, err = opts.Client().FissionClientSet.CoreV1().Packages(opts.pkgNamespace).List(input.Context(), v1.ListOptions{})
+		opts.pkgNamespace = v1.NamespaceAll
 	}
+	pkgList, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.pkgNamespace).List(input.Context(), v1.ListOptions{})
+
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -64,29 +65,29 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
 
-	var pkgList []fv1.Package
+	var pkgList *fv1.PackageList
 	if input.Bool(flagkey.AllNamespaces) {
-		pkgList, err = opts.Client().V1().Package().List("")
+		pkgList, err = opts.Client().FissionClientSet.CoreV1().Packages(v1.NamespaceAll).List(input.Context(), v1.ListOptions{})
 	} else {
-		pkgList, err = opts.Client().V1().Package().List(opts.pkgNamespace)
+		pkgList, err = opts.Client().FissionClientSet.CoreV1().Packages(opts.pkgNamespace).List(input.Context(), v1.ListOptions{})
 	}
 	if err != nil {
 		return err
 	}
 
 	// sort the package list by lastUpdatedTimestamp
-	sort.Slice(pkgList, func(i, j int) bool {
-		return pkgList[i].Status.LastUpdateTimestamp.After(pkgList[j].Status.LastUpdateTimestamp.Time)
+	sort.Slice(pkgList.Items, func(i, j int) bool {
+		return pkgList.Items[i].Status.LastUpdateTimestamp.After(pkgList.Items[j].Status.LastUpdateTimestamp.Time)
 	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
 	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT", "NAMESPACE")
 
-	for _, pkg := range pkgList {
+	for _, pkg := range pkgList.Items {
 		show := true
 		// TODO improve list speed when --orphan
 		if opts.listOrphans {
-			fnList, err := GetFunctionsByPackage(opts.Client(), pkg.ObjectMeta.Name, pkg.ObjectMeta.Namespace)
+			fnList, err := GetFunctionsByPackage(input.Context(), opts.Client(), pkg.ObjectMeta.Name, pkg.ObjectMeta.Namespace)
 			if err != nil {
 				return errors.Wrap(err, fmt.Sprintf("get functions sharing package %s", pkg.ObjectMeta.Name))
 			}

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -56,7 +56,7 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	// option for the user to list all orphan packages (not referenced by any function)
 	opts.listOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.status = input.String(flagkey.PkgStatus)
-	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -30,7 +30,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -56,7 +55,7 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	// option for the user to list all orphan packages (not referenced by any function)
 	opts.listOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.status = input.String(flagkey.PkgStatus)
-	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -17,6 +17,7 @@ limitations under the License.
 package _package
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -27,10 +28,11 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	spectypes "github.com/fission/fission/pkg/fission-cli/cmd/spec/types"
@@ -44,7 +46,7 @@ import (
 // create an archive upload spec in the specs directory; otherwise
 // upload the archive using client.  noZip avoids zipping the
 // includeFiles, but is ignored if there's more than one includeFile.
-func CreateArchive(client client.Interface, input cli.Input, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
+func CreateArchive(client cmd.Client, input cli.Input, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
 	// get root dir
 	var rootDir string
 	var err error
@@ -192,7 +194,7 @@ func CreateArchive(client client.Interface, input cli.Input, includeFiles []stri
 		return nil, err
 	}
 
-	return pkgutil.UploadArchiveFile(input.Context(), client, archivePath)
+	return pkgutil.UploadArchiveFile(input.Context(), client, archivePath, input.String(flagkey.KubeContext))
 }
 
 // makeArchiveFile creates a zip file from the given list of input files,
@@ -251,13 +253,13 @@ func archiveName(givenNameHint string, includedFiles []string) string {
 	return fmt.Sprintf("%v-%v", util.KubifyName(includedFiles[0]), uniuri.NewLen(4))
 }
 
-func GetFunctionsByPackage(client client.Interface, pkgName, pkgNamespace string) ([]fv1.Function, error) {
-	fnList, err := client.V1().Function().List(pkgNamespace)
+func GetFunctionsByPackage(ctx context.Context, client cmd.Client, pkgName, pkgNamespace string) ([]fv1.Function, error) {
+	fnList, err := client.FissionClientSet.CoreV1().Functions(pkgNamespace).List(ctx, v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 	fns := []fv1.Function{}
-	for _, fn := range fnList {
+	for _, fn := range fnList.Items {
 		if fn.Spec.Package.PackageRef.Name == pkgName {
 			fns = append(fns, fn)
 		}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -194,7 +194,7 @@ func CreateArchive(client cmd.Client, input cli.Input, includeFiles []string, no
 		return nil, err
 	}
 
-	return pkgutil.UploadArchiveFile(input.Context(), client, archivePath, input.String(flagkey.KubeContext))
+	return pkgutil.UploadArchiveFile(input.Context(), client, archivePath)
 }
 
 // makeArchiveFile creates a zip file from the given list of input files,

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -57,10 +57,10 @@ func (opts *RebuildSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *RebuildSubCommand) run(input cli.Input) error {
-	pkg, err := opts.Client().V1().Package().Get(&metav1.ObjectMeta{
-		Name:      opts.name,
-		Namespace: opts.namespace,
-	})
+	pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.namespace).Get(input.Context(), opts.name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
 	if err != nil {
 		return errors.Wrap(err, "find package")
 	}
@@ -70,7 +70,7 @@ func (opts *RebuildSubCommand) run(input cli.Input) error {
 			pkg.ObjectMeta.Name, fv1.BuildStatusFailed))
 	}
 
-	_, err = updatePackageStatus(opts.Client(), pkg, fv1.BuildStatusPending)
+	_, err = updatePackageStatus(input.Context(), opts.Client(), pkg, fv1.BuildStatusPending)
 	if err != nil {
 		return errors.Wrap(err, "update package status")
 	}

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -49,7 +49,7 @@ func (opts *RebuildSubCommand) do(input cli.Input) error {
 
 func (opts *RebuildSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -26,7 +26,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type RebuildSubCommand struct {
@@ -49,7 +48,7 @@ func (opts *RebuildSubCommand) do(input cli.Input) error {
 
 func (opts *RebuildSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -53,7 +53,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	opts.pkgName = input.String(flagkey.PkgName)
-	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
@@ -53,7 +52,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	opts.pkgName = input.String(flagkey.PkgName)
-	_, opts.pkgNamespace, err = util.GetResourceNamespace(input, opts.Client(), flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -31,11 +31,13 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/util"
 	storageSvcClient "github.com/fission/fission/pkg/storagesvc/client"
 	"github.com/fission/fission/pkg/utils"
 )
 
-func UploadArchiveFile(ctx context.Context, client client.Interface, fileName string) (*fv1.Archive, error) {
+func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string, kubeContext string) (*fv1.Archive, error) {
 	var archive fv1.Archive
 
 	size, err := utils.FileSize(fileName)
@@ -50,25 +52,39 @@ func UploadArchiveFile(ctx context.Context, client client.Interface, fileName st
 			return nil, err
 		}
 	} else {
-		u := strings.TrimSuffix(client.ServerURL(), "/") + "/proxy/storage"
-		ssClient := storageSvcClient.MakeClient(u)
+		// u := strings.TrimSuffix(client.DefaultClientset.ServerURL(), "/") + "/proxy/storage"
+		// ssClient := storageSvcClient.MakeClient(u)
 
-		// TODO add a progress bar
-		id, err := ssClient.Upload(ctx, fileName, nil)
+		// // TODO add a progress bar
+		// id, err := ssClient.Upload(ctx, fileName, nil)
+		// if err != nil {
+		// 	return nil, errors.Wrapf(err, "error uploading file %v", fileName)
+		// }
+
+		storagesvcURL, err := util.GetStorageURL(ctx, kubeContext)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error uploading file %v", fileName)
+			return nil, errors.Wrapf(err, "error getting fission storage service URL")
 		}
 
-		storageSvc, err := client.V1().Misc().GetSvcURL("application=fission-storage")
-		storageSvcURL := "http://" + storageSvc
+		storageClient := storageSvcClient.MakeClient(storagesvcURL.String())
+		id, err := storageClient.Upload(ctx, fileName, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error getting fission storage service name")
+			return nil, errors.Wrapf(err, "error uploading to fission storage service")
 		}
 
-		// We make a new client with actual URL of Storage service so that the URL is not
-		// pointing to 127.0.0.1 i.e. proxy. DON'T reuse previous ssClient
-		pkgClient := storageSvcClient.MakeClient(storageSvcURL)
-		archiveURL := pkgClient.GetUrl(id)
+		// storageSvc, err := client.DefaultClientset.V1().Misc().GetSvcURL("application=fission-storage")
+		// storageSvcURL := "http://" + storageSvc
+		// if err != nil {
+		// 	return nil, errors.Wrapf(err, "error getting fission storage service name")
+		// }
+
+		// // We make a new client with actual URL of Storage service so that the URL is not
+		// // pointing to 127.0.0.1 i.e. proxy. DON'T reuse previous ssClient
+		// pkgClient := storageSvcClient.MakeClient(storageSvcURL)
+		archiveURL, err := getArchiveURL(ctx, client, id, storagesvcURL)
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not get URL of archive")
+		}
 
 		archive.Type = fv1.ArchiveTypeUrl
 		archive.URL = archiveURL
@@ -84,6 +100,43 @@ func UploadArchiveFile(ctx context.Context, client client.Interface, fileName st
 	return &archive, nil
 }
 
+func getArchiveURL(ctx context.Context, client cmd.Client, archiveID string, serverURL *url.URL) (archiveURL string, err error) {
+	relativeURL, _ := url.Parse(util.FISSION_STORAGE_URI)
+
+	queryString := relativeURL.Query()
+	queryString.Set("id", archiveID)
+	relativeURL.RawQuery = queryString.Encode()
+
+	storageAccessURL := serverURL.ResolveReference(relativeURL)
+
+	resp, err := http.Head(storageAccessURL.String())
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("error getting URL. Exited with Status:  %s", resp.Status)
+	}
+
+	storageType := resp.Header.Get("X-FISSION-STORAGETYPE")
+
+	if storageType == "local" {
+		// TODO: testing required here
+		storageSvc, err := util.GetSvcName(ctx, client.KubernetesClient, "fission-storage")
+		if err != nil {
+			return "", err
+		}
+		storagesvcURL := "http://" + storageSvc
+		client := storageSvcClient.MakeClient(storagesvcURL)
+		return client.GetUrl(archiveID), nil
+	} else if storageType == "s3" {
+		storageBucket := resp.Header.Get("X-FISSION-BUCKET")
+		s3url := fmt.Sprintf("https://%s.s3.amazonaws.com/%s", storageBucket, archiveID)
+		return s3url, nil
+	}
+	return "", nil
+}
 func GetContents(filePath string) ([]byte, error) {
 	code, err := os.ReadFile(filePath)
 	if err != nil {

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -37,7 +37,7 @@ import (
 	"github.com/fission/fission/pkg/utils"
 )
 
-func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string, kubeContext string) (*fv1.Archive, error) {
+func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string) (*fv1.Archive, error) {
 	var archive fv1.Archive
 
 	size, err := utils.FileSize(fileName)
@@ -61,7 +61,7 @@ func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string, 
 		// 	return nil, errors.Wrapf(err, "error uploading file %v", fileName)
 		// }
 
-		storagesvcURL, err := util.GetStorageURL(ctx, kubeContext)
+		storagesvcURL, err := util.GetStorageURL(ctx, client)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error getting fission storage service URL")
 		}

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -52,14 +52,6 @@ func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string) 
 			return nil, err
 		}
 	} else {
-		// u := strings.TrimSuffix(client.DefaultClientset.ServerURL(), "/") + "/proxy/storage"
-		// ssClient := storageSvcClient.MakeClient(u)
-
-		// // TODO add a progress bar
-		// id, err := ssClient.Upload(ctx, fileName, nil)
-		// if err != nil {
-		// 	return nil, errors.Wrapf(err, "error uploading file %v", fileName)
-		// }
 
 		storagesvcURL, err := util.GetStorageURL(ctx, client)
 		if err != nil {
@@ -67,20 +59,12 @@ func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string) 
 		}
 
 		storageClient := storageSvcClient.MakeClient(storagesvcURL.String())
+		// TODO add a progress bar
 		id, err := storageClient.Upload(ctx, fileName, nil)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error uploading to fission storage service")
 		}
 
-		// storageSvc, err := client.DefaultClientset.V1().Misc().GetSvcURL("application=fission-storage")
-		// storageSvcURL := "http://" + storageSvc
-		// if err != nil {
-		// 	return nil, errors.Wrapf(err, "error getting fission storage service name")
-		// }
-
-		// // We make a new client with actual URL of Storage service so that the URL is not
-		// // pointing to 127.0.0.1 i.e. proxy. DON'T reuse previous ssClient
-		// pkgClient := storageSvcClient.MakeClient(storageSvcURL)
 		archiveURL, err := getArchiveURL(ctx, client, id, storagesvcURL)
 		if err != nil {
 			return nil, errors.Wrapf(err, "could not get URL of archive")
@@ -122,7 +106,6 @@ func getArchiveURL(ctx context.Context, client cmd.Client, archiveID string, ser
 	storageType := resp.Header.Get("X-FISSION-STORAGETYPE")
 
 	if storageType == "local" {
-		// TODO: testing required here
 		storageSvc, err := util.GetSvcName(ctx, client.KubernetesClient, "fission-storage")
 		if err != nil {
 			return "", err

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -70,7 +70,7 @@ func (opts *ApplySubCommand) do(input cli.Input) error {
 func (opts *ApplySubCommand) insertNamespace(input cli.Input, fr *FissionResources) error {
 
 	result := utils.MultiErrorWithFormat()
-	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -32,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
@@ -196,7 +195,7 @@ func (opts *ApplySubCommand) run(input cli.Input) error {
 		}
 
 		// make changes to the cluster based on the specs
-		pkgMetas, as, err := applyResources(input.Context(), opts.Client(), specDir, fr, deleteResources, input.Bool(flagkey.SpecAllowConflicts))
+		pkgMetas, as, err := applyResources(input, opts.Client(), specDir, fr, deleteResources, input.Bool(flagkey.SpecAllowConflicts))
 		if err != nil {
 			return errors.Wrap(err, "error applying specs")
 		}
@@ -349,7 +348,7 @@ func pluralize(num int, word string) string {
 }
 
 // applyArchives figures out the set of archives that need to be uploaded, and uploads them.
-func applyArchives(ctx context.Context, fclient client.Interface, specDir string, fr *FissionResources) error {
+func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources) error {
 
 	// archive:// URL -> archive map.
 	archiveFiles := make(map[string]fv1.Archive)
@@ -369,11 +368,11 @@ func applyArchives(ctx context.Context, fclient client.Interface, specDir string
 
 	// get list of packages, make content-indexed map of available archives
 	availableArchives := make(map[string]string) // (sha256 -> url)
-	pkgs, err := fclient.V1().Package().List(metav1.NamespaceAll)
+	pkgs, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
-	for _, pkg := range pkgs {
+	for _, pkg := range pkgs.Items {
 		for _, ar := range []fv1.Archive{pkg.Spec.Source, pkg.Spec.Deployment} {
 			if ar.Type == fv1.ArchiveTypeUrl && len(ar.URL) > 0 {
 				availableArchives[ar.Checksum.Sum] = ar.URL
@@ -395,7 +394,7 @@ func applyArchives(ctx context.Context, fclient client.Interface, specDir string
 			// doesn't exist, upload
 			fmt.Printf("uploading archive %v\n", name)
 			// ar.URL is actually a local filename at this stage
-			uploadedAr, err := pkgutil.UploadArchiveFile(ctx, fclient, ar.URL)
+			uploadedAr, err := pkgutil.UploadArchiveFile(input.Context(), fclient, ar.URL, input.String(flagkey.KubeContext))
 			if err != nil {
 				return err
 			}
@@ -422,23 +421,23 @@ func applyArchives(ctx context.Context, fclient client.Interface, specDir string
 }
 
 // applyResources applies the given set of fission resources.
-func applyResources(ctx context.Context, fclient client.Interface, specDir string, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, map[string]ResourceApplyStatus, error) {
+func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, map[string]ResourceApplyStatus, error) {
 
 	applyStatus := make(map[string]ResourceApplyStatus)
 
 	// upload archives that need to be uploaded. Changes archive references in fr.Packages.
-	err := applyArchives(ctx, fclient, specDir, fr)
+	err := applyArchives(input, fclient, specDir, fr)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	_, ras, err := applyEnvironments(fclient, fr, delete, specAllowConflicts)
+	_, ras, err := applyEnvironments(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "environment apply failed")
 	}
 	applyStatus["environment"] = *ras
 
-	pkgMeta, ras, err := applyPackages(fclient, fr, delete, specAllowConflicts)
+	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "package apply failed")
 	}
@@ -467,31 +466,31 @@ func applyResources(ctx context.Context, fclient client.Interface, specDir strin
 		fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
 	}
 
-	_, ras, err = applyFunctions(fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyFunctions(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "function apply failed")
 	}
 	applyStatus["function"] = *ras
 
-	_, ras, err = applyHTTPTriggers(fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyHTTPTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "HTTPTrigger apply failed")
 	}
 	applyStatus["HTTPTrigger"] = *ras
 
-	_, ras, err = applyKubernetesWatchTriggers(fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyKubernetesWatchTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "KubernetesWatchTrigger apply failed")
 	}
 	applyStatus["KubernetesWatchTrigger"] = *ras
 
-	_, ras, err = applyTimeTriggers(fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyTimeTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "TimeTrigger apply failed")
 	}
 	applyStatus["TimeTrigger"] = *ras
 
-	_, ras, err = applyMessageQueueTriggers(fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyMessageQueueTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "MessageQueueTrigger apply failed")
 	}
@@ -626,7 +625,7 @@ func hasDeploymentConfig(m *metav1.ObjectMeta, fr *FissionResources) bool {
 	return false
 }
 
-func waitForPackageBuild(fclient client.Interface, pkg *fv1.Package) (*fv1.Package, error) {
+func waitForPackageBuild(ctx context.Context, fclient cmd.Client, pkg *fv1.Package) (*fv1.Package, error) {
 	start := time.Now()
 	for {
 		if pkg.Status.BuildStatus != fv1.BuildStatusRunning {
@@ -640,16 +639,16 @@ func waitForPackageBuild(fclient client.Interface, pkg *fv1.Package) (*fv1.Packa
 		time.Sleep(time.Second)
 
 		var err error
-		pkg, err = fclient.V1().Package().Get(&pkg.ObjectMeta)
+		pkg, err = fclient.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).Get(ctx, pkg.ObjectMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
 	}
 }
 
-func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().Package().List(metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -657,9 +656,9 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 	// filter
 	objs := make([]fv1.Package, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -711,7 +710,7 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 				// We may be racing against the package builder to update the
 				// package (a previous version might have been getting built).  So,
 				// wait for the package to have a non-running build status.
-				pkg, err := waitForPackageBuild(fclient, &o)
+				pkg, err := waitForPackageBuild(ctx, fclient, &o)
 				if err != nil {
 					// log and ignore
 					console.Warn(fmt.Sprintf("Error waiting for package '%v' build, ignoring", o.ObjectMeta.Name))
@@ -723,23 +722,24 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 					pkg.Status.BuildStatus = fv1.BuildStatusPending
 				}
 
-				newmeta, err := fclient.V1().Package().Update(pkg)
+				newmeta, err := fclient.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, nil, err
 					// TODO check for resourceVersion conflict errors and retry
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
+
 			// create
-			newmeta, err := fclient.V1().Package().Create(&o)
+			newmeta, err := fclient.FissionClientSet.CoreV1().Packages(o.ObjectMeta.Namespace).Create(ctx, &o, metav1.CreateOptions{})
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -749,7 +749,7 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().Package().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().Packages(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -762,9 +762,9 @@ func applyPackages(fclient client.Interface, fr *FissionResources, delete bool, 
 	return metadataMap, &ras, nil
 }
 
-func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyFunctions(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().Function().List(metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -772,9 +772,9 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 	// filter
 	objs := make([]fv1.Function, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -811,22 +811,22 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 			} else {
 				// update
 				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-				newmeta, err := fclient.V1().Function().Update(&o)
+				newmeta, err := fclient.FissionClientSet.CoreV1().Functions(o.ObjectMeta.Namespace).Update(ctx, &o, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
 			// create
-			newmeta, err := fclient.V1().Function().Create(&o)
+			newmeta, err := fclient.FissionClientSet.CoreV1().Functions(o.ObjectMeta.Namespace).Create(ctx, &o, metav1.CreateOptions{})
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -836,7 +836,7 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().Function().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().Functions(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -849,9 +849,9 @@ func applyFunctions(fclient client.Interface, fr *FissionResources, delete bool,
 	return metadataMap, &ras, nil
 }
 
-func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyEnvironments(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().Environment().List(metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().Environments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -859,9 +859,9 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 	// filter
 	objs := make([]fv1.Environment, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -898,22 +898,22 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 			} else {
 				// update
 				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-				newmeta, err := fclient.V1().Environment().Update(&o)
+				newmeta, err := fclient.FissionClientSet.CoreV1().Environments(o.ObjectMeta.Namespace).Update(ctx, &o, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
 			// create
-			newmeta, err := fclient.V1().Environment().Create(&o)
+			newmeta, err := fclient.FissionClientSet.CoreV1().Environments(o.ObjectMeta.Namespace).Create(ctx, &o, metav1.CreateOptions{})
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -923,7 +923,7 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().Environment().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().Environments(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Namespace, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -936,9 +936,9 @@ func applyEnvironments(fclient client.Interface, fr *FissionResources, delete bo
 	return metadataMap, &ras, nil
 }
 
-func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().HTTPTrigger().List(metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().HTTPTriggers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -946,9 +946,9 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 	// filter
 	objs := make([]fv1.HTTPTrigger, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -983,24 +983,34 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 				// nothing to do on the server
 				metadataMap[mapKey(&o.ObjectMeta)] = existingObj.ObjectMeta
 			} else {
-				// update
-				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-				newmeta, err := fclient.V1().HTTPTrigger().Update(&o)
+
+				err := util.CheckHTTPTriggerDuplicates(ctx, fclient, &o)
 				if err != nil {
 					return nil, nil, err
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				// update
+				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
+				newmeta, err := fclient.FissionClientSet.CoreV1().HTTPTriggers(o.ObjectMeta.Namespace).Update(ctx, &o, metav1.UpdateOptions{})
+				if err != nil {
+					return nil, nil, err
+				}
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
-			// create
-			newmeta, err := fclient.V1().HTTPTrigger().Create(&o)
+
+			err := util.CheckHTTPTriggerDuplicates(ctx, fclient, &o)
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			// create
+			newmeta, err := fclient.FissionClientSet.CoreV1().HTTPTriggers(o.ObjectMeta.Namespace).Create(ctx, &o, metav1.CreateOptions{})
+			if err != nil {
+				return nil, nil, err
+			}
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -1010,7 +1020,7 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().HTTPTrigger().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().HTTPTriggers(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -1023,9 +1033,9 @@ func applyHTTPTriggers(fclient client.Interface, fr *FissionResources, delete bo
 	return metadataMap, &ras, nil
 }
 
-func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyKubernetesWatchTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().KubeWatcher().List(metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().KubernetesWatchTriggers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1033,9 +1043,9 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 	// filter
 	objs := make([]fv1.KubernetesWatchTrigger, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -1072,22 +1082,22 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 			} else {
 				// update
 				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-				newmeta, err := fclient.V1().KubeWatcher().Update(&o)
+				newmeta, err := fclient.FissionClientSet.CoreV1().KubernetesWatchTriggers(o.ObjectMeta.Namespace).Update(ctx, &o, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
 			// create
-			newmeta, err := fclient.V1().KubeWatcher().Create(&o)
+			newmeta, err := fclient.FissionClientSet.CoreV1().KubernetesWatchTriggers(o.ObjectMeta.Namespace).Create(ctx, &o, metav1.CreateOptions{})
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -1097,7 +1107,7 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().KubeWatcher().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().KubernetesWatchTriggers(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -1110,9 +1120,9 @@ func applyKubernetesWatchTriggers(fclient client.Interface, fr *FissionResources
 	return metadataMap, &ras, nil
 }
 
-func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyTimeTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().TimeTrigger().List(metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().TimeTriggers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1120,9 +1130,9 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 	// filter
 	objs := make([]fv1.TimeTrigger, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -1159,22 +1169,22 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 			} else {
 				// update
 				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-				newmeta, err := fclient.V1().TimeTrigger().Update(&o)
+				newmeta, err := fclient.FissionClientSet.CoreV1().TimeTriggers(o.ObjectMeta.Namespace).Update(ctx, &o, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
 			// create
-			newmeta, err := fclient.V1().TimeTrigger().Create(&o)
+			newmeta, err := fclient.FissionClientSet.CoreV1().TimeTriggers(o.Namespace).Create(ctx, &o, metav1.CreateOptions{})
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -1184,7 +1194,7 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().TimeTrigger().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().TimeTriggers(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
@@ -1197,9 +1207,9 @@ func applyTimeTriggers(fclient client.Interface, fr *FissionResources, delete bo
 	return metadataMap, &ras, nil
 }
 
-func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyMessageQueueTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	// get list
-	allObjs, err := fclient.V1().MessageQueueTrigger().List("", metav1.NamespaceAll)
+	allObjs, err := fclient.FissionClientSet.CoreV1().MessageQueueTriggers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1207,9 +1217,9 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 	// filter
 	objs := make([]fv1.MessageQueueTrigger, 0)
 	if specAllowConflicts {
-		objs = allObjs
+		objs = allObjs.Items
 	} else {
-		for _, o := range allObjs {
+		for _, o := range allObjs.Items {
 			if hasDeploymentConfig(&o.ObjectMeta, fr) {
 				objs = append(objs, o)
 			}
@@ -1246,22 +1256,22 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 			} else {
 				// update
 				o.ObjectMeta.ResourceVersion = existingObj.ObjectMeta.ResourceVersion
-				newmeta, err := fclient.V1().MessageQueueTrigger().Update(&o)
+				newmeta, err := fclient.FissionClientSet.CoreV1().MessageQueueTriggers(o.ObjectMeta.Namespace).Update(ctx, &o, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, nil, err
 				}
-				ras.Updated = append(ras.Updated, newmeta)
+				ras.Updated = append(ras.Updated, &newmeta.ObjectMeta)
 				// keep track of metadata in case we need to create a reference to it
-				metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+				metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 			}
 		} else {
 			// create
-			newmeta, err := fclient.V1().MessageQueueTrigger().Create(&o)
+			newmeta, err := fclient.FissionClientSet.CoreV1().MessageQueueTriggers(o.ObjectMeta.Namespace).Create(ctx, &o, metav1.CreateOptions{})
 			if err != nil {
 				return nil, nil, err
 			}
-			ras.Created = append(ras.Created, newmeta)
-			metadataMap[mapKey(&o.ObjectMeta)] = *newmeta
+			ras.Created = append(ras.Created, &newmeta.ObjectMeta)
+			metadataMap[mapKey(&o.ObjectMeta)] = newmeta.ObjectMeta
 		}
 	}
 
@@ -1271,7 +1281,7 @@ func applyMessageQueueTriggers(fclient client.Interface, fr *FissionResources, d
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.V1().MessageQueueTrigger().Delete(&o.ObjectMeta)
+				err := fclient.FissionClientSet.CoreV1().MessageQueueTriggers(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -70,7 +70,7 @@ func (opts *ApplySubCommand) do(input cli.Input) error {
 func (opts *ApplySubCommand) insertNamespace(input cli.Input, fr *FissionResources) error {
 
 	result := utils.MultiErrorWithFormat()
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}
@@ -394,7 +394,7 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 			// doesn't exist, upload
 			fmt.Printf("uploading archive %v\n", name)
 			// ar.URL is actually a local filename at this stage
-			uploadedAr, err := pkgutil.UploadArchiveFile(input.Context(), fclient, ar.URL, input.String(flagkey.KubeContext))
+			uploadedAr, err := pkgutil.UploadArchiveFile(input.Context(), fclient, ar.URL)
 			if err != nil {
 				return err
 			}

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -132,7 +132,7 @@ func (opts *DestroySubCommand) insertNSToResource(input cli.Input, fr *FissionRe
 
 	result := utils.MultiErrorWithFormat()
 
-	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -132,7 +132,7 @@ func (opts *DestroySubCommand) insertNSToResource(input cli.Input, fr *FissionRe
 
 	result := utils.MultiErrorWithFormat()
 
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -67,10 +67,10 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 	}
 
 	if input.Bool(flagkey.AllNamespaces) {
-		return opts.getResource(input, metav1.NamespaceAll, deployID)
-	} else {
-		return opts.getResource(input, currentNS, deployID)
+		currentNS = metav1.NamespaceAll
 	}
+
+	return opts.getResource(input, currentNS, deployID)
 
 }
 

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -61,7 +61,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		deployID = fr.DeploymentConfig.UID
 	}
 
-	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -61,7 +61,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		deployID = fr.DeploymentConfig.UID
 	}
 
-	_, currentNS, err := util.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/validate.go
+++ b/pkg/fission-cli/cmd/spec/validate.go
@@ -18,6 +18,7 @@ package spec
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -29,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller/client"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/console"
@@ -81,12 +81,12 @@ func (opts *ValidateSubCommand) run(input cli.Input, fr *FissionResources) (err 
 
 	var warnings []string
 	// this does the rest of the checks, like dangling refs
-	warnings, err = fr.Validate(input)
+	warnings, err = fr.Validate(input, opts.Client())
 	if err != nil {
 		return errors.Wrap(err, "error validating specs")
 	}
 
-	err = resourceConflictCheck(opts.Client(), fr, input.Bool(flagkey.SpecAllowConflicts), "")
+	err = resourceConflictCheck(input.Context(), opts.Client(), fr, input.Bool(flagkey.SpecAllowConflicts), "")
 	if err != nil {
 		return errors.Wrap(err, "name conflict error")
 	}
@@ -104,11 +104,11 @@ func (opts *ValidateSubCommand) run(input cli.Input, fr *FissionResources) (err 
 // the same name is already present in the same cluster namespace.
 // If a same name resource exists in the same namespace, a name
 // conflict error will be returned.
-func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowConflicts bool, namespace string) error {
+func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResources, specAllowConflicts bool, namespace string) error {
 	deployUID := fr.DeploymentConfig.UID
 	result := utils.MultiErrorWithFormat()
 
-	fnList, err := getAllFunctions(c, namespace)
+	fnList, err := getAllFunctions(ctx, c, namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get Functions %v", err.Error())
 	}
@@ -121,7 +121,7 @@ func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowCo
 		}
 	}
 
-	envList, err := getAllEnvironments(c, namespace)
+	envList, err := getAllEnvironments(ctx, c, namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get Environments %v", err.Error())
 	}
@@ -134,7 +134,7 @@ func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowCo
 		}
 	}
 
-	pkgList, err := getAllPackages(c, namespace)
+	pkgList, err := getAllPackages(ctx, c, namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get Packages %v", err.Error())
 	}
@@ -147,7 +147,7 @@ func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowCo
 		}
 	}
 
-	httptriggerList, err := getAllHTTPTriggers(c, namespace)
+	httptriggerList, err := getAllHTTPTriggers(ctx, c, namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get HTTPTrigger %v", err.Error())
 	}
@@ -160,7 +160,7 @@ func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowCo
 		}
 	}
 
-	mqtriggerList, err := getAllMessageQueueTriggers(c, "", namespace)
+	mqtriggerList, err := getAllMessageQueueTriggers(ctx, c, "", namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get Message Queue Trigger %v", err.Error())
 	}
@@ -173,7 +173,7 @@ func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowCo
 		}
 	}
 
-	timetriggerList, err := getAllTimeTriggers(c, namespace)
+	timetriggerList, err := getAllTimeTriggers(ctx, c, namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get Time Trigger %v", err.Error())
 	}
@@ -186,7 +186,7 @@ func resourceConflictCheck(c client.Interface, fr *FissionResources, specAllowCo
 		}
 	}
 
-	kubewatchtriggerList, err := getAllKubeWatchTriggers(c, namespace)
+	kubewatchtriggerList, err := getAllKubeWatchTriggers(ctx, c, namespace)
 	if err != nil {
 		return errors.Errorf("Unable to get Kubernetes Watch Trigger %v", err.Error())
 	}

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -74,7 +74,7 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"kubernetes-nodes":   resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesNode, ""),
 
 		// fission info
-		"fission-version": resources.NewFissionVersion(opts.Client()),
+		"fission-version": resources.NewFissionVersion(opts.Client(), input),
 
 		// fission component logs & spec
 		"fission-components-svc-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService,

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -29,7 +29,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/support/resources"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -51,7 +50,6 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 
 	nozip := input.Bool(flagkey.SupportNoZip)
 	outputDir := input.String(flagkey.SupportOutput)
-	kubeContext := input.String(flagkey.KubeContext)
 	// check whether the dump directory exists.
 	_, err := os.Stat(outputDir)
 	if err != nil && os.IsNotExist(err) {
@@ -68,10 +66,7 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		panic(errors.Wrap(err, "Error creating dump directory for dumping files"))
 	}
 
-	_, k8sClient, err := util.GetKubernetesClient(kubeContext)
-	if err != nil {
-		return err
-	}
+	k8sClient := opts.Client().KubernetesClient
 
 	ress := map[string]resources.Resource{
 		// kubernetes info

--- a/pkg/fission-cli/cmd/support/resources/fissionversion.go
+++ b/pkg/fission-cli/cmd/support/resources/fissionversion.go
@@ -21,15 +21,15 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type FissionVersion struct {
-	client client.Interface
+	client cmd.Client
 }
 
-func NewFissionVersion(client client.Interface) Resource {
+func NewFissionVersion(client cmd.Client) Resource {
 	return FissionVersion{client: client}
 }
 

--- a/pkg/fission-cli/cmd/support/resources/fissionversion.go
+++ b/pkg/fission-cli/cmd/support/resources/fissionversion.go
@@ -21,20 +21,22 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type FissionVersion struct {
 	client cmd.Client
+	input  cli.Input
 }
 
-func NewFissionVersion(client cmd.Client) Resource {
-	return FissionVersion{client: client}
+func NewFissionVersion(client cmd.Client, input cli.Input) Resource {
+	return FissionVersion{client: client, input: input}
 }
 
 func (res FissionVersion) Dump(ctx context.Context, dumpDir string) {
-	ver := util.GetVersion(ctx)
+	ver := util.GetVersion(ctx, res.input, res.client)
 	file := filepath.Clean(fmt.Sprintf("%v/%v", dumpDir, "fission-version.txt"))
 	writeToFile(file, ver)
 }

--- a/pkg/fission-cli/cmd/support/resources/fissionversion.go
+++ b/pkg/fission-cli/cmd/support/resources/fissionversion.go
@@ -34,7 +34,7 @@ func NewFissionVersion(client cmd.Client) Resource {
 }
 
 func (res FissionVersion) Dump(ctx context.Context, dumpDir string) {
-	ver := util.GetVersion(ctx, res.client)
+	ver := util.GetVersion(ctx)
 	file := filepath.Clean(fmt.Sprintf("%v/%v", dumpDir, "fission-version.txt"))
 	writeToFile(file, ver)
 }

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -149,7 +149,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 
 	fmt.Printf("trigger '%v' created\n", opts.trigger.ObjectMeta.Name)
 
-	t := util.GetServerInfo().ServerTime.CurrentTime.UTC()
+	t := util.GetServerInfo(input, opts.Client()).ServerTime.CurrentTime.UTC()
 
 	err = getCronNextNActivationTime(opts.trigger.Spec.Cron, t, 1)
 	if err != nil {

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -67,7 +67,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 		return errors.New("Need a function name to create a trigger, use --function")
 	}
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -67,7 +67,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 		return errors.New("Need a function name to create a trigger, use --function")
 	}
 
-	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceFunction)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/delete.go
+++ b/pkg/fission-cli/cmd/timetrigger/delete.go
@@ -26,7 +26,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type DeleteSubCommand struct {
@@ -39,7 +38,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/delete.go
+++ b/pkg/fission-cli/cmd/timetrigger/delete.go
@@ -39,7 +39,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/delete.go
+++ b/pkg/fission-cli/cmd/timetrigger/delete.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -42,19 +43,15 @@ func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	m := &metav1.ObjectMeta{
-		Name:      input.String(flagkey.TtName),
-		Namespace: namespace,
-	}
 
-	err = opts.Client().V1().TimeTrigger().Delete(m)
+	err = opts.Client().FissionClientSet.CoreV1().TimeTriggers(namespace).Delete(input.Context(), input.String(flagkey.TtName), metav1.DeleteOptions{})
 	if err != nil {
-		if input.Bool(flagkey.IgnoreNotFound) && util.IsNotFound(err) {
+		if input.Bool(flagkey.IgnoreNotFound) && kerrors.IsNotFound(err) {
 			return nil
 		}
 		return errors.Wrap(err, "error deleting trigger")
 	}
 
-	fmt.Printf("trigger '%v' deleted\n", m.Name)
+	fmt.Printf("trigger '%v' deleted\n", input.String(flagkey.TtName))
 	return nil
 }

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -28,7 +28,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -40,7 +39,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
-	_, ttNs, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, ttNs, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	v1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -44,12 +43,10 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 		return errors.Wrap(err, "error in deleting function ")
 	}
 
-	var tts *v1.TimeTriggerList
 	if input.Bool(flagkey.AllNamespaces) {
-		tts, err = opts.Client().FissionClientSet.CoreV1().TimeTriggers(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	} else {
-		tts, err = opts.Client().FissionClientSet.CoreV1().TimeTriggers(ttNs).List(input.Context(), metav1.ListOptions{})
+		ttNs = metav1.NamespaceAll
 	}
+	tts, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(ttNs).List(input.Context(), metav1.ListOptions{})
 
 	if err != nil {
 		return errors.Wrap(err, "list Time triggers")

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -40,7 +40,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
-	_, ttNs, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, ttNs, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/test.go
+++ b/pkg/fission-cli/cmd/timetrigger/test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ShowSubCommand struct {
@@ -44,12 +45,9 @@ func (opts *ShowSubCommand) run(flaginput cli.Input) error {
 		return errors.New("need a cron spec like '0 30 * * * *', '@every 1h30m', or '@hourly'; use --cron")
 	}
 
-	t, err := getAPITimeInfo(opts.Client())
-	if err != nil {
-		return err
-	}
+	t := util.GetServerInfo().ServerTime.CurrentTime.UTC()
 
-	err = getCronNextNActivationTime(cronSpec, t, round)
+	err := getCronNextNActivationTime(cronSpec, t, round)
 	if err != nil {
 		return errors.Wrap(err, "error passing cron spec examination")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/test.go
+++ b/pkg/fission-cli/cmd/timetrigger/test.go
@@ -45,7 +45,7 @@ func (opts *ShowSubCommand) run(flaginput cli.Input) error {
 		return errors.New("need a cron spec like '0 30 * * * *', '@every 1h30m', or '@hourly'; use --cron")
 	}
 
-	t := util.GetServerInfo().ServerTime.CurrentTime.UTC()
+	t := util.GetServerInfo(flaginput, opts.Client()).ServerTime.CurrentTime.UTC()
 
 	err := getCronNextNActivationTime(cronSpec, t, round)
 	if err != nil {

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -52,10 +52,8 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}
-	tt, err := opts.Client().V1().TimeTrigger().Get(&metav1.ObjectMeta{
-		Name:      input.String(flagkey.TtName),
-		Namespace: namespace,
-	})
+
+	tt, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(namespace).Get(input.Context(), input.String(flagkey.TtName), metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error getting time trigger")
 	}
@@ -70,7 +68,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String("function")
 	if len(fnName) > 0 {
 		functionList := []string{fnName}
-		err := util.CheckFunctionExistence(opts.Client(), functionList, namespace)
+		err := util.CheckFunctionExistence(input.Context(), opts.Client(), functionList, namespace)
 		if err != nil {
 			console.Warn(err.Error())
 		}
@@ -88,14 +86,14 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().V1().TimeTrigger().Update(opts.trigger)
+	_, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(opts.trigger.ObjectMeta.Namespace).Update(input.Context(), opts.trigger, metav1.UpdateOptions{})
 	if err != nil {
 		return errors.Wrap(err, "error updating Time trigger")
 	}
 
 	fmt.Printf("trigger '%v' updated\n", opts.trigger.ObjectMeta.Name)
 
-	t, err := getAPITimeInfo(opts.Client())
+	t := util.GetServerInfo().ServerTime.CurrentTime.UTC()
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -48,7 +48,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -93,7 +93,7 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 
 	fmt.Printf("trigger '%v' updated\n", opts.trigger.ObjectMeta.Name)
 
-	t := util.GetServerInfo().ServerTime.CurrentTime.UTC()
+	t := util.GetServerInfo(input, opts.Client()).ServerTime.CurrentTime.UTC()
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -48,7 +48,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
-	_, namespace, err := util.GetResourceNamespace(input, opts.Client(), flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return errors.Wrap(err, "error in deleting function ")
 	}

--- a/pkg/fission-cli/cmd/token/create.go
+++ b/pkg/fission-cli/cmd/token/create.go
@@ -64,9 +64,8 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 
 	jsonValue, _ := json.Marshal(values)
 
-	kubeContext := input.String(flagkey.KubeContext)
 	// Portforward to the fission router
-	localRouterPort, err := util.SetupPortForward(input.Context(), util.GetFissionNamespace(), "application=fission-router", kubeContext)
+	localRouterPort, err := util.SetupPortForward(input.Context(), opts.Client(), util.GetFissionNamespace(), "application=fission-router")
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/version/version.go
+++ b/pkg/fission-cli/cmd/version/version.go
@@ -36,7 +36,7 @@ func Version(input cli.Input) error {
 }
 
 func (opts *VersionSubCommand) do(input cli.Input) error {
-	ver := util.GetVersion(input.Context(), opts.Client())
+	ver := util.GetVersion(input.Context())
 	bs, err := yaml.Marshal(ver)
 	if err != nil {
 		return errors.Wrap(err, "error formatting versions")

--- a/pkg/fission-cli/cmd/version/version.go
+++ b/pkg/fission-cli/cmd/version/version.go
@@ -36,7 +36,7 @@ func Version(input cli.Input) error {
 }
 
 func (opts *VersionSubCommand) do(input cli.Input) error {
-	ver := util.GetVersion(input.Context())
+	ver := util.GetVersion(input.Context(), input, opts.Client())
 	bs, err := yaml.Marshal(ver)
 	if err != nil {
 		return errors.Wrap(err, "error formatting versions")

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -133,7 +133,6 @@ func GetVersion(ctx context.Context) info.Versions {
 		}
 	}
 
-	// TODO: verify it
 	serverInfo := GetServerInfo()
 
 	// Fetch server versions
@@ -476,11 +475,6 @@ func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) 
 	if len(ns) == 0 {
 		ns = metav1.NamespaceDefault
 	} else if ns != metav1.NamespaceDefault {
-		// TODO: does it remains the same now????
-		// If the function namespace is "default", executor
-		// will create function pods under "fission-function".
-		// Otherwise, the function pod will be created under
-		// the same namespace of function.
 		podNs = ns
 	}
 

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -19,11 +19,13 @@ package util
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/url"
 	"os"
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -39,9 +41,9 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/fission/fission/pkg/controller/client"
-	"github.com/fission/fission/pkg/controller/client/rest"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/info"
@@ -176,15 +178,10 @@ func GetKubernetesNamespace(kubeContext string) (currentNS string, err error) {
 }
 
 // given a list of functions, this checks if the functions actually exist on the cluster
-func CheckFunctionExistence(client client.Interface, functions []string, fnNamespace string) (err error) {
+func CheckFunctionExistence(ctx context.Context, client cmd.Client, functions []string, fnNamespace string) (err error) {
 	fnMissing := make([]string, 0)
 	for _, fnName := range functions {
-		meta := &metav1.ObjectMeta{
-			Name:      fnName,
-			Namespace: fnNamespace,
-		}
-
-		_, err := client.V1().Function().Get(meta)
+		_, err := client.FissionClientSet.CoreV1().Functions(fnNamespace).Get(ctx, fnName, metav1.GetOptions{})
 		if err != nil {
 			fnMissing = append(fnMissing, fnName)
 		}
@@ -197,7 +194,7 @@ func CheckFunctionExistence(client client.Interface, functions []string, fnNames
 	return nil
 }
 
-func GetVersion(ctx context.Context, client client.Interface) info.Versions {
+func GetVersion(ctx context.Context, client cmd.Client) info.Versions {
 	// Fetch client versions
 	versions := info.Versions{
 		Client: map[string]info.BuildMeta{
@@ -211,11 +208,8 @@ func GetVersion(ctx context.Context, client client.Interface) info.Versions {
 		}
 	}
 
-	serverInfo, err := client.V1().Misc().ServerInfo()
-	if err != nil {
-		console.Warn(fmt.Sprintf("Error getting Fission API version: %v", err))
-		serverInfo = &info.ServerInfo{}
-	}
+	// TODO: verify it
+	serverInfo := GetServerInfo()
 
 	// Fetch server versions
 	versions.Server = map[string]info.BuildMeta{
@@ -227,12 +221,8 @@ func GetVersion(ctx context.Context, client client.Interface) info.Versions {
 	return versions
 }
 
-func GetServer(input cli.Input) (c client.Interface, err error) {
-	serverUrl, err := GetServerURL(input)
-	if err != nil {
-		return nil, err
-	}
-	return client.MakeClientset(rest.NewRESTClient(serverUrl)), nil
+func GetServerInfo() info.ServerInfo {
+	return info.ApiInfo()
 }
 
 func GetServerURL(input cli.Input) (serverUrl string, err error) {
@@ -512,4 +502,158 @@ func GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, cu
 	console.Verbose(2, "Namespace for resource %s ", currentNS)
 
 	return namespace, currentNS, nil
+}
+
+// CheckHTTPTriggerDuplicates checks whether the tuple (Method, Host, URL) is duplicate or not.
+func CheckHTTPTriggerDuplicates(ctx context.Context, client cmd.Client, t *fv1.HTTPTrigger) error {
+	triggers, err := client.FissionClientSet.CoreV1().HTTPTriggers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, ht := range triggers.Items {
+		if ht.ObjectMeta.UID == t.ObjectMeta.UID {
+			// Same resource. No need to check.
+			continue
+		}
+		urlMatch := false
+		if (ht.Spec.RelativeURL != "" && ht.Spec.RelativeURL == t.Spec.RelativeURL) || (ht.Spec.Prefix != nil && t.Spec.Prefix != nil && *ht.Spec.Prefix != "" && *ht.Spec.Prefix == *t.Spec.Prefix) {
+			urlMatch = true
+		}
+		methodMatch := false
+		if ht.Spec.Method == t.Spec.Method && len(ht.Spec.Methods) == len(t.Spec.Methods) {
+			methodMatch = true
+			sort.Strings(ht.Spec.Methods)
+			sort.Strings(t.Spec.Methods)
+			for i, m1 := range ht.Spec.Methods {
+				if m1 != t.Spec.Methods[i] {
+					methodMatch = false
+				}
+			}
+		}
+		if urlMatch && methodMatch && ht.Spec.Method == t.Spec.Method && ht.Spec.Host == t.Spec.Host {
+			return fmt.Errorf("HTTPTrigger with same Host, URL & method already exists (%v)",
+				ht.ObjectMeta.Name)
+		}
+	}
+	return nil
+}
+
+func SecretExists(ctx context.Context, m *metav1.ObjectMeta, kClient kubernetes.Interface) error {
+
+	_, err := kClient.CoreV1().Secrets(m.Namespace).Get(ctx, m.Name, metav1.GetOptions{})
+	return err
+}
+
+func ConfigMapExists(ctx context.Context, m *metav1.ObjectMeta, kClient kubernetes.Interface) error {
+
+	_, err := kClient.CoreV1().ConfigMaps(m.Namespace).Get(ctx, m.Name, metav1.GetOptions{})
+	return err
+}
+
+func GetSvcName(ctx context.Context, kClient kubernetes.Interface, application string) (string, error) {
+	var podNamespace = os.Getenv("POD_NAMESPACE")
+	if podNamespace == "" {
+		podNamespace = "fission"
+	}
+
+	appLabelSelector := "application=" + application
+
+	services, err := kClient.CoreV1().Services(podNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: appLabelSelector,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(services.Items) > 1 || len(services.Items) == 0 {
+		return "", errors.Errorf("more than one service found for application=%s", application)
+	}
+	service := services.Items[0]
+	return service.Name + "." + podNamespace, nil
+}
+
+// FunctionPodLogs : Get logs for a function directly from pod
+func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) (err error) {
+
+	podNs := "fission-function"
+
+	if len(ns) == 0 {
+		ns = metav1.NamespaceDefault
+	} else if ns != metav1.NamespaceDefault {
+		// TODO: does it remains the same now????
+		// If the function namespace is "default", executor
+		// will create function pods under "fission-function".
+		// Otherwise, the function pod will be created under
+		// the same namespace of function.
+		podNs = ns
+	}
+
+	f, err := client.FissionClientSet.CoreV1().Functions(ns).Get(ctx, fnName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	// Get function Pods first
+	selector := map[string]string{
+		fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
+		fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
+		fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+	}
+	podList, err := client.KubernetesClient.CoreV1().Pods(podNs).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set(selector).AsSelector().String(),
+	})
+	if err != nil {
+		return err
+	}
+
+	// Get the logs for last Pod executed
+	pods := podList.Items
+	sort.Slice(pods, func(i, j int) bool {
+		rv1, _ := strconv.ParseInt(pods[i].ObjectMeta.ResourceVersion, 10, 32)
+		rv2, _ := strconv.ParseInt(pods[j].ObjectMeta.ResourceVersion, 10, 32)
+		return rv1 > rv2
+	})
+
+	if len(pods) <= 0 {
+		return errors.New("no active pods found")
+
+	}
+
+	// get the pod with highest resource version
+	err = getContainerLog(ctx, client.KubernetesClient, f, &pods[0])
+	if err != nil {
+		return errors.Wrapf(err, "error getting container logs")
+
+	}
+	return err
+}
+
+func getContainerLog(ctx context.Context, kubernetesClient kubernetes.Interface, fn *fv1.Function, pod *v1.Pod) (err error) {
+	seq := strings.Repeat("=", 35)
+
+	for _, container := range pod.Spec.Containers {
+		podLogOpts := v1.PodLogOptions{Container: container.Name} // Only the env container, not fetcher
+		podLogsReq := kubernetesClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.ObjectMeta.Name, &podLogOpts)
+
+		podLogs, err := podLogsReq.Stream(ctx)
+		if err != nil {
+			return errors.Wrapf(err, "error streaming pod log")
+		}
+
+		msg := fmt.Sprintf("\n%v\nFunction: %v\nEnvironment: %v\nNamespace: %v\nPod: %v\nContainer: %v\nNode: %v\n%v\n", seq,
+			fn.ObjectMeta.Name, fn.Spec.Environment.Name, pod.Namespace, pod.Name, container.Name, pod.Spec.NodeName, seq)
+
+		if _, err := io.WriteString(os.Stdout, msg); err != nil {
+			return errors.Wrapf(err, "error copying pod log")
+		}
+
+		_, err = io.Copy(os.Stdout, podLogs)
+		if err != nil {
+			return errors.Wrapf(err, "error copying pod log")
+		}
+
+		podLogs.Close()
+	}
+
+	return nil
 }

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -41,7 +41,6 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
-	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/info"
 	"github.com/fission/fission/pkg/plugin"
@@ -399,31 +398,6 @@ func GetStorageURL(ctx context.Context, client cmd.Client) (*url.URL, error) {
 	}
 
 	return serverURL, nil
-}
-
-func GetResourceNamespace(input cli.Input, client cmd.Client, deprecatedFlag string) (namespace, currentNS string, err error) {
-	namespace = input.String(deprecatedFlag)
-	currentNS = namespace
-
-	if input.String(flagkey.Namespace) != "" {
-		namespace = input.String(flagkey.Namespace)
-		currentNS = namespace
-		console.Verbose(2, "Namespace for resource %s ", currentNS)
-		return namespace, currentNS, err
-	}
-
-	if namespace == "" {
-		if os.Getenv("FISSION_DEFAULT_NAMESPACE") != "" {
-			currentNS = os.Getenv("FISSION_DEFAULT_NAMESPACE")
-		} else {
-			currentNS = client.Namespace
-			return namespace, currentNS, err
-		}
-	}
-
-	console.Verbose(2, "Namespace for resource %s ", currentNS)
-
-	return namespace, currentNS, nil
 }
 
 // CheckHTTPTriggerDuplicates checks whether the tuple (Method, Host, URL) is duplicate or not.

--- a/pkg/fission-cli/util/util_test.go
+++ b/pkg/fission-cli/util/util_test.go
@@ -65,10 +65,10 @@ func TestGetEnvVarFromStringSlice(t *testing.T) {
 	}
 }
 
-func TestGetConfig(t *testing.T) {
-	response, err := GetKubernetesNamespace("")
-	if err != nil {
-		t.Log(err)
-	}
-	t.Log("Current NS: ", response)
-}
+// func TestGetConfig(t *testing.T) {
+// 	response, err := GetKubernetesNamespace("")
+// 	if err != nil {
+// 		t.Log(err)
+// 	}
+// 	t.Log("Current NS: ", response)
+// }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller/client"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
@@ -55,7 +55,7 @@ type Checker struct {
 
 type Options struct {
 	KubeContext   string
-	FissionClient client.Interface
+	FissionClient cmd.Client
 }
 
 type HealthChecker struct {

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -53,15 +53,8 @@ type Checker struct {
 	check      func(ctx context.Context) error
 }
 
-type Options struct {
-	KubeContext   string
-	FissionClient cmd.Client
-}
-
 type HealthChecker struct {
-	categories []*Category
-	*Options
-
+	categories       []*Category
 	kubeAPI          kubernetes.Interface
 	fissionNamespace string
 }
@@ -121,7 +114,7 @@ func (hc *HealthChecker) CheckServiceStatus(ctx context.Context, namespace strin
 }
 
 func (hc *HealthChecker) CheckFissionVersion(ctx context.Context) error {
-	ver := util.GetVersion(ctx, hc.FissionClient)
+	ver := util.GetVersion(ctx)
 
 	clientVersion := ver.Client["fission/core"].Version
 	serverVersion := ver.Server["fission/core"].Version
@@ -200,14 +193,11 @@ func (hc *HealthChecker) allCategories() []*Category {
 	}
 }
 
-func NewHealthChecker(categoryIDs []CategoryID, options *Options) *HealthChecker {
+func NewHealthChecker(cmd cmd.Client, categoryIDs []CategoryID) *HealthChecker {
 	hc := &HealthChecker{
-		Options: options,
+		kubeAPI:          cmd.KubernetesClient,
+		fissionNamespace: "fission",
 	}
-
-	_, clientset, _ := util.GetKubernetesClient(hc.KubeContext)
-	hc.kubeAPI = clientset
-	hc.fissionNamespace = "fission"
 
 	hc.categories = hc.allCategories()
 

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
@@ -50,7 +51,7 @@ type Category struct {
 
 type Checker struct {
 	successMsg string
-	check      func(ctx context.Context) error
+	check      func(ctx context.Context, input cli.Input, client cmd.Client) error
 }
 
 type HealthChecker struct {
@@ -113,8 +114,8 @@ func (hc *HealthChecker) CheckServiceStatus(ctx context.Context, namespace strin
 	return nil
 }
 
-func (hc *HealthChecker) CheckFissionVersion(ctx context.Context) error {
-	ver := util.GetVersion(ctx)
+func (hc *HealthChecker) CheckFissionVersion(ctx context.Context, input cli.Input, client cmd.Client) error {
+	ver := util.GetVersion(ctx, input, client)
 
 	clientVersion := ver.Client["fission/core"].Version
 	serverVersion := ver.Server["fission/core"].Version
@@ -141,7 +142,7 @@ func (hc *HealthChecker) allCategories() []*Category {
 			[]Checker{
 				{
 					successMsg: "kubernetes version is compatible",
-					check: func(ctx context.Context) (err error) {
+					check: func(ctx context.Context, input cli.Input, client cmd.Client) (err error) {
 						return hc.CheckKubeVersion()
 					},
 				},
@@ -153,25 +154,25 @@ func (hc *HealthChecker) allCategories() []*Category {
 			[]Checker{
 				{
 					successMsg: "controller is running fine",
-					check: func(ctx context.Context) error {
+					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
 						return hc.CheckServiceStatus(ctx, hc.fissionNamespace, "controller")
 					},
 				},
 				{
 					successMsg: "executor is running fine",
-					check: func(ctx context.Context) error {
+					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
 						return hc.CheckServiceStatus(ctx, hc.fissionNamespace, "executor")
 					},
 				},
 				{
 					successMsg: "router is running fine",
-					check: func(ctx context.Context) error {
+					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
 						return hc.CheckServiceStatus(ctx, hc.fissionNamespace, "router")
 					},
 				},
 				{
 					successMsg: "storagesvc is running fine",
-					check: func(ctx context.Context) error {
+					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
 						return hc.CheckServiceStatus(ctx, hc.fissionNamespace, "storagesvc")
 					},
 				},
@@ -183,8 +184,8 @@ func (hc *HealthChecker) allCategories() []*Category {
 			[]Checker{
 				{
 					successMsg: "fission is up-to-date",
-					check: func(ctx context.Context) error {
-						return hc.CheckFissionVersion(ctx)
+					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
+						return hc.CheckFissionVersion(ctx, input, client)
 					},
 				},
 			},
@@ -214,13 +215,13 @@ func NewHealthChecker(cmd cmd.Client, categoryIDs []CategoryID) *HealthChecker {
 	return hc
 }
 
-func RunChecks(ctx context.Context, hc *HealthChecker) {
+func RunChecks(ctx context.Context, input cli.Input, client cmd.Client, hc *HealthChecker) {
 	for _, c := range hc.categories {
 		if c.enabled {
 			fmt.Println(c.ID)
 			fmt.Println(strings.Repeat("-", 20))
 			for _, checker := range c.checkers {
-				err := checker.check(ctx)
+				err := checker.check(ctx, input, client)
 				if err != nil {
 					fmt.Printf("%s %s\n", failStatus, err)
 				} else {

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -185,6 +185,21 @@ func (c *Client) Download(ctx context.Context, id string, filePath string) error
 	return nil
 }
 
+// Download fetches the file identified by ID to the local file path.
+// filePath must not exist.
+func (c *Client) GetFile(ctx context.Context, id string) (resp *http.Response, err error) {
+	// url for id
+	url := c.GetUrl(id)
+
+	// make request
+	resp, err = ctxhttp.Get(ctx, c.httpClient, url)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, err
+}
+
 func (c *Client) Delete(ctx context.Context, id string) error {
 	url := c.GetUrl(id)
 

--- a/pkg/utils/otel/log.go
+++ b/pkg/utils/otel/log.go
@@ -22,8 +22,8 @@ import (
 	"go.uber.org/zap"
 )
 
-func LoggerWithTraceID(context context.Context, logger *zap.Logger) *zap.Logger {
-	if span := trace.SpanContextFromContext(context); span.TraceID().IsValid() {
+func LoggerWithTraceID(ctx context.Context, logger *zap.Logger) *zap.Logger {
+	if span := trace.SpanContextFromContext(ctx); span.TraceID().IsValid() {
 		return logger.With(zap.String("trace_id", span.TraceID().String()))
 	}
 	return logger


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Use the Kubernetes and Fission Client from CLI instead of Controller API. 
This removes port-forwarding for controller 

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
All the CLI actions should work similarly. 
NOTE: We will now throw an error if the resource creation request was made for Namespace which is not present. This is to come inline with Kubernetes behaviour. 
## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
