### PR TITLE
Update create.go to handle namespace isolation

### DIFF
--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -64,16 +64,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) (err error) {
-	m := opts.env.ObjectMeta
-
-	envList, err := opts.Client().FissionClientSet.CoreV1().Environments(input.String(flagkey.Namespace)).List(input.Context(), metav1.ListOptions{})
-	if err != nil {
-		return err
-	} else if len(envList.Items) > 0 {
-		console.Verbose(2, "%d environment(s) are present in the %s namespace.  "+
-			"These environments are not isolated from each other; use separate namespaces if you need isolation.",
-			len(envList.Items), m.Namespace)
-	}
+	//m := opts.env.ObjectMeta
 
 	userDefinedNS, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
@@ -81,6 +72,15 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 	}
 	// we use user provided NS in spec. While creating actual record we use the current context's NS.
 	opts.env.ObjectMeta.Namespace = userDefinedNS
+
+	envList, err := opts.Client().FissionClientSet.CoreV1().Environments(opts.env.ObjectMeta.Namespace).List(input.Context(), metav1.ListOptions{})
+	if err != nil {
+		return err
+	} else if len(envList.Items) > 0 {
+		console.Verbose(2, "%d environment(s) are present in the %s namespace.  "+
+			"These environments are not isolated from each other; use separate namespaces if you need isolation.",
+			len(envList.Items), opts.env.ObjectMeta.Namespace)
+	}
 
 	// if we're writing a spec, don't call the API
 	// save to spec file or display the spec to console
@@ -99,7 +99,7 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 			return fv1.AggregateValidationErrors("Environment", err)
 		}
 
-		specFile := fmt.Sprintf("env-%v.yaml", m.Name)
+		specFile := fmt.Sprintf("env-%v.yaml", opts.env.ObjectMeta.Name)
 		err = spec.SpecSave(*opts.env, specFile, false)
 		if err != nil {
 			return errors.Wrap(err, "error saving environment spec")
@@ -114,7 +114,7 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 		return errors.Wrap(err, "error creating resource")
 	}
 
-	fmt.Printf("environment '%v' created\n", m.Name)
+	fmt.Printf("environment '%v' created\n", opts.env.ObjectMeta.Name)
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -64,7 +64,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) (err error) {
-	
+
 	userDefinedNS, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -66,7 +66,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 	m := opts.env.ObjectMeta
 
-	envList, err := opts.Client().FissionClientSet.CoreV1().Environments(m.Namespace).List(input.Context(), metav1.ListOptions{})
+	envList, err := opts.Client().FissionClientSet.CoreV1().Environments(input.String(flagkey.Namespace)).List(input.Context(), metav1.ListOptions{})
 	if err != nil {
 		return err
 	} else if len(envList.Items) > 0 {

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -64,8 +64,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) (err error) {
-	//m := opts.env.ObjectMeta
-
+	
 	userDefinedNS, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description

If the users on the cluster are namespace scoped they will not have permission to list environments from other namespaces. As you removed the Namespace variable from createEnvironmentFromCmd the m.Namespace will always be the default. This will not allow users to use fission cli to create environments

<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
