### PR TITLE
Fixed time unit loss problem after converting time

### DIFF
--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -108,7 +108,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 	)
 
 	fnTestTimeout := input.Duration(flagkey.FnTestTimeout)
-	fnSpecTimeout := time.Duration(function.Spec.FunctionTimeout)
+	fnSpecTimeout := time.Duration(function.Spec.FunctionTimeout) * time.Second
 
 	if input.IsSet(flagkey.FnTestTimeout) && (fnTestTimeout < fnSpecTimeout) {
 		reqTimeout = fnTestTimeout
@@ -121,7 +121,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 		ctx = input.Context()
 	} else {
 		var closeCtx context.CancelFunc
-		ctx, closeCtx = context.WithTimeoutCause(input.Context(), reqTimeout*time.Second, fmt.Errorf("function request timeout (%d)s exceeded", reqTimeout))
+		ctx, closeCtx = context.WithTimeoutCause(input.Context(), reqTimeout, fmt.Errorf("function request timeout (%d)s exceeded", reqTimeout))
 		defer closeCtx()
 	}
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
The time unit of 'function.Spec.FunctionTimeout' is second, but after conversion from the function time.Duration, the unit becomes nanosecond. So it needs to be repaired.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
