### PR TITLE
Set OwnerReferences to K8s resources created by Fission

### DIFF
--- a/pkg/buildermgr/envwatcher.go
+++ b/pkg/buildermgr/envwatcher.go
@@ -329,6 +329,14 @@ func (envw *environmentWatcher) createBuilderService(ctx context.Context, env *f
 			Namespace: ns,
 			Name:      name,
 			Labels:    sel,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "fission.io/v1",
+					Kind:       "Environment",
+					Name:       env.GetName(),
+					UID:        env.GetUID(),
+				},
+			},
 		},
 		Spec: apiv1.ServiceSpec{
 			Selector: sel,
@@ -440,6 +448,14 @@ func (envw *environmentWatcher) createBuilderDeployment(ctx context.Context, env
 			Namespace: ns,
 			Name:      name,
 			Labels:    sel,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "fission.io/v1",
+					Kind:       "Environment",
+					Name:       env.GetName(),
+					UID:        env.GetUID(),
+				},
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,

--- a/pkg/buildermgr/envwatcher.go
+++ b/pkg/buildermgr/envwatcher.go
@@ -28,6 +28,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -330,12 +331,11 @@ func (envw *environmentWatcher) createBuilderService(ctx context.Context, env *f
 			Name:      name,
 			Labels:    sel,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Environment",
-					Name:       env.GetName(),
-					UID:        env.GetUID(),
-				},
+				*metav1.NewControllerRef(env, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Environment",
+				}),
 			},
 		},
 		Spec: apiv1.ServiceSpec{
@@ -449,12 +449,11 @@ func (envw *environmentWatcher) createBuilderDeployment(ctx context.Context, env
 			Name:      name,
 			Labels:    sel,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Environment",
-					Name:       env.GetName(),
-					UID:        env.GetUID(),
-				},
+				*metav1.NewControllerRef(env, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Environment",
+				}),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -421,7 +421,7 @@ func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache
 		return nil, fmt.Errorf("error creating deployment %s: %w", objName, err)
 	}
 
-	hpa, err := caaf.hpaops.CreateOrGetHpa(ctx, objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
+	hpa, err := caaf.hpaops.CreateOrGetHpa(ctx, fn, objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
 	if err != nil {
 		caaf.logger.Error("error creating HPA", zap.Error(err), zap.String("hpa", objName))
 		go cleanupFunc(ns, objName)

--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -27,6 +27,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -270,12 +271,11 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Function",
-					Name:       fn.GetName(),
-					UID:        fn.GetUID(),
-				},
+				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Function",
+				}),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{

--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -86,6 +86,7 @@ func (cn *Container) createOrGetDeployment(ctx context.Context, fn *fv1.Function
 	if existingDepl.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != cn.instanceID {
 		existingDepl.Annotations = deployment.Annotations
 		existingDepl.Labels = deployment.Labels
+		existingDepl.OwnerReferences = deployment.OwnerReferences
 		existingDepl.Spec.Template.Spec.Containers = deployment.Spec.Template.Spec.Containers
 		existingDepl.Spec.Template.Spec.ServiceAccountName = deployment.Spec.Template.Spec.ServiceAccountName
 		existingDepl.Spec.Template.Spec.TerminationGracePeriodSeconds = deployment.Spec.Template.Spec.TerminationGracePeriodSeconds
@@ -268,6 +269,14 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 			Name:        deployName,
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "fission.io/v1",
+					Kind:       "Function",
+					Name:       fn.GetName(),
+					UID:        fn.GetUID(),
+				},
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -54,6 +54,14 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 			Name:        svcName,
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: "fission.io/v1",
+					Kind:       "Function",
+					Name:       fn.GetName(),
+					UID:        fn.GetUID(),
+				},
+			},
 		},
 		Spec: apiv1.ServiceSpec{
 			Ports: []apiv1.ServicePort{
@@ -74,6 +82,7 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 		if existingSvc.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != cn.instanceID {
 			existingSvc.Annotations = service.Annotations
 			existingSvc.Labels = service.Labels
+			existingSvc.OwnerReferences = service.OwnerReferences
 			existingSvc.Spec.Ports = service.Spec.Ports
 			existingSvc.Spec.Selector = service.Spec.Selector
 			existingSvc.Spec.Type = service.Spec.Type

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -24,6 +24,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -55,12 +56,11 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Function",
-					Name:       fn.GetName(),
-					UID:        fn.GetUID(),
-				},
+				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Function",
+				}),
 			},
 		},
 		Spec: apiv1.ServiceSpec{

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -29,6 +29,7 @@ import (
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 
@@ -251,12 +252,11 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Function",
-					Name:       fn.GetName(),
-					UID:        fn.GetUID(),
-				},
+				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Function",
+				}),
 			},
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -340,12 +340,11 @@ func (deploy *NewDeploy) createOrGetSvc(ctx context.Context, fn *fv1.Function, d
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Function",
-					Name:       fn.GetName(),
-					UID:        fn.GetUID(),
-				},
+				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Function",
+				}),
 			},
 		},
 		Spec: apiv1.ServiceSpec{

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -451,7 +451,7 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 	// Since newdeploy waits for pods of deployment to be ready,
 	// change the order of kubeObject creation (create service first,
 	// then deployment) to take advantage of waiting time.
-	svc, err := deploy.createOrGetSvc(ctx, deployLabels, deployAnnotations, objName, ns)
+	svc, err := deploy.createOrGetSvc(ctx, fn, deployLabels, deployAnnotations, objName, ns)
 	if err != nil {
 		deploy.logger.Error("error creating service", zap.Error(err), zap.String("service", objName))
 		go cleanupFunc(context.Background(), ns, objName)
@@ -466,7 +466,7 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 		return nil, fmt.Errorf("error creating deployment %s: %w", objName, err)
 	}
 
-	hpa, err := deploy.hpaops.CreateOrGetHpa(ctx, objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
+	hpa, err := deploy.hpaops.CreateOrGetHpa(ctx, fn, objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
 	if err != nil {
 		deploy.logger.Error("error creating HPA", zap.Error(err), zap.String("hpa", objName))
 		go cleanupFunc(context.Background(), ns, objName)

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -62,6 +62,14 @@ func (gp *GenericPool) genDeploymentMeta(env *fv1.Environment) metav1.ObjectMeta
 		Name:        getPoolName(env),
 		Labels:      deployLabels,
 		Annotations: deployAnnotations,
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				APIVersion: "fission.io/v1",
+				Kind:       "Environment",
+				Name:       env.GetName(),
+				UID:        env.GetUID(),
+			},
+		},
 	}
 }
 

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -26,6 +26,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
@@ -63,12 +64,11 @@ func (gp *GenericPool) genDeploymentMeta(env *fv1.Environment) metav1.ObjectMeta
 		Labels:      deployLabels,
 		Annotations: deployAnnotations,
 		OwnerReferences: []metav1.OwnerReference{
-			{
-				APIVersion: "fission.io/v1",
-				Kind:       "Environment",
-				Name:       env.GetName(),
-				UID:        env.GetUID(),
-			},
+			*metav1.NewControllerRef(env, schema.GroupVersionKind{
+				Group:   "fission.io",
+				Version: "v1",
+				Kind:    "Environment",
+			}),
 		},
 	}
 }

--- a/pkg/executor/util/hpa/hpa.go
+++ b/pkg/executor/util/hpa/hpa.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -104,12 +105,11 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, fn *fv1.Functio
 			Labels:      deployLabels,
 			Annotations: deployAnnotations,
 			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: "fission.io/v1",
-					Kind:       "Function",
-					Name:       fn.GetName(),
-					UID:        fn.GetUID(),
-				},
+				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+					Group:   "fission.io",
+					Version: "v1",
+					Kind:    "Function",
+				}),
 			},
 		},
 		Spec: asv2.HorizontalPodAutoscalerSpec{

--- a/pkg/executor/util/hpa/hpa_test.go
+++ b/pkg/executor/util/hpa/hpa_test.go
@@ -25,6 +25,7 @@ import (
 	asv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/kubernetes/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -67,7 +68,14 @@ func TestHpaOps(t *testing.T) {
 		"test-annotation": "test-annotation-value",
 	}
 	// Test CreateHPA
-	hpa, err := hpaops.CreateOrGetHpa(ctx, "test-hpa",
+	hpa, err := hpaops.CreateOrGetHpa(ctx,
+		&fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-fn",
+				UID:  uuid.NewUUID(),
+			},
+		},
+		"test-hpa",
 		&fv1.ExecutionStrategy{
 			ExecutorType:          fv1.ExecutorTypeNewdeploy,
 			MinScale:              1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Set OwnerReferences to Poolmanager and builderManager deployment and service created by environment.
- Set OwnerReferences to deployment, service and HPA created by newdeploy function.
- Set OwnerReferences to builderManager deployment and service created by environment.
- Set OwnerReferences to deployment, service and HPA created by container function.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2962 

## Testing
<!--- Please describe in detail how you tested your changes. -->
`OwnerReferences` are added for poolmanager deployement as follows:
```
$ kubectl get deploy poolmgr-go-122-default-253070 -oyaml
apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    deployment.kubernetes.io/revision: "1"
    executorInstanceId: lpd23pfg
  creationTimestamp: "2024-06-25T06:09:57Z"
  generation: 1
  labels:
    environmentName: go-122
    environmentNamespace: default
    environmentUid: e833d7f4-27bf-4f0d-9fe5-9d6169246de7
    executorType: poolmgr
    managed: "true"
  name: poolmgr-go-122-default-253070
  namespace: default
  ownerReferences:
  - apiVersion: fission.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: Environment
    name: go-122
    uid: e833d7f4-27bf-4f0d-9fe5-9d6169246de7
  resourceVersion: "253399"
  uid: c29919bf-4541-4c92-af66-696555bae54f
```
**Tried following tests scenarios:**
**Test 1:**
	Create env.
	Create poolmanager, newdeploy and container function.
	Delete poolmanager, newdeploy and container function.
	**Result:**
                 1. No issues, all resources were deleted.

**Test 2:**
	Create env.
	Create poolmanager, newdeploy and container function.
	Delete Environment.
	**Result:**
		1. Fission-CLI failed to delete environment, env is used by atleast one function.
		2. kubectl deleted the environment along with poolmanager deployment, builder deployement and builder service. Poolmanager function is not deleted but it does not work as expected.
		
**Test 3:**
	Create env.
	Create poolmanager, newdeploy and container function.
	Update poolmanager, newdeploy and container function.
	**Result:**
		1. Successfully updated the functions.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
