### PR TITLE
Fix `fission spec apply --delete` deleting environments

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -923,7 +923,7 @@ func applyEnvironments(ctx context.Context, fclient cmd.Client, fr *FissionResou
 		for _, o := range objs {
 			_, wanted := desired[mapKey(&o.ObjectMeta)]
 			if !wanted {
-				err := fclient.FissionClientSet.CoreV1().Environments(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Namespace, metav1.DeleteOptions{})
+				err := fclient.FissionClientSet.CoreV1().Environments(o.ObjectMeta.Namespace).Delete(ctx, o.ObjectMeta.Name, metav1.DeleteOptions{})
 				if err != nil {
 					return nil, nil, err
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Fixes `fission spec apply --delete`  failing to delete environments.

<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
There was a typo in `pkg/fission-cli/cmd/spec/apply.go`: the environment namespace was being used rather than the environment name.


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2942

## Testing
Tested manually. The example case in #2942 no longer fails, and the environment is correctly deleted.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
