### PR TITLE
K8s informer to work with specific namespaces for builder manager

### DIFF
--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
-	k8sInformers "k8s.io/client-go/informers"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
@@ -65,10 +64,9 @@ func Start(ctx context.Context, logger *zap.Logger, storageSvcUrl string) error 
 	envWatcher := makeEnvironmentWatcher(ctx, bmLogger, fissionClient, kubernetesClient, fetcherConfig, podSpecPatch)
 	envWatcher.Run(ctx)
 
-	k8sInformerFactory := k8sInformers.NewSharedInformerFactory(kubernetesClient, time.Minute*30)
-	podInformer := k8sInformerFactory.Core().V1().Pods().Informer()
 	pkgWatcher := makePackageWatcher(bmLogger, fissionClient,
-		kubernetesClient, storageSvcUrl, podInformer,
+		kubernetesClient, storageSvcUrl,
+		utils.GetK8sInformersForNamespaces(kubernetesClient, time.Minute*30, fv1.Pods),
 		utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.PackagesResource))
 	pkgWatcher.Run(ctx)
 	return nil

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -41,7 +41,7 @@ type (
 		fissionClient versioned.Interface
 		nsResolver    *utils.NamespaceResolver
 		k8sClient     kubernetes.Interface
-		podInformer   k8sCache.SharedIndexInformer
+		podInformer   map[string]k8sCache.SharedIndexInformer
 		pkgInformer   map[string]k8sCache.SharedIndexInformer
 		storageSvcUrl string
 		buildCache    *cache.Cache
@@ -49,7 +49,7 @@ type (
 )
 
 func makePackageWatcher(logger *zap.Logger, fissionClient versioned.Interface, k8sClientSet kubernetes.Interface,
-	storageSvcUrl string, podInformer k8sCache.SharedIndexInformer,
+	storageSvcUrl string, podInformer,
 	pkgInformer map[string]k8sCache.SharedIndexInformer) *packageWatcher {
 	pkgw := &packageWatcher{
 		logger:        logger.Named("package_watcher"),
@@ -131,140 +131,148 @@ func (pkgw *packageWatcher) build(ctx context.Context, srcpkg *fv1.Package) {
 	for healthCheckBackOff.NextExists() {
 		// Informer store is not able to use label to find the pod,
 		// iterate all available environment builders.
-		items := pkgw.podInformer.GetStore().List()
-		if err != nil {
-			pkgw.logger.Error("error retrieving pod information for environment", zap.Error(err), zap.String("environment", env.ObjectMeta.Name))
-			return
-		}
-
-		if len(items) == 0 {
-			pkgw.logger.Info("builder pod does not exist for environment, will retry again later", zap.String("environment", pkg.Spec.Environment.Name))
-			time.Sleep(healthCheckBackOff.GetCurrentBackoffDuration())
-			continue
-		}
-
-		for _, item := range items {
-			pod := item.(*apiv1.Pod)
-
-			builderNs := pkgw.nsResolver.GetBuilderNS(env.ObjectMeta.Namespace)
-
-			// Filter non-matching pods
-			if pod.ObjectMeta.Labels[LABEL_ENV_NAME] != env.ObjectMeta.Name ||
-				pod.ObjectMeta.Labels[LABEL_ENV_NAMESPACE] != builderNs ||
-				pod.ObjectMeta.Labels[LABEL_ENV_RESOURCEVERSION] != env.ObjectMeta.ResourceVersion {
-				continue
+		buildPkg := func(podInformer k8sCache.SharedIndexInformer) bool {
+			items := podInformer.GetStore().List()
+			if err != nil {
+				pkgw.logger.Error("error retrieving pod information for environment", zap.Error(err), zap.String("environment", env.ObjectMeta.Name))
+				return true
 			}
 
-			// Pod may become "Running" state but still failed at health check, so use
-			// pod.Status.ContainerStatuses instead of pod.Status.Phase to check pod readiness states.
-			podIsReady := true
-
-			for _, cStatus := range pod.Status.ContainerStatuses {
-				podIsReady = podIsReady && cStatus.Ready
-			}
-
-			if !podIsReady {
-				pkgw.logger.Info("builder pod is not ready for environment, will retry again later", zap.String("environment", pkg.Spec.Environment.Name))
+			if len(items) == 0 {
+				pkgw.logger.Info("builder pod does not exist for environment, will retry again later", zap.String("environment", pkg.Spec.Environment.Name))
 				time.Sleep(healthCheckBackOff.GetCurrentBackoffDuration())
-				break
 			}
 
-			// Add the package getter rolebinding to builder sa
-			// we continue here if role binding was not setup successfully. this is because without this, the fetcher won't be able to fetch the source pkg into the container and
-			// the build will fail eventually
-			err := utils.SetupRoleBinding(ctx, pkgw.logger, pkgw.k8sClient, fv1.PackageGetterRB, pkg.ObjectMeta.Namespace, utils.GetPackageGetterCR(), fv1.ClusterRole, fv1.FissionBuilderSA, builderNs)
-			if err != nil {
-				pkgw.logger.Error("error setting up role binding for package",
-					zap.Error(err),
-					zap.String("role_binding", fv1.PackageGetterRB),
-					zap.String("package_name", pkg.ObjectMeta.Name),
-					zap.String("package_namespace", pkg.ObjectMeta.Namespace))
-				continue
-			} else {
-				pkgw.logger.Info("setup rolebinding for sa package",
-					zap.String("sa", fmt.Sprintf("%s.%s", fv1.FissionBuilderSA, builderNs)),
-					zap.String("package", fmt.Sprintf("%s.%s", pkg.ObjectMeta.Name, pkg.ObjectMeta.Namespace)))
-			}
+			for _, item := range items {
+				pod := item.(*apiv1.Pod)
 
-			uploadResp, buildLogs, err := buildPackage(ctx, pkgw.logger, pkgw.fissionClient, builderNs, pkgw.storageSvcUrl, pkg)
-			if err != nil {
-				pkgw.logger.Error("error building package", zap.Error(err), zap.String("package_name", pkg.ObjectMeta.Name))
-				_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-				if er != nil {
-					pkgw.logger.Error(
-						"error updating package",
-						zap.String("package_name", pkg.ObjectMeta.Name),
-						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-						zap.Error(er),
-					)
+				builderNs := pkgw.nsResolver.GetBuilderNS(env.ObjectMeta.Namespace)
+
+				// Filter non-matching pods
+				if pod.ObjectMeta.Labels[LABEL_ENV_NAME] != env.ObjectMeta.Name ||
+					pod.ObjectMeta.Labels[LABEL_ENV_NAMESPACE] != builderNs ||
+					pod.ObjectMeta.Labels[LABEL_ENV_RESOURCEVERSION] != env.ObjectMeta.ResourceVersion {
+					continue
 				}
-				return
-			}
 
-			pkgw.logger.Info("starting package info update", zap.String("package_name", pkg.ObjectMeta.Name))
+				// Pod may become "Running" state but still failed at health check, so use
+				// pod.Status.ContainerStatuses instead of pod.Status.Phase to check pod readiness states.
+				podIsReady := true
 
-			fnList, err := pkgw.fissionClient.CoreV1().
-				Functions(pkg.Namespace).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				e := "error getting function list"
-				pkgw.logger.Error(e, zap.Error(err))
-				buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-				_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-				if er != nil {
-					pkgw.logger.Error(
-						"error updating package",
-						zap.String("package_name", pkg.ObjectMeta.Name),
-						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-						zap.Error(er),
-					)
+				for _, cStatus := range pod.Status.ContainerStatuses {
+					podIsReady = podIsReady && cStatus.Ready
 				}
-			}
 
-			// A package may be used by multiple functions. Update
-			// functions with old package resource version
-			for _, fn := range fnList.Items {
-				if fn.Spec.Package.PackageRef.Name == pkg.ObjectMeta.Name &&
-					fn.Spec.Package.PackageRef.Namespace == pkg.ObjectMeta.Namespace &&
-					fn.Spec.Package.PackageRef.ResourceVersion != pkg.ObjectMeta.ResourceVersion {
-					fn.Spec.Package.PackageRef.ResourceVersion = pkg.ObjectMeta.ResourceVersion
-					// update CRD
-					_, err = pkgw.fissionClient.CoreV1().Functions(fn.ObjectMeta.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
-					if err != nil {
-						e := "error updating function package resource version"
-						pkgw.logger.Error(e, zap.Error(err))
-						buildLogs += fmt.Sprintf("%s: %v\n", e, err)
-						_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-						if er != nil {
-							pkgw.logger.Error(
-								"error updating package",
-								zap.String("package_name", pkg.ObjectMeta.Name),
-								zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-								zap.Error(er),
-							)
-						}
-						return
+				if !podIsReady {
+					pkgw.logger.Info("builder pod is not ready for environment, will retry again later", zap.String("environment", pkg.Spec.Environment.Name))
+					time.Sleep(healthCheckBackOff.GetCurrentBackoffDuration())
+					break
+				}
+
+				// Add the package getter rolebinding to builder sa
+				// we continue here if role binding was not setup successfully. this is because without this, the fetcher won't be able to fetch the source pkg into the container and
+				// the build will fail eventually
+				err := utils.SetupRoleBinding(ctx, pkgw.logger, pkgw.k8sClient, fv1.PackageGetterRB, pkg.ObjectMeta.Namespace, utils.GetPackageGetterCR(), fv1.ClusterRole, fv1.FissionBuilderSA, builderNs)
+				if err != nil {
+					pkgw.logger.Error("error setting up role binding for package",
+						zap.Error(err),
+						zap.String("role_binding", fv1.PackageGetterRB),
+						zap.String("package_name", pkg.ObjectMeta.Name),
+						zap.String("package_namespace", pkg.ObjectMeta.Namespace))
+					continue
+				} else {
+					pkgw.logger.Info("setup rolebinding for sa package",
+						zap.String("sa", fmt.Sprintf("%s.%s", fv1.FissionBuilderSA, builderNs)),
+						zap.String("package", fmt.Sprintf("%s.%s", pkg.ObjectMeta.Name, pkg.ObjectMeta.Namespace)))
+				}
+
+				uploadResp, buildLogs, err := buildPackage(ctx, pkgw.logger, pkgw.fissionClient, builderNs, pkgw.storageSvcUrl, pkg)
+				if err != nil {
+					pkgw.logger.Error("error building package", zap.Error(err), zap.String("package_name", pkg.ObjectMeta.Name))
+					_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+					if er != nil {
+						pkgw.logger.Error(
+							"error updating package",
+							zap.String("package_name", pkg.ObjectMeta.Name),
+							zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+							zap.Error(er),
+						)
+					}
+					return false
+				}
+
+				pkgw.logger.Info("starting package info update", zap.String("package_name", pkg.ObjectMeta.Name))
+
+				fnList, err := pkgw.fissionClient.CoreV1().
+					Functions(pkg.Namespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					e := "error getting function list"
+					pkgw.logger.Error(e, zap.Error(err))
+					buildLogs += fmt.Sprintf("%s: %v\n", e, err)
+					_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+					if er != nil {
+						pkgw.logger.Error(
+							"error updating package",
+							zap.String("package_name", pkg.ObjectMeta.Name),
+							zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+							zap.Error(er),
+						)
 					}
 				}
-			}
 
-			_, err = updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg,
-				fv1.BuildStatusSucceeded, buildLogs, uploadResp)
-			if err != nil {
-				pkgw.logger.Error("error updating package info", zap.Error(err), zap.String("package_name", pkg.ObjectMeta.Name))
-				_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
-				if er != nil {
-					pkgw.logger.Error(
-						"error updating package",
-						zap.String("package_name", pkg.ObjectMeta.Name),
-						zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
-						zap.Error(er),
-					)
+				// A package may be used by multiple functions. Update
+				// functions with old package resource version
+				for _, fn := range fnList.Items {
+					if fn.Spec.Package.PackageRef.Name == pkg.ObjectMeta.Name &&
+						fn.Spec.Package.PackageRef.Namespace == pkg.ObjectMeta.Namespace &&
+						fn.Spec.Package.PackageRef.ResourceVersion != pkg.ObjectMeta.ResourceVersion {
+						fn.Spec.Package.PackageRef.ResourceVersion = pkg.ObjectMeta.ResourceVersion
+						// update CRD
+						_, err = pkgw.fissionClient.CoreV1().Functions(fn.ObjectMeta.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
+						if err != nil {
+							e := "error updating function package resource version"
+							pkgw.logger.Error(e, zap.Error(err))
+							buildLogs += fmt.Sprintf("%s: %v\n", e, err)
+							_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+							if er != nil {
+								pkgw.logger.Error(
+									"error updating package",
+									zap.String("package_name", pkg.ObjectMeta.Name),
+									zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+									zap.Error(er),
+								)
+							}
+							return false
+						}
+					}
 				}
+
+				_, err = updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg,
+					fv1.BuildStatusSucceeded, buildLogs, uploadResp)
+				if err != nil {
+					pkgw.logger.Error("error updating package info", zap.Error(err), zap.String("package_name", pkg.ObjectMeta.Name))
+					_, er := updatePackage(ctx, pkgw.logger, pkgw.fissionClient, pkg, fv1.BuildStatusFailed, buildLogs, nil)
+					if er != nil {
+						pkgw.logger.Error(
+							"error updating package",
+							zap.String("package_name", pkg.ObjectMeta.Name),
+							zap.String("resource_version", pkg.ObjectMeta.ResourceVersion),
+							zap.Error(er),
+						)
+					}
+					return false
+				}
+
+				pkgw.logger.Info("completed package build request", zap.String("package_name", pkg.ObjectMeta.Name))
+				return false
+			}
+			return true
+		}
+
+		for _, podInformer := range pkgw.podInformer {
+			if isContinue := buildPkg(podInformer); !isContinue {
 				return
 			}
-
-			pkgw.logger.Info("completed package build request", zap.String("package_name", pkg.ObjectMeta.Name))
-			return
 		}
 		time.Sleep(healthCheckBackOff.GetNext())
 	}
@@ -327,7 +335,9 @@ func (pkgw *packageWatcher) packageInformerHandler(ctx context.Context) k8sCache
 
 func (pkgw *packageWatcher) Run(ctx context.Context) {
 	go metrics.ServeMetrics(ctx, pkgw.logger)
-	go pkgw.podInformer.Run(ctx.Done())
+	for _, podInformer := range pkgw.podInformer {
+		go podInformer.Run(ctx.Done())
+	}
 	for _, pkgInformer := range pkgw.pkgInformer {
 		pkgInformer.AddEventHandler(pkgw.packageInformerHandler(ctx))
 		go pkgInformer.Run(ctx.Done())


### PR DESCRIPTION
## Description
With the support of multi tenancy, fission will work with roles instead of cluster roles. And to achieve this fission needs to work with only specific namespaces instead of all namespaces.
With these changes informers for builder manager will work only in specific namespaces as provided by user in helm chart.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
