### PR TITLE
Router authentication jwtSigningKey unique for every Fission installation 

### DIFF
--- a/charts/fission-all/templates/router/secret.yaml
+++ b/charts/fission-all/templates/router/secret.yaml
@@ -10,5 +10,5 @@ metadata:
 data:
   username: {{ .Values.authentication.authUsername | b64enc | quote }}
   password: {{ randAlphaNum 20 | b64enc | quote }}
-  jwtSigningKey: {{ .Values.authentication.jwtSigningKey | b64enc | quote }}
+  jwtSigningKey: {{ default (randAlphaNum 20) .Values.authentication.jwtSigningKey | b64enc | quote }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -682,7 +682,7 @@ authentication:
   ## jwtSigningKey is the signing key used for
   ## signing the JWT token
   ##
-  jwtSigningKey: serverless
+  jwtSigningKey: 
   ## jwtExpiryTime is the JWT expiry time
   ## in seconds
   ## default '120'


### PR DESCRIPTION
Removed jwtSigningKey default value from values.yaml and modified router secret to generate jwtSigningKey randomly if not passed in values.yaml

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Removed the default value set for jwtSigningKey in values.yaml file and added option to generate it randomly if not passed by in router secret.


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
