### PR TITLE
Wrong event name in websocket event listener

### DIFF
--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -711,7 +711,7 @@ func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(ctx context.Contex
 	defer close(stopper)
 
 	var wg wait.Group
-	for _, informer := range utils.GetInformerEventChecker(ctx, kubeClient, "WsConnectionStarted") {
+	for _, informer := range utils.GetInformerEventChecker(ctx, kubeClient, "NoActiveConnections") {
 		informer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				mObj := obj.(metav1.Object)


### PR DESCRIPTION
## Description
Websocket event listener uses wrong event name in  `NoActiveConnectionEventChecker` . 
It cause pod being killed immediately.

## Which issue(s) this PR fixes:
Fixes https://github.com/fission/fission/issues/2743


## Testing
This is a obvious bug. Maybe a typo
update: I run a websocket function on this fix with idletimeout = 120s, it keep alive for more than  5min.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
