### PR TITLE
A prototype for using OpenAPI subset to discover and document HTTPTriggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ build/
 dist/
 manifest/
 .vscode/
-coverage.txt
+coverage.*
 
 cosign.key
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,9 @@ code-checks:
 # run basic check scripts
 test-run: code-checks
 	hack/runtests.sh
-	@rm -f coverage.txt
+
+coverage-report:
+	go tool cover -html=coverage.txt -o coverage.html
 
 ### Binaries
 build-fission-cli:

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ delete-crds:
 
 ### Cleanup
 clean:
-	@rm -f dist/
+	@rm -fr dist/
 
 ### Misc
 generate-swagger-doc:

--- a/crds/v1/fission.io_canaryconfigs.yaml
+++ b/crds/v1/fission.io_canaryconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: canaryconfigs.fission.io
 spec:
   group: fission.io

--- a/crds/v1/fission.io_environments.yaml
+++ b/crds/v1/fission.io_environments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: environments.fission.io
 spec:
   group: fission.io
@@ -238,7 +238,7 @@ spec:
                           Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -259,8 +259,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -524,6 +524,12 @@ spec:
                                 - port
                                 type: object
                             type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
                         type: object
                       livenessProbe:
                         description: |-
@@ -1801,7 +1807,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -1816,7 +1821,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -1984,7 +1988,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1999,7 +2002,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2165,7 +2167,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -2180,7 +2181,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -2348,7 +2348,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2363,7 +2362,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -2625,7 +2623,7 @@ spec:
                                 Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
-                                  a set of ConfigMaps
+                                  a set of ConfigMaps or Secrets
                                 properties:
                                   configMapRef:
                                     description: The ConfigMap to select from
@@ -2646,8 +2644,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
-                                    description: An optional identifier to prepend
-                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
                                     description: The Secret to select from
@@ -2913,6 +2911,12 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
                               type: object
                             livenessProbe:
                               description: |-
@@ -4139,7 +4143,7 @@ spec:
                                 Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
-                                  a set of ConfigMaps
+                                  a set of ConfigMaps or Secrets
                                 properties:
                                   configMapRef:
                                     description: The ConfigMap to select from
@@ -4160,8 +4164,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
-                                    description: An optional identifier to prepend
-                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
                                     description: The Secret to select from
@@ -4424,6 +4428,12 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
                               type: object
                             livenessProbe:
                               description: Probes are not allowed for ephemeral containers.
@@ -5471,7 +5481,7 @@ spec:
                           Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
                           The resourceRequirements of an init container are taken into account during scheduling
                           by finding the highest request/limit for each resource type, and then using the max of
-                          of that value or the sum of the normal containers. Limits are applied to init containers
+                          that value or the sum of the normal containers. Limits are applied to init containers
                           in a similar fashion.
                           Init containers cannot currently be added or removed.
                           Cannot be updated.
@@ -5646,7 +5656,7 @@ spec:
                                 Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
-                                  a set of ConfigMaps
+                                  a set of ConfigMaps or Secrets
                                 properties:
                                   configMapRef:
                                     description: The ConfigMap to select from
@@ -5667,8 +5677,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
-                                    description: An optional identifier to prepend
-                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
                                     description: The Secret to select from
@@ -5934,6 +5944,12 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
                               type: object
                             livenessProbe:
                               description: |-
@@ -7648,7 +7664,6 @@ spec:
                                 - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                 If this value is nil, the behavior is equivalent to the Honor policy.
-                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             nodeTaintsPolicy:
                               description: |-
@@ -7659,7 +7674,6 @@ spec:
                                 - Ignore: node taints are ignored. All nodes are included.
 
                                 If this value is nil, the behavior is equivalent to the Ignore policy.
-                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             topologyKey:
                               description: |-
@@ -8638,7 +8652,7 @@ spec:
                                 The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                 The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                                 The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                 The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                               properties:
                                 pullPolicy:
@@ -9770,7 +9784,7 @@ spec:
                           Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                            of ConfigMaps or Secrets
                           properties:
                             configMapRef:
                               description: The ConfigMap to select from
@@ -9791,8 +9805,8 @@ spec:
                               type: object
                               x-kubernetes-map-type: atomic
                             prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                              description: Optional text to prepend to the name of
+                                each environment variable. Must be a C_IDENTIFIER.
                               type: string
                             secretRef:
                               description: The Secret to select from
@@ -10056,6 +10070,12 @@ spec:
                                 - port
                                 type: object
                             type: object
+                          stopSignal:
+                            description: |-
+                              StopSignal defines which signal will be sent to a container when it is being stopped.
+                              If not specified, the default is defined by the container runtime in use.
+                              StopSignal can only be set for Pods with a non-empty .spec.os.name
+                            type: string
                         type: object
                       livenessProbe:
                         description: |-
@@ -11341,7 +11361,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -11356,7 +11375,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -11524,7 +11542,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -11539,7 +11556,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -11705,7 +11721,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                             Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -11720,7 +11735,6 @@ spec:
                                             pod labels will be ignored. The default value is empty.
                                             The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                             Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                            This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                           items:
                                             type: string
                                           type: array
@@ -11888,7 +11902,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -11903,7 +11916,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -12165,7 +12177,7 @@ spec:
                                 Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
-                                  a set of ConfigMaps
+                                  a set of ConfigMaps or Secrets
                                 properties:
                                   configMapRef:
                                     description: The ConfigMap to select from
@@ -12186,8 +12198,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
-                                    description: An optional identifier to prepend
-                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
                                     description: The Secret to select from
@@ -12453,6 +12465,12 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
                               type: object
                             livenessProbe:
                               description: |-
@@ -13679,7 +13697,7 @@ spec:
                                 Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
-                                  a set of ConfigMaps
+                                  a set of ConfigMaps or Secrets
                                 properties:
                                   configMapRef:
                                     description: The ConfigMap to select from
@@ -13700,8 +13718,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
-                                    description: An optional identifier to prepend
-                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
                                     description: The Secret to select from
@@ -13964,6 +13982,12 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
                               type: object
                             livenessProbe:
                               description: Probes are not allowed for ephemeral containers.
@@ -15011,7 +15035,7 @@ spec:
                           Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
                           The resourceRequirements of an init container are taken into account during scheduling
                           by finding the highest request/limit for each resource type, and then using the max of
-                          of that value or the sum of the normal containers. Limits are applied to init containers
+                          that value or the sum of the normal containers. Limits are applied to init containers
                           in a similar fashion.
                           Init containers cannot currently be added or removed.
                           Cannot be updated.
@@ -15186,7 +15210,7 @@ spec:
                                 Cannot be updated.
                               items:
                                 description: EnvFromSource represents the source of
-                                  a set of ConfigMaps
+                                  a set of ConfigMaps or Secrets
                                 properties:
                                   configMapRef:
                                     description: The ConfigMap to select from
@@ -15207,8 +15231,8 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   prefix:
-                                    description: An optional identifier to prepend
-                                      to each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    description: Optional text to prepend to the name
+                                      of each environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
                                     description: The Secret to select from
@@ -15474,6 +15498,12 @@ spec:
                                       - port
                                       type: object
                                   type: object
+                                stopSignal:
+                                  description: |-
+                                    StopSignal defines which signal will be sent to a container when it is being stopped.
+                                    If not specified, the default is defined by the container runtime in use.
+                                    StopSignal can only be set for Pods with a non-empty .spec.os.name
+                                  type: string
                               type: object
                             livenessProbe:
                               description: |-
@@ -17188,7 +17218,6 @@ spec:
                                 - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                                 If this value is nil, the behavior is equivalent to the Honor policy.
-                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             nodeTaintsPolicy:
                               description: |-
@@ -17199,7 +17228,6 @@ spec:
                                 - Ignore: node taints are ignored. All nodes are included.
 
                                 If this value is nil, the behavior is equivalent to the Ignore policy.
-                                This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                               type: string
                             topologyKey:
                               description: |-
@@ -18178,7 +18206,7 @@ spec:
                                 The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                                 The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                                 The volume will be mounted read-only (ro) and non-executable files (noexec).
-                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                                Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                                 The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                               properties:
                                 pullPolicy:

--- a/crds/v1/fission.io_functions.yaml
+++ b/crds/v1/fission.io_functions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: functions.fission.io
 spec:
   group: fission.io
@@ -93,7 +93,9 @@ spec:
                               policies:
                                 description: |-
                                   policies is a list of potential scaling polices which can be used during scaling.
-                                  At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+                                  If not set, use the default values:
+                                  - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.
+                                  - For scale down: allow all pods to be removed in a 15s window.
                                 items:
                                   description: HPAScalingPolicy is a single policy
                                     which must hold true for a specified past interval.
@@ -136,6 +138,24 @@ spec:
                                   - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                                 format: int32
                                 type: integer
+                              tolerance:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  tolerance is the tolerance on the ratio between the current and desired
+                                  metric value under which no updates are made to the desired number of
+                                  replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not
+                                  set, the default cluster-wide tolerance is applied (by default 10%).
+
+                                  For example, if autoscaling is configured with a memory consumption target of 100Mi,
+                                  and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
+                                  triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
+
+                                  This is an alpha field and requires enabling the HPAConfigurableTolerance
+                                  feature gate.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                             type: object
                           scaleUp:
                             description: |-
@@ -148,7 +168,9 @@ spec:
                               policies:
                                 description: |-
                                   policies is a list of potential scaling polices which can be used during scaling.
-                                  At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+                                  If not set, use the default values:
+                                  - For scale up: allow doubling the number of pods, or an absolute change of 4 pods in a 15s window.
+                                  - For scale down: allow all pods to be removed in a 15s window.
                                 items:
                                   description: HPAScalingPolicy is a single policy
                                     which must hold true for a specified past interval.
@@ -191,6 +213,24 @@ spec:
                                   - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                                 format: int32
                                 type: integer
+                              tolerance:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: |-
+                                  tolerance is the tolerance on the ratio between the current and desired
+                                  metric value under which no updates are made to the desired number of
+                                  replicas (e.g. 0.01 for 1%). Must be greater than or equal to zero. If not
+                                  set, the default cluster-wide tolerance is applied (by default 10%).
+
+                                  For example, if autoscaling is configured with a memory consumption target of 100Mi,
+                                  and scale-down and scale-up tolerances of 5% and 1% respectively, scaling will be
+                                  triggered when the actual consumption falls below 95Mi or exceeds 101Mi.
+
+                                  This is an alpha field and requires enabling the HPAConfigurableTolerance
+                                  feature gate.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
                             type: object
                         type: object
                       hpaMetrics:
@@ -1047,7 +1087,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1062,7 +1101,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1229,7 +1267,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1244,7 +1281,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1409,7 +1445,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1424,7 +1459,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -1591,7 +1625,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1606,7 +1639,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1865,7 +1897,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                              set of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -1886,8 +1918,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: Optional text to prepend to the name
+                                  of each environment variable. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -2151,6 +2183,12 @@ spec:
                                   - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: |-
@@ -3372,7 +3410,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                              set of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -3393,8 +3431,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: Optional text to prepend to the name
+                                  of each environment variable. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -3654,6 +3692,12 @@ spec:
                                   - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: Probes are not allowed for ephemeral containers.
@@ -4700,7 +4744,7 @@ spec:
                       Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
                       The resourceRequirements of an init container are taken into account during scheduling
                       by finding the highest request/limit for each resource type, and then using the max of
-                      of that value or the sum of the normal containers. Limits are applied to init containers
+                      that value or the sum of the normal containers. Limits are applied to init containers
                       in a similar fashion.
                       Init containers cannot currently be added or removed.
                       Cannot be updated.
@@ -4872,7 +4916,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                              set of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -4893,8 +4937,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: Optional text to prepend to the name
+                                  of each environment variable. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -5158,6 +5202,12 @@ spec:
                                   - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: |-
@@ -6870,7 +6920,6 @@ spec:
                             - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                             If this value is nil, the behavior is equivalent to the Honor policy.
-                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                           type: string
                         nodeTaintsPolicy:
                           description: |-
@@ -6881,7 +6930,6 @@ spec:
                             - Ignore: node taints are ignored. All nodes are included.
 
                             If this value is nil, the behavior is equivalent to the Ignore policy.
-                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                           type: string
                         topologyKey:
                           description: |-
@@ -7855,7 +7903,7 @@ spec:
                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                             The volume will be mounted read-only (ro) and non-executable files (noexec).
-                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                           properties:
                             pullPolicy:

--- a/crds/v1/fission.io_httptriggers.yaml
+++ b/crds/v1/fission.io_httptriggers.yaml
@@ -122,6 +122,57 @@ spec:
                 items:
                   type: string
                 type: array
+              openapi:
+                description: |-
+                  A simplified OpenAPI spec that includes nothing more than the method and schema definitions that describe the HTTP trigger.
+                  openapi:
+                    get:
+                      summary: "Get a user"
+                      description: "Returns a user by ID"
+                      parameters:
+                        - name: id
+                          in: query
+                          required: true
+                          schema:
+                            type: string
+                      responses:
+                        "200":
+                          description: "Successful response"
+                          content:
+                            application/json:
+                              schema:
+                                $ref: "#/components/schemas/User"
+                        "400":
+                          description: "Bad request"
+                        "404":
+                          description: "Not found"
+                        "500":
+                          description: "Internal server error"
+                    schemas:
+                      User:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            description: "The ID of the user"
+                            example: "123"
+                          name:
+                            type: string
+                            description: "The name of the user"
+                            example: "John Doe"
+                          age:
+                            type: integer
+                            description: "The age of the user"
+                            minimum: 0
+                            maximum: 100
+                            example: 30
+                          email:
+                            type: string
+                            description: "The email of the user"
+                            example: "john.doe@example.com"
+                          createdAt:
+                            type: string
+                x-kubernetes-preserve-unknown-fields: true
               prefix:
                 description: |-
                   Prefix with which functions are exposed.

--- a/crds/v1/fission.io_httptriggers.yaml
+++ b/crds/v1/fission.io_httptriggers.yaml
@@ -126,6 +126,9 @@ spec:
                 description: |-
                   A simplified OpenAPI spec that includes nothing more than the method and schema definitions that describe the HTTP trigger.
                   openapi:
+                    servers:
+                      - url: https://api.example.com
+                        description: Production server
                     get:
                       summary: "Get a user"
                       description: "Returns a user by ID"

--- a/crds/v1/fission.io_httptriggers.yaml
+++ b/crds/v1/fission.io_httptriggers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: httptriggers.fission.io
 spec:
   group: fission.io

--- a/crds/v1/fission.io_kuberneteswatchtriggers.yaml
+++ b/crds/v1/fission.io_kuberneteswatchtriggers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: kuberneteswatchtriggers.fission.io
 spec:
   group: fission.io

--- a/crds/v1/fission.io_messagequeuetriggers.yaml
+++ b/crds/v1/fission.io_messagequeuetriggers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: messagequeuetriggers.fission.io
 spec:
   group: fission.io
@@ -412,7 +412,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -427,7 +426,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -594,7 +592,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -609,7 +606,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -774,7 +770,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                         Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -789,7 +784,6 @@ spec:
                                         pod labels will be ignored. The default value is empty.
                                         The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                         Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                        This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                       items:
                                         type: string
                                       type: array
@@ -956,7 +950,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both matchLabelKeys and labelSelector.
                                     Also, matchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -971,7 +964,6 @@ spec:
                                     pod labels will be ignored. The default value is empty.
                                     The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
                                     Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
-                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
                                   items:
                                     type: string
                                   type: array
@@ -1230,7 +1222,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                              set of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -1251,8 +1243,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: Optional text to prepend to the name
+                                  of each environment variable. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -1516,6 +1508,12 @@ spec:
                                   - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: |-
@@ -2737,7 +2735,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                              set of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -2758,8 +2756,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: Optional text to prepend to the name
+                                  of each environment variable. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -3019,6 +3017,12 @@ spec:
                                   - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: Probes are not allowed for ephemeral containers.
@@ -4065,7 +4069,7 @@ spec:
                       Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes.
                       The resourceRequirements of an init container are taken into account during scheduling
                       by finding the highest request/limit for each resource type, and then using the max of
-                      of that value or the sum of the normal containers. Limits are applied to init containers
+                      that value or the sum of the normal containers. Limits are applied to init containers
                       in a similar fashion.
                       Init containers cannot currently be added or removed.
                       Cannot be updated.
@@ -4237,7 +4241,7 @@ spec:
                             Cannot be updated.
                           items:
                             description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                              set of ConfigMaps or Secrets
                             properties:
                               configMapRef:
                                 description: The ConfigMap to select from
@@ -4258,8 +4262,8 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                description: Optional text to prepend to the name
+                                  of each environment variable. Must be a C_IDENTIFIER.
                                 type: string
                               secretRef:
                                 description: The Secret to select from
@@ -4523,6 +4527,12 @@ spec:
                                   - port
                                   type: object
                               type: object
+                            stopSignal:
+                              description: |-
+                                StopSignal defines which signal will be sent to a container when it is being stopped.
+                                If not specified, the default is defined by the container runtime in use.
+                                StopSignal can only be set for Pods with a non-empty .spec.os.name
+                              type: string
                           type: object
                         livenessProbe:
                           description: |-
@@ -6235,7 +6245,6 @@ spec:
                             - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
 
                             If this value is nil, the behavior is equivalent to the Honor policy.
-                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                           type: string
                         nodeTaintsPolicy:
                           description: |-
@@ -6246,7 +6255,6 @@ spec:
                             - Ignore: node taints are ignored. All nodes are included.
 
                             If this value is nil, the behavior is equivalent to the Ignore policy.
-                            This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                           type: string
                         topologyKey:
                           description: |-
@@ -7220,7 +7228,7 @@ spec:
                             The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
                             The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
                             The volume will be mounted read-only (ro) and non-executable files (noexec).
-                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath) before 1.33.
                             The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
                           properties:
                             pullPolicy:

--- a/crds/v1/fission.io_packages.yaml
+++ b/crds/v1/fission.io_packages.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: packages.fission.io
 spec:
   group: fission.io

--- a/crds/v1/fission.io_timetriggers.yaml
+++ b/crds/v1/fission.io_timetriggers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.1
+    controller-gen.kubebuilder.io/version: v0.17.2
   name: timetriggers.fission.io
 spec:
   group: fission.io

--- a/crds/v1/kustomization.yaml
+++ b/crds/v1/kustomization.yaml
@@ -1,13 +1,15 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-commonLabels:
-  group: fission.io
 resources:
-  - fission.io_canaryconfigs.yaml
-  - fission.io_environments.yaml
-  - fission.io_functions.yaml
-  - fission.io_httptriggers.yaml
-  - fission.io_kuberneteswatchtriggers.yaml
-  - fission.io_messagequeuetriggers.yaml
-  - fission.io_packages.yaml
-  - fission.io_timetriggers.yaml
+- fission.io_canaryconfigs.yaml
+- fission.io_environments.yaml
+- fission.io_functions.yaml
+- fission.io_httptriggers.yaml
+- fission.io_kuberneteswatchtriggers.yaml
+- fission.io_messagequeuetriggers.yaml
+- fission.io_packages.yaml
+- fission.io_timetriggers.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    group: fission.io

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0
+	github.com/getkin/kin-openapi v0.132.0
 	github.com/go-git/go-git/v5 v5.16.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
@@ -210,10 +211,13 @@ require (
 	github.com/moby/term v0.5.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/nwaples/rardecode/v2 v2.1.0 // indirect
+	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
+	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.2.3 // indirect
@@ -221,6 +225,7 @@ require (
 	github.com/opentracing-contrib/go-stdlib v1.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.1-0.20220228012449-10b1cf09e00b // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
+	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
 	github.com/pierrec/lz4/v4 v4.1.22 // indirect
 	github.com/pires/go-proxyproto v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -257,6 +257,8 @@ github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
+github.com/getkin/kin-openapi v0.132.0 h1:3ISeLMsQzcb5v26yeJrBcdTCEQTag36ZjaGk7MIRUwk=
+github.com/getkin/kin-openapi v0.132.0/go.mod h1:3OlG51PCYNsPByuiMB0t4fjnNlIDnaEDsjiKUV8nL58=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
@@ -309,6 +311,8 @@ github.com/go-sql-driver/mysql v1.9.1/go.mod h1:qn46aNg1333BRMNU69Lq93t8du/dwxI6
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
+github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/go-viper/mapstructure/v2 v2.1.0 h1:gHnMa2Y/pIxElCH2GlZZ1lZSsn6XMtufpGyP1XxdC/w=
 github.com/go-viper/mapstructure/v2 v2.1.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gobuffalo/flect v1.0.3 h1:xeWBM2nui+qnVvNM4S3foBhCAL2XgPU+a7FdpelbTq4=
@@ -608,6 +612,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -620,6 +626,10 @@ github.com/nwaples/rardecode/v2 v2.1.0 h1:JQl9ZoBPDy+nIZGb1mx8+anfHp/LV3NE2MjMiv
 github.com/nwaples/rardecode/v2 v2.1.0/go.mod h1:7uz379lSxPe6j9nvzxUZ+n7mnJNgjsRNb6IbvGVHRmw=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 h1:G7ERwszslrBzRxj//JalHPu/3yz+De2J+4aLtSRlHiY=
+github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037/go.mod h1:2bpvgLBZEtENV5scfDFEtB/5+1M4hkQhDQrccEJ/qGw=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
@@ -648,6 +658,8 @@ github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0Mw
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
+github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
+github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pierrec/lz4/v4 v4.1.22 h1:cKFw6uJDK+/gfw5BcDL0JL5aBsAFdsIT18eRtLj7VIU=
@@ -783,6 +795,8 @@ github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaO
 github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
+github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
+github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
 github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -711,6 +711,9 @@ type (
 		// +kubebuilder:validation:XPreserveUnknownFields
 		// +kubebuilder:example:
 		// openapi:
+		//   servers:
+		//     - url: https://api.example.com
+		//       description: Production server
 		//   get:
 		//     summary: "Get a user"
 		//     description: "Returns a user by ID"

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1
 
 import (
+	"github.com/getkin/kin-openapi/openapi3"
 	asv2 "k8s.io/api/autoscaling/v2"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -653,6 +654,11 @@ type (
 	// Triggers
 	//
 
+	OpenAPISpec struct {
+		openapi3.PathItem `json:",inline"`
+		Schemas           map[string]openapi3.Schema `json:"schemas,omitempty"`
+	}
+
 	// HTTPTriggerSpec is for router to expose user functions at the given URL path.
 	HTTPTriggerSpec struct {
 		// TODO: remove this field since we have IngressConfig already
@@ -697,6 +703,61 @@ type (
 		// IngressConfig for router to set up Ingress.
 		// +optional
 		IngressConfig IngressConfig `json:"ingressconfig"`
+
+		// A simplified OpenAPI spec that includes nothing more than the method and schema definitions that describe the HTTP trigger.
+		// +optional
+		// +kubebuilder:pruning:PreserveUnknownFields
+		// +kubebuilder:validation:Schemaless
+		// +kubebuilder:validation:XPreserveUnknownFields
+		// +kubebuilder:example:
+		// openapi:
+		//   get:
+		//     summary: "Get a user"
+		//     description: "Returns a user by ID"
+		//     parameters:
+		//       - name: id
+		//         in: query
+		//         required: true
+		//         schema:
+		//           type: string
+		//     responses:
+		//       "200":
+		//         description: "Successful response"
+		//         content:
+		//           application/json:
+		//             schema:
+		//               $ref: "#/components/schemas/User"
+		//       "400":
+		//         description: "Bad request"
+		//       "404":
+		//         description: "Not found"
+		//       "500":
+		//         description: "Internal server error"
+		//   schemas:
+		//     User:
+		//       type: object
+		//       properties:
+		//         id:
+		//           type: string
+		//           description: "The ID of the user"
+		//           example: "123"
+		//         name:
+		//           type: string
+		//           description: "The name of the user"
+		//           example: "John Doe"
+		//         age:
+		//           type: integer
+		//           description: "The age of the user"
+		//           minimum: 0
+		//           maximum: 100
+		//           example: 30
+		//         email:
+		//           type: string
+		//           description: "The email of the user"
+		//           example: "john.doe@example.com"
+		//         createdAt:
+		//           type: string
+		OpenAPISpec *OpenAPISpec `json:"openapi,omitempty"`
 	}
 
 	// IngressConfig is for router to set up Ingress.

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -444,8 +444,8 @@ func (spec HTTPTriggerSpec) Validate() error {
 		}
 	}
 
-	// If OpenAPI spec has server entries, ensure IngressConfig is set
-	if spec.OpenAPISpec != nil && len(spec.OpenAPISpec.Servers) > 0 {
+	// If OpenAPI spec has server entries, ensure IngressConfig is set when CreateIngress is true
+	if spec.CreateIngress && spec.OpenAPISpec != nil && len(spec.OpenAPISpec.Servers) > 0 {
 		if spec.IngressConfig.Host == "" {
 			// Extract host from first server URL
 			serverURL := spec.OpenAPISpec.Servers[0].URL
@@ -457,9 +457,9 @@ func (spec HTTPTriggerSpec) Validate() error {
 				} else {
 					// Set the host in IngressConfig
 					spec.IngressConfig.Host = parsedURL.Host
-					// Set TLS if scheme is https
-					if parsedURL.Scheme == "https" {
-						spec.IngressConfig.TLS = "true"
+
+					if parsedURL.Path != "" {
+						spec.IngressConfig.Path = parsedURL.Path
 					}
 				}
 			}

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -440,6 +441,28 @@ func (spec HTTPTriggerSpec) Validate() error {
 		e := validation.IsDNS1123Subdomain(spec.Host)
 		if len(e) > 0 {
 			result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "HTTPTriggerSpec.Host", spec.Host, e...))
+		}
+	}
+
+	// If OpenAPI spec has server entries, ensure IngressConfig is set
+	if spec.OpenAPISpec != nil && len(spec.OpenAPISpec.Servers) > 0 {
+		if spec.IngressConfig.Host == "" {
+			// Extract host from first server URL
+			serverURL := spec.OpenAPISpec.Servers[0].URL
+			if serverURL != "" {
+				// Parse the URL to get the host
+				parsedURL, err := url.Parse(serverURL)
+				if err != nil {
+					result = multierror.Append(result, MakeValidationErr(ErrorInvalidValue, "HTTPTriggerSpec.OpenAPISpec.Servers[0].URL", serverURL, "invalid URL format"))
+				} else {
+					// Set the host in IngressConfig
+					spec.IngressConfig.Host = parsedURL.Host
+					// Set TLS if scheme is https
+					if parsedURL.Scheme == "https" {
+						spec.IngressConfig.TLS = "true"
+					}
+				}
+			}
 		}
 	}
 

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -18,6 +18,8 @@ package router
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -40,6 +42,7 @@ import (
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/manager"
 	"github.com/fission/fission/pkg/utils/metrics"
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // HTTPTriggerSet represents an HTTP trigger set
@@ -62,6 +65,21 @@ type HTTPTriggerSet struct {
 	svcAddrUpdateThrottler     *throttler.Throttler
 	unTapServiceTimeout        time.Duration
 	syncDebouncer              func(func())
+}
+
+// contextKey is a type for context keys
+type contextKey string
+
+const httpTriggerSetKey contextKey = "httpTriggerSet"
+
+// withHTTPTriggerSet is a middleware that adds the HTTPTriggerSet to the request context
+func withHTTPTriggerSet(ts *HTTPTriggerSet) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), httpTriggerSetKey, ts)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 func makeHTTPTriggerSet(logger *zap.Logger, fmap *functionServiceMap, fissionClient versioned.Interface,
@@ -141,6 +159,100 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func openAPIHandler(w http.ResponseWriter, r *http.Request) {
+	ts, ok := r.Context().Value(httpTriggerSetKey).(*HTTPTriggerSet)
+	if !ok {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	type OpenAPISpec struct {
+		OpenAPI    string                       `json:"openapi"`
+		Info       map[string]interface{}       `json:"info"`
+		Paths      map[string]openapi3.PathItem `json:"paths"`
+		Components struct {
+			Schemas map[string]openapi3.Schema `json:"schemas"`
+		} `json:"components"`
+	}
+
+	spec := OpenAPISpec{
+		OpenAPI: "3.0.0",
+		Info: map[string]interface{}{
+			"title":       "Fission HTTP Triggers",
+			"description": "Auto-generated OpenAPI spec for Fission HTTP Triggers",
+			"version":     "1.0.0",
+		},
+		Paths: map[string]openapi3.PathItem{},
+		Components: struct {
+			Schemas map[string]openapi3.Schema `json:"schemas"`
+		}{
+			Schemas: map[string]openapi3.Schema{},
+		},
+	}
+
+	for _, trigger := range ts.triggers {
+		if trigger.Spec.OpenAPISpec != nil {
+			spec.Paths[trigger.Spec.RelativeURL] = trigger.Spec.OpenAPISpec.PathItem
+
+			for name, schema := range trigger.Spec.OpenAPISpec.Schemas {
+				spec.Components.Schemas[name] = schema
+			}
+		} else {
+			methods := trigger.Spec.Methods
+			if len(methods) == 0 && trigger.Spec.Method != "" {
+				methods = []string{trigger.Spec.Method}
+			}
+			if len(methods) == 0 {
+				methods = []string{"POST"}
+			}
+			item := openapi3.PathItem{
+				Summary:     fmt.Sprintf("Trigger: %s", trigger.ObjectMeta.Name),
+				Description: fmt.Sprintf("Function: %s", trigger.Spec.FunctionReference.Name),
+			}
+			for _, m := range methods {
+				verb := strings.ToLower(m)
+				switch verb {
+				case "get":
+					item.Get = openapi3.NewOperation()
+					item.Get.Responses = openapi3.NewResponses(
+						openapi3.WithName("200", openapi3.NewResponse().WithDescription("Successful response")),
+					)
+				case "post":
+					item.Post = openapi3.NewOperation()
+					item.Post.Responses = openapi3.NewResponses(
+						openapi3.WithName("200", openapi3.NewResponse().WithDescription("Successful response")),
+					)
+				case "put":
+					item.Put = openapi3.NewOperation()
+					item.Put.Responses = openapi3.NewResponses(
+						openapi3.WithName("200", openapi3.NewResponse().WithDescription("Successful response")),
+					)
+				case "delete":
+					item.Delete = openapi3.NewOperation()
+					item.Delete.Responses = openapi3.NewResponses(
+						openapi3.WithName("200", openapi3.NewResponse().WithDescription("Successful response")),
+					)
+				}
+			}
+			spec.Paths[trigger.Spec.RelativeURL] = item
+		}
+	}
+
+	jsonData, err := json.Marshal(spec)
+	if err != nil {
+		http.Error(w, "Error generating OpenAPI spec", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, err = w.Write(jsonData)
+	if err != nil {
+		http.Error(w, "Error writing response", http.StatusInternalServerError)
+		return
+	}
+}
+
 func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router, error) {
 
 	featureConfig, err := config.GetFeatureConfig(ts.logger)
@@ -153,6 +265,9 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 	if featureConfig.AuthConfig.IsEnabled {
 		muxRouter.Use(authMiddleware(featureConfig))
 	}
+
+	// Add the OpenAPI endpoint
+	muxRouter.Handle("/v2/openapi", withHTTPTriggerSet(ts)(http.HandlerFunc(openAPIHandler))).Methods("GET")
 
 	// HTTP triggers setup by the user
 	homeHandled := false
@@ -202,17 +317,59 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 			}
 		}
 
-		methods := trigger.Spec.Methods
-		if len(trigger.Spec.Method) > 0 {
-			present := false
-			for _, m := range trigger.Spec.Methods {
-				if m == trigger.Spec.Method {
-					present = true
-					break
+		// Get methods from OpenAPISpec if available, otherwise use basic configuration
+		var methods []string
+		if trigger.Spec.OpenAPISpec != nil {
+			if trigger.Spec.OpenAPISpec.Connect != nil {
+				methods = append(methods, "CONNECT")
+			}
+			if trigger.Spec.OpenAPISpec.Delete != nil {
+				methods = append(methods, "DELETE")
+			}
+			if trigger.Spec.OpenAPISpec.Get != nil {
+				methods = append(methods, "GET")
+			}
+			if trigger.Spec.OpenAPISpec.Head != nil {
+				methods = append(methods, "HEAD")
+			}
+			if trigger.Spec.OpenAPISpec.Options != nil {
+				methods = append(methods, "OPTIONS")
+			}
+			if trigger.Spec.OpenAPISpec.Patch != nil {
+				methods = append(methods, "PATCH")
+			}
+			if trigger.Spec.OpenAPISpec.Post != nil {
+				methods = append(methods, "POST")
+			}
+			if trigger.Spec.OpenAPISpec.Put != nil {
+				methods = append(methods, "PUT")
+			}
+			if trigger.Spec.OpenAPISpec.Trace != nil {
+				methods = append(methods, "TRACE")
+			}
+
+			if len(methods) == 0 {
+				methods = []string{"POST"}
+			}
+		}
+
+		// Fall back to basic method configuration if no methods found in OpenAPISpec
+		if len(methods) == 0 {
+			methods = trigger.Spec.Methods
+			if len(trigger.Spec.Method) > 0 {
+				present := false
+				for _, m := range trigger.Spec.Methods {
+					if m == trigger.Spec.Method {
+						present = true
+						break
+					}
+				}
+				if !present {
+					methods = append(methods, trigger.Spec.Method)
 				}
 			}
-			if !present {
-				methods = append(methods, trigger.Spec.Method)
+			if len(methods) == 0 {
+				methods = []string{"POST"} // default fallback
 			}
 		}
 

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/bep/debounce"
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -42,7 +43,6 @@ import (
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/manager"
 	"github.com/fission/fission/pkg/utils/metrics"
-	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // HTTPTriggerSet represents an HTTP trigger set

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -295,7 +295,7 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 	}
 
 	// Add the OpenAPI endpoint
-	muxRouter.Handle("/v2/openapi", withHTTPTriggerSet(ts)(http.HandlerFunc(openAPIHandler))).Methods("GET")
+	muxRouter.Handle("/openapi", withHTTPTriggerSet(ts)(http.HandlerFunc(openAPIHandler))).Methods("GET")
 
 	// HTTP triggers setup by the user
 	homeHandled := false

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -211,7 +211,7 @@ func openAPIHandler(w http.ResponseWriter, r *http.Request) {
 				if trigger.Spec.IngressConfig.TLS != "" {
 					scheme = "https"
 				}
-				serverURL := fmt.Sprintf("%s://%s", scheme, trigger.Spec.IngressConfig.Host)
+				serverURL := fmt.Sprintf("%s://%s%s", scheme, trigger.Spec.IngressConfig.Host, trigger.Spec.IngressConfig.Path)
 				if _, exists := serverMap[serverURL]; !exists {
 					spec.Servers = append(spec.Servers, openapi3.Server{
 						URL: serverURL,

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -21,12 +21,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
 func Test_withHTTPTriggerSet(t *testing.T) {

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -184,6 +184,40 @@ func Test_openAPIHandler(t *testing.T) {
 			},
 			want: `{"openapi":"3.0.0","info":{"description":"Auto-generated OpenAPI spec for Fission HTTP Triggers","title":"Fission HTTP Triggers","version":"1.0.0"},"paths":{"/prefix":{"get":{"operationId":"get_dummy","parameters":[{"in":"path","name":"suffix","schema":{"type":"string"}}],"responses":null},"summary":"Trigger: dummy"}}}`,
 		},
+		{
+			name: "test-3",
+			args: args{
+				ts: &HTTPTriggerSet{
+					logger: logger,
+					triggers: []fv1.HTTPTrigger{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "dummy",
+								Namespace: "dummy-bar",
+							},
+							Spec: fv1.HTTPTriggerSpec{
+								Prefix: stringPtr("/prefix"),
+								OpenAPISpec: &fv1.OpenAPISpec{
+									PathItem: openapi3.PathItem{
+										Summary: "Trigger: dummy",
+										Get: &openapi3.Operation{
+											OperationID: "get_dummy",
+										},
+										Servers: openapi3.Servers{
+											{
+												URL:         "https://api.example.com",
+												Description: "Production server",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: `{"openapi":"3.0.0","info":{"description":"Auto-generated OpenAPI spec for Fission HTTP Triggers","title":"Fission HTTP Triggers","version":"1.0.0"},"paths":{"/prefix":{"get":{"operationId":"get_dummy","responses":null},"servers":[{"description":"Production server","url":"https://api.example.com"}],"summary":"Trigger: dummy"}}}`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2016 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_withHTTPTriggerSet(t *testing.T) {
+	config := zap.NewDevelopmentConfig()
+	config.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	logger, err := config.Build()
+	assert.Nil(t, err)
+
+	ts := &HTTPTriggerSet{
+		logger: logger,
+		functions: []fv1.Function{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dummy",
+					Namespace: "dummy-bar",
+				},
+			},
+		},
+	}
+
+	handler := withHTTPTriggerSet(ts)
+	h := handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, ts, r.Context().Value(httpTriggerSetKey))
+	}))
+
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "http://foobar.com", nil)
+	assert.Nil(t, err)
+	h.ServeHTTP(recorder, req)
+	assert.Equal(t, 200, recorder.Code)
+}


### PR DESCRIPTION
## Description
### Discovery
The first part is to provide an `/openapi` path from the router that makes all registered HttpTriggers discoverable. Each HTTPTrigger would result in at least basic information derivable from existing configuration information.

### Documentation
The second part is to provide a richer alternative way of describing HttpTriggers using a subset of the OpenAPI specifications something like the following:

```yaml
apiVersion: fission.io/v1
kind: HTTPTrigger
metadata:
  name: users
  namespace: default
spec:
  createingress: true
  functionref:
    functionweights: null
    name: users-go
    type: name
  relativeurl: /users/{id}
  openapi:
    servers:
      - url: https://api.example.com
        description: Production server
    get:
      summary: "Get a user"
      description: "Returns a user by ID"
      parameters:
        - name: id
          in: query
          required: true
          schema:
            type: string
      responses:
        "200":
          description: "Successful response"
          content:
            application/json:
              schema:
                $ref: "#/components/schemas/User"
        "400":
          description: "Bad request"
        "404":
          description: "Not found"
        "500":
          description: "Internal server error"
    schemas:
      User:
        type: object
        properties:
          id:
            type: string
            description: "The ID of the user"
            example: "123"
          name:
            type: string
            description: "The name of the user"
            example: "John Doe"
          age:
            type: integer
            description: "The age of the user"
            minimum: 0
            maximum: 100
            example: 30
          email:
            type: string
            description: "The email of the user"
            example: "john.doe@example.com"
          createdAt:
            type: string
```

Not only would this richer detail provide enhanced documentation to the `/openapi` endpoint but methods, ingressconfig and other details could be derived from the spec.

This implementation is far from complete but it needs feedback before I go too far.

## Which issue(s) this PR fixes:
The only existing issue is with scale of FaaS in general. Discovery is an afterthought and documentation is entirely out of band which makes it very difficult to manage at scale.

This kind of enhancement could elevate Fission to that of centralized self-documented enterprise function library as well as a runtime. With discoverable, documented endpoints external sources of documentation would be unnecessary. Development experience for HttpTrigger consumers would improve dramatically.

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3234)
<!-- Reviewable:end -->
