### PR TITLE
Fix SBOM and provenance for releases 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Login to docker.io
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: tripples
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install Cosign
@@ -183,7 +183,7 @@ jobs:
     with:
       image: ${{ fromJson(toJson(matrix)).image }}
       digest: ${{ fromJson(toJson(matrix)).checksum }}
-      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+      registry-username: tripples
     secrets:
       registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Login to docker.io
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
-          username: tripples
+          username: fission
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Install Cosign
@@ -183,7 +183,7 @@ jobs:
     with:
       image: ${{ fromJson(toJson(matrix)).image }}
       digest: ${{ fromJson(toJson(matrix)).checksum }}
-      registry-username: tripples
+      registry-username: fission
     secrets:
       registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,17 +9,19 @@ env:
   KIND_VERSION: v0.23.0
   KIND_NODE_IMAGE_TAG: v1.25.16
   KIND_CLUSTER_NAME: kind
-
+  COSIGN_VERSION: v2.4.1
 
 jobs:
   create-draft-release:
     outputs:
       hashes: ${{ steps.binary.outputs.hashes }}
-      # image: ${{ steps.image.outputs.name }}
-      # digest: ${{ steps.image.outputs.digest }}
+      ghcr_images: ${{ steps.image.outputs.ghcr_images }}
+      docker_images: ${{ steps.image.outputs.docker_images }}
+      version: ${{ steps.get_version.outputs.VERSION }}
     permissions:
-      contents: write  # for goreleaser/goreleaser-action to create a GitHub release
-      packages: write    # for goreleaser/goreleaser-action to upload artifacts to GitHub Packages
+      contents: write # for goreleaser/goreleaser-action to create a GitHub release
+      packages: write # for goreleaser/goreleaser-action to upload artifacts to GitHub Packages
+      id-token: write # for cosign to sign the image and binary
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -49,7 +51,7 @@ jobs:
           version: "~> v2"
 
       - name: Kind Cluster
-        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
+        uses: helm/kind-action@ae94020eaf628e9b9b9f341a10cc0cdcf5c018fb # v1.11.0
         with:
           node_image: kindest/node:${{ env.KIND_NODE_IMAGE_TAG }}
           version: ${{ env.KIND_VERSION }}
@@ -75,18 +77,12 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
         with:
-          cosign-release: "v2.2.1"
+          cosign-release: ${{ env.COSIGN_VERSION }}
 
       - name: Check cosign install!
         run: cosign version
 
-      - uses: anchore/sbom-action/download-syft@v0.17.9
-
-      - name: Write cosign signing key to disk
-        run: 'echo "$KEY" > cosign.key'
-        shell: bash
-        env:
-          KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+      - uses: anchore/sbom-action/download-syft@df80a981bc6edbc4e220a492d3cbe9f5547a6e75 #v0.17.9
 
       - name: Generate yaml for manifest, Minikube and Openshift installation
         run: ${GITHUB_WORKSPACE}/hack/build-yaml.sh $VERSION
@@ -101,7 +97,7 @@ jobs:
           version: "~> v2"
           args: release
         env:
-          COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
+          # COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           GORELEASER_CURRENT_TAG: ${{ steps.get_version.outputs.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_CLI_EXPERIMENTAL: "enabled"
@@ -114,17 +110,35 @@ jobs:
 
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
           echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
-      # - name: Image digest
-      #   id: image
-      #   env:
-      #     ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
-      #   run: |
-      #     set -euo pipefail
-      #     image_and_digest=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Docker Manifest") | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {name} + {digest} | join("@") | sub("^sha256:";"")')
-      #     image=$(echo "${image_and_digest}" | grep ghcr.io | cut -d'@' -f1 | cut -d':' -f1)
-      #     digest=$(echo "${image_and_digest}" | grep ghcr.io | cut -d'@' -f2)
-      #     echo "name=$image" >> "$GITHUB_OUTPUT"
-      #     echo "digest=$digest" >> "$GITHUB_OUTPUT"
+      - name: Image digest
+        id: image
+        env:
+          ARTIFACTS: "${{ steps.goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+          image_and_digest=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Docker Manifest") | {name, "digest": (.extra.Digest // .extra.Checksum)} | select(.digest) | {name} + {digest} | join("@") | sub("^sha256:";"")' | grep -v latest)
+          ghcr_images=$(echo "${image_and_digest}" | grep ghcr.io | jq -R -s -c '
+            split("\n")
+            | map(select(. != ""))
+            | map(
+                split("@")
+                | {
+                    "image": .[0] | split(":")[0],
+                    "checksum": .[1]
+                  }
+              )')
+          echo "ghcr_images=$ghcr_images" >> "$GITHUB_OUTPUT"
+          docker_images=$(echo "${image_and_digest}" | grep -v ghcr.io | jq -R -s -c '
+            split("\n")
+            | map(select(. != ""))
+            | map(
+                split("@")
+                | {
+                    "image": .[0] | split(":")[0],
+                    "checksum": .[1]
+                  }
+              )')
+          echo "docker_images=$docker_images" >> "$GITHUB_OUTPUT"
 
   binary-provenance:
     needs: [create-draft-release]
@@ -132,83 +146,116 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.0.0  # Do not use commit hash
     with:
       base64-subjects: "${{ needs.create-draft-release.outputs.hashes }}"
-      provenance-name: "fission.intoto.jsonl"
+      provenance-name: "fission_${{ needs.create-draft-release.outputs.version }}.intoto.jsonl"
       upload-assets: true # upload to a new release
+      draft-release: true # create a draft release
 
-  # image-provenance:
-  #   needs: [create-draft-release]
-  #   permissions:
-  #     actions: read
-  #     id-token: write
-  #     packages: write
-  #   uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v1.9.0
-  #   with:
-  #     image: ${{ needs.create-draft-release.outputs.image }}
-  #     digest: ${{ needs.create-draft-release.outputs.digest }}
-  #     registry-username: ${{ github.actor }}
-  #   secrets:
-  #     registry-password: ${{ secrets.GITHUB_TOKEN }}
+  image-provenance-ghcr:
+    needs: [create-draft-release]
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.create-draft-release.outputs.ghcr_images) }}
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0 # Do not use commit hash
+    with:
+      image: ${{ fromJson(toJson(matrix)).image }}
+      digest: ${{ fromJson(toJson(matrix)).checksum }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-  # verification-with-slsa-verifier:
-  #   needs: [create-draft-release, binary-provenance]
-  #   runs-on: ubuntu-latest
-  #   permissions: read-all
-  #   steps:
-  #     - name: Install the verifier
-  #       uses: slsa-framework/slsa-verifier/actions/installer@v2.6.0
+  image-provenance-docker:
+    needs: [create-draft-release]
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.create-draft-release.outputs.docker_images) }}
+    permissions:
+      actions: read
+      id-token: write
+      packages: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0 # Do not use commit hash
+    with:
+      image: ${{ fromJson(toJson(matrix)).image }}
+      digest: ${{ fromJson(toJson(matrix)).checksum }}
+      registry-username: ${{ secrets.DOCKERHUB_USERNAME }}
+    secrets:
+      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  #     - name: Download assets
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         PROVENANCE: "${{ needs.binary-provenance.outputs.provenance-name }}"
-  #       run: |
-  #         set -euo pipefail
-  #         gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.tar.gz"
-  #         gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "*.zip"
-  #         gh -R "$GITHUB_REPOSITORY" release download "$GITHUB_REF_NAME" -p "$PROVENANCE"
-  #     - name: Verify assets
-  #       env:
-  #         CHECKSUMS: ${{ needs.create-draft-release.outputs.hashes }}
-  #         PROVENANCE: "${{ needs.binary-provenance.outputs.provenance-name }}"
-  #       run: |
-  #         set -euo pipefail
-  #         checksums=$(echo "$CHECKSUMS" | base64 -d)
-  #         while read -r line; do
-  #             fn=$(echo $line | cut -d ' ' -f2)
-  #             echo "Verifying $fn"
-  #             slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
-  #                                           --source-uri "github.com/$GITHUB_REPOSITORY" \
-  #                                           --source-tag "$GITHUB_REF_NAME" \
-  #                                           "$fn"
-  #         done <<<"$checksums"
+  verification-with-slsa-verifier:
+    needs: [create-draft-release, binary-provenance]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # To download the assets from draft release.
+    steps:
+      - name: Install the verifier
+        uses: slsa-framework/slsa-verifier/actions/installer@3714a2a4684014deb874a0e737dffa0ee02dd647 # v2.6.0
 
-  # verification-with-cosign:
-  #   needs: [create-draft-release, image-provenance]
-  #   runs-on: ubuntu-latest
-  #   permissions: read-all
-  #   steps:
-  #     - name: Login
-  #       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-  #       with:
-  #         registry: ghcr.io
-  #         username: ${{ github.actor }}
-  #         password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROVENANCE: ${{ needs.binary-provenance.outputs.provenance-name }}
+          VERSION: ${{ needs.create-draft-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "repo=$GITHUB_REPOSITORY"
+          echo "ref=$VERSION"
+          gh -R "$GITHUB_REPOSITORY" release download "$VERSION" -p "$PROVENANCE"
 
-  #     - name: Install Cosign
-  #       uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-  #       with:
-  #         cosign-release: "v2.2.1"
+      - name: Verify assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CHECKSUMS: ${{ needs.create-draft-release.outputs.hashes }}
+          PROVENANCE: ${{ needs.binary-provenance.outputs.provenance-name }}
+          VERSION: ${{ needs.create-draft-release.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "CHECKSUMS=$CHECKSUMS"
+          echo "PROVENANCE=$PROVENANCE"
+          checksums=$(echo "$CHECKSUMS" | base64 -d)
+          while read -r line; do
+              fn=$(echo $line | cut -d ' ' -f2)
+              echo "Verifying $fn"
+              gh -R "$GITHUB_REPOSITORY" release download "$VERSION" -p "$fn"
+              slsa-verifier verify-artifact --provenance-path "$PROVENANCE" \
+                                            --source-uri "github.com/$GITHUB_REPOSITORY" \
+                                            --source-tag "$VERSION" \
+                                            "$fn"
+          done <<<"$checksums"
 
-  #     - name: Verify image
-  #       env:
-  #         IMAGE: ${{ needs.create-draft-release.outputs.image }}
-  #         DIGEST: ${{ needs.create-draft-release.outputs.digest }}
-  #       run: |
-  #         cosign verify-attestation \
-  #            --type slsaprovenance \
-  #            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  #            --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
-  #            $IMAGE@$DIGEST
+  verification-with-cosign-ghcr:
+    needs: [create-draft-release, image-provenance-ghcr]
+    strategy:
+      matrix:
+        include: ${{ fromJson(needs.create-draft-release.outputs.ghcr_images) }}
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - name: Login
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+
+      - name: Verify image
+        env:
+          IMAGE: ${{ fromJson(toJson(matrix)).image }}
+          DIGEST: ${{ fromJson(toJson(matrix)).checksum }}
+        run: |
+          echo "Verifying $IMAGE@$DIGEST"
+          cosign verify-attestation \
+             --type slsaprovenance \
+             --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+             --certificate-identity-regexp '^https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@refs/tags/v[0-9]+.[0-9]+.[0-9]+$' \
+             $IMAGE@$DIGEST

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ env:
 
 jobs:
   create-draft-release:
+    name: Create Draft Release with Goreleaser
     outputs:
       hashes: ${{ steps.binary.outputs.hashes }}
       ghcr_images: ${{ steps.image.outputs.ghcr_images }}
-      docker_images: ${{ steps.image.outputs.docker_images }}
       version: ${{ steps.get_version.outputs.VERSION }}
     permissions:
       contents: write # for goreleaser/goreleaser-action to create a GitHub release
@@ -68,12 +68,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to docker.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
-        with:
-          username: fission
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Install Cosign
         uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
         with:
@@ -100,6 +94,7 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ steps.get_version.outputs.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_CLI_EXPERIMENTAL: "enabled"
+
       - name: Generate binary hashes
         id: binary
         env:
@@ -109,6 +104,7 @@ jobs:
 
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
           echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
+
       - name: Image digest
         id: image
         env:
@@ -127,19 +123,9 @@ jobs:
                   }
               )')
           echo "ghcr_images=$ghcr_images" >> "$GITHUB_OUTPUT"
-          docker_images=$(echo "${image_and_digest}" | grep -v ghcr.io | jq -R -s -c '
-            split("\n")
-            | map(select(. != ""))
-            | map(
-                split("@")
-                | {
-                    "image": .[0] | split(":")[0],
-                    "checksum": .[1]
-                  }
-              )')
-          echo "docker_images=$docker_images" >> "$GITHUB_OUTPUT"
 
   binary-provenance:
+    name: Create Binary Provenance
     needs: [create-draft-release]
     permissions:
       actions: read # To read the workflow path.
@@ -153,6 +139,7 @@ jobs:
       draft-release: true # create a draft release
 
   image-provenance-ghcr:
+    name: Create Image Provenance
     needs: [create-draft-release]
     strategy:
       matrix:
@@ -169,24 +156,51 @@ jobs:
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
 
-  image-provenance-docker:
+  image-sbom-ghcr:
+    name: Create SBOM for container images
+    # Goreleaser does not support generating SBOM for container images.
     needs: [create-draft-release]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        include: ${{ fromJson(needs.create-draft-release.outputs.docker_images) }}
+        include: ${{ fromJson(needs.create-draft-release.outputs.ghcr_images) }}
     permissions:
-      actions: read
+      actions: write
       id-token: write
       packages: write
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0 # Do not use commit hash
-    with:
-      image: ${{ fromJson(toJson(matrix)).image }}
-      digest: ${{ fromJson(toJson(matrix)).checksum }}
-      registry-username: fission
-    secrets:
-      registry-password: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Trivy in fs mode to generate SBOM
+        uses: aquasecurity/trivy-action@18f2510ee396bbf400402947b394f2dd8c87dbb0 # v0.29.0
+        with:
+          scan-type: "fs"
+          format: "spdx-json"
+          output: "spdx.sbom.json"
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        with:
+          cosign-release: ${{ env.COSIGN_VERSION }}
+      - name: Sign image and sbom
+        env:
+          IMAGE: ${{ fromJson(toJson(matrix)).image }}
+          DIGEST: ${{ fromJson(toJson(matrix)).checksum }}
+        run: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          cosign attach sbom --sbom spdx.sbom.json $IMAGE@$DIGEST
+          cosign sign -a git_sha=$GITHUB_SHA --attachment sbom $IMAGE@$DIGEST --yes
 
-  verification-with-slsa-verifier:
+  binary-provenance-verification-with-slsa-verifier:
+    name : Verify Binary Provenance
     needs: [create-draft-release, binary-provenance]
     runs-on: ubuntu-latest
     permissions:
@@ -227,7 +241,8 @@ jobs:
                                             "$fn"
           done <<<"$checksums"
 
-  verification-with-cosign-ghcr:
+  image-provenance-verification-with-cosign:
+    name: Verify Image Provenance
     needs: [create-draft-release, image-provenance-ghcr]
     strategy:
       matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,7 @@ jobs:
           version: "~> v2"
 
       - name: Kind Cluster
-        uses: helm/kind-action@ae94020eaf628e9b9b9f341a10cc0cdcf5c018fb # v1.11.0
+        uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           node_image: kindest/node:${{ env.KIND_NODE_IMAGE_TAG }}
           version: ${{ env.KIND_VERSION }}
@@ -97,7 +97,6 @@ jobs:
           version: "~> v2"
           args: release
         env:
-          # COSIGN_PWD: ${{ secrets.COSIGN_PWD }}
           GORELEASER_CURRENT_TAG: ${{ steps.get_version.outputs.VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DOCKER_CLI_EXPERIMENTAL: "enabled"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,12 @@
 version: 2
 
 env:
-  - GHCR_REPO=ghcr.io/fission
+  - GHCR_REPO=ghcr.io/sanketsudake
 
 project_name: fission
 release:
   github:
-    owner: fission
+    owner: sanketsudake
     name: fission
   prerelease: "true"
   draft: true
@@ -88,6 +88,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-amd64
     ids:
       - fetcher
@@ -102,6 +105,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-amd64
     ids:
       - fission-bundle
@@ -116,6 +122,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-amd64
     ids:
       - pre-upgrade-checks
@@ -130,6 +139,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-amd64
     ids:
       - reporter
@@ -144,6 +156,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - &docker-arm64
     use: buildx
     goos: linux
@@ -161,6 +176,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-arm64
     ids:
       - fetcher
@@ -175,6 +193,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-arm64
     ids:
       - fission-bundle
@@ -189,6 +210,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-arm64
     ids:
       - pre-upgrade-checks
@@ -203,6 +227,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
   - <<: *docker-arm64
     ids:
       - reporter
@@ -217,6 +244,9 @@ dockers:
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
+      - "--label=org.opencontainers.image.authors=The Fission Authors https://fission.io/"
+      - "--label=org.opencontainers.image.vendor=Fission"
+      - "--label=org.opencontainers.image.url=https://fission.io/"
 docker_manifests:
   - name_template: "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}"
     image_templates:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ version: 2
 project_name: fission
 release:
   github:
-    owner: sanketsudake
+    owner: fission
     name: fission
   prerelease: true
   draft: true
@@ -75,13 +75,12 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "docker.io/tripples/builder:latest-amd64"
-      - "docker.io/tripples/builder:{{ .Tag }}-amd64"
-      - "ghcr.io/sanketsudake/builder:latest-amd64"
-      - "ghcr.io/sanketsudake/builder:{{ .Tag }}-amd64"
+      - "docker.io/fission/builder:latest-amd64"
+      - "docker.io/fission/builder:{{ .Tag }}-amd64"
+      - "ghcr.io/fission/builder:latest-amd64"
+      - "ghcr.io/fission/builder:{{ .Tag }}-amd64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -92,13 +91,12 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "docker.io/tripples/fetcher:latest-amd64"
-      - "docker.io/tripples/fetcher:{{ .Tag }}-amd64"
-      - "ghcr.io/sanketsudake/fetcher:latest-amd64"
-      - "ghcr.io/sanketsudake/fetcher:{{ .Tag }}-amd64"
+      - "docker.io/fission/fetcher:latest-amd64"
+      - "docker.io/fission/fetcher:{{ .Tag }}-amd64"
+      - "ghcr.io/fission/fetcher:latest-amd64"
+      - "ghcr.io/fission/fetcher:{{ .Tag }}-amd64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -109,13 +107,12 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "docker.io/tripples/fission-bundle:latest-amd64"
-      - "docker.io/tripples/fission-bundle:{{ .Tag }}-amd64"
-      - "ghcr.io/sanketsudake/fission-bundle:latest-amd64"
-      - "ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-amd64"
+      - "docker.io/fission/fission-bundle:latest-amd64"
+      - "docker.io/fission/fission-bundle:{{ .Tag }}-amd64"
+      - "ghcr.io/fission/fission-bundle:latest-amd64"
+      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -126,13 +123,12 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "docker.io/tripples/pre-upgrade-checks:latest-amd64"
-      - "docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-amd64"
-      - "ghcr.io/sanketsudake/pre-upgrade-checks:latest-amd64"
-      - "ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "docker.io/fission/pre-upgrade-checks:latest-amd64"
+      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "ghcr.io/fission/pre-upgrade-checks:latest-amd64"
+      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -143,13 +139,12 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "docker.io/tripples/reporter:latest-amd64"
-      - "docker.io/tripples/reporter:{{ .Tag }}-amd64"
-      - "ghcr.io/sanketsudake/reporter:latest-amd64"
-      - "ghcr.io/sanketsudake/reporter:{{ .Tag }}-amd64"
+      - "docker.io/fission/reporter:latest-amd64"
+      - "docker.io/fission/reporter:{{ .Tag }}-amd64"
+      - "ghcr.io/fission/reporter:latest-amd64"
+      - "ghcr.io/fission/reporter:{{ .Tag }}-amd64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -163,13 +158,12 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "docker.io/tripples/builder:latest-arm64"
-      - "docker.io/tripples/builder:{{ .Tag }}-arm64"
-      - "ghcr.io/sanketsudake/builder:latest-arm64"
-      - "ghcr.io/sanketsudake/builder:{{ .Tag }}-arm64"
+      - "docker.io/fission/builder:latest-arm64"
+      - "docker.io/fission/builder:{{ .Tag }}-arm64"
+      - "ghcr.io/fission/builder:latest-arm64"
+      - "ghcr.io/fission/builder:{{ .Tag }}-arm64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -180,13 +174,12 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "docker.io/tripples/fetcher:latest-arm64"
-      - "docker.io/tripples/fetcher:{{ .Tag }}-arm64"
-      - "ghcr.io/sanketsudake/fetcher:latest-arm64"
-      - "ghcr.io/sanketsudake/fetcher:{{ .Tag }}-arm64"
+      - "docker.io/fission/fetcher:latest-arm64"
+      - "docker.io/fission/fetcher:{{ .Tag }}-arm64"
+      - "ghcr.io/fission/fetcher:latest-arm64"
+      - "ghcr.io/fission/fetcher:{{ .Tag }}-arm64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -197,13 +190,12 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "docker.io/tripples/fission-bundle:latest-arm64"
-      - "docker.io/tripples/fission-bundle:{{ .Tag }}-arm64"
-      - "ghcr.io/sanketsudake/fission-bundle:latest-arm64"
-      - "ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-arm64"
+      - "docker.io/fission/fission-bundle:latest-arm64"
+      - "docker.io/fission/fission-bundle:{{ .Tag }}-arm64"
+      - "ghcr.io/fission/fission-bundle:latest-arm64"
+      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -214,13 +206,12 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "docker.io/tripples/pre-upgrade-checks:latest-arm64"
-      - "docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-arm64"
-      - "ghcr.io/sanketsudake/pre-upgrade-checks:latest-arm64"
-      - "ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "docker.io/fission/pre-upgrade-checks:latest-arm64"
+      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "ghcr.io/fission/pre-upgrade-checks:latest-arm64"
+      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -231,13 +222,12 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "docker.io/tripples/reporter:latest-arm64"
-      - "docker.io/tripples/reporter:{{ .Tag }}-arm64"
-      - "ghcr.io/sanketsudake/reporter:latest-arm64"
-      - "ghcr.io/sanketsudake/reporter:{{ .Tag }}-arm64"
+      - "docker.io/fission/reporter:latest-arm64"
+      - "docker.io/fission/reporter:{{ .Tag }}-arm64"
+      - "ghcr.io/fission/reporter:latest-arm64"
+      - "ghcr.io/fission/reporter:{{ .Tag }}-arm64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
-      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -245,86 +235,86 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
 docker_manifests:
-  - name_template: ghcr.io/sanketsudake/builder:{{ .Tag }}
+  - name_template: ghcr.io/fission/builder:{{ .Tag }}
     image_templates:
-      - ghcr.io/sanketsudake/builder:{{ .Tag }}-amd64
-      - ghcr.io/sanketsudake/builder:{{ .Tag }}-arm64
+      - ghcr.io/fission/builder:{{ .Tag }}-amd64
+      - ghcr.io/fission/builder:{{ .Tag }}-arm64
   - name_template: fission/builder:{{ .Tag }}
     image_templates:
-      - docker.io/tripples/builder:{{ .Tag }}-amd64
-      - docker.io/tripples/builder:{{ .Tag }}-arm64
-  - name_template: ghcr.io/sanketsudake/fetcher:{{ .Tag }}
+      - docker.io/fission/builder:{{ .Tag }}-amd64
+      - docker.io/fission/builder:{{ .Tag }}-arm64
+  - name_template: ghcr.io/fission/fetcher:{{ .Tag }}
     image_templates:
-      - ghcr.io/sanketsudake/fetcher:{{ .Tag }}-amd64
-      - ghcr.io/sanketsudake/fetcher:{{ .Tag }}-arm64
+      - ghcr.io/fission/fetcher:{{ .Tag }}-amd64
+      - ghcr.io/fission/fetcher:{{ .Tag }}-arm64
   - name_template: fission/fetcher:{{ .Tag }}
     image_templates:
-      - docker.io/tripples/fetcher:{{ .Tag }}-amd64
-      - docker.io/tripples/fetcher:{{ .Tag }}-arm64
-  - name_template: ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}
+      - docker.io/fission/fetcher:{{ .Tag }}-amd64
+      - docker.io/fission/fetcher:{{ .Tag }}-arm64
+  - name_template: ghcr.io/fission/fission-bundle:{{ .Tag }}
     image_templates:
-      - ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-amd64
-      - ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-arm64
+      - ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64
+      - ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64
   - name_template: fission/fission-bundle:{{ .Tag }}
     image_templates:
-      - docker.io/tripples/fission-bundle:{{ .Tag }}-amd64
-      - docker.io/tripples/fission-bundle:{{ .Tag }}-arm64
-  - name_template: ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}
+      - docker.io/fission/fission-bundle:{{ .Tag }}-amd64
+      - docker.io/fission/fission-bundle:{{ .Tag }}-arm64
+  - name_template: ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
-      - ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-amd64
-      - ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-arm64
+      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
+      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
   - name_template: fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
-      - docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-amd64
-      - docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-arm64
-  - name_template: ghcr.io/sanketsudake/reporter:{{ .Tag }}
+      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
+      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
+  - name_template: ghcr.io/fission/reporter:{{ .Tag }}
     image_templates:
-      - ghcr.io/sanketsudake/reporter:{{ .Tag }}-amd64
-      - ghcr.io/sanketsudake/reporter:{{ .Tag }}-arm64
+      - ghcr.io/fission/reporter:{{ .Tag }}-amd64
+      - ghcr.io/fission/reporter:{{ .Tag }}-arm64
   - name_template: fission/reporter:{{ .Tag }}
     image_templates:
-      - docker.io/tripples/reporter:{{ .Tag }}-amd64
-      - docker.io/tripples/reporter:{{ .Tag }}-arm64
-  - name_template: ghcr.io/sanketsudake/builder:latest
+      - docker.io/fission/reporter:{{ .Tag }}-amd64
+      - docker.io/fission/reporter:{{ .Tag }}-arm64
+  - name_template: ghcr.io/fission/builder:latest
     image_templates:
-      - ghcr.io/sanketsudake/builder:latest-amd64
-      - ghcr.io/sanketsudake/builder:latest-arm64
+      - ghcr.io/fission/builder:latest-amd64
+      - ghcr.io/fission/builder:latest-arm64
   - name_template: fission/builder:latest
     image_templates:
-      - docker.io/tripples/builder:latest-amd64
-      - docker.io/tripples/builder:latest-arm64
-  - name_template: ghcr.io/sanketsudake/fetcher:latest
+      - docker.io/fission/builder:latest-amd64
+      - docker.io/fission/builder:latest-arm64
+  - name_template: ghcr.io/fission/fetcher:latest
     image_templates:
-      - ghcr.io/sanketsudake/fetcher:latest-amd64
-      - ghcr.io/sanketsudake/fetcher:latest-arm64
+      - ghcr.io/fission/fetcher:latest-amd64
+      - ghcr.io/fission/fetcher:latest-arm64
   - name_template: fission/fetcher:latest
     image_templates:
-      - docker.io/tripples/fetcher:latest-amd64
-      - docker.io/tripples/fetcher:latest-arm64
-  - name_template: ghcr.io/sanketsudake/fission-bundle:latest
+      - docker.io/fission/fetcher:latest-amd64
+      - docker.io/fission/fetcher:latest-arm64
+  - name_template: ghcr.io/fission/fission-bundle:latest
     image_templates:
-      - ghcr.io/sanketsudake/fission-bundle:latest-amd64
-      - ghcr.io/sanketsudake/fission-bundle:latest-arm64
+      - ghcr.io/fission/fission-bundle:latest-amd64
+      - ghcr.io/fission/fission-bundle:latest-arm64
   - name_template: fission/fission-bundle:latest
     image_templates:
-      - docker.io/tripples/fission-bundle:latest-amd64
-      - docker.io/tripples/fission-bundle:latest-arm64
-  - name_template: ghcr.io/sanketsudake/pre-upgrade-checks:latest
+      - docker.io/fission/fission-bundle:latest-amd64
+      - docker.io/fission/fission-bundle:latest-arm64
+  - name_template: ghcr.io/fission/pre-upgrade-checks:latest
     image_templates:
-      - ghcr.io/sanketsudake/pre-upgrade-checks:latest-amd64
-      - ghcr.io/sanketsudake/pre-upgrade-checks:latest-arm64
+      - ghcr.io/fission/pre-upgrade-checks:latest-amd64
+      - ghcr.io/fission/pre-upgrade-checks:latest-arm64
   - name_template: fission/pre-upgrade-checks:latest
     image_templates:
-      - docker.io/tripples/pre-upgrade-checks:latest-amd64
-      - docker.io/tripples/pre-upgrade-checks:latest-arm64
-  - name_template: ghcr.io/sanketsudake/reporter:latest
+      - docker.io/fission/pre-upgrade-checks:latest-amd64
+      - docker.io/fission/pre-upgrade-checks:latest-arm64
+  - name_template: ghcr.io/fission/reporter:latest
     image_templates:
-      - ghcr.io/sanketsudake/reporter:latest-amd64
-      - ghcr.io/sanketsudake/reporter:latest-arm64
+      - ghcr.io/fission/reporter:latest-amd64
+      - ghcr.io/fission/reporter:latest-arm64
   - name_template: fission/reporter:latest
     image_templates:
-      - docker.io/tripples/reporter:latest-amd64
-      - docker.io/tripples/reporter:latest-arm64
+      - docker.io/fission/reporter:latest-amd64
+      - docker.io/fission/reporter:latest-arm64
 changelog:
   disable: true
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -81,6 +81,7 @@ dockers:
       - "ghcr.io/sanketsudake/builder:{{ .Tag }}-amd64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -97,6 +98,7 @@ dockers:
       - "ghcr.io/sanketsudake/fetcher:{{ .Tag }}-amd64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -113,6 +115,7 @@ dockers:
       - "ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-amd64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -129,6 +132,7 @@ dockers:
       - "ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-amd64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -145,6 +149,7 @@ dockers:
       - "ghcr.io/sanketsudake/reporter:{{ .Tag }}-amd64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/amd64"
@@ -164,6 +169,7 @@ dockers:
       - "ghcr.io/sanketsudake/builder:{{ .Tag }}-arm64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -180,6 +186,7 @@ dockers:
       - "ghcr.io/sanketsudake/fetcher:{{ .Tag }}-arm64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -196,6 +203,7 @@ dockers:
       - "ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-arm64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -212,6 +220,7 @@ dockers:
       - "ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-arm64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"
@@ -228,6 +237,7 @@ dockers:
       - "ghcr.io/sanketsudake/reporter:{{ .Tag }}-arm64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
+      - "--sbom=true"
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--platform=linux/arm64"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,8 +75,8 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "fission/builder:latest-amd64"
-      - "fission/builder:{{ .Tag }}-amd64"
+      - "docker.io/fission/builder:latest-amd64"
+      - "docker.io/fission/builder:{{ .Tag }}-amd64"
       - "ghcr.io/fission/builder:latest-amd64"
       - "ghcr.io/fission/builder:{{ .Tag }}-amd64"
     dockerfile: cmd/builder/Dockerfile
@@ -91,8 +91,8 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "fission/fetcher:latest-amd64"
-      - "fission/fetcher:{{ .Tag }}-amd64"
+      - "docker.io/fission/fetcher:latest-amd64"
+      - "docker.io/fission/fetcher:{{ .Tag }}-amd64"
       - "ghcr.io/fission/fetcher:latest-amd64"
       - "ghcr.io/fission/fetcher:{{ .Tag }}-amd64"
     dockerfile: cmd/fetcher/Dockerfile
@@ -107,8 +107,8 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "fission/fission-bundle:latest-amd64"
-      - "fission/fission-bundle:{{ .Tag }}-amd64"
+      - "docker.io/fission/fission-bundle:latest-amd64"
+      - "docker.io/fission/fission-bundle:{{ .Tag }}-amd64"
       - "ghcr.io/fission/fission-bundle:latest-amd64"
       - "ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64"
     dockerfile: cmd/fission-bundle/Dockerfile
@@ -123,8 +123,8 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "fission/pre-upgrade-checks:latest-amd64"
-      - "fission/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "docker.io/fission/pre-upgrade-checks:latest-amd64"
+      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
       - "ghcr.io/fission/pre-upgrade-checks:latest-amd64"
       - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
     dockerfile: cmd/preupgradechecks/Dockerfile
@@ -139,8 +139,8 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "fission/reporter:latest-amd64"
-      - "fission/reporter:{{ .Tag }}-amd64"
+      - "docker.io/fission/reporter:latest-amd64"
+      - "docker.io/fission/reporter:{{ .Tag }}-amd64"
       - "ghcr.io/fission/reporter:latest-amd64"
       - "ghcr.io/fission/reporter:{{ .Tag }}-amd64"
     dockerfile: cmd/reporter/Dockerfile
@@ -158,8 +158,8 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "fission/builder:latest-arm64"
-      - "fission/builder:{{ .Tag }}-arm64"
+      - "docker.io/fission/builder:latest-arm64"
+      - "docker.io/fission/builder:{{ .Tag }}-arm64"
       - "ghcr.io/fission/builder:latest-arm64"
       - "ghcr.io/fission/builder:{{ .Tag }}-arm64"
     dockerfile: cmd/builder/Dockerfile
@@ -174,8 +174,8 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "fission/fetcher:latest-arm64"
-      - "fission/fetcher:{{ .Tag }}-arm64"
+      - "docker.io/fission/fetcher:latest-arm64"
+      - "docker.io/fission/fetcher:{{ .Tag }}-arm64"
       - "ghcr.io/fission/fetcher:latest-arm64"
       - "ghcr.io/fission/fetcher:{{ .Tag }}-arm64"
     dockerfile: cmd/fetcher/Dockerfile
@@ -190,8 +190,8 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "fission/fission-bundle:latest-arm64"
-      - "fission/fission-bundle:{{ .Tag }}-arm64"
+      - "docker.io/fission/fission-bundle:latest-arm64"
+      - "docker.io/fission/fission-bundle:{{ .Tag }}-arm64"
       - "ghcr.io/fission/fission-bundle:latest-arm64"
       - "ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64"
     dockerfile: cmd/fission-bundle/Dockerfile
@@ -206,8 +206,8 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "fission/pre-upgrade-checks:latest-arm64"
-      - "fission/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "docker.io/fission/pre-upgrade-checks:latest-arm64"
+      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
       - "ghcr.io/fission/pre-upgrade-checks:latest-arm64"
       - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
     dockerfile: cmd/preupgradechecks/Dockerfile
@@ -222,8 +222,8 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "fission/reporter:latest-arm64"
-      - "fission/reporter:{{ .Tag }}-arm64"
+      - "docker.io/fission/reporter:latest-arm64"
+      - "docker.io/fission/reporter:{{ .Tag }}-arm64"
       - "ghcr.io/fission/reporter:latest-arm64"
       - "ghcr.io/fission/reporter:{{ .Tag }}-arm64"
     dockerfile: cmd/reporter/Dockerfile
@@ -241,80 +241,80 @@ docker_manifests:
       - ghcr.io/fission/builder:{{ .Tag }}-arm64
   - name_template: fission/builder:{{ .Tag }}
     image_templates:
-      - fission/builder:{{ .Tag }}-amd64
-      - fission/builder:{{ .Tag }}-arm64
+      - docker.io/fission/builder:{{ .Tag }}-amd64
+      - docker.io/fission/builder:{{ .Tag }}-arm64
   - name_template: ghcr.io/fission/fetcher:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/fetcher:{{ .Tag }}-amd64
       - ghcr.io/fission/fetcher:{{ .Tag }}-arm64
   - name_template: fission/fetcher:{{ .Tag }}
     image_templates:
-      - fission/fetcher:{{ .Tag }}-amd64
-      - fission/fetcher:{{ .Tag }}-arm64
+      - docker.io/fission/fetcher:{{ .Tag }}-amd64
+      - docker.io/fission/fetcher:{{ .Tag }}-arm64
   - name_template: ghcr.io/fission/fission-bundle:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64
       - ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64
   - name_template: fission/fission-bundle:{{ .Tag }}
     image_templates:
-      - fission/fission-bundle:{{ .Tag }}-amd64
-      - fission/fission-bundle:{{ .Tag }}-arm64
+      - docker.io/fission/fission-bundle:{{ .Tag }}-amd64
+      - docker.io/fission/fission-bundle:{{ .Tag }}-arm64
   - name_template: ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
       - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
   - name_template: fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
-      - fission/pre-upgrade-checks:{{ .Tag }}-amd64
-      - fission/pre-upgrade-checks:{{ .Tag }}-arm64
+      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
+      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
   - name_template: ghcr.io/fission/reporter:{{ .Tag }}
     image_templates:
       - ghcr.io/fission/reporter:{{ .Tag }}-amd64
       - ghcr.io/fission/reporter:{{ .Tag }}-arm64
   - name_template: fission/reporter:{{ .Tag }}
     image_templates:
-      - fission/reporter:{{ .Tag }}-amd64
-      - fission/reporter:{{ .Tag }}-arm64
+      - docker.io/fission/reporter:{{ .Tag }}-amd64
+      - docker.io/fission/reporter:{{ .Tag }}-arm64
   - name_template: ghcr.io/fission/builder:latest
     image_templates:
       - ghcr.io/fission/builder:latest-amd64
       - ghcr.io/fission/builder:latest-arm64
   - name_template: fission/builder:latest
     image_templates:
-      - fission/builder:latest-amd64
-      - fission/builder:latest-arm64
+      - docker.io/fission/builder:latest-amd64
+      - docker.io/fission/builder:latest-arm64
   - name_template: ghcr.io/fission/fetcher:latest
     image_templates:
       - ghcr.io/fission/fetcher:latest-amd64
       - ghcr.io/fission/fetcher:latest-arm64
   - name_template: fission/fetcher:latest
     image_templates:
-      - fission/fetcher:latest-amd64
-      - fission/fetcher:latest-arm64
+      - docker.io/fission/fetcher:latest-amd64
+      - docker.io/fission/fetcher:latest-arm64
   - name_template: ghcr.io/fission/fission-bundle:latest
     image_templates:
       - ghcr.io/fission/fission-bundle:latest-amd64
       - ghcr.io/fission/fission-bundle:latest-arm64
   - name_template: fission/fission-bundle:latest
     image_templates:
-      - fission/fission-bundle:latest-amd64
-      - fission/fission-bundle:latest-arm64
+      - docker.io/fission/fission-bundle:latest-amd64
+      - docker.io/fission/fission-bundle:latest-arm64
   - name_template: ghcr.io/fission/pre-upgrade-checks:latest
     image_templates:
       - ghcr.io/fission/pre-upgrade-checks:latest-amd64
       - ghcr.io/fission/pre-upgrade-checks:latest-arm64
   - name_template: fission/pre-upgrade-checks:latest
     image_templates:
-      - fission/pre-upgrade-checks:latest-amd64
-      - fission/pre-upgrade-checks:latest-arm64
+      - docker.io/fission/pre-upgrade-checks:latest-amd64
+      - docker.io/fission/pre-upgrade-checks:latest-arm64
   - name_template: ghcr.io/fission/reporter:latest
     image_templates:
       - ghcr.io/fission/reporter:latest-amd64
       - ghcr.io/fission/reporter:latest-arm64
   - name_template: fission/reporter:latest
     image_templates:
-      - fission/reporter:latest-amd64
-      - fission/reporter:latest-arm64
+      - docker.io/fission/reporter:latest-amd64
+      - docker.io/fission/reporter:latest-arm64
 changelog:
   disable: true
 archives:
@@ -330,29 +330,37 @@ checksum:
 # signs the checksum file
 # https://goreleaser.com/customization/sign
 signs:
-- cmd: cosign
-  artifacts: all
-  stdin: '{{ .Env.COSIGN_PWD }}'
-  output: true
-  args:
-    - sign-blob
-    - '--key=cosign.key'
-    - '--output-certificate=${certificate}'
-    - '--output-signature=${signature}'
-    - '${artifact}'
-    - '--yes' # needed for cosign 2.0.0+
+  - id: cosign-binary
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    certificate: "${artifact}.pem"
+    cmd: cosign
+    artifacts: binary
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes" # needed for cosign 2.0.0+
 
 # signs our docker image
 # https://goreleaser.com/customization/docker_sign
 docker_signs:
-- cmd: cosign
-  artifacts: all
-  stdin: '{{ .Env.COSIGN_PWD }}'
-  output: true
-  args:
-    - 'sign'
-    - '--key=cosign.key'
-    - '${artifact}'
-    - '--yes' # needed for cosign 2.0.0+
+  - cmd: cosign
+    env:
+      - COSIGN_EXPERIMENTAL=1
+    artifacts: all
+    args:
+      - sign
+      - "${artifact}"
+      - "--yes" # needed for cosign 2.0.0+
+
 sboms:
   - artifacts: archive
+    id: archive
+  - artifacts: source
+    id: source
+  - artifacts: binary
+    id: binary
+  - artifacts: package
+    id: package

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ version: 2
 project_name: fission
 release:
   github:
-    owner: fission
+    owner: sanketsudake
     name: fission
   prerelease: true
   draft: true
@@ -75,10 +75,10 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "docker.io/fission/builder:latest-amd64"
-      - "docker.io/fission/builder:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/builder:latest-amd64"
-      - "ghcr.io/fission/builder:{{ .Tag }}-amd64"
+      - "docker.io/tripples/builder:latest-amd64"
+      - "docker.io/tripples/builder:{{ .Tag }}-amd64"
+      - "ghcr.io/sanketsudake/builder:latest-amd64"
+      - "ghcr.io/sanketsudake/builder:{{ .Tag }}-amd64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
@@ -91,10 +91,10 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "docker.io/fission/fetcher:latest-amd64"
-      - "docker.io/fission/fetcher:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/fetcher:latest-amd64"
-      - "ghcr.io/fission/fetcher:{{ .Tag }}-amd64"
+      - "docker.io/tripples/fetcher:latest-amd64"
+      - "docker.io/tripples/fetcher:{{ .Tag }}-amd64"
+      - "ghcr.io/sanketsudake/fetcher:latest-amd64"
+      - "ghcr.io/sanketsudake/fetcher:{{ .Tag }}-amd64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
@@ -107,10 +107,10 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "docker.io/fission/fission-bundle:latest-amd64"
-      - "docker.io/fission/fission-bundle:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/fission-bundle:latest-amd64"
-      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64"
+      - "docker.io/tripples/fission-bundle:latest-amd64"
+      - "docker.io/tripples/fission-bundle:{{ .Tag }}-amd64"
+      - "ghcr.io/sanketsudake/fission-bundle:latest-amd64"
+      - "ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-amd64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
@@ -123,10 +123,10 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "docker.io/fission/pre-upgrade-checks:latest-amd64"
-      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/pre-upgrade-checks:latest-amd64"
-      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "docker.io/tripples/pre-upgrade-checks:latest-amd64"
+      - "docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "ghcr.io/sanketsudake/pre-upgrade-checks:latest-amd64"
+      - "ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-amd64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
@@ -139,10 +139,10 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "docker.io/fission/reporter:latest-amd64"
-      - "docker.io/fission/reporter:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/reporter:latest-amd64"
-      - "ghcr.io/fission/reporter:{{ .Tag }}-amd64"
+      - "docker.io/tripples/reporter:latest-amd64"
+      - "docker.io/tripples/reporter:{{ .Tag }}-amd64"
+      - "ghcr.io/sanketsudake/reporter:latest-amd64"
+      - "ghcr.io/sanketsudake/reporter:{{ .Tag }}-amd64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
@@ -158,10 +158,10 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "docker.io/fission/builder:latest-arm64"
-      - "docker.io/fission/builder:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/builder:latest-arm64"
-      - "ghcr.io/fission/builder:{{ .Tag }}-arm64"
+      - "docker.io/tripples/builder:latest-arm64"
+      - "docker.io/tripples/builder:{{ .Tag }}-arm64"
+      - "ghcr.io/sanketsudake/builder:latest-arm64"
+      - "ghcr.io/sanketsudake/builder:{{ .Tag }}-arm64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
@@ -174,10 +174,10 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "docker.io/fission/fetcher:latest-arm64"
-      - "docker.io/fission/fetcher:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/fetcher:latest-arm64"
-      - "ghcr.io/fission/fetcher:{{ .Tag }}-arm64"
+      - "docker.io/tripples/fetcher:latest-arm64"
+      - "docker.io/tripples/fetcher:{{ .Tag }}-arm64"
+      - "ghcr.io/sanketsudake/fetcher:latest-arm64"
+      - "ghcr.io/sanketsudake/fetcher:{{ .Tag }}-arm64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
@@ -190,10 +190,10 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "docker.io/fission/fission-bundle:latest-arm64"
-      - "docker.io/fission/fission-bundle:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/fission-bundle:latest-arm64"
-      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64"
+      - "docker.io/tripples/fission-bundle:latest-arm64"
+      - "docker.io/tripples/fission-bundle:{{ .Tag }}-arm64"
+      - "ghcr.io/sanketsudake/fission-bundle:latest-arm64"
+      - "ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-arm64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
@@ -206,10 +206,10 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "docker.io/fission/pre-upgrade-checks:latest-arm64"
-      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/pre-upgrade-checks:latest-arm64"
-      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "docker.io/tripples/pre-upgrade-checks:latest-arm64"
+      - "docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "ghcr.io/sanketsudake/pre-upgrade-checks:latest-arm64"
+      - "ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-arm64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
@@ -222,10 +222,10 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "docker.io/fission/reporter:latest-arm64"
-      - "docker.io/fission/reporter:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/reporter:latest-arm64"
-      - "ghcr.io/fission/reporter:{{ .Tag }}-arm64"
+      - "docker.io/tripples/reporter:latest-arm64"
+      - "docker.io/tripples/reporter:{{ .Tag }}-arm64"
+      - "ghcr.io/sanketsudake/reporter:latest-arm64"
+      - "ghcr.io/sanketsudake/reporter:{{ .Tag }}-arm64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
@@ -235,86 +235,86 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
 docker_manifests:
-  - name_template: ghcr.io/fission/builder:{{ .Tag }}
+  - name_template: ghcr.io/sanketsudake/builder:{{ .Tag }}
     image_templates:
-      - ghcr.io/fission/builder:{{ .Tag }}-amd64
-      - ghcr.io/fission/builder:{{ .Tag }}-arm64
+      - ghcr.io/sanketsudake/builder:{{ .Tag }}-amd64
+      - ghcr.io/sanketsudake/builder:{{ .Tag }}-arm64
   - name_template: fission/builder:{{ .Tag }}
     image_templates:
-      - docker.io/fission/builder:{{ .Tag }}-amd64
-      - docker.io/fission/builder:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/fetcher:{{ .Tag }}
+      - docker.io/tripples/builder:{{ .Tag }}-amd64
+      - docker.io/tripples/builder:{{ .Tag }}-arm64
+  - name_template: ghcr.io/sanketsudake/fetcher:{{ .Tag }}
     image_templates:
-      - ghcr.io/fission/fetcher:{{ .Tag }}-amd64
-      - ghcr.io/fission/fetcher:{{ .Tag }}-arm64
+      - ghcr.io/sanketsudake/fetcher:{{ .Tag }}-amd64
+      - ghcr.io/sanketsudake/fetcher:{{ .Tag }}-arm64
   - name_template: fission/fetcher:{{ .Tag }}
     image_templates:
-      - docker.io/fission/fetcher:{{ .Tag }}-amd64
-      - docker.io/fission/fetcher:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/fission-bundle:{{ .Tag }}
+      - docker.io/tripples/fetcher:{{ .Tag }}-amd64
+      - docker.io/tripples/fetcher:{{ .Tag }}-arm64
+  - name_template: ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}
     image_templates:
-      - ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64
-      - ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64
+      - ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-amd64
+      - ghcr.io/sanketsudake/fission-bundle:{{ .Tag }}-arm64
   - name_template: fission/fission-bundle:{{ .Tag }}
     image_templates:
-      - docker.io/fission/fission-bundle:{{ .Tag }}-amd64
-      - docker.io/fission/fission-bundle:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}
+      - docker.io/tripples/fission-bundle:{{ .Tag }}-amd64
+      - docker.io/tripples/fission-bundle:{{ .Tag }}-arm64
+  - name_template: ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}
     image_templates:
-      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
-      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
+      - ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-amd64
+      - ghcr.io/sanketsudake/pre-upgrade-checks:{{ .Tag }}-arm64
   - name_template: fission/pre-upgrade-checks:{{ .Tag }}
     image_templates:
-      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
-      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/reporter:{{ .Tag }}
+      - docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-amd64
+      - docker.io/tripples/pre-upgrade-checks:{{ .Tag }}-arm64
+  - name_template: ghcr.io/sanketsudake/reporter:{{ .Tag }}
     image_templates:
-      - ghcr.io/fission/reporter:{{ .Tag }}-amd64
-      - ghcr.io/fission/reporter:{{ .Tag }}-arm64
+      - ghcr.io/sanketsudake/reporter:{{ .Tag }}-amd64
+      - ghcr.io/sanketsudake/reporter:{{ .Tag }}-arm64
   - name_template: fission/reporter:{{ .Tag }}
     image_templates:
-      - docker.io/fission/reporter:{{ .Tag }}-amd64
-      - docker.io/fission/reporter:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/builder:latest
+      - docker.io/tripples/reporter:{{ .Tag }}-amd64
+      - docker.io/tripples/reporter:{{ .Tag }}-arm64
+  - name_template: ghcr.io/sanketsudake/builder:latest
     image_templates:
-      - ghcr.io/fission/builder:latest-amd64
-      - ghcr.io/fission/builder:latest-arm64
+      - ghcr.io/sanketsudake/builder:latest-amd64
+      - ghcr.io/sanketsudake/builder:latest-arm64
   - name_template: fission/builder:latest
     image_templates:
-      - docker.io/fission/builder:latest-amd64
-      - docker.io/fission/builder:latest-arm64
-  - name_template: ghcr.io/fission/fetcher:latest
+      - docker.io/tripples/builder:latest-amd64
+      - docker.io/tripples/builder:latest-arm64
+  - name_template: ghcr.io/sanketsudake/fetcher:latest
     image_templates:
-      - ghcr.io/fission/fetcher:latest-amd64
-      - ghcr.io/fission/fetcher:latest-arm64
+      - ghcr.io/sanketsudake/fetcher:latest-amd64
+      - ghcr.io/sanketsudake/fetcher:latest-arm64
   - name_template: fission/fetcher:latest
     image_templates:
-      - docker.io/fission/fetcher:latest-amd64
-      - docker.io/fission/fetcher:latest-arm64
-  - name_template: ghcr.io/fission/fission-bundle:latest
+      - docker.io/tripples/fetcher:latest-amd64
+      - docker.io/tripples/fetcher:latest-arm64
+  - name_template: ghcr.io/sanketsudake/fission-bundle:latest
     image_templates:
-      - ghcr.io/fission/fission-bundle:latest-amd64
-      - ghcr.io/fission/fission-bundle:latest-arm64
+      - ghcr.io/sanketsudake/fission-bundle:latest-amd64
+      - ghcr.io/sanketsudake/fission-bundle:latest-arm64
   - name_template: fission/fission-bundle:latest
     image_templates:
-      - docker.io/fission/fission-bundle:latest-amd64
-      - docker.io/fission/fission-bundle:latest-arm64
-  - name_template: ghcr.io/fission/pre-upgrade-checks:latest
+      - docker.io/tripples/fission-bundle:latest-amd64
+      - docker.io/tripples/fission-bundle:latest-arm64
+  - name_template: ghcr.io/sanketsudake/pre-upgrade-checks:latest
     image_templates:
-      - ghcr.io/fission/pre-upgrade-checks:latest-amd64
-      - ghcr.io/fission/pre-upgrade-checks:latest-arm64
+      - ghcr.io/sanketsudake/pre-upgrade-checks:latest-amd64
+      - ghcr.io/sanketsudake/pre-upgrade-checks:latest-arm64
   - name_template: fission/pre-upgrade-checks:latest
     image_templates:
-      - docker.io/fission/pre-upgrade-checks:latest-amd64
-      - docker.io/fission/pre-upgrade-checks:latest-arm64
-  - name_template: ghcr.io/fission/reporter:latest
+      - docker.io/tripples/pre-upgrade-checks:latest-amd64
+      - docker.io/tripples/pre-upgrade-checks:latest-arm64
+  - name_template: ghcr.io/sanketsudake/reporter:latest
     image_templates:
-      - ghcr.io/fission/reporter:latest-amd64
-      - ghcr.io/fission/reporter:latest-arm64
+      - ghcr.io/sanketsudake/reporter:latest-amd64
+      - ghcr.io/sanketsudake/reporter:latest-arm64
   - name_template: fission/reporter:latest
     image_templates:
-      - docker.io/fission/reporter:latest-amd64
-      - docker.io/fission/reporter:latest-arm64
+      - docker.io/tripples/reporter:latest-amd64
+      - docker.io/tripples/reporter:latest-arm64
 changelog:
   disable: true
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,11 +1,14 @@
 version: 2
 
+env:
+  - GHCR_REPO=ghcr.io/fission
+
 project_name: fission
 release:
   github:
     owner: fission
     name: fission
-  prerelease: true
+  prerelease: "true"
   draft: true
   header: |
     Release Highlights: https://fission.io/docs/releases/{{ .Tag }}/
@@ -75,10 +78,8 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "docker.io/fission/builder:latest-amd64"
-      - "docker.io/fission/builder:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/builder:latest-amd64"
-      - "ghcr.io/fission/builder:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-amd64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
@@ -91,10 +92,8 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "docker.io/fission/fetcher:latest-amd64"
-      - "docker.io/fission/fetcher:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/fetcher:latest-amd64"
-      - "ghcr.io/fission/fetcher:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-amd64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
@@ -107,10 +106,8 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "docker.io/fission/fission-bundle:latest-amd64"
-      - "docker.io/fission/fission-bundle:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/fission-bundle:latest-amd64"
-      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-amd64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
@@ -123,10 +120,8 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "docker.io/fission/pre-upgrade-checks:latest-amd64"
-      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/pre-upgrade-checks:latest-amd64"
-      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-amd64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
@@ -139,10 +134,8 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "docker.io/fission/reporter:latest-amd64"
-      - "docker.io/fission/reporter:{{ .Tag }}-amd64"
-      - "ghcr.io/fission/reporter:latest-amd64"
-      - "ghcr.io/fission/reporter:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-amd64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
@@ -158,10 +151,8 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "docker.io/fission/builder:latest-arm64"
-      - "docker.io/fission/builder:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/builder:latest-arm64"
-      - "ghcr.io/fission/builder:{{ .Tag }}-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-arm64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
@@ -174,10 +165,8 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "docker.io/fission/fetcher:latest-arm64"
-      - "docker.io/fission/fetcher:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/fetcher:latest-arm64"
-      - "ghcr.io/fission/fetcher:{{ .Tag }}-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-arm64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
@@ -190,10 +179,8 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "docker.io/fission/fission-bundle:latest-arm64"
-      - "docker.io/fission/fission-bundle:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/fission-bundle:latest-arm64"
-      - "ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-arm64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
@@ -206,10 +193,8 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "docker.io/fission/pre-upgrade-checks:latest-arm64"
-      - "docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/pre-upgrade-checks:latest-arm64"
-      - "ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-arm64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
@@ -222,10 +207,8 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "docker.io/fission/reporter:latest-arm64"
-      - "docker.io/fission/reporter:{{ .Tag }}-arm64"
-      - "ghcr.io/fission/reporter:latest-arm64"
-      - "ghcr.io/fission/reporter:{{ .Tag }}-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-arm64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-arm64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
@@ -235,86 +218,46 @@ dockers:
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Tag}}"
 docker_manifests:
-  - name_template: ghcr.io/fission/builder:{{ .Tag }}
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}"
     image_templates:
-      - ghcr.io/fission/builder:{{ .Tag }}-amd64
-      - ghcr.io/fission/builder:{{ .Tag }}-arm64
-  - name_template: fission/builder:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}"
     image_templates:
-      - docker.io/fission/builder:{{ .Tag }}-amd64
-      - docker.io/fission/builder:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/fetcher:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}"
     image_templates:
-      - ghcr.io/fission/fetcher:{{ .Tag }}-amd64
-      - ghcr.io/fission/fetcher:{{ .Tag }}-arm64
-  - name_template: fission/fetcher:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}"
     image_templates:
-      - docker.io/fission/fetcher:{{ .Tag }}-amd64
-      - docker.io/fission/fetcher:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/fission-bundle:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}"
     image_templates:
-      - ghcr.io/fission/fission-bundle:{{ .Tag }}-amd64
-      - ghcr.io/fission/fission-bundle:{{ .Tag }}-arm64
-  - name_template: fission/fission-bundle:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/builder:latest"
     image_templates:
-      - docker.io/fission/fission-bundle:{{ .Tag }}-amd64
-      - docker.io/fission/fission-bundle:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest"
     image_templates:
-      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
-      - ghcr.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
-  - name_template: fission/pre-upgrade-checks:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest"
     image_templates:
-      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-amd64
-      - docker.io/fission/pre-upgrade-checks:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/reporter:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest"
     image_templates:
-      - ghcr.io/fission/reporter:{{ .Tag }}-amd64
-      - ghcr.io/fission/reporter:{{ .Tag }}-arm64
-  - name_template: fission/reporter:{{ .Tag }}
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-arm64"
+  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest"
     image_templates:
-      - docker.io/fission/reporter:{{ .Tag }}-amd64
-      - docker.io/fission/reporter:{{ .Tag }}-arm64
-  - name_template: ghcr.io/fission/builder:latest
-    image_templates:
-      - ghcr.io/fission/builder:latest-amd64
-      - ghcr.io/fission/builder:latest-arm64
-  - name_template: fission/builder:latest
-    image_templates:
-      - docker.io/fission/builder:latest-amd64
-      - docker.io/fission/builder:latest-arm64
-  - name_template: ghcr.io/fission/fetcher:latest
-    image_templates:
-      - ghcr.io/fission/fetcher:latest-amd64
-      - ghcr.io/fission/fetcher:latest-arm64
-  - name_template: fission/fetcher:latest
-    image_templates:
-      - docker.io/fission/fetcher:latest-amd64
-      - docker.io/fission/fetcher:latest-arm64
-  - name_template: ghcr.io/fission/fission-bundle:latest
-    image_templates:
-      - ghcr.io/fission/fission-bundle:latest-amd64
-      - ghcr.io/fission/fission-bundle:latest-arm64
-  - name_template: fission/fission-bundle:latest
-    image_templates:
-      - docker.io/fission/fission-bundle:latest-amd64
-      - docker.io/fission/fission-bundle:latest-arm64
-  - name_template: ghcr.io/fission/pre-upgrade-checks:latest
-    image_templates:
-      - ghcr.io/fission/pre-upgrade-checks:latest-amd64
-      - ghcr.io/fission/pre-upgrade-checks:latest-arm64
-  - name_template: fission/pre-upgrade-checks:latest
-    image_templates:
-      - docker.io/fission/pre-upgrade-checks:latest-amd64
-      - docker.io/fission/pre-upgrade-checks:latest-arm64
-  - name_template: ghcr.io/fission/reporter:latest
-    image_templates:
-      - ghcr.io/fission/reporter:latest-amd64
-      - ghcr.io/fission/reporter:latest-arm64
-  - name_template: fission/reporter:latest
-    image_templates:
-      - docker.io/fission/reporter:latest-amd64
-      - docker.io/fission/reporter:latest-arm64
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-amd64"
+      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-arm64"
 changelog:
   disable: true
 archives:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,12 +1,12 @@
 version: 2
 
 env:
-  - GHCR_REPO=ghcr.io/sanketsudake
+  - GHCR_REPO=ghcr.io/fission
 
 project_name: fission
 release:
   github:
-    owner: sanketsudake
+    owner: fission
     name: fission
   prerelease: "true"
   draft: true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -78,8 +78,8 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/builder:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/builder:{{ .Tag }}-amd64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
@@ -95,8 +95,8 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/fetcher:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/fetcher:{{ .Tag }}-amd64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
@@ -112,8 +112,8 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:{{ .Tag }}-amd64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
@@ -129,8 +129,8 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:{{ .Tag }}-amd64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
@@ -146,8 +146,8 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/reporter:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/reporter:{{ .Tag }}-amd64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
@@ -166,8 +166,8 @@ dockers:
     ids:
       - builder
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-arm64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-arm64"
+      - "{{ .Env.GHCR_REPO }}/builder:latest-arm64"
+      - "{{ .Env.GHCR_REPO }}/builder:{{ .Tag }}-arm64"
     dockerfile: cmd/builder/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The builder assists in building the fission function source code for deployment."
@@ -183,8 +183,8 @@ dockers:
     ids:
       - fetcher
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-arm64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-arm64"
+      - "{{ .Env.GHCR_REPO }}/fetcher:latest-arm64"
+      - "{{ .Env.GHCR_REPO }}/fetcher:{{ .Tag }}-arm64"
     dockerfile: cmd/fetcher/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Fetcher is a lightweight component used by environment and builder pods. Fetcher helps in fetch and upload of source/deployment packages and specializing environments."
@@ -200,8 +200,8 @@ dockers:
     ids:
       - fission-bundle
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-arm64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-arm64"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:latest-arm64"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:{{ .Tag }}-arm64"
     dockerfile: cmd/fission-bundle/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=fission-bundle is a component which is a single binary for all components. Most server side components running on server side are fission-bundle binary wrapped in container and used with different arguments."
@@ -217,8 +217,8 @@ dockers:
     ids:
       - pre-upgrade-checks
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-arm64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-arm64"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:latest-arm64"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:{{ .Tag }}-arm64"
     dockerfile: cmd/preupgradechecks/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=Preupgradechecks ensures that Fission is ready for the targeted version upgrade by performing checks beforehand."
@@ -234,8 +234,8 @@ dockers:
     ids:
       - reporter
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-arm64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-arm64"
+      - "{{ .Env.GHCR_REPO }}/reporter:latest-arm64"
+      - "{{ .Env.GHCR_REPO }}/reporter:{{ .Tag }}-arm64"
     dockerfile: cmd/reporter/Dockerfile
     build_flag_templates:
       - "--label=org.opencontainers.image.description=The reporter gathers information that assists in improving fission."
@@ -248,46 +248,46 @@ dockers:
       - "--label=org.opencontainers.image.vendor=Fission"
       - "--label=org.opencontainers.image.url=https://fission.io/"
 docker_manifests:
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}"
+  - name_template: "{{ .Env.GHCR_REPO }}/builder:{{ .Tag }}"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:{{ .Tag }}-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}"
+      - "{{ .Env.GHCR_REPO }}/builder:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/builder:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/fetcher:{{ .Tag }}"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:{{ .Tag }}-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}"
+      - "{{ .Env.GHCR_REPO }}/fetcher:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/fetcher:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/fission-bundle:{{ .Tag }}"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:{{ .Tag }}-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:{{ .Tag }}"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:{{ .Tag }}-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/reporter:{{ .Tag }}"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:{{ .Tag }}-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/builder:latest"
+      - "{{ .Env.GHCR_REPO }}/reporter:{{ .Tag }}-amd64"
+      - "{{ .Env.GHCR_REPO }}/reporter:{{ .Tag }}-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/builder:latest"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/builder:latest-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest"
+      - "{{ .Env.GHCR_REPO }}/builder:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/builder:latest-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/fetcher:latest"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fetcher:latest-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest"
+      - "{{ .Env.GHCR_REPO }}/fetcher:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/fetcher:latest-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/fission-bundle:latest"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/fission-bundle:latest-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/fission-bundle:latest-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:latest"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/pre-upgrade-checks:latest-arm64"
-  - name_template: "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/pre-upgrade-checks:latest-arm64"
+  - name_template: "{{ .Env.GHCR_REPO }}/reporter:latest"
     image_templates:
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-amd64"
-      - "{{ .Env.GITHUB_REPOSITORY }}/reporter:latest-arm64"
+      - "{{ .Env.GHCR_REPO }}/reporter:latest-amd64"
+      - "{{ .Env.GHCR_REPO }}/reporter:latest-arm64"
 changelog:
   disable: true
 archives:

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -91,7 +91,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 			return err
 		}
 		if !exists {
-			console.Warn(fmt.Sprintf("TimeTrigger '%v' references unknown Function '%v', please create it before applying spec",
+			console.Warn(fmt.Sprintf("TimeTrigger '%s' references unknown Function '%s', please create it before applying spec",
 				name, fnName))
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

- Add SBOM for all binaries and container images
- Provenance generation and verification in the release pipeline.
- Removed docker registry image push, only kept GHCR now. Due to maintenance efforts.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
Changes verified via Release https://github.com/sanketsudake/fission/releases/tag/v1.22.0-rc2
And image https://github.com/sanketsudake/fission/pkgs/container/fetcher/328810497?tag=v1.22.0-rc2

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
