### PR TITLE
Ensure handling for specialization failure in pool manager

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -162,7 +162,7 @@ func (executor *Executor) getServiceForFunction(ctx context.Context, fn *fv1.Fun
 		if resp.funcSvc != nil {
 			unTapFunc(resp.funcSvc)
 		} else {
-			et.ReduceSpecializationInProgress(ctx, crd.CacheKey(&fn.ObjectMeta))
+			et.MarkSpecializationFailure(ctx, crd.CacheKey(&fn.ObjectMeta))
 		}
 		return "", ferror.MakeError(499, "client leave early in the process of getServiceForFunction")
 	}
@@ -170,7 +170,7 @@ func (executor *Executor) getServiceForFunction(ctx context.Context, fn *fv1.Fun
 		if resp.funcSvc != nil {
 			unTapFunc(resp.funcSvc)
 		} else {
-			et.ReduceSpecializationInProgress(ctx, crd.CacheKey(&fn.ObjectMeta))
+			et.MarkSpecializationFailure(ctx, crd.CacheKey(&fn.ObjectMeta))
 		}
 		return "", resp.err
 	}

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -31,8 +31,10 @@ import (
 	"go.uber.org/zap"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/crd"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/client"
+	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/metrics"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -148,7 +150,25 @@ func (executor *Executor) getServiceForFunction(ctx context.Context, fn *fv1.Fun
 		respChan: respChan,
 	}
 	resp := <-respChan
+
+	unTapFunc := func(funcSvc *fscache.FuncSvc) {
+		et, ok := executor.executorTypes[funcSvc.Executor]
+		if ok {
+			et.UnTapService(ctx, crd.CacheKey(funcSvc.Function), resp.funcSvc.Address)
+		} else {
+			executor.logger.Error("unknown executor type received in function service", zap.Any("executor", funcSvc.Executor))
+		}
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		if resp.funcSvc != nil {
+			unTapFunc(resp.funcSvc)
+		}
+		return "", ferror.MakeError(499, "client leave early in the process of getServiceForFunction")
+	}
 	if resp.err != nil {
+		if resp.funcSvc != nil {
+			unTapFunc(resp.funcSvc)
+		}
 		return "", resp.err
 	}
 	return resp.funcSvc.Address, resp.err

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -177,6 +177,11 @@ func (caaf *Container) UnTapService(ctx context.Context, key string, svcHost str
 	// Not Implemented for CaaF.
 }
 
+// ReduceSpecializationInProgress has not been implemented for CaaF.
+func (caaf *Container) ReduceSpecializationInProgress(ctx context.Context, key string) {
+	// Not Implemented for CaaF.
+}
+
 // GetFuncSvc returns a function service; error otherwise.
 func (caaf *Container) GetFuncSvc(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	return caaf.createFunction(ctx, fn)

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -177,8 +177,8 @@ func (caaf *Container) UnTapService(ctx context.Context, key string, svcHost str
 	// Not Implemented for CaaF.
 }
 
-// ReduceSpecializationInProgress has not been implemented for CaaF.
-func (caaf *Container) ReduceSpecializationInProgress(ctx context.Context, key string) {
+// MarkSpecializationFailure has not been implemented for CaaF.
+func (caaf *Container) MarkSpecializationFailure(ctx context.Context, key string) {
 	// Not Implemented for CaaF.
 }
 

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -48,6 +48,9 @@ type ExecutorType interface {
 	// UnTapService updates the isActive to false
 	UnTapService(ctx context.Context, key string, svcHost string)
 
+	// ReduceSpecializationInProgress updates the svcWaiting count in funcSvcGroup
+	ReduceSpecializationInProgress(ctx context.Context, key string)
+
 	// IsValid returns true if a function service is valid. Different executor types
 	// use distinct ways to examine the function service.
 	IsValid(context.Context, *fscache.FuncSvc) bool

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -49,7 +49,7 @@ type ExecutorType interface {
 	UnTapService(ctx context.Context, key string, svcHost string)
 
 	// ReduceSpecializationInProgress updates the svcWaiting count in funcSvcGroup
-	ReduceSpecializationInProgress(ctx context.Context, key string)
+	MarkSpecializationFailure(ctx context.Context, key string)
 
 	// IsValid returns true if a function service is valid. Different executor types
 	// use distinct ways to examine the function service.

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -199,8 +199,8 @@ func (deploy *NewDeploy) UnTapService(ctx context.Context, key string, svcHost s
 	// Not Implemented for NewDeployment. Will be used when support of concurrent specialization of same function is added.
 }
 
-// ReduceSpecializationInProgress has not been implemented for NewDeployment.
-func (deploy *NewDeploy) ReduceSpecializationInProgress(ctx context.Context, key string) {
+// MarkSpecializationFailure has not been implemented for NewDeployment.
+func (deploy *NewDeploy) MarkSpecializationFailure(ctx context.Context, key string) {
 	// Not Implemented for NewDeployment. Will be used when support of concurrent specialization of same function is added.
 }
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -199,6 +199,11 @@ func (deploy *NewDeploy) UnTapService(ctx context.Context, key string, svcHost s
 	// Not Implemented for NewDeployment. Will be used when support of concurrent specialization of same function is added.
 }
 
+// ReduceSpecializationInProgress has not been implemented for NewDeployment.
+func (deploy *NewDeploy) ReduceSpecializationInProgress(ctx context.Context, key string) {
+	// Not Implemented for NewDeployment. Will be used when support of concurrent specialization of same function is added.
+}
+
 // TapService makes a TouchByAddress request to the cache.
 func (deploy *NewDeploy) TapService(ctx context.Context, svcHost string) error {
 	otelUtils.SpanTrackEvent(ctx, "TapService")

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -226,7 +226,7 @@ func (gp *GenericPool) updateCPUUtilizationSvc(ctx context.Context) {
 // returns the key and pod API object.
 func (gp *GenericPool) choosePod(ctx context.Context, newLabels map[string]string) (string, *apiv1.Pod, error) {
 	startTime := time.Now()
-	var podTimeout = startTime.Add(gp.podReadyTimeout)
+	podTimeout := startTime.Add(gp.podReadyTimeout)
 	deadline, ok := ctx.Deadline()
 	if ok {
 		deadline = deadline.Add(-1 * time.Second)

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -226,6 +226,14 @@ func (gp *GenericPool) updateCPUUtilizationSvc(ctx context.Context) {
 // returns the key and pod API object.
 func (gp *GenericPool) choosePod(ctx context.Context, newLabels map[string]string) (string, *apiv1.Pod, error) {
 	startTime := time.Now()
+	var podTimeout = startTime.Add(gp.podReadyTimeout)
+	deadline, ok := ctx.Deadline()
+	if ok {
+		deadline = deadline.Add(-1 * time.Second)
+		if deadline.Before(podTimeout) {
+			podTimeout = deadline
+		}
+	}
 	expoDelay := 100 * time.Millisecond
 	logger := otelUtils.LoggerWithTraceID(ctx, gp.logger)
 	if !cache.WaitForCacheSync(ctx.Done(), gp.readyPodListerSynced) {
@@ -234,9 +242,13 @@ func (gp *GenericPool) choosePod(ctx context.Context, newLabels map[string]strin
 	}
 	for {
 		// Retries took too long, error out.
-		if time.Since(startTime) > gp.podReadyTimeout {
-			logger.Error("timed out waiting for pod", zap.Any("labels", newLabels), zap.Duration("timeout", gp.podReadyTimeout))
+		if time.Now().After(podTimeout) {
+			logger.Error("timed out waiting for pod", zap.Any("labels", newLabels), zap.Duration("timeout", podTimeout.Sub(startTime)))
 			return "", nil, errors.New("timeout: waited too long to get a ready pod")
+		}
+		if ctx.Err() != nil {
+			logger.Error("context canceled while waiting for pod", zap.Any("labels", newLabels), zap.Duration("timeout", podTimeout.Sub(startTime)))
+			return "", nil, fmt.Errorf("context canceled while waiting for pod: %w", ctx.Err())
 		}
 
 		var chosenPod *apiv1.Pod

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -252,10 +252,12 @@ func (gpm *GenericPoolManager) TapService(ctx context.Context, svcHost string) e
 	return nil
 }
 
-func (gpm *GenericPoolManager) ReduceSpecializationInProgress(ctx context.Context, key string) {
-	otelUtils.SpanTrackEvent(ctx, "ReduceSpecializationInProgress",
+func (gpm *GenericPoolManager) MarkSpecializationFailure(ctx context.Context, key string) {
+	otelUtils.SpanTrackEvent(ctx, "MarkSpecializationFailure",
 		attribute.KeyValue{Key: "key", Value: attribute.StringValue(key)})
-	gpm.fsCache.ReduceSpecializationInProgress(key)
+	logger := otelUtils.LoggerWithTraceID(ctx, gpm.logger)
+	logger.Info("marking specialization failure", zap.Any("key", key))
+	gpm.fsCache.MarkSpecializationFailure(key)
 }
 
 // IsValid checks if pod is not deleted and that it has the address passed as the argument. Also checks that all the

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -252,6 +252,12 @@ func (gpm *GenericPoolManager) TapService(ctx context.Context, svcHost string) e
 	return nil
 }
 
+func (gpm *GenericPoolManager) ReduceSpecializationInProgress(ctx context.Context, key string) {
+	otelUtils.SpanTrackEvent(ctx, "ReduceSpecializationInProgress",
+		attribute.KeyValue{Key: "key", Value: attribute.StringValue(key)})
+	gpm.fsCache.ReduceSpecializationInProgress(key)
+}
+
 // IsValid checks if pod is not deleted and that it has the address passed as the argument. Also checks that all the
 // containers in it are reporting a ready status for the healthCheck.
 func (gpm *GenericPoolManager) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) bool {

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -244,8 +244,8 @@ func (fsc *FunctionServiceCache) MarkAvailable(key string, svcHost string) {
 	fsc.connFunctionCache.MarkAvailable(key, svcHost)
 }
 
-func (fsc *FunctionServiceCache) ReduceSpecializationInProgress(key string) {
-	fsc.connFunctionCache.ReduceSpecializationInProgress(key)
+func (fsc *FunctionServiceCache) MarkSpecializationFailure(key string) {
+	fsc.connFunctionCache.MarkSpecializationFailure(key)
 }
 
 // Add adds a function service to cache if it does not exist already.

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -244,6 +244,10 @@ func (fsc *FunctionServiceCache) MarkAvailable(key string, svcHost string) {
 	fsc.connFunctionCache.MarkAvailable(key, svcHost)
 }
 
+func (fsc *FunctionServiceCache) ReduceSpecializationInProgress(key string) {
+	fsc.connFunctionCache.ReduceSpecializationInProgress(key)
+}
+
 // Add adds a function service to cache if it does not exist already.
 func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 	existing, err := fsc.byFunction.Set(crd.CacheKey(fsvc.Function), &fsvc)

--- a/pkg/executor/fscache/queue.go
+++ b/pkg/executor/fscache/queue.go
@@ -46,11 +46,11 @@ func (q *Queue) Expired() int {
 	svcExpired := []*list.Element{}
 	for item := q.items.Front(); item != nil; item = item.Next() {
 		svcWait, ok := item.Value.(*svcWait)
-		close(svcWait.svcChannel)
 		if !ok {
 			continue
 		}
 		if svcWait.ctx.Err() != nil {
+			close(svcWait.svcChannel)
 			svcExpired = append(svcExpired, item)
 			expired = expired + 1
 		}

--- a/pkg/executor/fscache/queue.go
+++ b/pkg/executor/fscache/queue.go
@@ -3,20 +3,16 @@ package fscache
 import (
 	"container/list"
 	"sync"
-
-	"go.uber.org/zap"
 )
 
 type Queue struct {
-	items  *list.List
-	mutex  sync.Mutex
-	logger *zap.Logger
+	items *list.List
+	mutex sync.Mutex
 }
 
-func NewQueue(logger *zap.Logger) *Queue {
+func NewQueue() *Queue {
 	return &Queue{
-		items:  list.New(),
-		logger: logger,
+		items: list.New(),
 	}
 }
 
@@ -50,6 +46,7 @@ func (q *Queue) Expired() int {
 	svcExpired := []*list.Element{}
 	for item := q.items.Front(); item != nil; item = item.Next() {
 		svcWait, ok := item.Value.(*svcWait)
+		close(svcWait.svcChannel)
 		if !ok {
 			continue
 		}

--- a/pkg/executor/fscache/queue_test.go
+++ b/pkg/executor/fscache/queue_test.go
@@ -115,7 +115,7 @@ func TestQueueLen(t *testing.T) {
 	}
 }
 
-func TestExpired(t *testing.T) {
+func TestExpiredWhenAllItemsExpired(t *testing.T) {
 	q := NewQueue()
 	if q.Expired() != 0 {
 		t.Errorf("Expected Expired to return 0, got %d", q.Expired())
@@ -134,6 +134,58 @@ func TestExpired(t *testing.T) {
 		t.Errorf("Expected Expired to return 1, got %d", q.Expired())
 	}
 	if q.Len() != 0 {
+		t.Errorf("Expected queue length to be 0, got %d", q.Len())
+	}
+}
+
+func TestExpiredWhenFewItemsExpired(t *testing.T) {
+	q := NewQueue()
+	if q.Expired() != 0 {
+		t.Errorf("Expected Expired to return 0, got %d", q.Expired())
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	q.Push(&svcWait{
+		svcChannel: make(chan *FuncSvc),
+		ctx:        ctx,
+	})
+	q.Push(&svcWait{
+		svcChannel: make(chan *FuncSvc),
+		ctx:        context.Background(),
+	})
+	if q.Len() != 2 {
+		t.Errorf("Expected queue length to be 1, got %d", q.Len())
+	}
+	cancel()
+	if q.Expired() != 1 {
+		t.Errorf("Expected Expired to return 1, got %d", q.Expired())
+	}
+	if q.Len() != 1 {
+		t.Errorf("Expected queue length to be 0, got %d", q.Len())
+	}
+}
+
+func TestExpiredWhenNoItemsExpired(t *testing.T) {
+	q := NewQueue()
+	if q.Expired() != 0 {
+		t.Errorf("Expected Expired to return 0, got %d", q.Expired())
+	}
+
+	q.Push(&svcWait{
+		svcChannel: make(chan *FuncSvc),
+		ctx:        context.Background(),
+	})
+	q.Push(&svcWait{
+		svcChannel: make(chan *FuncSvc),
+		ctx:        context.Background(),
+	})
+	if q.Len() != 2 {
+		t.Errorf("Expected queue length to be 1, got %d", q.Len())
+	}
+	if q.Expired() != 0 {
+		t.Errorf("Expected Expired to return 1, got %d", q.Expired())
+	}
+	if q.Len() != 2 {
 		t.Errorf("Expected queue length to be 0, got %d", q.Len())
 	}
 }

--- a/pkg/executor/fscache/queue_test.go
+++ b/pkg/executor/fscache/queue_test.go
@@ -4,19 +4,17 @@ import (
 	"context"
 	"sync"
 	"testing"
-
-	"go.uber.org/zap"
 )
 
 func TestNewQueue(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	if q == nil {
 		t.Error("NewQueue returned nil")
 	}
 }
 
 func TestQueuePushWithSingleRequest(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	item := &svcWait{
 		svcChannel: make(chan *FuncSvc),
 		ctx:        nil,
@@ -28,7 +26,7 @@ func TestQueuePushWithSingleRequest(t *testing.T) {
 }
 
 func TestQueuePopWithSingleRequest(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	item := &svcWait{
 		svcChannel: make(chan *FuncSvc),
 		ctx:        nil,
@@ -47,7 +45,7 @@ func TestQueuePopWithSingleRequest(t *testing.T) {
 }
 
 func TestQueuePushWithConcurrentRequest(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	noOfRequests := 20
 	var wg sync.WaitGroup
 	wg.Add(noOfRequests)
@@ -70,7 +68,7 @@ func TestQueuePushWithConcurrentRequest(t *testing.T) {
 }
 
 func TestQueuePopWithConcurrentRequest(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	noOfPush := 20
 	noOfPop := 15
 
@@ -103,7 +101,7 @@ func TestQueuePopWithConcurrentRequest(t *testing.T) {
 }
 
 func TestQueueLen(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	if q.Len() != 0 {
 		t.Errorf("Expected queue length to be 0, got %d", q.Len())
 	}
@@ -118,7 +116,7 @@ func TestQueueLen(t *testing.T) {
 }
 
 func TestExpired(t *testing.T) {
-	q := NewQueue(&zap.Logger{})
+	q := NewQueue()
 	if q.Expired() != 0 {
 		t.Errorf("Expected Expired to return 0, got %d", q.Expired())
 	}


### PR DESCRIPTION
This PR adds a couple of fixes to handling specialization failures.

- Cleanup svc waiting for the counter in the pool manager if specialization fails 
- Cleanup active requests counter in pool manager if client exists the demand for function service while we have allocated function service
- Consider specialization timeout if pod ready timeout > specialization timeout in waiting for ready pod. We also consider if the request to choosePod is cancelled.
- We ensure if we have requests waiting for service requests but if there is no pod in the specialization we clean up those.
