### PR TITLE
PR-3051: Fix download deploy package out of k8s cluster

### DIFF
--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -170,7 +170,7 @@ func DownloadStrorageURL(ctx context.Context, client cmd.Client, fileUrl string)
 		return nil, err
 	}
 
-	if strings.HasPrefix(fileUrl, storagesvcURL.String()+"/v1/archive?id=") {
+	if !strings.HasPrefix(fileUrl, storagesvcURL.String()+"/v1/archive?id=") {
 		url, err := url.Parse(fileUrl)
 		if err != nil {
 			return nil, err

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -165,12 +165,14 @@ func DownloadURL(fileUrl string) (io.ReadCloser, error) {
 
 func DownloadStrorageURL(ctx context.Context, client cmd.Client, fileUrl string) (io.ReadCloser, error) {
 	var resp *http.Response
-	storagesvcURL, err := util.GetStorageURL(ctx, client)
-	if err != nil {
-		return nil, err
-	}
+	var err error
 
-	if !strings.HasPrefix(fileUrl, storagesvcURL.String()+"/v1/archive?id=") {
+	if strings.Contains(fileUrl, "/v1/archive?id=") {
+		storagesvcURL, err := util.GetStorageURL(ctx, client)
+		if err != nil {
+			return nil, err
+		}
+
 		url, err := url.Parse(fileUrl)
 		if err != nil {
 			return nil, err

--- a/pkg/fission-cli/cmd/package/util/util_test.go
+++ b/pkg/fission-cli/cmd/package/util/util_test.go
@@ -32,3 +32,35 @@ func TestPrintPackageSummary(t *testing.T) {
 		t.Errorf("PrintPackageBuildLog() = %v, want %v", gotWriter, expected)
 	}
 }
+
+func TestValidArchiveURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected bool
+	}{
+		{
+			name:     "Valid Archive URL",
+			url:      "http://storagesvc.fission/v1/archive?id=/fission/fission-functions/Fc4c15f47-bb49-47c5-b382-526a6539841d",
+			expected: true,
+		},
+		{
+			name:     "Invalid Archive URL",
+			url:      "https://raw.githubusercontent.com/imaginery/training/refs/heads/fission/hello-go?token=ABCD",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validArchiveURL(tt.url)
+			if err != nil {
+				t.Errorf("got error %v", err)
+			}
+
+			if got != tt.expected {
+				t.Errorf("expected %t got %t", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

Original author for PR https://github.com/fission/fission/pull/3051 is inactive. Therefore created this duplicate PR with additional fixes.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->
Verified these two scenarios:
- Deployment URL belongs to storagesvc.
- Deployment URL is outside k8s cluster.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
