### PR TITLE
Update GoReleaser configurations

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -292,10 +292,11 @@ changelog:
   disable: true
 archives:
   - id: fission
-    builds:
+    ids:
       - fission-cli
     name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
-    format: binary
+    formats:
+      - binary
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/fission/fission/actions/runs/15524850992/job/43702986616#step:12:22): 
```
DEPRECATED: archives.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat for more info
DEPRECATED: archives.builds should not be used anymore, check https://goreleaser.com/deprecations#archivesbuilds for more info
```

## Which issue(s) this PR fixes:

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
