### PR TITLE
Add Fission version API to router for CLI consumption

### DIFF
--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -150,26 +150,26 @@ func GetVersion(ctx context.Context, input cli.Input, cmdClient cmd.Client) info
 
 func GetServerInfo(input cli.Input, cmdClient cmd.Client) *info.ServerInfo {
 
+	var serverInfo info.ServerInfo
 	serverURL, err := getRouterURL(input.Context(), cmdClient)
 	if err != nil {
 		console.Warn("could not connect to server")
-		return nil
+		return &serverInfo
 	}
 	// make request
 	resp, err := http.Get(serverURL.String() + "/_version")
 	if err != nil {
 		console.Warn("could not get data from server")
-		return nil
+		return &serverInfo
 	}
 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		msg := fmt.Sprintf("HTTP error %v", resp.StatusCode)
 		console.Warn(msg)
-		return nil
+		return &serverInfo
 	}
 
-	var serverInfo info.ServerInfo
 	err = json.NewDecoder(resp.Body).Decode(&serverInfo)
 	if err != nil {
 		console.Warn(fmt.Sprintf("Error getting Fission API version: %v", err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Exposed a version API on router to fetch server version info.
Used the API from CLI instead of using controller APIs
## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
