### PR TITLE
CLI: Use fntimeout to stop terminating of function in middle

### DIFF
--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -58,7 +58,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 
 	function, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(input.Context(), fnName, metav1.GetOptions{})
 	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("read function '%v'", fnName))
+		return errors.Wrap(err, fmt.Sprintf("read function '%s'", fnName))
 	}
 
 	m := &metav1.ObjectMeta{
@@ -122,7 +122,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnTestTimeout) && (fnTestTimeout < fnSpecTimeout) {
 		reqTimeout = fnTestTimeout
-		console.Warn("timeout specified using flag is less than the actual functionTimeout specified for function")
+		console.Warn(fmt.Sprintf("timeout specified is less than functionTimeout %d Overriding value to %d", fnTestTimeout, fnSpecTimeout))
 	} else {
 		reqTimeout = fnSpecTimeout
 	}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -56,7 +56,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 		return errors.Wrap(err, "error in testing function ")
 	}
 
-	function, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(input.Context(), input.String(flagkey.FnName), metav1.GetOptions{})
+	function, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(input.Context(), fnName, metav1.GetOptions{})
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("read function '%v'", fnName))
 	}


### PR DESCRIPTION
## Description
Currently if user define function timeout(--fntimeout) while creating function to execute function for a long time and test function using fission-cli then function doesn't consider value of fntimeout and terminate in middle of processing even after defining functionTimeout.

These changes will make sure function should wait till the fntimeout is reached.


## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
