### PR TITLE
Secrets for router not created if authentication is enabled during helm upgrade

### DIFF
--- a/charts/fission-all/templates/router/secret.yaml
+++ b/charts/fission-all/templates/router/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 data:
   username: {{ .Values.authentication.authUsername | b64enc | quote }}
   password: {{ randAlphaNum 20 | b64enc | quote }}


### PR DESCRIPTION
## Description
This issue occurs only during helm upgrade if authentication is enabled, router pod fails to run because of secret for router is not available. This issue happen because template rendered before creating a secret for router during helm upgrade.

With these changes, we will make sure secret for router should get created before rendering the router templates. 

## Which issue(s) this PR fixes:

Fixes https://github.com/fission/fission/issues/2690

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
