### PR TITLE
Fixed: Print pod log error when response status is 404 returned by te…

### DIFF
--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -63,10 +63,16 @@ func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFil
 		podNs = logFilter.PodNamespace
 	}
 	// Get function Pods first
-	selector := map[string]string{
-		fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
-		fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
-		fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
+		selector := map[string]string{
+			fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
+			fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
+			fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+		}
+	} else {
+		selector := map[string]string{
+			fv1.FUNCTION_UID: string(f.ObjectMeta.UID),
+		}
 	}
 
 	podNs = util.ResolveFunctionNS(podNs)

--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -63,6 +63,7 @@ func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFil
 		podNs = logFilter.PodNamespace
 	}
 	// Get function Pods first
+	var selector map[string]string
 	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
 		selector := map[string]string{
 			fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),


### PR DESCRIPTION
…st function

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
When I tested the function under the default namespace, the response status returned was 404. At this point, the pod log corresponding to the function is queried, but it is always queried under the 'fission-function' namespace, which results in an error because the pod cannot be found.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/fission/fission/issues/3014

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
