### PR TITLE
Log only related configmap and secret

### DIFF
--- a/pkg/executor/cms/cmhandler.go
+++ b/pkg/executor/cms/cmhandler.go
@@ -58,13 +58,18 @@ func ConfigMapEventHandlers(ctx context.Context, logger *zap.Logger, fissionClie
 			oldCm := oldObj.(*apiv1.ConfigMap)
 			newCm := newObj.(*apiv1.ConfigMap)
 			if oldCm.ObjectMeta.ResourceVersion != newCm.ObjectMeta.ResourceVersion {
-				logger.Debug("Configmap changed",
-					zap.String("configmap_name", newCm.ObjectMeta.Name),
-					zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))
 				funcs, err := getConfigmapRelatedFuncs(ctx, logger, &newCm.ObjectMeta, fissionClient)
 				if err != nil {
 					logger.Error("Failed to get functions related to configmap", zap.String("configmap_name", newCm.ObjectMeta.Name), zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))
 				}
+
+				if len(funcs) == 0 {
+					return
+				}
+
+				logger.Debug("Configmap changed",
+					zap.String("configmap_name", newCm.ObjectMeta.Name),
+					zap.String("configmap_namespace", newCm.ObjectMeta.Namespace))
 				refreshPods(ctx, logger, funcs, types)
 			}
 		},

--- a/pkg/executor/cms/secrethandler.go
+++ b/pkg/executor/cms/secrethandler.go
@@ -57,13 +57,18 @@ func SecretEventHandlers(ctx context.Context, logger *zap.Logger, fissionClient 
 			oldS := oldObj.(*apiv1.Secret)
 			newS := newObj.(*apiv1.Secret)
 			if oldS.ObjectMeta.ResourceVersion != newS.ObjectMeta.ResourceVersion {
-				logger.Debug("Secret changed",
-					zap.String("configmap_name", newS.ObjectMeta.Name),
-					zap.String("configmap_namespace", newS.ObjectMeta.Namespace))
 				funcs, err := getSecretRelatedFuncs(ctx, logger, &newS.ObjectMeta, fissionClient)
 				if err != nil {
 					logger.Error("Failed to get functions related to secret", zap.String("secret_name", newS.ObjectMeta.Name), zap.String("secret_namespace", newS.ObjectMeta.Namespace))
 				}
+
+				if len(funcs) == 0 {
+					return
+				}
+
+				logger.Debug("Secret changed",
+					zap.String("secret_name", newS.ObjectMeta.Name),
+					zap.String("secret_namespace", newS.ObjectMeta.Namespace))
 				refreshPods(ctx, logger, funcs, types)
 			}
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

When I debug executor pod logs, it logs many unrelated updated configmap logs, like this（other operator updates the configmap periodically in k8s）:
![image](https://github.com/user-attachments/assets/25e77fcb-1d4c-4078-9a24-a97e9ab4fe78)

It make some trouble for me to find the logs I need. It should only debug log configmap/secret related the fission functions.



## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
