### PR TITLE
Remove otel handler per function handler in router

### DIFF
--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -39,7 +39,6 @@ import (
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/metrics"
-	"github.com/fission/fission/pkg/utils/otel"
 )
 
 // HTTPTriggerSet represents an HTTP trigger set
@@ -200,12 +199,7 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router 
 			}
 		}
 
-		var handler http.Handler
-		if trigger.Spec.Prefix != nil && *trigger.Spec.Prefix != "" {
-			handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), *trigger.Spec.Prefix)
-		} else {
-			handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), trigger.Spec.RelativeURL)
-		}
+		handler := http.HandlerFunc(fh.handler)
 
 		if trigger.Spec.Prefix != nil && *trigger.Spec.Prefix != "" {
 			prefix := *trigger.Spec.Prefix
@@ -269,11 +263,9 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router 
 			unTapServiceTimeout:    ts.unTapServiceTimeout,
 		}
 
-		var handler http.Handler
 		internalRoute := utils.UrlForFunction(fn.ObjectMeta.Name, fn.ObjectMeta.Namespace)
 		internalPrefixRoute := internalRoute + "/"
-		handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), internalRoute)
-
+		handler := http.HandlerFunc(fh.handler)
 		muxRouter.Handle(internalRoute, handler)
 		muxRouter.PathPrefix(internalPrefixRoute).Handler(handler)
 		ts.logger.Debug("add internal handler and prefix route for function", zap.String("router", internalRoute), zap.Any("function", fn))


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

As we already register Otel handler at router level here https://github.com/fission/fission/blob/300739c031cd34e6f2f0b2e804d218303fa16423/pkg/router/router.go
We don't need to define an Otel handler for the function handler level. 

Initial analysis was done by Alex
https://fissionio.slack.com/archives/C3LUX6BBP/p1670500425911999

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
All span connections working properly.

![image](https://user-images.githubusercontent.com/1511975/206917554-3a4482fa-ccd0-487f-9290-21f6ca9dc034.png)

![image](https://user-images.githubusercontent.com/1511975/206917565-023369dc-5b48-4aae-a8af-eac37fe9212d.png)


## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
