### PR TITLE
add version info in fission check CLI

### DIFF
--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -101,13 +101,14 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
 
 		// CRD resources
-		"fission-crd-packages":     resources.NewCrdDumper(opts.Client(), resources.CrdPackage),
-		"fission-crd-environments": resources.NewCrdDumper(opts.Client(), resources.CrdEnvironment),
-		"fission-crd-functions":    resources.NewCrdDumper(opts.Client(), resources.CrdFunction),
-		"fission-crd-httptriggers": resources.NewCrdDumper(opts.Client(), resources.CrdHttpTrigger),
-		"fission-crd-kubewatchers": resources.NewCrdDumper(opts.Client(), resources.CrdKubeWatcher),
-		"fission-crd-mqtriggers":   resources.NewCrdDumper(opts.Client(), resources.CrdMessageQueueTrigger),
-		"fission-crd-timetriggers": resources.NewCrdDumper(opts.Client(), resources.CrdTimeTrigger),
+		"fission-crd-packages":      resources.NewCrdDumper(opts.Client(), resources.CrdPackage),
+		"fission-crd-environments":  resources.NewCrdDumper(opts.Client(), resources.CrdEnvironment),
+		"fission-crd-functions":     resources.NewCrdDumper(opts.Client(), resources.CrdFunction),
+		"fission-crd-httptriggers":  resources.NewCrdDumper(opts.Client(), resources.CrdHttpTrigger),
+		"fission-crd-kubewatchers":  resources.NewCrdDumper(opts.Client(), resources.CrdKubeWatcher),
+		"fission-crd-mqtriggers":    resources.NewCrdDumper(opts.Client(), resources.CrdMessageQueueTrigger),
+		"fission-crd-timetriggers":  resources.NewCrdDumper(opts.Client(), resources.CrdTimeTrigger),
+		"fission-crd-canaryconfigs": resources.NewCrdDumper(opts.Client(), resources.CrdCanaryConfig),
 	}
 
 	dumpName := fmt.Sprintf("%v_%v", DUMP_ARCHIVE_PREFIX, time.Now().Unix())

--- a/pkg/fission-cli/cmd/support/resources/crd.go
+++ b/pkg/fission-cli/cmd/support/resources/crd.go
@@ -36,6 +36,8 @@ const (
 	CrdKubeWatcher         = "KubeWatcher"
 	CrdMessageQueueTrigger = "MessageQueue"
 	CrdTimeTrigger         = "TimeTrigger"
+
+	CrdCanaryConfig = "CanaryConfig"
 )
 
 type CrdDumper struct {
@@ -128,6 +130,18 @@ func (res CrdDumper) Dump(ctx context.Context, dumpDir string) {
 
 	case CrdTimeTrigger:
 		items, err := res.client.FissionClientSet.CoreV1().TimeTriggers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
+			return
+		}
+
+		for _, item := range items.Items {
+			f := getFileName(dumpDir, item.ObjectMeta)
+			writeToFile(f, item)
+		}
+
+	case CrdCanaryConfig:
+		items, err := res.client.FissionClientSet.CoreV1().CanaryConfigs(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.crdType, err))
 			return


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
add canary config in dump
check `webhook` server is running fine

eg,
![fissionCheck](https://user-images.githubusercontent.com/23420056/204520234-6cbd0741-9d33-4094-b98d-c0a39b9d70d1.png)
 
also,
`fission check -v 2` gives info about Fission version  

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
