### PR TITLE
Add resource namespace to logger

### DIFF
--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -118,7 +118,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-          {{- include "fission-resource-namespace.envs" . | indent 8 }}
+            {{- include "fission-resource-namespace.envs" . | indent 8 }}
           command: ["/fission-bundle"]
           args: ["--logger"]
           volumeMounts:

--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -118,7 +118,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- include "fission-resource-namespace.envs" . | indent 8 }}
+            {{- include "fission-resource-namespace.envs" . | indent 12 }}
           command: ["/fission-bundle"]
           args: ["--logger"]
           volumeMounts:

--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -118,6 +118,7 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+          {{- include "fission-resource-namespace.envs" . | indent 8 }}
           command: ["/fission-bundle"]
           args: ["--logger"]
           volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This change adds the fission-resource-namespace.envs helper to the logger (fluentbit) helm charts so that FISSION_RESOURCE_NAMESPACES is correctly exposed to the logger pod. This allows the logger to capture logs from functions that are running in non-default namespaces that are defined in additionalFissionNamespaces.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

## Testing
<!--- Please describe in detail how you tested your changes. -->
Deployed into EKS and checked that the logs are correctly captured from the non-default namespaces into influxdb.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
