### PR TITLE
Support in-cluster configuration to create a Fission client

### DIFF
--- a/pkg/fission-cli/cmd/client.go
+++ b/pkg/fission-cli/cmd/client.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -26,6 +27,8 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/util/cert"
 
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/fission-cli/console"
@@ -84,17 +87,86 @@ func getLoadingRules() (loadingRules *clientcmd.ClientConfigLoadingRules, err er
 	return loadingRules, nil
 }
 
-func GetClientConfig(kubeContext string) (clientcmd.ClientConfig, error) {
-	loadingRules, err := getLoadingRules()
+// InClusterConfig returns a config object which uses the service account
+// kubernetes gives to pods. It's intended for clients that expect to be
+// running inside a pod running on kubernetes. It will return ErrNotInCluster
+// if called from a process not running in a kubernetes environment.
+func InClusterConfig() (*rest.Config, error) {
+	const (
+		tokenFile  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+		rootCAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+	)
+	host, port := os.Getenv("KUBERNETES_SERVICE_HOST"), os.Getenv("KUBERNETES_SERVICE_PORT")
+	if len(host) == 0 || len(port) == 0 {
+		return nil, fmt.Errorf("unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined")
+	}
+
+	token, err := os.ReadFile(tokenFile)
 	if err != nil {
 		return nil, err
 	}
-	overrides := &clientcmd.ConfigOverrides{}
-	if len(kubeContext) > 0 {
-		console.Verbose(2, "Using kubeconfig context %q", kubeContext)
-		overrides.CurrentContext = kubeContext
+
+	tlsClientConfig := rest.TLSClientConfig{}
+
+	if _, err := cert.NewPool(rootCAFile); err != nil {
+		return nil, fmt.Errorf("failed to load root CA config from %s: %v", rootCAFile, err)
+	} else {
+		tlsClientConfig.CAFile = rootCAFile
 	}
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides), nil
+
+	config := &rest.Config{
+		Host:            "https://" + net.JoinHostPort(host, port),
+		TLSClientConfig: tlsClientConfig,
+		BearerToken:     string(token),
+		BearerTokenFile: tokenFile,
+	}
+	return config, nil
+}
+
+func GetClientConfig(kubeContext string) (clientcmd.ClientConfig, error) {
+	loadingRules, err := getLoadingRules()
+	if err == nil {
+		overrides := &clientcmd.ConfigOverrides{}
+		if len(kubeContext) > 0 {
+			console.Verbose(2, "Using kubeconfig context %q", kubeContext)
+			overrides.CurrentContext = kubeContext
+		}
+		return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides), nil
+	}
+
+	console.Verbose(2, "Could not load kubeconfig, falling back to in-cluster config")
+
+	inClusterConfig, err := InClusterConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	console.Verbose(2, "InClusterConfig correct")
+
+	apiConfig := &api.Config{
+		Clusters: map[string]*api.Cluster{
+			"default": {
+				Server:                   inClusterConfig.Host,
+				CertificateAuthority:     inClusterConfig.TLSClientConfig.CAFile,
+				CertificateAuthorityData: inClusterConfig.TLSClientConfig.CAData,
+			},
+		},
+		AuthInfos: map[string]*api.AuthInfo{
+			"default": {
+				Token:     inClusterConfig.BearerToken,
+				TokenFile: inClusterConfig.BearerTokenFile,
+			},
+		},
+		Contexts: map[string]*api.Context{
+			"default": {
+				Cluster:  "default",
+				AuthInfo: "default",
+			},
+		},
+		CurrentContext: "default",
+	}
+
+	return clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{}), nil
 }
 
 func NewClient(opts ClientOptions) (*Client, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

This is the solution we implemented and works properly in our Kubernetes cluster. The `GetClientConfig` function (from fission-cli) was modified to support configuration credentials from a Kubernetes cluster.

We rely on the implementation done in the Kubernetes client, specifically, in the function `InClusterConfig`: https://github.com/kubernetes/client-go/blob/v12.0.0/rest/config.go#L395

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes https://github.com/fission/fission/issues/2994

## Testing:

We tested from a pod (where we deployed our microservice) and it worked correctly.

```
~/fission via  v18.17.1 via  v3.9.19 on   (us-east-1)
$ k exec -n fission -it pod/fission-cli-v1.0.1-test -- sh                                                        (base)
/usr/local/bin # fission check -v 2
Could not load kubeconfig, falling back to in-cluster config
InClusterConfig correct
Kubeconfig default namespace "default"
fission-services
--------------------
√ executor is running fine
√ router is running fine
√ storagesvc is running fine
√ webhook is running fine

fission-version
--------------------
Setting up port forward to application=fission-router in namespace
Waiting for local port 46737
Starting port forward from local port 46737
Connected to Kubernetes API
Connecting to port 8888 on pod fission/router-d565dd88c-p9pq7
Starting port forwarder
Forwarding from [127.0.0.1:46737](http://127.0.0.1:46737/) -> 8888
Forwarding from [::1]:46737 -> 8888
Waiting for port forward 46737 to start...
Port forward from local port 46737 started
Handling connection for 46737
Handling connection for 46737
clientVersion: v0.0.0
serverVersion: v1.20.3
× client version v0.0.0 does not match with server version v1.20.3
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
