### PR TITLE
Fix fission-cli cmd `pkg getdeploy`

### DIFF
--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -71,7 +71,6 @@ func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) error {
-
 	pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.namespace).Get(input.Context(), opts.name, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -79,7 +78,7 @@ func (opts *GetSubCommand) run(input cli.Input) error {
 
 	var reader io.Reader
 	archive := pkg.Spec.Source
-	if opts.archiveType == util.DEPLOY_ARCHIVE || archive.Type == "" {
+	if (opts.archiveType == util.DEPLOY_ARCHIVE || archive.Type == "") && (pkg.Spec.Deployment.Type != "") {
 		archive = pkg.Spec.Deployment
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
If the deployment archive is not available in package resource then we see below error. Deployment archive is not available if package is being built or in failed state.
This PR resolve this issue by returning the source archive if deployment archive is not available.
```
$ fission pkg getdeploy --name hello-6492eb75-0f4e-4916-a47a-2b94a4deeb58
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4b097e]

goroutine 1 [running]:
io.copyBuffer({0x29d8180, 0xc000117488}, {0x0, 0x0}, {0x0, 0x0, 0x0})
	/usr/local/go/src/io/io.go:429 +0x17e
io.Copy(...)
	/usr/local/go/src/io/io.go:388
os.genericReadFrom(0xc000090028?, {0x0, 0x0})
	/usr/local/go/src/os/file.go:179 +0x58
os.(*File).ReadFrom(0xc000090028, {0x0, 0x0})
	/usr/local/go/src/os/file.go:155 +0x9c
io.copyBuffer({0x29d8200, 0xc000090028}, {0x0, 0x0}, {0x0, 0x0, 0x0})
	/usr/local/go/src/io/io.go:415 +0x151
io.Copy(...)
	/usr/local/go/src/io/io.go:388
github.com/fission/fission/pkg/fission-cli/cmd/package.(*GetSubCommand).run(0xc000557c08, {0x2a0faf0, 0xc000154660})
	pkg/fission-cli/cmd/package/get.go:102 +0x545
github.com/fission/fission/pkg/fission-cli/cmd/package.(*GetSubCommand).do(0xc000557c08, {0x2a0faf0, 0xc000154660})
	pkg/fission-cli/cmd/package/get.go:60 +0x45
github.com/fission/fission/pkg/fission-cli/cmd/package.GetDeploy({0x2a0faf0?, 0xc000154660?})
	pkg/fission-cli/cmd/package/get.go:52 +0x55
github.com/fission/fission/pkg/fission-cli/cmd/package.Commands.Wrapper.func3(0xc0003b4d00?, {0xc0003b0b80?, 0x4?, 0x24327e3?})
	pkg/fission-cli/cliwrapper/driver/cobra/cobra.go:51 +0x62
github.com/spf13/cobra.(*Command).execute(0xc000452608, {0xc0003b0b60, 0x2, 0x2})
	/home/soharab/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc000600608)
	/home/soharab/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x0?)
	/home/soharab/go/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x13
main.main()
	cmd/fission-cli/main.go:31 +0x2b
```

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
Package resource
```
apiVersion: fission.io/v1
kind: Package
metadata:
  creationTimestamp: "2024-06-19T07:33:18Z"
  generation: 3
  name: hello-6492eb75-0f4e-4916-a47a-2b94a4deeb58
  namespace: default
  resourceVersion: "789319"
  uid: 3cabf95a-2af9-459f-8d0f-0c5463c02320
spec:
  deployment:
    checksum: {}
  environment:
    name: go-120
    namespace: default
  source:
    checksum: {}
    literal: UEsDBBQACAAIACY801gAAAAAAAAAAAAAAAAIAAkAaGVsbG8uZ29VVAUAAbiJcmY0zD1LxEAQh/E68yn+pkrkuPSCvbUggi/Fmp0kg5fZdWZCCH55Ubz2gedX0/iZZsaaRIlkrcUCHTWtcgxLRG2pJxoGPCTNFzaIIxYGa9iBWkQDUzHEIo5J3KUopk3HkKI0bTpez27Hr3d+ZK9FnZ9Ngu0Ew+1//9rYo8c3NavPuLtH+1RzCs54kVo5n7AXu+SbN22p2c9/QPf6/nEEd6vPfU8/AwBQSwcIuyKb76UAAADOAAAAUEsBAhQDFAAIAAgAJjzTWLsim++lAAAAzgAAAAgACQAAAAAAAAAAALSBAAAAAGhlbGxvLmdvVVQFAAG4iXJmUEsFBgAAAAABAAEAPwAAAOQAAAAAAA==
    type: literal
```
```
$ fission pkg getdeploy --name hello-6492eb75-0f4e-4916-a47a-2b94a4deeb58
&<�X    hello.goUT��rf4�=K�@��:�)��J�􂽵 �/Ś�$���uf~yQ����W���fƚD�d��5�r
                                                                      KDm�'�<$�6�#k؁ZDS1�"�Iܥ(�Mǐ�4m:^�nǯw~d�E��M������أ�75�ϸ�G�Ts
�x�Z9����7m���@���qw��}O?P�"���&<�X�"�����hello.goUT��rfPK?�
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
