### PR TITLE
helm: Add support for HorizontalPodAutoscaller on router

### DIFF
--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     svc: router
     application: fission-router
 spec:
-{{- if not .Values.router.deployAsDaemonSet }}
+{{- if and (not .Values.router.deployAsDaemonSet) (not .Values.router.autoscaling.enabled) }}
   replicas: {{ .Values.router.replicas | default 1 }}
 {{- end }}
   selector:

--- a/charts/fission-all/templates/router/hpa.yaml
+++ b/charts/fission-all/templates/router/hpa.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.router.autoscaling.enabled }}
+apiVersion: {{ .Values.autoscalingApiVersion }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: router
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: router
+    application: fission-router
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    {{- if not .Values.router.deployAsDaemonSet }}
+    kind: Deployment
+    {{- else }}
+    kind: DaemonSet
+    {{- end }}
+    name: router
+  minReplicas: {{ .Values.router.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.router.autoscaling.maxReplicas }}
+  metrics:
+  {{- if .Values.router.autoscaling.metrics }}
+  metrics:
+  {{ toYaml .Values.router.autoscaling.metrics | indent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -41,6 +41,10 @@ imagePullSecrets: []
 ##
 priorityClassName: ""
 
+## autoscalingApiVersion represents the version of the Autoscaling API to use for HorizontalPodAutoscaler on Fiison components.
+## Refer to https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/
+autoscalingApiVersion: autoscaling/v2
+
 ## terminationMessagePath is the path at which the pod termination message will be written.
 ## executor.terminationMessagePath takes precedence over this value for executor.
 ## router.terminationMessagePath takes precedence over this value for router.
@@ -214,6 +218,27 @@ router:
   ## replicas decides how many router pods to deploy. Only used when deployAsDaemonSet is false.
   ##
   replicas: 1
+  ## autoscaling decides whether to enable HorizontalPodAutoscaler for router.
+  ##
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    ## metrics is the list of metrics to be used for autoscaling.
+    ## For details, see https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-resource-metrics
+    ## metrics:
+    ##   - type: Resource
+    ##     resource:
+    ##       name: cpu
+    ##       target:
+    ##         type: Utilization
+    ##         averageUtilization: 60
+    ##   - type: Resource
+    ##     resource:
+    ##       name: memory
+    ##       target:
+    ##         type: Utilization
+    ##         averageUtilization: 60
   ## svcAddressMaxRetries is the max times for router to retry with a specific function service address
   ##
   svcAddressMaxRetries: 5


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This PR add new options in the Helm chart values allowing to deploy and HorizontalPodAutoscaler for the `router` component.

This is basically the implementation of this part of the doc : https://fission.io/docs/installation/advanced-setup/#create-hpa-for-router-service

By default, nothing change for the user.

User can select the Kubernetes autoscaling `apiVersion` allowing support for user with cluster version under v1.23. By default the `autoscalingApiVersion` used is `autoscaling/v2` (support v1.23+ and required in v1.26+).
The `router.autoscaling.metrics` handle the full metrics structure regardless of the `apiVersion`.

I have placed the value `autoscalingApiVersion` at the root allowing a reuse if we want to add autoscaling to other components of Fission in the futur.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Didn't find any

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Deploying the plateform without setting any values => same as before
- Deploying the plateform with `autoscaling.enabled=true`
```
kubectl get hpa

NAME     REFERENCE           TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
router   Deployment/router   <unknown>/80%   1         10        2          9m14s
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/2843)
<!-- Reviewable:end -->
