### PR TITLE
Run logger as root to allow access to log files from host

### DIFF
--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -99,7 +99,11 @@ spec:
         - name: init
           image: {{ .Values.busyboxImage | quote }}
           imagePullPolicy: {{ .Values.pullPolicy }}
-          command: ['mkdir', '-p', '/var/log/fission']
+          command: 
+            - "/bin/sh"
+            - "-c"
+            # create the log directory and allow others read/write access
+            - "mkdir -p /var/log/fission && chmod o+wr /var/log/fission"
           volumeMounts:
             - name: container-log
               mountPath: /var/log/
@@ -130,7 +134,6 @@ spec:
 {{- if .Values.logger.enableSecurityContext }}
           securityContext:
             privileged: true
-            runAsUser: 0
 {{- end }}
         - name: fluentbit
 {{- if .Values.repository }}

--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -107,7 +107,6 @@ spec:
 {{- if .Values.logger.enableSecurityContext }}
           securityContext:
             privileged: true
-            runAsUser: 0
 {{- end }}
       containers:
         - name: logger
@@ -131,6 +130,7 @@ spec:
 {{- if .Values.logger.enableSecurityContext }}
           securityContext:
             privileged: true
+            runAsUser: 0
 {{- end }}
         - name: fluentbit
 {{- if .Values.repository }}

--- a/charts/fission-all/templates/fluentbit/fluentbit.yaml
+++ b/charts/fission-all/templates/fluentbit/fluentbit.yaml
@@ -107,6 +107,7 @@ spec:
 {{- if .Values.logger.enableSecurityContext }}
           securityContext:
             privileged: true
+            runAsUser: 0
 {{- end }}
       containers:
         - name: logger


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This change sets the user for the logger pod to be root in the helm charts. 

This allows the logger app to access the log file exposed from the host where it would normally be run as a non-root user. 

This would normally result in the following error:

> "error":"symlink /var/log/containers/poolmgr-opensearch-stats-default-46119364-685c75bc5b-fz87g_default_opensearch-stats-ffc3bf78135a5d7e5b8cacc25655bf2a81a02e130a499414fae42f0021fcebb4.log /var/log/fission/poolmgr-opensearch-stats-default-46119364-685c75bc5b-fz87g_default_opensearch-stats-ffc3bf78135a5d7e5b8cacc25655bf2a81a02e130a499414fae42f0021fcebb4.log: permission denied"


## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
None

## Testing
<!--- Please describe in detail how you tested your changes. -->
Deployed to EKS and tested that the 

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
