### PR TITLE
Fixed mqtrigger scaling issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,7 +82,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@7ec5c2b0c6cdda6e8bbb49444bc797dd33d74dd8 # v5.0.0
         with:
-          version: latest
+          version: "~> v1"
           args: release
         env:
           COSIGN_PWD: ${{ secrets.COSIGN_PWD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -241,191 +241,87 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
-  - &docker-armv7
-    use: buildx
-    goos: linux
-    goarch: arm
-    goarm: 7
-    ids:
-      - builder
-    image_templates:
-      - "fission/builder:latest-armv7"
-      - "fission/builder:{{ .Tag }}-armv7"
-      - "ghcr.io/fission/builder:latest-armv7"
-      - "ghcr.io/fission/builder:{{ .Tag }}-armv7"
-    dockerfile: cmd/builder/Dockerfile
-    build_flag_templates:
-      - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
-  - <<: *docker-armv7
-    ids:
-      - fetcher
-    image_templates:
-      - "fission/fetcher:latest-armv7"
-      - "fission/fetcher:{{ .Tag }}-armv7"
-      - "ghcr.io/fission/fetcher:latest-armv7"
-      - "ghcr.io/fission/fetcher:{{ .Tag }}-armv7"
-    dockerfile: cmd/fetcher/Dockerfile
-    build_flag_templates:
-      - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
-  - <<: *docker-armv7
-    ids:
-      - fission-bundle
-    image_templates:
-      - "fission/fission-bundle:latest-armv7"
-      - "fission/fission-bundle:{{ .Tag }}-armv7"
-      - "ghcr.io/fission/fission-bundle:latest-armv7"
-      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-armv7"
-    dockerfile: cmd/fission-bundle/Dockerfile
-    build_flag_templates:
-      - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
-  - <<: *docker-armv7
-    ids:
-      - pre-upgrade-checks
-    image_templates:
-      - "fission/pre-upgrade-checks:latest-armv7"
-      - "fission/pre-upgrade-checks:{{ .Tag }}-armv7"
-      - "ghcr.io/fission/pre-upgrade-checks:latest-armv7"
-      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-armv7"
-    dockerfile: cmd/preupgradechecks/Dockerfile
-    build_flag_templates:
-      - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
-  - <<: *docker-armv7
-    ids:
-      - reporter
-    image_templates:
-      - "fission/reporter:latest-armv7"
-      - "fission/reporter:{{ .Tag }}-armv7"
-      - "ghcr.io/fission/reporter:latest-armv7"
-      - "ghcr.io/fission/reporter:{{ .Tag }}-armv7"
-    dockerfile: cmd/reporter/Dockerfile
-    build_flag_templates:
-      - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
-      - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/arm/v7"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Tag}}"
 docker_manifests:
   - name_template: ghcr.io/fission/builder:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/builder:{{ .Tag }}-amd64
       - ghcr.io/fission/builder:{{ .Tag }}-arm64
-      - ghcr.io/fission/builder:{{ .Tag }}-armv7
   - name_template: fission/builder:{{ .Tag }}
     image_templates:
       - fission/builder:{{ .Tag }}-amd64
       - fission/builder:{{ .Tag }}-arm64
-      - fission/builder:{{ .Tag }}-armv7
   - name_template: ghcr.io/fission/fetcher:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/fetcher:{{ .Tag }}-amd64
       - ghcr.io/fission/fetcher:{{ .Tag }}-arm64
-      - ghcr.io/fission/fetcher:{{ .Tag }}-armv7
   - name_template: fission/fetcher:{{ .Tag }}
     image_templates:
       - fission/fetcher:{{ .Tag }}-amd64
       - fission/fetcher:{{ .Tag }}-arm64
-      - fission/fetcher:{{ .Tag }}-armv7
   - name_template: ghcr.io/fission/fission-bundle:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64
       - ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64
-      - ghcr.io/fission/fission-bundle:{{ .Tag }}-armv7
   - name_template: fission/fission-bundle:{{ .Tag }}
     image_templates:
       - fission/fission-bundle:{{ .Tag }}-amd64
       - fission/fission-bundle:{{ .Tag }}-arm64
-      - fission/fission-bundle:{{ .Tag }}-armv7
   - name_template: ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
       - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
-      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-armv7
   - name_template: fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
       - fission/pre-upgrade-checks:{{ .Tag }}-amd64
       - fission/pre-upgrade-checks:{{ .Tag }}-arm64
-      - fission/pre-upgrade-checks:{{ .Tag }}-armv7
   - name_template: ghcr.io/fission/reporter:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/reporter:{{ .Tag }}-amd64
       - ghcr.io/fission/reporter:{{ .Tag }}-arm64
-      - ghcr.io/fission/reporter:{{ .Tag }}-armv7
   - name_template: fission/reporter:{{ .Tag }}
     image_templates:
       - fission/reporter:{{ .Tag }}-amd64
       - fission/reporter:{{ .Tag }}-arm64
-      - fission/reporter:{{ .Tag }}-armv7
   - name_template: ghcr.io/fission/builder:latest
     image_templates:
       - ghcr.io/fission/builder:latest-amd64
       - ghcr.io/fission/builder:latest-arm64
-      - ghcr.io/fission/builder:latest-armv7
   - name_template: fission/builder:latest
     image_templates:
       - fission/builder:latest-amd64
       - fission/builder:latest-arm64
-      - fission/builder:latest-armv7
   - name_template: ghcr.io/fission/fetcher:latest
     image_templates:
       - ghcr.io/fission/fetcher:latest-amd64
       - ghcr.io/fission/fetcher:latest-arm64
-      - ghcr.io/fission/fetcher:latest-armv7
   - name_template: fission/fetcher:latest
     image_templates:
       - fission/fetcher:latest-amd64
       - fission/fetcher:latest-arm64
-      - fission/fetcher:latest-armv7 
   - name_template: ghcr.io/fission/fission-bundle:latest
     image_templates:
       - ghcr.io/fission/fission-bundle:latest-amd64
       - ghcr.io/fission/fission-bundle:latest-arm64
-      - ghcr.io/fission/fission-bundle:latest-armv7
   - name_template: fission/fission-bundle:latest
     image_templates:
       - fission/fission-bundle:latest-amd64
       - fission/fission-bundle:latest-arm64
-      - fission/fission-bundle:latest-armv7
   - name_template: ghcr.io/fission/pre-upgrade-checks:latest
     image_templates:
       - ghcr.io/fission/pre-upgrade-checks:latest-amd64
       - ghcr.io/fission/pre-upgrade-checks:latest-arm64
-      - ghcr.io/fission/pre-upgrade-checks:latest-armv7
   - name_template: fission/pre-upgrade-checks:latest
     image_templates:
       - fission/pre-upgrade-checks:latest-amd64
       - fission/pre-upgrade-checks:latest-arm64
-      - fission/pre-upgrade-checks:latest-armv7
   - name_template: ghcr.io/fission/reporter:latest
     image_templates:
       - ghcr.io/fission/reporter:latest-amd64
       - ghcr.io/fission/reporter:latest-arm64
-      - ghcr.io/fission/reporter:latest-armv7
   - name_template: fission/reporter:latest
     image_templates:
       - fission/reporter:latest-amd64
       - fission/reporter:latest-arm64
-      - fission/reporter:latest-armv7
 changelog:
   skip: false
 archives:

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -74,6 +74,8 @@ func NewMqtConsumerGroupHandler(version sarama.KafkaVersion,
 
 // Setup implemented to satisfy the sarama.ConsumerGroupHandler interface
 func (ch MqtConsumerGroupHandler) Setup(session sarama.ConsumerGroupSession) error {
+	mqtrigger.SetTriggerStatus(ch.trigger.ObjectMeta.Name, ch.trigger.ObjectMeta.Namespace)
+	mqtrigger.IncreaseInprocessCount()
 	ch.logger.With(
 		zap.String("trigger", ch.trigger.ObjectMeta.Name),
 		zap.String("topic", ch.trigger.Spec.Topic),
@@ -88,6 +90,8 @@ func (ch MqtConsumerGroupHandler) Setup(session sarama.ConsumerGroupSession) err
 
 // Cleanup implemented to satisfy the sarama.ConsumerGroupHandler interface
 func (ch MqtConsumerGroupHandler) Cleanup(session sarama.ConsumerGroupSession) error {
+	mqtrigger.ResetTriggerStatus(ch.trigger.ObjectMeta.Name, ch.trigger.ObjectMeta.Namespace)
+	mqtrigger.DecreaseInprocessCount()
 	ch.logger.With(
 		zap.String("trigger", ch.trigger.ObjectMeta.Name),
 		zap.String("topic", ch.trigger.Spec.Topic),

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -45,6 +45,20 @@ var (
 		},
 		[]string{"trigger_name", "trigger_namespace", "topic", "partition"},
 	)
+	triggerStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "fission_mqt_trigger_status",
+			Help: "Status of a trigger",
+		},
+		[]string{"trigger_name", "trigger_namespace"},
+	)
+	mqtInprocessCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "fission_mqt_inprocess",
+			Help: "Total number of mqt in process",
+		},
+		[]string{},
+	)
 )
 
 func IncreaseSubscriptionCount() {
@@ -53,6 +67,22 @@ func IncreaseSubscriptionCount() {
 
 func DecreaseSubscriptionCount() {
 	subscriptionCount.WithLabelValues().Dec()
+}
+
+func SetTriggerStatus(trigname, trignamespace string) {
+	triggerStatus.WithLabelValues(trigname, trignamespace).Inc()
+}
+
+func ResetTriggerStatus(trigname, trignamespace string) {
+	triggerStatus.WithLabelValues(trigname, trignamespace).Dec()
+}
+
+func IncreaseInprocessCount() {
+	mqtInprocessCount.WithLabelValues().Inc()
+}
+
+func DecreaseInprocessCount() {
+	mqtInprocessCount.WithLabelValues().Dec()
 }
 
 func IncreaseMessageCount(trigname, trignamespace string) {
@@ -68,4 +98,6 @@ func init() {
 	registry.MustRegister(subscriptionCount)
 	registry.MustRegister(messageCount)
 	registry.MustRegister(messageLagCount)
+	registry.MustRegister(mqtInprocessCount)
+	registry.MustRegister(triggerStatus)
 }

--- a/pkg/mqtrigger/metrics.go
+++ b/pkg/mqtrigger/metrics.go
@@ -47,15 +47,15 @@ var (
 	)
 	triggerStatus = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "fission_mqt_trigger_status",
-			Help: "Status of a trigger",
+			Name: "fission_mqt_status",
+			Help: "Status of an individual trigger 1 if processing otherwise 0",
 		},
 		[]string{"trigger_name", "trigger_namespace"},
 	)
 	mqtInprocessCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "fission_mqt_inprocess",
-			Help: "Total number of mqt in process",
+			Help: "Total number of MQTs in active processing",
 		},
 		[]string{},
 	)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Creating large number of MQTs (10+) was making mqtrigger-kafka pod very slow.
- Due to this new MQTs were not creating and trigger processing for old MQTs was also not working.
- We have added two metrics for more visibility.
- `fission_mqt_inprocess` for total number of MQTs in active processing.
- `fission_mqt_status` for status of an individual trigger, 1 if processing otherwise 0..

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Tested on kind cluster by creating 100 MQTs.
- All 100 MQTs were created under five minutes and trigger processing was also working.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
