### PR TITLE
Set goreleaser version to v1 for CI tests

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -87,6 +87,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           install-only: true
+          version: "~> v1"
 
       - name: Setup Prometheus Stack
         run: |
@@ -229,6 +230,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           install-only: true
+          version: "~> v1"
 
       - name: Setup Prometheus Stack
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           install-only: true
+          version: "~> v1"
 
       - name: Kind Clutser
         uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0

--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -61,6 +61,7 @@ jobs:
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
           install-only: true
+          version: "~> v1"
 
       - name: Setup kubectl & fetch node information
         run: |

--- a/pkg/fission-cli/cmd/check/check.go
+++ b/pkg/fission-cli/cmd/check/check.go
@@ -36,7 +36,7 @@ func (opts *CheckSubCommand) do(input cli.Input) error {
 
 	userProvidedNS, _, err := opts.GetResourceNamespace(input, flagkey.Namespace)
 	if err != nil {
-		return fmt.Errorf("error retrieving user provided namespace: %w", err)
+		return fmt.Errorf("error retrieving user provided namespace information: %w", err)
 	}
 
 	if input.IsSet(flagkey.PreCheckOnly) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
By default goreleaser-action `v5.0.0` sets goreleaser version to `latest`. Latest goreleaser version has some breaking changes and involves major version change to v2.
Due to this, we are seeing this issue while building `fission-cli`
```
• only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
  ⨯ build failed after 0s                    error=only configurations files on version: 2 are supported, yours is version: 0, please update your configuration
```
This PR sets the goreleaser version to `v1`.
## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
