### PR TITLE
Add support to customise storagesvc deployment strategy

### DIFF
--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -12,6 +12,12 @@ spec:
     matchLabels:
       svc: storagesvc
       application: fission-storage
+  strategy:
+    type: {{ .Values.storagesvc.deploymentStrategy.type }}
+    {{- if eq .Values.storagesvc.deploymentStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      {{- toYaml .Values.storagesvc.deploymentStrategy.rollingUpdate | nindent 6}}
+    {{- end }}
   template:
     metadata:
       labels:
@@ -113,7 +119,7 @@ spec:
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
     {{- with .Values.imagePullSecrets }}
-      imagePullSecrets: 
+      imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
 {{- if .Values.extraCoreComponentPodConfig }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -31,7 +31,7 @@ imageTag: v1.21.0
 ##
 pullPolicy: IfNotPresent
 
-## imageppullsecrets 
+## imagepullsecrets
 imagePullSecrets: []
 
 ## priorityClassName represents the priority class name to use for Fission components.

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -80,7 +80,7 @@ builderNamespace: ""
 functionNamespace: ""
 
 ## Fission will watch the following namespaces along with the `defaultNamespace` for fission custom resources.
-## additionalFissionNamespaces: 
+## additionalFissionNamespaces:
 ## - namespace1
 ## - namespace2
 ## - namespace3
@@ -163,7 +163,7 @@ executor:
   ## This is applicable to Pool Manager executor type only.
   ##
   podReadyTimeout: 300s
-  
+
   ## Pod resources as:
   ##  resources:
   ##    limits:
@@ -336,7 +336,7 @@ router:
     runAsGroup: 10001
 
 ## The builder manager watches the package & environments CRD changes and manages the builds of function source code.
-## 
+##
 buildermgr:
   ## Pod resources as:
   ##  resources:
@@ -362,7 +362,7 @@ buildermgr:
     runAsGroup: 10001
 
 ## webhook is the component that validates API calls.
-## It contains validation and mutation for functions, triggers, environments, Kubernetes event watches, etc. 
+## It contains validation and mutation for functions, triggers, environments, Kubernetes event watches, etc.
 ##
 webhook:
   ## Pod resources as:
@@ -438,6 +438,16 @@ storagesvc:
   ##      memory: <tbd>
   ##
   resources: {}
+
+  ## Deployment strategy defaults to RollingUpdate but use Recreate if new pods fail to
+  ## attach to the volume until the old pod has released it.
+  ## deploymentStrategy:
+  ##   type: Recreate
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
 
   ## Archive pruner removes archives from storage which are not referenced by any package.
   archivePruner:
@@ -541,7 +551,7 @@ serviceMonitor:
   #  key: "value"
 
 # The following components expose Prometheus metrics and have podmonitors in this chart (disabled by default)
-# 
+#
 podMonitor:
   enabled: false
   ##namespace in which you want to deploy podmonitor
@@ -577,7 +587,7 @@ persistence:
   #   region: <awsRegion>
   ## For Minio and other s3 compatible storage systems set endPoint property
   #   endPoint: <s3StorageUrl>
-  
+
   ## A manually managed Persistent Volume Claim name
   ## Requires persistence.enabled: true
   ## If defined, PVC must be created manually before volume will be bound
@@ -764,12 +774,12 @@ authentication:
   ## jwtSigningKey is the signing key used for
   ## signing the JWT token
   ##
-  jwtSigningKey: 
+  jwtSigningKey:
   ## jwtExpiryTime is the JWT expiry time
   ## in seconds
   ## default '120'
   ##
-  jwtExpiryTime: 
+  jwtExpiryTime:
   ## jwtIssuer is the issuer of JWT
   ## default 'fission'
   ##
@@ -874,7 +884,7 @@ runtimePodSpec:
   ## Setting it false by default so that integration tests pass
   ##
   enabled: false
-  
+
   ## Checkout PodSpec in https://fission.io/docs/reference/crd-reference/#runtime
   ##
   podSpec:


### PR DESCRIPTION
Add suport to `values.yaml` to allow customisation of the storagesvc deployment strategy. The default is a rolling update with `maxSurge` and `maxUnavailable` of 25%. Users with ReadWriteOnce persistent storage can use the `Recreate` strategy.

Issue 3195

## Description
Add templating to the storagesvc `deployment.yaml` file to populate the deployment's deployment strategy from values in the helm release.
Add values to the default `values.yaml` file that result in the current default fission behaviour (a rollingUpdate strategy with 25% `maxSurge` and `maxUnavailable`).
Add comments above the new default values that give an example of how to use the `Recreate` strategy.
This allows users to specify their own deployment strategy, eg to use `Recreate` if persistent storage does not support read many.

Fixes #3195

## Testing
Used helmfile template to generate manifests with the default value and overrides for the strategy type and different values for the maxSurge and maxUnavailable

## Checklist:
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes - there are no tests for the helmfile.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
