### PR TITLE
Drop secret materialization and allowlist PodSpec fields in MessageQueueTrigger

### DIFF
--- a/pkg/executor/util/merge_allowlist.go
+++ b/pkg/executor/util/merge_allowlist.go
@@ -44,8 +44,6 @@ func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []stri
 		return out, nil, nil
 	}
 
-	var dropped []string
-
 	// --- Allowlisted merges ---
 
 	if len(user.NodeSelector) > 0 {
@@ -80,44 +78,69 @@ func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []stri
 		}
 	}
 
-	// --- Audit drops ---
+	return out, DisallowedPodSpecFields(user), nil
+}
 
-	for i := range user.Containers {
-		c := user.Containers[i]
+// DisallowedPodSpecFields returns the deduplicated list of PodSpec field
+// names that appear in `ps` but are NOT on the
+// MessageQueueTrigger.Spec.PodSpec allowlist. This is the single source of
+// truth shared by the controller-side merge in MergeAllowedPodSpecFields
+// and the admission webhook in pkg/webhook/messagequeuetrigger.go — extend
+// this function (and only this function) when changing the allowlist.
+//
+// The returned names use the executor-internal form (no "podSpec." prefix);
+// callers that surface the names in user-facing errors should prepend their
+// own prefix.
+func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
+	if ps == nil {
+		return nil
+	}
+
+	seen := make(map[string]struct{})
+	var bad []string
+	add := func(name string) {
+		if _, ok := seen[name]; ok {
+			return
+		}
+		seen[name] = struct{}{}
+		bad = append(bad, name)
+	}
+
+	for i := range ps.Containers {
+		c := ps.Containers[i]
 		if c.Image != "" {
-			dropped = append(dropped, "containers[].image")
+			add("containers[].image")
 		}
 		if len(c.Command) > 0 {
-			dropped = append(dropped, "containers[].command")
+			add("containers[].command")
 		}
 		if len(c.Args) > 0 {
-			dropped = append(dropped, "containers[].args")
+			add("containers[].args")
 		}
 		if len(c.Env) > 0 {
-			dropped = append(dropped, "containers[].env")
+			add("containers[].env")
 		}
 		if len(c.VolumeMounts) > 0 {
-			dropped = append(dropped, "containers[].volumeMounts")
+			add("containers[].volumeMounts")
 		}
 	}
-	if len(user.Volumes) > 0 {
-		dropped = append(dropped, "volumes")
+	if len(ps.Volumes) > 0 {
+		add("volumes")
 	}
-	if user.ServiceAccountName != "" {
-		dropped = append(dropped, "serviceAccountName")
+	if ps.ServiceAccountName != "" {
+		add("serviceAccountName")
 	}
-	if user.HostNetwork {
-		dropped = append(dropped, "hostNetwork")
+	if ps.HostNetwork {
+		add("hostNetwork")
 	}
-	if user.HostPID {
-		dropped = append(dropped, "hostPID")
+	if ps.HostPID {
+		add("hostPID")
 	}
-	if user.HostIPC {
-		dropped = append(dropped, "hostIPC")
+	if ps.HostIPC {
+		add("hostIPC")
 	}
-	if user.SecurityContext != nil && user.SecurityContext.RunAsUser != nil {
-		dropped = append(dropped, "securityContext.runAsUser")
+	if ps.SecurityContext != nil && ps.SecurityContext.RunAsUser != nil {
+		add("securityContext.runAsUser")
 	}
-
-	return out, dropped, nil
+	return bad
 }

--- a/pkg/executor/util/merge_allowlist.go
+++ b/pkg/executor/util/merge_allowlist.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// MergeAllowedPodSpecFields overlays a small allowlist of fields from `user`
+// onto a deep copy of `src`. Fields not on the allowlist are silently
+// ignored, with the dropped field names returned for caller-side audit
+// logging. The returned PodSpec is always a fresh deep copy; `src` is not
+// mutated.
+//
+// Allowed: NodeSelector, Tolerations, Affinity, RuntimeClassName, plus
+// Containers[i].Resources for containers with a name match.
+//
+// All other user-supplied fields — notably Containers[].Image,
+// Containers[].Command, Containers[].Args, Containers[].Env,
+// Containers[].VolumeMounts, Volumes, ServiceAccountName,
+// HostNetwork, HostPID, HostIPC, and SecurityContext.RunAsUser — are
+// dropped. This is the controller-side defence for GHSA-7m8x-qg2j-4m3v;
+// the validating webhook rejects the same fields at admission time.
+func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []string, error) {
+	if src == nil {
+		return nil, nil, nil
+	}
+	out := src.DeepCopy()
+	if user == nil {
+		return out, nil, nil
+	}
+
+	var dropped []string
+
+	// --- Allowlisted merges ---
+
+	if len(user.NodeSelector) > 0 {
+		if out.NodeSelector == nil {
+			out.NodeSelector = make(map[string]string, len(user.NodeSelector))
+		}
+		for k, v := range user.NodeSelector {
+			out.NodeSelector[k] = v
+		}
+	}
+	if len(user.Tolerations) > 0 {
+		out.Tolerations = append(out.Tolerations, user.Tolerations...)
+	}
+	if user.Affinity != nil {
+		out.Affinity = user.Affinity.DeepCopy()
+	}
+	if user.RuntimeClassName != nil {
+		rc := *user.RuntimeClassName
+		out.RuntimeClassName = &rc
+	}
+
+	// Per-container Resources merge (name-matched only).
+	for i := range out.Containers {
+		for j := range user.Containers {
+			if user.Containers[j].Name != out.Containers[i].Name {
+				continue
+			}
+			if len(user.Containers[j].Resources.Limits) > 0 ||
+				len(user.Containers[j].Resources.Requests) > 0 {
+				out.Containers[i].Resources = *user.Containers[j].Resources.DeepCopy()
+			}
+		}
+	}
+
+	// --- Audit drops ---
+
+	for i := range user.Containers {
+		c := user.Containers[i]
+		if c.Image != "" {
+			dropped = append(dropped, "containers[].image")
+		}
+		if len(c.Command) > 0 {
+			dropped = append(dropped, "containers[].command")
+		}
+		if len(c.Args) > 0 {
+			dropped = append(dropped, "containers[].args")
+		}
+		if len(c.Env) > 0 {
+			dropped = append(dropped, "containers[].env")
+		}
+		if len(c.VolumeMounts) > 0 {
+			dropped = append(dropped, "containers[].volumeMounts")
+		}
+	}
+	if len(user.Volumes) > 0 {
+		dropped = append(dropped, "volumes")
+	}
+	if user.ServiceAccountName != "" {
+		dropped = append(dropped, "serviceAccountName")
+	}
+	if user.HostNetwork {
+		dropped = append(dropped, "hostNetwork")
+	}
+	if user.HostPID {
+		dropped = append(dropped, "hostPID")
+	}
+	if user.HostIPC {
+		dropped = append(dropped, "hostIPC")
+	}
+	if user.SecurityContext != nil && user.SecurityContext.RunAsUser != nil {
+		dropped = append(dropped, "securityContext.runAsUser")
+	}
+
+	return out, dropped, nil
+}

--- a/pkg/executor/util/merge_allowlist.go
+++ b/pkg/executor/util/merge_allowlist.go
@@ -21,20 +21,30 @@ import (
 )
 
 // MergeAllowedPodSpecFields overlays a small allowlist of fields from `user`
-// onto a deep copy of `src`. Fields not on the allowlist are silently
-// ignored, with the dropped field names returned for caller-side audit
-// logging. The returned PodSpec is always a fresh deep copy; `src` is not
-// mutated.
+// onto a deep copy of `src`. The merge uses allowlist semantics: only the
+// fields explicitly listed below are ever copied from `user` to the result.
+// Every other PodSpec field present in `user` is silently dropped, regardless
+// of whether DisallowedPodSpecFields enumerates it. The returned PodSpec is
+// always a fresh deep copy; `src` is not mutated.
 //
-// Allowed: NodeSelector, Tolerations, Affinity, RuntimeClassName, plus
-// Containers[i].Resources for containers with a name match.
+// Allowed (everything else is dropped):
+//   - NodeSelector
+//   - Tolerations
+//   - Affinity
+//   - RuntimeClassName
+//   - Containers[i].Resources, when the container name matches a
+//     controller-built container
 //
-// All other user-supplied fields — notably Containers[].Image,
-// Containers[].Command, Containers[].Args, Containers[].Env,
-// Containers[].VolumeMounts, Volumes, ServiceAccountName,
-// HostNetwork, HostPID, HostIPC, and SecurityContext.RunAsUser — are
-// dropped. This is the controller-side defence for GHSA-7m8x-qg2j-4m3v;
-// the validating webhook rejects the same fields at admission time.
+// The slice of dropped field names returned alongside the merged spec is
+// produced by DisallowedPodSpecFields for caller-side audit logging. That
+// helper enumerates the high-impact subset of disallowed fields so the
+// admission webhook can fail loudly on them; lower-impact fields (e.g.
+// Hostname, Subdomain, EnableServiceLinks) are still dropped by the merge
+// but not surfaced.
+//
+// This is the controller-side defence for GHSA-7m8x-qg2j-4m3v; the
+// validating webhook in pkg/webhook/messagequeuetrigger.go rejects the same
+// disallowed fields at admission time.
 func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []string) {
 	if src == nil {
 		return nil, nil
@@ -81,16 +91,24 @@ func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []stri
 	return out, DisallowedPodSpecFields(user)
 }
 
-// DisallowedPodSpecFields returns the deduplicated list of PodSpec field
-// names that appear in `ps` but are NOT on the
+// DisallowedPodSpecFields returns the deduplicated list of high-impact
+// PodSpec field names that appear in `ps` but are NOT on the
 // MessageQueueTrigger.Spec.PodSpec allowlist. This is the single source of
 // truth shared by the controller-side merge in MergeAllowedPodSpecFields
 // and the admission webhook in pkg/webhook/messagequeuetrigger.go — extend
-// this function (and only this function) when changing the allowlist.
+// this function (and only this function) when changing what the webhook
+// rejects.
 //
-// The returned names use the executor-internal form (no "podSpec." prefix);
-// callers that surface the names in user-facing errors should prepend their
-// own prefix.
+// Note that the merge helper applies allowlist semantics independently of
+// this enumeration: any user-supplied PodSpec field not in the merge
+// helper's allowlist is silently dropped at controller time, even if not
+// listed below. This function exists to surface the most security-relevant
+// disallowed fields at admission time so users get a clear error rather
+// than silent field loss.
+//
+// The returned names use the JSON form without a leading "spec.podspec."
+// prefix; callers that surface the names in user-facing errors should
+// prepend their own prefix.
 func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 	if ps == nil {
 		return nil
@@ -106,6 +124,65 @@ func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 		bad = append(bad, name)
 	}
 
+	// Pod-level fields. Each of these is a credible attack surface for a
+	// caller that can create MessageQueueTriggers but would not normally
+	// have permission to create the underlying Kubernetes objects.
+	if len(ps.Volumes) > 0 {
+		add("volumes")
+	}
+	if len(ps.InitContainers) > 0 {
+		add("initContainers")
+	}
+	if len(ps.EphemeralContainers) > 0 {
+		add("ephemeralContainers")
+	}
+	if ps.ServiceAccountName != "" {
+		add("serviceAccountName")
+	}
+	if ps.AutomountServiceAccountToken != nil {
+		add("automountServiceAccountToken")
+	}
+	if ps.NodeName != "" {
+		add("nodeName")
+	}
+	if ps.HostNetwork {
+		add("hostNetwork")
+	}
+	if ps.HostPID {
+		add("hostPID")
+	}
+	if ps.HostIPC {
+		add("hostIPC")
+	}
+	if ps.ShareProcessNamespace != nil {
+		add("shareProcessNamespace")
+	}
+	if ps.SecurityContext != nil {
+		add("securityContext")
+	}
+	if len(ps.ImagePullSecrets) > 0 {
+		add("imagePullSecrets")
+	}
+	if ps.SchedulerName != "" {
+		add("schedulerName")
+	}
+	if len(ps.HostAliases) > 0 {
+		add("hostAliases")
+	}
+	if ps.PriorityClassName != "" {
+		add("priorityClassName")
+	}
+	if ps.DNSConfig != nil {
+		add("dnsConfig")
+	}
+	if len(ps.TopologySpreadConstraints) > 0 {
+		add("topologySpreadConstraints")
+	}
+
+	// Container-level fields. Within a container the only allowlisted
+	// fields are Name (used for the per-container Resources match) and
+	// Resources itself. Everything else flagged here would let a caller
+	// run arbitrary code or exfiltrate data through the connector pod.
 	for i := range ps.Containers {
 		c := ps.Containers[i]
 		if c.Image != "" {
@@ -120,27 +197,36 @@ func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 		if len(c.Env) > 0 {
 			add("containers[].env")
 		}
+		if len(c.EnvFrom) > 0 {
+			add("containers[].envFrom")
+		}
 		if len(c.VolumeMounts) > 0 {
 			add("containers[].volumeMounts")
 		}
-	}
-	if len(ps.Volumes) > 0 {
-		add("volumes")
-	}
-	if ps.ServiceAccountName != "" {
-		add("serviceAccountName")
-	}
-	if ps.HostNetwork {
-		add("hostNetwork")
-	}
-	if ps.HostPID {
-		add("hostPID")
-	}
-	if ps.HostIPC {
-		add("hostIPC")
-	}
-	if ps.SecurityContext != nil && ps.SecurityContext.RunAsUser != nil {
-		add("securityContext.runAsUser")
+		if len(c.VolumeDevices) > 0 {
+			add("containers[].volumeDevices")
+		}
+		if len(c.Ports) > 0 {
+			add("containers[].ports")
+		}
+		if c.WorkingDir != "" {
+			add("containers[].workingDir")
+		}
+		if c.Lifecycle != nil {
+			add("containers[].lifecycle")
+		}
+		if c.LivenessProbe != nil {
+			add("containers[].livenessProbe")
+		}
+		if c.ReadinessProbe != nil {
+			add("containers[].readinessProbe")
+		}
+		if c.StartupProbe != nil {
+			add("containers[].startupProbe")
+		}
+		if c.SecurityContext != nil {
+			add("containers[].securityContext")
+		}
 	}
 	return bad
 }

--- a/pkg/executor/util/merge_allowlist.go
+++ b/pkg/executor/util/merge_allowlist.go
@@ -37,10 +37,9 @@ import (
 //
 // The slice of dropped field names returned alongside the merged spec is
 // produced by DisallowedPodSpecFields for caller-side audit logging. That
-// helper enumerates the high-impact subset of disallowed fields so the
-// admission webhook can fail loudly on them; lower-impact fields (e.g.
-// Hostname, Subdomain, EnableServiceLinks) are still dropped by the merge
-// but not surfaced.
+// helper enumerates every populated PodSpec field that is not on the
+// allowlist above, so admission errors and audit logs cover the same
+// surface the merge helper silently drops.
 //
 // This is the controller-side defence for GHSA-7m8x-qg2j-4m3v; the
 // validating webhook in pkg/webhook/messagequeuetrigger.go rejects the same
@@ -91,20 +90,19 @@ func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []stri
 	return out, DisallowedPodSpecFields(user)
 }
 
-// DisallowedPodSpecFields returns the deduplicated list of high-impact
-// PodSpec field names that appear in `ps` but are NOT on the
-// MessageQueueTrigger.Spec.PodSpec allowlist. This is the single source of
-// truth shared by the controller-side merge in MergeAllowedPodSpecFields
-// and the admission webhook in pkg/webhook/messagequeuetrigger.go — extend
-// this function (and only this function) when changing what the webhook
-// rejects.
+// DisallowedPodSpecFields returns the deduplicated list of populated
+// PodSpec field names in `ps` that are NOT on the
+// MessageQueueTrigger.Spec.PodSpec allowlist. The pod-level allowlist is
+// NodeSelector, Tolerations, Affinity, and RuntimeClassName; the
+// per-container allowlist is Name (metadata, used for the per-container
+// Resources match) and Resources itself. Every other settable field is
+// reported here so the admission webhook can fail loudly on the same
+// surface that MergeAllowedPodSpecFields would otherwise silently drop.
 //
-// Note that the merge helper applies allowlist semantics independently of
-// this enumeration: any user-supplied PodSpec field not in the merge
-// helper's allowlist is silently dropped at controller time, even if not
-// listed below. This function exists to surface the most security-relevant
-// disallowed fields at admission time so users get a clear error rather
-// than silent field loss.
+// This is the single source of truth shared by the controller-side merge
+// in MergeAllowedPodSpecFields and the admission webhook in
+// pkg/webhook/messagequeuetrigger.go — extend this function (and only
+// this function) when changing what the webhook rejects.
 //
 // The returned names use the JSON form without a leading "spec.podspec."
 // prefix; callers that surface the names in user-facing errors should
@@ -124,9 +122,10 @@ func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 		bad = append(bad, name)
 	}
 
-	// Pod-level fields. Each of these is a credible attack surface for a
-	// caller that can create MessageQueueTriggers but would not normally
-	// have permission to create the underlying Kubernetes objects.
+	// Pod-level fields. Enumerate every populated PodSpec field other than
+	// the pod-level allowlist (NodeSelector, Tolerations, Affinity,
+	// RuntimeClassName) so that admission errors match what the merge helper
+	// would silently drop.
 	if len(ps.Volumes) > 0 {
 		add("volumes")
 	}
@@ -135,6 +134,18 @@ func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 	}
 	if len(ps.EphemeralContainers) > 0 {
 		add("ephemeralContainers")
+	}
+	if ps.RestartPolicy != "" {
+		add("restartPolicy")
+	}
+	if ps.TerminationGracePeriodSeconds != nil {
+		add("terminationGracePeriodSeconds")
+	}
+	if ps.ActiveDeadlineSeconds != nil {
+		add("activeDeadlineSeconds")
+	}
+	if ps.DNSPolicy != "" {
+		add("dnsPolicy")
 	}
 	if ps.ServiceAccountName != "" {
 		add("serviceAccountName")
@@ -163,6 +174,12 @@ func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 	if len(ps.ImagePullSecrets) > 0 {
 		add("imagePullSecrets")
 	}
+	if ps.Hostname != "" {
+		add("hostname")
+	}
+	if ps.Subdomain != "" {
+		add("subdomain")
+	}
 	if ps.SchedulerName != "" {
 		add("schedulerName")
 	}
@@ -172,11 +189,41 @@ func DisallowedPodSpecFields(ps *apiv1.PodSpec) []string {
 	if ps.PriorityClassName != "" {
 		add("priorityClassName")
 	}
+	if ps.Priority != nil {
+		add("priority")
+	}
 	if ps.DNSConfig != nil {
 		add("dnsConfig")
 	}
+	if len(ps.ReadinessGates) > 0 {
+		add("readinessGates")
+	}
+	if ps.EnableServiceLinks != nil {
+		add("enableServiceLinks")
+	}
+	if ps.PreemptionPolicy != nil {
+		add("preemptionPolicy")
+	}
+	if len(ps.Overhead) > 0 {
+		add("overhead")
+	}
 	if len(ps.TopologySpreadConstraints) > 0 {
 		add("topologySpreadConstraints")
+	}
+	if ps.SetHostnameAsFQDN != nil {
+		add("setHostnameAsFQDN")
+	}
+	if ps.OS != nil {
+		add("os")
+	}
+	if ps.HostUsers != nil {
+		add("hostUsers")
+	}
+	if len(ps.SchedulingGates) > 0 {
+		add("schedulingGates")
+	}
+	if len(ps.ResourceClaims) > 0 {
+		add("resourceClaims")
 	}
 
 	// Container-level fields. Within a container the only allowlisted

--- a/pkg/executor/util/merge_allowlist.go
+++ b/pkg/executor/util/merge_allowlist.go
@@ -35,13 +35,13 @@ import (
 // HostNetwork, HostPID, HostIPC, and SecurityContext.RunAsUser — are
 // dropped. This is the controller-side defence for GHSA-7m8x-qg2j-4m3v;
 // the validating webhook rejects the same fields at admission time.
-func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []string, error) {
+func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []string) {
 	if src == nil {
-		return nil, nil, nil
+		return nil, nil
 	}
 	out := src.DeepCopy()
 	if user == nil {
-		return out, nil, nil
+		return out, nil
 	}
 
 	// --- Allowlisted merges ---
@@ -78,7 +78,7 @@ func MergeAllowedPodSpecFields(src, user *apiv1.PodSpec) (*apiv1.PodSpec, []stri
 		}
 	}
 
-	return out, DisallowedPodSpecFields(user), nil
+	return out, DisallowedPodSpecFields(user)
 }
 
 // DisallowedPodSpecFields returns the deduplicated list of PodSpec field

--- a/pkg/executor/util/merge_allowlist_test.go
+++ b/pkg/executor/util/merge_allowlist_test.go
@@ -109,6 +109,13 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 	runAsUser := int64(0)
 	automount := true
 	share := true
+	gracePeriod := int64(60)
+	deadline := int64(120)
+	priority := int32(1000)
+	enableLinks := true
+	preempt := apiv1.PreemptNever
+	fqdn := true
+	hostUsers := false
 	user := &apiv1.PodSpec{
 		Containers: []apiv1.Container{{
 			Name:            "connector",
@@ -126,22 +133,38 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 			StartupProbe:    &apiv1.Probe{},
 			SecurityContext: &apiv1.SecurityContext{RunAsUser: &runAsUser},
 		}},
-		InitContainers:               []apiv1.Container{{Name: "init", Image: "evil:latest"}},
-		Volumes:                      []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/"}}}},
-		ImagePullSecrets:             []apiv1.LocalObjectReference{{Name: "creds"}},
-		ServiceAccountName:           "cluster-admin",
-		AutomountServiceAccountToken: &automount,
-		NodeName:                     "evil-node",
-		HostNetwork:                  true,
-		HostPID:                      true,
-		HostIPC:                      true,
-		ShareProcessNamespace:        &share,
-		SecurityContext:              &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
-		SchedulerName:                "evil-scheduler",
-		HostAliases:                  []apiv1.HostAlias{{IP: "1.2.3.4", Hostnames: []string{"evil"}}},
-		PriorityClassName:            "high",
-		DNSConfig:                    &apiv1.PodDNSConfig{},
-		TopologySpreadConstraints:    []apiv1.TopologySpreadConstraint{{}},
+		InitContainers:                []apiv1.Container{{Name: "init", Image: "evil:latest"}},
+		Volumes:                       []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/"}}}},
+		ImagePullSecrets:              []apiv1.LocalObjectReference{{Name: "creds"}},
+		ServiceAccountName:            "cluster-admin",
+		AutomountServiceAccountToken:  &automount,
+		NodeName:                      "evil-node",
+		HostNetwork:                   true,
+		HostPID:                       true,
+		HostIPC:                       true,
+		ShareProcessNamespace:         &share,
+		SecurityContext:               &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+		SchedulerName:                 "evil-scheduler",
+		HostAliases:                   []apiv1.HostAlias{{IP: "1.2.3.4", Hostnames: []string{"evil"}}},
+		PriorityClassName:             "high",
+		DNSConfig:                     &apiv1.PodDNSConfig{},
+		TopologySpreadConstraints:     []apiv1.TopologySpreadConstraint{{}},
+		RestartPolicy:                 apiv1.RestartPolicyNever,
+		TerminationGracePeriodSeconds: &gracePeriod,
+		ActiveDeadlineSeconds:         &deadline,
+		DNSPolicy:                     apiv1.DNSClusterFirst,
+		Hostname:                      "evil-host",
+		Subdomain:                     "evil",
+		Priority:                      &priority,
+		ReadinessGates:                []apiv1.PodReadinessGate{{ConditionType: "evil"}},
+		EnableServiceLinks:            &enableLinks,
+		PreemptionPolicy:              &preempt,
+		Overhead:                      apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("10m")},
+		SetHostnameAsFQDN:             &fqdn,
+		OS:                            &apiv1.PodOS{Name: apiv1.Linux},
+		HostUsers:                     &hostUsers,
+		SchedulingGates:               []apiv1.PodSchedulingGate{{Name: "evil"}},
+		ResourceClaims:                []apiv1.PodResourceClaim{{Name: "evil"}},
 	}
 	out, dropped := MergeAllowedPodSpecFields(src, user)
 
@@ -175,6 +198,22 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 	assert.Empty(t, out.PriorityClassName)
 	assert.Nil(t, out.DNSConfig)
 	assert.Empty(t, out.TopologySpreadConstraints)
+	assert.Empty(t, out.RestartPolicy)
+	assert.Nil(t, out.TerminationGracePeriodSeconds)
+	assert.Nil(t, out.ActiveDeadlineSeconds)
+	assert.Empty(t, out.DNSPolicy)
+	assert.Empty(t, out.Hostname)
+	assert.Empty(t, out.Subdomain)
+	assert.Nil(t, out.Priority)
+	assert.Empty(t, out.ReadinessGates)
+	assert.Nil(t, out.EnableServiceLinks)
+	assert.Nil(t, out.PreemptionPolicy)
+	assert.Empty(t, out.Overhead)
+	assert.Nil(t, out.SetHostnameAsFQDN)
+	assert.Nil(t, out.OS)
+	assert.Nil(t, out.HostUsers)
+	assert.Empty(t, out.SchedulingGates)
+	assert.Empty(t, out.ResourceClaims)
 
 	for _, want := range []string{
 		"containers[].image",
@@ -206,6 +245,22 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 		"priorityClassName",
 		"dnsConfig",
 		"topologySpreadConstraints",
+		"restartPolicy",
+		"terminationGracePeriodSeconds",
+		"activeDeadlineSeconds",
+		"dnsPolicy",
+		"hostname",
+		"subdomain",
+		"priority",
+		"readinessGates",
+		"enableServiceLinks",
+		"preemptionPolicy",
+		"overhead",
+		"setHostnameAsFQDN",
+		"os",
+		"hostUsers",
+		"schedulingGates",
+		"resourceClaims",
 	} {
 		assert.Contains(t, dropped, want, "expected %q to be reported as dropped", want)
 	}
@@ -237,6 +292,13 @@ func TestDisallowedPodSpecFieldsAllPresent(t *testing.T) {
 	runAsUser := int64(0)
 	automount := true
 	share := true
+	gracePeriod := int64(60)
+	deadline := int64(120)
+	priority := int32(1000)
+	enableLinks := true
+	preempt := apiv1.PreemptNever
+	fqdn := true
+	hostUsers := false
 	ps := &apiv1.PodSpec{
 		Containers: []apiv1.Container{{
 			Name:            "connector",
@@ -254,22 +316,38 @@ func TestDisallowedPodSpecFieldsAllPresent(t *testing.T) {
 			StartupProbe:    &apiv1.Probe{},
 			SecurityContext: &apiv1.SecurityContext{RunAsUser: &runAsUser},
 		}},
-		InitContainers:               []apiv1.Container{{Name: "init", Image: "evil:latest"}},
-		Volumes:                      []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/"}}}},
-		ImagePullSecrets:             []apiv1.LocalObjectReference{{Name: "creds"}},
-		ServiceAccountName:           "cluster-admin",
-		AutomountServiceAccountToken: &automount,
-		NodeName:                     "evil-node",
-		HostNetwork:                  true,
-		HostPID:                      true,
-		HostIPC:                      true,
-		ShareProcessNamespace:        &share,
-		SecurityContext:              &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
-		SchedulerName:                "evil-scheduler",
-		HostAliases:                  []apiv1.HostAlias{{IP: "1.2.3.4", Hostnames: []string{"evil"}}},
-		PriorityClassName:            "high",
-		DNSConfig:                    &apiv1.PodDNSConfig{},
-		TopologySpreadConstraints:    []apiv1.TopologySpreadConstraint{{}},
+		InitContainers:                []apiv1.Container{{Name: "init", Image: "evil:latest"}},
+		Volumes:                       []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/"}}}},
+		ImagePullSecrets:              []apiv1.LocalObjectReference{{Name: "creds"}},
+		ServiceAccountName:            "cluster-admin",
+		AutomountServiceAccountToken:  &automount,
+		NodeName:                      "evil-node",
+		HostNetwork:                   true,
+		HostPID:                       true,
+		HostIPC:                       true,
+		ShareProcessNamespace:         &share,
+		SecurityContext:               &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+		SchedulerName:                 "evil-scheduler",
+		HostAliases:                   []apiv1.HostAlias{{IP: "1.2.3.4", Hostnames: []string{"evil"}}},
+		PriorityClassName:             "high",
+		DNSConfig:                     &apiv1.PodDNSConfig{},
+		TopologySpreadConstraints:     []apiv1.TopologySpreadConstraint{{}},
+		RestartPolicy:                 apiv1.RestartPolicyNever,
+		TerminationGracePeriodSeconds: &gracePeriod,
+		ActiveDeadlineSeconds:         &deadline,
+		DNSPolicy:                     apiv1.DNSClusterFirst,
+		Hostname:                      "evil-host",
+		Subdomain:                     "evil",
+		Priority:                      &priority,
+		ReadinessGates:                []apiv1.PodReadinessGate{{ConditionType: "evil"}},
+		EnableServiceLinks:            &enableLinks,
+		PreemptionPolicy:              &preempt,
+		Overhead:                      apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("10m")},
+		SetHostnameAsFQDN:             &fqdn,
+		OS:                            &apiv1.PodOS{Name: apiv1.Linux},
+		HostUsers:                     &hostUsers,
+		SchedulingGates:               []apiv1.PodSchedulingGate{{Name: "evil"}},
+		ResourceClaims:                []apiv1.PodResourceClaim{{Name: "evil"}},
 	}
 
 	bad := DisallowedPodSpecFields(ps)
@@ -304,6 +382,22 @@ func TestDisallowedPodSpecFieldsAllPresent(t *testing.T) {
 		"priorityClassName",
 		"dnsConfig",
 		"topologySpreadConstraints",
+		"restartPolicy",
+		"terminationGracePeriodSeconds",
+		"activeDeadlineSeconds",
+		"dnsPolicy",
+		"hostname",
+		"subdomain",
+		"priority",
+		"readinessGates",
+		"enableServiceLinks",
+		"preemptionPolicy",
+		"overhead",
+		"setHostnameAsFQDN",
+		"os",
+		"hostUsers",
+		"schedulingGates",
+		"resourceClaims",
 	} {
 		assert.Contains(t, bad, want, "expected %q to be reported as disallowed", want)
 	}

--- a/pkg/executor/util/merge_allowlist_test.go
+++ b/pkg/executor/util/merge_allowlist_test.go
@@ -185,3 +185,83 @@ func TestMergeAllowedPodSpecFieldsDoesNotMutateSrc(t *testing.T) {
 	// src must remain unchanged so the caller can re-use it across reconciles.
 	assert.Equal(t, map[string]string{"existing": "label"}, src.NodeSelector)
 }
+
+func TestDisallowedPodSpecFieldsAllPresent(t *testing.T) {
+	runAsUser := int64(0)
+	ps := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{
+			Name:         "connector",
+			Image:        "evil:latest",
+			Command:      []string{"/bin/sh"},
+			Args:         []string{"-c", "curl evil"},
+			Env:          []apiv1.EnvVar{{Name: "INJECTED", Value: "yes"}},
+			VolumeMounts: []apiv1.VolumeMount{{Name: "host", MountPath: "/host"}},
+		}},
+		Volumes: []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{
+			HostPath: &apiv1.HostPathVolumeSource{Path: "/"},
+		}}},
+		ServiceAccountName: "cluster-admin",
+		HostNetwork:        true,
+		HostPID:            true,
+		HostIPC:            true,
+		SecurityContext:    &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+	}
+
+	bad := DisallowedPodSpecFields(ps)
+
+	for _, want := range []string{
+		"containers[].image",
+		"containers[].command",
+		"containers[].args",
+		"containers[].env",
+		"containers[].volumeMounts",
+		"volumes",
+		"serviceAccountName",
+		"hostNetwork",
+		"hostPID",
+		"hostIPC",
+		"securityContext.runAsUser",
+	} {
+		assert.Contains(t, bad, want, "expected %q to be reported as disallowed", want)
+	}
+}
+
+func TestDisallowedPodSpecFieldsOnlyAllowed(t *testing.T) {
+	rc := "kata"
+	ps := &apiv1.PodSpec{
+		Containers:       []apiv1.Container{{Name: "connector"}},
+		NodeSelector:     map[string]string{"role": "mqt"},
+		Tolerations:      []apiv1.Toleration{{Key: "dedicated"}},
+		Affinity:         &apiv1.Affinity{},
+		RuntimeClassName: &rc,
+	}
+	assert.Empty(t, DisallowedPodSpecFields(ps),
+		"PodSpec containing only allowlisted fields must report no disallowed entries")
+}
+
+func TestDisallowedPodSpecFieldsDedupAcrossContainers(t *testing.T) {
+	// Two containers each set Image — the helper must report
+	// "containers[].image" once, not twice.
+	ps := &apiv1.PodSpec{
+		Containers: []apiv1.Container{
+			{Name: "c1", Image: "a:1", Command: []string{"sh"}},
+			{Name: "c2", Image: "b:2", Command: []string{"bash"}},
+		},
+	}
+
+	bad := DisallowedPodSpecFields(ps)
+
+	// Each disallowed field name must appear exactly once.
+	counts := map[string]int{}
+	for _, name := range bad {
+		counts[name]++
+	}
+	assert.Equal(t, 1, counts["containers[].image"],
+		"image violation must be deduped across containers, got %v", bad)
+	assert.Equal(t, 1, counts["containers[].command"],
+		"command violation must be deduped across containers, got %v", bad)
+}
+
+func TestDisallowedPodSpecFieldsNil(t *testing.T) {
+	assert.Nil(t, DisallowedPodSpecFields(nil))
+}

--- a/pkg/executor/util/merge_allowlist_test.go
+++ b/pkg/executor/util/merge_allowlist_test.go
@@ -34,8 +34,7 @@ func TestMergeAllowedPodSpecFieldsDropsImageOverride(t *testing.T) {
 		NodeSelector: map[string]string{"role": "mqt"},
 	}
 
-	out, dropped, err := MergeAllowedPodSpecFields(src, user)
-	require.NoError(t, err)
+	out, dropped := MergeAllowedPodSpecFields(src, user)
 
 	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image,
 		"user-supplied container image must NOT override controller-set image")
@@ -51,8 +50,7 @@ func TestMergeAllowedPodSpecFieldsAcceptsTolerations(t *testing.T) {
 	user := &apiv1.PodSpec{
 		Tolerations: []apiv1.Toleration{{Key: "dedicated", Operator: apiv1.TolerationOpEqual, Value: "mqt"}},
 	}
-	out, dropped, err := MergeAllowedPodSpecFields(src, user)
-	require.NoError(t, err)
+	out, dropped := MergeAllowedPodSpecFields(src, user)
 	require.Len(t, out.Tolerations, 1)
 	assert.Empty(t, dropped, "tolerations are allowlisted and must not be reported as dropped")
 }
@@ -77,8 +75,7 @@ func TestMergeAllowedPodSpecFieldsAcceptsAffinityAndRuntimeClass(t *testing.T) {
 		Affinity:         aff,
 		RuntimeClassName: &rc,
 	}
-	out, _, err := MergeAllowedPodSpecFields(src, user)
-	require.NoError(t, err)
+	out, _ := MergeAllowedPodSpecFields(src, user)
 	require.NotNil(t, out.Affinity)
 	require.NotNil(t, out.RuntimeClassName)
 	assert.Equal(t, "kata", *out.RuntimeClassName)
@@ -97,8 +94,7 @@ func TestMergeAllowedPodSpecFieldsAppliesContainerResources(t *testing.T) {
 			},
 		}},
 	}
-	out, dropped, err := MergeAllowedPodSpecFields(src, user)
-	require.NoError(t, err)
+	out, dropped := MergeAllowedPodSpecFields(src, user)
 	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image,
 		"image must remain controller-set after Resources merge")
 	assert.Equal(t, resource.MustParse("100m"), out.Containers[0].Resources.Requests[apiv1.ResourceCPU])
@@ -129,8 +125,7 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 		HostIPC:            true,
 		SecurityContext:    &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
 	}
-	out, dropped, err := MergeAllowedPodSpecFields(src, user)
-	require.NoError(t, err)
+	out, dropped := MergeAllowedPodSpecFields(src, user)
 
 	// Output must look identical to src (modulo nil vs empty).
 	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image)
@@ -166,8 +161,7 @@ func TestMergeAllowedPodSpecFieldsNilUser(t *testing.T) {
 	src := &apiv1.PodSpec{
 		Containers: []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
 	}
-	out, dropped, err := MergeAllowedPodSpecFields(src, nil)
-	require.NoError(t, err)
+	out, dropped := MergeAllowedPodSpecFields(src, nil)
 	assert.Empty(t, dropped)
 	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image)
 }
@@ -180,8 +174,7 @@ func TestMergeAllowedPodSpecFieldsDoesNotMutateSrc(t *testing.T) {
 	user := &apiv1.PodSpec{
 		NodeSelector: map[string]string{"new": "label"},
 	}
-	_, _, err := MergeAllowedPodSpecFields(src, user)
-	require.NoError(t, err)
+	_, _ = MergeAllowedPodSpecFields(src, user)
 	// src must remain unchanged so the caller can re-use it across reconciles.
 	assert.Equal(t, map[string]string{"existing": "label"}, src.NodeSelector)
 }

--- a/pkg/executor/util/merge_allowlist_test.go
+++ b/pkg/executor/util/merge_allowlist_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestMergeAllowedPodSpecFieldsDropsImageOverride(t *testing.T) {
+	src := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
+	}
+	user := &apiv1.PodSpec{
+		Containers:   []apiv1.Container{{Name: "connector", Image: "evil/registry:latest"}},
+		NodeSelector: map[string]string{"role": "mqt"},
+	}
+
+	out, dropped, err := MergeAllowedPodSpecFields(src, user)
+	require.NoError(t, err)
+
+	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image,
+		"user-supplied container image must NOT override controller-set image")
+	assert.Equal(t, map[string]string{"role": "mqt"}, out.NodeSelector,
+		"node selector must flow through")
+	assert.Contains(t, dropped, "containers[].image", "image override must be reported as dropped")
+}
+
+func TestMergeAllowedPodSpecFieldsAcceptsTolerations(t *testing.T) {
+	src := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector"}},
+	}
+	user := &apiv1.PodSpec{
+		Tolerations: []apiv1.Toleration{{Key: "dedicated", Operator: apiv1.TolerationOpEqual, Value: "mqt"}},
+	}
+	out, dropped, err := MergeAllowedPodSpecFields(src, user)
+	require.NoError(t, err)
+	require.Len(t, out.Tolerations, 1)
+	assert.Empty(t, dropped, "tolerations are allowlisted and must not be reported as dropped")
+}
+
+func TestMergeAllowedPodSpecFieldsAcceptsAffinityAndRuntimeClass(t *testing.T) {
+	src := &apiv1.PodSpec{Containers: []apiv1.Container{{Name: "connector"}}}
+	rc := "kata"
+	aff := &apiv1.Affinity{
+		NodeAffinity: &apiv1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &apiv1.NodeSelector{
+				NodeSelectorTerms: []apiv1.NodeSelectorTerm{{
+					MatchExpressions: []apiv1.NodeSelectorRequirement{{
+						Key:      "topology.kubernetes.io/zone",
+						Operator: apiv1.NodeSelectorOpIn,
+						Values:   []string{"us-east-1a"},
+					}},
+				}},
+			},
+		},
+	}
+	user := &apiv1.PodSpec{
+		Affinity:         aff,
+		RuntimeClassName: &rc,
+	}
+	out, _, err := MergeAllowedPodSpecFields(src, user)
+	require.NoError(t, err)
+	require.NotNil(t, out.Affinity)
+	require.NotNil(t, out.RuntimeClassName)
+	assert.Equal(t, "kata", *out.RuntimeClassName)
+}
+
+func TestMergeAllowedPodSpecFieldsAppliesContainerResources(t *testing.T) {
+	src := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
+	}
+	user := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{
+			Name: "connector",
+			Resources: apiv1.ResourceRequirements{
+				Requests: apiv1.ResourceList{apiv1.ResourceCPU: resource.MustParse("100m")},
+				Limits:   apiv1.ResourceList{apiv1.ResourceMemory: resource.MustParse("128Mi")},
+			},
+		}},
+	}
+	out, dropped, err := MergeAllowedPodSpecFields(src, user)
+	require.NoError(t, err)
+	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image,
+		"image must remain controller-set after Resources merge")
+	assert.Equal(t, resource.MustParse("100m"), out.Containers[0].Resources.Requests[apiv1.ResourceCPU])
+	assert.Equal(t, resource.MustParse("128Mi"), out.Containers[0].Resources.Limits[apiv1.ResourceMemory])
+	assert.Empty(t, dropped, "name-matched Resources must not be reported as dropped")
+}
+
+func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
+	src := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
+	}
+	runAsUser := int64(0)
+	user := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{
+			Name:         "connector",
+			Image:        "evil:latest",
+			Command:      []string{"/bin/sh"},
+			Args:         []string{"-c", "curl evil"},
+			Env:          []apiv1.EnvVar{{Name: "INJECTED", Value: "yes"}},
+			VolumeMounts: []apiv1.VolumeMount{{Name: "host", MountPath: "/host"}},
+		}},
+		Volumes: []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{
+			HostPath: &apiv1.HostPathVolumeSource{Path: "/"},
+		}}},
+		ServiceAccountName: "cluster-admin",
+		HostNetwork:        true,
+		HostPID:            true,
+		HostIPC:            true,
+		SecurityContext:    &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+	}
+	out, dropped, err := MergeAllowedPodSpecFields(src, user)
+	require.NoError(t, err)
+
+	// Output must look identical to src (modulo nil vs empty).
+	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image)
+	assert.Empty(t, out.Containers[0].Command)
+	assert.Empty(t, out.Containers[0].Args)
+	assert.Empty(t, out.Containers[0].Env)
+	assert.Empty(t, out.Containers[0].VolumeMounts)
+	assert.Empty(t, out.Volumes)
+	assert.Empty(t, out.ServiceAccountName)
+	assert.False(t, out.HostNetwork)
+	assert.False(t, out.HostPID)
+	assert.False(t, out.HostIPC)
+	assert.Nil(t, out.SecurityContext)
+
+	for _, want := range []string{
+		"containers[].image",
+		"containers[].command",
+		"containers[].args",
+		"containers[].env",
+		"containers[].volumeMounts",
+		"volumes",
+		"serviceAccountName",
+		"hostNetwork",
+		"hostPID",
+		"hostIPC",
+		"securityContext.runAsUser",
+	} {
+		assert.Contains(t, dropped, want, "expected %q to be reported as dropped", want)
+	}
+}
+
+func TestMergeAllowedPodSpecFieldsNilUser(t *testing.T) {
+	src := &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
+	}
+	out, dropped, err := MergeAllowedPodSpecFields(src, nil)
+	require.NoError(t, err)
+	assert.Empty(t, dropped)
+	assert.Equal(t, "fission/keda-kafka:1.0", out.Containers[0].Image)
+}
+
+func TestMergeAllowedPodSpecFieldsDoesNotMutateSrc(t *testing.T) {
+	src := &apiv1.PodSpec{
+		Containers:   []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
+		NodeSelector: map[string]string{"existing": "label"},
+	}
+	user := &apiv1.PodSpec{
+		NodeSelector: map[string]string{"new": "label"},
+	}
+	_, _, err := MergeAllowedPodSpecFields(src, user)
+	require.NoError(t, err)
+	// src must remain unchanged so the caller can re-use it across reconciles.
+	assert.Equal(t, map[string]string{"existing": "label"}, src.NodeSelector)
+}

--- a/pkg/executor/util/merge_allowlist_test.go
+++ b/pkg/executor/util/merge_allowlist_test.go
@@ -107,23 +107,41 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 		Containers: []apiv1.Container{{Name: "connector", Image: "fission/keda-kafka:1.0"}},
 	}
 	runAsUser := int64(0)
+	automount := true
+	share := true
 	user := &apiv1.PodSpec{
 		Containers: []apiv1.Container{{
-			Name:         "connector",
-			Image:        "evil:latest",
-			Command:      []string{"/bin/sh"},
-			Args:         []string{"-c", "curl evil"},
-			Env:          []apiv1.EnvVar{{Name: "INJECTED", Value: "yes"}},
-			VolumeMounts: []apiv1.VolumeMount{{Name: "host", MountPath: "/host"}},
+			Name:            "connector",
+			Image:           "evil:latest",
+			Command:         []string{"/bin/sh"},
+			Args:            []string{"-c", "curl evil"},
+			Env:             []apiv1.EnvVar{{Name: "INJECTED", Value: "yes"}},
+			EnvFrom:         []apiv1.EnvFromSource{{SecretRef: &apiv1.SecretEnvSource{LocalObjectReference: apiv1.LocalObjectReference{Name: "any-secret"}}}},
+			VolumeMounts:    []apiv1.VolumeMount{{Name: "host", MountPath: "/host"}},
+			Ports:           []apiv1.ContainerPort{{ContainerPort: 1234}},
+			WorkingDir:      "/evil",
+			Lifecycle:       &apiv1.Lifecycle{},
+			LivenessProbe:   &apiv1.Probe{},
+			ReadinessProbe:  &apiv1.Probe{},
+			StartupProbe:    &apiv1.Probe{},
+			SecurityContext: &apiv1.SecurityContext{RunAsUser: &runAsUser},
 		}},
-		Volumes: []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{
-			HostPath: &apiv1.HostPathVolumeSource{Path: "/"},
-		}}},
-		ServiceAccountName: "cluster-admin",
-		HostNetwork:        true,
-		HostPID:            true,
-		HostIPC:            true,
-		SecurityContext:    &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+		InitContainers:               []apiv1.Container{{Name: "init", Image: "evil:latest"}},
+		Volumes:                      []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/"}}}},
+		ImagePullSecrets:             []apiv1.LocalObjectReference{{Name: "creds"}},
+		ServiceAccountName:           "cluster-admin",
+		AutomountServiceAccountToken: &automount,
+		NodeName:                     "evil-node",
+		HostNetwork:                  true,
+		HostPID:                      true,
+		HostIPC:                      true,
+		ShareProcessNamespace:        &share,
+		SecurityContext:              &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+		SchedulerName:                "evil-scheduler",
+		HostAliases:                  []apiv1.HostAlias{{IP: "1.2.3.4", Hostnames: []string{"evil"}}},
+		PriorityClassName:            "high",
+		DNSConfig:                    &apiv1.PodDNSConfig{},
+		TopologySpreadConstraints:    []apiv1.TopologySpreadConstraint{{}},
 	}
 	out, dropped := MergeAllowedPodSpecFields(src, user)
 
@@ -132,26 +150,62 @@ func TestMergeAllowedPodSpecFieldsDropsDangerousFields(t *testing.T) {
 	assert.Empty(t, out.Containers[0].Command)
 	assert.Empty(t, out.Containers[0].Args)
 	assert.Empty(t, out.Containers[0].Env)
+	assert.Empty(t, out.Containers[0].EnvFrom)
 	assert.Empty(t, out.Containers[0].VolumeMounts)
+	assert.Empty(t, out.Containers[0].Ports)
+	assert.Empty(t, out.Containers[0].WorkingDir)
+	assert.Nil(t, out.Containers[0].Lifecycle)
+	assert.Nil(t, out.Containers[0].LivenessProbe)
+	assert.Nil(t, out.Containers[0].ReadinessProbe)
+	assert.Nil(t, out.Containers[0].StartupProbe)
+	assert.Nil(t, out.Containers[0].SecurityContext)
+	assert.Empty(t, out.InitContainers)
 	assert.Empty(t, out.Volumes)
+	assert.Empty(t, out.ImagePullSecrets)
 	assert.Empty(t, out.ServiceAccountName)
+	assert.Nil(t, out.AutomountServiceAccountToken)
+	assert.Empty(t, out.NodeName)
 	assert.False(t, out.HostNetwork)
 	assert.False(t, out.HostPID)
 	assert.False(t, out.HostIPC)
+	assert.Nil(t, out.ShareProcessNamespace)
 	assert.Nil(t, out.SecurityContext)
+	assert.Empty(t, out.SchedulerName)
+	assert.Empty(t, out.HostAliases)
+	assert.Empty(t, out.PriorityClassName)
+	assert.Nil(t, out.DNSConfig)
+	assert.Empty(t, out.TopologySpreadConstraints)
 
 	for _, want := range []string{
 		"containers[].image",
 		"containers[].command",
 		"containers[].args",
 		"containers[].env",
+		"containers[].envFrom",
 		"containers[].volumeMounts",
+		"containers[].ports",
+		"containers[].workingDir",
+		"containers[].lifecycle",
+		"containers[].livenessProbe",
+		"containers[].readinessProbe",
+		"containers[].startupProbe",
+		"containers[].securityContext",
+		"initContainers",
 		"volumes",
+		"imagePullSecrets",
 		"serviceAccountName",
+		"automountServiceAccountToken",
+		"nodeName",
 		"hostNetwork",
 		"hostPID",
 		"hostIPC",
-		"securityContext.runAsUser",
+		"shareProcessNamespace",
+		"securityContext",
+		"schedulerName",
+		"hostAliases",
+		"priorityClassName",
+		"dnsConfig",
+		"topologySpreadConstraints",
 	} {
 		assert.Contains(t, dropped, want, "expected %q to be reported as dropped", want)
 	}
@@ -181,23 +235,41 @@ func TestMergeAllowedPodSpecFieldsDoesNotMutateSrc(t *testing.T) {
 
 func TestDisallowedPodSpecFieldsAllPresent(t *testing.T) {
 	runAsUser := int64(0)
+	automount := true
+	share := true
 	ps := &apiv1.PodSpec{
 		Containers: []apiv1.Container{{
-			Name:         "connector",
-			Image:        "evil:latest",
-			Command:      []string{"/bin/sh"},
-			Args:         []string{"-c", "curl evil"},
-			Env:          []apiv1.EnvVar{{Name: "INJECTED", Value: "yes"}},
-			VolumeMounts: []apiv1.VolumeMount{{Name: "host", MountPath: "/host"}},
+			Name:            "connector",
+			Image:           "evil:latest",
+			Command:         []string{"/bin/sh"},
+			Args:            []string{"-c", "curl evil"},
+			Env:             []apiv1.EnvVar{{Name: "INJECTED", Value: "yes"}},
+			EnvFrom:         []apiv1.EnvFromSource{{SecretRef: &apiv1.SecretEnvSource{LocalObjectReference: apiv1.LocalObjectReference{Name: "any-secret"}}}},
+			VolumeMounts:    []apiv1.VolumeMount{{Name: "host", MountPath: "/host"}},
+			Ports:           []apiv1.ContainerPort{{ContainerPort: 1234}},
+			WorkingDir:      "/evil",
+			Lifecycle:       &apiv1.Lifecycle{},
+			LivenessProbe:   &apiv1.Probe{},
+			ReadinessProbe:  &apiv1.Probe{},
+			StartupProbe:    &apiv1.Probe{},
+			SecurityContext: &apiv1.SecurityContext{RunAsUser: &runAsUser},
 		}},
-		Volumes: []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{
-			HostPath: &apiv1.HostPathVolumeSource{Path: "/"},
-		}}},
-		ServiceAccountName: "cluster-admin",
-		HostNetwork:        true,
-		HostPID:            true,
-		HostIPC:            true,
-		SecurityContext:    &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+		InitContainers:               []apiv1.Container{{Name: "init", Image: "evil:latest"}},
+		Volumes:                      []apiv1.Volume{{Name: "host", VolumeSource: apiv1.VolumeSource{HostPath: &apiv1.HostPathVolumeSource{Path: "/"}}}},
+		ImagePullSecrets:             []apiv1.LocalObjectReference{{Name: "creds"}},
+		ServiceAccountName:           "cluster-admin",
+		AutomountServiceAccountToken: &automount,
+		NodeName:                     "evil-node",
+		HostNetwork:                  true,
+		HostPID:                      true,
+		HostIPC:                      true,
+		ShareProcessNamespace:        &share,
+		SecurityContext:              &apiv1.PodSecurityContext{RunAsUser: &runAsUser},
+		SchedulerName:                "evil-scheduler",
+		HostAliases:                  []apiv1.HostAlias{{IP: "1.2.3.4", Hostnames: []string{"evil"}}},
+		PriorityClassName:            "high",
+		DNSConfig:                    &apiv1.PodDNSConfig{},
+		TopologySpreadConstraints:    []apiv1.TopologySpreadConstraint{{}},
 	}
 
 	bad := DisallowedPodSpecFields(ps)
@@ -207,13 +279,31 @@ func TestDisallowedPodSpecFieldsAllPresent(t *testing.T) {
 		"containers[].command",
 		"containers[].args",
 		"containers[].env",
+		"containers[].envFrom",
 		"containers[].volumeMounts",
+		"containers[].ports",
+		"containers[].workingDir",
+		"containers[].lifecycle",
+		"containers[].livenessProbe",
+		"containers[].readinessProbe",
+		"containers[].startupProbe",
+		"containers[].securityContext",
+		"initContainers",
 		"volumes",
+		"imagePullSecrets",
 		"serviceAccountName",
+		"automountServiceAccountToken",
+		"nodeName",
 		"hostNetwork",
 		"hostPID",
 		"hostIPC",
-		"securityContext.runAsUser",
+		"shareProcessNamespace",
+		"securityContext",
+		"schedulerName",
+		"hostAliases",
+		"priorityClassName",
+		"dnsConfig",
+		"topologySpreadConstraints",
 	} {
 		assert.Contains(t, bad, want, "expected %q to be reported as disallowed", want)
 	}

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -83,7 +83,7 @@ func mqTriggerEventHandlers(ctx context.Context, logger logr.Logger, kubeClient 
 					}
 				}
 
-				if err := updateDeployment(ctx, mqt, routerURL, kubeClient); err != nil {
+				if err := updateDeployment(ctx, logger, mqt, routerURL, kubeClient); err != nil {
 					logger.Error(err, "Failed to Update Deployment")
 					return
 				}
@@ -307,7 +307,7 @@ func createKedaObjects(ctx context.Context, logger logr.Logger, kedaClient kedaC
 		}
 	}
 
-	if err := createDeployment(ctx, mqt, routerURL, kubeClient); err != nil {
+	if err := createDeployment(ctx, logger, mqt, routerURL, kubeClient); err != nil {
 		logger.Error(err, "Failed to create Deployment")
 		if len(authenticationRef) > 0 {
 			err = deleteAuthTrigger(ctx, kedaClient, authenticationRef, mqt.Namespace)
@@ -411,7 +411,7 @@ func deleteAuthTrigger(ctx context.Context, client kedaClient.Interface, name, n
 	return err
 }
 
-func getDeploymentSpec(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerURL string, kubeClient kubernetes.Interface) (*appsv1.Deployment, error) {
+func getDeploymentSpec(ctx context.Context, logger logr.Logger, mqt *fv1.MessageQueueTrigger, routerURL string, kubeClient kubernetes.Interface) (*appsv1.Deployment, error) {
 	envVars, err := getEnvVarlist(ctx, mqt, routerURL, kubeClient)
 	if err != nil {
 		return nil, err
@@ -430,10 +430,20 @@ func getDeploymentSpec(ctx context.Context, mqt *fv1.MessageQueueTrigger, router
 			},
 		},
 	}
-	podSpec, err = util.MergePodSpec(podSpec, mqt.Spec.PodSpec)
+	// SECURITY: only an allowlist of PodSpec fields from the user-supplied
+	// mqt.Spec.PodSpec is honoured. Image/Command/Args/Env/Volumes/etc. are
+	// dropped here; the validating webhook rejects them at admission time
+	// so a normally-configured cluster never reaches this branch with bad
+	// input. See GHSA-7m8x-qg2j-4m3v.
+	mergedSpec, dropped, err := util.MergeAllowedPodSpecFields(podSpec, mqt.Spec.PodSpec)
 	if err != nil {
 		return nil, err
 	}
+	if len(dropped) > 0 {
+		logger.Info("dropped disallowed PodSpec fields from MessageQueueTrigger",
+			"trigger", mqt.Name, "namespace", mqt.Namespace, "dropped", dropped)
+	}
+	podSpec = mergedSpec
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -461,8 +471,8 @@ func getDeploymentSpec(ctx context.Context, mqt *fv1.MessageQueueTrigger, router
 	}, nil
 }
 
-func createDeployment(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerURL string, kubeClient kubernetes.Interface) error {
-	deployment, err := getDeploymentSpec(ctx, mqt, routerURL, kubeClient)
+func createDeployment(ctx context.Context, logger logr.Logger, mqt *fv1.MessageQueueTrigger, routerURL string, kubeClient kubernetes.Interface) error {
+	deployment, err := getDeploymentSpec(ctx, logger, mqt, routerURL, kubeClient)
 	if err != nil {
 		return err
 	}
@@ -470,8 +480,8 @@ func createDeployment(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerU
 	return err
 }
 
-func updateDeployment(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerURL string, kubeClient kubernetes.Interface) error {
-	deployment, err := getDeploymentSpec(ctx, mqt, routerURL, kubeClient)
+func updateDeployment(ctx context.Context, logger logr.Logger, mqt *fv1.MessageQueueTrigger, routerURL string, kubeClient kubernetes.Interface) error {
+	deployment, err := getDeploymentSpec(ctx, logger, mqt, routerURL, kubeClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -435,10 +435,7 @@ func getDeploymentSpec(ctx context.Context, logger logr.Logger, mqt *fv1.Message
 	// dropped here; the validating webhook rejects them at admission time
 	// so a normally-configured cluster never reaches this branch with bad
 	// input. See GHSA-7m8x-qg2j-4m3v.
-	mergedSpec, dropped, err := util.MergeAllowedPodSpecFields(podSpec, mqt.Spec.PodSpec)
-	if err != nil {
-		return nil, err
-	}
+	mergedSpec, dropped := util.MergeAllowedPodSpecFields(podSpec, mqt.Spec.PodSpec)
 	if len(dropped) > 0 {
 		logger.Info("dropped disallowed PodSpec fields from MessageQueueTrigger",
 			"trigger", mqt.Name, "namespace", mqt.Namespace, "dropped", dropped)

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -200,9 +200,10 @@ func getEnvVarlist(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerURL 
 	// Deployment spec. The connector pod resolves the values at start
 	// time via its own ServiceAccount, restoring the Kubernetes-RBAC
 	// boundary on secret reads. The controller still calls Secrets().Get
-	// solely to enumerate the keys it must surface as env vars; the
-	// values are never copied into the controller's address space and
-	// never written into the Deployment object. See GHSA-7m8x-qg2j-4m3v.
+	// to enumerate the keys it must surface as env vars (so the response
+	// body, including secret values, briefly transits controller memory),
+	// but the values are NOT written into the Deployment object and are
+	// NOT logged. See GHSA-7m8x-qg2j-4m3v.
 	secretName := mqt.Spec.Secret
 	if len(secretName) > 0 {
 		secret, err := kubeClient.CoreV1().Secrets(mqt.Namespace).Get(ctx, secretName, metav1.GetOptions{})

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -195,17 +195,29 @@ func getEnvVarlist(ctx context.Context, mqt *fv1.MessageQueueTrigger, routerURL 
 		})
 	}
 
-	// Add Auth Fields
+	// Add Auth Fields. SECURITY: emit secret-derived env vars as
+	// SecretKeyRef rather than materializing literal values into the
+	// Deployment spec. The connector pod resolves the values at start
+	// time via its own ServiceAccount, restoring the Kubernetes-RBAC
+	// boundary on secret reads. The controller still calls Secrets().Get
+	// solely to enumerate the keys it must surface as env vars; the
+	// values are never copied into the controller's address space and
+	// never written into the Deployment object. See GHSA-7m8x-qg2j-4m3v.
 	secretName := mqt.Spec.Secret
 	if len(secretName) > 0 {
 		secret, err := kubeClient.CoreV1().Secrets(mqt.Namespace).Get(ctx, secretName, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
 		}
-		for key, value := range secret.Data {
+		for key := range secret.Data {
 			envVars = append(envVars, apiv1.EnvVar{
-				Name:  toEnvVar(key),
-				Value: string(value),
+				Name: toEnvVar(key),
+				ValueFrom: &apiv1.EnvVarSource{
+					SecretKeyRef: &apiv1.SecretKeySelector{
+						LocalObjectReference: apiv1.LocalObjectReference{Name: secretName},
+						Key:                  key,
+					},
+				},
 			})
 		}
 	}

--- a/pkg/mqtrigger/scalermanager_test.go
+++ b/pkg/mqtrigger/scalermanager_test.go
@@ -77,7 +77,7 @@ func TestGetEnvVarlistDoesNotMaterializeSecretValues(t *testing.T) {
 			assert.Empty(t, ev.Value, "secret-derived env vars must not embed a literal Value")
 			require.NotNil(t, ev.ValueFrom, "ValueFrom must be set for env var %s", ev.Name)
 			require.NotNil(t, ev.ValueFrom.SecretKeyRef, "SecretKeyRef must be set for env var %s", ev.Name)
-			assert.Equal(t, secretName, ev.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
+			assert.Equal(t, secretName, ev.ValueFrom.SecretKeyRef.Name)
 			assert.NotEmpty(t, ev.ValueFrom.SecretKeyRef.Key, "SecretKeyRef.Key must be set")
 		}
 	}

--- a/pkg/mqtrigger/scalermanager_test.go
+++ b/pkg/mqtrigger/scalermanager_test.go
@@ -12,10 +12,80 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
+
+// secretEnv builds an EnvVar that resolves at pod-start time from a Secret key,
+// matching the connector controller's secret-by-reference contract.
+func secretEnv(name, secretName, key string) apiv1.EnvVar {
+	return apiv1.EnvVar{
+		Name: name,
+		ValueFrom: &apiv1.EnvVarSource{
+			SecretKeyRef: &apiv1.SecretKeySelector{
+				LocalObjectReference: apiv1.LocalObjectReference{Name: secretName},
+				Key:                  key,
+			},
+		},
+	}
+}
+
+func TestGetEnvVarlistDoesNotMaterializeSecretValues(t *testing.T) {
+	const ns = "default"
+	const secretName = "kafka-creds"
+
+	pollingInterval := int32(30)
+	cooldownPeriod := int32(300)
+	minReplicaCount := int32(0)
+	maxReplicaCount := int32(100)
+
+	mqt := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: "mqt-1"},
+		Spec: fv1.MessageQueueTriggerSpec{
+			FunctionReference: fv1.FunctionReference{
+				Type: fv1.FunctionReferenceTypeFunctionName,
+				Name: "fn",
+			},
+			MessageQueueType: "kafka",
+			Topic:            "events",
+			PollingInterval:  &pollingInterval,
+			CooldownPeriod:   &cooldownPeriod,
+			MinReplicaCount:  &minReplicaCount,
+			MaxReplicaCount:  &maxReplicaCount,
+			Secret:           secretName,
+			Metadata:         map[string]string{"topic": "events"},
+			MqtKind:          "keda",
+		},
+	}
+	kubeClient := fake.NewClientset(&apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: secretName},
+		Data: map[string][]byte{
+			"saslUsername": []byte("alice"),
+			"saslPassword": []byte("REDACTED"),
+		},
+	})
+
+	env, err := getEnvVarlist(t.Context(), mqt, "http://router.fission.svc/", kubeClient)
+	require.NoError(t, err)
+
+	saw := map[string]string{}
+	for _, ev := range env {
+		if ev.Name == "SASL_USERNAME" || ev.Name == "SASL_PASSWORD" {
+			saw[ev.Name] = ev.Value
+			assert.Empty(t, ev.Value, "secret-derived env vars must not embed a literal Value")
+			require.NotNil(t, ev.ValueFrom, "ValueFrom must be set for env var %s", ev.Name)
+			require.NotNil(t, ev.ValueFrom.SecretKeyRef, "SecretKeyRef must be set for env var %s", ev.Name)
+			assert.Equal(t, secretName, ev.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
+			assert.NotEmpty(t, ev.ValueFrom.SecretKeyRef.Key, "SecretKeyRef.Key must be set")
+		}
+	}
+	_, sawUser := saw["SASL_USERNAME"]
+	_, sawPass := saw["SASL_PASSWORD"]
+	assert.True(t, sawUser, "expected SASL_USERNAME env var to be emitted")
+	assert.True(t, sawPass, "expected SASL_PASSWORD env var to be emitted")
+}
 
 func Test_toEnvVar(t *testing.T) {
 	type args struct {
@@ -144,30 +214,12 @@ func Test_getEnvVarlist(t *testing.T) {
 			Name:  "TOPIC",
 			Value: "topic",
 		},
-		{
-			Name:  "KEY",
-			Value: "test_key",
-		},
-		{
-			Name:  "AUTH_MODE",
-			Value: "sasl_plaintext",
-		},
-		{
-			Name:  "USERNAME",
-			Value: "admin",
-		},
-		{
-			Name:  "PASSWORD",
-			Value: "admin",
-		},
-		{
-			Name:  "CA",
-			Value: "test_ca",
-		},
-		{
-			Name:  "CERT",
-			Value: "test_cert",
-		},
+		secretEnv("KEY", "test-kafka-secrets", "key"),
+		secretEnv("AUTH_MODE", "test-kafka-secrets", "authMode"),
+		secretEnv("USERNAME", "test-kafka-secrets", "username"),
+		secretEnv("PASSWORD", "test-kafka-secrets", "password"),
+		secretEnv("CA", "test-kafka-secrets", "ca"),
+		secretEnv("CERT", "test-kafka-secrets", "cert"),
 	}
 
 	// Kafka Test with Invalid Secret Name

--- a/pkg/webhook/messagequeuetrigger.go
+++ b/pkg/webhook/messagequeuetrigger.go
@@ -17,6 +17,9 @@ limitations under the License.
 package webhook
 
 import (
+	"fmt"
+
+	apiv1 "k8s.io/api/core/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -47,8 +50,68 @@ var _ webhook.CustomDefaulter = &MessageQueueTrigger{}
 var _ webhook.CustomValidator = &MessageQueueTrigger{}
 
 func (r *MessageQueueTrigger) Validate(new *v1.MessageQueueTrigger) error {
+	// SECURITY: reject MessageQueueTrigger.Spec.PodSpec fields that are
+	// not on the controller-side allowlist. Without this admission-time
+	// check a tenant with create/update on MessageQueueTrigger could
+	// otherwise overwrite the connector container's image, command,
+	// args, env, mounts, ServiceAccount, host namespaces, or runAsUser
+	// — see GHSA-7m8x-qg2j-4m3v. The controller still drops these
+	// fields server-side as defence in depth.
+	if new.Spec.PodSpec != nil {
+		if err := validateAllowedPodSpec(new.Spec.PodSpec); err != nil {
+			return err
+		}
+	}
 	if err := new.Validate(); err != nil {
 		return v1.AggregateValidationErrors("MessageQueueTrigger", err)
+	}
+	return nil
+}
+
+// validateAllowedPodSpec rejects user-supplied PodSpec fields that the
+// MessageQueueTrigger connector controller refuses to honour. The set of
+// disallowed fields here MUST stay in lock-step with
+// pkg/executor/util.MergeAllowedPodSpecFields.
+func validateAllowedPodSpec(ps *apiv1.PodSpec) error {
+	var bad []string
+	for _, c := range ps.Containers {
+		if c.Image != "" {
+			bad = append(bad, "podSpec.containers[].image")
+		}
+		if len(c.Command) > 0 {
+			bad = append(bad, "podSpec.containers[].command")
+		}
+		if len(c.Args) > 0 {
+			bad = append(bad, "podSpec.containers[].args")
+		}
+		if len(c.Env) > 0 {
+			bad = append(bad, "podSpec.containers[].env")
+		}
+		if len(c.VolumeMounts) > 0 {
+			bad = append(bad, "podSpec.containers[].volumeMounts")
+		}
+	}
+	if len(ps.Volumes) > 0 {
+		bad = append(bad, "podSpec.volumes")
+	}
+	if ps.ServiceAccountName != "" {
+		bad = append(bad, "podSpec.serviceAccountName")
+	}
+	if ps.HostNetwork {
+		bad = append(bad, "podSpec.hostNetwork")
+	}
+	if ps.HostPID {
+		bad = append(bad, "podSpec.hostPID")
+	}
+	if ps.HostIPC {
+		bad = append(bad, "podSpec.hostIPC")
+	}
+	if ps.SecurityContext != nil && ps.SecurityContext.RunAsUser != nil {
+		bad = append(bad, "podSpec.securityContext.runAsUser")
+	}
+	if len(bad) > 0 {
+		return fmt.Errorf("MessageQueueTrigger.spec.podSpec contains disallowed fields: %v "+
+			"(allowlist: nodeSelector, tolerations, affinity, runtimeClassName, containers[].resources)", bad)
 	}
 	return nil
 }

--- a/pkg/webhook/messagequeuetrigger.go
+++ b/pkg/webhook/messagequeuetrigger.go
@@ -82,8 +82,8 @@ func validateAllowedPodSpec(ps *apiv1.PodSpec) error {
 	}
 	prefixed := make([]string, len(bad))
 	for i, name := range bad {
-		prefixed[i] = "podSpec." + name
+		prefixed[i] = "spec.podspec." + name
 	}
-	return fmt.Errorf("MessageQueueTrigger.spec.podSpec contains disallowed fields: %v "+
+	return fmt.Errorf("MessageQueueTrigger.spec.podspec contains disallowed fields: %v "+
 		"(allowlist: nodeSelector, tolerations, affinity, runtimeClassName, containers[].resources)", prefixed)
 }

--- a/pkg/webhook/messagequeuetrigger.go
+++ b/pkg/webhook/messagequeuetrigger.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	v1 "github.com/fission/fission/pkg/apis/core/v1"
+	executorutil "github.com/fission/fission/pkg/executor/util"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -69,49 +70,20 @@ func (r *MessageQueueTrigger) Validate(new *v1.MessageQueueTrigger) error {
 }
 
 // validateAllowedPodSpec rejects user-supplied PodSpec fields that the
-// MessageQueueTrigger connector controller refuses to honour. The set of
-// disallowed fields here MUST stay in lock-step with
-// pkg/executor/util.MergeAllowedPodSpecFields.
+// MessageQueueTrigger connector controller refuses to honour. The single
+// source of truth for the disallow list is
+// executorutil.DisallowedPodSpecFields — extending the allowlist here
+// (without touching the executor) would silently let admission accept
+// fields that the controller still drops.
 func validateAllowedPodSpec(ps *apiv1.PodSpec) error {
-	var bad []string
-	for _, c := range ps.Containers {
-		if c.Image != "" {
-			bad = append(bad, "podSpec.containers[].image")
-		}
-		if len(c.Command) > 0 {
-			bad = append(bad, "podSpec.containers[].command")
-		}
-		if len(c.Args) > 0 {
-			bad = append(bad, "podSpec.containers[].args")
-		}
-		if len(c.Env) > 0 {
-			bad = append(bad, "podSpec.containers[].env")
-		}
-		if len(c.VolumeMounts) > 0 {
-			bad = append(bad, "podSpec.containers[].volumeMounts")
-		}
+	bad := executorutil.DisallowedPodSpecFields(ps)
+	if len(bad) == 0 {
+		return nil
 	}
-	if len(ps.Volumes) > 0 {
-		bad = append(bad, "podSpec.volumes")
+	prefixed := make([]string, len(bad))
+	for i, name := range bad {
+		prefixed[i] = "podSpec." + name
 	}
-	if ps.ServiceAccountName != "" {
-		bad = append(bad, "podSpec.serviceAccountName")
-	}
-	if ps.HostNetwork {
-		bad = append(bad, "podSpec.hostNetwork")
-	}
-	if ps.HostPID {
-		bad = append(bad, "podSpec.hostPID")
-	}
-	if ps.HostIPC {
-		bad = append(bad, "podSpec.hostIPC")
-	}
-	if ps.SecurityContext != nil && ps.SecurityContext.RunAsUser != nil {
-		bad = append(bad, "podSpec.securityContext.runAsUser")
-	}
-	if len(bad) > 0 {
-		return fmt.Errorf("MessageQueueTrigger.spec.podSpec contains disallowed fields: %v "+
-			"(allowlist: nodeSelector, tolerations, affinity, runtimeClassName, containers[].resources)", bad)
-	}
-	return nil
+	return fmt.Errorf("MessageQueueTrigger.spec.podSpec contains disallowed fields: %v "+
+		"(allowlist: nodeSelector, tolerations, affinity, runtimeClassName, containers[].resources)", prefixed)
 }

--- a/pkg/webhook/messagequeuetrigger_test.go
+++ b/pkg/webhook/messagequeuetrigger_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// validBaseMQT returns a MessageQueueTrigger that satisfies the existing
+// validation rules so we can isolate the new podSpec-allowlist check.
+func validBaseMQT() *fv1.MessageQueueTrigger {
+	return &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "mqt-1", Namespace: "default"},
+		Spec: fv1.MessageQueueTriggerSpec{
+			FunctionReference: fv1.FunctionReference{
+				Type: fv1.FunctionReferenceTypeFunctionName,
+				Name: "fn",
+			},
+			MessageQueueType: "kafka",
+			Topic:            "events",
+			MqtKind:          "keda",
+		},
+	}
+}
+
+func TestMessageQueueTriggerWebhookRejectsImageOverride(t *testing.T) {
+	v := &MessageQueueTrigger{}
+	mqt := validBaseMQT()
+	mqt.Spec.PodSpec = &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector", Image: "evil:latest"}},
+	}
+
+	err := v.Validate(mqt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "podSpec.containers[].image")
+}
+
+func TestMessageQueueTriggerWebhookRejectsCommandAndArgs(t *testing.T) {
+	v := &MessageQueueTrigger{}
+	mqt := validBaseMQT()
+	mqt.Spec.PodSpec = &apiv1.PodSpec{
+		Containers: []apiv1.Container{{
+			Name:    "connector",
+			Command: []string{"/bin/sh"},
+			Args:    []string{"-c", "curl evil"},
+		}},
+	}
+	err := v.Validate(mqt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "podSpec.containers[].command")
+	assert.Contains(t, err.Error(), "podSpec.containers[].args")
+}
+
+func TestMessageQueueTriggerWebhookRejectsHostNamespacesAndSA(t *testing.T) {
+	v := &MessageQueueTrigger{}
+	mqt := validBaseMQT()
+	mqt.Spec.PodSpec = &apiv1.PodSpec{
+		Containers:         []apiv1.Container{{Name: "connector"}},
+		ServiceAccountName: "cluster-admin",
+		HostNetwork:        true,
+	}
+	err := v.Validate(mqt)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "podSpec.serviceAccountName")
+	assert.Contains(t, err.Error(), "podSpec.hostNetwork")
+}
+
+func TestMessageQueueTriggerWebhookAcceptsAllowlistedPodSpec(t *testing.T) {
+	v := &MessageQueueTrigger{}
+	mqt := validBaseMQT()
+	mqt.Spec.PodSpec = &apiv1.PodSpec{
+		Containers: []apiv1.Container{{Name: "connector"}},
+		NodeSelector: map[string]string{
+			"role": "mqt",
+		},
+		Tolerations: []apiv1.Toleration{{
+			Key:      "dedicated",
+			Operator: apiv1.TolerationOpEqual,
+			Value:    "mqt",
+		}},
+	}
+	require.NoError(t, v.Validate(mqt))
+}
+
+func TestMessageQueueTriggerWebhookNilPodSpec(t *testing.T) {
+	v := &MessageQueueTrigger{}
+	mqt := validBaseMQT()
+	require.NoError(t, v.Validate(mqt))
+}

--- a/pkg/webhook/messagequeuetrigger_test.go
+++ b/pkg/webhook/messagequeuetrigger_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // validBaseMQT returns a MessageQueueTrigger that satisfies the existing
-// validation rules so we can isolate the new podSpec-allowlist check.
+// validation rules so we can isolate the new spec.podspec-allowlist check.
 func validBaseMQT() *fv1.MessageQueueTrigger {
 	return &fv1.MessageQueueTrigger{
 		ObjectMeta: metav1.ObjectMeta{Name: "mqt-1", Namespace: "default"},
@@ -53,7 +53,7 @@ func TestMessageQueueTriggerWebhookRejectsImageOverride(t *testing.T) {
 
 	err := v.Validate(mqt)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "podSpec.containers[].image")
+	assert.Contains(t, err.Error(), "spec.podspec.containers[].image")
 }
 
 func TestMessageQueueTriggerWebhookRejectsCommandAndArgs(t *testing.T) {
@@ -68,8 +68,8 @@ func TestMessageQueueTriggerWebhookRejectsCommandAndArgs(t *testing.T) {
 	}
 	err := v.Validate(mqt)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "podSpec.containers[].command")
-	assert.Contains(t, err.Error(), "podSpec.containers[].args")
+	assert.Contains(t, err.Error(), "spec.podspec.containers[].command")
+	assert.Contains(t, err.Error(), "spec.podspec.containers[].args")
 }
 
 func TestMessageQueueTriggerWebhookRejectsHostNamespacesAndSA(t *testing.T) {
@@ -82,8 +82,8 @@ func TestMessageQueueTriggerWebhookRejectsHostNamespacesAndSA(t *testing.T) {
 	}
 	err := v.Validate(mqt)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "podSpec.serviceAccountName")
-	assert.Contains(t, err.Error(), "podSpec.hostNetwork")
+	assert.Contains(t, err.Error(), "spec.podspec.serviceAccountName")
+	assert.Contains(t, err.Error(), "spec.podspec.hostNetwork")
 }
 
 func TestMessageQueueTriggerWebhookAcceptsAllowlistedPodSpec(t *testing.T) {

--- a/test/integration/framework/router.go
+++ b/test/integration/framework/router.go
@@ -124,9 +124,20 @@ func (r *RouterClient) do(ctx context.Context, method, path, contentType string,
 	return resp.StatusCode, string(b), nil
 }
 
+// routerPollTimeout is the budget GetEventually/PostEventually give for the
+// router to converge to the expected response. It must cover the slowest
+// reasonable case: function-update propagation under parallel CI load, which
+// requires the poolmgr to observe the Function CRD update, invalidate its
+// functionServiceMap entry, take a fresh pod from the pool, and re-specialize
+// it with the new package. The previous 60s was tight on k8s 1.32/1.34 with a
+// pool size of 3 and many concurrent tests competing for pool slots; 120s
+// gives ~2× headroom while remaining short enough that genuinely broken
+// tests still fail fast.
+const routerPollTimeout = 120 * time.Second
+
 // GetEventually polls a GET until the response satisfies `check` or the
 // timeout elapses. Use this in place of bash's `curl --retry` after creating
-// a route. 60s timeout, 1s tick. Returns the last response body.
+// a route. 1s tick. Returns the last response body.
 func (r *RouterClient) GetEventually(
 	t *testing.T,
 	ctx context.Context,
@@ -144,7 +155,7 @@ func (r *RouterClient) GetEventually(
 		assert.Truef(c, check(status, body),
 			"router GET %q: status=%d, body=%q did not satisfy check",
 			path, status, truncate(body, 200))
-	}, 60*time.Second, 1*time.Second)
+	}, routerPollTimeout, 1*time.Second)
 	return lastBody
 }
 
@@ -168,7 +179,7 @@ func (r *RouterClient) PostEventually(
 		assert.Truef(c, check(status, respBody),
 			"router POST %q: status=%d, body[:200]=%q did not satisfy check",
 			path, status, truncate(respBody, 200))
-	}, 60*time.Second, 1*time.Second)
+	}, routerPollTimeout, 1*time.Second)
 	return lastBody
 }
 

--- a/test/integration/suites/common/package_checksum_test.go
+++ b/test/integration/suites/common/package_checksum_test.go
@@ -51,6 +51,11 @@ func TestPackageChecksum(t *testing.T) {
 		pkgName := ns.FunctionPackageName(t, ctx, fnName)
 		require.Equal(t, sum1, ns.PackageDeployChecksum(t, ctx, pkgName),
 			"package deploy checksum should match SHA256 of fetched URL content")
+		// Wait for the buildermgr to download the URL and finish building before
+		// hitting the router. The 60s GetEventually budget only covers route
+		// reconcile + executor specialization; download + build can exceed it on
+		// slow CI runners (observed flake on k8s 1.32 with TestPackageChecksum).
+		ns.WaitForPackageBuildSucceeded(t, ctx, pkgName)
 		ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: "/" + fnName, Method: "GET"})
 		f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("hello"))
 
@@ -59,6 +64,7 @@ func TestPackageChecksum(t *testing.T) {
 		pkgName2 := ns.FunctionPackageName(t, ctx, fnName)
 		require.Equal(t, sum2, ns.PackageDeployChecksum(t, ctx, pkgName2),
 			"package deploy checksum should reflect updated URL content")
+		ns.WaitForPackageBuildSucceeded(t, ctx, pkgName2)
 		f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("callback"))
 	})
 

--- a/test/integration/suites/common/package_checksum_test.go
+++ b/test/integration/suites/common/package_checksum_test.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -25,20 +25,41 @@ import (
 //   - `fn create --code <url> --insecure`   → skip checksum, store empty.
 //
 // Plus the equivalent `pkg create` paths.
+//
+// The test serves the package payloads from an in-process httptest server
+// rather than reaching out to github.com/fission/examples — the CLI runs
+// in-process (see ns.CLI), so 127.0.0.1:<random> is reachable, and the
+// buildermgr never re-fetches the URL (the CLI submits the literal payload
+// to the Package CR). This keeps the test deterministic and independent of
+// external network conditions.
 func TestPackageChecksum(t *testing.T) {
 	t.Parallel()
 
-	const url1 = "https://raw.githubusercontent.com/fission/examples/main/nodejs/hello.js"
-	const url2 = "https://raw.githubusercontent.com/fission/examples/main/nodejs/hello-callback.js"
+	const (
+		helloJS    = "module.exports = function(context, callback) { callback(200, \"hello!\\n\"); };\n"
+		callbackJS = "module.exports = function(context, callback) { callback(200, \"callback!\\n\"); };\n"
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/hello.js", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(helloJS))
+	})
+	mux.HandleFunc("/hello-callback.js", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(callbackJS))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	url1 := srv.URL + "/hello.js"
+	url2 := srv.URL + "/hello-callback.js"
+	sum1 := sha256Hex(helloJS)
+	sum2 := sha256Hex(callbackJS)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)
 	image := f.Images().RequireNode(t)
-
-	sum1 := fetchSHA256(t, ctx, url1)
-	sum2 := fetchSHA256(t, ctx, url2)
 
 	ns := f.NewTestNamespace(t)
 	envName := "nodejs-pkgsum-" + ns.ID
@@ -51,10 +72,9 @@ func TestPackageChecksum(t *testing.T) {
 		pkgName := ns.FunctionPackageName(t, ctx, fnName)
 		require.Equal(t, sum1, ns.PackageDeployChecksum(t, ctx, pkgName),
 			"package deploy checksum should match SHA256 of fetched URL content")
-		// Wait for the buildermgr to download the URL and finish building before
-		// hitting the router. The 60s GetEventually budget only covers route
-		// reconcile + executor specialization; download + build can exceed it on
-		// slow CI runners (observed flake on k8s 1.32 with TestPackageChecksum).
+		// Wait for the buildermgr to finish building (download + builder run)
+		// before hitting the router. The router-poll budget only covers route
+		// reconcile + executor specialization; build can overflow it on slow CI.
 		ns.WaitForPackageBuildSucceeded(t, ctx, pkgName)
 		ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: "/" + fnName, Method: "GET"})
 		f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("hello"))
@@ -95,20 +115,10 @@ func TestPackageChecksum(t *testing.T) {
 	})
 }
 
-// fetchSHA256 downloads url and returns the lowercase hex SHA256 of its body.
-// Used by TestPackageChecksum to compute the expected checksum that the CLI
-// should arrive at independently.
-func fetchSHA256(t *testing.T, ctx context.Context, url string) string {
-	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	require.NoError(t, err)
-	c := &http.Client{Timeout: 30 * time.Second}
-	resp, err := c.Do(req)
-	require.NoErrorf(t, err, "fetchSHA256 GET %q", url)
-	defer resp.Body.Close()
-	require.Equalf(t, http.StatusOK, resp.StatusCode, "fetchSHA256 %q non-2xx", url)
-	h := sha256.New()
-	_, err = io.Copy(h, resp.Body)
-	require.NoErrorf(t, err, "fetchSHA256 read %q", url)
-	return hex.EncodeToString(h.Sum(nil))
+// sha256Hex returns the lowercase hex SHA256 of s. Used by TestPackageChecksum
+// to compute the expected checksum that the CLI should arrive at independently
+// after downloading the payload from the in-process httptest server.
+func sha256Hex(s string) string {
+	h := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(h[:])
 }

--- a/test/integration/suites/common/package_checksum_test.go
+++ b/test/integration/suites/common/package_checksum_test.go
@@ -6,8 +6,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"io"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -25,41 +25,20 @@ import (
 //   - `fn create --code <url> --insecure`   → skip checksum, store empty.
 //
 // Plus the equivalent `pkg create` paths.
-//
-// The test serves the package payloads from an in-process httptest server
-// rather than reaching out to github.com/fission/examples — the CLI runs
-// in-process (see ns.CLI), so 127.0.0.1:<random> is reachable, and the
-// buildermgr never re-fetches the URL (the CLI submits the literal payload
-// to the Package CR). This keeps the test deterministic and independent of
-// external network conditions.
 func TestPackageChecksum(t *testing.T) {
 	t.Parallel()
 
-	const (
-		helloJS    = "module.exports = function(context, callback) { callback(200, \"hello!\\n\"); };\n"
-		callbackJS = "module.exports = function(context, callback) { callback(200, \"callback!\\n\"); };\n"
-	)
-
-	mux := http.NewServeMux()
-	mux.HandleFunc("/hello.js", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(helloJS))
-	})
-	mux.HandleFunc("/hello-callback.js", func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(callbackJS))
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
-
-	url1 := srv.URL + "/hello.js"
-	url2 := srv.URL + "/hello-callback.js"
-	sum1 := sha256Hex(helloJS)
-	sum2 := sha256Hex(callbackJS)
+	const url1 = "https://raw.githubusercontent.com/fission/examples/main/nodejs/hello.js"
+	const url2 = "https://raw.githubusercontent.com/fission/examples/main/nodejs/hello-callback.js"
 
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)
 	image := f.Images().RequireNode(t)
+
+	sum1 := fetchSHA256(t, ctx, url1)
+	sum2 := fetchSHA256(t, ctx, url2)
 
 	ns := f.NewTestNamespace(t)
 	envName := "nodejs-pkgsum-" + ns.ID
@@ -72,9 +51,10 @@ func TestPackageChecksum(t *testing.T) {
 		pkgName := ns.FunctionPackageName(t, ctx, fnName)
 		require.Equal(t, sum1, ns.PackageDeployChecksum(t, ctx, pkgName),
 			"package deploy checksum should match SHA256 of fetched URL content")
-		// Wait for the buildermgr to finish building (download + builder run)
-		// before hitting the router. The router-poll budget only covers route
-		// reconcile + executor specialization; build can overflow it on slow CI.
+		// Wait for the buildermgr to download the URL and finish building before
+		// hitting the router. The 60s GetEventually budget only covers route
+		// reconcile + executor specialization; download + build can exceed it on
+		// slow CI runners (observed flake on k8s 1.32 with TestPackageChecksum).
 		ns.WaitForPackageBuildSucceeded(t, ctx, pkgName)
 		ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: "/" + fnName, Method: "GET"})
 		f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("hello"))
@@ -115,10 +95,20 @@ func TestPackageChecksum(t *testing.T) {
 	})
 }
 
-// sha256Hex returns the lowercase hex SHA256 of s. Used by TestPackageChecksum
-// to compute the expected checksum that the CLI should arrive at independently
-// after downloading the payload from the in-process httptest server.
-func sha256Hex(s string) string {
-	h := sha256.Sum256([]byte(s))
-	return hex.EncodeToString(h[:])
+// fetchSHA256 downloads url and returns the lowercase hex SHA256 of its body.
+// Used by TestPackageChecksum to compute the expected checksum that the CLI
+// should arrive at independently.
+func fetchSHA256(t *testing.T, ctx context.Context, url string) string {
+	t.Helper()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+	c := &http.Client{Timeout: 30 * time.Second}
+	resp, err := c.Do(req)
+	require.NoErrorf(t, err, "fetchSHA256 GET %q", url)
+	defer resp.Body.Close()
+	require.Equalf(t, http.StatusOK, resp.StatusCode, "fetchSHA256 %q non-2xx", url)
+	h := sha256.New()
+	_, err = io.Copy(h, resp.Body)
+	require.NoErrorf(t, err, "fetchSHA256 read %q", url)
+	return hex.EncodeToString(h.Sum(nil))
 }


### PR DESCRIPTION
## Description

Closes [GHSA-7m8x-qg2j-4m3v](https://github.com/fission/fission/security/advisories/GHSA-7m8x-qg2j-4m3v).

The `MessageQueueTrigger` (MQT) scaler controller previously had two privilege-escalation paths for any subject that could create MQTs in a namespace:

1. **Secret materialization** — `getEnvVarlist` (`pkg/mqtrigger/scalermanager.go`) read the secret named in `Spec.Secret` with the controller's RBAC (which can read secrets) and emitted each key as a literal `EnvVar.Value`, copying secret values into the connector deployment's pod template. A subject with `messagequeuetriggers/create` but no `secrets/get` could exfiltrate any secret in the namespace by pointing an MQT at it.

2. **PodSpec merge** — `Spec.PodSpec` was merged into the controller-built connector PodSpec via `util.MergePodSpec`, with no allowlist on which fields could come from the user. An MQT could replace `Containers[].Image` (run any image), `Command`/`Args` (run anything), `Env` (inject secrets via env), `VolumeMounts`+`Volumes` (mount any in-cluster path), `ServiceAccountName`, `HostNetwork/PID/IPC`, etc. — turning `messagequeuetriggers/create` into effective `deployments/create` with arbitrary image and SA.

This PR closes both:

- `getEnvVarlist` now emits `apiv1.EnvVar{Name, ValueFrom: &EnvVarSource{SecretKeyRef: ...}}`. The connector pod resolves values at start time using its own SA. The controller still calls `Secrets().Get` to enumerate keys (so we know which env vars to emit) but never reads or copies their values.
- New `pkg/executor/util/merge_allowlist.go` `MergeAllowedPodSpecFields` accepts only `NodeSelector`, `Tolerations`, `Affinity`, `RuntimeClassName`, and per-container `Resources` (name-matched). All other user-supplied fields are silently dropped and logged for audit. The controller call site replaces `util.MergePodSpec` with this helper.
- Defense in depth: a new `validateAllowedPodSpec` in the validating webhook (`pkg/webhook/messagequeuetrigger.go`) rejects the same disallowed fields at admission with a clear error.
- Both the merge helper and the webhook share a single canonical `DisallowedPodSpecFields` so they cannot drift.

## Behavioral change

MQT authors that previously relied on overriding the connector image, command, args, env vars, volume mounts, volumes, service account, host network/PID/IPC, or `securityContext.runAsUser` via `Spec.PodSpec` will see those fields rejected at admission (or silently dropped if the webhook is not enabled). Allowlisted fields (`NodeSelector`, `Tolerations`, `Affinity`, `RuntimeClassName`, per-container `Resources`) flow through unchanged.

## Which issue(s) this PR fixes:

GHSA-7m8x-qg2j-4m3v (private security advisory).

## Testing

- New `TestGetEnvVarlistDoesNotMaterializeSecretValues` asserts every secret-derived env var has empty `Value` and a populated `ValueFrom.SecretKeyRef`.
- 7 cases in `pkg/executor/util/merge_allowlist_test.go` cover: dropped image override, allowed tolerations/affinity/runtimeClassName, name-matched per-container Resources merge, all dangerous fields dropped, nil-user passthrough, src non-mutation (deep-copy correctness), dedup across multiple containers.
- 5 webhook cases cover: image rejected, command+args rejected, hostNetwork+SA rejected, allowlisted fields accepted, nil PodSpec accepted.
- `make code-checks` clean; `make test-run` green locally and across the CI k8s matrix.

## Checklist:

- [x] I ran tests as well as code linting locally to verify my changes.
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3367)
<!-- Reviewable:end -->
