### PR TITLE
Make ghcr.io to default container registry

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -55,6 +55,22 @@ This template generates the image name for the deployment depending on the value
 {{- end }}
 {{- end -}}
 
+{{- define "reporterImage" -}}
+{{- if .Values.repository -}}
+  {{- if eq .Values.imageTag "" -}}
+    {{ .Values.repository }}/{{ .Values.postInstallReportImage }}
+  {{- else -}}
+    {{ .Values.repository }}/{{ .Values.postInstallReportImage }}:{{ .Values.imageTag }}
+  {{- end }}
+{{- else -}}
+  {{- if eq .Values.imageTag "" -}}
+    {{ .Values.postInstallReportImage }}
+  {{- else -}}
+    {{ .Values.postInstallReportImage }}:{{ .Values.imageTag }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
 {{- define "opentelemtry.envs" }}
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   value: "{{ .Values.openTelemetry.otlpCollectorEndpoint }}"

--- a/charts/fission-all/templates/analytics/nonhelm-install-job.yaml
+++ b/charts/fission-all/templates/analytics/nonhelm-install-job.yaml
@@ -26,11 +26,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-        {{- if .Values.imageTag }}
-          image: {{ .Values.postInstallReportImage }}:{{ .Values.imageTag }}
-        {{- else }}
-          image: {{ .Values.postInstallReportImage }}
-        {{- end }}
+          image: {{ include "reporterImage" . | quote }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: [ "/reporter" ]
           args: ["event", "-c", "fission-use", "-a", "yaml-post-install", "-l", "{{ .Chart.Name }}-{{ .Chart.Version }}"]

--- a/charts/fission-all/templates/analytics/post-install-job.yaml
+++ b/charts/fission-all/templates/analytics/post-install-job.yaml
@@ -30,11 +30,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-install-job
-        {{- if .Values.imageTag }}
-          image: {{ .Values.postInstallReportImage }}:{{ .Values.imageTag }}
-        {{- else }}
-          image: {{ .Values.postInstallReportImage }}
-        {{- end }}
+          image: {{ include "reporterImage" . | quote }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: [ "/reporter" ]
           args: ["event", "-c", "fission-use", "-a", "helm-post-install", "-l", "{{ .Chart.Name }}-{{ .Chart.Version }}"]

--- a/charts/fission-all/templates/analytics/post-upgrade-job.yaml
+++ b/charts/fission-all/templates/analytics/post-upgrade-job.yaml
@@ -30,11 +30,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: post-upgrade-job
-        {{- if .Values.imageTag }}
-          image: {{ .Values.postInstallReportImage }}:{{ .Values.imageTag }}
-        {{- else }}
-          image: {{ .Values.postInstallReportImage }}
-        {{- end }}
+          image: {{ include "reporterImage" . | quote }}
           imagePullPolicy: {{ .Values.pullPolicy }}
           command: [ "/reporter" ]
           args: ["event", "-c", "fission-use", "-a", "helm-post-upgrade", "-l", "{{ .Chart.Name }}-{{ .Chart.Version }}"]

--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -25,11 +25,7 @@ spec:
     spec:
       containers:
       - name: mqtrigger
-      {{- if eq .Values.imageTag "" }}
-        image: "{{ .Values.image }}"
-      {{- else }}
-        image: "{{ .Values.image }}:{{ .Values.imageTag }}"
-      {{- end }}
+        image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}"]

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -14,7 +14,7 @@ routerServiceType: LoadBalancer
 ## repository represents base repository for images used in the chart.
 ## Keep it empty for using existing local image
 ##
-repository: index.docker.io
+repository: ghcr.io
 
 ## image represents the base image fission-bundle used by multiple Fission components.
 ## We alter arguments to the image to run a particular component.

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -106,7 +106,7 @@ profiles:
   patches:
   - op: replace
     path: /manifests/helm/releases/0/setValues/repository
-    value: "ghcr.io"
+    value: ""
   - op: replace
     path: /manifests/helm/releases/0/setValues/storagesvc.archivePruner.interval
     value: 1
@@ -132,7 +132,7 @@ profiles:
   patches:
   - op: replace
     path: /manifests/helm/releases/0/setValues/repository
-    value: "ghcr.io"
+    value: ""
   - op: replace
     path: /manifests/helm/releases/0/setValues/storagesvc.archivePruner.interval
     value: 1

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -61,7 +61,7 @@ manifests:
         preUpgradeChecks.imageTag: ""
         priorityClassName: system-cluster-critical
         prometheus.serviceEndpoint: ""
-        repository: index.docker.io
+        repository: ghcr.io
         routerServiceType: LoadBalancer
         runtimePodSpec.enabled: "false"
         serviceMonitor.additionalServiceMonitorLabels.release: prometheus

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -106,7 +106,7 @@ profiles:
   patches:
   - op: replace
     path: /manifests/helm/releases/0/setValues/repository
-    value: ""
+    value: "ghcr.io"
   - op: replace
     path: /manifests/helm/releases/0/setValues/storagesvc.archivePruner.interval
     value: 1
@@ -132,7 +132,7 @@ profiles:
   patches:
   - op: replace
     path: /manifests/helm/releases/0/setValues/repository
-    value: ""
+    value: "ghcr.io"
   - op: replace
     path: /manifests/helm/releases/0/setValues/storagesvc.archivePruner.interval
     value: 1

--- a/test/upgrade_test/fission_objects.sh
+++ b/test/upgrade_test/fission_objects.sh
@@ -5,7 +5,7 @@ ns="fission"
 ROOT=$(pwd)
 PREV_STABLE_VERSION=v1.16.3
 HELM_VARS_PREV_RELEASE="routerServiceType=NodePort,analytics=false"
-HELM_VARS_LATEST_RELEASE="routerServiceType=NodePort,repository=ghcr.io,image=fission-bundle,pullPolicy=IfNotPresent,imageTag=latest,fetcher.image=ghcr.io/fetcher,fetcher.imageTag=latest,postInstallReportImage=reporter,preUpgradeChecks.image=preupgradechecks,preUpgradeChecks.imageTag=latest,analytics=false"
+HELM_VARS_LATEST_RELEASE="routerServiceType=NodePort,repository=ghcr.io,image=fission/fission-bundle,pullPolicy=IfNotPresent,imageTag=latest,fetcher.image=fission/fetcher,fetcher.imageTag=latest,postInstallReportImage=fission/reporter,preUpgradeChecks.image=fission/pre-upgrade-checks,preUpgradeChecks.imageTag=latest,analytics=false"
 
 doit() {
     echo "! $*"

--- a/test/upgrade_test/fission_objects.sh
+++ b/test/upgrade_test/fission_objects.sh
@@ -5,7 +5,7 @@ ns="fission"
 ROOT=$(pwd)
 PREV_STABLE_VERSION=v1.16.3
 HELM_VARS_PREV_RELEASE="routerServiceType=NodePort,analytics=false"
-HELM_VARS_LATEST_RELEASE="routerServiceType=NodePort,repository=docker.io/library,image=fission-bundle,pullPolicy=IfNotPresent,imageTag=latest,fetcher.image=docker.io/library/fetcher,fetcher.imageTag=latest,postInstallReportImage=reporter,preUpgradeChecks.image=preupgradechecks,preUpgradeChecks.imageTag=latest,analytics=false"
+HELM_VARS_LATEST_RELEASE="routerServiceType=NodePort,repository=ghcr.io,image=fission-bundle,pullPolicy=IfNotPresent,imageTag=latest,fetcher.image=ghcr.io/fetcher,fetcher.imageTag=latest,postInstallReportImage=reporter,preUpgradeChecks.image=preupgradechecks,preUpgradeChecks.imageTag=latest,analytics=false"
 
 doit() {
     echo "! $*"


### PR DESCRIPTION
## Description
We have changed our release process to push fission images to github container registry(ghcr.io) instead of docker.io. So now in order to pull fission images from ghcr.io, we need to make changes in helm chart.

This PR includes changes in helm chart to pull images from ghcr.io.

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
