### PR TITLE
Allow service account check to run only once at start of executor

### DIFF
--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -192,8 +192,9 @@ executor:
     enabled: true
     ## indicates the time interval in minutes, after that fission will create service account, roles and rolebinding for builder and fetcher.
     ## interval will be applicable only if enable value is set to true.
-    ## default timing will be 30 minutes.
-    interval: 30  
+    ## default timing will be 0 minutes. That means check will run only once.
+    ## if you want to run check every 30 minutes then set interval to 30.
+    interval: 0
 ## router is responsible for routing function calls to the appropriate function.
 ##
 router:

--- a/pkg/utils/serviceaccount_test.go
+++ b/pkg/utils/serviceaccount_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+func TestServiceAccountCheck(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	kubernetesClient := fake.NewSimpleClientset()
+	logger := loggerfactory.GetLogger()
+	os.Setenv(ENV_CREATE_SA, "true")
+	CreateMissingPermissionForSA(ctx, kubernetesClient, logger)
+
+	// Get rolebinding for a service account
+	rolebindings, err := kubernetesClient.RbacV1().RoleBindings("default").List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rolebindings.Items) != 2 {
+		t.Fatal("Rolebinding not created", len(rolebindings.Items))
+	}
+	regexp := regexp.MustCompile(`fission\-(fetcher|builder)\-rolebinding\-[a-z0-9]{6}`)
+	for _, rolebinding := range rolebindings.Items {
+		if !regexp.Match([]byte(rolebinding.Name)) {
+			t.Fatal("Rolebinding not created for fission-builder or fission-fetcher", rolebinding.Name)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Allow setting interval to 0 so that service account check only once
- Set namespace in LocalSubjectAccessReview 
- Change log level to Info for important logs

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
