### PR TITLE
Set latest envVersion 3 as default

### DIFF
--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -138,11 +138,6 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 		envVersion = 1
 	}
 
-	if input.IsSet(flagkey.EnvPoolsize) {
-		// TODO: remove silently version 3 assignment, we need to warn user to set it explicitly.
-		envVersion = 3
-	}
-
 	if !input.IsSet(flagkey.EnvPoolsize) {
 		console.Info("poolsize setting default to 3")
 	}
@@ -154,10 +149,6 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 
 	envBuilderImg := input.String(flagkey.EnvBuilderImage)
 	if len(envBuilderImg) > 0 {
-		if !input.IsSet(flagkey.EnvVersion) {
-			// TODO: remove set env version to 2 silently, we need to warn user to set it explicitly.
-			envVersion = 2
-		}
 		if len(envBuildCmd) == 0 {
 			envBuildCmd = "build"
 		}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -182,7 +182,7 @@ var (
 	EnvKeepArchive            = Flag{Type: Bool, Name: flagkey.EnvKeeparchive, Usage: "Keep the archive instead of extracting it into a directory (mainly for the JVM environment because .jar is one kind of zip archive)"}
 	EnvExternalNetwork        = Flag{Type: Bool, Name: flagkey.EnvExternalNetwork, Usage: "Allow pod to access external network (only works when istio feature is enabled)"}
 	EnvTerminationGracePeriod = Flag{Type: Int64, Name: flagkey.EnvGracePeriod, Aliases: []string{"period"}, Usage: "Grace time (in seconds) for pod to perform connection draining before termination (only non-negative values considered)", DefaultValue: 360}
-	EnvVersion                = Flag{Type: Int, Name: flagkey.EnvVersion, Usage: "Environment API version (1 means v1 interface)", DefaultValue: 1}
+	EnvVersion                = Flag{Type: Int, Name: flagkey.EnvVersion, Usage: "Environment API version (1 means v1 interface)", DefaultValue: 3}
 	EnvImagePullSecret        = Flag{Type: String, Name: flagkey.EnvImagePullSecret, Usage: "Secret for Kubernetes to pull an image from a private registry"}
 	EnvExecutorType           = Flag{Type: String, Name: flagkey.EnvExecutorType, Usage: "Executor type of pod in environment; one of 'poolmgr', 'newdeploy', 'container'"}
 	EnvForce                  = Flag{Type: Bool, Name: flagkey.EnvForce, Short: "f", Usage: "Force delete env even if one or more functions exist", DefaultValue: false}

--- a/test/e2e/cli/cli_test.go
+++ b/test/e2e/cli/cli_test.go
@@ -46,6 +46,7 @@ func TestFissionCLI(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("environment", func(t *testing.T) {
+		defaultEnvVersion := 3
 		t.Run("create", func(t *testing.T) {
 			_, err := cli.ExecCommand(f, ctx, "env", "create", "--name", "test-env", "--image", "fission/python-env")
 			require.NoError(t, err)
@@ -55,6 +56,7 @@ func TestFissionCLI(t *testing.T) {
 			require.NotNil(t, env)
 			require.Equal(t, "test-env", env.Name)
 			require.Equal(t, "fission/python-env", env.Spec.Runtime.Image)
+			require.Equal(t, defaultEnvVersion, env.Spec.Version)
 		})
 
 		t.Run("list", func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
Make latest envVersion 3 as default version.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
Now we can create env pods with poolsize=1 
```
fission env create --name go --image fission/go-env-1.16 --builder fission/go-builder-1.16 --poolsize 1
```
```
$ kubectl get po
NAME                                         READY   STATUS    RESTARTS   AGE
go-564499-69b8db6f7-ltzhp                    2/2     Running   0          73s
poolmgr-go-default-564499-79c65c544b-mpmlz   2/2     Running   0          73s
```
## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
