### PR TITLE
Invalid error unwrap for the httperror

### DIFF
--- a/pkg/error/httperror.go
+++ b/pkg/error/httperror.go
@@ -17,6 +17,7 @@ limitations under the License.
 package error
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -106,8 +107,8 @@ func (err Error) Description() string {
 func GetHTTPError(err error) (int, string) {
 	var msg string
 	var code int
-	fe, ok := err.(Error)
-	if ok {
+	var fe Error
+	if errors.As(err, &fe) {
 		code = fe.HTTPStatus()
 		msg = fe.Message
 	} else {
@@ -118,10 +119,11 @@ func GetHTTPError(err error) (int, string) {
 }
 
 func IsNotFound(err error) bool {
-	fe, ok := err.(Error)
-	if !ok {
+	var fe Error
+	if !errors.As(err, &fe) {
 		return false
 	}
+
 	return fe.Code == ErrorNotFound
 }
 

--- a/pkg/error/httperror_test.go
+++ b/pkg/error/httperror_test.go
@@ -1,0 +1,36 @@
+package error
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsNotFound(t *testing.T) {
+	errs := map[error]bool{
+		nil: false,
+		MakeError(ErrorNotFound, "someone not found"):                                          true,
+		MakeError(ErrorTooManyRequests, "too many requests"):                                   false,
+		errors.Wrap(MakeError(ErrorNotFound, "someone not found"), "other information"):        true,
+		errors.Wrap(MakeError(ErrorTooManyRequests, "too many requests"), "other information"): false,
+	}
+
+	for err, want := range errs {
+		assert.Equal(t, want, IsNotFound(err))
+	}
+}
+
+func TestGetHTTPError(t *testing.T) {
+	errs := map[int]error{
+		http.StatusBadRequest:      MakeError(ErrorInvalidArgument, ""),
+		http.StatusConflict:        errors.Wrap(MakeError(ErrorNameExists, ""), ""),
+		http.StatusNotFound:        errors.Wrap(MakeError(ErrorNotFound, ""), ""),
+		http.StatusTooManyRequests: errors.Wrap(MakeError(ErrorTooManyRequests, "too many requests"), "other information"),
+	}
+	for want, err := range errs {
+		code, _ := GetHTTPError(err)
+		assert.Equal(t, want, code)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
The old unwrap code is invalid for the `Error` when the error is wrapped by the `errors.Wrap`.

As a result, the error code returned is always 500

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
