### PR TITLE
Removed armv7 references from goreleaser file

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -36,9 +36,6 @@ builds:
     goarch:
       - amd64
       - arm64
-      - arm
-    goarm:
-      - 7
     binary: builder
     dir: ./cmd/builder
   - <<: *build-linux
@@ -60,12 +57,6 @@ builds:
     ignore:
       - goos: windows
         goarch: arm64
-      - goos: darwin
-        goarch: arm
-        goarm: 7
-      - goos: windows
-        goarch: arm
-        goarm: 7
   - <<: *build-linux
     id: pre-upgrade-checks
     binary: pre-upgrade-checks


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Armv7 support is removed from Fission `v1.20.3` release.
- This PR removes armv7 references from `goreleaser.yml` file.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
