### PR TITLE
handle addr when port is passed in host:port format in the StartServer func

### DIFF
--- a/pkg/utils/httpserver/server.go
+++ b/pkg/utils/httpserver/server.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"go.uber.org/zap"
 )
 
 func StartServer(ctx context.Context, log *zap.Logger, svc string, port string, handler http.Handler) {
+	if !strings.Contains(port, ":") {
+		port = fmt.Sprintf(":%s", port)
+	}
 	server := http.Server{
-		Addr:    fmt.Sprintf(":%s", port),
+		Addr:    port,
 		Handler: handler,
 	}
 	l := log.With(zap.String("service", svc), zap.String("addr", server.Addr))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This PR ensures to pass the correct value of addr in case when port is passed in `host:port` format in the [StartServer](https://github.com/fission/fission/blob/main/pkg/utils/httpserver/server.go#L11) func.
## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2744

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
