### PR TITLE
Print pod log error when response status is 404 returned by test function

### DIFF
--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -67,16 +67,11 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	}
 
 	envName := input.String(flagkey.FnEnvironmentName)
-	envNamespace := input.String(flagkey.NamespaceEnvironment)
 	// if the new env specified is the same as the old one, no need to update package
 	// same is true for all update parameters, but, for now, we don't check all of them - because, its ok to
 	// re-write the object with same old values, we just end up getting a new resource version for the object.
 	if len(envName) > 0 && envName == function.Spec.Environment.Name {
 		envName = ""
-	}
-
-	if envNamespace == function.Spec.Environment.Namespace {
-		envNamespace = ""
 	}
 
 	pkgName := input.String(flagkey.FnPackageName)
@@ -131,10 +126,6 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 
 	if len(envName) > 0 {
 		function.Spec.Environment.Name = envName
-	}
-
-	if len(envNamespace) > 0 {
-		function.Spec.Environment.Namespace = envNamespace
 	}
 
 	if len(entrypoint) > 0 {

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -32,7 +32,6 @@ import (
 
 	ignore "github.com/sabhiram/go-gitignore"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -535,7 +534,7 @@ func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) 
 
 	if len(ns) == 0 {
 		ns = metav1.NamespaceDefault
-	} else if ns != metav1.NamespaceDefault {
+	} else {
 		podNs = ns
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
When I tested the function under the default namespace, the response status returned was 404. At this point, the pod log corresponding to the function is queried, but it is always queried under the 'fission-function' namespace, which results in an error because the pod cannot be found.
## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3014 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
