### PR TITLE
Remove singleDefaultNamespace field from helm chart

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -74,7 +74,7 @@ This template generates the image name for the deployment depending on the value
 
 {{- define "fission-resource-namespace.envs" }}
 - name: FISSION_RESOURCE_NAMESPACES
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
   value: "{{ .Values.defaultNamespace }},{{ join "," .Values.additionalFissionNamespaces }}"
 {{- else }}
   value: {{ .Values.defaultNamespace }}  

--- a/charts/fission-all/templates/buildermgr/role-fission-cr.yaml
+++ b/charts/fission-all/templates/buildermgr/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "buildermgr") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "buildermgr") $) }}
 {{- end }}

--- a/charts/fission-all/templates/buildermgr/role-kubernetes.yaml
+++ b/charts/fission-all/templates/buildermgr/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "buildermgr") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "buildermgr") $) }}
 {{- end }}

--- a/charts/fission-all/templates/canary-config/role-fission-cr.yaml
+++ b/charts/fission-all/templates/canary-config/role-fission-cr.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.canaryDeployment.enabled }}
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "canaryconfig") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "canaryconfig") $) }}
 {{- end }}

--- a/charts/fission-all/templates/canary-config/role-kubernetes.yaml
+++ b/charts/fission-all/templates/canary-config/role-kubernetes.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.canaryDeployment.enabled }}
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "canaryconfig") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "canaryconfig") $) }}
 {{- end }}

--- a/charts/fission-all/templates/controller/role-fission-cr.yaml
+++ b/charts/fission-all/templates/controller/role-fission-cr.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.controller.enabled }}
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "controller") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "controller") $) }}
 {{- end }}

--- a/charts/fission-all/templates/controller/role-kubernetes.yaml
+++ b/charts/fission-all/templates/controller/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "controller") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "controller") $) }}
 {{- end }}

--- a/charts/fission-all/templates/executor/role-fission-cr.yaml
+++ b/charts/fission-all/templates/executor/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "executor") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "executor") $) }}
 {{- end }}

--- a/charts/fission-all/templates/executor/role-kubernetes.yaml
+++ b/charts/fission-all/templates/executor/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "executor") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "executor") $) }}
 {{- end }}

--- a/charts/fission-all/templates/fluentbit/role-kubernetes.yaml
+++ b/charts/fission-all/templates/fluentbit/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "fluentbit") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "fluentbit") $) }}
 {{- end }}

--- a/charts/fission-all/templates/kubewatcher/role-fission-cr.yaml
+++ b/charts/fission-all/templates/kubewatcher/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "kubewatcher") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "kubewatcher") $) }}
 {{- end }}

--- a/charts/fission-all/templates/kubewatcher/role-kubernetes.yaml
+++ b/charts/fission-all/templates/kubewatcher/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "kubewatcher") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "kubewatcher") $) }}
 {{- end }}

--- a/charts/fission-all/templates/misc-functions/role.yaml
+++ b/charts/fission-all/templates/misc-functions/role.yaml
@@ -5,7 +5,7 @@ can be used
  */}}
 {{ include "fissionFunction.roles" (merge (dict "namespace" .Values.defaultNamespace) .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fissionFunction.roles" (merge (dict "namespace" $namespace) $) }}
 {{- end }}

--- a/charts/fission-all/templates/misc-functions/rolebinding.yaml
+++ b/charts/fission-all/templates/misc-functions/rolebinding.yaml
@@ -5,7 +5,7 @@ can be used
  */}}
 {{ include "fissionFunction.rolebindings" (merge (dict "namespace" .Values.defaultNamespace) .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fissionFunction.rolebindings" (merge (dict "namespace" $namespace) $) }}
 {{- end }}

--- a/charts/fission-all/templates/mqt-fission-kafka/role-fission-cr.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "kafka") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "kafka") $) }}
 {{- end }}

--- a/charts/fission-all/templates/mqt-fission-kafka/role-kubernetes.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "kafka") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "kafka") $) }}
 {{- end }}

--- a/charts/fission-all/templates/mqt-keda/role-fission-cr.yaml
+++ b/charts/fission-all/templates/mqt-keda/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "keda") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "keda") $) }}
 {{- end }}

--- a/charts/fission-all/templates/mqt-keda/role-kubernetes.yaml
+++ b/charts/fission-all/templates/mqt-keda/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "keda") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "keda") $) }}
 {{- end }}

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "preupgrade") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "preupgrade") $) }}
 {{- end }}

--- a/charts/fission-all/templates/router/role-fission-cr.yaml
+++ b/charts/fission-all/templates/router/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "router") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "router") $) }}
 {{- end }}

--- a/charts/fission-all/templates/router/role-kubernetes.yaml
+++ b/charts/fission-all/templates/router/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "router") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "router") $) }}
 {{- end }}

--- a/charts/fission-all/templates/storagesvc/role-fission-cr.yaml
+++ b/charts/fission-all/templates/storagesvc/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "storagesvc") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "storagesvc") $) }}
 {{- end }}

--- a/charts/fission-all/templates/timer/role-fission-cr.yaml
+++ b/charts/fission-all/templates/timer/role-fission-cr.yaml
@@ -1,6 +1,6 @@
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "timer") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "timer") $) }}
 {{- end }}

--- a/charts/fission-all/templates/timer/role-kubernetes.yaml
+++ b/charts/fission-all/templates/timer/role-kubernetes.yaml
@@ -1,6 +1,6 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "timer") .) }}
 
-{{- if not .Values.singleDefaultNamespace }}
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}
 {{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "timer") $) }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -65,7 +65,6 @@ routerPort: 31314
 ## This is different from the release namespace.
 ## Please consider setting `singleDefaultNamespace` and `additionalFissionNamespaces` if you want
 ## more than one namespace to be used for Fission custom resources.
-## Fission will watch the defaultNamespace only if `singleDefaultNamespace` is true.
 ##
 defaultNamespace: default
 
@@ -81,12 +80,7 @@ builderNamespace: ""
 ##
 functionNamespace: ""
 
-## If true, fission will only watch for fission custom resources created in the `defaultNamespace` above.
-##
-singleDefaultNamespace: true
-
 ## Fission will watch the following namespaces along with the `defaultNamespace` for fission custom resources.
-## Only works if `singleDefaultNamespace` is false.
 ## additionalFissionNamespaces: 
 ## - namespace1
 ## - namespace2

--- a/pkg/utils/serviceaccount.go
+++ b/pkg/utils/serviceaccount.go
@@ -52,7 +52,7 @@ var (
 		permissions: []*PermissionCheck{
 			{
 				gvr:  &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
-				verb: "list",
+				verb: "get",
 			},
 			{
 				gvr:  &schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"},


### PR DESCRIPTION
## Description
We have removed `singleDefaultNamespace` field from helm chart. Fission will work with both default and additional namespace(if values present in additional namespace).

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
