### PR TITLE
Creating large number of MQTs takes time

### DIFF
--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
-	k8sCache "k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
@@ -88,17 +87,13 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger *
 		return err
 	}
 
-	informers := make([]k8sCache.SharedIndexInformer, 0)
 	// Start informer factory
 	for _, factory := range finformerFactory {
-		informer := factory.Core().V1().MessageQueueTriggers().Informer()
-		informers = append(informers, informer)
+		factory.Start(ctx.Done())
 	}
 
-	err = mqtMgr.Run(ctx, ctx.Done(), mgr, informers...)
-	if err != nil {
-		return err
-	}
+	mqtMgr.Run(ctx, ctx.Done(), mgr)
+
 	return nil
 }
 

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -22,16 +22,20 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	k8sCache "k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
+	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/mqtrigger/factory"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/kafka"
+	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/manager"
 )
 
@@ -73,8 +77,25 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger *
 	if err != nil {
 		logger.Fatal("failed to connect to remote message queue server", zap.Error(err))
 	}
-	mqtMgr := mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, mq)
-	err = mqtMgr.Run(ctx, mgr)
+
+	finformerFactory := make(map[string]genInformer.SharedInformerFactory, 0)
+	for _, ns := range utils.DefaultNSResolver().FissionResourceNS {
+		finformerFactory[ns] = genInformer.NewFilteredSharedInformerFactory(fissionClient, time.Minute*30, ns, nil)
+	}
+
+	mqtMgr, err := mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, finformerFactory, mq)
+	if err != nil {
+		return err
+	}
+
+	informers := make([]k8sCache.SharedIndexInformer, 0)
+	// Start informer factory
+	for _, factory := range finformerFactory {
+		informer := factory.Core().V1().MessageQueueTriggers().Informer()
+		informers = append(informers, informer)
+	}
+
+	err = mqtMgr.Run(ctx, ctx.Done(), mgr, informers...)
 	if err != nil {
 		return err
 	}

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -98,15 +98,9 @@ func MakeMessageQueueTriggerManager(logger *zap.Logger,
 
 	for ns, informer := range finformerFactory {
 		_, err := informer.Core().V1().MessageQueueTriggers().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj interface{}) {
-				IncreaseMqtCount()
-				mqTriggerMgr.enqueueMqtAdd(obj)
-			},
+			AddFunc:    mqTriggerMgr.enqueueMqtAdd,
 			UpdateFunc: mqTriggerMgr.enqueueMqtUpdate,
-			DeleteFunc: func(obj interface{}) {
-				mqTriggerMgr.enqueueMqtDelete(obj)
-				DecreaseMqtCount()
-			},
+			DeleteFunc: mqTriggerMgr.enqueueMqtDelete,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Creating 100 MQTs takes around 5 minutes of time.
- This PR introduces workqueue to be used by MessageQueueTriggerManager for create, update and delete of MQTs.
- For create and update, four workers will be running.
- This fix will bring down 100 MQTs creation time from 5 minutes to 1-1.5 minutes.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Created 100 MQTs which took around 1-1.5 minutes of time.
- Trigger processing was also working..


## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
