### PR TITLE
Fix: Storage leak in Builder and Fetcher

### DIFF
--- a/cmd/builder/app/server.go
+++ b/cmd/builder/app/server.go
@@ -32,6 +32,7 @@ func Run(ctx context.Context, logger *zap.Logger, mgr manager.Interface, shareVo
 	builder := builder.MakeBuilder(logger, shareVolume)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", builder.Handler)
+	mux.HandleFunc("/clean", builder.Clean)
 	mux.HandleFunc("/version", builder.VersionHandler)
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -35,6 +35,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/fission/fission/pkg/info"
+	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -58,6 +59,10 @@ type (
 	PackageBuildResponse struct {
 		ArtifactFilename string `json:"artifactFilename"`
 		BuildLogs        string `json:"buildLogs"`
+	}
+
+	PackageCleanRequest struct {
+		SrcPkgFilename string `json:"srcPkgFilename"`
 	}
 
 	Builder struct {
@@ -152,6 +157,54 @@ func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	builder.reply(r.Context(), w, deployPkgFilename, buildLogs, http.StatusOK)
+}
+
+func (builder *Builder) Clean(w http.ResponseWriter, r *http.Request) {
+	logger := otelUtils.LoggerWithTraceID(r.Context(), builder.logger)
+
+	if r.Method != "POST" {
+		e := "method not allowed"
+		logger.Error(e, zap.String("http_method", r.Method))
+		builder.reply(r.Context(), w, "", fmt.Sprintf("%s: %s", e, r.Method), http.StatusMethodNotAllowed)
+		return
+	}
+
+	startTime := time.Now()
+	defer func() {
+		elapsed := time.Since(startTime)
+		logger.Info("clean request complete", zap.Duration("elapsed_time", elapsed))
+	}()
+
+	// parse request
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		e := "error reading request body"
+		logger.Error(e, zap.Error(err))
+		builder.reply(r.Context(), w, "", fmt.Sprintf("%s: %s", e, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	var req PackageCleanRequest
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		e := "error parsing json body"
+		logger.Error(e, zap.Error(err))
+		builder.reply(r.Context(), w, "", fmt.Sprintf("%s: %s", e, err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	srcPkgPath := filepath.Join(builder.sharedVolumePath, req.SrcPkgFilename)
+
+	logger.Info("builder received clean request", zap.Any("request", req))
+
+	err = utils.DeleteOldPackages(srcPkgPath, envSrcPkg)
+	if err != nil {
+		e := "error deleting src package after build"
+		logger.Error(e, zap.Error(err))
+		builder.reply(r.Context(), w, req.SrcPkgFilename, "", http.StatusInternalServerError)
+		return
+	}
+
+	builder.reply(r.Context(), w, req.SrcPkgFilename, "", http.StatusOK)
 }
 
 func (builder *Builder) reply(ctx context.Context, w http.ResponseWriter, pkgFilename string, buildLogs string, statusCode int) {

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -171,43 +171,42 @@ func TestBuilder(t *testing.T) {
 
 	// Test CleanHandler
 	t.Run("CleanHandler", func(t *testing.T) {
-
 		for _, test := range []struct {
-			name             string
-			cleanRequest     *PackageCleanRequest
-			sharedVolumePath string
-			expected         *PackageBuildResponse
-			status           int
+			name           string
+			srcPkgFilename string
+			handler        func(w http.ResponseWriter, r *http.Request)
+			status         int
 		}{
 			{
-				name: "should fail deleting src pkg",
-				cleanRequest: &PackageCleanRequest{
-					SrcPkgFilename: "test2",
-				},
-				expected: &PackageBuildResponse{
-					ArtifactFilename: "test2",
-					BuildLogs:        "",
+				name:           "should fail deleting src pkg: invalid shared volume path",
+				srcPkgFilename: "test2",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					builder.Clean(w, r)
 				},
 				status: http.StatusInternalServerError,
 			},
+			{
+				name:           "should fail deleting src pkg: method not allowed",
+				srcPkgFilename: "test3",
+				handler: func(w http.ResponseWriter, r *http.Request) {
+					builder.Handler(w, r)
+				},
+				status: http.StatusMethodNotAllowed,
+			},
 		} {
 			t.Run(test.name, func(t *testing.T) {
-				_, err := os.MkdirTemp(dir, test.cleanRequest.SrcPkgFilename)
+				_, err := os.MkdirTemp(dir, test.srcPkgFilename)
 				if err != nil {
 					t.Fatal(err)
 				}
-				srcFile, err := os.Create(dir + "/" + test.cleanRequest.SrcPkgFilename)
+				srcFile, err := os.Create(dir + "/" + test.srcPkgFilename)
 				if err != nil {
 					t.Fatal(err)
 				}
 				defer srcFile.Close()
-				body, err := json.Marshal(test.cleanRequest)
-				if err != nil {
-					t.Fatal(err)
-				}
 				w := httptest.NewRecorder()
-				r := httptest.NewRequest(http.MethodPost, "/clean", bytes.NewReader(body))
-				builder.Clean(w, r)
+				r := httptest.NewRequest(http.MethodDelete, "/clean/"+test.srcPkgFilename, http.NoBody)
+				test.handler(w, r)
 				resp := w.Result()
 				if resp.StatusCode != test.status {
 					t.Errorf("expected status code %d, got %d", test.status, resp.StatusCode)

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -131,11 +131,7 @@ func buildPackage(ctx context.Context, logger *zap.Logger, fissionClient version
 }
 
 func cleanPackage(ctx context.Context, builderClient builderClient.ClientInterface, srcPkgFileName string) error {
-	pkgCleanReq := &builder.PackageCleanRequest{
-		SrcPkgFilename: srcPkgFileName,
-	}
-
-	err := builderClient.Clean(ctx, pkgCleanReq)
+	err := builderClient.Clean(ctx, srcPkgFileName)
 	if err != nil {
 		return err
 	}

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -525,6 +525,14 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	srcFilepath := filepath.Join(fetcher.sharedVolumePath, req.Filename)
 	dstFilepath := filepath.Join(fetcher.sharedVolumePath, zipFilename)
 
+	defer func() {
+		errC := utils.DeleteOldPackages(srcFilepath, "DEPLOY_PKG")
+		if errC != nil {
+			m := "error deleting deploy package after upload"
+			logger.Error(m, zap.Error(errC))
+		}
+	}()
+
 	if req.ArchivePackage {
 		err = fetcher.archive(srcFilepath, dstFilepath)
 		if err != nil {
@@ -585,12 +593,6 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 	}
 
-	// delete src pkg
-	err = utils.DeleteOldPackages(srcFilepath, "DEPLOY_PKG")
-	if err != nil {
-		e := "error deleting deploy package after upload"
-		logger.Error(e, zap.Error(err))
-	}
 }
 
 func (fetcher *Fetcher) rename(src string, dst string) error {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -584,6 +584,13 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Error(e, zap.Error(err))
 		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
 	}
+
+	// delete src pkg
+	err = utils.DeleteOldPackages(srcFilepath, "DEPLOY_PKG")
+	if err != nil {
+		e := "error deleting deploy package after upload"
+		logger.Error(e, zap.Error(err))
+	}
 }
 
 func (fetcher *Fetcher) rename(src string, dst string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -268,6 +268,10 @@ func FindFreePort() (int, error) {
 	return port, nil
 }
 
+// DeleteOldPackages deletes src and built deployment packages from builder's storage.
+// The function also verifies that sharedVolumePath for builder and fetcher containers
+// is /packages. A source_package contains a directory and a .tmp file while a deployment
+// package contains a directory and a .zip file.
 func DeleteOldPackages(pkgPath, pkgType string) error {
 	sharedVolumePath := "/packages"
 	if !strings.HasPrefix(pkgPath, sharedVolumePath) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -267,3 +267,23 @@ func FindFreePort() (int, error) {
 
 	return port, nil
 }
+
+func DeleteOldPackages(pkgPath, pkgType string) error {
+	var file string
+	if pkgType == "DEPLOY_PKG" {
+		file = pkgPath + ".zip"
+	} else if pkgType == "SRC_PKG" {
+		file = pkgPath + ".tmp"
+	}
+
+	err := os.RemoveAll(pkgPath)
+	if err != nil {
+		return err
+	}
+	err = os.Remove(file)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -269,6 +269,11 @@ func FindFreePort() (int, error) {
 }
 
 func DeleteOldPackages(pkgPath, pkgType string) error {
+	sharedVolumePath := "/packages"
+	if !strings.HasPrefix(pkgPath, sharedVolumePath) {
+		return fmt.Errorf("invalid shared volume path: %s", pkgPath)
+	}
+
 	var file string
 	if pkgType == "DEPLOY_PKG" {
 		file = pkgPath + ".zip"


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Builder pod contains builder and fetcher containers and they share a volume.
- Builder build the packages and fetcher uploads the packages to storage service.
- In case of build/upload failure, packages remains in the shared volume. These packages are of no use and needs to be cleaned up. 
- Added a `Clean` API in builder package. This API will be called by `buildermgr` for deleting src pkg after pkg is build and deployment is uploaded. I wanted to delete the src package from builder pod directly after failed/successful build but `buildermgr` uses `retryablehttp` client so in case of build failure `buildermgr` will retry build by sending `Build` request.
- To delete deployment pkg, fetcher `UploadHandler` will delete the deployment pkg after successful/failed upload.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2821

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Added a negative test for builder's `Clean` API.
- Adding a positive test involves creating a `/packages` directory for which `root` permissions are required.Therefore, did not add any positive test.
```
{"level":"info","ts":"2024-07-10T10:45:48.563Z","logger":"builder","caller":"builder/builder.go:197","msg":"builder received clean request","request":{"srcPkgFilename":"hello-test-fdebb12e-60ff-4e95-b41b-e3531444a4a4-kfezxl"}}
{"level":"info","ts":"2024-07-10T10:45:48.564Z","logger":"builder","caller":"builder/builder.go:175","msg":"clean request complete","elapsed_time":0.001311227}
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
