### PR TITLE
feat(cli): provide imagepullsecret option for container as function

### DIFF
--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -173,6 +173,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory,
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
+			flag.RunImagePullSecret,
 
 			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
 		},

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -106,6 +106,8 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 		console.Warn("grace period must be a non-negative integer, using default value (6 mins)")
 	}
 
+	pullSecret := []apiv1.LocalObjectReference{{Name: input.String(flagkey.RunImagePullSecret)}}
+
 	var imageName string
 	var port int
 	var command, args string
@@ -208,6 +210,7 @@ func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	opts.function.Spec.PodSpec = &apiv1.PodSpec{
 		Containers:                    []apiv1.Container{*container},
 		TerminationGracePeriodSeconds: &fnGracePeriod,
+		ImagePullSecrets:              pullSecret,
 	}
 
 	return nil

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -96,6 +96,7 @@ var (
 	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}
 	RunTimeMinMemory     = Flag{Type: Int, Name: flagkey.RuntimeMinmemory, Usage: "Minimum memory to be assigned to pod (In megabyte)"}
 	RunTimeMaxMemory     = Flag{Type: Int, Name: flagkey.RuntimeMaxmemory, Usage: "Maximum memory to be assigned to pod (In megabyte)"}
+	RunImagePullSecret   = Flag{Type: String, Name: flagkey.RunImagePullSecret, Usage: "Secret for Kubernetes to pull an image from a private registry"}
 
 	ReplicasMin = Flag{Type: Int, Name: flagkey.ReplicasMinscale, Usage: "Minimum number of pods (Uses resource inputs to configure HPA)", DefaultValue: 1}
 	ReplicasMax = Flag{Type: Int, Name: flagkey.ReplicasMaxscale, Usage: "Maximum number of pods (Uses resource inputs to configure HPA)", DefaultValue: 1}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -44,11 +44,12 @@ const (
 	NamespacePod         = "pod-namespace"
 	ForceDelete          = "force"
 
-	RuntimeMincpu    = "mincpu"
-	RuntimeMaxcpu    = "maxcpu"
-	RuntimeMinmemory = "minmemory"
-	RuntimeMaxmemory = "maxmemory"
-	RuntimeTargetcpu = "targetcpu"
+	RuntimeMincpu      = "mincpu"
+	RuntimeMaxcpu      = "maxcpu"
+	RuntimeMinmemory   = "minmemory"
+	RuntimeMaxmemory   = "maxmemory"
+	RuntimeTargetcpu   = "targetcpu"
+	RunImagePullSecret = "imagepullsecret"
 
 	ReplicasMinscale = "minscale"
 	ReplicasMaxscale = "maxscale"


### PR DESCRIPTION
Signed-off-by: Shubham Nazare <shubham4443@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
While creating container as function, if the image is from a private registry then the user can specify the `imagepullsecret` through the cli.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2569 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
