### PR TITLE
Fix download deploy package out of k8s cluster

### DIFF
--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -170,7 +170,7 @@ func DownloadStrorageURL(ctx context.Context, client cmd.Client, fileUrl string)
 		return nil, err
 	}
 
-	if strings.HasPrefix(fileUrl, storagesvcURL.String()+"/v1/archive?id=") {
+	if !strings.HasPrefix(fileUrl, storagesvcURL.String()+"/v1/archive?id=") {
 		url, err := url.Parse(fileUrl)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

when I run `fission pkg getdeploy --name hello-pkg-sp -o ./hello-pkg-sp.zip`, it raise errors. 

hello-pkg-sp package is a builded package, its yaml:

```
spec:
  buildcmd: ./build.sh
  deployment:
    checksum:
      sum: d32c0ab6e49f4043dc44f02fca6231be1e303bae779a10d0bc2682efcacd7278
      type: sha256
    type: url
    url: >-
      http://storagesvc.fission/v1/archive?id=%2Ffission%2Ffission-functions%2Fbb568aa7-f0c6-4933-97cf-72e180aad802
      
  environment:
    name: python-27
    namespace: default
  source:
    checksum: {}
    literal: >-
      UEsDBBQACAAAAK0+V1kAAAAAAAAAAAxxxxxxxxxxxxxx
    type: literal

```

error is like:
<img width="1706" alt="image" src="https://github.com/user-attachments/assets/1b63d44b-3c56-4eb1-a361-8efa186400b4">

the code `fileUrl` is like `http://storagesvc.fission/v1/archive?id=124`, `storagesvcURL.String()` is like "localhost:52373" with port-forward out of k8s, so `strings.HasPrefix` should has `!`.
```
func DownloadStrorageURL(ctx context.Context, client cmd.Client, fileUrl string) (io.ReadCloser, error) {
	var resp *http.Response
	storagesvcURL, err := util.GetStorageURL(ctx, client)
	if err != nil {
		return nil, err
	}

	if !strings.HasPrefix(fileUrl, storagesvcURL.String()+"/v1/archive?id=") {
		url, err := url.Parse(fileUrl)
		if err != nil {
			return nil, err
		}
		id := url.Query().Get("id")

		client := storageSvcClient.MakeClient(storagesvcURL.String())
		resp, err = client.GetFile(ctx, id)
		if err != nil {
			return nil, err
		}
	} else {
		resp, err = http.Get(fileUrl)
	}

	if err != nil {
		return nil, err
	}
```




## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
