### PR TITLE
Fix: fission-cli adds incorrect url for source archive in fission's package

### DIFF
--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -104,11 +104,12 @@ func getArchiveURL(ctx context.Context, client cmd.Client, archiveID string, ser
 	storageType := resp.Header.Get("X-FISSION-STORAGETYPE")
 
 	if storageType == "local" {
-		storagesvcURL, err := util.GetStorageURL(ctx, client)
+		storageSvc, err := util.GetSvcName(ctx, client.KubernetesClient, "fission-storage")
 		if err != nil {
 			return "", err
 		}
-		client := storageSvcClient.MakeClient(storagesvcURL.String())
+		storagesvcURL := "http://" + storageSvc
+		client := storageSvcClient.MakeClient(storagesvcURL)
 		return client.GetUrl(archiveID), nil
 	} else if storageType == "s3" {
 		storageBucket := resp.Header.Get("X-FISSION-BUCKET")

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -511,6 +511,23 @@ func ConfigMapExists(ctx context.Context, m *metav1.ObjectMeta, kClient kubernet
 	return err
 }
 
+func GetSvcName(ctx context.Context, kClient kubernetes.Interface, application string) (string, error) {
+	appLabelSelector := "application=" + application
+
+	services, err := kClient.CoreV1().Services("").List(ctx, metav1.ListOptions{
+		LabelSelector: appLabelSelector,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(services.Items) > 1 || len(services.Items) == 0 {
+		return "", errors.Errorf("more than one service found for application=%s", application)
+	}
+	service := services.Items[0]
+	return service.Name + "." + service.Namespace, nil
+}
+
 // FunctionPodLogs : Get logs for a function directly from pod
 func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) (err error) {
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Fission-cli create package resource with incorrect url domain name for sourcearchive and we see below error when builder pod tries to fetch the source form storagesvc for building the source.
```
error fetching source package: Invalid argument - failed to download url : Get "http://127.0.0.1:51862/v1/archive?id=%2Ffission%2Ffission-functions%2F0ef2ca22-0a16-4832-b7a6-c54f7a895424": dial tcp 127.0.0.1:51862: connect: connection refused%
```
The correct URL should be like this where `storagesvc` is storage service and `fission` is namespace where fission is installed.
```
http://storagesvc.fission/v1/archive?id=%2Ffission%2Ffission-functions%2F0ef2ca22-0a16-4832-b7a6-c54f7a895424
```
- This PR fixes this issue by fetching services across all K8s namespaces then filtering those services using label `application=fission-storage` and using this service to create sourcearchive url.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2980

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
