### PR TITLE
Show warning that `--yolo`, `--concurrency` and `--rpp` fields are valid for executortype `poolmgr` only

### DIFF
--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -98,7 +98,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 	fnIdleTimeout := input.Int(flagkey.FnIdleTimeout)
 
-	err = executorTypeNotPoolManager(input, fv1.ExecutorTypePoolmgr)
+	err = checkExecutorPoolManager(input, fv1.ExecutorTypePoolmgr)
 	if err != nil {
 		return err
 	}
@@ -454,7 +454,7 @@ func getInvokeStrategy(input cli.Input, existingInvokeStrategy *fv1.InvokeStrate
 
 // Show warning when --con, --rpp and --yolo flags are used with executortype other than `poolmgr`.
 // These flags are specifically introduced for executortype `poolmgr`.
-func executorTypeNotPoolManager(input cli.Input, existingExecutorType fv1.ExecutorType) error {
+func checkExecutorPoolManager(input cli.Input, existingExecutorType fv1.ExecutorType) error {
 	var isNotPoolManager bool
 	if input.IsSet(flagkey.EnvExecutorType) {
 		executorType, err := getExecutorType(input)

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -98,15 +98,29 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 	fnIdleTimeout := input.Int(flagkey.FnIdleTimeout)
 
+	executorType, err := getExecutorType(input)
+	if err != nil {
+		return err
+	}
+
 	fnConcurrency := DEFAULT_CONCURRENCY
 	if input.IsSet(flagkey.FnConcurrency) {
 		fnConcurrency = input.Int(flagkey.FnConcurrency)
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+			console.Warn("--concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`")
+		}
 	}
 
 	requestsPerPod := input.Int(flagkey.FnRequestsPerPod)
+	if input.IsSet(flagkey.FnRequestsPerPod) && string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+		console.Warn("--requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`")
+	}
 	retainPods := input.Int(flagkey.FnRetainPods)
 
 	fnOnceOnly := input.Bool(flagkey.FnOnceOnly)
+	if input.IsSet(flagkey.FnOnceOnly) && string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+		console.Warn("--onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`")
+	}
 
 	pkgName := input.String(flagkey.FnPackageName)
 

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -161,14 +161,14 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnConcurrency) {
 		function.Spec.Concurrency = input.Int(flagkey.FnConcurrency)
-		if string(executorType) != string(fv1.ExecutorTypePoolmgr) || string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) {
+		if (string(executorType) != string(fv1.ExecutorTypePoolmgr)) || (string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) && string(executorType) != string(fv1.ExecutorTypePoolmgr)) {
 			console.Warn("--concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`")
 		}
 	}
 
 	if input.IsSet(flagkey.FnRequestsPerPod) {
 		function.Spec.RequestsPerPod = input.Int(flagkey.FnRequestsPerPod)
-		if string(executorType) != string(fv1.ExecutorTypePoolmgr) || string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) {
+		if (string(executorType) != string(fv1.ExecutorTypePoolmgr)) || (string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) && string(executorType) != string(fv1.ExecutorTypePoolmgr)) {
 			console.Warn("--requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`")
 		}
 	}
@@ -179,7 +179,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnOnceOnly) {
 		function.Spec.OnceOnly = input.Bool(flagkey.FnOnceOnly)
-		if string(executorType) != string(fv1.ExecutorTypePoolmgr) || string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) {
+		if (string(executorType) != string(fv1.ExecutorTypePoolmgr)) || (string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) && string(executorType) != string(fv1.ExecutorTypePoolmgr)) {
 			console.Warn("--onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`")
 		}
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -154,12 +154,23 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 		function.Spec.IdleTimeout = &fnTimeout
 	}
 
+	executorType, err := getExecutorType(input)
+	if err != nil {
+		return err
+	}
+
 	if input.IsSet(flagkey.FnConcurrency) {
 		function.Spec.Concurrency = input.Int(flagkey.FnConcurrency)
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+			console.Warn("--concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`")
+		}
 	}
 
 	if input.IsSet(flagkey.FnRequestsPerPod) {
 		function.Spec.RequestsPerPod = input.Int(flagkey.FnRequestsPerPod)
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+			console.Warn("--requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`")
+		}
 	}
 
 	if input.IsSet(flagkey.FnRetainPods) {
@@ -168,6 +179,9 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnOnceOnly) {
 		function.Spec.OnceOnly = input.Bool(flagkey.FnOnceOnly)
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+			console.Warn("--onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`")
+		}
 	}
 	if len(pkgName) == 0 {
 		pkgName = function.Spec.Package.PackageRef.Name

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -161,14 +161,14 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnConcurrency) {
 		function.Spec.Concurrency = input.Int(flagkey.FnConcurrency)
-		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) || string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) {
 			console.Warn("--concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`")
 		}
 	}
 
 	if input.IsSet(flagkey.FnRequestsPerPod) {
 		function.Spec.RequestsPerPod = input.Int(flagkey.FnRequestsPerPod)
-		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) || string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) {
 			console.Warn("--requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`")
 		}
 	}
@@ -179,7 +179,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnOnceOnly) {
 		function.Spec.OnceOnly = input.Bool(flagkey.FnOnceOnly)
-		if string(executorType) != string(fv1.ExecutorTypePoolmgr) {
+		if string(executorType) != string(fv1.ExecutorTypePoolmgr) || string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) {
 			console.Warn("--onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`")
 		}
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -154,7 +154,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 		function.Spec.IdleTimeout = &fnTimeout
 	}
 
-	err = executorTypeNotPoolManager(input, function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType)
+	err = checkExecutorPoolManager(input, function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -154,23 +154,17 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 		function.Spec.IdleTimeout = &fnTimeout
 	}
 
-	executorType, err := getExecutorType(input)
+	err = executorTypeNotPoolManager(input, function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType)
 	if err != nil {
 		return err
 	}
 
 	if input.IsSet(flagkey.FnConcurrency) {
 		function.Spec.Concurrency = input.Int(flagkey.FnConcurrency)
-		if (string(executorType) != string(fv1.ExecutorTypePoolmgr)) || (string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) && string(executorType) != string(fv1.ExecutorTypePoolmgr)) {
-			console.Warn("--concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`")
-		}
 	}
 
 	if input.IsSet(flagkey.FnRequestsPerPod) {
 		function.Spec.RequestsPerPod = input.Int(flagkey.FnRequestsPerPod)
-		if (string(executorType) != string(fv1.ExecutorTypePoolmgr)) || (string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) && string(executorType) != string(fv1.ExecutorTypePoolmgr)) {
-			console.Warn("--requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`")
-		}
 	}
 
 	if input.IsSet(flagkey.FnRetainPods) {
@@ -179,9 +173,6 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if input.IsSet(flagkey.FnOnceOnly) {
 		function.Spec.OnceOnly = input.Bool(flagkey.FnOnceOnly)
-		if (string(executorType) != string(fv1.ExecutorTypePoolmgr)) || (string(function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType) != string(fv1.ExecutorTypePoolmgr) && string(executorType) != string(fv1.ExecutorTypePoolmgr)) {
-			console.Warn("--onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`")
-		}
 	}
 	if len(pkgName) == 0 {
 		pkgName = function.Spec.Package.PackageRef.Name

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -126,9 +126,9 @@ var (
 	FnTestHeader            = Flag{Type: StringSlice, Name: flagkey.FnTestHeader, Short: "H", Usage: "Request headers"}
 	FnTestQuery             = Flag{Type: StringSlice, Name: flagkey.FnTestQuery, Short: "q", Usage: "Request query parameters: -q key1=value1 -q key2=value2"}
 	FnIdleTimeout           = Flag{Type: Int, Name: flagkey.FnIdleTimeout, Usage: "The length of time (in seconds) that a function is idle before pod(s) are eligible for recycling", DefaultValue: 120}
-	FnConcurrency           = Flag{Type: Int, Name: flagkey.FnConcurrency, Aliases: []string{"con"}, Usage: "Maximum number of pods specialized concurrently to serve requests", DefaultValue: 500}
-	FnRequestsPerPod        = Flag{Type: Int, Name: flagkey.FnRequestsPerPod, Aliases: []string{"rpp"}, Usage: "Maximum number of concurrent requests that can be served by a specialized pod", DefaultValue: 1}
-	FnOnceOnly              = Flag{Type: Bool, Name: flagkey.FnOnceOnly, Aliases: []string{"yolo"}, Usage: "Specifies if specialized pod will serve exactly one request in its lifetime"}
+	FnConcurrency           = Flag{Type: Int, Name: flagkey.FnConcurrency, Aliases: []string{"con"}, Usage: "Maximum number of pods specialized concurrently to serve requests (Only valid for executortype; `poolmgr`)", DefaultValue: 500}
+	FnRequestsPerPod        = Flag{Type: Int, Name: flagkey.FnRequestsPerPod, Aliases: []string{"rpp"}, Usage: "Maximum number of concurrent requests that can be served by a specialized pod (Only valid for executortype; `poolmgr`)", DefaultValue: 1}
+	FnOnceOnly              = Flag{Type: Bool, Name: flagkey.FnOnceOnly, Aliases: []string{"yolo"}, Usage: "Specifies if specialized pod will serve exactly one request in its lifetime (Only valid for executortype; `poolmgr`)"}
 	FnSubPath               = Flag{Type: String, Name: flagkey.FnSubPath, Usage: "Sub Path to check if function internally supports routing"}
 	FnLogAllPods            = Flag{Type: Bool, Name: flagkey.FnLogAllPods, Usage: "Get all pod's logs in the function."}
 	FnRetainPods            = Flag{Type: Int, Name: flagkey.FnRetainPods, Usage: "Number of pods to retain after pods specialization.", DefaultValue: 0}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- `--yolo`, `--concurrency` and `--rpp` fields are only valid for executortype `poolmgr` only.
- Show warning to users if these field are used with other executortype.
- Update CLI `--help` page with this information.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
```
$ fission fn create --help
Create a function (and optionally, an HTTP route to it)

Options:
  --concurrency=500 (--con)             Maximum number of pods specialized concurrently to serve
                                        requests (Only valid for executortype; `poolmgr`)
  --requestsperpod=1 (--rpp)            Maximum number of concurrent requests that can be served by a
                                        specialized pod (Only valid for executortype; `poolmgr`)
  --onceonly=false (--yolo)             Specifies if specialized pod will serve exactly one request in
                                        its lifetime (Only valid for executortype; `poolmgr`)
```
```
$ fission fn create --name hello-yolo --env go-120 --src hello.go --entrypoint Handler --executortype newdeploy --yolo
Warning: --onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`
Package 'hello-yolo-1f035d38-7351-420c-9f2f-6cb4251e7e54' created
function 'hello-yolo' created
$ fission fn create --name hello-yolo --env go-120 --src hello.go --entrypoint Handler --yolo
Package 'hello-yolo-c9a9ec72-dff5-457e-aaf4-834a11c0b0a7' created
function 'hello-yolo' created
```
```
$ fission fn create --name hello-pool --env go-120 --src hello.go --entrypoint Handler --executortype newdeploy --rpp 1
Warning: --requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`
Package 'hello-pool-4977f1c0-49e9-43f5-9662-54f735960d5c' created
function 'hello-pool' created
$ fission fn create --name hello-pool --env go-120 --src hello.go --entrypoint Handler --rpp 1
Package 'hello-pool-7425b8d6-1ac5-4155-b5db-2e82fc586e81' created
function 'hello-pool' created
```
```
$ fission fn create --name hello-con --env go-120 --src hello.go --entrypoint Handler --executortype newdeploy --concurrency 1
Warning: --concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`
Package 'hello-con-aeaa4cf7-b1bc-4ed4-8ce3-ef4fa0bea3ea' created
function 'hello-con' created
$ fission fn create --name hello-con --env go-120 --src hello.go --entrypoint Handler --concurrency 1
Package 'hello-con-36d32155-d0fe-4b0c-b95b-3109ee0be5bd' created
function 'hello-con' created
```
```
$ fission fn create --name hello-newdeploy --env go-120 --src hello.go --entrypoint Handler --executortype newdeploy
Package 'hello-newdeploy-96b0182b-afe9-4dd6-ab58-72923f734591' created
function 'hello-newdeploy' created

$ fission fn update --name hello-newdeploy --con 1 --rpp 1 --yolo
Warning: --concurrency is only valid for executortype; `poolmgr`. Check `fission function create --help`
Warning: --requestsperpod is only valid for executortype; `poolmgr`. Check `fission function create --help`
Warning: --onceonly is only valid for executortype; `poolmgr`. Check `fission function create --help`
Function 'hello-newdeploy' updated
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
