### PR TITLE
fix: miss untap for the cancel request

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -149,7 +149,7 @@ func (executor *Executor) getServiceForFunction(ctx context.Context, fn *fv1.Fun
 		respChan: respChan,
 	}
 	resp := <-respChan
-	if errors.Is(ctx.Err(), context.Canceled) {
+	if resp.funcSvc != nil && errors.Is(ctx.Err(), context.Canceled) {
 		et := executor.executorTypes[resp.funcSvc.Executor]
 		et.UnTapService(ctx, crd.CacheKey(resp.funcSvc.Function), resp.funcSvc.Address)
 		return "", ferror.MakeError(499, "client leave early in the process of getServiceForFunction")


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
The untap call depends on the router, when the request cancels, the untap can't be called. 

We can add a compensation logic to untap in the executor api `getServiceForFunction`.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2741

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
