### PR TITLE
Use in-cluster config when kubeconfig file is not found

### DIFF
--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -100,14 +100,14 @@ func GetClientConfig(kubeContext string) (clientcmd.ClientConfig, error) {
 
 func NewClient(opts ClientOptions) (*Client, error) {
 	client := &Client{}
-	var err error
+	var err1 error
 	var cmdConfig clientcmd.ClientConfig
 	if len(opts.Namespace) > 0 {
 		client.Namespace = opts.Namespace
 	} else {
-		cmdConfig, err = GetClientConfig(opts.KubeContext)
-		if err != nil {
-			console.Verbose(2, err.Error())
+		cmdConfig, err1 = GetClientConfig(opts.KubeContext)
+		if err1 != nil {
+			console.Verbose(2, err1.Error())
 		}
 
 		if cmdConfig != nil {
@@ -130,10 +130,9 @@ func NewClient(opts ClientOptions) (*Client, error) {
 		client.RestConfig = restConfig
 	} else {
 		console.Verbose(2, "Using in-cluster config")
-		restConfig, err := rest.InClusterConfig()
-		if err != nil {
-			return nil, errors.New("couldn't find kubeconfig file " +
-				"and unable to load in-cluster configuration.")
+		restConfig, err2 := rest.InClusterConfig()
+		if err2 != nil {
+			return nil, errors.Join(err1, err2)
 		}
 
 		client.RestConfig = restConfig

--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -102,7 +102,6 @@ func NewClient(opts ClientOptions) (*Client, error) {
 	client := &Client{}
 	var err error
 	var cmdConfig clientcmd.ClientConfig
-	var restConfig *rest.Config
 	if len(opts.Namespace) > 0 {
 		client.Namespace = opts.Namespace
 	} else {
@@ -131,13 +130,14 @@ func NewClient(opts ClientOptions) (*Client, error) {
 		client.RestConfig = restConfig
 	} else {
 		console.Verbose(2, "Using in-cluster config")
-		restConfig, err = rest.InClusterConfig()
+		restConfig, err := rest.InClusterConfig()
 		if err != nil {
-			return nil, err
+			return nil, errors.New("couldn't find kubeconfig file " +
+				"and unable to load in-cluster configuration.")
 		}
 
 		client.RestConfig = restConfig
-		client.Namespace = getInClusterConfigamespace()
+		client.Namespace = getInClusterConfigNamespace()
 		console.Verbose(2, "In-cluster config default namespace %q", client.Namespace)
 	}
 
@@ -158,7 +158,7 @@ func NewClient(opts ClientOptions) (*Client, error) {
 }
 
 // Fetch default namespace for inClusterConfig
-func getInClusterConfigamespace() string {
+func getInClusterConfigNamespace() string {
 	// This way assumes you've set the POD_NAMESPACE environment variable using the downward API.
 	// This check has to be done first for backwards compatibility with the way InClusterConfig was originally set up
 	if ns, ok := os.LookupEnv("POD_NAMESPACE"); ok {

--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -121,17 +121,6 @@ func NewClient(opts ClientOptions) (*Client, error) {
 		}
 	}
 
-	if cmdConfig == nil {
-		console.Verbose(2, "Using in-cluster config")
-		restConfig, err = rest.InClusterConfig()
-		if err != nil {
-			return nil, err
-		}
-
-		client.Namespace = getInClusterConfigamespace()
-		console.Verbose(2, "In-cluster config default namespace %q", client.Namespace)
-	}
-
 	if opts.RestConfig != nil {
 		client.RestConfig = opts.RestConfig
 	} else if cmdConfig != nil {
@@ -141,7 +130,15 @@ func NewClient(opts ClientOptions) (*Client, error) {
 		}
 		client.RestConfig = restConfig
 	} else {
+		console.Verbose(2, "Using in-cluster config")
+		restConfig, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+
 		client.RestConfig = restConfig
+		client.Namespace = getInClusterConfigamespace()
+		console.Verbose(2, "In-cluster config default namespace %q", client.Namespace)
 	}
 
 	clientGen := crd.NewClientGeneratorWithRestConfig(client.RestConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- The PR adds support to `fission-cli` to use in-cluster config if kubeconfig file is not found.
- Now fission-cli can be used to do CRUD operations on fission's resources from inside a pod using service account.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #2994

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Created ClusterRole, ClusterRoleBinding and a service account.
- Created a docker image of the fission-cli.
- Created a deployment with fission-cli docker image.
- Exec to fission-cli container and run fission commands.
```
/ # ./fission check -v 2
couldn't find kubeconfig file. Set the KUBECONFIG environment variable to your kubeconfig's path.
Using in-cluster config
In-cluster config default namespace "default"
fission-services
--------------------
√ executor is running fine
√ router is running fine
√ storagesvc is running fine
√ webhook is running fine

fission-version
--------------------
Setting up port forward to application=fission-router in namespace 
Waiting for local port 38849
Starting port forward from local port 38849
Connected to Kubernetes API
Connecting to port 8888 on pod fission/router-5d5555f64-t7srv
Starting port forwarder
Forwarding from 127.0.0.1:38849 -> 8888
Forwarding from [::1]:38849 -> 8888
Waiting for port forward 38849 to start...
Port forward from local port 38849 started
Handling connection for 38849
Handling connection for 38849
clientVersion: v0.0.0
serverVersion: v0.0.0
√ fission is up-to-date
```
- Attaching the respective yaml files.
[fission-user-rolebinding.txt](https://github.com/user-attachments/files/16708786/fission-user-rolebinding.txt)
[fission-user-role.txt](https://github.com/user-attachments/files/16708807/fission-user-role.txt)
[fission-user-service-account.yaml.txt](https://github.com/user-attachments/files/16708808/fission-user-service-account.yaml.txt)


## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
