### PR TITLE
Add leader election for executor

### DIFF
--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -97,6 +97,16 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - delete
+  - patch
+  - update
 {{- if .Values.executor.serviceAccountCheck.enabled }}  
 - apiGroups:
   - ""

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -6,7 +6,11 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     svc: executor
 spec:
+  {{- if .Values.executor.leaderElection.enabled }}
+  replicas: {{ .Values.executor.leaderElection.replicas }}
+  {{- else }}
   replicas: 1
+  {{- end }}
   selector:
     matchLabels:
       svc: executor
@@ -27,7 +31,11 @@ spec:
         image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
+        {{- if .Values.executor.leaderElection.enabled }}
+        args: ["--leaderElection", "--executorPort", "8888"]
+        {{- else }}
         args: ["--executorPort", "8888"]
+        {{- end }}
         env:
         - name: FETCHER_IMAGE
         {{- if eq .Values.fetcher.imageTag "" }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   {{- else }}
   replicas: 1
   {{- end }}
+  {{- if .Values.executor.leaderElection.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       svc: executor

--- a/charts/fission-all/templates/executor/role-kubernetes.yaml
+++ b/charts/fission-all/templates/executor/role-kubernetes.yaml
@@ -1,4 +1,5 @@
 {{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "executor") .) }}
+{{- include "kubernetes-role-generator" (merge (dict "namespace" .Release.Namespace "component" "executor") .) }}
 
 {{- if gt (len .Values.additionalFissionNamespaces) 0 }}
 {{- range $namespace := $.Values.additionalFissionNamespaces }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -203,6 +203,7 @@ executor:
     ##
     ## objectReaperInterval: 5
 
+  ## Enables running multiple replicas of executor for high avilability.
   leaderElection:
     enabled: false
     replicas: 2

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -203,6 +203,10 @@ executor:
     ##
     ## objectReaperInterval: 5
 
+  leaderElection:
+    enabled: false
+    replicas: 2
+
   serviceAccountCheck:
     ## enables fission to create service account, roles and rolebinding for missing permission for builder and fetcher.
     enabled: true

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -270,18 +270,12 @@ Options:
 
 	if arguments["--executorPort"] != nil {
 		port := getPort(logger, arguments["--executorPort"])
-		if arguments["--leaderElection"] == true {
-			err = runExecutor(ctx, clientGen, logger, mgr, port, true)
-			if err != nil {
-				logger.Error("executor exited", zap.Error(err))
-				return
-			}
-		} else {
-			err = runExecutor(ctx, clientGen, logger, mgr, port, false)
-			if err != nil {
-				logger.Error("executor exited", zap.Error(err))
-				return
-			}
+		leaderElection := arguments["--leaderElection"].(bool)
+
+		err = runExecutor(ctx, clientGen, logger, mgr, port, leaderElection)
+		if err != nil {
+			logger.Error("executor exited", zap.Error(err))
+			return
 		}
 	}
 

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -46,7 +46,6 @@ import (
 	"github.com/fission/fission/pkg/utils/manager"
 	"github.com/fission/fission/pkg/utils/otel"
 	"github.com/fission/fission/pkg/utils/profile"
-	"github.com/fission/fission/pkg/utils/uuid"
 	"github.com/fission/fission/pkg/webhook"
 )
 
@@ -65,17 +64,14 @@ func runRouter(ctx context.Context, clientGen crd.ClientGeneratorInterface, logg
 	return router.Start(ctx, clientGen, logger, mgr, port, eclient.MakeClient(logger, executorUrl))
 }
 
-func runExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger *zap.Logger, mgr manager.Interface, port int) error {
-	lock, err := leaderelection.CreateLeaseLockObject(ctx, "executor", uuid.NewString())
-	if err != nil {
-		return err
-	}
-
-	leaderelection.RunLeaderElection(ctx, logger, lock, func() error {
+func runExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger *zap.Logger, mgr manager.Interface, port int, leaderElection bool) error {
+	if leaderElection {
+		return leaderelection.RunLeaderElection(ctx, logger, "executor", clientGen, func() error {
+			return executor.StartExecutor(ctx, clientGen, logger, mgr, port)
+		})
+	} else {
 		return executor.StartExecutor(ctx, clientGen, logger, mgr, port)
-	})
-
-	return nil
+	}
 }
 
 func runKubeWatcher(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger *zap.Logger, mgr manager.Interface, routerUrl string) error {
@@ -191,7 +187,7 @@ Use it to start one or more of the fission servers:
 Usage:
   fission-bundle --canaryConfig
   fission-bundle --routerPort=<port> [--executorUrl=<url>]
-  fission-bundle --executorPort=<port> [--namespace=<namespace>] [--fission-namespace=<namespace>]
+  fission-bundle --executorPort=<port> [--namespace=<namespace>] [--fission-namespace=<namespace>] [--leaderElection]
   fission-bundle --kubewatcher [--routerUrl=<url>]
   fission-bundle --storageServicePort=<port> --storageType=<storateType>
   fission-bundle --builderMgr [--storageSvcUrl=<url>] [--envbuilder-namespace=<namespace>]
@@ -218,6 +214,7 @@ Options:
   --mqt                           Start message queue trigger.
   --mqt_keda					  Start message queue trigger of kind KEDA
   --builderMgr                    Start builder manager.
+  --leaderElection                Run leader elecion.
   --version                       Print version information
 `
 	logger := loggerfactory.GetLogger()
@@ -273,10 +270,18 @@ Options:
 
 	if arguments["--executorPort"] != nil {
 		port := getPort(logger, arguments["--executorPort"])
-		err = runExecutor(ctx, clientGen, logger, mgr, port)
-		if err != nil {
-			logger.Error("executor exited", zap.Error(err))
-			return
+		if arguments["--leaderElection"] == true {
+			err = runExecutor(ctx, clientGen, logger, mgr, port, true)
+			if err != nil {
+				logger.Error("executor exited", zap.Error(err))
+				return
+			}
+		} else {
+			err = runExecutor(ctx, clientGen, logger, mgr, port, false)
+			if err != nil {
+				logger.Error("executor exited", zap.Error(err))
+				return
+			}
 		}
 	}
 

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -1,0 +1,124 @@
+package leaderelection
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+type LeaderElection interface {
+	// CreateLeaseLockObject will fetch K8s config using InClusterConfig
+	// and will create a `Lease` K8s object using pod_name, pod_namespace and unique id
+	CreateLeaseLockObject(ctx context.Context, leaseLockName, id string) (*resourcelock.LeaseLock, error)
+
+	// Start the leader election code loop
+	RunLeaderElection(ctx context.Context, logger *zap.Logger, lock *resourcelock.LeaseLock, function func() error)
+}
+
+func CreateLeaseLockObject(ctx context.Context, leaseLockName, id string) (*resourcelock.LeaseLock, error) {
+
+	client, err := getK8sClient()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed loading K8s client")
+	}
+
+	leaseLockNamespace, err := getInClusterNamespace()
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to find leader election namespace: %v", err)
+	}
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{
+			Name:      leaseLockName,
+			Namespace: leaseLockNamespace,
+		},
+		Client: client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: id,
+		},
+	}
+
+	return lock, nil
+}
+
+func RunLeaderElection(ctx context.Context, logger *zap.Logger, lock *resourcelock.LeaseLock, f func() error) {
+	identity := lock.LockConfig.Identity
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
+		Lock: lock,
+		// IMPORTANT: you MUST ensure that any code you have that
+		// is protected by the lease must terminate **before**
+		// you call cancel. Otherwise, you could have a background
+		// loop still running and another process could
+		// get elected before your background loop finished, violating
+		// the stated goal of the lease.
+		ReleaseOnCancel: true,
+		LeaseDuration:   15 * time.Second,
+		RenewDeadline:   10 * time.Second,
+		RetryPeriod:     2 * time.Second,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(ctx context.Context) {
+				logger.Info("started leading", zap.String("identity", identity))
+				err := f()
+				if err != nil {
+					logger.Error("error executing function", zap.Error(err))
+				}
+			},
+			OnStoppedLeading: func() {
+				logger.Info("leader lost", zap.String("identity", identity))
+				os.Exit(0)
+			},
+			OnNewLeader: func(leaderIdentity string) {
+				logger.Info("new leader elected", zap.String("leaderIdentity", leaderIdentity))
+				if leaderIdentity == identity {
+					return
+				}
+				logger.Info("waiting for leader election", zap.String("identity", identity))
+				<-ctx.Done()
+			},
+		},
+	})
+}
+
+func getK8sClient() (*kubernetes.Clientset, error) {
+	// Use in-cluster config
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed loading InClusterConfig")
+	}
+
+	// Create a clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed creating clientset")
+	}
+
+	return clientset, nil
+}
+
+func getInClusterNamespace() (string, error) {
+	// Check whether the namespace file exists.
+	// If not, we are not running in cluster so can't guess the namespace.
+	if _, err := os.Stat(inClusterNamespacePath); os.IsNotExist(err) {
+		return "", fmt.Errorf("not running in-cluster, please specify LeaderElectionNamespace")
+	} else if err != nil {
+		return "", fmt.Errorf("error checking namespace file: %w", err)
+	}
+
+	// Load the namespace file and return its content
+	namespace, err := os.ReadFile(inClusterNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading namespace file: %w", err)
+	}
+	return string(namespace), nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -305,3 +305,21 @@ func IsOwnerReferencesEnabled() bool {
 	disableOwnerReference, _ := strconv.ParseBool(os.Getenv(ENV_DISABLE_OWNER_REFERENCES))
 	return !disableOwnerReference
 }
+
+// Fetch default namespace for inClusterConfig
+func GetInClusterConfigNamespace() string {
+	// This way assumes you've set the POD_NAMESPACE environment variable using the downward API.
+	// This check has to be done first for backwards compatibility with the way InClusterConfig was originally set up
+	if ns, ok := os.LookupEnv("POD_NAMESPACE"); ok {
+		return ns
+	}
+
+	// Fall back to the namespace associated with the service account token, if available
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
+			return ns
+		}
+	}
+
+	return "default"
+}

--- a/test/e2e/executor/executor_test.go
+++ b/test/e2e/executor/executor_test.go
@@ -1,0 +1,75 @@
+package executor_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/fission/fission/pkg/executor"
+	"github.com/fission/fission/pkg/leaderelection"
+	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+	"github.com/fission/fission/pkg/utils/manager"
+	"github.com/fission/fission/test/e2e/framework"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExecutorLeaderElection(t *testing.T) {
+	mgr := manager.New()
+	f := framework.NewFramework()
+	ctx, cancel := context.WithCancel(context.Background())
+	err := f.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		cancel()
+		mgr.Wait()
+		err = f.Stop()
+		require.NoError(t, err)
+	}()
+
+	k8sClient, err := f.ClientGen().GetKubernetesClient()
+	require.NoError(t, err)
+
+	executorPort, err := utils.FindFreePort()
+	if err != nil {
+		t.Errorf("error finding unused port: %v", err)
+	}
+
+	logger := loggerfactory.GetLogger()
+	defer logger.Sync()
+
+	t.Log("Start first executor instance")
+	go func() {
+		err := leaderelection.RunLeaderElection(ctx, logger, "executor", f.ClientGen(), func() error {
+			return executor.StartExecutor(ctx, f.ClientGen(), logger, mgr, executorPort)
+		})
+		if err != nil {
+			logger.Error("Failed to start the first executor instance", zap.Error(err))
+		}
+	}()
+
+	t.Log("Start second executor instance")
+	go func() {
+		err := leaderelection.RunLeaderElection(ctx, logger, "executor", f.ClientGen(), func() error {
+			return executor.StartExecutor(ctx, f.ClientGen(), logger, mgr, executorPort)
+		})
+		if err != nil {
+			logger.Error("Failed to start the second executor instance", zap.Error(err))
+		}
+	}()
+
+	time.Sleep(5 * time.Second)
+
+	leases, err := k8sClient.CoordinationV1().Leases(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list leases: %v", err)
+	}
+
+	numLeases := len(leases.Items)
+	expectedLeases := 1
+	if numLeases != expectedLeases {
+		t.Fatalf("expected %d leases, got %d: %v", expectedLeases, numLeases, err)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
- Added leader election to executor for high availability.
- It is a Kubernetes resource that helps manage and ensure only one pod acts as the leader at any given time. If the leader pod fails, another pod can quickly take over, ensuring the application remains highly available.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
- Tested by increasing the number of replicas in executor deployment. Leader election is working as expected.
- The non-leader pods keep crashing and restarting because of `liveness` and `readiness` probes failed. To fix this issue, we need to restructure the starting steps of executor and start the server before the leader election loop. I am working on it.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3041)
<!-- Reviewable:end -->
