### PR TITLE
Validation to allow functions use secrets/configmap from function's namespace 

### DIFF
--- a/pkg/apis/core/v1/function_webhook.go
+++ b/pkg/apis/core/v1/function_webhook.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,6 +52,20 @@ var _ webhook.Validator = &Function{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Function) ValidateCreate() error {
 	functionlog.Debug("validate create", zap.String("name", r.Name))
+
+	for _, cnfMap := range r.Spec.ConfigMaps {
+		if cnfMap.Namespace != r.ObjectMeta.Namespace {
+			err := fmt.Errorf("ConfigMap's [%s] and function's Namespace [%s] are different. ConfigMap needs to be present in the same namespace as function", cnfMap.Namespace, r.ObjectMeta.Namespace)
+			return AggregateValidationErrors("Function", err)
+		}
+	}
+	for _, secret := range r.Spec.Secrets {
+		if secret.Namespace != r.ObjectMeta.Namespace {
+			err := fmt.Errorf("secret  [%s] and function's Namespace [%s] are different. Secret needs to be present in the same namespace as function", secret.Namespace, r.ObjectMeta.Namespace)
+			return AggregateValidationErrors("Function", err)
+		}
+	}
+
 	err := r.Validate()
 	if err != nil {
 		return AggregateValidationErrors("Function", err)
@@ -60,6 +76,20 @@ func (r *Function) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *Function) ValidateUpdate(old runtime.Object) error {
 	functionlog.Debug("validate update", zap.String("name", r.Name))
+
+	for _, cnfMap := range r.Spec.ConfigMaps {
+		if cnfMap.Namespace != r.ObjectMeta.Namespace {
+			err := fmt.Errorf("ConfigMap's [%s] and function's Namespace [%s] are different. ConfigMap needs to be present in the same namespace as function", cnfMap.Namespace, r.ObjectMeta.Namespace)
+			return AggregateValidationErrors("Function", err)
+		}
+	}
+	for _, secret := range r.Spec.Secrets {
+		if secret.Namespace != r.ObjectMeta.Namespace {
+			err := fmt.Errorf("secret  [%s] and function's Namespace [%s] are different. Secret needs to be present in the same namespace as function", secret.Namespace, r.ObjectMeta.Namespace)
+			return AggregateValidationErrors("Function", err)
+		}
+	}
+
 	err := r.Validate()
 	if err != nil {
 		return AggregateValidationErrors("Function", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Validation will make sure that functions and its corresponding secrets/configmaps are present in same namespace.
This helps in achieving multi-tenancy goals

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
