### PR TITLE
Avoid duplicate role in release namespace for router

### DIFF
--- a/charts/fission-all/templates/router/role-kubernetes.yaml
+++ b/charts/fission-all/templates/router/role-kubernetes.yaml
@@ -1,5 +1,4 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "router") .) }}
-{{- include "kubernetes-role-generator" (merge (dict "namespace" .Release.Namespace "component" "router") .) }}
 
 {{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

Avoid unnecessary role and rolebinding creation for router . 
We are creating role and rolebinding in release namespace for router which is not required and causes installation issue when release namespace and default namespace is same.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/fission/fission/issues/2855

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
