### PR TITLE
Fix `fission check` command doesnt work for namespace other than `fission`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fission/fission
 
-go 1.22
+go 1.22.2
 
 require (
 	dario.cat/mergo v1.0.0

--- a/pkg/fission-cli/cmd/check/check.go
+++ b/pkg/fission-cli/cmd/check/check.go
@@ -14,11 +14,12 @@ limitations under the License.
 package check
 
 import (
+	"fmt"
+
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/healthcheck"
-	"github.com/pkg/errors"
 )
 
 type CheckSubCommand struct {
@@ -33,9 +34,9 @@ func (opts *CheckSubCommand) do(input cli.Input) error {
 
 	checks := []healthcheck.CategoryID{}
 
-	userProvidedNS, _, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, _, err := opts.GetResourceNamespace(input, flagkey.Namespace)
 	if err != nil {
-		return errors.Wrap(err, "error retrieving user provided namespace information")
+		return fmt.Errorf("error retrieving user provided namespace information: %w", err)
 	}
 
 	if input.IsSet(flagkey.PreCheckOnly) {

--- a/pkg/fission-cli/util/constants.go
+++ b/pkg/fission-cli/util/constants.go
@@ -18,11 +18,12 @@ package util
 
 // fission-cli options
 const (
-	SPEC_IGNORE_FILE    = ".specignore"
-	COMMIT_LABEL        = "commit"
-	FISSION_AUTH_URI    = "/auth/login"
-	FISSION_AUTH_TOKEN  = "FISSION_AUTH_TOKEN"
-	FISSION_STORAGE_URI = "/v1/archive"
+	SPEC_IGNORE_FILE          = ".specignore"
+	COMMIT_LABEL              = "commit"
+	FISSION_AUTH_URI          = "/auth/login"
+	FISSION_AUTH_TOKEN        = "FISSION_AUTH_TOKEN"
+	FISSION_STORAGE_URI       = "/v1/archive"
+	FISSION_DEFAULT_NAMESPACE = "fission"
 )
 
 const (

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -203,10 +203,14 @@ func (hc *HealthChecker) allCategories() []*Category {
 	}
 }
 
-func NewHealthChecker(cmd cmd.Client, categoryIDs []CategoryID) *HealthChecker {
+func NewHealthChecker(cmd cmd.Client, categoryIDs []CategoryID, fissionNamespace string) *HealthChecker {
+	if fissionNamespace == "" {
+		fissionNamespace = util.FISSION_DEFAULT_NAMESPACE
+	}
+
 	hc := &HealthChecker{
 		kubeAPI:          cmd.KubernetesClient,
-		fissionNamespace: "fission",
+		fissionNamespace: fissionNamespace,
 	}
 
 	hc.categories = hc.allCategories()

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -366,6 +366,11 @@ func TestFissionCLI(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("check --namespace", func(t *testing.T) {
+		_, err := cli.ExecCommand(f, ctx, "check", "--namespace", "default")
+		require.NoError(t, err)
+	})
+
 	t.Run("version", func(t *testing.T) {
 		_, err := cli.ExecCommand(f, ctx, "version")
 		require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
`fission check` command does not work outside of "fission" namespace. If user provides namespace then use it for running `fission check` command otherwise use `fission` as default namespace.


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2924

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Fission installed in `fission` namespace.
```
$ fission check
fission-services
--------------------
√ executor is running fine
√ router is running fine
√ storagesvc is running fine
√ webhook is running fine

fission-version
--------------------
√ fission is up-to-date
```
- Fission installed in `check` namespace.
```
$ fission check
fission-services
--------------------
× failed to get executor deployment status
× failed to get router deployment status
× failed to get storagesvc deployment status
Error: Error found: failed to get webhook deployment status
× failed to get webhook deployment status

fission-version
--------------------
√ fission is up-to-date
```
```
$ fission check --namespace check
fission-services
--------------------
√ executor is running fine
√ router is running fine
√ storagesvc is running fine
√ webhook is running fine

fission-version
--------------------
√ fission is up-to-date
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
