### PR TITLE
Fixed: Allow to disable owner references for cross namespace access with builder and function namespace 

### DIFF
--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           value: {{ .Values.fetcher.resource.mem.limits | quote }}
         - name: DEBUG_ENV
           value: {{ .Values.debugEnv | quote }}
+        - name: DISABLE_OWNER_REFERENCES
+          value: {{ .Values.disableOwnerReference | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
         - name: HELM_RELEASE_NAME

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -76,6 +76,8 @@ spec:
           value: {{ .Values.executor.serviceAccountCheck.enabled | quote }}  
         - name: SERVICEACCOUNT_CHECK_INTERVAL
           value: {{ .Values.executor.serviceAccountCheck.interval | quote }}
+        - name: DISABLE_OWNER_REFERENCES
+          value: {{ .Values.disableOwnerReference | quote }}
         {{- end}}  
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "kube_client.envs" . | indent 8 }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -88,6 +88,13 @@ additionalFissionNamespaces: []
 ##
 createNamespace: true
 
+## disableOwnerReference decides to set OwnerReference to K8s resources like deployment, services, hpa etc. created by Fission.
+## If set to true, the K8s resources created by Fission will not have OwnerReference set.
+## Set to false if you want to add OwnerReference to K8s resources created by Fission.
+##
+## Set to true if you are using cross namespace meaning `builderNamespace` and `functionNamespace` are set.
+disableOwnerReference: false
+
 ## enableIstio indicates whether to enable istio integration.
 ##
 enableIstio: false

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -60,6 +60,8 @@ type (
 
 		requestChan chan *createFuncServiceRequest
 		fsCreateWg  sync.Map
+
+		enableOwnerReferences bool
 	}
 	createFuncServiceRequest struct {
 		context  context.Context

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -60,8 +60,6 @@ type (
 
 		requestChan chan *createFuncServiceRequest
 		fsCreateWg  sync.Map
-
-		enableOwnerReferences bool
 	}
 	createFuncServiceRequest struct {
 		context  context.Context

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -88,6 +88,8 @@ type (
 
 		hpaops                     *hpautils.HpaOperations
 		objectReaperIntervalSecond time.Duration
+
+		enableOwnerReferences bool
 	}
 )
 
@@ -131,6 +133,8 @@ func MakeContainer(
 		deplListerSynced:           make(map[string]k8sCache.InformerSynced),
 		svcLister:                  make(map[string]corelisters.ServiceLister),
 		svcListerSynced:            make(map[string]k8sCache.InformerSynced),
+
+		enableOwnerReferences: utils.IsOwnerReferencesEnabled(),
 	}
 
 	for ns, informerFactory := range cnmInformerFactory {

--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -19,7 +19,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -33,7 +32,6 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
-	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -268,7 +266,7 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 	pod.Spec = *(util.ApplyImagePullSecret("", pod.Spec))
 
 	var ownerReferences []metav1.OwnerReference
-	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+	if cn.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
 				Group:   "fission.io",

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -19,7 +19,6 @@ package container
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"go.uber.org/zap"
 	apiv1 "k8s.io/api/core/v1"
@@ -29,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -53,7 +51,7 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 	}
 	logger := otelUtils.LoggerWithTraceID(ctx, cn.logger)
 	var ownerReferences []metav1.OwnerReference
-	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+	if cn.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
 				Group:   "fission.io",

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 
@@ -36,7 +35,6 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
-	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -249,7 +247,7 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))
 
 	var ownerReferences []metav1.OwnerReference
-	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+	if deploy.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
 				Group:   "fission.io",
@@ -342,7 +340,7 @@ func (deploy *NewDeploy) getResources(env *fv1.Environment, fn *fv1.Function) ap
 func (deploy *NewDeploy) createOrGetSvc(ctx context.Context, fn *fv1.Function, deployLabels map[string]string, deployAnnotations map[string]string, svcName string, svcNamespace string) (*apiv1.Service, error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, deploy.logger)
 	var ownerReferences []metav1.OwnerReference
-	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+	if deploy.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
 				Group:   "fission.io",

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
+	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -246,18 +248,23 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 
 	pod.Spec = *(util.ApplyImagePullSecret(env.Spec.ImagePullSecret, pod.Spec))
 
+	var ownerReferences []metav1.OwnerReference
+	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+		ownerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+				Group:   "fission.io",
+				Version: "v1",
+				Kind:    "Function",
+			}),
+		}
+	}
+
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        deployName,
-			Labels:      deployLabels,
-			Annotations: deployAnnotations,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-					Group:   "fission.io",
-					Version: "v1",
-					Kind:    "Function",
-				}),
-			},
+			Name:            deployName,
+			Labels:          deployLabels,
+			Annotations:     deployAnnotations,
+			OwnerReferences: ownerReferences,
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
@@ -334,18 +341,23 @@ func (deploy *NewDeploy) getResources(env *fv1.Environment, fn *fv1.Function) ap
 
 func (deploy *NewDeploy) createOrGetSvc(ctx context.Context, fn *fv1.Function, deployLabels map[string]string, deployAnnotations map[string]string, svcName string, svcNamespace string) (*apiv1.Service, error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, deploy.logger)
+	var ownerReferences []metav1.OwnerReference
+	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+		ownerReferences = []metav1.OwnerReference{
+			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
+				Group:   "fission.io",
+				Version: "v1",
+				Kind:    "Function",
+			}),
+		}
+	}
+
 	service := &apiv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        svcName,
-			Labels:      deployLabels,
-			Annotations: deployAnnotations,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-					Group:   "fission.io",
-					Version: "v1",
-					Kind:    "Function",
-				}),
-			},
+			Name:            svcName,
+			Labels:          deployLabels,
+			Annotations:     deployAnnotations,
+			OwnerReferences: ownerReferences,
 		},
 		Spec: apiv1.ServiceSpec{
 			Ports: []apiv1.ServicePort{

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -92,6 +92,8 @@ type (
 
 		podSpecPatch               *apiv1.PodSpec
 		objectReaperIntervalSecond time.Duration
+
+		enableOwnerReferences bool
 	}
 )
 
@@ -139,6 +141,8 @@ func MakeNewDeploy(
 		deplListerSynced: make(map[string]k8sCache.InformerSynced),
 		svcLister:        make(map[string]corelisters.ServiceLister),
 		svcListerSynced:  make(map[string]k8sCache.InformerSynced),
+
+		enableOwnerReferences: utils.IsOwnerReferencesEnabled(),
 	}
 
 	for ns, informerFactory := range ndmInformerFactory {

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -79,6 +79,7 @@ type (
 		poolInstanceID           string // small random string to uniquify pod names
 		instanceID               string // poolmgr instance id
 		podSpecPatch             *apiv1.PodSpec
+		enableOwnerReferences    bool
 		// TODO: move this field into fsCache
 		podFSVCMap sync.Map
 	}
@@ -131,6 +132,7 @@ func MakeGenericPool(
 		instanceID:               instanceID,
 		podFSVCMap:               sync.Map{},
 		podSpecPatch:             podSpecPatch,
+		enableOwnerReferences:    utils.IsOwnerReferencesEnabled(),
 		lock:                     sync.Mutex{},
 	}
 

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -19,7 +19,6 @@ package poolmgr
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"go.uber.org/zap"
@@ -31,7 +30,6 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
-	"github.com/fission/fission/pkg/utils"
 )
 
 // getPoolName returns a unique name of an environment
@@ -63,7 +61,7 @@ func (gp *GenericPool) genDeploymentMeta(env *fv1.Environment) metav1.ObjectMeta
 	deployAnnotations := gp.getDeployAnnotations(env)
 
 	var ownerReferences []metav1.OwnerReference
-	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+	if gp.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(env, schema.GroupVersionKind{
 				Group:   "fission.io",

--- a/pkg/executor/util/hpa/hpa.go
+++ b/pkg/executor/util/hpa/hpa.go
@@ -18,7 +18,6 @@ package hpa
 import (
 	"context"
 	"errors"
-	"os"
 
 	"go.uber.org/zap"
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,16 +40,18 @@ const (
 )
 
 type HpaOperations struct {
-	logger           *zap.Logger
-	kubernetesClient kubernetes.Interface
-	instanceID       string
+	logger                *zap.Logger
+	kubernetesClient      kubernetes.Interface
+	instanceID            string
+	enableOwnerReferences bool
 }
 
 func NewHpaOperations(logger *zap.Logger, kubernetesClient kubernetes.Interface, instanceID string) *HpaOperations {
 	return &HpaOperations{
-		logger:           logger,
-		kubernetesClient: kubernetesClient,
-		instanceID:       instanceID,
+		logger:                logger,
+		kubernetesClient:      kubernetesClient,
+		instanceID:            instanceID,
+		enableOwnerReferences: utils.IsOwnerReferencesEnabled(),
 	}
 }
 
@@ -102,7 +103,7 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, fn *fv1.Functio
 	}
 
 	var ownerReferences []metav1.OwnerReference
-	if os.Getenv(utils.ENV_DISABLE_OWNER_REFERENCES) == "false" {
+	if hpaops.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
 				Group:   "fission.io",

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -300,3 +300,8 @@ func DeleteOldPackages(pkgPath, pkgType string) error {
 
 	return nil
 }
+
+func IsOwnerReferencesEnabled() bool {
+	disableOwnerReference, _ := strconv.ParseBool(os.Getenv(ENV_DISABLE_OWNER_REFERENCES))
+	return !disableOwnerReference
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -39,6 +39,10 @@ import (
 	"github.com/fission/fission/pkg/utils/uuid"
 )
 
+const (
+	ENV_DISABLE_OWNER_REFERENCES string = "DISABLE_OWNER_REFERENCES"
+)
+
 func UrlForFunction(name, namespace string) string {
 	prefix := "/fission-function"
 	if namespace != metav1.NamespaceDefault {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- We would be adding `DISABLE_OWNER_REFERENCES` env variable to executor and buildermgr which would be `false` by default. If user is setting cross namespace `builderNamespace` and `functionNamespace` access then they would need to set it true.
- We would add support to set `disableOwnerReference` to true via helm chart.
- We would support existing behaviour in short term but eventually we would get rid of following.
```
builderNamespace: ""
functionNamespace: ""
disable_owner_reference: false
```

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3023 

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
