### PR TITLE
Enable security context by default

### DIFF
--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -166,7 +166,7 @@ executor:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -303,7 +303,7 @@ router:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -329,7 +329,7 @@ buildermgr:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -357,7 +357,7 @@ controller:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -394,7 +394,7 @@ webhook:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -421,7 +421,7 @@ kubewatcher:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -453,7 +453,7 @@ storagesvc:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -480,7 +480,7 @@ timer:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001
@@ -725,7 +725,7 @@ canaryDeployment:
   ## This is an experimental section, please verify before enabling in production.
   ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
   securityContext:
-    enabled: false
+    enabled: true
     ## Mark it false, if you want to stop the non root user validation
     runAsNonRoot: true
     fsGroup: 10001

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -58,13 +58,6 @@ deploy:
         # Use /var/log directory for kind logs export
         terminationMessagePath: /var/log/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
-        executor.securityContext.enabled: true
-        router.securityContext.enabled: true
-        buildermgr.securityContext.enabled: true
-        controller.securityContext.enabled: true
-        kubewatcher.securityContext.enabled: true
-        webhook.securityContext.enabled: true
-        storagesvc.securityContext.enabled: true
         controller.enabled: false
         serviceMonitor.enabled: false
         serviceMonitor.namespace: monitoring


### PR DESCRIPTION
We enable security context by default now, so that fission pod do not have root access to system.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
