### PR TITLE
Fix: error on `fission spec validate` but `fission spec apply` works fine

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -177,16 +177,16 @@ func (opts *ApplySubCommand) run(input cli.Input) error {
 			return errors.Wrap(err, "error reading specs")
 		}
 
-		err = opts.insertNamespace(input, fr)
-		if err != nil {
-			return errors.Wrap(err, "error reading specs")
-		}
-
 		if validateSpecs {
 			err = validateForApply(input, fr)
 			if err != nil {
 				return errors.Wrap(err, "abort applying resources")
 			}
+		}
+
+		err = opts.insertNamespace(input, fr)
+		if err != nil {
+			return errors.Wrap(err, "error inserting namespace")
 		}
 
 		err = warnIfDirtyWorkTree(filepath.Clean(specDir + "/.."))


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

- For `fission spec validate`, we read the specs and call validate function to validate it.
- For `fission spec apply`, we read the specs, insert namespace if empty or forceNamespace flag is set then call validate function to validate it. If validation is successful then specs are applied.
- The additional step in `fission spec apply` to insert namespace is what causing this issue.
- To fix the issue, I moved the insert namespace step after validation step.

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #3163 

## Testing
<!--- Please describe in detail how you tested your changes. -->
```
$ fission spec apply
DeployUID: 17620142-925f-4a11-bbcb-0fe30c8f180b
Resources:
 * 1 Functions
 * 1 Environments
 * 1 Packages 
 * 1 Http Triggers 
 * 0 MessageQueue Triggers
 * 0 Time Triggers
 * 0 Kube Watchers
 * 1 ArchiveUploadSpec

Options:
  --specdir=''                       Directory to store specs, defaults to ./specs
  --specignore=''                    File containing specs to be ignored inside --specdir, defaults to
                                     .specignore
  --delete=false                     Allow apply to delete resources that no longer exist in the
                                     specification
  --wait=false                       Wait for package builds
  --watch=false                      Watch local files for change, and re-apply specs as necessary
  --validation=''                    Turns server side validations of Fission objects on/off
  --commitlabel=false                Apply commit label to the resources
  --allowconflicts=false             If true, spec apply will be forced even if conflicting resources
                                     exist
  --force-namespace=false (--force)  If true, resources will be created in namespace provided by
                                     (--namespace flag ) even if spec file contains some other namespace

Global Options:
  --verbosity=1 (-v)   CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)
  --kube-context=''    Kubernetes context to be used for the execution of Fission commands
  --namespace='' (-n)  If present, the namespace scope for this CLI request

Usage:
  fission spec apply [options]

Error: abort applying resources: error validating specs: 2 errors occurred:
	* /home/soharab/work/proj-fission/specs/function-hello-newdeploy.yaml:26: function 'hello-newdeploy' references a package outside of its namespace /hello-newdeploy-5e29f432-108a-4fdc-aeec-b8ddfed87565
	* /home/soharab/work/proj-fission/specs/route-hello.yaml:1: HTTPTrigger 'hello' references unknown function 'hello-newdeploy'
```
```
$ fission spec validate
DeployUID: 17620142-925f-4a11-bbcb-0fe30c8f180b
Resources:
 * 1 Functions
 * 1 Environments
 * 1 Packages 
 * 1 Http Triggers 
 * 0 MessageQueue Triggers
 * 0 Time Triggers
 * 0 Kube Watchers
 * 1 ArchiveUploadSpec

Options:
  --specdir=''             Directory to store specs, defaults to ./specs
  --specignore=''          File containing specs to be ignored inside --specdir, defaults to .specignore
  --allowconflicts=false   If true, spec apply will be forced even if conflicting resources exist

Global Options:
  --verbosity=1 (-v)   CLI verbosity (0 is quiet, 1 is the default, 2 is verbose)
  --kube-context=''    Kubernetes context to be used for the execution of Fission commands
  --namespace='' (-n)  If present, the namespace scope for this CLI request

Usage:
  fission spec validate [options]

Error: error validating specs: 2 errors occurred:
	* /home/soharab/work/proj-fission/specs/function-hello-newdeploy.yaml:26: function 'hello-newdeploy' references a package outside of its namespace /hello-newdeploy-5e29f432-108a-4fdc-aeec-b8ddfed87565
	* /home/soharab/work/proj-fission/specs/route-hello.yaml:1: HTTPTrigger 'hello' references unknown function 'hello-newdeploy'
```
## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
