### PR TITLE
Make common cache typed with generics

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -29,7 +29,7 @@ func checkErr(err error) {
 }
 
 func TestCache(t *testing.T) {
-	c := MakeCache(100*time.Millisecond, 100*time.Millisecond)
+	c := MakeCache[string, string](100*time.Millisecond, 100*time.Millisecond)
 
 	_, err := c.Set("a", "b")
 	checkErr(err)

--- a/pkg/canaryconfigmgr/canaryConfigCache.go
+++ b/pkg/canaryconfigmgr/canaryConfigCache.go
@@ -27,7 +27,7 @@ import (
 
 type (
 	canaryConfigCancelFuncMap struct {
-		cache *cache.Cache[metadataKey, *CanaryProcessingInfo] // map[metadataKey]*context.Context
+		cache *cache.Cache[metadataKey, *CanaryProcessingInfo]
 	}
 
 	// metav1.ObjectMeta is not hashable, so we make a hashable copy

--- a/pkg/canaryconfigmgr/canaryConfigCache.go
+++ b/pkg/canaryconfigmgr/canaryConfigCache.go
@@ -27,7 +27,7 @@ import (
 
 type (
 	canaryConfigCancelFuncMap struct {
-		cache *cache.Cache // map[metadataKey]*context.Context
+		cache *cache.Cache[metadataKey, *CanaryProcessingInfo] // map[metadataKey]*context.Context
 	}
 
 	// metav1.ObjectMeta is not hashable, so we make a hashable copy
@@ -45,7 +45,7 @@ type (
 
 func makecanaryConfigCancelFuncMap() *canaryConfigCancelFuncMap {
 	return &canaryConfigCancelFuncMap{
-		cache: cache.MakeCache(0, 0),
+		cache: cache.MakeCache[metadataKey, *CanaryProcessingInfo](0, 0),
 	}
 }
 
@@ -62,8 +62,7 @@ func (cancelFuncMap *canaryConfigCancelFuncMap) lookup(f *metav1.ObjectMeta) (*C
 	if err != nil {
 		return nil, err
 	}
-	value := item.(*CanaryProcessingInfo)
-	return value, nil
+	return item, nil
 }
 
 func (cancelFuncMap *canaryConfigCancelFuncMap) assign(f *metav1.ObjectMeta, value *CanaryProcessingInfo) error {

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -78,7 +78,7 @@ type (
 		nsResolver       *utils.NamespaceResolver
 
 		fissionClient  versioned.Interface
-		functionEnv    *cache.Cache
+		functionEnv    *cache.Cache[crd.CacheKeyUR, *fv1.Environment]
 		fsCache        *fscache.FunctionServiceCache
 		instanceID     string
 		requestChannel chan *request
@@ -147,7 +147,7 @@ func MakeGenericPoolManager(ctx context.Context,
 		nsResolver:                 utils.DefaultNSResolver(),
 		metricsClient:              metricsClient,
 		fissionClient:              fissionClient,
-		functionEnv:                cache.MakeCache(10*time.Second, 0),
+		functionEnv:                cache.MakeCache[crd.CacheKeyUR, *fv1.Environment](10*time.Second, 0),
 		fsCache:                    fscache.MakeFunctionServiceCache(gpmLogger),
 		instanceID:                 instanceID,
 		requestChannel:             make(chan *request),
@@ -595,8 +595,7 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 	// TODO: the cache should be able to search by <env name, fn namespace> instead of function metadata.
 	result, err := gpm.functionEnv.Get(crd.CacheKeyURFromMeta(&fn.ObjectMeta))
 	if err == nil {
-		env = result.(*fv1.Environment)
-		return env, nil
+		return result, nil
 	}
 
 	// Get env from controller

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -68,12 +68,12 @@ type (
 	// FunctionServiceCache represents the function service cache
 	FunctionServiceCache struct {
 		logger            *zap.Logger
-		byFunction        *cache.Cache // function-key -> funcSvc  : map[string]*funcSvc
-		byAddress         *cache.Cache // address      -> function : map[string]metav1.ObjectMeta
-		byFunctionUID     *cache.Cache // function uid -> function : map[string]metav1.ObjectMeta
-		connFunctionCache *PoolCache   // function-key -> funcSvc : map[string]*funcSvc
-		PodToFsvc         sync.Map     // pod-name -> funcSvc: map[string]*FuncSvc
-		WebsocketFsvc     sync.Map     // funcSvc-name -> bool: map[string]bool
+		byFunction        *cache.Cache[crd.CacheKeyUR, *FuncSvc]     // function-key -> funcSvc  : map[string]*funcSvc
+		byAddress         *cache.Cache[string, metav1.ObjectMeta]    // address      -> function : map[string]metav1.ObjectMeta
+		byFunctionUID     *cache.Cache[types.UID, metav1.ObjectMeta] // function uid -> function : map[string]metav1.ObjectMeta
+		connFunctionCache *PoolCache                                 // function-key -> funcSvc : map[string]*funcSvc
+		PodToFsvc         sync.Map                                   // pod-name -> funcSvc: map[string]*FuncSvc
+		WebsocketFsvc     sync.Map                                   // funcSvc-name -> bool: map[string]bool
 		requestChannel    chan *fscRequest
 	}
 
@@ -110,9 +110,9 @@ func IsNameExistError(err error) bool {
 func MakeFunctionServiceCache(logger *zap.Logger) *FunctionServiceCache {
 	fsc := &FunctionServiceCache{
 		logger:            logger.Named("function_service_cache"),
-		byFunction:        cache.MakeCache(0, 0),
-		byAddress:         cache.MakeCache(0, 0),
-		byFunctionUID:     cache.MakeCache(0, 0),
+		byFunction:        cache.MakeCache[crd.CacheKeyUR, *FuncSvc](0, 0),
+		byAddress:         cache.MakeCache[string, metav1.ObjectMeta](0, 0),
+		byFunctionUID:     cache.MakeCache[types.UID, metav1.ObjectMeta](0, 0),
 		connFunctionCache: NewPoolCache(logger.Named("conn_function_cache")),
 		requestChannel:    make(chan *fscRequest),
 	}
@@ -132,14 +132,12 @@ func (fsc *FunctionServiceCache) service() {
 			// get svcs idle for > req.age
 			fscs := fsc.byFunctionUID.Copy()
 			funcObjects := make([]*FuncSvc, 0)
-			for _, funcSvc := range fscs {
-				mI := funcSvc.(metav1.ObjectMeta)
-				fsvcI, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&mI))
+			for _, m := range fscs {
+				fsvc, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
 				if err != nil {
 					fsc.logger.Error("error while getting service", zap.String("error", err.Error()))
 					return
 				}
-				fsvc := fsvcI.(*FuncSvc)
 				if time.Since(fsvc.Atime) > req.age {
 					funcObjects = append(funcObjects, fsvc)
 				}
@@ -149,8 +147,7 @@ func (fsc *FunctionServiceCache) service() {
 			fsc.logger.Info("dumping function service cache")
 			funcCopy := fsc.byFunction.Copy()
 			info := []string{}
-			for key, fsvcI := range funcCopy {
-				fsvc := fsvcI.(*FuncSvc)
+			for key, fsvc := range funcCopy {
 				for _, kubeObj := range fsvc.KubernetesObjects {
 					info = append(info, fmt.Sprintf("%v\t%v\t%v", key, kubeObj.Kind, kubeObj.Name))
 				}
@@ -196,13 +193,12 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 func (fsc *FunctionServiceCache) GetByFunction(m *metav1.ObjectMeta) (*FuncSvc, error) {
 	key := crd.CacheKeyURFromMeta(m)
 
-	fsvcI, err := fsc.byFunction.Get(key)
+	fsvc, err := fsc.byFunction.Get(key)
 	if err != nil {
 		return nil, err
 	}
 
 	// update atime
-	fsvc := fsvcI.(*FuncSvc)
 	fsvc.Atime = time.Now()
 
 	fsvcCopy := *fsvc
@@ -228,20 +224,17 @@ func (fsc *FunctionServiceCache) GetFuncSvc(ctx context.Context, m *metav1.Objec
 
 // GetByFunctionUID gets a function service from cache using function UUID.
 func (fsc *FunctionServiceCache) GetByFunctionUID(uid types.UID) (*FuncSvc, error) {
-	mI, err := fsc.byFunctionUID.Get(uid)
+	m, err := fsc.byFunctionUID.Get(uid)
 	if err != nil {
 		return nil, err
 	}
 
-	m := mI.(metav1.ObjectMeta)
-
-	fsvcI, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
+	fsvc, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
 	if err != nil {
 		return nil, err
 	}
 
 	// update atime
-	fsvc := fsvcI.(*FuncSvc)
 	fsvc.Atime = time.Now()
 
 	fsvcCopy := *fsvc
@@ -279,12 +272,11 @@ func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
 	existing, err := fsc.byFunction.Set(crd.CacheKeyURFromMeta(fsvc.Function), &fsvc)
 	if err != nil {
 		if IsNameExistError(err) {
-			f := existing.(*FuncSvc)
-			err2 := fsc.TouchByAddress(f.Address)
+			err2 := fsc.TouchByAddress(existing.Address)
 			if err2 != nil {
 				return nil, err2
 			}
-			fCopy := *f
+			fCopy := *existing
 			return &fCopy, nil
 		}
 		return nil, err
@@ -333,16 +325,14 @@ func (fsc *FunctionServiceCache) TouchByAddress(address string) error {
 }
 
 func (fsc *FunctionServiceCache) _touchByAddress(address string) error {
-	mI, err := fsc.byAddress.Get(address)
+	m, err := fsc.byAddress.Get(address)
 	if err != nil {
 		return err
 	}
-	m := mI.(metav1.ObjectMeta)
-	fsvcI, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
+	fsvc, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
 	if err != nil {
 		return err
 	}
-	fsvc := fsvcI.(*FuncSvc)
 	fsvc.Atime = time.Now()
 	return nil
 }

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -68,12 +68,12 @@ type (
 	// FunctionServiceCache represents the function service cache
 	FunctionServiceCache struct {
 		logger            *zap.Logger
-		byFunction        *cache.Cache[crd.CacheKeyUR, *FuncSvc]     // function-key -> funcSvc  : map[string]*funcSvc
-		byAddress         *cache.Cache[string, metav1.ObjectMeta]    // address      -> function : map[string]metav1.ObjectMeta
-		byFunctionUID     *cache.Cache[types.UID, metav1.ObjectMeta] // function uid -> function : map[string]metav1.ObjectMeta
-		connFunctionCache *PoolCache                                 // function-key -> funcSvc : map[string]*funcSvc
-		PodToFsvc         sync.Map                                   // pod-name -> funcSvc: map[string]*FuncSvc
-		WebsocketFsvc     sync.Map                                   // funcSvc-name -> bool: map[string]bool
+		byFunction        *cache.Cache[crd.CacheKeyUR, *FuncSvc]
+		byAddress         *cache.Cache[string, metav1.ObjectMeta]
+		byFunctionUID     *cache.Cache[types.UID, metav1.ObjectMeta]
+		connFunctionCache *PoolCache // function-key -> funcSvc : map[string]*funcSvc
+		PodToFsvc         sync.Map   // pod-name -> funcSvc: map[string]*FuncSvc
+		WebsocketFsvc     sync.Map   // funcSvc-name -> bool: map[string]bool
 		requestChannel    chan *fscRequest
 	}
 

--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -215,9 +215,5 @@ func (frr *functionReferenceResolver) delete(namespace string, triggerName, trig
 }
 
 func (frr *functionReferenceResolver) copy() map[namespacedTriggerReference]resolveResult {
-	cache := make(map[namespacedTriggerReference]resolveResult)
-	for k, v := range frr.refCache.Copy() {
-		cache[k] = v
-	}
-	return cache
+	return frr.refCache.Copy()
 }

--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -34,7 +34,7 @@ type (
 	// reference into a resolveResult
 	functionReferenceResolver struct {
 		// FunctionReference -> function metadata
-		refCache     *cache.Cache
+		refCache     *cache.Cache[namespacedTriggerReference, resolveResult]
 		funcInformer map[string]k8sCache.SharedIndexInformer
 		logger       *zap.Logger
 		// store    k8sCache.Store
@@ -73,7 +73,7 @@ const (
 
 func makeFunctionReferenceResolver(logger *zap.Logger, funcInformer map[string]k8sCache.SharedIndexInformer) *functionReferenceResolver {
 	frr := &functionReferenceResolver{
-		refCache:     cache.MakeCache(time.Minute, 0),
+		refCache:     cache.MakeCache[namespacedTriggerReference, resolveResult](time.Minute, 0),
 		funcInformer: funcInformer,
 		logger:       logger.Named("function_ref_resolver"),
 	}
@@ -89,9 +89,8 @@ func (frr *functionReferenceResolver) resolve(trigger fv1.HTTPTrigger) (*resolve
 	}
 
 	// check cache
-	rrInt, err := frr.refCache.Get(nfr)
+	result, err := frr.refCache.Get(nfr)
 	if err == nil {
-		result := rrInt.(resolveResult)
 		return &result, nil
 	}
 
@@ -218,9 +217,7 @@ func (frr *functionReferenceResolver) delete(namespace string, triggerName, trig
 func (frr *functionReferenceResolver) copy() map[namespacedTriggerReference]resolveResult {
 	cache := make(map[namespacedTriggerReference]resolveResult)
 	for k, v := range frr.refCache.Copy() {
-		key := k.(namespacedTriggerReference)
-		val := v.(resolveResult)
-		cache[key] = val
+		cache[k] = v
 	}
 	return cache
 }

--- a/pkg/router/functionServiceMap.go
+++ b/pkg/router/functionServiceMap.go
@@ -29,7 +29,7 @@ import (
 type (
 	functionServiceMap struct {
 		logger *zap.Logger
-		cache  *cache.Cache[metadataKey, *url.URL] // map[metadataKey]*url.URL
+		cache  *cache.Cache[metadataKey, *url.URL]
 	}
 
 	// metav1.ObjectMeta is not hashable, so we make a hashable copy

--- a/pkg/router/functionServiceMap.go
+++ b/pkg/router/functionServiceMap.go
@@ -29,7 +29,7 @@ import (
 type (
 	functionServiceMap struct {
 		logger *zap.Logger
-		cache  *cache.Cache // map[metadataKey]*url.URL
+		cache  *cache.Cache[metadataKey, *url.URL] // map[metadataKey]*url.URL
 	}
 
 	// metav1.ObjectMeta is not hashable, so we make a hashable copy
@@ -44,7 +44,7 @@ type (
 func makeFunctionServiceMap(logger *zap.Logger, expiry time.Duration) *functionServiceMap {
 	return &functionServiceMap{
 		logger: logger.Named("function_service_map"),
-		cache:  cache.MakeCache(expiry, 0),
+		cache:  cache.MakeCache[metadataKey, *url.URL](expiry, 0),
 	}
 }
 
@@ -62,15 +62,14 @@ func (fmap *functionServiceMap) lookup(f *metav1.ObjectMeta) (*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
-	u := item.(*url.URL)
-	return u, nil
+	return item, nil
 }
 
 func (fmap *functionServiceMap) assign(f *metav1.ObjectMeta, serviceURL *url.URL) {
 	mk := keyFromMetadata(f)
 	old, err := fmap.cache.Set(*mk, serviceURL)
 	if err != nil {
-		if *serviceURL == *(old.(*url.URL)) {
+		if *serviceURL == *old {
 			return
 		}
 		fmap.logger.Error("error caching service url for function with a different value", zap.Error(err))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description

Making typed common cache with generics so that we don't use wrong types
across set/get methods and more higher level methods can be
defined for the cache.

Currently, we are not able to operate over all keys of the cache due to generic types.

Primary changes made in [pkg/cache/cache.go](https://github.com/fission/fission/pull/2896/files#diff-964e351ee2375d359c78d69e514c4edc42577219761c4475f391ed2daf715e51)
## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
