### PR TITLE
fix: add missing imagePullSecrets sections to pods

### DIFF
--- a/charts/fission-all/templates/analytics/nonhelm-install-job.yaml
+++ b/charts/fission-all/templates/analytics/nonhelm-install-job.yaml
@@ -37,4 +37,8 @@ spec:
           env:
             - name: GA_TRACKING_ID
               value: "{{ .Values.gaTrackingID }}"
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/fission-all/templates/analytics/post-install-job.yaml
+++ b/charts/fission-all/templates/analytics/post-install-job.yaml
@@ -47,4 +47,8 @@ spec:
         {{- if .Values.terminationMessagePolicy }}
           terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/fission-all/templates/analytics/post-upgrade-job.yaml
+++ b/charts/fission-all/templates/analytics/post-upgrade-job.yaml
@@ -47,4 +47,8 @@ spec:
           {{- if .Values.terminationMessagePolicy }}
           terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
           {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -185,6 +185,10 @@ spec:
         - name: fluentbit-config
           configMap:
             name: {{ .Release.Name }}-fission-fluentbit
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
   updateStrategy:
     type: RollingUpdate
 {{- end }}

--- a/charts/fission-all/templates/influxdb/deployment.yaml
+++ b/charts/fission-all/templates/influxdb/deployment.yaml
@@ -49,6 +49,10 @@ spec:
             secretKeyRef:
               name: influxdb
               key: password
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}
 {{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
 {{- end }}

--- a/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
@@ -44,4 +44,8 @@ spec:
         terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
       serviceAccountName: fission-preupgrade
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: 
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
Some pods in the helm chart do not use the image pull secrets defined in the values. This adds the required sections to make use of the image pull secrets in the respective pods.

As requested in https://github.com/fission/fission-charts/pull/68 I created a new pull request in this repo.