### PR TITLE
fetcher when call uploadHandler ,archive zip, Use newZip instead of t…

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -611,12 +611,16 @@ func (fetcher *Fetcher) archive(src string, dst string) error {
 	} else {
 		files = append(files, src)
 	}
-	return archiver.DefaultZip.Archive(files, dst)
+	zip := archiver.NewZip()
+	defer zip.Close()
+	return zip.Archive(files, dst)
 }
 
 // unarchive is a function that unzips a zip file to destination
 func (fetcher *Fetcher) unarchive(src string, dst string) error {
-	err := archiver.DefaultZip.Unarchive(src, dst)
+	zip := archiver.NewZip()
+	defer zip.Close()
+	err := zip.Unarchive(src, dst)
 	if err != nil {
 		return fmt.Errorf("failed to unzip file: %w", err)
 	}


### PR DESCRIPTION
## Description
when I can try sending multiple packaging requests in one second,fission env throws error message： Error uploading deployment package: Internal error - error archiving zip file: file already exists: /packages/zip-test12-c39404ab-6fbc-40a2-8592-ebd9ea9ea6a8-ixnecf-lvvg6k.zip，so  fetcher when call uploadHandler ,archive zip, Use newZip instead of the default DefaultZip to improve the fetcher to accept more upload requests.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/fission/fission/issues/2936

## Testing
<!--- Please describe in detail how you tested your changes. -->
This is a test screenshot of our environment，it is very successful
![image](https://github.com/fission/fission/assets/35413731/85c200ff-6d21-49d4-aca0-feb203b25a3d)

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
