### PR TITLE
get builder log in package create command

### DIFF
--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -33,7 +33,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgBuildCmd,
-			flag.NamespacePackage, flag.SpecSave, flag.SpecDry},
+			flag.NamespacePackage, flag.SpecSave, flag.SpecDry, flag.StreamLog},
 	})
 
 	getSrcCmd := &cobra.Command{

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -207,6 +207,7 @@ var (
 	PkgSrcArchive     = Flag{Type: StringSlice, Name: flagkey.PkgSrcArchive, Aliases: []string{"source", "src"}, Usage: "URL or local paths for source archive"}
 	PkgSrcChecksum    = Flag{Type: String, Name: flagkey.PkgSrcChecksum, Usage: "SHA256 checksum of source archive when providing URL"}
 	PkgInsecure       = Flag{Type: Bool, Name: flagkey.PkgInsecure, Usage: "Skip generating SHA256 checksum for file integrity validation"}
+	StreamLog         = Flag{Type: Bool, Name: flagkey.StreamLog, Usage: "View the build logs"}
 
 	SpecSave             = Flag{Type: Bool, Name: flagkey.SpecSave, Usage: "Save to the spec directory instead of creating on cluster"}
 	SpecDir              = Flag{Type: String, Name: flagkey.SpecDir, Usage: "Directory to store specs, defaults to ./specs"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -159,6 +159,7 @@ const (
 	PkgOutput         = Output
 	PkgStatus         = "status"
 	PkgOrphan         = "orphan"
+	StreamLog         = "streamlog"
 
 	SpecSave             = "spec"
 	SpecDir              = "specdir"

--- a/pkg/utils/variables.go
+++ b/pkg/utils/variables.go
@@ -1,0 +1,6 @@
+package utils
+
+var (
+	Service = "svc"
+	BuilMgr = "buildermgr"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
added `--streamlog` tag in  `package create` command . 
This will fetch logs of `package creation`

example,
![builderLog](https://user-images.githubusercontent.com/23420056/204264425-e578e8c8-7ec0-430e-aac8-0b71d036388d.png)


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/2643)
<!-- Reviewable:end -->
