### PR TITLE
Fixed: Print pod log error when response status is 404 returned by te…

### DIFF
--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -63,10 +63,17 @@ func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFil
 		podNs = logFilter.PodNamespace
 	}
 	// Get function Pods first
-	selector := map[string]string{
-		fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
-		fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
-		fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+	var selector map[string]string
+	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
+		selector := map[string]string{
+			fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
+			fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
+			fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+		}
+	} else {
+		selector := map[string]string{
+			fv1.FUNCTION_UID: string(f.ObjectMeta.UID),
+		}
 	}
 
 	podNs = util.ResolveFunctionNS(podNs)

--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -65,13 +65,13 @@ func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFil
 	// Get function Pods first
 	var selector map[string]string
 	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
-		selector := map[string]string{
+		selector = map[string]string{
 			fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
 			fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
 			fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
 		}
 	} else {
-		selector := map[string]string{
+		selector = map[string]string{
 			fv1.FUNCTION_UID: string(f.ObjectMeta.UID),
 		}
 	}

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -542,13 +542,13 @@ func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) 
 	// Get function Pods first
 	var selector map[string]string
 	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
-		selector := map[string]string{
+		selector = map[string]string{
 			fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
 			fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
 			fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
 		}
 	} else {
-		selector := map[string]string{
+		selector = map[string]string{
 			fv1.FUNCTION_UID: string(f.ObjectMeta.UID),
 		}
 	}

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -32,7 +32,6 @@ import (
 
 	ignore "github.com/sabhiram/go-gitignore"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -531,12 +530,8 @@ func GetSvcName(ctx context.Context, kClient kubernetes.Interface, application s
 // FunctionPodLogs : Get logs for a function directly from pod
 func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) (err error) {
 
-	podNs := "fission-function"
-
 	if len(ns) == 0 {
 		ns = metav1.NamespaceDefault
-	} else if ns != metav1.NamespaceDefault {
-		podNs = ns
 	}
 
 	f, err := client.FissionClientSet.CoreV1().Functions(ns).Get(ctx, fnName, metav1.GetOptions{})
@@ -545,12 +540,19 @@ func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) 
 	}
 
 	// Get function Pods first
-	selector := map[string]string{
-		fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
-		fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
-		fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+	var selector map[string]string
+	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
+		selector := map[string]string{
+			fv1.FUNCTION_UID:          string(f.ObjectMeta.UID),
+			fv1.ENVIRONMENT_NAME:      f.Spec.Environment.Name,
+			fv1.ENVIRONMENT_NAMESPACE: f.Spec.Environment.Namespace,
+		}
+	} else {
+		selector := map[string]string{
+			fv1.FUNCTION_UID: string(f.ObjectMeta.UID),
+		}
 	}
-	podList, err := client.KubernetesClient.CoreV1().Pods(podNs).List(ctx, metav1.ListOptions{
+	podList, err := client.KubernetesClient.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(selector).AsSelector().String(),
 	})
 	if err != nil {
@@ -566,7 +568,7 @@ func FunctionPodLogs(ctx context.Context, fnName, ns string, client cmd.Client) 
 	})
 
 	if len(pods) <= 0 {
-		return errors.New("no active pods found for function in namespace " + podNs)
+		return errors.New("no active pods found for function in namespace " + ns)
 	}
 
 	// get the pod with highest resource version


### PR DESCRIPTION
…st function

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
When I tested the function under the default namespace, the response status returned was 404. At this point, the pod log corresponding to the function is queried, but it is always queried under the 'fission-function' namespace, which results in an error because the pod cannot be found.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3014

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
