### PR TITLE
Fix: an invalid env manifest file breaks the executor component which stops the creation and deletion of envs

### DIFF
--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -548,7 +548,7 @@ func (gpm *GenericPoolManager) service() {
 			pool, ok := gpm.pools[key]
 			if !ok {
 				gpm.logger.Error("Could not find pool", zap.String("environment", env.ObjectMeta.Name), zap.String("namespace", env.ObjectMeta.Namespace))
-				return
+				continue
 			}
 			delete(gpm.pools, key)
 			if pool != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- If we create an environment with invalid values in manifest file then environment creation will fail. We will see the respective logs in executor. No issues here.
- Now if we delete that environment then `poolmgr` cleanup service is called and `return` statement in this service breaks the Go routine.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Create environment manifest using `fission spec` command.
```
$ fission spec init
$ fission env create --name go --image ghcr.io/fission/go-env --builder ghcr.io/fission/go-builder --spec
```
- Now edit the `specs/env-go.yaml` file and use an invalid container name for `runtime`. Valid name = envName
**spec.runtime.container.name = invalid**
```
apiVersion: fission.io/v1
kind: Environment
metadata:
  creationTimestamp: null
  name: go
spec:
  builder:
    command: build
    container:
      name: ""
      resources: {}
    image: ghcr.io/fission/go-builder
  imagepullsecret: ""
  keeparchive: false
  poolsize: 3
  resources: {}
  runtime:
    container:
      name: "invalid"
      resources: {}
    image: ghcr.io/fission/go-env
  version: 3
```
- Now, run `fission spec apply`. The poolmgr deployment will not be created but builder deployment will be created.
- Run `fission spec destroy` to delete the environment.
- Fix above manifest file and run `fission spec apply` again. Poolmgr deployment is not created because the Go routine responsible for creating deployment was killed when we ran `fission spec destroy`. Create any other environment and you will see the issue.
- Now apply this fix and follow the steps again.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
