### PR TITLE
internal: Making poolcache typed and merge into fscache

### DIFF
--- a/pkg/executor/fscache/poolcache_test.go
+++ b/pkg/executor/fscache/poolcache_test.go
@@ -1,4 +1,4 @@
-package poolcache
+package fscache
 
 import (
 	"context"
@@ -22,11 +22,17 @@ func TestPoolCache(t *testing.T) {
 	logger := loggerfactory.GetLogger()
 	c := NewPoolCache(logger)
 
-	c.SetValue(ctx, "func", "ip", "value", resource.MustParse("45m"))
+	c.SetSvcValue(ctx, "func", "ip", &FuncSvc{
+		Name: "value",
+	}, resource.MustParse("45m"))
 
-	c.SetValue(ctx, "func2", "ip2", "value2", resource.MustParse("50m"))
+	c.SetSvcValue(ctx, "func2", "ip2", &FuncSvc{
+		Name: "value2",
+	}, resource.MustParse("50m"))
 
-	c.SetValue(ctx, "func2", "ip22", "value22", resource.MustParse("33m"))
+	c.SetSvcValue(ctx, "func2", "ip22", &FuncSvc{
+		Name: "value22",
+	}, resource.MustParse("33m"))
 
 	checkErr(c.DeleteValue(ctx, "func2", "ip2"))
 
@@ -37,7 +43,7 @@ func TestPoolCache(t *testing.T) {
 
 	c.MarkAvailable("func", "ip")
 
-	_, active, err := c.GetValue(ctx, "func", 5)
+	_, active, err := c.GetSvcValue(ctx, "func", 5)
 	if active != 1 {
 		log.Panicln("Expected 1 active, found", active)
 	}
@@ -45,20 +51,22 @@ func TestPoolCache(t *testing.T) {
 
 	checkErr(c.DeleteValue(ctx, "func", "ip"))
 
-	_, _, err = c.GetValue(ctx, "func", 5)
+	_, _, err = c.GetSvcValue(ctx, "func", 5)
 	if err == nil {
 		log.Panicf("found deleted element")
 	}
 
-	c.SetValue(ctx, "cpulimit", "100", "value", resource.MustParse("3m"))
+	c.SetSvcValue(ctx, "cpulimit", "100", &FuncSvc{
+		Name: "value",
+	}, resource.MustParse("3m"))
 	c.SetCPUUtilization("cpulimit", "100", resource.MustParse("4m"))
 
-	_, _, err = c.GetValue(ctx, "cpulimit", 5)
+	_, _, err = c.GetSvcValue(ctx, "cpulimit", 5)
 
 	if err == nil {
 		log.Panicf("received pod address with higher CPU usage than limit")
 	}
 	c.SetCPUUtilization("cpulimit", "100", resource.MustParse("2m"))
-	_, _, err = c.GetValue(ctx, "cpulimit", 5)
+	_, _, err = c.GetSvcValue(ctx, "cpulimit", 5)
 	checkErr(err)
 }


### PR DESCRIPTION
Merged pool cache package into fscache to avoid import cycle. Also changed all types in pool cache from interface to specific types.

Signed-off-by: Sanket Sudake <sanketsudake@gmail.com>

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
