### PR TITLE
Update the Kubernetes autoscaling API to v2 (#2722)

### DIFF
--- a/crds/v1/fission.io_functions.yaml
+++ b/crds/v1/fission.io_functions.yaml
@@ -112,10 +112,11 @@ spec:
                                   - value
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               selectPolicy:
                                 description: selectPolicy is used to specify which
                                   policy should be used. If not set, the default value
-                                  MaxPolicySelect is used.
+                                  Max is used.
                                 type: string
                               stabilizationWindowSeconds:
                                 description: 'stabilizationWindowSeconds is the number
@@ -168,10 +169,11 @@ spec:
                                   - value
                                   type: object
                                 type: array
+                                x-kubernetes-list-type: atomic
                               selectPolicy:
                                 description: selectPolicy is used to specify which
                                   policy should be used. If not set, the default value
-                                  MaxPolicySelect is used.
+                                  Max is used.
                                 type: string
                               stabilizationWindowSeconds:
                                 description: 'stabilizationWindowSeconds is the number
@@ -198,7 +200,7 @@ spec:
                             should be set at once).
                           properties:
                             containerResource:
-                              description: container resource refers to a resource
+                              description: containerResource refers to a resource
                                 metric (such as those specified in requests and limits)
                                 known to Kubernetes describing a single container
                                 in each pod of the current scale target (e.g. CPU
@@ -381,9 +383,8 @@ spec:
                                 on an Ingress object).
                               properties:
                                 describedObject:
-                                  description: CrossVersionObjectReference contains
-                                    enough information to let you identify the referred
-                                    resource.
+                                  description: describedObject specifies the descriptions
+                                    of a object,such as kind,name apiVersion
                                   properties:
                                     apiVersion:
                                       description: apiVersion is the API version of

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1
 
 import (
-	asv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -475,12 +475,12 @@ type (
 		// created for the function.
 		// Applicable for executor type newdeploy and container.
 		// +optional
-		Metrics []asv2beta2.MetricSpec `json:"hpaMetrics,omitempty"`
+		Metrics []asv2.MetricSpec `json:"hpaMetrics,omitempty"`
 
 		// hpaBehavior is the behavior of HPA when scaling in up/down direction.
 		// Applicable for executor type newdeploy and container.
 		// +optional
-		Behavior *asv2beta2.HorizontalPodAutoscalerBehavior `json:"hpaBehavior,omitempty"`
+		Behavior *asv2.HorizontalPodAutoscalerBehavior `json:"hpaBehavior,omitempty"`
 	}
 
 	// FunctionReferenceType refers to type of Function

--- a/pkg/apis/core/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -302,14 +302,14 @@ func (in *ExecutionStrategy) DeepCopyInto(out *ExecutionStrategy) {
 	*out = *in
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
-		*out = make([]v2beta2.MetricSpec, len(*in))
+		*out = make([]asv2.MetricSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Behavior != nil {
 		in, out := &in.Behavior, &out.Behavior
-		*out = new(v2beta2.HorizontalPodAutoscalerBehavior)
+		*out = new(asv2.HorizontalPodAutoscalerBehavior)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/pkg/apis/core/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1
 
 import (
-	asv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -302,14 +302,14 @@ func (in *ExecutionStrategy) DeepCopyInto(out *ExecutionStrategy) {
 	*out = *in
 	if in.Metrics != nil {
 		in, out := &in.Metrics, &out.Metrics
-		*out = make([]asv2.MetricSpec, len(*in))
+		*out = make([]v2.MetricSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Behavior != nil {
 		in, out := &in.Behavior, &out.Behavior
-		*out = new(asv2.HorizontalPodAutoscalerBehavior)
+		*out = new(v2.HorizontalPodAutoscalerBehavior)
 		(*in).DeepCopyInto(*out)
 	}
 }

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -56,7 +56,7 @@ func CleanupKubeObject(ctx context.Context, logger *zap.Logger, kubeClient kuber
 		}
 
 	case "horizontalpodautoscaler":
-		err := kubeClient.AutoscalingV2beta2().HorizontalPodAutoscalers(kubeobj.Namespace).Delete(ctx, kubeobj.Name, metav1.DeleteOptions{})
+		err := kubeClient.AutoscalingV2().HorizontalPodAutoscalers(kubeobj.Namespace).Delete(ctx, kubeobj.Name, metav1.DeleteOptions{})
 		if err != nil {
 			logger.Error("error cleaning up horizontalpodautoscaler", zap.Error(err), zap.String("horizontalpodautoscaler", kubeobj.Name))
 		}
@@ -180,7 +180,7 @@ func CleanupServices(ctx context.Context, logger *zap.Logger, client kubernetes.
 // CleanupHpa deletes horizontal pod autoscaler(s) for a given instanceID
 func CleanupHpa(ctx context.Context, logger *zap.Logger, client kubernetes.Interface, instanceID string, listOps metav1.ListOptions) error {
 	cleanupHpa := func(namespace string) error {
-		hpaList, err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(namespace).List(ctx, listOps)
+		hpaList, err := client.AutoscalingV2().HorizontalPodAutoscalers(namespace).List(ctx, listOps)
 		if err != nil {
 			return err
 		}
@@ -193,7 +193,7 @@ func CleanupHpa(ctx context.Context, logger *zap.Logger, client kubernetes.Inter
 			}
 			if ok && id != instanceID {
 				logger.Info("cleaning up HPA", zap.String("hpa", hpa.ObjectMeta.Name))
-				err := client.AutoscalingV2beta2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(ctx, hpa.ObjectMeta.Name, metav1.DeleteOptions{})
+				err := client.AutoscalingV2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Delete(ctx, hpa.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					logger.Error("error cleaning up HPA",
 						zap.Error(err),

--- a/pkg/executor/util/hpa/hpa.go
+++ b/pkg/executor/util/hpa/hpa.go
@@ -21,7 +21,7 @@ import (
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
-	asv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,21 +51,21 @@ func NewHpaOperations(logger *zap.Logger, kubernetesClient kubernetes.Interface,
 	}
 }
 
-func ConvertTargetCPUToCustomMetric(targetCPUVal int32) asv2beta2.MetricSpec {
-	return asv2beta2.MetricSpec{
-		Type: asv2beta2.ResourceMetricSourceType,
-		Resource: &asv2beta2.ResourceMetricSource{
+func ConvertTargetCPUToCustomMetric(targetCPUVal int32) asv2.MetricSpec {
+	return asv2.MetricSpec{
+		Type: asv2.ResourceMetricSourceType,
+		Resource: &asv2.ResourceMetricSource{
 			Name: corev1.ResourceCPU,
-			Target: asv2beta2.MetricTarget{
-				Type:               asv2beta2.UtilizationMetricType,
+			Target: asv2.MetricTarget{
+				Type:               asv2.UtilizationMetricType,
 				AverageUtilization: &targetCPUVal,
 			},
 		},
 	}
 }
 
-func getScaleTargetRef(deployment *appsv1.Deployment) asv2beta2.CrossVersionObjectReference {
-	return asv2beta2.CrossVersionObjectReference{
+func getScaleTargetRef(deployment *appsv1.Deployment) asv2.CrossVersionObjectReference {
+	return asv2.CrossVersionObjectReference{
 		APIVersion: DeploymentVersion,
 		Kind:       DeploymentKind,
 		Name:       deployment.ObjectMeta.Name,
@@ -73,7 +73,7 @@ func getScaleTargetRef(deployment *appsv1.Deployment) asv2beta2.CrossVersionObje
 }
 
 func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, hpaName string, execStrategy *fv1.ExecutionStrategy,
-	depl *appsv1.Deployment, deployLabels map[string]string, deployAnnotations map[string]string) (*asv2beta2.HorizontalPodAutoscaler, error) {
+	depl *appsv1.Deployment, deployLabels map[string]string, deployAnnotations map[string]string) (*asv2.HorizontalPodAutoscaler, error) {
 
 	if depl == nil {
 		return nil, errors.New("failed to create HPA, found empty deployment")
@@ -89,7 +89,7 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, hpaName string,
 		maxRepl = minRepl
 	}
 	targetCPU := int32(execStrategy.TargetCPUPercent) // nolint: staticcheck
-	var hpaMetrics []asv2beta2.MetricSpec
+	var hpaMetrics []asv2.MetricSpec
 	if targetCPU > 0 && targetCPU < 100 {
 		hpaMetrics = append(hpaMetrics, ConvertTargetCPUToCustomMetric(targetCPU))
 	}
@@ -98,13 +98,13 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, hpaName string,
 		hpaMetrics = append(hpaMetrics, execStrategy.Metrics...)
 	}
 
-	hpa := &asv2beta2.HorizontalPodAutoscaler{
+	hpa := &asv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        hpaName,
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
 		},
-		Spec: asv2beta2.HorizontalPodAutoscalerSpec{
+		Spec: asv2.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: getScaleTargetRef(depl),
 			MinReplicas:    &minRepl,
 			MaxReplicas:    maxRepl,
@@ -120,7 +120,7 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, hpaName string,
 			existingHpa.Annotations = hpa.Annotations
 			existingHpa.Labels = hpa.Labels
 			existingHpa.Spec = hpa.Spec
-			existingHpa, err = hpaops.kubernetesClient.AutoscalingV2beta2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Update(ctx, existingHpa, metav1.UpdateOptions{})
+			existingHpa, err = hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Update(ctx, existingHpa, metav1.UpdateOptions{})
 			if err != nil {
 				logger.Warn("error adopting HPA", zap.Error(err),
 					zap.String("HPA", hpaName), zap.String("ns", depl.ObjectMeta.Namespace))
@@ -129,10 +129,10 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, hpaName string,
 		}
 		return existingHpa, err
 	} else if k8s_err.IsNotFound(err) {
-		cHpa, err := hpaops.kubernetesClient.AutoscalingV2beta2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Create(ctx, hpa, metav1.CreateOptions{})
+		cHpa, err := hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Create(ctx, hpa, metav1.CreateOptions{})
 		if err != nil {
 			if k8s_err.IsAlreadyExists(err) {
-				cHpa, err = hpaops.kubernetesClient.AutoscalingV2beta2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Get(ctx, hpaName, metav1.GetOptions{})
+				cHpa, err = hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Get(ctx, hpaName, metav1.GetOptions{})
 			}
 			if err != nil {
 				return nil, err
@@ -144,15 +144,15 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, hpaName string,
 	return nil, err
 }
 
-func (hpaops *HpaOperations) GetHpa(ctx context.Context, ns, name string) (*asv2beta2.HorizontalPodAutoscaler, error) {
-	return hpaops.kubernetesClient.AutoscalingV2beta2().HorizontalPodAutoscalers(ns).Get(ctx, name, metav1.GetOptions{})
+func (hpaops *HpaOperations) GetHpa(ctx context.Context, ns, name string) (*asv2.HorizontalPodAutoscaler, error) {
+	return hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Get(ctx, name, metav1.GetOptions{})
 }
 
-func (hpaops *HpaOperations) UpdateHpa(ctx context.Context, hpa *asv2beta2.HorizontalPodAutoscaler) error {
-	_, err := hpaops.kubernetesClient.AutoscalingV2beta2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Update(ctx, hpa, metav1.UpdateOptions{})
+func (hpaops *HpaOperations) UpdateHpa(ctx context.Context, hpa *asv2.HorizontalPodAutoscaler) error {
+	_, err := hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(hpa.ObjectMeta.Namespace).Update(ctx, hpa, metav1.UpdateOptions{})
 	return err
 }
 
 func (hpaops *HpaOperations) DeleteHpa(ctx context.Context, ns string, name string) error {
-	return hpaops.kubernetesClient.AutoscalingV2beta2().HorizontalPodAutoscalers(ns).Delete(ctx, name, metav1.DeleteOptions{})
+	return hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(ns).Delete(ctx, name, metav1.DeleteOptions{})
 }

--- a/pkg/executor/util/hpa/hpa_test.go
+++ b/pkg/executor/util/hpa/hpa_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/dchest/uniuri"
 	appsv1 "k8s.io/api/apps/v1"
-	asv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -33,13 +33,13 @@ import (
 
 func TestConvertTargetCPUToCustomMetric(t *testing.T) {
 	metricSpec := ConvertTargetCPUToCustomMetric(50)
-	if metricSpec.Type != asv2beta2.ResourceMetricSourceType {
+	if metricSpec.Type != asv2.ResourceMetricSourceType {
 		t.Errorf("Expected metric type to be Resource, got %v", metricSpec.Type)
 	}
 	if metricSpec.Resource.Name != corev1.ResourceCPU {
 		t.Errorf("Expected metric name to be cpu, got %v", metricSpec.Resource.Name)
 	}
-	if metricSpec.Resource.Target.Type != asv2beta2.UtilizationMetricType {
+	if metricSpec.Resource.Target.Type != asv2.UtilizationMetricType {
 		t.Errorf("Expected metric target type to be Utilization, got %v", metricSpec.Resource.Target.Type)
 	}
 	if metricSpec.Resource.Target.AverageUtilization == nil {
@@ -92,13 +92,13 @@ func TestHpaOps(t *testing.T) {
 	if hpa.Spec.MaxReplicas != 5 {
 		t.Errorf("Expected max replicas to be 5, got %v", hpa.Spec.MaxReplicas)
 	}
-	if hpa.Spec.Metrics[0].Type != asv2beta2.ResourceMetricSourceType {
+	if hpa.Spec.Metrics[0].Type != asv2.ResourceMetricSourceType {
 		t.Errorf("Expected metric type to be Resource, got %v", hpa.Spec.Metrics[0].Type)
 	}
 	if hpa.Spec.Metrics[0].Resource.Name != corev1.ResourceCPU {
 		t.Errorf("Expected metric name to be cpu, got %v", hpa.Spec.Metrics[0].Resource.Name)
 	}
-	if hpa.Spec.Metrics[0].Resource.Target.Type != asv2beta2.UtilizationMetricType {
+	if hpa.Spec.Metrics[0].Resource.Target.Type != asv2.UtilizationMetricType {
 		t.Errorf("Expected metric target type to be Utilization, got %v", hpa.Spec.Metrics[0].Resource.Target.Type)
 	}
 	if hpa.Spec.Metrics[0].Resource.Target.AverageUtilization == nil {

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	asv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 	apiv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -527,7 +527,7 @@ func getExecutionStrategy(fnExecutor fv1.ExecutorType, input cli.Input) (strateg
 			if err != nil {
 				return nil, err
 			}
-			strategy.Metrics = []asv2beta2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(int32(targetCPU))}
+			strategy.Metrics = []asv2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(int32(targetCPU))}
 		}
 	}
 
@@ -620,7 +620,7 @@ func updateExecutionStrategy(input cli.Input, existingExecutionStrategy *fv1.Exe
 			if err != nil {
 				return nil, err
 			}
-			strategy.Metrics = []asv2beta2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(int32(targetCPU))}
+			strategy.Metrics = []asv2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(int32(targetCPU))}
 		}
 
 	}

--- a/pkg/fission-cli/cmd/function/function_test.go
+++ b/pkg/fission-cli/cmd/function/function_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	asv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util/hpa"
@@ -277,7 +277,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 					ExecutorType:          fv1.ExecutorTypeNewdeploy,
 					MinScale:              DEFAULT_MIN_SCALE,
 					MaxScale:              DEFAULT_MIN_SCALE,
-					Metrics:               []asv2beta2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(50)},
+					Metrics:               []asv2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(50)},
 					SpecializationTimeout: fv1.DefaultSpecializationTimeOut,
 				},
 			},
@@ -295,7 +295,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 					ExecutorType:          fv1.ExecutorTypeNewdeploy,
 					MinScale:              2,
 					MaxScale:              5,
-					Metrics:               []asv2beta2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(88)},
+					Metrics:               []asv2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(88)},
 					SpecializationTimeout: fv1.DefaultSpecializationTimeOut,
 				},
 			},
@@ -305,7 +305,7 @@ func TestGetInvokeStrategy(t *testing.T) {
 					ExecutorType:          fv1.ExecutorTypeNewdeploy,
 					MinScale:              2,
 					MaxScale:              5,
-					Metrics:               []asv2beta2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(20)},
+					Metrics:               []asv2.MetricSpec{hpa.ConvertTargetCPUToCustomMetric(20)},
 					SpecializationTimeout: fv1.DefaultSpecializationTimeOut,
 				},
 			},

--- a/pkg/fission-cli/cmd/support/resources/kubernetes.go
+++ b/pkg/fission-cli/cmd/support/resources/kubernetes.go
@@ -116,7 +116,7 @@ func (res KubernetesObjectDumper) Dump(ctx context.Context, dumpDir string) {
 		}
 
 	case KubernetesHPA:
-		objs, err := res.client.AutoscalingV2beta2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: res.selector})
+		objs, err := res.client.AutoscalingV2().HorizontalPodAutoscalers(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: res.selector})
 		if err != nil {
 			console.Error(fmt.Sprintf("Error getting %v list with selector %v: %v", res.objType, res.selector, err))
 			return

--- a/pkg/utils/otel/attributes.go
+++ b/pkg/utils/otel/attributes.go
@@ -6,7 +6,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	appsv1 "k8s.io/api/apps/v1"
-	asv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	asv2 "k8s.io/api/autoscaling/v2"
 
 	apiv1 "k8s.io/api/core/v1"
 
@@ -77,7 +77,7 @@ func GetAttributesForDeployment(deployment *appsv1.Deployment) []attribute.KeyVa
 	}
 }
 
-func GetAttributesForHPA(hpa *asv2beta2.HorizontalPodAutoscaler) []attribute.KeyValue {
+func GetAttributesForHPA(hpa *asv2.HorizontalPodAutoscaler) []attribute.KeyValue {
 	if hpa == nil {
 		return []attribute.KeyValue{}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This PR update the Kubernetes Autoscaling API to v2.

This allow support for Kubernetes cluster in version v1.26 and latest. However, this drop the support for Kubernetes clusters in version under v1.23

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2722
Fixes #2838

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Unitests with `./hack/runtests.sh`
- Builded the `fission/fission-bundle` image locally with `goreleaser` and replaced the `executor` image
- Deployed the following function :
```bash
fission env create --name nodejs --image fission/node-env --poolsize 1 --version 3
fission function create --name hello-js --env nodejs --code  functions/hello.js --minscale=0 --maxscale=5 --executortype newdeploy
```
- Verify :
```bash
kubectl version

Client Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.2", GitCommit:"7f6f68fdabc4df88cfea2dcf9a19b2b830f1e647", GitTreeState:"clean", BuildDate:"2023-05-17T14:20:07Z", GoVersion:"go1.20.4", Compiler:"gc", Platform:"darwin/arm64"}
Kustomize Version: v5.0.1
Server Version: version.Info{Major:"1", Minor:"27", GitVersion:"v1.27.2", GitCommit:"7f6f68fdabc4df88cfea2dcf9a19b2b830f1e647", GitTreeState:"clean", BuildDate:"2023-05-17T14:13:28Z", GoVersion:"go1.20.4", Compiler:"gc", Platform:"linux/arm64"}

kubectl get hpa
NAME                                                     REFERENCE                                                           TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
newdeploy-hello-js-fission-functions-b6d5-29977d82419c   Deployment/newdeploy-hello-js-fission-functions-b6d5-29977d82419c   <unknown>/80%   1         5         1          2m24s
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
