### PR TITLE
Executor user informer factory in executors in place of informers

### DIFF
--- a/pkg/crd/client.go
+++ b/pkg/crd/client.go
@@ -33,6 +33,7 @@ import (
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
+	"github.com/fission/fission/pkg/utils"
 )
 
 // GetKubernetesClient gets a kubernetes client using the kubeconfig file at the
@@ -91,9 +92,13 @@ func MakeFissionClient() (versioned.Interface, kubernetes.Interface, apiextensio
 // WaitForCRDs does a timeout to check if CRDs have been installed
 func WaitForCRDs(ctx context.Context, logger *zap.Logger, fissionClient versioned.Interface) error {
 	logger.Info("Waiting for CRDs to be installed")
+	defaultNs := utils.DefaultNSResolver().DefaultNamespace
+	if defaultNs == "" {
+		defaultNs = metav1.NamespaceDefault
+	}
 	start := time.Now()
 	for {
-		fi := fissionClient.CoreV1().Functions(metav1.NamespaceDefault)
+		fi := fissionClient.CoreV1().Functions(defaultNs)
 		_, err := fi.List(ctx, metav1.ListOptions{})
 		if err != nil {
 			time.Sleep(100 * time.Millisecond)

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -49,7 +49,7 @@ import (
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
+	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/maps"
@@ -98,7 +98,7 @@ func MakeContainer(
 	fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface,
 	instanceID string,
-	funcInformer map[string]finformerv1.FunctionInformer,
+	finformerFactory map[string]genInformer.SharedInformerFactory,
 	cnmInformerFactory map[string]k8sInformers.SharedInformerFactory,
 ) (executortype.ExecutorType, error) {
 	enableIstio := false
@@ -139,8 +139,8 @@ func MakeContainer(
 		caaf.svcLister[ns] = informerFactory.Core().V1().Services().Lister()
 		caaf.svcListerSynced[ns] = informerFactory.Core().V1().Services().Informer().HasSynced
 	}
-	for _, informer := range funcInformer {
-		informer.Informer().AddEventHandler(caaf.FuncInformerHandler(ctx))
+	for _, factory := range finformerFactory {
+		factory.Core().V1().Functions().Informer().AddEventHandler(caaf.FuncInformerHandler(ctx))
 	}
 	return caaf, nil
 }

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -51,7 +51,7 @@ import (
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
+	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/maps"
@@ -103,8 +103,7 @@ func MakeNewDeploy(
 	kubernetesClient kubernetes.Interface,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	funcInformer map[string]finformerv1.FunctionInformer,
-	envInformer map[string]finformerv1.EnvironmentInformer,
+	finformerFactory map[string]genInformer.SharedInformerFactory,
 	ndmInformerFactory map[string]k8sInformers.SharedInformerFactory,
 	podSpecPatch *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
@@ -148,11 +147,11 @@ func MakeNewDeploy(
 		nd.svcLister[ns] = informerFactory.Core().V1().Services().Lister()
 		nd.svcListerSynced[ns] = informerFactory.Core().V1().Services().Informer().HasSynced
 	}
-	for _, fnInformer := range funcInformer {
-		fnInformer.Informer().AddEventHandler(nd.FunctionEventHandlers(ctx))
+	for _, factory := range finformerFactory {
+		factory.Core().V1().Functions().Informer().AddEventHandler(nd.FunctionEventHandlers(ctx))
 	}
-	for _, envInformer := range envInformer {
-		envInformer.Informer().AddEventHandler(nd.EnvEventHandlers(ctx))
+	for _, factory := range finformerFactory {
+		factory.Core().V1().Environments().Informer().AddEventHandler(nd.EnvEventHandlers(ctx))
 	}
 	return nd, nil
 }

--- a/pkg/executor/executortype/poolmgr/funchandlers.go
+++ b/pkg/executor/executortype/poolmgr/funchandlers.go
@@ -59,12 +59,6 @@ func FunctionEventHandlers(ctx context.Context, logger *zap.Logger, kubernetesCl
 				return
 			}
 
-			// create or update role-binding
-			envNs := fissionfnNamespace
-			if fn.Spec.Environment.Namespace != metav1.NamespaceDefault {
-				envNs = fn.Spec.Environment.Namespace
-			}
-
 			if istioEnabled {
 				// create a same name service for function
 				// since istio only allows the traffic to service
@@ -74,6 +68,7 @@ func FunctionEventHandlers(ctx context.Context, logger *zap.Logger, kubernetesCl
 				}
 
 				svcName := utils.GetFunctionIstioServiceName(fn.ObjectMeta.Name, fn.ObjectMeta.Namespace)
+				envNs := utils.DefaultNSResolver().GetFunctionNS(fn.Spec.Environment.Namespace)
 
 				// service for accepting user traffic
 				svc := apiv1.Service{
@@ -124,12 +119,9 @@ func FunctionEventHandlers(ctx context.Context, logger *zap.Logger, kubernetesCl
 				return
 			}
 
-			envNs := fissionfnNamespace
-			if fn.Spec.Environment.Namespace != metav1.NamespaceDefault {
-				envNs = fn.Spec.Environment.Namespace
-			}
-
 			if istioEnabled {
+				envNs := utils.DefaultNSResolver().GetFunctionNS(fn.Spec.Environment.Namespace)
+
 				svcName := utils.GetFunctionIstioServiceName(fn.ObjectMeta.Name, fn.ObjectMeta.Namespace)
 				// delete function istio service
 				err := kubernetesClient.CoreV1().Services(envNs).Delete(ctx, svcName, metav1.DeleteOptions{})

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -50,7 +50,7 @@ import (
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
+	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
@@ -117,8 +117,7 @@ func MakeGenericPoolManager(ctx context.Context,
 	metricsClient metricsclient.Interface,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	funcInformer map[string]finformerv1.FunctionInformer,
-	envInformer map[string]finformerv1.EnvironmentInformer,
+	finformerFactory map[string]genInformer.SharedInformerFactory,
 	gpmInformerFactory map[string]k8sInformers.SharedInformerFactory,
 	podSpecPatch *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
@@ -135,7 +134,7 @@ func MakeGenericPoolManager(ctx context.Context,
 	}
 
 	poolPodC := NewPoolPodController(ctx, gpmLogger, kubernetesClient,
-		enableIstio, funcInformer, envInformer, gpmInformerFactory)
+		enableIstio, finformerFactory, gpmInformerFactory)
 
 	gpm := &GenericPoolManager{
 		logger:                     gpmLogger,

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -86,8 +86,10 @@ func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 		envDeleteQueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EnvDeleteQueue"),
 		spCleanupPodQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SpecializedPodCleanupQueue"),
 	}
-	for _, factory := range finformerFactory {
-		factory.Core().V1().Functions().Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace), p.enableIstio))
+	if p.enableIstio {
+		for _, factory := range finformerFactory {
+			factory.Core().V1().Functions().Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace), p.enableIstio))
+		}
 	}
 	for ns, informer := range finformerFactory {
 		informer.Core().V1().Environments().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -37,7 +37,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
-	finformerv1 "github.com/fission/fission/pkg/generated/informers/externalversions/core/v1"
+	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	flisterv1 "github.com/fission/fission/pkg/generated/listers/core/v1"
 	"github.com/fission/fission/pkg/utils"
 )
@@ -70,8 +70,7 @@ type (
 func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 	kubernetesClient kubernetes.Interface,
 	enableIstio bool,
-	funcInformer map[string]finformerv1.FunctionInformer,
-	envInformer map[string]finformerv1.EnvironmentInformer,
+	finformerFactory map[string]genInformer.SharedInformerFactory,
 	gpmInformerFactory map[string]k8sInformers.SharedInformerFactory) *PoolPodController {
 	logger = logger.Named("pool_pod_controller")
 	p := &PoolPodController{
@@ -87,17 +86,17 @@ func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 		envDeleteQueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "EnvDeleteQueue"),
 		spCleanupPodQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SpecializedPodCleanupQueue"),
 	}
-	for _, informer := range funcInformer {
-		informer.Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace), p.enableIstio))
+	for _, factory := range finformerFactory {
+		factory.Core().V1().Functions().Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace), p.enableIstio))
 	}
-	for ns, informer := range envInformer {
-		informer.Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+	for ns, informer := range finformerFactory {
+		informer.Core().V1().Environments().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
 			AddFunc:    p.enqueueEnvAdd,
 			UpdateFunc: p.enqueueEnvUpdate,
 			DeleteFunc: p.enqueueEnvDelete,
 		})
-		p.envLister[ns] = informer.Lister()
-		p.envListerSynced[ns] = informer.Informer().HasSynced
+		p.envLister[ns] = informer.Core().V1().Environments().Lister()
+		p.envListerSynced[ns] = informer.Core().V1().Environments().Informer().HasSynced
 	}
 	for ns, informerFactory := range gpmInformerFactory {
 		informerFactory.Apps().V1().ReplicaSets().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
@@ -105,8 +104,8 @@ func NewPoolPodController(ctx context.Context, logger *zap.Logger,
 			UpdateFunc: p.handleRSUpdate,
 			DeleteFunc: p.handleRSDelete,
 		})
-		p.podLister[ns] = informerFactory.Core().V1().Pods().Lister()
 		p.podListerSynced[ns] = informerFactory.Core().V1().Pods().Informer().HasSynced
+		p.podLister[ns] = informerFactory.Core().V1().Pods().Lister()
 	}
 
 	p.logger.Info("pool pod controller handlers registered")

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -217,7 +217,7 @@ func getEnvVarlist(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerURL 
 	// Add Auth Fields
 	secretName := mqt.Spec.Secret
 	if len(secretName) > 0 {
-		secret, err := kubeClient.CoreV1().Secrets(apiv1.NamespaceDefault).Get(ctx, secretName, metav1.GetOptions{})
+		secret, err := kubeClient.CoreV1().Secrets(mqt.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
@@ -304,7 +304,7 @@ func checkAndUpdateTriggerFields(mqt, newMqt *fv1.MessageQueueTrigger) bool {
 }
 
 func getAuthTriggerSpec(ctx context.Context, mqt *fv1.MessageQueueTrigger, authenticationRef string, kubeClient kubernetes.Interface) (*unstructured.Unstructured, error) {
-	secret, err := kubeClient.CoreV1().Secrets(apiv1.NamespaceDefault).Get(ctx, mqt.Spec.Secret, metav1.GetOptions{})
+	secret, err := kubeClient.CoreV1().Secrets(mqt.Namespace).Get(ctx, mqt.Spec.Secret, metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description

- Pass the informer factory directly to all executors instead of individual informers
- Factory registers informers based on references
- We make a start call on the factory. Whichever informers are registered will be started
- Run function informer handlers in pool pod controller only if istio enabled
- Fix default namespace hardcoding in WaitForCRDs and mqt scalar manager code

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
