### PR TITLE
Use default namespace for fission function and builder

### DIFF
--- a/charts/fission-all/templates/_function-access-role.tpl
+++ b/charts/fission-all/templates/_function-access-role.tpl
@@ -61,7 +61,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fission-fetcher
-    namespace: {{ .Values.functionNamespace }}
+    namespace: {{template "fission-function-ns" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -75,5 +75,5 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fission-builder
-    namespace: {{ .Values.builderNamespace }}
+    namespace: {{ template "fission-builder-ns" . }}
 {{- end -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -87,3 +87,19 @@ Define the svc's name
 {{- define "fission-webhook.svc" -}}
 {{- printf "webhook-service" -}}
 {{- end -}}
+
+{{- define "fission-function-ns" -}}
+{{- if .Values.functionNamespace -}}
+{{- printf "%s" .Values.functionNamespace -}}
+{{- else -}}
+{{- printf "%s" .Values.defaultNamespace -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "fission-builder-ns" -}}
+{{- if .Values.builderNamespace -}}
+{{- printf "%s" .Values.builderNamespace -}}
+{{- else -}}
+{{- printf "%s" .Values.builderNamespace -}}
+{{- end -}}
+{{- end -}}

--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]
+        args: ["--builderMgr", "--storageSvcUrl", "http://storagesvc.{{ .Release.Namespace }}"]
         env:
         - name: FETCHER_IMAGE
         {{- if eq .Values.fetcher.imageTag "" }}
@@ -39,6 +39,12 @@ spec:
           value: "{{ .Values.pullPolicy }}"
         - name: BUILDER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        - name: FISSION_BUILDER_NAMESPACE
+          value: "{{ .Values.builderNamespace }}"
+        - name: FISSION_FUNCTION_NAMESPACE
+          value: "{{ .Values.functionNamespace }}"
+        - name: FISSION_DEFAULT_NAMESPACE
+          value: "{{ .Values.defaultNamespace }}"      
         - name: ENABLE_ISTIO
           value: "{{ .Values.enableIstio }}"
         - name: FETCHER_MINCPU

--- a/charts/fission-all/templates/controller/deployment.yaml
+++ b/charts/fission-all/templates/controller/deployment.yaml
@@ -33,8 +33,12 @@ spec:
         command: ["/fission-bundle"]
         args: ["--controllerPort", "8888"]
         env:
+        - name: FISSION_DEFAULT_NAMESPACE
+          value: "{{ .Values.defaultNamespace }}"
+        - name: FISSION_BUILDER_NAMESPACE
+          value: "{{ .Values.builderNamespace }}"
         - name: FISSION_FUNCTION_NAMESPACE
-          value: "{{ .Values.functionNamespace }}"
+          value: "{{ .Values.functionNamespace }}"  
         - name: DEBUG_ENV
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--executorPort", "8888", "--namespace", "{{ .Values.functionNamespace }}"]
+        args: ["--executorPort", "8888", "--namespace", "{{ .Values.defaultNamespace }}"]
         env:
         - name: FETCHER_IMAGE
         {{- if eq .Values.fetcher.imageTag "" }}
@@ -37,6 +37,12 @@ spec:
         {{- end }}
         - name: FETCHER_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
+        - name: FISSION_BUILDER_NAMESPACE
+          value: "{{ .Values.builderNamespace }}"
+        - name: FISSION_FUNCTION_NAMESPACE
+          value: "{{ .Values.functionNamespace }}"
+        - name: FISSION_DEFAULT_NAMESPACE
+          value: "{{ .Values.defaultNamespace }}"  
         - name: RUNTIME_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
         - name: ADOPT_EXISTING_RESOURCES

--- a/charts/fission-all/templates/misc-functions/namespace.yaml
+++ b/charts/fission-all/templates/misc-functions/namespace.yaml
@@ -1,24 +1,29 @@
 {{- if .Values.createNamespace }}
+{{- if and (ne .Values.functionNamespace "default") (ne .Values.functionNamespace "") }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.functionNamespace }}
+  name: {{ template "fission-function-ns" . }}
   labels:
     name: fission-function
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     {{- if .Values.enableIstio }}
     istio-injection: enabled
     {{- end }}
+{{- end}}
 
 ---
+
+{{- if and (ne .Values.builderNamespace "default") (ne .Values.builderNamespace "") }}
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.builderNamespace }}
+  name: {{ template "fission-builder-ns" . }}
   labels:
     name: fission-builder
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     {{- if .Values.enableIstio }}
     istio-injection: enabled
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/misc-functions/role.yaml
+++ b/charts/fission-all/templates/misc-functions/role.yaml
@@ -8,7 +8,7 @@ can be used
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: {{ .Values.functionNamespace }}
+  namespace: {{ template "fission-function-ns" . }}
   name: {{ .Release.Name }}-event-fetcher
 rules:
 - apiGroups:

--- a/charts/fission-all/templates/misc-functions/rolebinding.yaml
+++ b/charts/fission-all/templates/misc-functions/rolebinding.yaml
@@ -9,7 +9,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ .Release.Name }}-fission-fetcher-pod-reader
-  namespace: {{ .Values.functionNamespace }}
+  namespace: {{ template "fission-function-ns" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -17,7 +17,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: fission-fetcher
-    namespace: {{ .Values.functionNamespace }}
+    namespace: {{ template "fission-function-ns" . }}
 
 {{- if not .Values.singleDefaultNamespace }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}

--- a/charts/fission-all/templates/misc-functions/serviceaccount.yaml
+++ b/charts/fission-all/templates/misc-functions/serviceaccount.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fission-fetcher
-  namespace: {{ .Values.functionNamespace }}
+  namespace: {{ template "fission-function-ns" . }}
 
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fission-builder
-  namespace: {{ .Values.builderNamespace }}
+  namespace: {{ template "fission-builder-ns" . }}

--- a/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
@@ -35,7 +35,6 @@ spec:
       {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: [ "/pre-upgrade-checks" ]
-        args: ["--fn-pod-namespace", "{{ .Values.functionNamespace }}", "--envbuilder-namespace", "{{ .Values.builderNamespace }}"]
         env:
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- if .Values.terminationMessagePath }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -61,16 +61,6 @@ controllerPort: 31313
 ##
 routerPort: 31314
 
-## functionNamespace represents the namespace in which Fission Function resources will be created.
-## This is different from the release namespace.
-##
-functionNamespace: fission-function
-
-## builderNamespace represents the namespace in which Fission Builder resources will be created.
-## This is different from the release namespace.
-##
-builderNamespace: fission-builder
-
 ## defaultNamespace represents the namespace in which Fission custom resources will be created by the Fission user.
 ## This is different from the release namespace.
 ## Please consider setting `singleDefaultNamespace` and `additionalFissionNamespaces` if you want
@@ -78,6 +68,18 @@ builderNamespace: fission-builder
 ## Fission will watch the defaultNamespace only if `singleDefaultNamespace` is true.
 ##
 defaultNamespace: default
+
+functionNamespace: ""
+
+## builderNamespace represents the namespace in which Fission Builder resources will be created.
+## This is different from the release namespace.
+##
+builderNamespace: ""
+
+## functionNamespace represents the namespace in which Fission Function resources will be created.
+## This is different from the release namespace.
+##
+functionNamespace: ""
 
 ## If true, fission will only watch for fission custom resources created in the `defaultNamespace` above.
 ##

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -62,8 +62,8 @@ func runRouter(ctx context.Context, logger *zap.Logger, port int, executorUrl st
 	router.Start(ctx, logger, port, executorUrl)
 }
 
-func runExecutor(ctx context.Context, logger *zap.Logger, port int, functionNamespace, envBuilderNamespace string) error {
-	return executor.StartExecutor(ctx, logger, functionNamespace, envBuilderNamespace, port)
+func runExecutor(ctx context.Context, logger *zap.Logger, port int, defaultNamespace string) error {
+	return executor.StartExecutor(ctx, logger, defaultNamespace, port)
 }
 
 func runKubeWatcher(ctx context.Context, logger *zap.Logger, routerUrl string) error {
@@ -87,8 +87,8 @@ func runStorageSvc(ctx context.Context, logger *zap.Logger, port int, storage st
 	return storagesvc.Start(ctx, logger, storage, port)
 }
 
-func runBuilderMgr(ctx context.Context, logger *zap.Logger, storageSvcUrl string, envBuilderNamespace string) error {
-	return buildermgr.Start(ctx, logger, storageSvcUrl, envBuilderNamespace)
+func runBuilderMgr(ctx context.Context, logger *zap.Logger, storageSvcUrl string) error {
+	return buildermgr.Start(ctx, logger, storageSvcUrl)
 }
 
 func runLogger(ctx context.Context, logger *zap.Logger) {
@@ -232,8 +232,7 @@ Options:
 		defer shutdown(ctx)
 	}
 
-	functionNs := getStringArgWithDefault(arguments["--namespace"], "fission-function")
-	envBuilderNs := getStringArgWithDefault(arguments["--envbuilder-namespace"], "fission-builder")
+	defaultNs := getStringArgWithDefault(arguments["--namespace"], "fission-function")
 
 	executorUrl := getStringArgWithDefault(arguments["--executorUrl"], "http://executor.fission")
 	routerUrl := getStringArgWithDefault(arguments["--routerUrl"], "http://router.fission")
@@ -270,7 +269,7 @@ Options:
 
 	if arguments["--executorPort"] != nil {
 		port := getPort(logger, arguments["--executorPort"])
-		err = runExecutor(ctx, logger, port, functionNs, envBuilderNs)
+		err = runExecutor(ctx, logger, port, defaultNs)
 		if err != nil {
 			logger.Error("executor exited", zap.Error(err))
 			return
@@ -310,7 +309,7 @@ Options:
 	}
 
 	if arguments["--builderMgr"] == true {
-		err = runBuilderMgr(ctx, logger, storageSvcUrl, envBuilderNs)
+		err = runBuilderMgr(ctx, logger, storageSvcUrl)
 		if err != nil {
 			logger.Error("builder manager exited", zap.Error(err))
 			return

--- a/cmd/preupgradechecks/checks.go
+++ b/cmd/preupgradechecks/checks.go
@@ -42,8 +42,6 @@ type (
 		fissionClient versioned.Interface
 		k8sClient     kubernetes.Interface
 		apiExtClient  apiextensionsclient.Interface
-		fnPodNs       string
-		envBuilderNs  string
 	}
 )
 
@@ -53,7 +51,7 @@ const (
 	MqtCRD      = "messagequeuetriggers.fission.io"
 )
 
-func makePreUpgradeTaskClient(logger *zap.Logger, fnPodNs, envBuilderNs string) (*PreUpgradeTaskClient, error) {
+func makePreUpgradeTaskClient(logger *zap.Logger) (*PreUpgradeTaskClient, error) {
 	fissionClient, k8sClient, apiExtClient, _, err := crd.MakeFissionClient()
 	if err != nil {
 		return nil, errors.Wrap(err, "error making fission client")
@@ -63,8 +61,6 @@ func makePreUpgradeTaskClient(logger *zap.Logger, fnPodNs, envBuilderNs string) 
 		logger:        logger.Named("pre_upgrade_task_client"),
 		fissionClient: fissionClient,
 		k8sClient:     k8sClient,
-		fnPodNs:       fnPodNs,
-		envBuilderNs:  envBuilderNs,
 		apiExtClient:  apiExtClient,
 	}, nil
 }

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -17,42 +17,17 @@ limitations under the License.
 package main
 
 import (
-	"github.com/docopt/docopt-go"
 	"go.uber.org/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
-	"github.com/fission/fission/pkg/info"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
-
-func getStringArgWithDefault(arg interface{}, defaultValue string) string {
-	if arg != nil {
-		return arg.(string)
-	} else {
-		return defaultValue
-	}
-}
 
 func main() {
 	logger := loggerfactory.GetLogger()
 	defer logger.Sync()
 
-	usage := `Package to perform operations needed prior to fission installation
-Usage:
-  pre-upgrade-checks --fn-pod-namespace=<podNamespace> --envbuilder-namespace=<envBuilderNamespace>
-Options:
-  --fn-pod-namespace=<podNamespace>                        Namespace where function pods get deployed.
-  --envbuilder-namespace=<envBuilderNamespace>             Namespace where builder env pods are deployed.`
-
-	arguments, err := docopt.ParseArgs(usage, nil, info.BuildInfo().String())
-	if err != nil {
-		logger.Fatal("Could not parse command line arguments", zap.Error(err))
-	}
-
-	functionPodNs := getStringArgWithDefault(arguments["--fn-pod-namespace"], "fission-function")
-	envBuilderNs := getStringArgWithDefault(arguments["--envbuilder-namespace"], "fission-builder")
-
-	crdBackedClient, err := makePreUpgradeTaskClient(logger, functionPodNs, envBuilderNs)
+	crdBackedClient, err := makePreUpgradeTaskClient(logger)
 	if err != nil {
 		logger.Fatal("error creating a crd client, please retry helm upgrade",
 			zap.Error(err))

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -164,3 +164,9 @@ const (
 	PackagesResource        = "packages"
 	TimeTriggerResource     = "timetriggers"
 )
+
+const (
+	ENV_FUNCTION_NAMESPACE = "FISSION_FUNCTION_NAMEPSACE"
+	ENV_BUILDER_NAMESPACE  = "FISSION_BUILDER_NAMESPACE"
+	ENV_DEFAULT_NAMESPACE  = "FISSION_DEFAULT_NAMESPACE"
+)

--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -33,7 +33,7 @@ import (
 )
 
 // Start the buildermgr service.
-func Start(ctx context.Context, logger *zap.Logger, storageSvcUrl string, envBuilderNamespace string) error {
+func Start(ctx context.Context, logger *zap.Logger, storageSvcUrl string) error {
 	bmLogger := logger.Named("builder_manager")
 
 	fissionClient, kubernetesClient, _, _, err := crd.MakeFissionClient()
@@ -62,13 +62,13 @@ func Start(ctx context.Context, logger *zap.Logger, storageSvcUrl string, envBui
 		}
 	}
 
-	envWatcher := makeEnvironmentWatcher(ctx, bmLogger, fissionClient, kubernetesClient, fetcherConfig, envBuilderNamespace, podSpecPatch)
+	envWatcher := makeEnvironmentWatcher(ctx, bmLogger, fissionClient, kubernetesClient, fetcherConfig, podSpecPatch)
 	envWatcher.Run(ctx)
 
 	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
 	podInformer := k8sInformerFactory.Core().V1().Pods().Informer()
 	pkgWatcher := makePackageWatcher(bmLogger, fissionClient,
-		kubernetesClient, envBuilderNamespace, storageSvcUrl, podInformer,
+		kubernetesClient, storageSvcUrl, podInformer,
 		utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.PackagesResource))
 	pkgWatcher.Run(ctx)
 	return nil

--- a/pkg/controller/api.go
+++ b/pkg/controller/api.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/logdb"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
@@ -91,11 +92,10 @@ func MakeAPI(logger *zap.Logger) (*API, error) {
 		api.workflowApiUrl = "http://workflows-apiserver"
 	}
 
-	fnNs := os.Getenv("FISSION_FUNCTION_NAMESPACE")
-	if len(fnNs) > 0 {
-		api.functionNamespace = fnNs
+	if os.Getenv(fv1.ENV_BUILDER_NAMESPACE) == "" || os.Getenv(fv1.ENV_FUNCTION_NAMESPACE) == "" {
+		api.functionNamespace = os.Getenv(fv1.ENV_DEFAULT_NAMESPACE)
 	} else {
-		api.functionNamespace = "fission-function"
+		api.functionNamespace = os.Getenv(fv1.ENV_FUNCTION_NAMESPACE)
 	}
 
 	return api, err

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -255,7 +255,7 @@ func (executor *Executor) getFunctionServiceFromCache(ctx context.Context, fn *f
 
 // StartExecutor Starts executor and the executor components such as Poolmgr,
 // deploymgr and potential future executor types
-func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace string, envBuilderNamespace string, port int) error {
+func StartExecutor(ctx context.Context, logger *zap.Logger, defaultNs string, port int) error {
 	fissionClient, kubernetesClient, _, metricsClient, err := crd.MakeFissionClient()
 	if err != nil {
 		return errors.Wrap(err, "failed to get kubernetes client")
@@ -306,7 +306,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	gpm, err := poolmgr.MakeGenericPoolManager(ctx,
 		logger,
 		fissionClient, kubernetesClient, metricsClient,
-		functionNamespace, fetcherConfig, executorInstanceID,
+		fetcherConfig, executorInstanceID,
 		funcInformer, pkgInformer, envInformer,
 		gpmPodInformer, gpmRsInformer, podSpecPatch)
 	if err != nil {
@@ -322,7 +322,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	ndm, err := newdeploy.MakeNewDeploy(ctx,
 		logger,
 		fissionClient, kubernetesClient,
-		functionNamespace, fetcherConfig, executorInstanceID,
+		fetcherConfig, executorInstanceID,
 		funcInformer, envInformer,
 		ndmDeplInformer, ndmSvcInformer, podSpecPatch)
 	if err != nil {
@@ -338,7 +338,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	cnm, err := container.MakeContainer(
 		ctx, logger,
 		fissionClient, kubernetesClient,
-		functionNamespace, executorInstanceID, funcInformer,
+		executorInstanceID, funcInformer,
 		cnmDeplInformer, cnmSvcInformer)
 	if err != nil {
 		return errors.Wrap(err, "container manager creation failed")
@@ -408,7 +408,7 @@ func StartExecutor(ctx context.Context, logger *zap.Logger, functionNamespace st
 	if err != nil {
 		return err
 	}
-	go reaper.CleanupRoleBindings(ctx, logger, kubernetesClient, fissionClient, functionNamespace, envBuilderNamespace, time.Minute*30)
+	go reaper.CleanupRoleBindings(ctx, logger, kubernetesClient, fissionClient, defaultNs, time.Minute*30)
 	go metrics.ServeMetrics(ctx, logger)
 	go api.Serve(ctx, port)
 

--- a/pkg/executor/executor_test.go
+++ b/pkg/executor/executor_test.go
@@ -174,7 +174,7 @@ func TestExecutor(t *testing.T) {
 
 	// create poolmgr
 	port := 9999
-	err = StartExecutor(ctx, logger, functionNs, "fission-builder", port)
+	err = StartExecutor(ctx, logger, functionNs, port)
 	if err != nil {
 		log.Panicf("failed to start poolmgr: %v", err)
 	}

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -57,7 +57,9 @@ import (
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
-var _ executortype.ExecutorType = &Container{}
+var (
+	_ executortype.ExecutorType = &Container{}
+)
 
 type (
 	// Container represents an executor type
@@ -67,10 +69,10 @@ type (
 		kubernetesClient kubernetes.Interface
 		fissionClient    versioned.Interface
 		instanceID       string
+		nsResolver       *utils.NamespaceResolver
 		// fetcherConfig    *fetcherConfig.Config
 
 		runtimeImagePullPolicy apiv1.PullPolicy
-		namespace              string
 		useIstio               bool
 
 		fsCache *fscache.FunctionServiceCache // cache funcSvc's by function, address and pod name
@@ -96,7 +98,6 @@ func MakeContainer(
 	logger *zap.Logger,
 	fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface,
-	namespace string,
 	instanceID string,
 	funcInformer map[string]finformerv1.FunctionInformer,
 	deplInformer appsinformers.DeploymentInformer,
@@ -117,8 +118,8 @@ func MakeContainer(
 		fissionClient:    fissionClient,
 		kubernetesClient: kubernetesClient,
 		instanceID:       instanceID,
+		nsResolver:       utils.GetFissionNamespaces(),
 
-		namespace: namespace,
 		fsCache:   fscache.MakeFunctionServiceCache(logger),
 		throttler: throttler.MakeThrottler(1 * time.Minute),
 
@@ -129,6 +130,7 @@ func MakeContainer(
 		objectReaperIntervalSecond: time.Duration(executorUtils.GetObjectReaperInterval(logger, fv1.ExecutorTypeContainer, 5)) * time.Second,
 		hpaops:                     hpautils.NewHpaOperations(logger, kubernetesClient, instanceID),
 	}
+
 	caaf.deplLister = deplInformer.Lister()
 	caaf.deplListerSynced = deplInformer.Informer().HasSynced
 
@@ -382,10 +384,7 @@ func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns
-	ns := caaf.namespace
-	if fn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-		ns = fn.ObjectMeta.Namespace
-	}
+	ns := caaf.nsResolver.GetFunctionNS(fn.ObjectMeta.Namespace)
 
 	// Envoy(istio-proxy) returns 404 directly before istio pilot
 	// propagates latest Envoy-specific configuration.
@@ -499,10 +498,7 @@ func (caaf *Container) updateFunction(ctx context.Context, oldFn *fv1.Function, 
 	if !reflect.DeepEqual(oldFn.Spec.InvokeStrategy, newFn.Spec.InvokeStrategy) {
 		// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 		// deployment of the function in fission-function ns, so cleaning up resources there
-		ns := caaf.namespace
-		if newFn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-			ns = newFn.ObjectMeta.Namespace
-		}
+		ns := caaf.nsResolver.GetFunctionNS(newFn.ObjectMeta.Namespace)
 
 		fsvc, err := caaf.fsCache.GetByFunctionUID(newFn.ObjectMeta.UID)
 		if err != nil {
@@ -598,10 +594,7 @@ func (caaf *Container) updateFuncDeployment(ctx context.Context, fn *fv1.Functio
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns
-	ns := caaf.namespace
-	if fn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-		ns = fn.ObjectMeta.Namespace
-	}
+	ns := caaf.nsResolver.GetFunctionNS(fn.ObjectMeta.Namespace)
 
 	existingDepl, err := caaf.kubernetesClient.AppsV1().Deployments(ns).Get(ctx, fnObjName, metav1.GetOptions{})
 	if err != nil {
@@ -651,10 +644,7 @@ func (caaf *Container) fnDelete(ctx context.Context, fn *fv1.Function) error {
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns, so cleaning up resources there
-	ns := caaf.namespace
-	if fn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-		ns = fn.ObjectMeta.Namespace
-	}
+	ns := caaf.nsResolver.GetFunctionNS(fn.ObjectMeta.Namespace)
 
 	err = caaf.cleanupContainer(ctx, ns, objName)
 	multierr = multierror.Append(multierr, err)

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -59,7 +59,9 @@ import (
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
-var _ executortype.ExecutorType = &NewDeploy{}
+var (
+	_ executortype.ExecutorType = &NewDeploy{}
+)
 
 type (
 	// NewDeploy represents an ExecutorType
@@ -70,9 +72,9 @@ type (
 		fissionClient    versioned.Interface
 		instanceID       string
 		fetcherConfig    *fetcherConfig.Config
+		nsResolver       *utils.NamespaceResolver
 
 		runtimeImagePullPolicy apiv1.PullPolicy
-		namespace              string
 		useIstio               bool
 
 		fsCache *fscache.FunctionServiceCache // cache funcSvc's by function, address and pod name
@@ -100,7 +102,6 @@ func MakeNewDeploy(
 	logger *zap.Logger,
 	fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface,
-	namespace string,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
 	funcInformer map[string]finformerv1.FunctionInformer,
@@ -124,10 +125,9 @@ func MakeNewDeploy(
 		fissionClient:    fissionClient,
 		kubernetesClient: kubernetesClient,
 		instanceID:       instanceID,
-
-		namespace: namespace,
-		fsCache:   fscache.MakeFunctionServiceCache(logger),
-		throttler: throttler.MakeThrottler(1 * time.Minute),
+		fsCache:          fscache.MakeFunctionServiceCache(logger),
+		throttler:        throttler.MakeThrottler(1 * time.Minute),
+		nsResolver:       utils.GetFissionNamespaces(),
 
 		fetcherConfig:          fetcherConfig,
 		runtimeImagePullPolicy: utils.GetImagePullPolicy(os.Getenv("RUNTIME_IMAGE_PULL_POLICY")),
@@ -428,10 +428,7 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns
-	ns := deploy.namespace
-	if fn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-		ns = fn.ObjectMeta.Namespace
-	}
+	ns := deploy.nsResolver.GetFunctionNS(fn.ObjectMeta.Namespace)
 
 	// Envoy(istio-proxy) returns 404 directly before istio pilot
 	// propagates latest Envoy-specific configuration.
@@ -549,10 +546,7 @@ func (deploy *NewDeploy) updateFunction(ctx context.Context, oldFn *fv1.Function
 
 		// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 		// deployment of the function in fission-function ns, so cleaning up resources there
-		ns := deploy.namespace
-		if newFn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-			ns = newFn.ObjectMeta.Namespace
-		}
+		ns := deploy.nsResolver.GetFunctionNS(newFn.ObjectMeta.Namespace)
 
 		fsvc, err := deploy.fsCache.GetByFunctionUID(newFn.ObjectMeta.UID)
 		if err != nil {
@@ -654,10 +648,7 @@ func (deploy *NewDeploy) updateFuncDeployment(ctx context.Context, fn *fv1.Funct
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns
-	ns := deploy.namespace
-	if fn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-		ns = fn.ObjectMeta.Namespace
-	}
+	ns := deploy.nsResolver.GetFunctionNS(fn.ObjectMeta.Namespace)
 
 	existingDepl, err := deploy.kubernetesClient.AppsV1().Deployments(ns).Get(ctx, fnObjName, metav1.GetOptions{})
 	if err != nil {
@@ -708,10 +699,7 @@ func (deploy *NewDeploy) fnDelete(ctx context.Context, fn *fv1.Function) error {
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns, so cleaning up resources there
-	ns := deploy.namespace
-	if fn.ObjectMeta.Namespace != metav1.NamespaceDefault {
-		ns = fn.ObjectMeta.Namespace
-	}
+	ns := deploy.nsResolver.GetFunctionNS(fn.ObjectMeta.Namespace)
 
 	err = deploy.cleanupNewdeploy(ctx, ns, objName)
 	multierr = multierror.Append(multierr, err)

--- a/pkg/executor/executortype/newdeploy/newdeploymgr_test.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr_test.go
@@ -80,7 +80,7 @@ func TestRefreshFuncPods(t *testing.T) {
 		t.Fatalf("Error creating fetcher config: %s", err)
 	}
 
-	executor, err := MakeNewDeploy(ctx, logger, fissionClient, kubernetesClient, functionNamespace, fetcherConfig, "test",
+	executor, err := MakeNewDeploy(ctx, logger, fissionClient, kubernetesClient, fetcherConfig, "test",
 		funcInformer, envInformer, deployInformer, svcInformer, podSpecPatch)
 	if err != nil {
 		t.Fatalf("new deploy manager creation failed: %s", err)

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -62,7 +62,6 @@ type (
 		env                      *fv1.Environment
 		deployment               *appsv1.Deployment            // kubernetes deployment
 		namespace                string                        // namespace to keep our resources
-		functionNamespace        string                        // fallback namespace for fission functions
 		podReadyTimeout          time.Duration                 // timeout for generic pods to become ready
 		fsCache                  *fscache.FunctionServiceCache // cache funcSvc's by function, address and podname
 		useSvc                   bool                          // create k8s service for specialized pods
@@ -92,7 +91,6 @@ func MakeGenericPool(
 	metricsClient metricsclient.Interface,
 	env *fv1.Environment,
 	namespace string,
-	functionNamespace string,
 	fsCache *fscache.FunctionServiceCache,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
@@ -122,7 +120,6 @@ func MakeGenericPool(
 		kubernetesClient:         kubernetesClient,
 		metricsClient:            metricsClient,
 		namespace:                namespace,
-		functionNamespace:        functionNamespace,
 		podReadyTimeout:          podReadyTimeout,
 		fsCache:                  fsCache,
 		fetcherConfig:            fetcherConfig,
@@ -446,7 +443,7 @@ func (gp *GenericPool) createSvc(ctx context.Context, name string, labels map[st
 }
 
 func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
-	logger := otelUtils.LoggerWithTraceID(ctx, gp.logger).With(zap.String("function", fn.ObjectMeta.Name), zap.String("functionNamespace", fn.ObjectMeta.Namespace),
+	logger := otelUtils.LoggerWithTraceID(ctx, gp.logger).With(zap.String("function", fn.ObjectMeta.Name), zap.String("namespace", fn.ObjectMeta.Namespace),
 		zap.String("env", fn.Spec.Environment.Name), zap.String("envNamespace", fn.Spec.Environment.Namespace))
 
 	logger.Info("choosing pod from pool")

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -40,14 +40,15 @@ import (
 	"github.com/fission/fission/pkg/executor/fscache"
 	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
 	flisterv1 "github.com/fission/fission/pkg/generated/listers/core/v1"
+	"github.com/fission/fission/pkg/utils"
 )
 
 type (
 	PoolPodController struct {
 		logger           *zap.Logger
 		kubernetesClient kubernetes.Interface
-		namespace        string
 		enableIstio      bool
+		nsResolver       *utils.NamespaceResolver
 
 		envLister       map[string]flisterv1.EnvironmentLister
 		envListerSynced map[string]k8sCache.InformerSynced
@@ -69,7 +70,6 @@ type (
 
 func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 	kubernetesClient kubernetes.Interface,
-	namespace string,
 	enableIstio bool,
 	funcInformer map[string]finformerv1.FunctionInformer,
 	pkgInformer map[string]finformerv1.PackageInformer,
@@ -79,8 +79,8 @@ func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 	logger = logger.Named("pool_pod_controller")
 	p := &PoolPodController{
 		logger:               logger,
+		nsResolver:           utils.GetFissionNamespaces(),
 		kubernetesClient:     kubernetesClient,
-		namespace:            namespace,
 		enableIstio:          enableIstio,
 		envLister:            make(map[string]flisterv1.EnvironmentLister, 0),
 		envListerSynced:      make(map[string]k8sCache.InformerSynced, 0),
@@ -89,10 +89,10 @@ func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 		spCleanupPodQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SpecializedPodCleanupQueue"),
 	}
 	for _, informer := range funcInformer {
-		informer.Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.namespace, p.enableIstio))
+		informer.Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace), p.enableIstio))
 	}
 	for _, informer := range pkgInformer {
-		informer.Informer().AddEventHandler(PackageEventHandlers(ctx, p.logger, p.kubernetesClient, p.namespace))
+		informer.Informer().AddEventHandler(PackageEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace)))
 	}
 	for ns, informer := range envInformer {
 		informer.Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
@@ -373,7 +373,7 @@ func (p *PoolPodController) envDeleteQueueProcessFunc(ctx context.Context) bool 
 	p.logger.Debug("env delete request processing")
 	p.gpm.cleanupPool(ctx, env)
 	specializePodLables := getSpecializedPodLabels(env)
-	specializedPods, err := p.podLister.Pods(p.gpm.namespace).List(labels.SelectorFromSet(specializePodLables))
+	specializedPods, err := p.podLister.Pods(p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace)).List(labels.SelectorFromSet(specializePodLables))
 	if err != nil {
 		p.logger.Error("failed to list specialized pods", zap.Error(err))
 		p.envDeleteQueue.Forget(obj)

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
@@ -68,8 +68,7 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 	gpmPodInformer := gpmInformerFactory.Core().V1().Pods()
 	gpmRsInformer := gpmInformerFactory.Apps().V1().ReplicaSets()
 
-	fnNamespace := "fission-function"
-	ppc := NewPoolPodController(ctx, logger, kubernetesClient, fnNamespace, false,
+	ppc := NewPoolPodController(ctx, logger, kubernetesClient, false,
 		funcInformer,
 		pkgInformer,
 		envInformer,
@@ -85,7 +84,7 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 	executor, err := MakeGenericPoolManager(ctx,
 		logger,
 		fissionClient, kubernetesClient, metricsClient,
-		fnNamespace, fetcherConfig, executorInstanceID,
+		fetcherConfig, executorInstanceID,
 		funcInformer, pkgInformer, envInformer,
 		gpmPodInformer, gpmRsInformer, nil)
 	if err != nil {

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -184,7 +184,7 @@ func CleanupHpa(ctx context.Context, logger *zap.Logger, client kubernetes.Inter
 
 // CleanupRoleBindings periodically lists rolebindings across all namespaces and removes Service Accounts from them or
 // deletes the rolebindings completely if there are no Service Accounts in a rolebinding object.
-func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, fissionClient versioned.Interface, functionNs, envBuilderNs string, cleanupRoleBindingInterval time.Duration) {
+func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, fissionClient versioned.Interface, functionNs string, cleanupRoleBindingInterval time.Duration) {
 	for {
 		// some sleep before the next reaper iteration
 		time.Sleep(cleanupRoleBindingInterval)
@@ -238,8 +238,7 @@ func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kuberne
 				// so now we need to look for the objects in default namespace.
 				saNs := subj.Namespace
 				isInReservedNS := false
-				if subj.Namespace == functionNs ||
-					subj.Namespace == envBuilderNs {
+				if subj.Namespace == functionNs {
 					saNs = metav1.NamespaceDefault
 					isInReservedNS = true
 				}
@@ -249,7 +248,7 @@ func CleanupRoleBindings(ctx context.Context, logger *zap.Logger, client kuberne
 				for _, fn := range funcList.Items {
 					if fn.Spec.Environment.Namespace == saNs ||
 						//  For the case that the environment is created in the reserved namespace.
-						(isInReservedNS && (fn.Spec.Environment.Namespace == functionNs || fn.Spec.Environment.Namespace == envBuilderNs)) {
+						(isInReservedNS && (fn.Spec.Environment.Namespace == functionNs)) {
 						funcEnvReference = true
 						break
 					}

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -1,0 +1,55 @@
+package utils
+
+import (
+	"os"
+
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type NamespaceResolver struct {
+	FunctionNamespace string
+	BuiderNamespace   string
+	DefaultNamespace  string
+}
+
+func (nsr *NamespaceResolver) GetBuilderNS(namespace string) string {
+	if nsr.FunctionNamespace == "" || nsr.BuiderNamespace == "" {
+		return nsr.DefaultNamespace
+	}
+
+	var ns string
+	ns = nsr.BuiderNamespace
+	if namespace != metav1.NamespaceDefault {
+		ns = namespace
+	}
+	return ns
+}
+
+func (nsr *NamespaceResolver) GetFunctionNS(namespace string) string {
+	if nsr.FunctionNamespace == "" || nsr.BuiderNamespace == "" {
+		return nsr.DefaultNamespace
+	}
+
+	ns := nsr.FunctionNamespace
+	if namespace != metav1.NamespaceDefault {
+		ns = namespace
+	}
+	return ns
+}
+
+func (nsr *NamespaceResolver) ResolveNamespace(namespace string) string {
+	if nsr.FunctionNamespace == "" || nsr.BuiderNamespace == "" {
+		return nsr.DefaultNamespace
+	}
+	return namespace
+}
+
+// GetFissionNamespaces => return all fission core component namespaces
+func GetFissionNamespaces() *NamespaceResolver {
+	return &NamespaceResolver{
+		FunctionNamespace: os.Getenv(v1.ENV_FUNCTION_NAMESPACE),
+		BuiderNamespace:   os.Getenv(v1.ENV_FUNCTION_NAMESPACE),
+		DefaultNamespace:  os.Getenv(v1.ENV_DEFAULT_NAMESPACE),
+	}
+}


### PR DESCRIPTION
Create function/builder namespace if not exists

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

Add variables for function/builder namespace in test

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

remove builderNamespace from fission

remove functionNamespace from fission

support for existing fission namespaces

code review changes

Replace builder and function namespace with template

Fix namespace creation template

Revert changes merged

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
