### PR TITLE
Fix: Message queue trigger update

### DIFF
--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -128,7 +128,8 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	}
 
 	if input.IsSet(flagkey.MqtMetadata) {
-		updated = updated || util.UpdateMapFromStringSlice(&mqt.Spec.Metadata, metadataParams)
+		_ = util.UpdateMapFromStringSlice(&mqt.Spec.Metadata, metadataParams)
+		updated = true
 	}
 	if input.IsSet(flagkey.MqtSecret) {
 		mqt.Spec.Secret = secret


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This PR fixes a couple of issues:
- Handle `mqt update` which is ignored in mqtManager.
- Update scalemanager to handle scenarios when mqtkind is updated from keda to fission and vice-versa.
- Fix short circuit evaluation in `mqt update` which may fail the metadata update. 

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Updated mqtkind from fission to keda and verified that `scaledobject`, `triggerauthentications` and `deployment` objects are being created.
- Updated mqtkind from keda to fission and verified that `scaledobject`, `triggerauthentications`  and `deployment` objects are being deleted.
- Verified mqt.Spec.Metadata is being updated.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
