### PR TITLE
Handle logs from all pods in function and error condition in fission fn log command

### DIFF
--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -133,7 +133,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{
 			flag.FnLogFollow, flag.FnLogReverseQuery, flag.FnLogCount,
-			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.FnLogDBType, flag.NamespacePod},
+			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.FnLogDBType, flag.NamespacePod, flag.FnLogAllPods},
 	})
 
 	testCmd := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -52,6 +52,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 
 	logReverseQuery := !input.Bool(flagkey.FnLogFollow) && input.Bool(flagkey.FnLogReverseQuery)
 
+	allPods := input.Bool(flagkey.FnLogAllPods)
 	recordLimit := input.Int(flagkey.FnLogCount)
 	if recordLimit <= 0 {
 		recordLimit = 1000
@@ -94,6 +95,7 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 					FunctionObject: f,
 					Details:        detail,
 					WarnUser:       warn,
+					AllPods:        allPods,
 				}
 
 				buf := new(bytes.Buffer)

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -130,6 +130,7 @@ var (
 	FnRequestsPerPod        = Flag{Type: Int, Name: flagkey.FnRequestsPerPod, Aliases: []string{"rpp"}, Usage: "Maximum number of concurrent requests that can be served by a specialized pod", DefaultValue: 1}
 	FnOnceOnly              = Flag{Type: Bool, Name: flagkey.FnOnceOnly, Aliases: []string{"yolo"}, Usage: "Specifies if specialized pod will serve exactly one request in its lifetime"}
 	FnSubPath               = Flag{Type: String, Name: flagkey.FnSubPath, Usage: "Sub Path to check if function internally supports routing"}
+	FnLogAllPods            = Flag{Type: Bool, Name: flagkey.FnLogAllPods, Usage: "Get all pod's logs in the function."}
 	// Termination Grace Period configurable at function creation/update only for container functions
 	FnTerminationGracePeriod = Flag{Type: Int64, Name: flagkey.FnGracePeriod, Usage: "Grace time (in seconds) for pod to perform connection draining before termination (default value will be used if negative value is given)", DefaultValue: 360}
 

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -84,6 +84,7 @@ const (
 	FnOnceOnly              = "onceonly"
 	FnSubPath               = "subpath"
 	FnGracePeriod           = "graceperiod"
+	FnLogAllPods            = "all-pods"
 
 	HtName              = resourceName
 	HtMethod            = "method"

--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
@@ -101,7 +100,6 @@ func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFil
 
 func streamContainerLog(ctx context.Context, kubernetesClient kubernetes.Interface, pod *v1.Pod, logFilter LogFilter) (output *bytes.Buffer, err error) {
 
-	seq := strings.Repeat("=", 35)
 	output = new(bytes.Buffer)
 
 	for _, container := range pod.Spec.Containers {
@@ -121,9 +119,8 @@ func streamContainerLog(ctx context.Context, kubernetesClient kubernetes.Interfa
 
 		if logFilter.Details {
 			fn := logFilter.FunctionObject
-			msg := fmt.Sprintf("\n%v\nFunction: %v\nEnvironment: %v\nNamespace: %v\nPod: %v\nContainer: %v\nNode: %v\n%v\n", seq,
-				fn.ObjectMeta.Name, fn.Spec.Environment.Name, pod.Namespace, pod.Name, container.Name, pod.Spec.NodeName, seq)
-
+			msg := fmt.Sprintf("\n=== Function=%s Environment=%s Namespace=%s Pod=%s Container=%s Node=%s\n",
+				fn.ObjectMeta.Name, fn.Spec.Environment.Name, pod.Namespace, pod.Name, container.Name, pod.Spec.NodeName)
 			if _, err := output.WriteString(msg); err != nil {
 				return output, errors.Wrapf(err, "error copying pod log")
 			}

--- a/pkg/fission-cli/logdb/logdb.go
+++ b/pkg/fission-cli/logdb/logdb.go
@@ -31,7 +31,7 @@ const (
 )
 
 type LogDatabase interface {
-	GetLogs(context.Context, LogFilter) (*bytes.Buffer, error)
+	GetLogs(context.Context, LogFilter, *bytes.Buffer) error
 }
 
 type LogFilter struct {
@@ -44,6 +44,7 @@ type LogFilter struct {
 	RecordLimit    int
 	FunctionObject *v1.Function
 	Details        bool
+	WarnUser       bool
 }
 
 type LogEntry struct {

--- a/pkg/fission-cli/logdb/logdb.go
+++ b/pkg/fission-cli/logdb/logdb.go
@@ -45,6 +45,7 @@ type LogFilter struct {
 	FunctionObject *v1.Function
 	Details        bool
 	WarnUser       bool
+	AllPods        bool
 }
 
 type LogEntry struct {

--- a/test/upgrade_test/fission_objects.sh
+++ b/test/upgrade_test/fission_objects.sh
@@ -3,7 +3,7 @@ set -eu
 
 ns="fission"
 ROOT=$(pwd)
-PREV_STABLE_VERSION=1.13.1
+PREV_STABLE_VERSION=v1.16.3
 HELM_VARS_PREV_RELEASE="routerServiceType=NodePort,analytics=false"
 HELM_VARS_LATEST_RELEASE="routerServiceType=NodePort,repository=docker.io/library,image=fission-bundle,pullPolicy=IfNotPresent,imageTag=latest,fetcher.image=docker.io/library/fetcher,fetcher.imageTag=latest,postInstallReportImage=reporter,preUpgradeChecks.image=preupgradechecks,preUpgradeChecks.imageTag=latest,analytics=false"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
- Handle error while fetching logs
- use %s instead of %v while printing data to CLI
- use correct time to fetch updated logs 
- add `--all-pods` flag-
        - all-pods= true - fetches logs from all the Pods which are running for the Fission function. 
        - all-pods= false(**default value**) -  fetches logs for latest pod which was running for the function
eg of `fn log` command with `--all-pods` flag,
![log-all-pod](https://user-images.githubusercontent.com/23420056/203545665-71517759-1b9b-4ff8-80f5-7114e7582626.png)
 

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
