### PR TITLE
use namespace flag from global options for watch command

### DIFF
--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -19,6 +19,7 @@ package function
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -61,7 +62,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 	}
 
 	server, err := util.GetApplicationUrl(input.Context(), opts.Client(), "application=fission-api")
-	if err != nil {
+	if err != nil && !strings.Contains(err.Error(), "no available pod for port-forwarding with label selector") {
 		return err
 	}
 

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -19,7 +19,6 @@ package function
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -62,7 +61,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 	}
 
 	server, err := util.GetApplicationUrl(input.Context(), opts.Client(), "application=fission-api")
-	if err != nil && !strings.Contains(err.Error(), "no available pod for port-forwarding with label selector") {
+	if err != nil {
 		return err
 	}
 

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}
 	wrapper.SetFlags(createCmd, flag.FlagSet{
 		Required: []flag.Flag{flag.KwFnName},
-		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.KwNamespace, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
+		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
 		// TODO: add label selector flag
 		// flag.KwLabelsFlag
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Use namespace flag (--namespace) from the global options for watch command instead of local flag for specifying ns value.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #
https://github.com/fission/fission/issues/2595

## Testing
<!--- Please describe in detail how you tested your changes. -->
use: -n or --namespace flag for specifying namespace value in `watch` command. 
eg, `fission watch list -n ns1`

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
