### PR TITLE
Use concurrency in poolmanager as per old behaviour

### DIFF
--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -149,7 +149,6 @@ func (c *PoolCache) service() {
 				continue
 			}
 			concurrencyUsed := len(funcSvcGroup.svcs) + (funcSvcGroup.svcWaiting - funcSvcGroup.queue.Len())
-			fmt.Println("cused", concurrencyUsed, "svcsLen", len(funcSvcGroup.svcs), "svcWaiting", funcSvcGroup.svcWaiting, "queue", funcSvcGroup.queue.Len())
 			// if concurrency is available then be aggressive and use it
 			if req.concurrency > 0 && concurrencyUsed < req.concurrency {
 				funcSvcGroup.svcWaiting++

--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -121,6 +121,7 @@ func (c *PoolCache) service() {
 		case getValue:
 			funcSvcGroup, ok := c.cache[req.function]
 			if !ok {
+				// first request for this function, create a new group
 				c.cache[req.function] = NewFuncSvcGroup()
 				c.cache[req.function].svcWaiting++
 				resp.error = ferror.MakeError(ferror.ErrorNotFound,
@@ -130,6 +131,7 @@ func (c *PoolCache) service() {
 			}
 			found := false
 			totalActiveRequests := 0
+			// check if any specialized pod is available
 			for addr := range funcSvcGroup.svcs {
 				totalActiveRequests += funcSvcGroup.svcs[addr].activeRequests
 				if funcSvcGroup.svcs[addr].activeRequests < req.requestsPerPod &&
@@ -144,20 +146,20 @@ func (c *PoolCache) service() {
 					break
 				}
 			}
+			// if specialized pod is available then return svc
 			if found {
 				req.responseChannel <- resp
 				continue
 			}
 			concurrencyUsed := len(funcSvcGroup.svcs) + (funcSvcGroup.svcWaiting - funcSvcGroup.queue.Len())
-			// if concurrency is available then be aggressive and use it
+			// if concurrency is available then be aggressive and use it as we are not sure if specialization will complete for other requests
 			if req.concurrency > 0 && concurrencyUsed < req.concurrency {
 				funcSvcGroup.svcWaiting++
 				resp.error = ferror.MakeError(ferror.ErrorNotFound, fmt.Sprintf("function '%s' not found", req.function))
 				req.responseChannel <- resp
 				continue
 			}
-			// if no concurrency is available then check if there is any capacity in the existing pods
-			// in pods in specialization in progress.
+			// if no concurrency is available then check if there is any virtual capacity in the existing pods to serve the request in future
 			// if specialization doesnt complete within request then request will be timeout
 			capacity := (concurrencyUsed * req.requestsPerPod) - (totalActiveRequests + funcSvcGroup.svcWaiting)
 			if capacity > 0 {
@@ -173,7 +175,7 @@ func (c *PoolCache) service() {
 			}
 
 			// concurrency should not be set to zero and
-			//sum of specialization in progress and specialized pods should be less then req.concurrency
+			// sum of specialization in progress and specialized pods should be less then req.concurrency
 			if req.concurrency > 0 && concurrencyUsed >= req.concurrency {
 				resp.error = ferror.MakeError(ferror.ErrorTooManyRequests, fmt.Sprintf("function '%s' concurrency '%d' limit reached.", req.function, req.concurrency))
 			} else {

--- a/pkg/executor/fscache/poolcache_test.go
+++ b/pkg/executor/fscache/poolcache_test.go
@@ -245,9 +245,10 @@ func TestPoolCacheRequests(t *testing.T) {
 						if svc == nil {
 							t.Log(reqno, "=>", "svc is nil")
 							atomic.AddUint64(&failedRequests, 1)
-						} else {
-							t.Log(reqno, "=>", svc.Name)
 						}
+						// } else {
+						// 	t.Log(reqno, "=>", svc.Name)
+						// }
 					}
 				}(reqno)
 				if reqno%simultaneous == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
Earlier we made fixes for #1939 and #2452
As part of the above issues, we added more swift way to handle concurrency https://github.com/fission/fission/pull/2737
and reduce bursts in pod specialization when initial bulk calls are made to the function.
In the earlier approach, we used all the capacity of a single pod(actual + virtual) and then used to specialize further pods.
This causes failure of requests if specific pod specialization fails.

This PR changes the approach a bit and uses concurrency aggressively until a point it is available(to the limit). Once we exhausted concurrency we consider using the virtual capacity of the pods until specialization finishes.

Combining this and old approach will ensure we specialize pods as much as possible and then switch to virtual capacity up to request per pod limit.


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes  https://github.com/fission/fission/issues/1939


## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
