### PR TITLE
Dump function service cache for executor

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -244,6 +244,20 @@ func (executor *Executor) unTapService(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// dumpFunctionService => dump function service for pool cache
+func (executor *Executor) dumpFunctionService(w http.ResponseWriter, r *http.Request) {
+	// currently we are considering dumping function only for pool manager
+	et := executor.executorTypes[fv1.ExecutorTypePoolmgr]
+	if err := et.DumpFnSvcCache(r.Context()); err != nil {
+		code, msg := ferror.GetHTTPError(err)
+		http.Error(w, msg, code)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	return
+}
+
 // GetHandler returns an http.Handler.
 func (executor *Executor) GetHandler() http.Handler {
 	r := mux.NewRouter()
@@ -253,6 +267,7 @@ func (executor *Executor) GetHandler() http.Handler {
 	r.HandleFunc("/v2/tapServices", executor.tapServices).Methods("POST")
 	r.HandleFunc("/healthz", executor.healthHandler).Methods("GET")
 	r.HandleFunc("/v2/unTapService", executor.unTapService).Methods("POST")
+	r.HandleFunc("/v2/dumpFunctionService", executor.dumpFunctionService).Methods("GET")
 	return r
 }
 

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -244,11 +244,11 @@ func (executor *Executor) unTapService(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// dumpFunctionService => dump function service for pool cache
-func (executor *Executor) dumpFunctionService(w http.ResponseWriter, r *http.Request) {
+// dumpDebugInfo => dump function service for pool cache
+func (executor *Executor) dumpDebugInfo(w http.ResponseWriter, r *http.Request) {
 	// currently we are considering dumping function only for pool manager
 	et := executor.executorTypes[fv1.ExecutorTypePoolmgr]
-	if err := et.DumpFnSvcCache(r.Context()); err != nil {
+	if err := et.DumpDebugInfo(r.Context()); err != nil {
 		code, msg := ferror.GetHTTPError(err)
 		http.Error(w, msg, code)
 		return
@@ -267,7 +267,7 @@ func (executor *Executor) GetHandler() http.Handler {
 	r.HandleFunc("/v2/tapServices", executor.tapServices).Methods("POST")
 	r.HandleFunc("/healthz", executor.healthHandler).Methods("GET")
 	r.HandleFunc("/v2/unTapService", executor.unTapService).Methods("POST")
-	r.HandleFunc("/v2/dumpFunctionService", executor.dumpFunctionService).Methods("GET")
+	r.HandleFunc("/v2/debugInfo", executor.dumpDebugInfo).Methods("GET")
 	return r
 }
 

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -782,3 +782,7 @@ func getDeploymentObj(kubeobjs []apiv1.ObjectReference) *apiv1.ObjectReference {
 	}
 	return nil
 }
+
+func (caaf *Container) DumpFnSvcCache(ctx context.Context) error {
+	return nil
+}

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -783,6 +783,6 @@ func getDeploymentObj(kubeobjs []apiv1.ObjectReference) *apiv1.ObjectReference {
 	return nil
 }
 
-func (caaf *Container) DumpFnSvcCache(ctx context.Context) error {
+func (caaf *Container) DumpDebugInfo(ctx context.Context) error {
 	return nil
 }

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -38,8 +38,8 @@ type ExecutorType interface {
 	// GetFuncSvcFromCache retrieves function service from cache.
 	GetFuncSvcFromCache(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 
-	// DumpFnSvcCache dump function service cache to /tmp directory of executor pod.
-	DumpFnSvcCache(context.Context) error
+	// DumpDebugInfo dump function service cache to /tmp directory of executor pod.
+	DumpDebugInfo(context.Context) error
 
 	// DeleteFuncSvcFromCache deletes function service entry in cache.
 	DeleteFuncSvcFromCache(context.Context, *fscache.FuncSvc)

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -38,7 +38,7 @@ type ExecutorType interface {
 	// GetFuncSvcFromCache retrieves function service from cache.
 	GetFuncSvcFromCache(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 
-	// DumpDebugInfo dump function service cache to /tmp directory of executor pod.
+	// DumpDebugInfo dump function service cache to temporary directory of executor pod.
 	DumpDebugInfo(context.Context) error
 
 	// DeleteFuncSvcFromCache deletes function service entry in cache.

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -38,6 +38,9 @@ type ExecutorType interface {
 	// GetFuncSvcFromCache retrieves function service from cache.
 	GetFuncSvcFromCache(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 
+	// DumpFnSvcCache dump function service cache to /tmp directory of executor pod.
+	DumpFnSvcCache(context.Context) error
+
 	// DeleteFuncSvcFromCache deletes function service entry in cache.
 	DeleteFuncSvcFromCache(context.Context, *fscache.FuncSvc)
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -885,6 +885,6 @@ func (deploy *NewDeploy) scaleDeployment(ctx context.Context, deplNS string, dep
 	return err
 }
 
-func (deploy *NewDeploy) DumpFnSvcCache(ctx context.Context) error {
+func (deploy *NewDeploy) DumpDebugInfo(ctx context.Context) error {
 	return nil
 }

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -884,3 +884,7 @@ func (deploy *NewDeploy) scaleDeployment(ctx context.Context, deplNS string, dep
 	}, metav1.UpdateOptions{})
 	return err
 }
+
+func (deploy *NewDeploy) DumpFnSvcCache(ctx context.Context) error {
+	return nil
+}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -756,5 +756,5 @@ func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(ctx context.Contex
 }
 
 func (gpm *GenericPoolManager) DumpDebugInfo(ctx context.Context) error {
-	return gpm.fsCache.DumpDebugInfo(ctx, "poolmgr")
+	return gpm.fsCache.DumpDebugInfo(ctx)
 }

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -754,3 +754,7 @@ func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(ctx context.Contex
 	}
 	wg.Wait()
 }
+
+func (gpm *GenericPoolManager) DumpFnSvcCache(ctx context.Context) error {
+	return gpm.fsCache.DumpFnSvcCache(ctx)
+}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -755,6 +755,6 @@ func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(ctx context.Contex
 	wg.Wait()
 }
 
-func (gpm *GenericPoolManager) DumpFnSvcCache(ctx context.Context) error {
-	return gpm.fsCache.DumpFnSvcCache(ctx)
+func (gpm *GenericPoolManager) DumpDebugInfo(ctx context.Context) error {
+	return gpm.fsCache.DumpDebugInfo(ctx, "poolmgr")
 }

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -176,7 +176,7 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	fsc.logger.Info("dumping function service")
 
 	file, err := util.CreateDumpFile(fsc.logger)
-	file.Close() // nolint errcheck
+	defer file.Close() // nolint errcheck
 
 	if err != nil {
 		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -176,7 +176,7 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	fsc.logger.Info("dumping function service")
 
 	file, err := util.CreateDumpFile(fsc.logger)
-	defer file.Close() // nolint errcheck
+	defer file.Close() //nolint: errCheck
 
 	if err != nil {
 		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -171,18 +171,19 @@ func (fsc *FunctionServiceCache) service() {
 	}
 }
 
-// DumpDebugInfo => dump function service cache data to /tmp directory of executor pod.
-func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context, fileName string) error {
+// DumpDebugInfo => dump function service cache data to temporary directory of executor pod.
+func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	fsc.logger.Info("dumping function service")
 
-	file, err := util.CreateDirAndFile(fileName, fsc.logger)
+	file, err := util.CreateDumpFile(fsc.logger)
+	defer file.Close()
+
 	if err != nil {
-		file.Close()
 		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))
 		return err
 	}
 
-	fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
+	_ = fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
 
 	fsc.logger.Info("dumped function service")
 	return nil

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -176,9 +176,9 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	fsc.logger.Info("dumping function service")
 
 	file, err := util.CreateDumpFile(fsc.logger)
+	file.Close() // nolint errcheck
 
 	if err != nil {
-		file.Close()
 		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))
 		return err
 	}
@@ -186,7 +186,6 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	_ = fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
 
 	fsc.logger.Info("dumped function service")
-	file.Close()
 	return nil
 }
 

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -17,16 +17,12 @@ limitations under the License.
 package fscache
 
 import (
-	"bufio"
 	"context"
 	"fmt"
-	"os"
-	"strings"
 	"sync"
 	"time"
 
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
@@ -39,6 +35,7 @@ import (
 	"github.com/fission/fission/pkg/crd"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/metrics"
+	"github.com/fission/fission/pkg/executor/util"
 )
 
 type fscRequestType int
@@ -51,11 +48,6 @@ const (
 	LISTOLD
 	LOG
 	LISTOLDPOOL
-)
-
-const (
-	path     string = "/tmp"
-	fileName string = "dump"
 )
 
 type (
@@ -179,80 +171,21 @@ func (fsc *FunctionServiceCache) service() {
 	}
 }
 
-// DumpFnSvcCache => dump function service cache data to /tmp directory of executor pod.
-func (fsc *FunctionServiceCache) DumpFnSvcCache(ctx context.Context) error {
-	fsc.logger.Info("dumping function service group cache")
-	fnSvcGroup := fsc.connFunctionCache.GetFnSvcGroup(ctx)
+// DumpDebugInfo => dump function service cache data to /tmp directory of executor pod.
+func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context, fileName string) error {
+	fsc.logger.Info("dumping function service")
 
-	if len(fnSvcGroup) == 0 {
-		return ferror.MakeError(ferror.ErrorNotFound, "function service not found")
-	}
-	fsc.logger.Debug("dump func svc", zap.Int("lenght", len(fnSvcGroup)), zap.Any("fn svc", fnSvcGroup))
-	info := []string{}
-	for _, fnSvcGrp := range fnSvcGroup {
-		data := fmt.Sprintf("svc_waiting:%d\tqueue_len:%d", fnSvcGrp.svcWaiting, fnSvcGrp.queue.Len())
-		fsc.logger.Debug("inside fnSvcGroup", zap.Any("func svc", fnSvcGrp), zap.Int("svc_wait", fnSvcGrp.svcWaiting), zap.Int("len_queue", fnSvcGrp.queue.Len()))
-		for addr, fnSvc := range fnSvcGrp.svcs {
-			// info = append(info, fmt.Sprintf("function_name:%s\tfn_svc_address:%s\tactive_req:%d\tsvc_waiting:%d\tqueue_len:%d\tcurrent_cpu_usage:%v\tcpu_limit:%v",
-			// 	fnSvc.val.Function.Name, addr, fnSvc.activeRequests, fnSvcGrp.svcWaiting, fnSvcGrp.queue.Len(), fnSvc.currentCPUUsage, fnSvc.cpuLimit))
-			data = fmt.Sprintf("%s\tfunction_name:%s\tfn_svc_address:%s\tcurrent_cpu_usage:%v\tcpu_limit:%v",
-				data, fnSvc.val.Function.Name, addr, fnSvc.currentCPUUsage, fnSvc.cpuLimit)
-			fsc.logger.Debug("dump data info", zap.Any("data info", info))
-		}
-		info = append(info, data)
-	}
-
-	fsc.logger.Debug("dump data", zap.Any("data", info))
-
-	if err := dumpData(info, fsc.logger); err != nil {
-		fsc.logger.Error("error while dumping function service group cache", zap.Error(err))
+	file, err := util.CreateDirAndFile(fileName, fsc.logger)
+	if err != nil {
+		file.Close()
+		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))
 		return err
 	}
 
-	fsc.logger.Info("dumped function service group cache")
+	fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
+
+	fsc.logger.Info("dumped function service")
 	return nil
-}
-
-// check whether /tmp dir exists or not
-// if not exists then create /tmp dir and then dump data to a file, if exists then dump data directly to a file
-// new file will be created on every request with unique id
-func dumpData(data []string, logger *zap.Logger) error {
-	logger.Debug("started dumping data")
-	writeData := func(data []string) error {
-		uid, err := uuid.NewV4()
-		if err != nil {
-			return ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while generating UID %s", err.Error()))
-		}
-		// always create a new file with random id under /tmp directory => /tmp/dump_718b5b6e.txt
-		file, err := os.Create(fmt.Sprintf("%s/%s_%s.txt", path, fileName, strings.Split(uid.String(), "-")[0]))
-		if err != nil {
-			return ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating file %s", err.Error()))
-		}
-
-		datawriter := bufio.NewWriter(file)
-
-		for _, str := range data {
-			_, _ = datawriter.WriteString(str + "\n")
-		}
-
-		datawriter.Flush()
-		file.Close()
-		return nil
-	}
-
-	// check whether /tmp dir exists or not
-	_, err := os.Stat(path)
-	if err == nil {
-		return writeData(data)
-	}
-	if os.IsNotExist(err) {
-		// create /tmp dir with read and write permission
-		if err := os.Mkdir(path, 0755); err != nil {
-			return ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating directory %s", err.Error()))
-		}
-		return writeData(data)
-	}
-	return ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while dumping data %s", err.Error()))
 }
 
 // GetByFunction gets a function service from cache using function key.

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -176,9 +176,9 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	fsc.logger.Info("dumping function service")
 
 	file, err := util.CreateDumpFile(fsc.logger)
-	defer file.Close()
 
 	if err != nil {
+		file.Close()
 		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))
 		return err
 	}
@@ -186,6 +186,7 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	_ = fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
 
 	fsc.logger.Info("dumped function service")
+	file.Close()
 	return nil
 }
 

--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -244,11 +244,11 @@ func (c *PoolCache) service() {
 			for _, fnSvcGrp := range c.cache {
 				datawriter.WriteString(fmt.Sprintf("svc_waiting:%d\tqueue_len:%d", fnSvcGrp.svcWaiting, fnSvcGrp.queue.Len()))
 				if len(fnSvcGrp.svcs) == 0 {
-					datawriter.WriteString("\n") // nolint errcheck
+					datawriter.WriteString("\n") //nolint: errCheck
 				}
 				for addr, fnSvc := range fnSvcGrp.svcs {
 					datawriter.WriteString(fmt.Sprintf("\tfunction_name:%s\tfn_svc_address:%s\tactive_req:%d\tcurrent_cpu_usage:%v\tcpu_limit:%v\n",
-						fnSvc.val.Function.Name, addr, fnSvc.activeRequests, fnSvc.currentCPUUsage, fnSvc.cpuLimit)) // nolint errcheck
+						fnSvc.val.Function.Name, addr, fnSvc.activeRequests, fnSvc.currentCPUUsage, fnSvc.cpuLimit)) //nolint: errCheck
 				}
 			}
 			datawriter.Flush() // don't put this in defer statement

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -32,7 +32,12 @@ import (
 	"sigs.k8s.io/yaml"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/utils"
+)
+
+const (
+	path string = "/tmp/fission-executor-dump"
 )
 
 // ApplyImagePullSecret applies image pull secret to the give pod spec.
@@ -151,4 +156,40 @@ func GetObjectReaperInterval(logger *zap.Logger, executorType fv1.ExecutorType, 
 
 func getExecutorEnvVarName(executor fv1.ExecutorType) string {
 	return strings.ToUpper(string(executor)) + "_OBJECT_REAPER_INTERVAL"
+}
+
+func CreateDirAndFile(fileName string, logger *zap.Logger) (*os.File, error) {
+	createFile := func(fileName string) (*os.File, error) {
+		time := time.Now().Unix()
+		// always create a new file with random id under /tmp/fission-executor-dump directory => /tmp/fission-executor-dump/fileName_718b5b6e.txt
+		file, err := os.Create(fmt.Sprintf("%s/%s_%d.txt", path, fileName, time))
+		if err != nil {
+			return nil, ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating file %s", err.Error()))
+		}
+		return file, nil
+	}
+
+	if fileName == "" {
+		return nil, ferror.MakeError(ferror.ErrorInternal, "file name can't be empty")
+	}
+
+	// check whether /tmp/fission-executor-dump dir exists or not
+	_, err := os.Stat(path)
+	if err == nil {
+		logger.Info("dir already present, creating file", zap.String("dir", path))
+		return createFile(fileName)
+	}
+
+	if os.IsNotExist(err) {
+		// create /tmp/fission-executor-dump dir with read and write permission
+		logger.Debug("dir not exists, creating dir", zap.String("dir", path))
+		if err := os.Mkdir(path, 0755); err != nil {
+			logger.Debug("error while creating dir", zap.String("dir", path))
+			return nil, ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating directory %s", err.Error()))
+		}
+		logger.Info("dir created successfully, creating file", zap.String("dir", path))
+		return createFile(fileName)
+	}
+
+	return nil, ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating dir/file %s", err.Error()))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
These changes will help to dump some necessary information to debug executor. Currently we will be supporting dump of pool manager functions only. 

A new dump file will get created for every request under temporary directory of executor pod.
Dump file name will be in the format of fission-dump-*.txt
* -> asterisk represents unique id, that will be unix timezone.

To get the dump, user needs to hit HTTP end point for executor.
End point - /v2/debugInfo
![Screenshot from 2023-05-11 18-07-11](https://github.com/fission/fission/assets/62992590/3c763466-0564-4ef7-93a5-0395e54c732e)


## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
