### PR TITLE
Duplicate Job names in helm chart templates

### DIFF
--- a/charts/fission-all/templates/analytics/post-install-job.yaml
+++ b/charts/fission-all/templates/analytics/post-install-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}-{{ .Chart.Version }}
+  name: {{ template "fullname" . }}-{{ .Chart.Version }}-post-install
   labels:
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.

--- a/charts/fission-all/templates/analytics/post-upgrade-job.yaml
+++ b/charts/fission-all/templates/analytics/post-upgrade-job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "fullname" . }}-{{ .Chart.Version }}
+  name: {{ template "fullname" . }}-{{ .Chart.Version }}-post-upgrade
   labels:
     # The "release" convention makes it easy to tie a release to all of the
     # Kubernetes resources that were created as part of that release.


### PR DESCRIPTION
Fixes #3127

Update job names in helm chart templates to avoid conflicts.

* Change the `metadata.name` field in `charts/fission-all/templates/analytics/post-install-job.yaml` to `{{ template "fullname" . }}-{{ .Chart.Version }}-post-install`.
* Change the `metadata.name` field in `charts/fission-all/templates/analytics/post-upgrade-job.yaml` to `{{ template "fullname" . }}-{{ .Chart.Version }}-post-upgrade`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fission/fission/pull/3150?shareId=79f9c404-ab6f-4fcf-ab0f-19f1753b8323).