### PR TITLE
fix: custom runtime container name is invalid

### DIFF
--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -283,8 +283,12 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 
 	// If custom runtime container name - default env name
 	mainContainerName := env.ObjectMeta.Name
-	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" {
-		mainContainerName = env.Spec.Runtime.Container.Name
+	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" && env.Spec.Runtime.PodSpec != nil {
+		if util.DoesContainerExistInPodSpec(env.Spec.Runtime.Container.Name, env.Spec.Runtime.PodSpec) {
+			mainContainerName = env.Spec.Runtime.Container.Name
+		} else {
+			return nil, fmt.Errorf("runtime container %s not found in pod spec", env.Spec.Runtime.Container.Name)
+		}
 	}
 
 	// Order of merging is important here - first fetcher, then containers and lastly pod spec

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -281,7 +281,6 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		},
 	}
 
-
 	// If custom runtime container name - default env name
 	mainContainerName := env.ObjectMeta.Name
 	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" {

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -281,10 +281,17 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		},
 	}
 
+
+	// If custom runtime container name - default env name
+	mainContainerName := env.ObjectMeta.Name
+	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" {
+		mainContainerName = env.Spec.Runtime.Container.Name
+	}
+
 	// Order of merging is important here - first fetcher, then containers and lastly pod spec
 	err = deploy.fetcherConfig.AddSpecializingFetcherToPodSpec(
 		&deployment.Spec.Template.Spec,
-		env.ObjectMeta.Name,
+		mainContainerName,
 		fn,
 		env,
 	)

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -191,8 +191,12 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 
 	// If custom runtime container name - default env name
 	mainContainerName := env.ObjectMeta.Name
-	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" {
-		mainContainerName = env.Spec.Runtime.Container.Name
+	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" && env.Spec.Runtime.PodSpec != nil {
+		if util.DoesContainerExistInPodSpec(env.Spec.Runtime.Container.Name, env.Spec.Runtime.PodSpec) {
+			mainContainerName = env.Spec.Runtime.Container.Name
+		} else {
+			return nil, fmt.Errorf("runtime container %s not found in pod spec", env.Spec.Runtime.Container.Name)
+		}
 	}
 
 	// Order of merging is important here - first fetcher, then containers and lastly pod spec

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -189,8 +189,14 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 		Template: pod,
 	}
 
+	// If custom runtime container name - default env name
+	mainContainerName := env.ObjectMeta.Name
+	if env.Spec.Runtime.Container != nil && env.Spec.Runtime.Container.Name != "" {
+		mainContainerName = env.Spec.Runtime.Container.Name
+	}
+
 	// Order of merging is important here - first fetcher, then containers and lastly pod spec
-	err = gp.fetcherConfig.AddFetcherToPodSpec(&deploymentSpec.Template.Spec, env.ObjectMeta.Name)
+	err = gp.fetcherConfig.AddFetcherToPodSpec(&deploymentSpec.Template.Spec, mainContainerName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -168,3 +168,13 @@ func CreateDumpFile(logger *zap.Logger) (*os.File, error) {
 
 	return os.Create(fmt.Sprintf("%s/%s-%d.txt", dumpPath, dumpFileName, time.Now().Unix()))
 }
+
+// DoesContainerExistInPodSpec checks if the container with the given name exists in the pod spec
+func DoesContainerExistInPodSpec(containerName string, podSpec *apiv1.PodSpec) bool {
+	for _, container := range podSpec.Containers {
+		if container.Name == containerName {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
fix executor container name is error when runtime container custom name， like this
![image](https://github.com/user-attachments/assets/52aff218-858f-4b6e-940d-18318be87e97)
![image](https://github.com/user-attachments/assets/1fedfb08-fa2a-47b7-a2a8-88b6a972c902)


Fixes #

## Testing
I Have Tested This Fix In My Production Env.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ √ ] I ran tests as well as code linting locally to verify my changes. 
- [√ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [√  ] I have signed all of my commits.
