### PR TITLE
Set default package status to none if deployment exists

### DIFF
--- a/pkg/apis/core/v1/package_webhook.go
+++ b/pkg/apis/core/v1/package_webhook.go
@@ -47,7 +47,16 @@ var _ webhook.Defaulter = &Package{}
 func (r *Package) Default() {
 	packagelog.Debug("default", zap.String("name", r.Name))
 	if r.Status.BuildStatus == "" {
-		r.Status.BuildStatus = BuildStatusPending
+		if !r.Spec.Deployment.IsEmpty() {
+			// deployment package exists
+			r.Status.BuildStatus = BuildStatusNone
+		} else if !r.Spec.Source.IsEmpty() {
+			// source package with no deployment is a pending build
+			r.Status.BuildStatus = BuildStatusPending
+		} else {
+			r.Status.BuildStatus = BuildStatusFailed // empty package
+			r.Status.BuildLog = "Both source and deployment are empty"
+		}
 	}
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
If a package has deployment already, we should set the package status to none instead of pending. If we have a package that has source, we set the status to pending. If both source and deployment are empty, the package is marked as failure.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
