### PR TITLE
Add debug-github-ci skill

### DIFF
--- a/.claude/skills/debug-github-ci/SKILL.md
+++ b/.claude/skills/debug-github-ci/SKILL.md
@@ -86,6 +86,12 @@ Most failures in this repo land in one of these categories. Match the error stri
 | `package "<pkg>" never reached build status "succeeded"` | One of the buildermgr → builder → fetcher steps failed | `resources/build-pipeline-flow.md` |
 | `Error uploading deployment package: ...` | fetcher's UploadHandler failing — wrapped error is the real cause | `resources/build-pipeline-flow.md` |
 | `bufio.Scanner: token too long` in builder log | Build script line >64KB (pip progress bars do this) | `resources/build-pipeline-flow.md` |
+| `dial tcp <env-svc>:8000: i/o timeout` after `CreateEnv(Builder=...)` | Builder/runtime pod readiness race; layered settle fix in framework | `resources/integration-test-framework.md` |
+| Selector `envName=<env>` returns no pods | Wrong label key — runtime pods use `environmentName=`, builder pods use `envName=` | `resources/integration-test-framework.md` |
+| `ns.CLI` returns empty string for a subcommand that's known to print | Subcommand prints to `os.Stdout` directly (e.g. `archive list`, `function logs`) — use `ns.CLICaptureStdout` | `resources/integration-test-framework.md` |
+| Test fixture file is missing from `embed.FS` despite being on disk | The fixture's parent dir contains a `go.mod` (nested module) — `embed` skips it | `resources/integration-test-framework.md` |
+| Spec test fails with `unknown flag: --specdir` or wrong cwd | `fission env create --spec` writes `./specs` relative to cwd; needs `ns.WithCWD` | `resources/integration-test-framework.md` |
+| Package update doesn't trigger a rebuild | Package CR has no `/status` subresource; must explicitly set `Status.BuildStatus = pending` along with spec change | `resources/integration-test-framework.md` |
 
 ### Lint / Go module
 
@@ -130,6 +136,7 @@ When a Helm-chart feature should be on in CI but off by default for users (e.g. 
 - `resources/shared-volume-permissions.md` — `/packages` shared volume, builder vs. fetcher UID model, why `0o750` breaks things.
 - `resources/skaffold-kind-ci-profile.md` — adding CI-only Helm flags via the kind-ci profile.
 - `resources/builder-image-origin.md` — the gotcha that env-builder images are not rebuilt per-PR.
+- `resources/integration-test-framework.md` — Go-test-framework quirks the bash→Go migration uncovered: builder/runtime readiness race (8 layered fixes), pod-label conventions, `ns.CLI` capture limitations, `embed.FS` nested-module skip, spec-test cwd handling, Package CR `/status` subresource gap.
 - `resources/monitor-poll-loop.md` — the canonical `gh pr checks` poll loop for the push-fix-monitor cycle.
 - `resources/gh-commands-cheatsheet.md` — every `gh` invocation we use during a debug session, with notes.
 

--- a/.claude/skills/debug-github-ci/SKILL.md
+++ b/.claude/skills/debug-github-ci/SKILL.md
@@ -1,0 +1,169 @@
+---
+name: debug-github-ci
+description: Investigate and fix GitHub Actions CI failures on the Fission repo's PRs efficiently. Use when CI is red on an open PR, when an integration test needs triaging, when the user asks "why is X failing in CI", or after pushing changes to verify CI before claiming work is done. Optimised for the push-fix-monitor loop and the Fission-specific failure patterns we hit repeatedly: builder/fetcher build pipeline, storagesvc archive flow, NetworkPolicy selectors, /packages shared-volume permissions, kind-ci profile patches.
+---
+
+# Debug GitHub CI failures (Fission)
+
+Playbook for triaging and fixing CI failures on PRs in this repo. Optimised for **separating real regressions from pre-existing noise** and for **pattern-matching the same handful of recurring failure modes** before reading the full log.
+
+This file is the orchestrator. Detailed playbooks for each domain live under `resources/` — read them on demand when a phase decision points there.
+
+## When to invoke
+
+Trigger phrases: "CI failed on PR #X", "investigate the failed checks", "why are integration tests red", "the pipeline is broken on my branch", "did CI pass after the push".
+
+Skip if the user already knows the root cause and wants you to apply a specific fix — that's an edit + commit, no triage needed.
+
+## Phase 0 — Separate noise from regression (do this first; saves hours)
+
+1. List checks for the PR:
+   ```bash
+   gh pr checks <PR> --json name,bucket,state,link \
+     --jq '.[] | select(.name != null) | "\(.bucket)\t\(.name)\t\(.link)"'
+   ```
+   Don't read logs yet. Just see who's red.
+
+2. Compare against `main`:
+   ```bash
+   gh run list --branch main --workflow=push_pr.yaml --limit 5 \
+     --json conclusion,headSha
+   gh api repos/fission/fission/commits/<main-sha>/status \
+     --jq '.statuses[] | {context, state, description}'
+   ```
+   If the same check is also failing on `main`, it is **pre-existing noise** and the rest of this playbook does not apply to that check.
+
+3. Known stickers in this repo (don't chase):
+   - **`License Compliance` (FOSSA)** — fails persistently on main with "11 issues found".
+   - **Tests requiring a local Docker daemon** (e.g. `TestS3StorageService` in `pkg/storagesvc/client`) — failures locally without `dockerd` are environmental.
+
+4. If main is green and PR is red → real regression. Continue.
+
+## Phase 1 — Get the right logs (cheapest first)
+
+Order from cheapest to most expensive — escalate only if the previous step doesn't surface the failing line.
+
+| Step | Command | Notes |
+|---|---|---|
+| 1 | `gh run view <runId> --log-failed` | Failed steps only. Blocked while other jobs in the run are still pending. |
+| 2 | `gh api repos/fission/fission/actions/jobs/<jobId>/logs` | Per-job. Works mid-run. `<jobId>` comes from the `link` URL in `gh pr checks`. |
+| 3 | `gh api repos/fission/fission/commits/<sha>/status` | External checks (FOSSA, codecov). Run-level not job-level. |
+| 4 | `gh run download <runId> -n go-integration-logs-<runId>-v<k8s>` | Per-test diag dirs with pod logs, yamls. The big artefact for integration-test failures. |
+
+Filter aggressively. Useful first-pass grep:
+```bash
+grep -E '(FAIL|--- FAIL|fatal:|panic|error:|Error:|denied|connection refused|i/o timeout|context deadline exceeded)'
+```
+
+Don't pull `gh run view <runId> --log` (the full archive) unless 1-3 above failed. It's tens of MB.
+
+Full cheatsheet: `resources/gh-commands-cheatsheet.md`.
+
+## Phase 2 — Pattern-match the symptom
+
+Most failures in this repo land in one of these categories. Match the error string first, then load the matching resource for deeper diagnosis.
+
+### Network / connectivity
+
+| Symptom | Root cause | Resource |
+|---|---|---|
+| `dial tcp <ip>:<port>: i/o timeout` (Fission pod → storagesvc) | NetworkPolicy dropping the request, or pod labels don't match policy selectors | `resources/networkpolicy-debugging.md` |
+| `dial tcp ...: connection refused` to `127.0.0.1:8888` | `kubectl port-forward svc/router` race in the test runner. CI has a 30s wait loop. Usually a flake. | — |
+| `404 Not Found` from `raw.githubusercontent.com/...` | Test data URL broken upstream. Not a regression. | — |
+
+### Filesystem / permissions
+
+| Symptom | Root cause | Resource |
+|---|---|---|
+| `permission denied` / `openfdat …: permission denied` on `/packages/...` | Cross-container UID mismatch on shared volume. `0o750` breaks fetcher access; need `0o755`. | `resources/shared-volume-permissions.md` |
+| `no files found for globs: [/packages/<deploy>/*]` | Deploy dir empty or unreadable from fetcher | `resources/shared-volume-permissions.md` + `resources/build-pipeline-flow.md` |
+| `failed to get source directory info: stat /packages/<path>: no such file or directory` | Build script never wrote the path; pipeline broke earlier | `resources/build-pipeline-flow.md` |
+
+### Build pipeline
+
+| Symptom | Root cause | Resource |
+|---|---|---|
+| `package "<pkg>" never reached build status "succeeded"` | One of the buildermgr → builder → fetcher steps failed | `resources/build-pipeline-flow.md` |
+| `Error uploading deployment package: ...` | fetcher's UploadHandler failing — wrapped error is the real cause | `resources/build-pipeline-flow.md` |
+| `bufio.Scanner: token too long` in builder log | Build script line >64KB (pip progress bars do this) | `resources/build-pipeline-flow.md` |
+
+### Lint / Go module
+
+| Symptom | Root cause |
+|---|---|
+| `printf: non-constant format string in call to ... (govet)` | Caller passed `fmt.Sprintf(...)` as a printf-helper format arg. Pass `format, args...` directly, or wrap the dynamic string with `"%s", str`. |
+| `invalid version: unknown revision v29.x.y` for `github.com/docker/docker` | Docker re-tagged that import path with `docker-vX.Y.Z` prefixed tags; Go module proxy doesn't index those. Fix: bump `docker/cli` to v29.x — its transitive `moby/moby/v2` import drops `docker/docker` from go.mod entirely. |
+| `go: github.com/foo/bar@vX: invalid version` | Module path moved or got retracted. Check upstream `releases/latest` and actual git tags. |
+
+## Phase 3 — Verify hypothesis before pushing
+
+1. **Check the running binary's version**, not your local source.
+   - `fission-bundle`, `fetcher`, `pre-upgrade-checks`, `reporter` images are built per-PR by `make skaffold-deploy`.
+   - **Env-builder images** (`python-builder`, `node-builder-22`, `go-builder-1.23`, etc.) are pre-built on GHCR. Their `/builder` binary was compiled at image-build time, NOT per-PR. Changes to `pkg/builder/builder.go` do not affect their behaviour in CI integration tests.
+   - Confirm with the `caller":"builder/builder.go:NN"` field in pod logs vs. local file line numbers.
+   - Full explanation: `resources/builder-image-origin.md`.
+
+2. **Read the source at the cited line** before iterating on a flake. Per the user's `feedback_read_source_before_iterating.md` memory, after 2 failed timing-based fixes, stop guessing — read the code path.
+
+3. **Sanity-test locally** for the affected scope:
+   ```bash
+   make code-checks                                              # lint
+   go test -race -count=1 -timeout 5m ./pkg/<affected>/...       # focused tests
+   helm lint charts/fission-all                                  # if Helm changed
+   helm template charts/fission-all --set <vals> | sed -n '/^kind: <Kind>/,/^---/p'   # render check
+   ```
+
+## Phase 4 — Push and monitor
+
+After pushing the fix, arm the `Monitor` tool with the standard poll loop so terminal-state notifications arrive instead of you polling. Full recipe and rationale: `resources/monitor-poll-loop.md`.
+
+If a check flips back to red after a fix, **don't push another fix immediately** — return to Phase 1 with the new logs. The new failure is often a different root cause exposed by the previous fix; reusing the previous hypothesis wastes a CI cycle.
+
+## CI-only Helm features via skaffold profile
+
+When a Helm-chart feature should be on in CI but off by default for users (e.g. `networkPolicy.enabled`), patch it via the `kind-ci` skaffold profile. Two-step: declare the chart-default in base `setValues`, then `replace`-patch it in the profile. Full instructions and rationale: `resources/skaffold-kind-ci-profile.md`.
+
+## Other resources
+
+- `resources/networkpolicy-debugging.md` — NetworkPolicy selectors, cross-namespace rules, pod label reference.
+- `resources/build-pipeline-flow.md` — buildermgr → builder → fetcher → storagesvc dance, where each container's log lives, mapping symptom to failing step.
+- `resources/shared-volume-permissions.md` — `/packages` shared volume, builder vs. fetcher UID model, why `0o750` breaks things.
+- `resources/skaffold-kind-ci-profile.md` — adding CI-only Helm flags via the kind-ci profile.
+- `resources/builder-image-origin.md` — the gotcha that env-builder images are not rebuilt per-PR.
+- `resources/monitor-poll-loop.md` — the canonical `gh pr checks` poll loop for the push-fix-monitor cycle.
+- `resources/gh-commands-cheatsheet.md` — every `gh` invocation we use during a debug session, with notes.
+
+## Out of scope
+
+- Triaging non-Fission GitHub Actions workflows (no shared CI infra).
+- Re-running the SAST scanner — that's the `go-deps-security-upgrade` skill or a maintainer-driven scan.
+- Fixing the underlying business logic of a failing test — once *cause of failure* is identified, the actual code change is normal edit-test-commit.
+- Forensic analysis of merged-main breakage — main reverts and hotfixes have their own flow.
+
+## Canonical execution outline
+
+```
+1. Phase 0:
+   gh pr checks <PR>                                 # see who's red
+   gh run list --branch main --limit 5               # cross-check: red on main too?
+   → cross out pre-existing noise (FOSSA, etc.)
+
+2. Phase 1 (escalate from cheap to expensive):
+   a. gh run view <runId> --log-failed | grep -E '<patterns>'
+   b. gh api .../jobs/<jobId>/logs | grep -B2 -A8 '<patterns>'
+   c. gh run download <runId> -n go-integration-logs-* -D /tmp/
+
+3. Phase 2:
+   Match error string against the tables above.
+   Load the matching resources/<topic>.md for the deep dive.
+
+4. Phase 3:
+   Read source at cited line. Verify which binary is actually running
+   (fission-bundle/fetcher = per-PR; env-builder images = pre-built GHCR).
+   Run focused local tests + helm template if Helm/skaffold changed.
+
+5. Phase 4:
+   Push. Arm Monitor with the poll loop (timeout 2400000ms).
+   On notification: if green, done. If red, restart Phase 1 with new logs —
+   don't reuse the previous hypothesis without re-reading.
+```

--- a/.claude/skills/debug-github-ci/resources/build-pipeline-flow.md
+++ b/.claude/skills/debug-github-ci/resources/build-pipeline-flow.md
@@ -1,0 +1,97 @@
+# Fission build pipeline — what happens when a Package is built
+
+Most integration-test failures involving `pkg/builder`, `pkg/buildermgr`, `pkg/fetcher`, or `pkg/storagesvc` come from misunderstanding which component does what at which step. This file is the reference.
+
+## End-to-end flow for a v2 (source) package build
+
+```
+User CLI  →  k8s API  →  Package CR (state=pending)
+                              │
+                              │  watched by:
+                              ▼
+                         buildermgr controller (in fission-bundle)
+                              │
+                              │  1. fetch source archive
+                              ▼
+                         fetcher sidecar (in env-builder pod)
+                              │  HTTP GET archive.URL
+                              ▼
+                         storagesvc  ──→  /packages/<srcPkgFilename>/  (extracted)
+                              │
+                              │  2. trigger build
+                              ▼
+                         builder container (in env-builder pod)
+                              │  exec.Command(buildCommand)
+                              │  with SRC_PKG=/packages/<srcPkgFilename>
+                              │       DEPLOY_PKG=/packages/<srcPkgFilename>-<rand>
+                              │
+                              │  3. upload deploy archive
+                              ▼
+                         fetcher sidecar (same env-builder pod)
+                              │  utils.Archive(srcFilepath, dstFilepath)
+                              │  storagesvc.Upload(dstFilepath)
+                              ▼
+                         storagesvc  ──→  Package CR (state=succeeded, with deploy archive ID)
+                              │
+                              │  4. cleanup
+                              ▼
+                         builder container (Clean handler) — removes /packages/<srcPkgFilename>
+                         fetcher (UploadHandler defer) — removes /packages/<deployPkg>
+```
+
+## Mapping symptom → likely failing step
+
+| Test message | Failing step |
+|---|---|
+| `package "<pkg>" never reached build status "succeeded" (last="pending")` | Step 1 missed entirely. buildermgr controller didn't pick up the CR. Check `logs-buildermgr-*` (in `kind-logs-*` artifact, not the per-test artifact). |
+| `(last="running", last build log: )` (empty log) | Step 2 stuck — env-builder pod not Ready, or builder container probe failing. Look at events.yaml for the env-builder Deployment. |
+| `(last="failed", last build log: <stuff>)` with build-script output | Step 2 ran but the script returned non-zero, OR step 3 failed. Read the build log for clues. |
+| `Error uploading deployment package: ... no files found for globs: [/packages/<deploy>/*]` | Step 3 — the deploy directory is empty or unreadable. Cross-check shared-volume permissions (see `shared-volume-permissions.md`). |
+| `Error uploading deployment package: ... failed to get source directory info: stat /packages/<deploy>: no such file or directory` | Step 2 build script never wrote to `$DEPLOY_PKG`. Either the script crashed mid-way (check `cmd.Wait` errors in builder log), or it wrote to the wrong path. |
+| `Error uploading deployment package: ... dial tcp <ip>:80: i/o timeout` | Step 3 reached fetcher but fetcher → storagesvc was blocked. NetworkPolicy issue (see `networkpolicy-debugging.md`). |
+
+## Where each container's log lives
+
+In a downloaded `go-integration-logs-*` artifact, per-test diag dirs contain:
+
+| File | Comes from |
+|---|---|
+| `logs-<env>-<rv>-<deploy-hash>-builder.log` | The `builder` container — env image's `/builder` binary. Logs build-script stdout/stderr verbatim between `===== START =====` / `===== END =====` markers, plus structured logger lines around them. |
+| `logs-<env>-<rv>-<deploy-hash>-fetcher.log` | The `fetcher` sidecar of the **env-builder pod**. Handles fetch (step 2 input) and upload (step 3 output). |
+| `logs-poolmgr-<fn>-*-fetcher.log` / `logs-newdeploy-<fn>-*-fetcher.log` | The fetcher sidecar of a **function pod**. Only handles specialise-time downloads (step 2 of a different flow), never uploads. |
+| `logs-poolmgr-<fn>-*-<env-runtime-name>.log` | The user function's *runtime* container (the actual code execution). |
+
+Higher-level logs (buildermgr controller, executor controller, router, storagesvc) come from a different artifact — `kind-logs-<runId>-v<k8s>` — under `fission/` namespace pod logs. Only download those if you suspect a controller issue (step 1 failure).
+
+## Reading a builder log
+
+A successful build log looks like:
+```
+{"level":"info","msg":"builder received request","srcPkgFilename":"...","buildCommandLen":11}
+{"level":"info","msg":"building source package","command":"./build.sh","args":[],"env":[...]}
+========= START =========
+<actual build script stdout/stderr>
+========= END ===========
+{"level":"info","msg":"build request complete","elapsed_time":...}
+```
+
+Failure modes:
+- Logger line `"error starting cmd"` → the `exec.Command()` call failed before the process ran. Permission issue on the script, or PATH lookup failure.
+- Logger line `"error waiting for cmd"` → the process started but exited non-zero. Look at the captured stdout/stderr between `START`/`END` for the script's own error message.
+- No `END` marker at all → log capture was truncated. Either `bufio.Scanner` hit its 64KB line limit (pip progress bars do this), or the pod was killed mid-build.
+
+## Builder image vs Fission image distinction
+
+The env-builder pods run images from `ghcr.io/fission/<lang>-builder` (e.g. `python-builder`, `node-builder-22`). Each image has the `/builder` binary baked in **at build time** of that image — not rebuilt per-PR.
+
+Fission CI's `make skaffold-deploy` step builds:
+- `fission-bundle` (multi-headed, hosts buildermgr, executor, router, storagesvc, etc.)
+- `fetcher` (sidecar image)
+- `pre-upgrade-checks`
+- `reporter`
+
+It does **not** rebuild the env-builder images. So a change to `pkg/builder/builder.go` does not affect env-builder pod behaviour in CI integration tests until those images are republished. Confirm by reading the `caller":"builder/builder.go:NN"` field in pod logs and comparing line numbers to your local file. See `builder-image-origin.md` for more.
+
+## The `BuildCommand` allowlist
+
+After the 2026-05 security fixes, `pkg/builder/builder.go` rejects `BuildCommand` strings that contain shell metacharacters (`;|&\`$()<>\n\r`). If a previously-working test starts failing with HTTP 400 and message "error: invalid buildCommand: contains shell metacharacter", the fix is to rewrite the command to not need shell features (e.g. push the `&&` into the script's shebang line — `#!/bin/sh` will interpret it inside the script body). See `pkg/builder/builder.go` `resolveBuildCommand`.

--- a/.claude/skills/debug-github-ci/resources/builder-image-origin.md
+++ b/.claude/skills/debug-github-ci/resources/builder-image-origin.md
@@ -1,0 +1,54 @@
+# Env-builder images are NOT rebuilt per-PR
+
+A subtle gotcha that has burned at least one CI debug cycle: when you change `pkg/builder/builder.go` and CI runs your PR, the env-builder pods (the ones running `python-builder`, `node-builder-22`, `go-builder-1.23`, etc.) **do not contain your changes**.
+
+## Why
+
+Fission has two ways binaries reach the cluster:
+
+1. **Fission control-plane images** — built per-PR by `make skaffold-deploy`, which goreleaser-builds:
+   - `fission-bundle` (multi-headed: hosts buildermgr, executor, router, storagesvc, kubewatcher, timer, mqtrigger, builder controller, canary, webhook, logger, pre-upgrade-checks dispatcher, ...)
+   - `fetcher` (sidecar image)
+   - `pre-upgrade-checks`
+   - `reporter`
+   - `builder` (the binary, used as a sidecar in the env-builder *pod*, but the env-builder *image* doesn't pull it from here)
+
+2. **Environment images** — pre-built and published to GHCR by Fission environment maintainers, separately from this repo:
+   - `ghcr.io/fission/python-builder`
+   - `ghcr.io/fission/node-builder-22`
+   - `ghcr.io/fission/go-builder-1.23`
+   - … and one runtime image per env (e.g. `python-env`, `node-env-22`)
+
+Each environment image is essentially `<lang base image> + /builder binary baked in + /build script`. The `/builder` binary inside that image is what runs in the builder container of the env-builder pod. **It was compiled at the time the image was built and pushed — not from this PR's source.**
+
+## The cluster's view at PR test time
+
+When CI integration tests run on PR:
+- The fission-bundle, fetcher, etc. **do** reflect your PR's source code.
+- The env-builder pods (e.g. `python-01e06b-6925-5d689969f5-6dmzg`) pull their image from `ghcr.io/fission/python-builder` and run the `/builder` binary that was baked into that image at release time.
+
+So if you changed `pkg/builder/builder.go` to add a log line "builder received request" with new structured fields, you'll still see the **old** log format in the builder pod's logs in CI.
+
+## How to verify which version is actually running
+
+Read the structured logger output in the pod log and compare the `caller` field against your local file:
+
+```
+{"level":"info","msg":"builder received request","caller":"builder/builder.go:122","request":{"srcPkgFilename":"...","command":"./build.sh"}}
+```
+
+If `caller":"builder/builder.go:122"` points at a `return` or unrelated line in your local source, the binary in CI is from a different commit (the one baked into the env image).
+
+## Workarounds for testing builder.go changes
+
+1. **Unit + integration test mock** — write a Go test that exercises the changed code path without involving the env-builder image at all. This is the highest-confidence path.
+2. **Build a local env-builder image** — there are Dockerfiles in the [`fission/environments` repo](https://github.com/fission/environments) (separate from this one). Build one locally with your patched `cmd/builder` binary, push to a registry, and override `Builder.Image` in the test's Environment CR. This is the path used when testing builder behaviour in a real cluster.
+3. **Add a fission-bundle-only test** — the `fission-bundle` binary is rebuilt per-PR. Behaviour that lives in `pkg/buildermgr` (the controller, in fission-bundle) IS exercised. Behaviour purely in `cmd/builder` / `pkg/builder/builder.go` (the sidecar binary) is not.
+
+## When *is* `pkg/builder/` exercised in CI?
+
+The `pkg/builder` Go tests (`pkg/builder/builder_test.go`) run as part of the regular `make test-run` step. They cover the package logic in isolation. They do **not** run as part of the integration-test job — that one only exercises pre-built env-builder images.
+
+## How to spot this confusion in logs
+
+If you push a PR that changes `pkg/builder/builder.go` and the integration test still fails with behaviour matching the **old** code, but unit tests pass and lint is clean, this is almost certainly your situation. Check the `caller` line numbers in the builder pod log.

--- a/.claude/skills/debug-github-ci/resources/gh-commands-cheatsheet.md
+++ b/.claude/skills/debug-github-ci/resources/gh-commands-cheatsheet.md
@@ -1,0 +1,112 @@
+# `gh` CLI cheatsheet for CI debugging
+
+Every `gh` command we use during a CI debug session, ordered by frequency. Copy-paste oriented.
+
+## See PR check states
+
+```bash
+# All checks — bucket is one of: pass | fail | pending | skipping
+gh pr checks <PR> --json name,bucket,state,link \
+  --jq '.[] | select(.name != null) | "\(.bucket)\t\(.name)\t\(.link)"'
+
+# Just failures
+gh pr checks <PR> --json name,bucket,link \
+  --jq '.[] | select(.bucket=="fail") | "\(.name)\t\(.link)"'
+
+# Summary count
+gh pr checks <PR> --json name,bucket \
+  --jq '.[] | select(.name != null) | "\(.bucket)\t\(.name)"' | sort | uniq -c | head
+```
+
+## Compare PR against `main`
+
+```bash
+# Recent main runs — same workflow as PR
+gh run list --branch main --workflow=push_pr.yaml --limit 5 \
+  --json conclusion,headSha,databaseId,createdAt
+
+# Status checks for a specific commit on main (FOSSA, codecov, etc.)
+gh api repos/fission/fission/commits/<sha>/status \
+  --jq '.statuses[] | {context, state, description}'
+```
+
+If a check is `error`/`failure` on main with the same `description` as your PR, it's pre-existing noise.
+
+## Get logs
+
+```bash
+# Cheapest — failed steps only (works after run completes)
+gh run view <runId> --log-failed 2>&1 | head -200
+
+# Per-job logs — works mid-run, useful when other jobs are still pending
+gh api repos/fission/fission/actions/jobs/<jobId>/logs 2>&1 \
+  | grep -B2 -A8 'FAIL: Test\|error|denied|i/o timeout' | head -60
+
+# Full run log — ONLY if cheaper paths failed; tens of MB
+gh run view <runId> --log
+```
+
+`<jobId>` comes from the `link` field in `gh pr checks` output: `https://github.com/fission/fission/actions/runs/<runId>/job/<jobId>`.
+
+## Download artifacts
+
+```bash
+# List artifacts on a run
+gh api repos/fission/fission/actions/runs/<runId>/artifacts \
+  --jq '.artifacts[] | {name, size_in_bytes}'
+
+# Download by name (prefer this over the URL form)
+rm -rf /tmp/ci-logs && gh run download <runId> \
+  -n go-integration-logs-<runId>-v<k8s-version> -D /tmp/ci-logs
+ls /tmp/ci-logs/
+```
+
+The interesting artifacts on a Fission integration test job:
+- `go-integration-logs-<runId>-v<k8s>` — per-test diag dirs (`testbuildermgr/`, `testkubectlapply/`, etc.) with pod logs and yamls
+- `kind-logs-<runId>-v<k8s>` — node-level kubelet/containerd logs and `fission` namespace pod logs
+- `prom-dump-<runId>-v<k8s>` — Prometheus snapshot
+
+## Find Dependabot alerts
+
+```bash
+# Open alerts summary
+gh api 'repos/fission/fission/dependabot/alerts?state=open&per_page=100' \
+  --jq '.[] | "\(.security_advisory.severity)\t\(.security_advisory.ghsa_id)\t\(.dependency.package.name)\t\(.security_advisory.summary)"'
+
+# With CVE IDs and fix versions
+gh api 'repos/fission/fission/dependabot/alerts?state=open&per_page=100' \
+  --jq '.[] | "\(.security_advisory.severity)\t\(.security_advisory.ghsa_id)\t\(.dependency.package.name)\tfixed_in: \(.security_advisory.vulnerabilities[0].first_patched_version.identifier // "?")"'
+```
+
+Common surprise: alert lists "fixed_in: 2.0.0-beta.8" for `github.com/docker/docker` because the fix is at the new `github.com/moby/moby/v2` import path, not the old one. Bumping `docker/cli` to v29.x usually pulls the fix in transitively and drops `docker/docker` from go.mod.
+
+## PR-level operations
+
+```bash
+# Open a PR
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- ...
+## Test plan
+- [x] ...
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+
+# Inspect a PR's view
+gh pr view <PR> --json number,title,state,mergeable,statusCheckRollup
+```
+
+## Cancelling a run
+
+```bash
+gh run cancel <runId>
+```
+
+Rarely needed — usually it's faster to push a fix and let the new run supersede.
+
+## Repository conventions for this repo
+
+- Workflow file: `.github/workflows/push_pr.yaml` (Fission CI), plus `codeql.yaml`, `dependency-review.yml`, `lint.yaml`, etc.
+- The PR template lives at `.github/PULL_REQUEST_TEMPLATE.md` — Fish doesn't use a `## Test plan` section convention by default; following the template form is preferred for human reviewers but Claude-generated PRs typically still include it for traceability.
+- License Compliance via `app.fossa.com` is configured but is currently red on `main` with "11 issues found" — pre-existing.

--- a/.claude/skills/debug-github-ci/resources/integration-test-framework.md
+++ b/.claude/skills/debug-github-ci/resources/integration-test-framework.md
@@ -1,0 +1,108 @@
+# Go integration-test framework — quirks the bash→Go migration uncovered
+
+The `test/integration/framework/` package was built during the 2026-04/05 bash→Go migration. Across that work the framework was iterated dozens of times to close races and capture gotchas the bash suite had been silently ignoring or working around. This file is the distilled "things that made tests flake" list — read it before assuming a flake is random.
+
+Authoritative reference: `docs/test-migration/02-framework-api.md`. This file is the "what burned us" companion.
+
+## The builder ↔ runtime ↔ Service readiness race (top source of flakes)
+
+Symptom: `dial tcp <svc>:8000: i/o timeout` from buildermgr → fetcher when a test calls `CreatePackage(Src=...)` shortly after `CreateEnv(Builder=...)`. Layered fix shipped over six iterations:
+
+1. **Wait for builder pod Ready** (`WaitForBuilderReady`, by `envName=<env>` label).
+2. **Also wait for runtime pool pod Ready** — buildermgr's POST goes through a Service that round-robins, so even one not-Ready pool pod causes timeouts.
+3. **Wait for ALL pool pods** (`waitForRuntimePoolReady`) — the Service round-robins; one Ready pod isn't enough when the Service points at three.
+4. **Wait for the env Service to publish endpoints** — `Pod.Status.Conditions[Ready]=True` fires before kube-proxy programs iptables. The build POST can land on a stale endpoint.
+5. **Use EndpointSlices via service-name prefix, not Endpoints by name** — the env Service has a port-hash suffix (`<env>-<rv>-<hash>`); listing Endpoints by exact name returns 404. EndpointSlices carry a `kubernetes.io/service-name` label that supports prefix matching.
+6. **Target the *builder* Service, not the runtime pool** — buildermgr POSTs to the Service named `<env>-<env.RV>` (selecting `envName=<env>`), not the runtime pool (which selects `environmentName=<env>`). The earlier "wait for runtime pool" was load-bearing on a misunderstanding; the real race is on the builder Service. Reference: `pkg/buildermgr/common.go:57`.
+7. **5-second settle after EndpointSlice readiness** — even after pod Ready + endpoint published, the fetcher process can take a beat to bind port 8000. K8s 1.28 needed 15s in CI (commit `9bc0c573`).
+8. **Retry on transient build failure** — final safety net. `WaitForPackageBuildSucceeded` retries up to 3× on the known transient signature `dial tcp …:8000: i/o timeout`, resetting `Status.BuildStatus → pending` to re-trigger the buildermgr's UpdateFunc.
+
+Folded into `CreateEnv` automatically when `EnvOptions.Builder` is set, so test authors don't have to think about this — but if a test file *bypasses* `CreateEnv` and directly creates Environments via `f.FissionClient()`, this race is back.
+
+## Test-cadence vs production-cadence (why we didn't fix Fission proper)
+
+In production, builds happen well after env creation: `env create` → user push to repo → CI build kicks off. Kube-proxy has long since propagated. The race is purely a test-cadence artefact (env create → immediate build). Fixing in the framework is correct; "fixing" Fission would just add complexity to a path that doesn't bite real users.
+
+## Pod label conventions — why selectors silently miss
+
+| Pod | Labels | Where set |
+|---|---|---|
+| **Per-env builder pod** (env builder + fetcher sidecar) | `envName=<env>, envNamespace=<ns>, envResourceVersion=<rv>, owner=buildermgr` | `pkg/buildermgr/envwatcher.go` `getLabels()` |
+| **Runtime pool pod** (poolmgr) | `environmentName=<env>, functionName=<fn>, executorType=poolmgr, managed=<bool>, executorInstanceId=<id>, environmentNamespace=<ns>, environmentUid=<uid>` | `pkg/apis/core/v1/const.go` (label keys) |
+| **Newdeploy function pod** | Same as above with `executorType=newdeploy` | same |
+| **Container-executor function pod** | Same with `executorType=container` | same |
+
+Pitfalls:
+- A selector `envName=<env>` matches **builder pods**, NOT runtime pods. Runtime pods carry `environmentName=` (longer key).
+- `WaitForBuilderReady` uses `envName=`. `WaitForRuntimePodReady` uses `environmentName=`. Mixing them up was a recurring bug during migration.
+- For function-specific log reading, use `functionName=<fn>` directly — narrower than env label and exactly the specialised pod. See `ns.FunctionLogs()` in `framework/function.go`.
+
+## `ns.CLI` captures cobra writers, not `os.Stdout`
+
+The in-process Fission CLI sets cobra's `Out`/`Err` to a `bytes.Buffer` that `ns.CLI` returns. But these subcommands print to `os.Stdout` directly:
+
+- `fission function logs` (kubectl-style log streaming)
+- `fission archive list / download / get-url / delete`
+
+For those, use `ns.CLICaptureStdout` (or the cleanup-friendly `CLICaptureStdoutBestEffort`). It takes the process-global `cliMu` write lock to serialize against any concurrent `ns.CLI` call — cross-test `os.Stdout` capture under `t.Parallel()` would race. Don't reach for `os.Stdout` redirection in your test code; it'll race with sibling tests.
+
+For env-var-driven CLI flags (e.g. `FISSION_DEFAULT_NAMESPACE`), use `ns.CLIWithEnv(t, ctx, env, args...)` — same `cliMu` write-lock idea, restoring env on return.
+
+## `embed.FS` skips nested Go modules
+
+Symptom: a file under `test/integration/testdata/<lang>/<feature>/` exists on disk but `WriteTestData(t, "<lang>/<feature>/<file>")` fails with "file does not exist".
+
+Cause: `//go:embed` silently excludes any directory that contains its own `go.mod` — Go treats it as a separate module. `testdata/go/module_example/` had this problem.
+
+Workaround: store as `.txt` on disk, strip the `.txt` suffix when materializing. `TestGoEnv`'s `zipModuleExample` is the reference implementation.
+
+Also: `embed.FS` skips files starting with `_` or `.`. Don't store fixtures under `_internal` or `.hidden` paths.
+
+## Spec tests need `WithCWD`
+
+`fission spec init/apply/destroy` and `env create --spec`, `fn create --spec` write specs to `./specs` relative to `os.Getwd()` — there's no `--specdir` override on `env create` / `fn create` (only on `spec apply`).
+
+The framework helper `ns.WithCWD(t, workdir, func(){ … })` chdirs under a process-global `cwdMu`, runs the closure, restores. Other concurrent tests are unaffected as long as they pass absolute paths to the CLI (every framework helper does — verified during migration).
+
+Also relevant for `fn create --deploy "<glob>"` — globs expand against cwd.
+
+## Vendored spec YAMLs need rewriting per-test
+
+Bash spec tests had hardcoded names like `spec-merge-9f3a` baked into the YAMLs. Multiple parallel Go tests using the same fixture trip over each other. `framework.MaterializeSpecs(t, embedDir, replacements, workdir)` walks the embedded tree, applies a longest-old-string-first replacer, writes to `workdir`.
+
+Pair with `framework.NewSpecUID(t)` for the `DeploymentConfig.uid` field — `spec destroy` selects by uid, so per-test UIDs ensure cleanup only removes that test's resources.
+
+## Package CR has no `/status` subresource yet
+
+`pkg/buildermgr/pkgwatcher.go:259-262` only re-builds when `Package.Status.BuildStatus == "pending"`. Bash side-stepped this by using `kubectl replace`, which round-trips Status. Go clientset `Update()` overwrites Status — so a test that updates `Spec.Source.URL` and expects a rebuild **must explicitly set** `Status.BuildStatus = fv1.BuildStatusPending` along with the spec change.
+
+Once the `/status` subresource lands (long-standing TODO in pkgwatcher.go), generation-based diffing will work and this kludge can drop.
+
+## Cross-namespace lookups
+
+| Resource | Where it gets created | Test must list with |
+|---|---|---|
+| `Ingress` (created by router on HTTPTrigger with `--ingressrule`) | `POD_NAMESPACE` (defaults to `fission`) | `f.KubeClient().NetworkingV1().Ingresses(metav1.NamespaceAll).List(...)` — the label-selector (`functionName + triggerName`) is unique enough that cross-ns matching is safe. |
+
+If a test creates a CR in `default` and expects to see a side-effect resource also in `default`, double-check whether the controller writes it elsewhere. Router's Ingress creation is the only one we hit during migration; others may be similar.
+
+## Test debug checklist (when one fails)
+
+1. **Re-run alone** — `go test -tags=integration -run TestFooBar -v -count=1 ./test/integration/suites/common/...`. If it passes solo and fails in the parallel suite, it's a parallel-load issue (more pods, more contention, more kube-proxy lag).
+2. **Read the diagnostic dump** — `$LOG_DIR/<sanitized-test-name>/` has `events.yaml`, `pods.yaml`, container logs, CR yamls. The pod's `caller":"…"` field in structured logs tells you which Fission binary version is actually running.
+3. **Check `Status.BuildLog`** if a build failed — it's captured in the diag dump's `packages.yaml` AND in the `WaitForPackageBuildSucceeded` failure message.
+4. **Compare to bash counterpart** — `git log -- test/tests/<old-bash-test>.sh` may surface why a particular dance was needed. Many migration commits cite the bash precedent.
+5. **Hop the layered race fixes** — if it's a builder-pod-related test and you see `dial tcp …:8000: i/o timeout`, walk back through the 8 fixes above. Most likely you need a longer settle, not a new mechanism.
+6. **`fission#653` style hangs** — if specialize fails (invalid function code, runtime crash) the router's request never returns headers, so `GetEventually` polls until ctx timeout. Reduce the test to a happy-path assertion until upstream returns a proper error response.
+7. **Skipped under FIXME** — `TestIdleObjectsReaper` is currently skipped. Don't re-enable without addressing the parallel-CI fsvc-TTL refresh issue called out in commit `0fc53807`.
+
+## When the framework needs a new helper
+
+Adding a one-off API call to a test is fine. If the same idiom shows up in 2+ tests, hoist it to `framework/`:
+
+- Add to `framework.go` if cluster-scoped or namespace-creating.
+- Add to `namespace.go` if per-namespace state.
+- Add to a topic-specific file (`builder.go`, `canary.go`, `package.go`, etc.) if it's domain-specific.
+- Update `docs/test-migration/02-framework-api.md` in the same PR — the framework-api doc is the discoverability surface for future tests.
+
+The framework grew **49 helpers** during migration. The pattern that scaled was: introduce when a second test needs it, document in `02-framework-api.md` with the symptom that motivated it, register cleanup automatically. Tests that don't need to think about cleanup are tests that don't leak resources.

--- a/.claude/skills/debug-github-ci/resources/monitor-poll-loop.md
+++ b/.claude/skills/debug-github-ci/resources/monitor-poll-loop.md
@@ -1,0 +1,63 @@
+# Push-fix-monitor loop — the canonical poll script
+
+After pushing a fix, you don't want to busy-poll `gh pr checks` from inside a Bash call (that wastes context and turns). Use the `Monitor` tool with this poll loop so each terminal-state arrives as a notification.
+
+## Standard recipe (copy-paste)
+
+```bash
+prev=""
+while true; do
+  s=$(gh pr checks <PR> --json name,bucket,state 2>/dev/null) || { echo "gh-api-error"; sleep 30; continue; }
+  cur=$(jq -r '.[] | select(.name != null) | select(.bucket != "pending") | "\(.name): \(.bucket)"' <<<"$s" | sort)
+  comm -13 <(echo "$prev") <(echo "$cur")
+  prev=$cur
+  if jq -e 'map(select(.name != null)) | all(.bucket != "pending")' <<<"$s" >/dev/null 2>&1; then
+    echo "DONE: all checks completed"
+    break
+  fi
+  sleep 30
+done
+```
+
+## How to invoke it
+
+```
+Monitor:
+  description: "PR #<N> CI checks — emit each terminal state, exit when all done"
+  timeout_ms: 2400000      # 40 minutes — covers a full integration-test sweep
+  persistent: false        # exits after DONE
+  command: <the script above>
+```
+
+## How it works
+
+- Every 30s, it polls `gh pr checks` for the PR.
+- For each *newly-non-pending* check (compared to last tick), it emits one stdout line — that becomes one notification.
+- When every check has left `pending` state, it prints `DONE` and exits.
+- Output volume is bounded: at most 1 line per check transition + 1 final line.
+
+## Why not `gh pr checks --watch`?
+
+`gh pr checks --watch` is a TTY-oriented refresh — it overwrites the screen. The output isn't structured per-event, so the harness can't break it into per-event notifications. The `comm -13` diff approach above gives one event per check transition, which is what we want.
+
+## Why 30s polling?
+
+GitHub Actions check states update with low latency (sub-second), but `gh pr checks` against the API is rate-limited. 30s is a good middle ground: fast enough that you don't sit idle for long after a job completes, slow enough that 40 minutes of polling = 80 API calls (well under the 5000/hour limit).
+
+## Don't poll yourself in parallel
+
+The system reminders are clear: while a Monitor is armed, **do not** also run `gh pr checks` in foreground Bash calls to "check progress". Notifications will arrive on their own. Polling separately wastes context and can confuse you about stale states.
+
+## When a check goes red mid-loop
+
+The Monitor emits `<name>: fail` as soon as that check transitions. You can keep working in the foreground (e.g. start downloading artifacts for that job), but don't push another fix until the loop completes — sometimes a *different* check is pending that gives more diagnostic info, and you want to see it before deciding what's broken.
+
+If you do need to push a fix mid-loop because the failure is unambiguous (e.g. a typo in the previous push), the existing Monitor will continue running against the old run — push, then re-arm a new Monitor with the same recipe pointing at the new run. The old Monitor will eventually complete (all old checks complete) and then exit cleanly.
+
+## Cancelling a stale Monitor
+
+If you've pushed a fix and want to abandon waiting on the previous run:
+- Use `TaskStop` with the monitor's task ID (visible in earlier notifications), OR
+- Wait for it to time out (default 40 min in the recipe above).
+
+The runs themselves can be cancelled with `gh run cancel <runId>`, but that's rarely needed.

--- a/.claude/skills/debug-github-ci/resources/networkpolicy-debugging.md
+++ b/.claude/skills/debug-github-ci/resources/networkpolicy-debugging.md
@@ -1,0 +1,74 @@
+# NetworkPolicy debugging
+
+When a Fission pod can't reach another Fission service and the symptom is `dial tcp <ip>:<port>: i/o timeout`, the cause is almost always one of these three.
+
+## Quickly check whether NetworkPolicy is the suspect
+
+```bash
+kubectl get networkpolicies -n fission        # which policies are active
+kubectl describe networkpolicy <name> -n fission
+```
+
+If `networkPolicy.enabled=false` in the install (or the policy isn't there at all), this section doesn't apply — debug as a regular Service / DNS / firewall issue.
+
+## Pod labels — the source of truth
+
+A `NetworkPolicy` `from: [{ podSelector: ... }]` rule matches pod labels, **not** Service / Deployment names. The Fission control plane uses different label conventions for *controllers* vs the *worker pods* they create:
+
+| Pod kind | Labels |
+|---|---|
+| `buildermgr` controller (Deployment) | `svc=buildermgr` |
+| `executor` controller (Deployment) | `svc=executor` |
+| `router` controller (Deployment) | `svc=router, application=fission-router` |
+| `storagesvc` (Deployment) | `svc=storagesvc, application=fission-storage` |
+| **Per-env builder pods** (env builder + fetcher sidecar; created by buildermgr per Environment CR) | `owner=buildermgr, envName=<env>, envNamespace=<ns>, envResourceVersion=<rv>` |
+| **Function pods** (created by executor per Function CR) | `executorType=poolmgr|newdeploy|container, functionName=<name>, executorInstanceId=<id>, managed=<true|false>` |
+
+When writing a NetworkPolicy ingress rule that targets the *fetcher sidecar in worker pods*, you need to select on `owner=buildermgr` (env-builder pods) and `executorType in [...]` (function pods) — **not** on `svc=*` (those are the controllers, which don't actually talk to storagesvc directly).
+
+Constants: `pkg/apis/core/v1/const.go` (function-pod labels), `pkg/buildermgr/envwatcher.go` `getLabels()` (env-builder pod labels).
+
+## Cross-namespace selectors are mandatory
+
+Storagesvc lives in the Fission install namespace (`fission`). Env-builder pods and function pods live in user namespaces (`default` for the test framework, plus any namespace the operator deploys functions to).
+
+A `NetworkPolicy` in namespace `fission` with this rule:
+```yaml
+- from:
+    - podSelector:
+        matchLabels:
+          owner: buildermgr
+```
+matches **only pods in namespace `fission`**. Pods in other namespaces are dropped.
+
+To match labelled pods in any namespace, pair `podSelector` with an empty `namespaceSelector`:
+```yaml
+- from:
+    - namespaceSelector: {}
+      podSelector:
+        matchLabels:
+          owner: buildermgr
+```
+
+Symptom of missing this: `dial tcp <storagesvc-ip>:80: i/o timeout` from the fetcher sidecar, even though the pod's labels look correct.
+
+## Reference: storagesvc NetworkPolicy template
+
+`charts/fission-all/templates/networkpolicy.yaml` is the canonical example. It demonstrates:
+- `podSelector` on the *target* pod (storagesvc itself).
+- Three `ingress` rules: env-builder pods (port 8000), function pods (port 8000), Prometheus / metrics scraping (port 8080, no selector — allow from anywhere).
+- Each `from` peer pairs `namespaceSelector: {}` with the right `podSelector`.
+
+## Validation workflow before pushing a NetworkPolicy change
+
+1. `helm lint charts/fission-all` — clean YAML.
+2. `helm template charts/fission-all --set networkPolicy.enabled=true` — render and inspect the resource.
+3. Check that every `from` peer has `namespaceSelector: {}` if the target pod and source pod live in different namespaces.
+4. `kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.metadata.labels}{"\n"}{end}'` on a real cluster (kind-ci) to confirm real pod labels match the selectors. The CI integration test suite is a good proxy for this — failures will show up as `i/o timeout` in fetcher logs.
+
+## Verifying enforcement actually happens
+
+The default kindnet CNI enforces NetworkPolicy from kind v0.27 / k8s 1.30+. On older kind, or on EKS without an addon, `NetworkPolicy` resources are accepted by the API but never enforced. If a policy looks correct on disk but doesn't change behaviour, check the CNI:
+```bash
+kubectl get pods -n kube-system -o name | grep -E 'kindnet|cilium|calico|weave'
+```

--- a/.claude/skills/debug-github-ci/resources/shared-volume-permissions.md
+++ b/.claude/skills/debug-github-ci/resources/shared-volume-permissions.md
@@ -1,0 +1,56 @@
+# Shared-volume (`/packages`) permissions
+
+The env-builder pod is a **two-container pod**:
+- `builder` — the env image (e.g. `python-builder`), typically running as **root** (UID 0).
+- `fetcher` — Fission's sidecar, running as **UID 10001** (Fission pod default per `values.yaml`'s `podSpec.securityContext.runAsUser`).
+
+Both mount `/packages` as a shared `emptyDir` volume. The build script (in `builder`) writes deploy artefacts there; the `fetcher` sidecar reads them back to upload to storagesvc. Cross-container access requires the right modes.
+
+## The trap: `0o750` breaks the v2 builder flow
+
+If parent directories on `/packages` are created with mode `0o750` (`rwxr-x---`), the file owner is root (the builder container's UID) but the fetcher (UID 10001, in a different group) can't traverse them. Symptoms:
+
+```
+"error":"openfdat /packages/<pkg>-<rand>: permission denied"
+"error":"failed to get source directory info: stat /packages/<pkg>-<rand>: no such file or directory"
+"error":"no files found for globs: [/packages/<pkg>-<rand>/*]"
+```
+
+(The third one happens when the fetcher *can* stat the dir — because the parent above it was world-readable — but can't list its contents.)
+
+The fix: `/packages`-rooted directories must be world-readable, i.e. mode `0o755` (`rwxr-xr-x`) for dirs, default-mode (`0o644` after umask) for files. The build script's output files inherit umask from the builder process, so they're fine; only the *directory* mode matters for traversal.
+
+## Where this is enforced
+
+| File | What it does | Required mode |
+|---|---|---|
+| `pkg/utils/zip.go` `Unarchive` | Creates parent directories during package extraction (`os.MkdirAll(filepath.Dir(destPath), os.ModeDir|<mode>)`) | `0o755` |
+| `pkg/builder/builder.go` | The build script's `cp -r ${SRC_PKG} ${DEPLOY_PKG}` preserves perms via busybox cp on Alpine; if SRC was `0o755` then DEPLOY is too. So `Unarchive`'s mode flows through. | (inherits from upstream) |
+
+If you're tightening file modes elsewhere (CLI dump output, log directories, etc.), it's safe — those don't go through `/packages` and don't need cross-container access. The `0o600` / `0o700` modes used in `pkg/fission-cli/cmd/support/dump.go`, `pkg/fission-cli/cmd/package/util/util.go`, and `pkg/fission-cli/cmd/support/resources/resource.go` are all on the user's local filesystem, not the cluster shared volume.
+
+## How to verify before pushing
+
+```bash
+go test -race -count=1 ./pkg/utils/... ./pkg/storagesvc/...
+```
+The unit tests catch obvious regressions but **don't catch the cross-container case** (single-process tests can't simulate UID separation). The integration test suite is what catches it. The smoking-gun symptom in CI is `permission denied` on `openfdat` — search fetcher logs:
+
+```bash
+grep -E 'permission denied|openfdat|EACCES' /tmp/ci-logs/test*/logs-*-fetcher.log | head
+```
+
+## Why we can't just run both containers as the same UID
+
+Two reasons:
+1. The env-builder images are pre-built on GHCR by upstream maintainers; many of them (e.g. `python-builder`) are designed to install dependencies system-wide as root. Forcing them to non-root would break a lot of existing user environments.
+2. The Fission default `podSpec.securityContext` runs control-plane pods as UID 10001 to limit blast radius of any compromise. Loosening that affects more than just this pod.
+
+So we accept the UID asymmetry and use world-readable dirs on the shared volume.
+
+## When you change a mode in this area
+
+Always check whether the path can be reached by the fetcher sidecar. Quick decision tree:
+- Path is on `/packages/...`? → must be `0o755` for dirs.
+- Path is on the user's local filesystem (CLI tooling)? → tightening to `0o700`/`0o600` is fine.
+- Path is on a log volume read by something like fluent-bit on the host? → `0o755` to allow node-level log shipping.

--- a/.claude/skills/debug-github-ci/resources/skaffold-kind-ci-profile.md
+++ b/.claude/skills/debug-github-ci/resources/skaffold-kind-ci-profile.md
@@ -1,0 +1,83 @@
+# Adding a CI-only Helm flag via the `kind-ci` skaffold profile
+
+Some Helm-chart features are off by default for users (backwards compat, sane defaults) but should be **on** in CI to exercise the code path. The pattern in this repo is to flip them via the `kind-ci` skaffold profile.
+
+## When to use this pattern
+
+Examples that already use it:
+- `canaryDeployment.enabled: true`
+- `podMonitor.enabled: true` / `serviceMonitor.enabled: true`
+- `grafana.dashboards.enabled: true`
+- `prometheus.serviceEndpoint: <ci value>`
+- `storagesvc.archivePruner.interval: 1` (faster GC for tests)
+- `networkPolicy.enabled: true` (added 2026-05)
+
+Use it when:
+- The feature has a default-off Helm value users opt into.
+- Skipping it in CI means a code path is never exercised, allowing regressions.
+- Enabling it doesn't break the test framework (verify locally first).
+
+## Two-step pattern (skaffold uses JSONPatch, which requires `add` for missing keys)
+
+### Step 1 — Declare the value with its default in the base `setValues` block
+
+`skaffold.yaml` has a top-level `manifests.helm.releases[0].setValues` map. Every Helm value the profiles can patch must already exist here, with its **chart-default** value:
+
+```yaml
+manifests:
+  helm:
+    releases:
+      - chartPath: charts/fission-all
+        name: fission
+        namespace: fission
+        setValues:
+          ...
+          networkPolicy.enabled: "false"   # <- step 1: add with default
+          ...
+```
+
+Why: skaffold uses JSONPatch internally for profile patches. JSONPatch `replace` requires the path to exist; `add` would also work but `replace` matches the convention already in this file. By declaring with the default, `replace` semantics match.
+
+If you skip step 1 and try `replace` on a non-existent key, skaffold render fails with `path does not exist` — not always with a friendly error message.
+
+### Step 2 — Add a `replace` patch in the `kind-ci` profile
+
+```yaml
+profiles:
+  - name: kind-ci
+    patches:
+      ...existing patches...
+      - op: replace
+        path: /manifests/helm/releases/0/setValues/networkPolicy.enabled
+        value: true
+```
+
+Some notes:
+- `value: true` is parsed as a YAML boolean, then JSONPatch'd into the string-keyed map. Helm's `--set` accepts both, so this works.
+- The path uses dots inside the key segment (`networkPolicy.enabled`) because that's how the base map is keyed — JSONPatch path syntax allows this when the map keys themselves contain dots.
+
+### Step 3 — Verify the render
+
+```bash
+helm lint charts/fission-all
+helm template charts/fission-all --set networkPolicy.enabled=true \
+  | sed -n '/^kind: NetworkPolicy/,/^---/p' | head -50
+helm template charts/fission-all --set networkPolicy.enabled=false \
+  | grep -c 'kind: NetworkPolicy'   # should print 0
+```
+
+For a stronger check (validates skaffold's full pipeline, not just helm):
+```bash
+skaffold render --profile=kind-ci 2>&1 | grep -E 'kind: NetworkPolicy|networkPolicy'
+```
+This requires `skaffold` installed locally; CI will catch problems too if you skip it.
+
+## Don't forget to also expose the value to chart users
+
+If the feature should be tunable for users (and not just turned on in CI), add the same value to `charts/fission-all/values.yaml` with a comment explaining what it does and the default. The `kind-ci` patch then just overrides that user-visible default for CI.
+
+If the feature is purely an internal CI knob (no user-facing surface), skip the `values.yaml` entry — the skaffold patch is enough.
+
+## Mirror-check: `kind-ci-old` profile
+
+The repo also has a `kind-ci-old` profile that mirrors `kind-ci` for testing against older Fission releases. If you add a value that should be tested across both, mirror the patch there too. If it's specific to a behaviour only in current `main` (e.g. a NetworkPolicy template that doesn't exist in older charts), `kind-ci` only is correct.


### PR DESCRIPTION
## Summary

A new Claude Code skill at `.claude/skills/debug-github-ci/` that captures the patterns and pitfalls learned across debugging Fission CI failures. Mirrors the structure of the existing `.claude/skills/go-deps-security-upgrade` skill that's already on `main`.

## Why

We've burned significant time during recent security-fix and CI-investigation sessions on the same recurring failure modes:

- NetworkPolicy selectors that don't match real worker-pod labels (controller labels vs. pod labels).
- NetworkPolicy missing `namespaceSelector: {}` for cross-namespace flows (`fission` ↔ user namespaces).
- `/packages` shared-volume permissions breaking when tightened to `0o750` (env-builder pod runs containers under different UIDs).
- The non-obvious fact that env-builder images (`python-builder`, `node-builder-22`, etc.) are pre-built on GHCR and NOT rebuilt per-PR — so changes to `pkg/builder/builder.go` don't surface in integration tests.
- The push-fix-monitor cycle for waiting on CI without burning context.
- Pre-existing CI noise (FOSSA "License Compliance", Docker-required local tests) that shouldn't be chased.

## Structure (modular per request)

`SKILL.md` (169 lines) is the orchestrator — phases 0-4 of a CI debug session, with pattern-symptom tables for fast triage. It points to per-domain resource files for deeper dives:

```
.claude/skills/debug-github-ci/
├── SKILL.md
└── resources/
    ├── networkpolicy-debugging.md      # NP selectors, cross-NS, pod labels
    ├── build-pipeline-flow.md          # buildermgr → builder → fetcher → storagesvc
    ├── shared-volume-permissions.md    # /packages UID/GID model
    ├── skaffold-kind-ci-profile.md     # CI-only Helm flag pattern
    ├── builder-image-origin.md         # env-builder images aren't rebuilt per-PR
    ├── monitor-poll-loop.md            # gh pr checks poll loop
    └── gh-commands-cheatsheet.md       # all gh CLI invocations used
```

The model loads SKILL.md by default and reads resources/ files only when a phase decision points there. This keeps the on-load cost small and lets each domain stay deep without bloating the orchestrator.

## Trigger phrases (auto-discovery)

The skill's `description` field includes triggers so Claude auto-invokes it: "CI failed on PR #X", "investigate the failed checks", "why are integration tests red", "the pipeline is broken on my branch", "did CI pass after the push".

## Test plan

- [x] Files committed in the right project-level location (`.claude/skills/`) following the existing `go-deps-security-upgrade` precedent.
- [x] SKILL.md frontmatter validates (name + description present).
- [x] Skill auto-detected by Claude Code on save (visible in this session's available-skills list).
- [ ] Manual smoke test: invoke on a hypothetical CI failure scenario in a future session and verify the right resource file gets loaded for the right symptom.

Adopting this skill is a no-op for any non-Claude-Code workflow — it's purely tooling/documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3363)
<!-- Reviewable:end -->
