### PR TITLE
Create role and rolebinding for event-fetcher in multiple namespaces

### DIFF
--- a/charts/fission-all/templates/_function-access-role.tpl
+++ b/charts/fission-all/templates/_function-access-role.tpl
@@ -106,7 +106,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ .Release.Name }}-fission-fetcher-pod-reader
+  name: {{ .Release.Name }}-fission-fetcher-websocket
   namespace: {{ .namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/fission-all/templates/_function-access-role.tpl
+++ b/charts/fission-all/templates/_function-access-role.tpl
@@ -14,12 +14,6 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-- apiGroups:
   - fission.io
   resources:
   - packages
@@ -50,7 +44,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: {{ .namespace }}
-  name: {{ .Release.Name }}-event-fetcher
+  name: {{ .Release.Name }}-fission-fetcher-websocket
 rules:
 - apiGroups:
   - ""
@@ -62,7 +56,13 @@ rules:
   - "watch"
   - "create"
   - "update"
-  - "patch"  
+  - "patch"
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get  
 {{- end -}}
 
 {{- define "fissionFunction.rolebindings" }}
@@ -111,7 +111,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ .Release.Name }}-event-fetcher
+  name: {{ .Release.Name }}-fission-fetcher-websocket
 subjects:
   - kind: ServiceAccount
     name: fission-fetcher

--- a/charts/fission-all/templates/misc-functions/role.yaml
+++ b/charts/fission-all/templates/misc-functions/role.yaml
@@ -4,24 +4,6 @@ Need to use merge function to pass in the current scope so that ".Release" value
 can be used
  */}}
 {{ include "fissionFunction.roles" (merge (dict "namespace" .Values.defaultNamespace) .) }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: {{ template "fission-function-ns" . }}
-  name: {{ .Release.Name }}-event-fetcher
-rules:
-- apiGroups:
-  - ""
-  resources:
-  - "events"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
-  - "create"
-  - "update"
-  - "patch"
 
 {{- if not .Values.singleDefaultNamespace }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}

--- a/charts/fission-all/templates/misc-functions/rolebinding.yaml
+++ b/charts/fission-all/templates/misc-functions/rolebinding.yaml
@@ -4,20 +4,6 @@ Need to use merge function to pass in the current scope so that ".Release" value
 can be used
  */}}
 {{ include "fissionFunction.rolebindings" (merge (dict "namespace" .Values.defaultNamespace) .) }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: {{ .Release.Name }}-fission-fetcher-pod-reader
-  namespace: {{ template "fission-function-ns" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: {{ .Release.Name }}-event-fetcher
-subjects:
-  - kind: ServiceAccount
-    name: fission-fetcher
-    namespace: {{ template "fission-function-ns" . }}
 
 {{- if not .Values.singleDefaultNamespace }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}


### PR DESCRIPTION
## Description
As we have removed creating role and role bindings through backend code, So we need to make sure all role and role binding should get created through helm chart.

Currently fission is not able to create package for functions other than default namespace because of missing role and role binding of event-fetcher.
Now we have added roles and role binding for event-fetcher and with these changes fission will now able to create package for functions in multiple namespaces.

Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
