### PR TITLE
Change cron syntax to standard format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.37.0
-	github.com/robfig/cron v1.2.0
+	github.com/robfig/cron/v3 v3.0.0
 	github.com/sabhiram/go-gitignore v0.0.0-20210923224102-525f6e181f06
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -607,8 +607,8 @@ github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0ua
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
-github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
-github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
+github.com/robfig/cron/v3 v3.0.0 h1:kQ6Cb7aHOHTSzNVNEhmp8EcWKLb4CbiMW9h9VyIhO4E=
+github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/apis/core/v1/timetrigger_webhook.go
+++ b/pkg/apis/core/v1/timetrigger_webhook.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1
 
 import (
-	"github.com/robfig/cron"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -59,7 +58,7 @@ func (r *TimeTrigger) ValidateCreate() error {
 		return err
 	}
 
-	_, err = cron.Parse(r.Spec.Cron)
+	err = IsValidCronSpec(r.Spec.Cron)
 	if err != nil {
 		err = ferror.MakeError(ferror.ErrorInvalidArgument, "TimeTrigger cron spec is not valid")
 		return err
@@ -76,7 +75,7 @@ func (r *TimeTrigger) ValidateUpdate(old runtime.Object) error {
 		return err
 	}
 
-	_, err = cron.Parse(r.Spec.Cron)
+	err = IsValidCronSpec(r.Spec.Cron)
 	if err != nil {
 		err = ferror.MakeError(ferror.ErrorInvalidArgument, "TimeTrigger cron spec is not valid")
 		return err

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 
@@ -170,7 +170,8 @@ func ValidateKubeReference(refName string, name string, namespace string) error 
 }
 
 func IsValidCronSpec(spec string) error {
-	_, err := cron.Parse(spec)
+	cronSpecParser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	_, err := cronSpecParser.Parse(spec)
 	return err
 }
 

--- a/pkg/controller/timeTriggerApi.go
+++ b/pkg/controller/timeTriggerApi.go
@@ -25,7 +25,6 @@ import (
 	restful "github.com/emicklei/go-restful/v3"
 	"github.com/go-openapi/spec"
 	"github.com/gorilla/mux"
-	"github.com/robfig/cron"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -135,7 +134,7 @@ func (a *API) TimeTriggerApiCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// validate
-	_, err = cron.Parse(t.Spec.Cron)
+	err = fv1.IsValidCronSpec(t.Spec.Cron)
 	if err != nil {
 		err = ferror.MakeError(ferror.ErrorInvalidArgument, "TimeTrigger cron spec is not valid")
 		a.respondWithError(w, err)
@@ -211,7 +210,7 @@ func (a *API) TimeTriggerApiUpdate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	_, err = cron.Parse(t.Spec.Cron)
+	err = fv1.IsValidCronSpec(t.Spec.Cron)
 	if err != nil {
 		err = ferror.MakeError(ferror.ErrorInvalidArgument, "TimeTrigger cron spec is not valid")
 		a.respondWithError(w, err)

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -23,7 +23,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 
 	"github.com/pkg/errors"
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 	uuid "github.com/satori/go.uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -74,7 +74,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 
 	cronSpec := input.String(flagkey.TtCron)
 	if len(cronSpec) == 0 {
-		return errors.New("Need a cron spec like '0 30 * * * *', '@every 1h30m', or '@hourly'; use --cron")
+		return errors.New("Need a cron spec like '30 * * * *', '@every 1h30m', or '@hourly'; use --cron")
 	}
 
 	if input.Bool(flagkey.SpecSave) {
@@ -160,7 +160,8 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 }
 
 func getCronNextNActivationTime(cronSpec string, serverTime time.Time, round int) error {
-	sched, err := cron.Parse(cronSpec)
+	cronSpecParser := cron.NewParser(cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+	sched, err := cronSpecParser.Parse(cronSpec)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/timetrigger/test.go
+++ b/pkg/fission-cli/cmd/timetrigger/test.go
@@ -42,7 +42,7 @@ func (opts *ShowSubCommand) run(flaginput cli.Input) error {
 	cronSpec := flaginput.String(flagkey.TtCron)
 
 	if len(cronSpec) == 0 {
-		return errors.New("need a cron spec like '0 30 * * * *', '@every 1h30m', or '@hourly'; use --cron")
+		return errors.New("need a cron spec like '0 30 * * * *', '*/2 * * * *', '@every 1h30m', or '@hourly'; use --cron")
 	}
 
 	t := util.GetServerInfo(flaginput, opts.Client()).ServerTime.CurrentTime.UTC()

--- a/pkg/timer/timer.go
+++ b/pkg/timer/timer.go
@@ -17,7 +17,7 @@ limitations under the License.
 package timer
 
 import (
-	"github.com/robfig/cron"
+	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -54,7 +54,10 @@ func MakeTimer(logger *zap.Logger, publisher publisher.Publisher) *Timer {
 }
 
 func (timer *Timer) newCron(t fv1.TimeTrigger) *cron.Cron {
-	c := cron.New()
+	c := cron.New(
+		cron.WithParser(
+			cron.NewParser(
+				cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)))
 	c.AddFunc(t.Spec.Cron, func() { //nolint: errCheck
 		headers := map[string]string{
 			"X-Fission-Timer-Name": t.Name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
1. Updated the robfig/cron module to the latest v3
2. Added support for writing cron syntax in its standard format i.e. (Min Hour DoM Month DoW)
3. Cron can still be written in the previous 6 fields format with the seconds field as optional.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1813 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
