### PR TITLE
Delete builder service associated with environment name

### DIFF
--- a/pkg/buildermgr/envwatcher.go
+++ b/pkg/buildermgr/envwatcher.go
@@ -113,9 +113,10 @@ func makeEnvironmentWatcher(
 	return envWatcher
 }
 
-func (env *environmentWatcher) getLabelForDeploymentOwner() map[string]string {
+func (env *environmentWatcher) getDeploymentLabels(envName string) map[string]string {
 	return map[string]string{
 		LABEL_DEPLOYMENT_OWNER: BUILDER_MGR,
+		LABEL_ENV_NAME:         envName,
 	}
 }
 
@@ -202,7 +203,7 @@ func (envw *environmentWatcher) getNamespace(env *fv1.Environment) string {
 
 func (envw *environmentWatcher) DeleteBuilderService(ctx context.Context, env *fv1.Environment) {
 	ns := envw.getNamespace(env)
-	svcList, err := envw.getBuilderServiceList(ctx, envw.getLabelForDeploymentOwner(), ns)
+	svcList, err := envw.getBuilderServiceList(ctx, envw.getDeploymentLabels(env.ObjectMeta.Name), ns)
 	if err != nil {
 		envw.logger.Error("error getting the builder service list", zap.Error(err))
 	}
@@ -227,7 +228,7 @@ func (envw *environmentWatcher) DeleteBuilderService(ctx context.Context, env *f
 
 func (envw *environmentWatcher) DeleteBuilderDeployment(ctx context.Context, env *fv1.Environment) {
 	ns := envw.getNamespace(env)
-	deployList, err := envw.getBuilderDeploymentList(ctx, envw.getLabelForDeploymentOwner(), ns)
+	deployList, err := envw.getBuilderDeploymentList(ctx, envw.getDeploymentLabels(env.ObjectMeta.Name), ns)
 	if err != nil {
 		envw.logger.Error("error getting the builder deployment list", zap.Error(err))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
fission env delete -> deletes wrong builder service in case of multiple environment.

These changes will select the and delete the builder service that is associate with environment name using environment label.

## Which issue(s) this PR fixes:

Fixes  https://github.com/fission/fission/issues/2615

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
