### PR TITLE
Removing comments from the environment creation process and eliminating redundant code during the update process

### DIFF
--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -132,8 +132,7 @@ func createEnvironmentFromCmd(input cli.Input) (*fv1.Environment, error) {
 	pullSecret := input.String(flagkey.EnvImagePullSecret)
 
 	envVersion := input.Int(flagkey.EnvVersion)
-	// Environment API interface version is not specified and
-	// builder image is empty, set default interface version
+
 	if envVersion == 0 {
 		envVersion = 1
 	}

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -97,9 +97,6 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 	if err != nil {
 		return errors.Wrap(err, "error updating environment")
 	}
-	if err != nil {
-		return errors.Wrap(err, "error updating environment")
-	}
 
 	fmt.Printf("environment '%v' updated\n", enew.ObjectMeta.Name)
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
(1) There are misleading comments in the implementation of parameter parsing for creating environment through CLI. The specific content is shown in the following figure. Currently, the parameter EnvVersion is set to a default value of 3. When this parameter is not set when creating env, it will be set to 3. Only when manually setting -- version to 0 will this logic be followed. The current annotations do not match the current implementation and are misleading. It is recommended to delete them.
![image](https://github.com/user-attachments/assets/1cdb234e-7278-4513-b255-e74cc39f8532)

(2) There is redundant code in the specific implementation of updating the environment through CLI, as shown in the following figure:
![image](https://github.com/user-attachments/assets/1c446c30-11d6-4d42-9d6b-491acddeffdd)

<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
