### PR TITLE
Remove healthy Controller check in CLI `fission check` command 

### DIFF
--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -153,12 +153,6 @@ func (hc *HealthChecker) allCategories() []*Category {
 			FissionServices,
 			[]Checker{
 				{
-					successMsg: "controller is running fine",
-					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
-						return hc.CheckServiceStatus(ctx, hc.fissionNamespace, "controller")
-					},
-				},
-				{
 					successMsg: "executor is running fine",
 					check: func(ctx context.Context, input cli.Input, client cmd.Client) error {
 						return hc.CheckServiceStatus(ctx, hc.fissionNamespace, "executor")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Removed CLI check for controller in  `fission check` command  as Controller is deprecated from 1.18-rc1 release. 

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
