### PR TITLE
Fix atomic usage

### DIFF
--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	readyToServe uint32
+	readyToServe atomic.Uint32
 )
 
 func Run(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, port string, podInfoMountDir string) error {
@@ -98,7 +98,7 @@ func Run(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger log
 				return
 			}
 		}
-		atomic.StoreUint32(&readyToServe, 1)
+		readyToServe.Store(1)
 	})
 
 	mux := http.NewServeMux()
@@ -110,7 +110,7 @@ func Run(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger log
 	mux.HandleFunc("/wsevent/end", f.WsEndHandler)
 
 	readinessHandler := func(w http.ResponseWriter, r *http.Request) {
-		if atomic.LoadUint32(&readyToServe) == 1 {
+		if readyToServe.Load() == 1 {
 			w.WriteHeader(http.StatusOK)
 		} else {
 			w.WriteHeader(http.StatusServiceUnavailable)

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/fission/fission
 
 go 1.26
-toolchain go1.26.0
+
+toolchain go1.26.2
 
 require (
 	dario.cat/mergo v1.0.2

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -93,7 +93,7 @@ func AggregateValidationErrors(objName string, err error) error {
 		return nil
 	}
 	var errMsg bytes.Buffer
-	errMsg.WriteString(fmt.Sprintf("Invalid fission %s objects:\n", objName))
+	fmt.Fprintf(&errMsg, "Invalid fission %s objects:\n", objName)
 
 	var unmaskError func(level int, err error)
 
@@ -108,9 +108,10 @@ func AggregateValidationErrors(objName string, err error) error {
 			}
 		} else {
 			if level > 0 {
+
 				errMsg.WriteString(strings.Repeat("  ", level-1))
 			}
-			errMsg.WriteString(fmt.Sprintf("* %s\n", err.Error()))
+			fmt.Fprintf(&errMsg, "* %v\n", err.Error())
 		}
 	}
 

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -262,25 +262,25 @@ func (builder *Builder) build(ctx context.Context, command string, args []string
 	}
 	fmt.Printf("========= START =========\n")
 	defer fmt.Printf("========= END ===========\n")
-	var buildLogs string
+	var buildLogs strings.Builder
 	// Runtime logs
 	for scanner.Scan() {
 		output := scanner.Text()
 		fmt.Println(output)
-		buildLogs += fmt.Sprintf("%s\n", output)
+		fmt.Fprintf(&buildLogs, "%s\n", output)
 	}
 
 	if err := scanner.Err(); err != nil {
 		scanErr := fmt.Errorf("error reading cmd output: %w", err)
 		fmt.Println(scanErr)
-		return buildLogs, scanErr
+		return buildLogs.String(), scanErr
 	}
 
 	err = cmd.Wait()
 	if err != nil {
 		cmdErr := fmt.Errorf("error waiting for cmd %q: %w", command, err)
 		fmt.Println(cmdErr)
-		return buildLogs, cmdErr
+		return buildLogs.String(), cmdErr
 	}
-	return buildLogs, nil
+	return buildLogs.String(), nil
 }

--- a/pkg/kubewatcher/kubewatcher.go
+++ b/pkg/kubewatcher/kubewatcher.go
@@ -48,7 +48,7 @@ import (
 type (
 	KubeWatcher struct {
 		logger           logr.Logger
-		watches          map[types.UID]watchSubscription
+		watches          map[types.UID]*watchSubscription
 		kubernetesClient kubernetes.Interface
 		publisher        publisher.Publisher
 	}
@@ -58,7 +58,7 @@ type (
 		watch               fv1.KubernetesWatchTrigger
 		kubeWatch           watch.Interface
 		lastResourceVersion string
-		stopped             *int32
+		stopped             atomic.Int32
 		kubernetesClient    kubernetes.Interface
 		publisher           publisher.Publisher
 	}
@@ -67,7 +67,7 @@ type (
 func MakeKubeWatcher(ctx context.Context, logger logr.Logger, kubernetesClient kubernetes.Interface, publisher publisher.Publisher) *KubeWatcher {
 	kw := &KubeWatcher{
 		logger:           logger.WithName("kube_watcher"),
-		watches:          make(map[types.UID]watchSubscription),
+		watches:          make(map[types.UID]*watchSubscription),
 		kubernetesClient: kubernetesClient,
 		publisher:        publisher,
 	}
@@ -130,7 +130,7 @@ func (kw *KubeWatcher) addWatch(ctx context.Context, w *fv1.KubernetesWatchTrigg
 	if err != nil {
 		return err
 	}
-	kw.watches[w.UID] = *ws
+	kw.watches[w.UID] = ws
 	return nil
 }
 
@@ -147,12 +147,11 @@ func (kw *KubeWatcher) removeWatch(w *fv1.KubernetesWatchTrigger) error {
 }
 
 func MakeWatchSubscription(ctx context.Context, logger logr.Logger, w *fv1.KubernetesWatchTrigger, kubeClient kubernetes.Interface, publisher publisher.Publisher) (*watchSubscription, error) {
-	var stopped int32 = 0
+
 	ws := &watchSubscription{
 		logger:              logger.WithName("watch_subscription"),
 		watch:               *w,
 		kubeWatch:           nil,
-		stopped:             &stopped,
 		kubernetesClient:    kubeClient,
 		publisher:           publisher,
 		lastResourceVersion: "",
@@ -274,10 +273,10 @@ func (ws *watchSubscription) eventDispatchLoop(ctx context.Context) {
 }
 
 func (ws *watchSubscription) stop() {
-	atomic.StoreInt32(ws.stopped, 1)
+	ws.stopped.Store(1)
 	ws.kubeWatch.Stop()
 }
 
 func (ws *watchSubscription) isStopped() bool {
-	return atomic.LoadInt32(ws.stopped) == 1
+	return ws.stopped.Load() == 1
 }

--- a/pkg/router/mutablemux.go
+++ b/pkg/router/mutablemux.go
@@ -32,7 +32,7 @@ import (
 
 type mutableRouter struct {
 	logger logr.Logger
-	router atomic.Value // mux.Router
+	router atomic.Pointer[mux.Router]
 }
 
 func newMutableRouter(logger logr.Logger, handler *mux.Router) *mutableRouter {
@@ -45,13 +45,13 @@ func newMutableRouter(logger logr.Logger, handler *mux.Router) *mutableRouter {
 
 func (mr *mutableRouter) ServeHTTP(responseWriter http.ResponseWriter, request *http.Request) {
 	// Atomically grab the underlying mux router and call it.
-	routerValue := mr.router.Load()
-	router, ok := routerValue.(*mux.Router)
-	if !ok {
-		mr.logger.Error(nil, "invalid router type")
-		os.Exit(1)
+	if router := mr.router.Load(); router != nil {
+		router.ServeHTTP(responseWriter, request)
+		return
 	}
-	router.ServeHTTP(responseWriter, request)
+	// This should never happen, but if it does, log an error and exit.
+	mr.logger.Error(nil, "router is nil")
+	os.Exit(1)
 }
 
 func (mr *mutableRouter) updateRouter(newHandler *mux.Router) {


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->
This pull request improves thread safety and code clarity by updating several components to use Go's new atomic types (from Go 1.19+), replacing older patterns that relied on primitive types and the `sync/atomic` package. It also modernizes string building and error formatting for efficiency and readability. The most significant changes are grouped below.

**Thread safety improvements with atomic types:**

* Replaced `uint32` and `int32` fields with `atomic.Uint32` and `atomic.Int32` in `cmd/fetcher/app/server.go` and `pkg/kubewatcher/kubewatcher.go` to improve thread-safe state management. Updated all related usage to use the new atomic types' methods. [[1]](diffhunk://#diff-5fb1bf8b708338b3c4389340f32523ea575d86a33b1503071cc37a66b52e91d5L41-R41) [[2]](diffhunk://#diff-5fb1bf8b708338b3c4389340f32523ea575d86a33b1503071cc37a66b52e91d5L101-R101) [[3]](diffhunk://#diff-5fb1bf8b708338b3c4389340f32523ea575d86a33b1503071cc37a66b52e91d5L113-R113) [[4]](diffhunk://#diff-68b6ee28903f056f0cf291012b1b76eac887e1c543f9753d2454f59e4df12c37L61-R61) [[5]](diffhunk://#diff-68b6ee28903f056f0cf291012b1b76eac887e1c543f9753d2454f59e4df12c37L277-R281)
* Updated `mutableRouter` in `pkg/router/mutablemux.go` to use `atomic.Pointer[mux.Router]` for safer concurrent router swaps, and simplified the router retrieval logic. [[1]](diffhunk://#diff-03b528f13c13e1b73ac5a5ee33fde3acb85a037215448b494af38e713869d8d0L35-R35) [[2]](diffhunk://#diff-03b528f13c13e1b73ac5a5ee33fde3acb85a037215448b494af38e713869d8d0L48-R54)

**Data structure and pointer usage improvements:**

* Changed `watches` in `KubeWatcher` from `map[types.UID]watchSubscription` to `map[types.UID]*watchSubscription`, ensuring consistent pointer usage and simplifying code. [[1]](diffhunk://#diff-68b6ee28903f056f0cf291012b1b76eac887e1c543f9753d2454f59e4df12c37L51-R51) [[2]](diffhunk://#diff-68b6ee28903f056f0cf291012b1b76eac887e1c543f9753d2454f59e4df12c37L70-R70) [[3]](diffhunk://#diff-68b6ee28903f056f0cf291012b1b76eac887e1c543f9753d2454f59e4df12c37L133-R133)
* Removed unnecessary `stopped` pointer initialization in `MakeWatchSubscription`.

**String and error handling enhancements:**

* Replaced string concatenation with `strings.Builder` in build logs and used `fmt.Fprintf` for more efficient string construction in `pkg/builder/builder.go` and `pkg/apis/core/v1/validation.go`. [[1]](diffhunk://#diff-11b45ccd73fa1439665b5a1f48bfb37a8042327fa5bfaa1e014b6719f932fa1fL265-R285) [[2]](diffhunk://#diff-ee35fbbc54289c2d4616586efa87c8ff68dd472566e2425e439d7de283f154a9L96-R96) [[3]](diffhunk://#diff-ee35fbbc54289c2d4616586efa87c8ff68dd472566e2425e439d7de283f154a9R111-R114)

**Dependency/toolchain update:**

* Updated Go toolchain version from `go1.26.0` to `go1.26.2` in `go.mod`.<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3348)
<!-- Reviewable:end -->
