### PR TITLE
Fix CLI command `pkg getsrc` returns deploy archive instead of source archive

### DIFF
--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -29,10 +29,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-)
-
-const (
-	deployArchive = iota
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -40,15 +37,19 @@ type GetSubCommand struct {
 	name        string
 	namespace   string
 	output      string
-	archiveType int
+	archiveType string
 }
 
 func GetSrc(input cli.Input) error {
-	return (&GetSubCommand{}).do(input)
+	opts := &GetSubCommand{}
+	opts.archiveType = util.SOURCE_ARCHIVE
+	return opts.do(input)
 }
 
 func GetDeploy(input cli.Input) error {
-	return (&GetSubCommand{}).do(input)
+	opts := &GetSubCommand{}
+	opts.archiveType = util.DEPLOY_ARCHIVE
+	return opts.do(input)
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
@@ -78,13 +79,13 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 
 	var reader io.Reader
 	archive := pkg.Spec.Source
-	if opts.archiveType == deployArchive {
+	if opts.archiveType == util.DEPLOY_ARCHIVE || archive.Type == "" {
 		archive = pkg.Spec.Deployment
 	}
 
-	if pkg.Spec.Deployment.Type == fv1.ArchiveTypeLiteral {
+	if archive.Type == fv1.ArchiveTypeLiteral {
 		reader = bytes.NewReader(archive.Literal)
-	} else if pkg.Spec.Deployment.Type == fv1.ArchiveTypeUrl {
+	} else if archive.Type == fv1.ArchiveTypeUrl {
 
 		readCloser, err := pkgutil.DownloadStrorageURL(input.Context(), opts.Client(), archive.URL)
 		if err != nil {

--- a/pkg/fission-cli/util/constants.go
+++ b/pkg/fission-cli/util/constants.go
@@ -24,6 +24,8 @@ const (
 	FISSION_AUTH_TOKEN        = "FISSION_AUTH_TOKEN"
 	FISSION_STORAGE_URI       = "/v1/archive"
 	FISSION_DEFAULT_NAMESPACE = "fission"
+	SOURCE_ARCHIVE            = "source"
+	DEPLOY_ARCHIVE            = "deploy"
 )
 
 const (

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -454,6 +454,7 @@ func TestFissionCLI(t *testing.T) {
 	t.Run("package", func(t *testing.T) {
 		testPkgName := "test-pkg"
 		envName := "test-env"
+		envName2 := "test-env-2"
 
 		t.Run("create", func(t *testing.T) {
 			_, err := cli.ExecCommand(f, ctx, "env", "create", "--name", envName, "--image", "fission/python-env")
@@ -495,17 +496,17 @@ func TestFissionCLI(t *testing.T) {
 		})
 
 		t.Run("update", func(t *testing.T) {
-			_, err := cli.ExecCommand(f, ctx, "env", "create", "--name", "test-env-2", "--image", "fission/python-env:v2")
+			_, err := cli.ExecCommand(f, ctx, "env", "create", "--name", envName2, "--image", "fission/python-env:v2")
 			require.NoError(t, err)
 
-			_, err = cli.ExecCommand(f, ctx, "pkg", "update", "--name", testPkgName, "--code", "./hello.js", "--env", "test-env-2")
+			_, err = cli.ExecCommand(f, ctx, "pkg", "update", "--name", testPkgName, "--code", "./hello.js", "--env", envName2)
 			require.NoError(t, err)
 
 			pkg, err := fissionClient.CoreV1().Packages(metav1.NamespaceDefault).Get(ctx, testPkgName, metav1.GetOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, pkg)
 			require.Equal(t, testPkgName, pkg.Name)
-			require.Equal(t, "test-env-2", pkg.Spec.Environment.Name)
+			require.Equal(t, envName2, pkg.Spec.Environment.Name)
 		})
 
 		t.Run("delete", func(t *testing.T) {
@@ -514,6 +515,12 @@ func TestFissionCLI(t *testing.T) {
 
 			_, err = fissionClient.CoreV1().Packages(metav1.NamespaceDefault).Get(ctx, testPkgName, metav1.GetOptions{})
 			require.Error(t, err)
+
+			_, err = cli.ExecCommand(f, ctx, "env", "delete", "--name", envName)
+			require.NoError(t, err)
+
+			_, err = cli.ExecCommand(f, ctx, "env", "delete", "--name", envName2)
+			require.NoError(t, err)
 		})
 	})
 }

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -450,4 +450,70 @@ func TestFissionCLI(t *testing.T) {
 		err = os.RemoveAll("specs")
 		require.NoError(t, err)
 	})
+
+	t.Run("package", func(t *testing.T) {
+		testPkgName := "test-pkg"
+		envName := "test-env"
+
+		t.Run("create", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "env", "create", "--name", envName, "--image", "fission/python-env")
+			require.NoError(t, err)
+
+			_, err = cli.ExecCommand(f, ctx, "pkg", "create", "--name", testPkgName, "--code", "./hello.js", "--env", envName)
+			require.NoError(t, err)
+
+			pkg, err := fissionClient.CoreV1().Packages(metav1.NamespaceDefault).Get(ctx, testPkgName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, pkg)
+			require.Equal(t, testPkgName, pkg.Name)
+			require.Equal(t, envName, pkg.Spec.Environment.Name)
+		})
+
+		t.Run("list", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "pkg", "list")
+			require.NoError(t, err)
+		})
+
+		t.Run("info", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "pkg", "info", "--name", testPkgName)
+			require.NoError(t, err)
+		})
+
+		t.Run("getsrc", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "pkg", "getsrc", "--name", testPkgName)
+			require.NoError(t, err)
+		})
+
+		t.Run("getdeploy", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "pkg", "getdeploy", "--name", testPkgName)
+			require.NoError(t, err)
+		})
+
+		t.Run("rebuild", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "pkg", "rebuild", "--name", testPkgName)
+			require.Error(t, err)
+		})
+
+		t.Run("update", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "env", "create", "--name", "test-env-2", "--image", "fission/python-env:v2")
+			require.NoError(t, err)
+
+			_, err = cli.ExecCommand(f, ctx, "pkg", "update", "--name", testPkgName, "--code", "./hello.js", "--env", "test-env-2")
+			require.NoError(t, err)
+
+			pkg, err := fissionClient.CoreV1().Packages(metav1.NamespaceDefault).Get(ctx, testPkgName, metav1.GetOptions{})
+			require.NoError(t, err)
+			require.NotNil(t, pkg)
+			require.Equal(t, testPkgName, pkg.Name)
+			require.Equal(t, "test-env-2", pkg.Spec.Environment.Name)
+		})
+
+		t.Run("delete", func(t *testing.T) {
+			_, err := cli.ExecCommand(f, ctx, "pkg", "delete", "--name", testPkgName)
+			require.NoError(t, err)
+
+			_, err = fissionClient.CoreV1().Packages(metav1.NamespaceDefault).Get(ctx, testPkgName, metav1.GetOptions{})
+			require.Error(t, err)
+		})
+	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Fix CLI command `pkg getsrc` to return source archive instead of deploy archive.
- If source archive is not available then return deploy archive.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2839

## Testing
<!--- Please describe in detail how you tested your changes. -->
```
$ fission package getsrc --name hello-py-06b10319-a196-4c84-819f-0238dc09100c
def main():
    return "Python, world!\n"
```
```
$ fission package getsrc --name hello-go-c38b5bc1-3a1e-467d-b2da-9d74f9c82af0 
package main

import (
	"net/http"
)

// Handler is the entry point for this fission function
func Handler(w http.ResponseWriter, r *http.Request) {
	msg := "Hello, world!\n"
	w.Write([]byte(msg))
}
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
