### PR TITLE
fix: nil panic for the latestDepl.Name if not return in the for cycle

### DIFF
--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -139,7 +139,7 @@ func (cn *Container) waitForDeploy(ctx context.Context, depl *appsv1.Deployment,
 	}
 
 	for i := 0; i < specializationTimeout; i++ {
-		latestDepl, err := cn.kubernetesClient.AppsV1().Deployments(depl.ObjectMeta.Namespace).Get(ctx, depl.Name, metav1.GetOptions{})
+		latestDepl, err = cn.kubernetesClient.AppsV1().Deployments(depl.ObjectMeta.Namespace).Get(ctx, depl.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Signed-off-by: saltbo <saltbo@foxmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
nil panic for the latestDepl.Name if not return in the for cycle

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2681

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
