### PR TITLE
Executor: Dump function service cache for pool manager functions

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -263,6 +263,20 @@ func (executor *Executor) unTapService(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
+// dumpDebugInfo => dump function service for pool cache
+func (executor *Executor) dumpDebugInfo(w http.ResponseWriter, r *http.Request) {
+	// currently we are considering dumping function only for pool manager
+	et := executor.executorTypes[fv1.ExecutorTypePoolmgr]
+	if err := et.DumpDebugInfo(r.Context()); err != nil {
+		code, msg := ferror.GetHTTPError(err)
+		http.Error(w, msg, code)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	return
+}
+
 // GetHandler returns an http.Handler.
 func (executor *Executor) GetHandler() http.Handler {
 	r := mux.NewRouter()
@@ -272,6 +286,7 @@ func (executor *Executor) GetHandler() http.Handler {
 	r.HandleFunc("/v2/tapServices", executor.tapServices).Methods("POST")
 	r.HandleFunc("/healthz", executor.healthHandler).Methods("GET")
 	r.HandleFunc("/v2/unTapService", executor.unTapService).Methods("POST")
+	r.HandleFunc("/v2/debugInfo", executor.dumpDebugInfo).Methods("GET")
 	return r
 }
 

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -274,7 +274,6 @@ func (executor *Executor) dumpDebugInfo(w http.ResponseWriter, r *http.Request) 
 	}
 
 	w.WriteHeader(http.StatusOK)
-	return
 }
 
 // GetHandler returns an http.Handler.

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -787,3 +787,7 @@ func getDeploymentObj(kubeobjs []apiv1.ObjectReference) *apiv1.ObjectReference {
 	}
 	return nil
 }
+
+func (caaf *Container) DumpDebugInfo(ctx context.Context) error {
+	return nil
+}

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -38,6 +38,9 @@ type ExecutorType interface {
 	// GetFuncSvcFromCache retrieves function service from cache.
 	GetFuncSvcFromCache(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 
+	// DumpDebugInfo dump function service cache to temporary directory of executor pod.
+	DumpDebugInfo(context.Context) error
+
 	// DeleteFuncSvcFromCache deletes function service entry in cache.
 	DeleteFuncSvcFromCache(context.Context, *fscache.FuncSvc)
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -889,3 +889,7 @@ func (deploy *NewDeploy) scaleDeployment(ctx context.Context, deplNS string, dep
 	}, metav1.UpdateOptions{})
 	return err
 }
+
+func (deploy *NewDeploy) DumpDebugInfo(ctx context.Context) error {
+	return nil
+}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -762,3 +762,7 @@ func (gpm *GenericPoolManager) NoActiveConnectionEventChecker(ctx context.Contex
 	}
 	wg.Wait()
 }
+
+func (gpm *GenericPoolManager) DumpDebugInfo(ctx context.Context) error {
+	return gpm.fsCache.DumpDebugInfo(ctx)
+}

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -35,6 +35,7 @@ import (
 	"github.com/fission/fission/pkg/crd"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/metrics"
+	"github.com/fission/fission/pkg/executor/util"
 )
 
 type fscRequestType int
@@ -168,6 +169,23 @@ func (fsc *FunctionServiceCache) service() {
 		}
 		req.responseChannel <- resp
 	}
+}
+
+// DumpDebugInfo => dump function service cache data to temporary directory of executor pod.
+func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
+	fsc.logger.Info("dumping function service")
+
+	file, err := util.CreateDumpFile(fsc.logger)
+	if err != nil {
+		fsc.logger.Error("error while creating file/dir", zap.String("error", err.Error()))
+		return err
+	}
+	defer file.Close()
+
+	_ = fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
+
+	fsc.logger.Info("dumped function service")
+	return nil
 }
 
 // GetByFunction gets a function service from cache using function key.

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -182,7 +182,11 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 	}
 	defer file.Close()
 
-	_ = fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
+	err = fsc.connFunctionCache.LogFnSvcGroup(ctx, file)
+	if err != nil {
+		fsc.logger.Error("error while logging function service group", zap.String("error", err.Error()))
+		return err
+	}
 
 	fsc.logger.Info("dumped function service")
 	return nil

--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -260,7 +260,8 @@ func (c *PoolCache) service() {
 						fnSvc.val.Function.Name, addr, fnSvc.activeRequests, fnSvc.currentCPUUsage, fnSvc.cpuLimit)) // nolint: errCheck
 				}
 			}
-			datawriter.Flush() // don't put this in defer statement
+			// don't put this in defer statement
+			datawriter.Flush() // nolint: errCheck
 			req.responseChannel <- resp
 		default:
 			resp.error = ferror.MakeError(ferror.ErrorInvalidArgument,

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -32,7 +32,12 @@ import (
 	"sigs.k8s.io/yaml"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/utils"
+)
+
+const (
+	dumpFileName string = "fission-dump"
 )
 
 // ApplyImagePullSecret applies image pull secret to the give pod spec.
@@ -151,4 +156,17 @@ func GetObjectReaperInterval(logger *zap.Logger, executorType fv1.ExecutorType, 
 
 func getExecutorEnvVarName(executor fv1.ExecutorType) string {
 	return strings.ToUpper(string(executor)) + "_OBJECT_REAPER_INTERVAL"
+}
+
+// CreateDumpFile => create dump file inside temp directory
+func CreateDumpFile(logger *zap.Logger) (*os.File, error) {
+	dumpPath := os.TempDir()
+	logger.Info("creating dump file", zap.String("dump_path", dumpPath))
+
+	file, err := os.Create(fmt.Sprintf("%s/%s-%d.txt", dumpPath, dumpFileName, time.Now().Unix()))
+	if err != nil {
+		return nil, ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating file %s", err.Error()))
+	}
+
+	return file, nil
 }

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -32,7 +32,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/utils"
 )
 
@@ -163,10 +162,5 @@ func CreateDumpFile(logger *zap.Logger) (*os.File, error) {
 	dumpPath := os.TempDir()
 	logger.Info("creating dump file", zap.String("dump_path", dumpPath))
 
-	file, err := os.Create(fmt.Sprintf("%s/%s-%d.txt", dumpPath, dumpFileName, time.Now().Unix()))
-	if err != nil {
-		return nil, ferror.MakeError(ferror.ErrorInternal, fmt.Sprintf("error while creating file %s", err.Error()))
-	}
-
-	return file, nil
+	return os.Create(fmt.Sprintf("%s/%s-%d.txt", dumpPath, dumpFileName, time.Now().Unix()))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
These changes will help to dump some necessary information to debug executor. Currently we will be supporting dump of pool manager functions only.

A new dump file will get created for every request under temporary directory of executor pod.
Dump file name will be in the format of fission-dump-*.txt

* -> asterisk represents unique id, that will be unix timezone.

To get the dump, user needs to hit HTTP end point for executor.
End point - /v2/debugInfo
![Screenshot from 2023-05-11 18-07-11](https://github.com/fission/fission/assets/62992590/48a5f7c7-0717-4374-9c27-311acf2dac8f)


Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
