### PR TITLE
Generate kubernetes roles in fission-function and fission-builder namespace

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -100,6 +100,6 @@ Define the svc's name
 {{- if .Values.builderNamespace -}}
 {{- printf "%s" .Values.builderNamespace -}}
 {{- else -}}
-{{- printf "%s" .Values.builderNamespace -}}
+{{- printf "%s" .Values.defaultNamespace -}}
 {{- end -}}
 {{- end -}}

--- a/charts/fission-all/templates/buildermgr/role-kubernetes.yaml
+++ b/charts/fission-all/templates/buildermgr/role-kubernetes.yaml
@@ -4,10 +4,10 @@
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "buildermgr") $) }}
 {{- end }}
+{{- end }}
 {{- if .Values.builderNamespace -}}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" .Values.builderNamespace "component" "buildermgr") $) }}
 {{- end }}
 {{- if .Values.functionNamespace -}}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" .Values.functionNamespace "component" "buildermgr") $) }}
-{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/controller/role-kubernetes.yaml
+++ b/charts/fission-all/templates/controller/role-kubernetes.yaml
@@ -4,10 +4,10 @@
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "controller") $) }}
 {{- end }}
+{{- end }}
 {{- if .Values.builderNamespace -}}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" .Values.builderNamespace "component" "controller") $) }}
 {{- end }}
 {{- if .Values.functionNamespace -}}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" .Values.functionNamespace "component" "controller") $) }}
-{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/executor/role-kubernetes.yaml
+++ b/charts/fission-all/templates/executor/role-kubernetes.yaml
@@ -4,10 +4,10 @@
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "executor") $) }}
 {{- end }}
+{{- end }}
 {{- if .Values.builderNamespace -}}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" .Values.builderNamespace "component" "executor") $) }}
 {{- end }}
 {{- if .Values.functionNamespace -}}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" .Values.functionNamespace "component" "executor") $) }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
## Description
To support the backward compatibility, fission should allow to create environment and builder pods in their respective namespaces as mentioned by user in helm chart.

As of now fission is not able to create environment/builder pods inside functionNamespace and builderNamespace, if value for singleDefaultNamespace is set to true in helm chart.
With these changes roles will get get created inside  functionNamespace and builderNamespace as mentioned by user in helm chart and fission will be able to create environment and builder pods in their respective namespaces.


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
