### PR TITLE
fix: fix slice init length

### DIFF
--- a/pkg/fission-cli/cliwrapper/driver/cobra/cobra.go
+++ b/pkg/fission-cli/cliwrapper/driver/cobra/cobra.go
@@ -266,7 +266,7 @@ func (u Cli) Int64(key string) int64 {
 
 func (u Cli) Int64Slice(key string) []int64 {
 	v, _ := u.c.Flags().GetIntSlice(key)
-	vals := make([]int64, len(v))
+	vals := make([]int64, 0, len(v))
 	for _, i := range v {
 		vals = append(vals, int64(i))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

The intention here should be to initialize a slice with a capacity of len(v)  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW



## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
