### PR TITLE
Extend HMAC application-layer auth to fetcher, builder, executor, and router-internal

### DIFF
--- a/.claude/skills/debug-github-ci/SKILL.md
+++ b/.claude/skills/debug-github-ci/SKILL.md
@@ -5,9 +5,11 @@ description: Investigate and fix GitHub Actions CI failures on the Fission repo'
 
 # Debug GitHub CI failures (Fission)
 
-Playbook for triaging and fixing CI failures on PRs in this repo. Optimised for **separating real regressions from pre-existing noise** and for **pattern-matching the same handful of recurring failure modes** before reading the full log.
+Playbook for triaging and fixing CI failures on PRs in this repo.
+Optimised for **separating real regressions from pre-existing noise** and for **pattern-matching the same handful of recurring failure modes** before reading the full log.
 
-This file is the orchestrator. Detailed playbooks for each domain live under `resources/` — read them on demand when a phase decision points there.
+This file is the orchestrator.
+Detailed playbooks for each domain live under `resources/` — read them on demand when a phase decision points there.
 
 ## When to invoke
 
@@ -17,27 +19,17 @@ Skip if the user already knows the root cause and wants you to apply a specific 
 
 ## Phase 0 — Separate noise from regression (do this first; saves hours)
 
-1. List checks for the PR:
-   ```bash
-   gh pr checks <PR> --json name,bucket,state,link \
-     --jq '.[] | select(.name != null) | "\(.bucket)\t\(.name)\t\(.link)"'
-   ```
-   Don't read logs yet. Just see who's red.
+1. List checks for the PR: ```bash gh pr checks <PR> --json name,bucket,state,link \ --jq '.[] | select(.name != null) | "\(.bucket)\t\(.name)\t\(.link)"' ``` Don't read logs yet.
+   Just see who's red.
 
-2. Compare against `main`:
-   ```bash
-   gh run list --branch main --workflow=push_pr.yaml --limit 5 \
-     --json conclusion,headSha
-   gh api repos/fission/fission/commits/<main-sha>/status \
-     --jq '.statuses[] | {context, state, description}'
-   ```
-   If the same check is also failing on `main`, it is **pre-existing noise** and the rest of this playbook does not apply to that check.
+2. Compare against `main`: ```bash gh run list --branch main --workflow=push_pr.yaml --limit 5 \ --json conclusion,headSha gh api repos/fission/fission/commits/<main-sha>/status \ --jq '.statuses[] | {context, state, description}' ``` If the same check is also failing on `main`, it is **pre-existing noise** and the rest of this playbook does not apply to that check.
 
 3. Known stickers in this repo (don't chase):
    - **`License Compliance` (FOSSA)** — fails persistently on main with "11 issues found".
    - **Tests requiring a local Docker daemon** (e.g. `TestS3StorageService` in `pkg/storagesvc/client`) — failures locally without `dockerd` are environmental.
 
-4. If main is green and PR is red → real regression. Continue.
+4. If main is green and PR is red → real regression.
+   Continue.
 
 ## Phase 1 — Get the right logs (cheapest first)
 
@@ -50,18 +42,21 @@ Order from cheapest to most expensive — escalate only if the previous step doe
 | 3 | `gh api repos/fission/fission/commits/<sha>/status` | External checks (FOSSA, codecov). Run-level not job-level. |
 | 4 | `gh run download <runId> -n go-integration-logs-<runId>-v<k8s>` | Per-test diag dirs with pod logs, yamls. The big artefact for integration-test failures. |
 
-Filter aggressively. Useful first-pass grep:
+Filter aggressively.
+Useful first-pass grep:
 ```bash
 grep -E '(FAIL|--- FAIL|fatal:|panic|error:|Error:|denied|connection refused|i/o timeout|context deadline exceeded)'
 ```
 
-Don't pull `gh run view <runId> --log` (the full archive) unless 1-3 above failed. It's tens of MB.
+Don't pull `gh run view <runId> --log` (the full archive) unless 1-3 above failed.
+It's tens of MB.
 
 Full cheatsheet: `resources/gh-commands-cheatsheet.md`.
 
 ## Phase 2 — Pattern-match the symptom
 
-Most failures in this repo land in one of these categories. Match the error string first, then load the matching resource for deeper diagnosis.
+Most failures in this repo land in one of these categories.
+Match the error string first, then load the matching resource for deeper diagnosis.
 
 ### Network / connectivity
 
@@ -92,6 +87,11 @@ Most failures in this repo land in one of these categories. Match the error stri
 | Test fixture file is missing from `embed.FS` despite being on disk | The fixture's parent dir contains a `go.mod` (nested module) — `embed` skips it | `resources/integration-test-framework.md` |
 | Spec test fails with `unknown flag: --specdir` or wrong cwd | `fission env create --spec` writes `./specs` relative to cwd; needs `ns.WithCWD` | `resources/integration-test-framework.md` |
 | Package update doesn't trigger a rebuild | Package CR has no `/status` subresource; must explicitly set `Status.BuildStatus = pending` along with spec change | `resources/integration-test-framework.md` |
+| `TestWebsocket` fails with `actual: "Error"` instead of expected echo on k8s 1.32+/1.34 (1.28 passes) | Function-pod warmup race: dial succeeds before ws-handler is attached; first frame is router's "Error" placeholder. Retry the full dial+write+read cycle. | `resources/integration-test-framework.md` |
+| `connection refused` on `127.0.0.1:8889` or `404` from `/fission-function/...` on integration tests | Missing `kubectl port-forward svc/router-internal 8889:8889 -n fission` (router listener split moved these routes off public 8888). | `resources/integration-test-framework.md` |
+| e2e test fails with router `404` for `/fission-function/...` even though integration suite is green | `test/e2e/framework/services/services.go` bypasses `cmd/fission-bundle/main.go` and missed mirroring its `ROUTER_INTERNAL_URL` resolution. | `resources/integration-test-framework.md` |
+| Same-namespace NetworkPolicy rule no-ops on some clusters | `namespaceSelector.matchLabels.kubernetes.io/metadata.name` not auto-populated; use `podSelector` alone (implicitly same-namespace). | `resources/networkpolicy-debugging.md` |
+| `USE_ENCODED_PATH=true` works at startup but stops working after a trigger reconcile | `buildMuxes` creates fresh `mux.NewRouter()` per reconciliation; `UseEncodedPath()` must be applied **inside** `buildMuxes`, not just in `router()` setup. | — |
 
 ### Lint / Go module
 
@@ -105,29 +105,30 @@ Most failures in this repo land in one of these categories. Match the error stri
 
 1. **Check the running binary's version**, not your local source.
    - `fission-bundle`, `fetcher`, `pre-upgrade-checks`, `reporter` images are built per-PR by `make skaffold-deploy`.
-   - **Env-builder images** (`python-builder`, `node-builder-22`, `go-builder-1.23`, etc.) are pre-built on GHCR. Their `/builder` binary was compiled at image-build time, NOT per-PR. Changes to `pkg/builder/builder.go` do not affect their behaviour in CI integration tests.
+   - **Env-builder images** (`python-builder`, `node-builder-22`, `go-builder-1.23`, etc.) are pre-built on GHCR.
+     Their `/builder` binary was compiled at image-build time, NOT per-PR.
+     Changes to `pkg/builder/builder.go` do not affect their behaviour in CI integration tests.
    - Confirm with the `caller":"builder/builder.go:NN"` field in pod logs vs. local file line numbers.
    - Full explanation: `resources/builder-image-origin.md`.
 
-2. **Read the source at the cited line** before iterating on a flake. Per the user's `feedback_read_source_before_iterating.md` memory, after 2 failed timing-based fixes, stop guessing — read the code path.
+2. **Read the source at the cited line** before iterating on a flake.
+   Per the user's `feedback_read_source_before_iterating.md` memory, after 2 failed timing-based fixes, stop guessing — read the code path.
 
-3. **Sanity-test locally** for the affected scope:
-   ```bash
-   make code-checks                                              # lint
-   go test -race -count=1 -timeout 5m ./pkg/<affected>/...       # focused tests
-   helm lint charts/fission-all                                  # if Helm changed
-   helm template charts/fission-all --set <vals> | sed -n '/^kind: <Kind>/,/^---/p'   # render check
-   ```
+3. **Sanity-test locally** for the affected scope: ```bash make code-checks                                              # lint go test -race -count=1 -timeout 5m ./pkg/<affected>/...       # focused tests helm lint charts/fission-all                                  # if Helm changed helm template charts/fission-all --set <vals> | sed -n '/^kind: <Kind>/,/^---/p'   # render check ```
 
 ## Phase 4 — Push and monitor
 
-After pushing the fix, arm the `Monitor` tool with the standard poll loop so terminal-state notifications arrive instead of you polling. Full recipe and rationale: `resources/monitor-poll-loop.md`.
+After pushing the fix, arm the `Monitor` tool with the standard poll loop so terminal-state notifications arrive instead of you polling.
+Full recipe and rationale: `resources/monitor-poll-loop.md`.
 
-If a check flips back to red after a fix, **don't push another fix immediately** — return to Phase 1 with the new logs. The new failure is often a different root cause exposed by the previous fix; reusing the previous hypothesis wastes a CI cycle.
+If a check flips back to red after a fix, **don't push another fix immediately** — return to Phase 1 with the new logs.
+The new failure is often a different root cause exposed by the previous fix; reusing the previous hypothesis wastes a CI cycle.
 
 ## CI-only Helm features via skaffold profile
 
-When a Helm-chart feature should be on in CI but off by default for users (e.g. `networkPolicy.enabled`), patch it via the `kind-ci` skaffold profile. Two-step: declare the chart-default in base `setValues`, then `replace`-patch it in the profile. Full instructions and rationale: `resources/skaffold-kind-ci-profile.md`.
+When a Helm-chart feature should be on in CI but off by default for users (e.g. `networkPolicy.enabled`), patch it via the `kind-ci` skaffold profile.
+Two-step: declare the chart-default in base `setValues`, then `replace`-patch it in the profile.
+Full instructions and rationale: `resources/skaffold-kind-ci-profile.md`.
 
 ## Other resources
 

--- a/.claude/skills/debug-github-ci/resources/integration-test-framework.md
+++ b/.claude/skills/debug-github-ci/resources/integration-test-framework.md
@@ -1,27 +1,40 @@
 # Go integration-test framework — quirks the bash→Go migration uncovered
 
-The `test/integration/framework/` package was built during the 2026-04/05 bash→Go migration. Across that work the framework was iterated dozens of times to close races and capture gotchas the bash suite had been silently ignoring or working around. This file is the distilled "things that made tests flake" list — read it before assuming a flake is random.
+The `test/integration/framework/` package was built during the 2026-04/05 bash→Go migration.
+Across that work the framework was iterated dozens of times to close races and capture gotchas the bash suite had been silently ignoring or working around.
+This file is the distilled "things that made tests flake" list — read it before assuming a flake is random.
 
-Authoritative reference: `docs/test-migration/02-framework-api.md`. This file is the "what burned us" companion.
+Authoritative reference: `docs/test-migration/02-framework-api.md`.
+This file is the "what burned us" companion.
 
 ## The builder ↔ runtime ↔ Service readiness race (top source of flakes)
 
-Symptom: `dial tcp <svc>:8000: i/o timeout` from buildermgr → fetcher when a test calls `CreatePackage(Src=...)` shortly after `CreateEnv(Builder=...)`. Layered fix shipped over six iterations:
+Symptom: `dial tcp <svc>:8000: i/o timeout` from buildermgr → fetcher when a test calls `CreatePackage(Src=...)` shortly after `CreateEnv(Builder=...)`.
+Layered fix shipped over six iterations:
 
 1. **Wait for builder pod Ready** (`WaitForBuilderReady`, by `envName=<env>` label).
 2. **Also wait for runtime pool pod Ready** — buildermgr's POST goes through a Service that round-robins, so even one not-Ready pool pod causes timeouts.
 3. **Wait for ALL pool pods** (`waitForRuntimePoolReady`) — the Service round-robins; one Ready pod isn't enough when the Service points at three.
-4. **Wait for the env Service to publish endpoints** — `Pod.Status.Conditions[Ready]=True` fires before kube-proxy programs iptables. The build POST can land on a stale endpoint.
-5. **Use EndpointSlices via service-name prefix, not Endpoints by name** — the env Service has a port-hash suffix (`<env>-<rv>-<hash>`); listing Endpoints by exact name returns 404. EndpointSlices carry a `kubernetes.io/service-name` label that supports prefix matching.
-6. **Target the *builder* Service, not the runtime pool** — buildermgr POSTs to the Service named `<env>-<env.RV>` (selecting `envName=<env>`), not the runtime pool (which selects `environmentName=<env>`). The earlier "wait for runtime pool" was load-bearing on a misunderstanding; the real race is on the builder Service. Reference: `pkg/buildermgr/common.go:57`.
-7. **5-second settle after EndpointSlice readiness** — even after pod Ready + endpoint published, the fetcher process can take a beat to bind port 8000. K8s 1.28 needed 15s in CI (commit `9bc0c573`).
-8. **Retry on transient build failure** — final safety net. `WaitForPackageBuildSucceeded` retries up to 3× on the known transient signature `dial tcp …:8000: i/o timeout`, resetting `Status.BuildStatus → pending` to re-trigger the buildermgr's UpdateFunc.
+4. **Wait for the env Service to publish endpoints** — `Pod.Status.Conditions[Ready]=True` fires before kube-proxy programs iptables.
+   The build POST can land on a stale endpoint.
+5. **Use EndpointSlices via service-name prefix, not Endpoints by name** — the env Service has a port-hash suffix (`<env>-<rv>-<hash>`); listing Endpoints by exact name returns 404.
+   EndpointSlices carry a `kubernetes.io/service-name` label that supports prefix matching.
+6. **Target the *builder* Service, not the runtime pool** — buildermgr POSTs to the Service named `<env>-<env.RV>` (selecting `envName=<env>`), not the runtime pool (which selects `environmentName=<env>`).
+   The earlier "wait for runtime pool" was load-bearing on a misunderstanding; the real race is on the builder Service.
+   Reference: `pkg/buildermgr/common.go:57`.
+7. **5-second settle after EndpointSlice readiness** — even after pod Ready + endpoint published, the fetcher process can take a beat to bind port 8000.
+   K8s 1.28 needed 15s in CI (commit `9bc0c573`).
+8. **Retry on transient build failure** — final safety net.
+   `WaitForPackageBuildSucceeded` retries up to 3× on the known transient signature `dial tcp …:8000: i/o timeout`, resetting `Status.BuildStatus → pending` to re-trigger the buildermgr's UpdateFunc.
 
 Folded into `CreateEnv` automatically when `EnvOptions.Builder` is set, so test authors don't have to think about this — but if a test file *bypasses* `CreateEnv` and directly creates Environments via `f.FissionClient()`, this race is back.
 
 ## Test-cadence vs production-cadence (why we didn't fix Fission proper)
 
-In production, builds happen well after env creation: `env create` → user push to repo → CI build kicks off. Kube-proxy has long since propagated. The race is purely a test-cadence artefact (env create → immediate build). Fixing in the framework is correct; "fixing" Fission would just add complexity to a path that doesn't bite real users.
+In production, builds happen well after env creation: `env create` → user push to repo → CI build kicks off.
+Kube-proxy has long since propagated.
+The race is purely a test-cadence artefact (env create → immediate build).
+Fixing in the framework is correct; "fixing" Fission would just add complexity to a path that doesn't bite real users.
 
 ## Pod label conventions — why selectors silently miss
 
@@ -33,18 +46,25 @@ In production, builds happen well after env creation: `env create` → user push
 | **Container-executor function pod** | Same with `executorType=container` | same |
 
 Pitfalls:
-- A selector `envName=<env>` matches **builder pods**, NOT runtime pods. Runtime pods carry `environmentName=` (longer key).
-- `WaitForBuilderReady` uses `envName=`. `WaitForRuntimePodReady` uses `environmentName=`. Mixing them up was a recurring bug during migration.
-- For function-specific log reading, use `functionName=<fn>` directly — narrower than env label and exactly the specialised pod. See `ns.FunctionLogs()` in `framework/function.go`.
+- A selector `envName=<env>` matches **builder pods**, NOT runtime pods.
+  Runtime pods carry `environmentName=` (longer key).
+- `WaitForBuilderReady` uses `envName=`.
+  `WaitForRuntimePodReady` uses `environmentName=`.
+  Mixing them up was a recurring bug during migration.
+- For function-specific log reading, use `functionName=<fn>` directly — narrower than env label and exactly the specialised pod.
+  See `ns.FunctionLogs()` in `framework/function.go`.
 
 ## `ns.CLI` captures cobra writers, not `os.Stdout`
 
-The in-process Fission CLI sets cobra's `Out`/`Err` to a `bytes.Buffer` that `ns.CLI` returns. But these subcommands print to `os.Stdout` directly:
+The in-process Fission CLI sets cobra's `Out`/`Err` to a `bytes.Buffer` that `ns.CLI` returns.
+But these subcommands print to `os.Stdout` directly:
 
 - `fission function logs` (kubectl-style log streaming)
 - `fission archive list / download / get-url / delete`
 
-For those, use `ns.CLICaptureStdout` (or the cleanup-friendly `CLICaptureStdoutBestEffort`). It takes the process-global `cliMu` write lock to serialize against any concurrent `ns.CLI` call — cross-test `os.Stdout` capture under `t.Parallel()` would race. Don't reach for `os.Stdout` redirection in your test code; it'll race with sibling tests.
+For those, use `ns.CLICaptureStdout` (or the cleanup-friendly `CLICaptureStdoutBestEffort`).
+It takes the process-global `cliMu` write lock to serialize against any concurrent `ns.CLI` call — cross-test `os.Stdout` capture under `t.Parallel()` would race.
+Don't reach for `os.Stdout` redirection in your test code; it'll race with sibling tests.
 
 For env-var-driven CLI flags (e.g. `FISSION_DEFAULT_NAMESPACE`), use `ns.CLIWithEnv(t, ctx, env, args...)` — same `cliMu` write-lock idea, restoring env on return.
 
@@ -52,29 +72,37 @@ For env-var-driven CLI flags (e.g. `FISSION_DEFAULT_NAMESPACE`), use `ns.CLIWith
 
 Symptom: a file under `test/integration/testdata/<lang>/<feature>/` exists on disk but `WriteTestData(t, "<lang>/<feature>/<file>")` fails with "file does not exist".
 
-Cause: `//go:embed` silently excludes any directory that contains its own `go.mod` — Go treats it as a separate module. `testdata/go/module_example/` had this problem.
+Cause: `//go:embed` silently excludes any directory that contains its own `go.mod` — Go treats it as a separate module.
+`testdata/go/module_example/` had this problem.
 
-Workaround: store as `.txt` on disk, strip the `.txt` suffix when materializing. `TestGoEnv`'s `zipModuleExample` is the reference implementation.
+Workaround: store as `.txt` on disk, strip the `.txt` suffix when materializing.
+`TestGoEnv`'s `zipModuleExample` is the reference implementation.
 
-Also: `embed.FS` skips files starting with `_` or `.`. Don't store fixtures under `_internal` or `.hidden` paths.
+Also: `embed.FS` skips files starting with `_` or `.`.
+Don't store fixtures under `_internal` or `.hidden` paths.
 
 ## Spec tests need `WithCWD`
 
 `fission spec init/apply/destroy` and `env create --spec`, `fn create --spec` write specs to `./specs` relative to `os.Getwd()` — there's no `--specdir` override on `env create` / `fn create` (only on `spec apply`).
 
-The framework helper `ns.WithCWD(t, workdir, func(){ … })` chdirs under a process-global `cwdMu`, runs the closure, restores. Other concurrent tests are unaffected as long as they pass absolute paths to the CLI (every framework helper does — verified during migration).
+The framework helper `ns.WithCWD(t, workdir, func(){ … })` chdirs under a process-global `cwdMu`, runs the closure, restores.
+Other concurrent tests are unaffected as long as they pass absolute paths to the CLI (every framework helper does — verified during migration).
 
 Also relevant for `fn create --deploy "<glob>"` — globs expand against cwd.
 
 ## Vendored spec YAMLs need rewriting per-test
 
-Bash spec tests had hardcoded names like `spec-merge-9f3a` baked into the YAMLs. Multiple parallel Go tests using the same fixture trip over each other. `framework.MaterializeSpecs(t, embedDir, replacements, workdir)` walks the embedded tree, applies a longest-old-string-first replacer, writes to `workdir`.
+Bash spec tests had hardcoded names like `spec-merge-9f3a` baked into the YAMLs.
+Multiple parallel Go tests using the same fixture trip over each other.
+`framework.MaterializeSpecs(t, embedDir, replacements, workdir)` walks the embedded tree, applies a longest-old-string-first replacer, writes to `workdir`.
 
 Pair with `framework.NewSpecUID(t)` for the `DeploymentConfig.uid` field — `spec destroy` selects by uid, so per-test UIDs ensure cleanup only removes that test's resources.
 
 ## Package CR has no `/status` subresource yet
 
-`pkg/buildermgr/pkgwatcher.go:259-262` only re-builds when `Package.Status.BuildStatus == "pending"`. Bash side-stepped this by using `kubectl replace`, which round-trips Status. Go clientset `Update()` overwrites Status — so a test that updates `Spec.Source.URL` and expects a rebuild **must explicitly set** `Status.BuildStatus = fv1.BuildStatusPending` along with the spec change.
+`pkg/buildermgr/pkgwatcher.go:259-262` only re-builds when `Package.Status.BuildStatus == "pending"`.
+Bash side-stepped this by using `kubectl replace`, which round-trips Status.
+Go clientset `Update()` overwrites Status — so a test that updates `Spec.Source.URL` and expects a rebuild **must explicitly set** `Status.BuildStatus = fv1.BuildStatusPending` along with the spec change.
 
 Once the `/status` subresource lands (long-standing TODO in pkgwatcher.go), generation-based diffing will work and this kludge can drop.
 
@@ -84,25 +112,89 @@ Once the `/status` subresource lands (long-standing TODO in pkgwatcher.go), gene
 |---|---|---|
 | `Ingress` (created by router on HTTPTrigger with `--ingressrule`) | `POD_NAMESPACE` (defaults to `fission`) | `f.KubeClient().NetworkingV1().Ingresses(metav1.NamespaceAll).List(...)` — the label-selector (`functionName + triggerName`) is unique enough that cross-ns matching is safe. |
 
-If a test creates a CR in `default` and expects to see a side-effect resource also in `default`, double-check whether the controller writes it elsewhere. Router's Ingress creation is the only one we hit during migration; others may be similar.
+If a test creates a CR in `default` and expects to see a side-effect resource also in `default`, double-check whether the controller writes it elsewhere.
+Router's Ingress creation is the only one we hit during migration; others may be similar.
 
 ## Test debug checklist (when one fails)
 
-1. **Re-run alone** — `go test -tags=integration -run TestFooBar -v -count=1 ./test/integration/suites/common/...`. If it passes solo and fails in the parallel suite, it's a parallel-load issue (more pods, more contention, more kube-proxy lag).
-2. **Read the diagnostic dump** — `$LOG_DIR/<sanitized-test-name>/` has `events.yaml`, `pods.yaml`, container logs, CR yamls. The pod's `caller":"…"` field in structured logs tells you which Fission binary version is actually running.
+1. **Re-run alone** — `go test -tags=integration -run TestFooBar -v -count=1 ./test/integration/suites/common/...`.
+   If it passes solo and fails in the parallel suite, it's a parallel-load issue (more pods, more contention, more kube-proxy lag).
+2. **Read the diagnostic dump** — `$LOG_DIR/<sanitized-test-name>/` has `events.yaml`, `pods.yaml`, container logs, CR yamls.
+   The pod's `caller":"…"` field in structured logs tells you which Fission binary version is actually running.
 3. **Check `Status.BuildLog`** if a build failed — it's captured in the diag dump's `packages.yaml` AND in the `WaitForPackageBuildSucceeded` failure message.
-4. **Compare to bash counterpart** — `git log -- test/tests/<old-bash-test>.sh` may surface why a particular dance was needed. Many migration commits cite the bash precedent.
-5. **Hop the layered race fixes** — if it's a builder-pod-related test and you see `dial tcp …:8000: i/o timeout`, walk back through the 8 fixes above. Most likely you need a longer settle, not a new mechanism.
-6. **`fission#653` style hangs** — if specialize fails (invalid function code, runtime crash) the router's request never returns headers, so `GetEventually` polls until ctx timeout. Reduce the test to a happy-path assertion until upstream returns a proper error response.
-7. **Skipped under FIXME** — `TestIdleObjectsReaper` is currently skipped. Don't re-enable without addressing the parallel-CI fsvc-TTL refresh issue called out in commit `0fc53807`.
+4. **Compare to bash counterpart** — `git log -- test/tests/<old-bash-test>.sh` may surface why a particular dance was needed.
+   Many migration commits cite the bash precedent.
+5. **Hop the layered race fixes** — if it's a builder-pod-related test and you see `dial tcp …:8000: i/o timeout`, walk back through the 8 fixes above.
+   Most likely you need a longer settle, not a new mechanism.
+6. **`fission#653` style hangs** — if specialize fails (invalid function code, runtime crash) the router's request never returns headers, so `GetEventually` polls until ctx timeout.
+   Reduce the test to a happy-path assertion until upstream returns a proper error response.
+7. **Skipped under FIXME** — `TestIdleObjectsReaper` is currently skipped.
+   Don't re-enable without addressing the parallel-CI fsvc-TTL refresh issue called out in commit `0fc53807`.
+
+## WebSocket dial succeeds but ReadMessage returns "Error"
+
+Symptom: `TestWebsocket` (or any direct `gorilla/websocket` client) fails on slower k8s versions (1.32+/1.34 in CI; 1.28 passes) with:
+```
+Error: Not equal:
+  expected: "hello-from-test"
+  actual  : "Error"
+```
+Dial succeeded (101 Switching Protocols), so the router upgraded the connection — but the function pod's ws-handler isn't fully attached yet, and the first frame back is the router's "Error" placeholder rather than `broadcast.js`'s echo.
+
+Fix: retry the **entire** dial+SetReadDeadline+WriteMessage+ReadMessage cycle, not just the dial.
+Pattern:
+```go
+require.EventuallyWithT(t, func(c *assert.CollectT) {
+    c2, _, err := websocket.DefaultDialer.DialContext(dctx, wsURL, hdr)
+    if !assert.NoError(c, err) { return }
+    if err := c2.WriteMessage(...); !assert.NoError(c, err) { _ = c2.Close(); return }
+    _, msg, err := c2.ReadMessage()
+    if !assert.NoError(c, err) { _ = c2.Close(); return }
+    if !assert.Equal(c, expected, string(msg)) { _ = c2.Close(); return }
+    conn = c2
+}, 90*time.Second, 2*time.Second)
+```
+Re-establishing the connection drives the retry through pod warmup.
+Re-sign the HMAC headers on every attempt so the timestamp stays inside the verifier's skew window — the framework's `RouterClient` does this automatically for HTTP, but ws dials done via raw `gorilla/websocket` need to construct the headers manually with `hmacauth.DeriveServiceKey(master, hmacauth.ServiceRouterInternal)` + `hmacauth.Sign(...)` (canonical = method, path, nil body, ts).
+
+## In-process e2e harness bypasses fission-bundle/main.go
+
+`test/e2e/framework/services/services.go` calls `timer.Start` / `kubewatcher.Start` / `mqtrigger.StartScalerManager` directly — it does NOT go through `cmd/fission-bundle/main.go`.
+Any env-resolution logic that lives in main.go (e.g. the `ROUTER_INTERNAL_URL` → `publishURL` override) has to be **mirrored explicitly** in services.go, or the in-process harness ends up pointing trigger publishers at the wrong URL.
+
+Symptom on miss: e2e tests under `test/e2e/` pass functionally but `/fission-function/...` requests from timer/kubewatcher hit the public listener (which doesn't register those routes after GHSA-3g33-6vg6-27m8) and 404.
+Easy to miss because the integration-test suite runs against a real fission-bundle and won't reproduce.
+
+Rule: when adding env-driven config to a `Start()` entrypoint, search for that env name in `test/e2e/framework/services/services.go` and either replicate the resolution there or pass the resolved value down explicitly.
+
+## Internal listener requires its own port-forward
+
+Integration-test bootstrap on a real cluster:
+```
+kubectl port-forward svc/router          8888:80   -n fission &
+kubectl port-forward svc/router-internal 8889:8889 -n fission &
+```
+The 8889 forward is **not optional** — `/fission-function/...` lives only there.
+Common mis-fix is `kubectl port-forward svc/router 8889:8889`, which silently fails because `svc/router` only exposes port 80→8888 since the listener split.
+Symptom: integration tests pass HTTPTrigger calls but fail any test that goes through `f.Router(t).Get("/fission-function/...")` with `connection refused`.
+
+If you also want the framework to sign requests, export the master HMAC secret to the test process:
+```
+export FISSION_INTERNAL_AUTH_SECRET=$(kubectl get secret fission-internal-auth -n fission \
+  -o jsonpath='{.data.master}' | base64 -d)
+```
+Empty secret means unsigned requests, which works only when the cluster is in pass-through mode (`internalAuth.enabled=false`) — the verifier's pass-through short-circuit accepts unsigned requests in that mode, but rejects them once the secret is configured.
 
 ## When the framework needs a new helper
 
-Adding a one-off API call to a test is fine. If the same idiom shows up in 2+ tests, hoist it to `framework/`:
+Adding a one-off API call to a test is fine.
+If the same idiom shows up in 2+ tests, hoist it to `framework/`:
 
 - Add to `framework.go` if cluster-scoped or namespace-creating.
 - Add to `namespace.go` if per-namespace state.
 - Add to a topic-specific file (`builder.go`, `canary.go`, `package.go`, etc.) if it's domain-specific.
 - Update `docs/test-migration/02-framework-api.md` in the same PR — the framework-api doc is the discoverability surface for future tests.
 
-The framework grew **49 helpers** during migration. The pattern that scaled was: introduce when a second test needs it, document in `02-framework-api.md` with the symptom that motivated it, register cleanup automatically. Tests that don't need to think about cleanup are tests that don't leak resources.
+The framework grew **49 helpers** during migration.
+The pattern that scaled was: introduce when a second test needs it, document in `02-framework-api.md` with the symptom that motivated it, register cleanup automatically.
+Tests that don't need to think about cleanup are tests that don't leak resources.

--- a/.claude/skills/debug-github-ci/resources/networkpolicy-debugging.md
+++ b/.claude/skills/debug-github-ci/resources/networkpolicy-debugging.md
@@ -13,7 +13,8 @@ If `networkPolicy.enabled=false` in the install (or the policy isn't there at al
 
 ## Pod labels — the source of truth
 
-A `NetworkPolicy` `from: [{ podSelector: ... }]` rule matches pod labels, **not** Service / Deployment names. The Fission control plane uses different label conventions for *controllers* vs the *worker pods* they create:
+A `NetworkPolicy` `from: [{ podSelector: ... }]` rule matches pod labels, **not** Service / Deployment names.
+The Fission control plane uses different label conventions for *controllers* vs the *worker pods* they create:
 
 | Pod kind | Labels |
 |---|---|
@@ -30,7 +31,8 @@ Constants: `pkg/apis/core/v1/const.go` (function-pod labels), `pkg/buildermgr/en
 
 ## Cross-namespace selectors are mandatory
 
-Storagesvc lives in the Fission install namespace (`fission`). Env-builder pods and function pods live in user namespaces (`default` for the test framework, plus any namespace the operator deploys functions to).
+Storagesvc lives in the Fission install namespace (`fission`).
+Env-builder pods and function pods live in user namespaces (`default` for the test framework, plus any namespace the operator deploys functions to).
 
 A `NetworkPolicy` in namespace `fission` with this rule:
 ```yaml
@@ -39,7 +41,8 @@ A `NetworkPolicy` in namespace `fission` with this rule:
         matchLabels:
           owner: buildermgr
 ```
-matches **only pods in namespace `fission`**. Pods in other namespaces are dropped.
+matches **only pods in namespace `fission`**.
+Pods in other namespaces are dropped.
 
 To match labelled pods in any namespace, pair `podSelector` with an empty `namespaceSelector`:
 ```yaml
@@ -54,7 +57,8 @@ Symptom of missing this: `dial tcp <storagesvc-ip>:80: i/o timeout` from the fet
 
 ## Reference: storagesvc NetworkPolicy template
 
-`charts/fission-all/templates/networkpolicy.yaml` is the canonical example. It demonstrates:
+`charts/fission-all/templates/networkpolicy.yaml` is the canonical example.
+It demonstrates:
 - `podSelector` on the *target* pod (storagesvc itself).
 - Three `ingress` rules: env-builder pods (port 8000), function pods (port 8000), Prometheus / metrics scraping (port 8080, no selector — allow from anywhere).
 - Each `from` peer pairs `namespaceSelector: {}` with the right `podSelector`.
@@ -64,11 +68,31 @@ Symptom of missing this: `dial tcp <storagesvc-ip>:80: i/o timeout` from the fet
 1. `helm lint charts/fission-all` — clean YAML.
 2. `helm template charts/fission-all --set networkPolicy.enabled=true` — render and inspect the resource.
 3. Check that every `from` peer has `namespaceSelector: {}` if the target pod and source pod live in different namespaces.
-4. `kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.metadata.labels}{"\n"}{end}'` on a real cluster (kind-ci) to confirm real pod labels match the selectors. The CI integration test suite is a good proxy for this — failures will show up as `i/o timeout` in fetcher logs.
+4. `kubectl get pods -A -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}: {.metadata.labels}{"\n"}{end}'` on a real cluster (kind-ci) to confirm real pod labels match the selectors.
+   The CI integration test suite is a good proxy for this — failures will show up as `i/o timeout` in fetcher logs.
+
+## Same-namespace `podSelector` doesn't need `namespaceSelector`
+
+For rules that target the *same* namespace as the NetworkPolicy itself — e.g. router internal-listener rules accepting traffic from in-namespace fission-bundle pods — use `podSelector` alone:
+```yaml
+- from:
+    - podSelector:
+        matchLabels:
+          svc: kubewatcher
+```
+This implicitly scopes to the policy's own namespace.
+Don't reach for `namespaceSelector.matchLabels.kubernetes.io/metadata.name: <ns>` to "be explicit" — that label is auto-populated by the `NamespaceDefaultLabelName` admission plugin which is **not guaranteed** across every supported k8s version/distribution.
+Adding it makes the policy silently no-op on clusters where it isn't set, while contributing nothing on clusters where it is.
+
+Rule of thumb:
+- Same namespace as the policy → `podSelector` only.
+- Different namespace → `namespaceSelector: {}` (any) or `namespaceSelector.matchLabels: {key: value}` where `key/value` is a label you **set yourself** on the source namespace.
 
 ## Verifying enforcement actually happens
 
-The default kindnet CNI enforces NetworkPolicy from kind v0.27 / k8s 1.30+. On older kind, or on EKS without an addon, `NetworkPolicy` resources are accepted by the API but never enforced. If a policy looks correct on disk but doesn't change behaviour, check the CNI:
+The default kindnet CNI enforces NetworkPolicy from kind v0.27 / k8s 1.30+.
+On older kind, or on EKS without an addon, `NetworkPolicy` resources are accepted by the API but never enforced.
+If a policy looks correct on disk but doesn't change behaviour, check the CNI:
 ```bash
 kubectl get pods -n kube-system -o name | grep -E 'kindnet|cilium|calico|weave'
 ```

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -153,19 +153,44 @@ jobs:
 
           kubectl port-forward svc/router 8888:80 -n "$FISSION_NAMESPACE" >/tmp/pf.log 2>&1 &
           PF_PID=$!
-          trap "kill $PF_PID 2>/dev/null || true" EXIT
+          # The router internal listener (GHSA-3g33-6vg6-27m8 fix) hosts
+          # /fission-function/<ns>/<name>; the framework routes those
+          # requests to localhost:8889 with HMAC signing. Forward the
+          # internal port too so integration tests that invoke functions
+          # by name (TestSpecArchive, TestSpecMerge, TestKubectlApply,
+          # TestWebsocket, TestInternalRouterRejectsUnsigned, ...) reach
+          # the right listener.
+          kubectl port-forward svc/router 8889:8889 -n "$FISSION_NAMESPACE" >/tmp/pf-internal.log 2>&1 &
+          PF_PID_INT=$!
+          trap "kill $PF_PID $PF_PID_INT 2>/dev/null || true" EXIT
+
+          # Export the master HMAC secret so the framework's RouterClient
+          # signs /fission-function/... requests against the internal
+          # listener. Empty when internalAuth is disabled — the framework
+          # falls back to unsigned and the verifier short-circuits.
+          if kubectl get secret fission-internal-auth -n "$FISSION_NAMESPACE" >/dev/null 2>&1; then
+            export FISSION_INTERNAL_AUTH_SECRET=$(kubectl get secret fission-internal-auth \
+              -n "$FISSION_NAMESPACE" -o jsonpath='{.data.secret}' | base64 -d)
+            echo "exported FISSION_INTERNAL_AUTH_SECRET (${#FISSION_INTERNAL_AUTH_SECRET} bytes)"
+          else
+            echo "fission-internal-auth Secret not present — running tests in unsigned mode"
+          fi
 
           # Wait for port-forward to accept TCP connections. Without -f, curl
           # exits 0 for any HTTP response (including 4xx/5xx) and exit 7 for
           # connection refused — exactly what we want here.
           for i in $(seq 1 30); do
-            if curl -sS --connect-timeout 1 --max-time 2 -o /dev/null "http://127.0.0.1:8888/" 2>/dev/null; then
-              echo "router port-forward ready after ${i}s"
+            ok_pub=0; ok_int=0
+            curl -sS --connect-timeout 1 --max-time 2 -o /dev/null "http://127.0.0.1:8888/" 2>/dev/null && ok_pub=1
+            curl -sS --connect-timeout 1 --max-time 2 -o /dev/null "http://127.0.0.1:8889/" 2>/dev/null && ok_int=1
+            if [ "$ok_pub" -eq 1 ] && [ "$ok_int" -eq 1 ]; then
+              echo "router port-forwards ready after ${i}s (8888=$ok_pub, 8889=$ok_int)"
               break
             fi
             if [ "$i" -eq 30 ]; then
-              echo "router port-forward did not become ready in 30s; pf log:"
+              echo "router port-forward did not become ready in 30s; pf logs:"
               cat /tmp/pf.log || true
+              cat /tmp/pf-internal.log || true
               exit 1
             fi
             sleep 1

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -155,12 +155,11 @@ jobs:
           PF_PID=$!
           # The router internal listener (GHSA-3g33-6vg6-27m8 fix) hosts
           # /fission-function/<ns>/<name>; the framework routes those
-          # requests to localhost:8889 with HMAC signing. Forward the
-          # internal port too so integration tests that invoke functions
-          # by name (TestSpecArchive, TestSpecMerge, TestKubectlApply,
-          # TestWebsocket, TestInternalRouterRejectsUnsigned, ...) reach
-          # the right listener.
-          kubectl port-forward svc/router 8889:8889 -n "$FISSION_NAMESPACE" >/tmp/pf-internal.log 2>&1 &
+          # requests to localhost:8889 with HMAC signing. The internal
+          # port lives on a separate ClusterIP-only Service (router-internal)
+          # so routerServiceType=NodePort/LoadBalancer doesn't expose
+          # the listener externally — port-forward that Service.
+          kubectl port-forward svc/router-internal 8889:8889 -n "$FISSION_NAMESPACE" >/tmp/pf-internal.log 2>&1 &
           PF_PID_INT=$!
           trap "kill $PF_PID $PF_PID_INT 2>/dev/null || true" EXIT
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,53 +4,85 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Fission is a Kubernetes-native serverless framework, written in Go (`github.com/fission/fission`, Go 1.26). The control plane is shipped as a single multi-headed binary (`fission-bundle`) that runs one of several subsystems based on flags. Functions execute inside per-environment pods that the executor manages; the user-facing CLI is `fission`.
+Fission is a Kubernetes-native serverless framework, written in Go (`github.com/fission/fission`, Go 1.26).
+The control plane is shipped as a single multi-headed binary (`fission-bundle`) that runs one of several subsystems based on flags.
+Functions execute inside per-environment pods that the executor manages; the user-facing CLI is `fission`.
 
 ## Common commands
 
 Build / lint / test (run from repo root):
-- `make build-fission-cli` — build the `fission` CLI via goreleaser (snapshot, single target). `make install-fission-cli` copies it to `/usr/local/bin/fission`.
+- `make build-fission-cli` — build the `fission` CLI via goreleaser (snapshot, single target).
+  `make install-fission-cli` copies it to `/usr/local/bin/fission`.
 - `make code-checks` — `golangci-lint run` (config in `.golangci.yaml`; goimports local prefix `github.com/fission/fission`).
-- `make test-run` — runs `hack/runtests.sh`: pulls `setup-envtest` Kubebuilder assets for k8s 1.30.x, then `go test -race -coverprofile=coverage.txt ./...`. Requires `KUBEBUILDER_ASSETS` (the script sets it).
+- `make test-run` — runs `hack/runtests.sh`: pulls `setup-envtest` Kubebuilder assets for k8s 1.30.x, then `go test -race -coverprofile=coverage.txt ./...`.
+  Requires `KUBEBUILDER_ASSETS` (the script sets it).
 - `make check` — full local gate: `test-run` + `build-fission-cli` + `clean`.
 - Run a single Go test: `go test -race -run TestName ./pkg/router/...` (set `KUBEBUILDER_ASSETS=$(go tool setup-envtest -p path use 1.30.x)` first if the package needs envtest).
 
 Code generation (run after editing `pkg/apis/core/v1/types.go`):
-- `make codegen` — regenerates clientset/listers/informers under `pkg/generated/` (via `hack/update-codegen.sh`) and deepcopy via controller-gen. Never hand-edit `pkg/generated/` or `zz_generated_*.go`.
+- `make codegen` — regenerates clientset/listers/informers under `pkg/generated/` (via `hack/update-codegen.sh`) and deepcopy via controller-gen.
+  Never hand-edit `pkg/generated/` or `zz_generated_*.go`.
 - `make generate-crds` — regenerates CRD YAMLs under `crds/v1/` from the Go types.
 - `make generate-webhooks` — regenerates webhook configs into the Helm chart from `// +kubebuilder:webhook` markers in `pkg/webhook/`.
 - `make all-generators` — runs all generators including swagger and CLI/CRD ref docs.
 
 Local cluster development (skaffold + kind):
 - `kind create cluster --config kind.yaml` then `kubectl create ns fission && make create-crds`.
-- `SKAFFOLD_PROFILE=kind make skaffold-deploy` — builds linux/amd64 images via goreleaser, copies per-binary Dockerfiles into `dist/*_linux_amd64_v1/`, and Helm-installs `charts/fission-all`. Other profiles: `kind-debug` (pprof + debugEnv), `kind-ci` (full observability), `kind-opentelemetry`.
+- `SKAFFOLD_PROFILE=kind make skaffold-deploy` — builds linux/amd64 images via goreleaser, copies per-binary Dockerfiles into `dist/*_linux_amd64_v1/`, and Helm-installs `charts/fission-all`.
+  Other profiles: `kind-debug` (pprof + debugEnv), `kind-ci` (full observability), `kind-opentelemetry`.
 
-Integration tests (`test/integration/`, Go + testify, build tag `//go:build integration`, expect a running Fission cluster with `kubectl port-forward svc/router 8888:80 -nfission`):
-- Run the full suite: `go test -tags=integration -timeout=30m -parallel 6 -v ./test/integration/suites/common/...`. Set runtime/builder image env vars (`NODE_RUNTIME_IMAGE`, `PYTHON_RUNTIME_IMAGE`, etc.) — tests `t.Skip` when their required image is unset. `TEST_NOCLEANUP=1` leaves resources for debugging.
+Integration tests (`test/integration/`, Go + testify, build tag `//go:build integration`, expect a running Fission cluster with two port-forwards):
+```
+kubectl port-forward svc/router          8888:80   -n fission &
+kubectl port-forward svc/router-internal 8889:8889 -n fission &
+```
+- The internal forward is required because `/fission-function/<ns>/<name>` moved off the public listener after GHSA-3g33-6vg6-27m8 (see Architecture).
+  Tests that invoke functions go through the framework's `Router(t)` HTTP client which auto-routes those paths to 8889, or dial the URL from `f.RouterInternalBaseURL()` directly.
+- Export `FISSION_INTERNAL_AUTH_SECRET` (read from `kubectl get secret fission-internal-auth -n fission -o jsonpath='{.data.master}' | base64 -d`) so the framework's transport signs requests on the internal listener — leave unset to test the verifier's pass-through mode.
+- Run the full suite: `go test -tags=integration -timeout=30m -parallel 6 -v ./test/integration/suites/common/...`.
+  Set runtime/builder image env vars (`NODE_RUNTIME_IMAGE`, `PYTHON_RUNTIME_IMAGE`, etc.) — tests `t.Skip` when their required image is unset.
+  `TEST_NOCLEANUP=1` leaves resources for debugging.
 - Run a single test: `go test -tags=integration -run TestNodeHelloHTTP -v ./test/integration/suites/common/...`.
 - Framework reference + "Adding a new test" 12-step guide: `docs/test-migration/02-framework-api.md`.
 - The previous bash test suite (`test/tests/`, `test/run_test.sh`, `test/kind_CI.sh`, `test/utils.sh`, etc.) was retired in 2026-05; the migration history lives in `docs/test-migration/`.
 
 ## Architecture
 
-`cmd/fission-bundle/main.go` is the dispatch point — the same binary becomes a different service depending on which `--<flag>` is passed (`--routerPort`, `--executorPort`, `--kubewatcher`, `--timer`, `--mqt`, `--mqt_keda`, `--builderMgr`, `--canaryConfig`, `--webhookPort`, `--storageServicePort`, `--logger`). Each flag dispatches to a `Start` function in the corresponding `pkg/` package. The Helm chart deploys this binary multiple times with different flags. Other binaries: `cmd/fission-cli` (user CLI), `cmd/builder` (per-env build sidecar), `cmd/fetcher` (per-env code-fetch sidecar), `cmd/preupgradechecks`, `cmd/reporter`.
+`cmd/fission-bundle/main.go` is the dispatch point — the same binary becomes a different service depending on which `--<flag>` is passed (`--routerPort`, `--executorPort`, `--kubewatcher`, `--timer`, `--mqt`, `--mqt_keda`, `--builderMgr`, `--canaryConfig`, `--webhookPort`, `--storageServicePort`, `--logger`).
+Each flag dispatches to a `Start` function in the corresponding `pkg/` package.
+The Helm chart deploys this binary multiple times with different flags.
+Other binaries: `cmd/fission-cli` (user CLI), `cmd/builder` (per-env build sidecar), `cmd/fetcher` (per-env code-fetch sidecar), `cmd/preupgradechecks`, `cmd/reporter`.
 
 Request path for an HTTP-triggered function:
-1. `pkg/router` receives the HTTP request, resolves the trigger to a function via `functionReferenceResolver`, looks up a service URL in `functionServiceMap`, and proxies the request. The mux is a `mutablemux` that hot-swaps routes when triggers change.
+1. `pkg/router` receives the HTTP request, resolves the trigger to a function via `functionReferenceResolver`, looks up a service URL in `functionServiceMap`, and proxies the request.
+   The mux is a `mutablemux` that hot-swaps routes when triggers change.
 2. On a cache miss the router asks `pkg/executor` (over HTTP, see `pkg/executor/client`) for a function service URL.
-3. `pkg/executor/executortype/{poolmgr,newdeploy,container}` provide the three execution backends. `poolmgr` is the default warm-pool path: generic env pods are created up front (`gpm`/`gp`/`poolpodcontroller`) and specialized on demand by calling `fetcher` to load the user's package; `newdeploy` creates a Deployment+Service per function; `container` runs an arbitrary user container image.
+3. `pkg/executor/executortype/{poolmgr,newdeploy,container}` provide the three execution backends.
+   `poolmgr` is the default warm-pool path: generic env pods are created up front (`gpm`/`gp`/`poolpodcontroller`) and specialized on demand by calling `fetcher` to load the user's package; `newdeploy` creates a Deployment+Service per function; `container` runs an arbitrary user container image.
 4. `pkg/buildermgr` watches `Package` CRDs in `pending` state and runs the env's `builder` sidecar (which calls into `pkg/builder`) to produce a deployment archive, uploaded to `pkg/storagesvc` (local FS or S3).
 
-Other trigger paths invoke the router URL: `pkg/kubewatcher` (watches arbitrary k8s resources), `pkg/timer` (cron), `pkg/mqtrigger` (Kafka/NATS/etc., plus a KEDA-driven scaler manager via `--mqt_keda`), `pkg/canaryconfigmgr` (gradual traffic shifting between two functions on an HTTPTrigger).
+Router listener split (post-GHSA-3g33-6vg6-27m8): the router runs **two** HTTP listeners — public (port 8888 on `svc/router`) for user HTTPTriggers + `/router-healthz` + `/_version`, and internal (port 8889 on the ClusterIP-only `svc/router-internal`) for `/fission-function/<ns>/<name>` invocations.
+The internal listener is wrapped with `pkg/auth/hmac.ServiceVerifier` (key derived for `ServiceRouterInternal` from `FISSION_INTERNAL_AUTH_SECRET`); empty secret = pass-through.
+`pkg/router/httpTriggers.go:buildMuxes` returns both routers and is called on every reconciliation, so anything that affects mux construction (e.g. `USE_ENCODED_PATH`) must be applied **inside `buildMuxes`** — applying it only at startup gets silently dropped on the first atomic mux swap.
 
-CRDs live in `pkg/apis/core/v1/` (`Function`, `Package`, `Environment`, `HTTPTrigger`, `KubernetesWatchTrigger`, `MessageQueueTrigger`, `TimeTrigger`, `CanaryConfig`). Validation lives in the same package (`validation.go`). When adding a new CRD type, follow the 10-step checklist in the comment at the top of `pkg/apis/core/v1/types.go` (create spec → type → list → register → CRUD interface → regenerate). `pkg/crd/client.go` wires the typed clients via `ClientGenerator`, which is what every `Start` function in `fission-bundle` receives. `pkg/webhook/` is a controller-runtime validating/mutating admission webhook for those CRDs; webhook YAML is generated from kubebuilder markers into `charts/fission-all/templates/webhook-server/`.
+Other trigger paths invoke the router URL: `pkg/kubewatcher` (watches arbitrary k8s resources), `pkg/timer` (cron), `pkg/mqtrigger` (Kafka/NATS/etc., plus a KEDA-driven scaler manager via `--mqt_keda`), `pkg/canaryconfigmgr` (gradual traffic shifting between two functions on an HTTPTrigger).
+They publish to `/fission-function/...` on the internal listener; `cmd/fission-bundle/main.go` resolves `ROUTER_INTERNAL_URL` from the env once and forwards it as the `routerUrl` argument into each subsystem's `Start` function — keep library constructors like `publisher.MakeWebhookPublisher` deterministic (no env reads) so unit tests with `httptest.Server` aren't broken.
+
+CRDs live in `pkg/apis/core/v1/` (`Function`, `Package`, `Environment`, `HTTPTrigger`, `KubernetesWatchTrigger`, `MessageQueueTrigger`, `TimeTrigger`, `CanaryConfig`).
+Validation lives in the same package (`validation.go`).
+When adding a new CRD type, follow the 10-step checklist in the comment at the top of `pkg/apis/core/v1/types.go` (create spec → type → list → register → CRUD interface → regenerate).
+`pkg/crd/client.go` wires the typed clients via `ClientGenerator`, which is what every `Start` function in `fission-bundle` receives.
+`pkg/webhook/` is a controller-runtime validating/mutating admission webhook for those CRDs; webhook YAML is generated from kubebuilder markers into `charts/fission-all/templates/webhook-server/`.
 
 The CLI (`cmd/fission-cli` + `pkg/fission-cli/`) talks to Kubernetes directly through the generated clientset rather than going through a controller — it creates/updates the CRDs and the controllers in `fission-bundle` reconcile.
 
 ## Things that bite
 
-- After editing `pkg/apis/core/v1/types.go`, you must run `make codegen` and `make generate-crds`; CI will fail otherwise. If you also change webhook markers, run `make generate-webhooks`.
+- After editing `pkg/apis/core/v1/types.go`, you must run `make codegen` and `make generate-crds`; CI will fail otherwise.
+  If you also change webhook markers, run `make generate-webhooks`.
 - `pkg/generated/`, `zz_generated_*.go`, and CRD YAMLs in `crds/v1/` are generated — edit the source types, not the output.
-- `hack/runtests.sh` deletes all Fission CRs in the `default` namespace of `$KUBECONFIG` if a `ok-to-destroy` configmap exists there. Don't point it at a shared cluster.
-- `skaffold-deploy` depends on `skaffold-prebuild`, which builds linux/amd64 binaries with goreleaser into `dist/` and copies Dockerfiles in. If a build looks stale, `make clean` and rerun.
+- `hack/runtests.sh` deletes all Fission CRs in the `default` namespace of `$KUBECONFIG` if a `ok-to-destroy` configmap exists there.
+  Don't point it at a shared cluster.
+- `skaffold-deploy` depends on `skaffold-prebuild`, which builds linux/amd64 binaries with goreleaser into `dist/` and copies Dockerfiles in.
+  If a build looks stale, `make clean` and rerun.
 - E2E tests on macOS require GNU coreutils on `PATH` — BSD versions silently behave differently.

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         # requires the HMAC headers; the env mounted by
         # internalAuth.envs supplies the secret used by the signer.
         - name: ROUTER_INTERNAL_URL
-          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
+          value: "http://router-internal.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "kube_client.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/kubewatcher/deployment.yaml
+++ b/charts/fission-all/templates/kubewatcher/deployment.yaml
@@ -29,9 +29,16 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        # /fission-function/<ns>/<name> lives only on the router's
+        # internal listener (GHSA-3g33-6vg6-27m8). Publishing there
+        # requires the HMAC headers; the env mounted by
+        # internalAuth.envs supplies the secret used by the signer.
+        - name: ROUTER_INTERNAL_URL
+          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "kube_client.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        {{- include "internalAuth.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.kubewatcher.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}

--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         # signs each invocation when FISSION_INTERNAL_AUTH_SECRET is
         # set (mounted by internalAuth.envs).
         - name: ROUTER_INTERNAL_URL
-          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
+          value: "http://router-internal.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
         {{- include "internalAuth.envs" . | indent 8 }}

--- a/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/deployment.yaml
@@ -43,8 +43,15 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
-        {{- include "fission-resource-namespace.envs" . | indent 8 }} 
+        # /fission-function/<ns>/<name> lives only on the router's
+        # internal listener (GHSA-3g33-6vg6-27m8). The kafka consumer
+        # signs each invocation when FISSION_INTERNAL_AUTH_SECRET is
+        # set (mounted by internalAuth.envs).
+        - name: ROUTER_INTERNAL_URL
+          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        {{- include "internalAuth.envs" . | indent 8 }}
         # TLS authentication is TLS with authentication (2 way)
         # More info: https://docs.confluent.io/current/kafka/authentication_ssl.html#ssl-overview
         {{- if .Values.kafka.authentication.tls.enabled }}

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         # build signing-aware connector images. See the comment on
         # StartScalerManager in pkg/mqtrigger/scalermanager.go.
         - name: ROUTER_INTERNAL_URL
-          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
+          value: "http://router-internal.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         - name: CONNECTOR_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
         - name: KAFKA_IMAGE

--- a/charts/fission-all/templates/mqt-keda/deployment.yaml
+++ b/charts/fission-all/templates/mqt-keda/deployment.yaml
@@ -28,6 +28,17 @@ spec:
         env:
         - name: DEBUG_ENV
           value: {{ .Values.debugEnv | quote }}
+        # KEDA-managed connector deployments invoke functions through
+        # /fission-function/<ns>/<name>, which moved to the router's
+        # internal listener with GHSA-3g33-6vg6-27m8. The scalermanager
+        # uses ROUTER_INTERNAL_URL (when set) as HTTP_ENDPOINT for the
+        # connector deployments it creates. Note: upstream KEDA
+        # connector images do not currently sign their requests, so
+        # operators that enable the HMAC verifier on the router must
+        # build signing-aware connector images. See the comment on
+        # StartScalerManager in pkg/mqtrigger/scalermanager.go.
+        - name: ROUTER_INTERNAL_URL
+          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         - name: CONNECTOR_IMAGE_PULL_POLICY
           value: "{{ .Values.pullPolicy }}"
         - name: KAFKA_IMAGE

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -36,7 +36,13 @@ spec:
         image: {{ include "fission-bundleImage" . | quote }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
-        args: ["--routerPort", "8888", "--executorUrl", "http://executor.{{ .Release.Namespace }}"]
+        args:
+          - "--routerPort"
+          - "8888"
+          - "--routerInternalPort"
+          - {{ .Values.router.internalPort | default 8889 | quote }}
+          - "--executorUrl"
+          - "http://executor.{{ .Release.Namespace }}"
         env:
         {{- if .Values.authentication.enabled }}
         - name: AUTH_USERNAME
@@ -111,6 +117,8 @@ spec:
           name: metrics
         - containerPort: 8888
           name: http
+        - containerPort: {{ .Values.router.internalPort | default 8889 }}
+          name: internal
         {{- if .Values.pprof.enabled }}
         - containerPort: 6060
           name: pprof

--- a/charts/fission-all/templates/router/networkpolicy.yaml
+++ b/charts/fission-all/templates/router/networkpolicy.yaml
@@ -60,6 +60,45 @@ spec:
       ports:
         - port: 8888
           protocol: TCP
+    # Internal listener (port {{ .Values.router.internalPort | default 8889 }}) — serves
+    # /fission-function/<ns>/<name>. After GHSA-3g33-6vg6-27m8 these
+    # routes are NOT registered on the public listener, so all
+    # in-cluster trigger callers must reach the router on this port.
+    # The HMAC verifier wraps the listener; this NetworkPolicy is the
+    # second layer of defence (zero-trust transport, per RFC-0004) that
+    # keeps unsigned attackers out of port {{ .Values.router.internalPort | default 8889 }} entirely.
+    - from:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: kubewatcher
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: timer
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: mqtrigger
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: mqtrigger-keda
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: canaryconfig
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: executor
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              svc: buildermgr
+      ports:
+        - port: {{ .Values.router.internalPort | default 8889 }}
+          protocol: TCP
     # Metrics endpoint open to any scraper.
     - ports:
         - port: 8080

--- a/charts/fission-all/templates/router/networkpolicy.yaml
+++ b/charts/fission-all/templates/router/networkpolicy.yaml
@@ -35,36 +35,26 @@ spec:
           protocol: TCP
     # Internal Fission components that publish events to the router.
     # Listed explicitly for documentation even though the open rule
-    # above already covers them.
+    # above already covers them. `podSelector` without
+    # `namespaceSelector` matches pods only in this NetworkPolicy's
+    # own namespace (the chart release namespace), which is the scope
+    # we want — and is portable across k8s versions/configs that may
+    # not auto-populate the `kubernetes.io/metadata.name` namespace
+    # label.
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: kubewatcher
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: timer
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: mqtrigger
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: mqtrigger-keda
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: canaryconfig
       ports:
@@ -78,46 +68,25 @@ spec:
     # second layer of defence (zero-trust transport, per RFC-0004) that
     # keeps unsigned attackers out of port {{ .Values.router.internalPort | default 8889 }} entirely.
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: kubewatcher
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: timer
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: mqtrigger
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: mqtrigger-keda
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: canaryconfig
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: executor
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
-          podSelector:
+        - podSelector:
             matchLabels:
               svc: buildermgr
       ports:

--- a/charts/fission-all/templates/router/networkpolicy.yaml
+++ b/charts/fission-all/templates/router/networkpolicy.yaml
@@ -37,23 +37,33 @@ spec:
     # Listed explicitly for documentation even though the open rule
     # above already covers them.
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: kubewatcher
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: timer
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: mqtrigger
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: mqtrigger-keda
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: canaryconfig
@@ -68,31 +78,45 @@ spec:
     # second layer of defence (zero-trust transport, per RFC-0004) that
     # keeps unsigned attackers out of port {{ .Values.router.internalPort | default 8889 }} entirely.
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: kubewatcher
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: timer
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: mqtrigger
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: mqtrigger-keda
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: canaryconfig
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: executor
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: buildermgr

--- a/charts/fission-all/templates/router/svc.yaml
+++ b/charts/fission-all/templates/router/svc.yaml
@@ -19,11 +19,26 @@ spec:
 {{- if eq .Values.routerServiceType "NodePort" }}
     nodePort: {{ .Values.routerPort }}
 {{- end }}
-  # internal port serves /fission-function/<ns>/<name> for in-cluster
-  # callers (executor / kubewatcher / timer / mqtrigger / canaryconfig /
-  # buildermgr). The named port lets internal callers reach it via
-  # http://router.<ns>.svc:{{ .Values.router.internalPort | default 8889 }}; the NetworkPolicy gates
-  # access to fission-bundle pods only.
+  selector:
+    svc: router
+---
+# router-internal is a separate ClusterIP-only Service so the internal
+# port stays cluster-internal regardless of routerServiceType. Keeping
+# the internal port on the same Service as the public listener would
+# expose /fission-function/<ns>/<name> via NodePort or LoadBalancer
+# whenever routerServiceType != ClusterIP — defeating the
+# GHSA-3g33-6vg6-27m8 split.
+apiVersion: v1
+kind: Service
+metadata:
+  name: router-internal
+  labels:
+    svc: router-internal
+    application: fission-router
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: ClusterIP
+  ports:
   - name: internal
     port: {{ .Values.router.internalPort | default 8889 }}
     targetPort: {{ .Values.router.internalPort | default 8889 }}

--- a/charts/fission-all/templates/router/svc.yaml
+++ b/charts/fission-all/templates/router/svc.yaml
@@ -13,10 +13,19 @@ metadata:
 spec:
   type: {{ .Values.routerServiceType }}
   ports:
-  - port: 80
+  - name: http
+    port: 80
     targetPort: 8888
 {{- if eq .Values.routerServiceType "NodePort" }}
     nodePort: {{ .Values.routerPort }}
 {{- end }}
+  # internal port serves /fission-function/<ns>/<name> for in-cluster
+  # callers (executor / kubewatcher / timer / mqtrigger / canaryconfig /
+  # buildermgr). The named port lets internal callers reach it via
+  # http://router.<ns>.svc:{{ .Values.router.internalPort | default 8889 }}; the NetworkPolicy gates
+  # access to fission-bundle pods only.
+  - name: internal
+    port: {{ .Values.router.internalPort | default 8889 }}
+    targetPort: {{ .Values.router.internalPort | default 8889 }}
   selector:
     svc: router

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -29,9 +29,16 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        # /fission-function/<ns>/<name> lives only on the router's
+        # internal listener (GHSA-3g33-6vg6-27m8). Publishing there
+        # requires HMAC signing; the env mounted by internalAuth.envs
+        # supplies the secret.
+        - name: ROUTER_INTERNAL_URL
+          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "kube_client.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}
+        {{- include "internalAuth.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.timer.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}

--- a/charts/fission-all/templates/timer/deployment.yaml
+++ b/charts/fission-all/templates/timer/deployment.yaml
@@ -34,7 +34,7 @@ spec:
         # requires HMAC signing; the env mounted by internalAuth.envs
         # supplies the secret.
         - name: ROUTER_INTERNAL_URL
-          value: "http://router.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
+          value: "http://router-internal.{{ .Release.Namespace }}:{{ .Values.router.internalPort | default 8889 }}"
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "kube_client.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -218,6 +218,14 @@ executor:
 ## router is responsible for routing function calls to the appropriate function.
 ##
 router:
+  ## internalPort is the port that backs the router's internal listener.
+  ## /fission-function/<ns>/<name> is registered ONLY on this listener
+  ## (see GHSA-3g33-6vg6-27m8). The Service exposes it as a named port
+  ## "internal" and a NetworkPolicy gates it to fission-bundle pods
+  ## (executor / kubewatcher / timer / mqtrigger / mqtrigger-keda /
+  ## canaryconfig / buildermgr) only.
+  ##
+  internalPort: 8889
   ## router priorityClassName
   ## Ref. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   ## Recommended to use system-cluster-critical for router pods.

--- a/cmd/builder/app/server.go
+++ b/cmd/builder/app/server.go
@@ -19,9 +19,11 @@ package app
 import (
 	"context"
 	"net/http"
+	"os"
 
 	"github.com/go-logr/logr"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	builder "github.com/fission/fission/pkg/builder"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/manager"
@@ -37,5 +39,23 @@ func Run(ctx context.Context, logger logr.Logger, mgr manager.Interface, shareVo
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	httpserver.StartServer(ctx, logger, mgr, "builder", "8001", mux)
+	// Wrap the mux with the HMAC verifier middleware. The master
+	// secret (when set via FISSION_INTERNAL_AUTH_SECRET on the builder
+	// pod) is derived per-service for ServiceBuilder so a leak of this
+	// builder's runtime memory cannot forge requests on other Fission
+	// internal channels (storagesvc, fetcher, executor,
+	// router-internal). An empty master means the underlying Verifier
+	// short-circuits to pass-through, preserving backwards
+	// compatibility for installs with internalAuth disabled. /healthz
+	// is bypassed so kubelet probes continue to pass without signing.
+	// See docs/internal-auth/00-design.md.
+	master := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+	masterOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
+	verifier := hmacauth.ServiceVerifier(master, masterOld, hmacauth.ServiceBuilder, hmacauth.VerifierOpts{
+		SkewSec:      60,
+		Bypass:       []string{"/healthz"},
+		MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
+		Logger:       logger.WithName("hmac"),
+	})
+	httpserver.StartServer(ctx, logger, mgr, "builder", "8001", verifier(mux))
 }

--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/fetcher"
 	"github.com/fission/fission/pkg/utils/httpserver"
@@ -124,7 +125,26 @@ func Run(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger log
 
 	logger.Info("fetcher ready to receive requests")
 
-	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-fetcher", otelUtils.UrlsToIgnore("/healthz", "/readiness-healthz"))
+	// Wrap the mux with the HMAC verifier middleware. The master
+	// secret (when set via FISSION_INTERNAL_AUTH_SECRET on the function
+	// pod's fetcher container) is derived per-service for
+	// ServiceFetcher so a leak of this fetcher's runtime memory cannot
+	// forge requests on other Fission internal channels (storagesvc,
+	// builder, executor, router-internal). An empty master means the
+	// underlying Verifier short-circuits to pass-through, preserving
+	// backwards compatibility for installs with internalAuth disabled.
+	// /healthz and /readiness-healthz are bypassed so kubelet probes
+	// continue to pass without signing. See
+	// docs/internal-auth/00-design.md.
+	master := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+	masterOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
+	verifier := hmacauth.ServiceVerifier(master, masterOld, hmacauth.ServiceFetcher, hmacauth.VerifierOpts{
+		SkewSec:      60,
+		Bypass:       []string{"/healthz", "/readiness-healthz"},
+		MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
+		Logger:       logger.WithName("hmac"),
+	})
+	handler := otelUtils.GetHandlerWithOTEL(verifier(mux), "fission-fetcher", otelUtils.UrlsToIgnore("/healthz", "/readiness-healthz"))
 	httpserver.StartServer(ctx, logger, mgr, "fetcher", port, handler)
 	return nil
 }

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -61,6 +61,7 @@ type CommandLineArgs struct {
 	// Port values
 	webhookPort        int
 	routerPort         int
+	routerInternalPort int
 	executorPort       int
 	storageServicePort int
 
@@ -190,6 +191,7 @@ func setupCommandLineArgs() *CommandLineArgs {
 	// Port flags
 	flag.IntVar(&args.webhookPort, "webhookPort", 0, "Port that the webhook should listen on")
 	flag.IntVar(&args.routerPort, "routerPort", 0, "Port that the router should listen on")
+	flag.IntVar(&args.routerInternalPort, "routerInternalPort", router.DefaultInternalListenerPort, "Port for the router internal listener that serves /fission-function/<ns>/<name>")
 	flag.IntVar(&args.executorPort, "executorPort", 0, "Port that the executor should listen on")
 	flag.IntVar(&args.storageServicePort, "storageServicePort", 0, "Port that the storage service should listen on")
 
@@ -254,7 +256,7 @@ func startRequestedService(ctx context.Context, args *CommandLineArgs, clientGen
 	}
 
 	if args.routerPort != 0 {
-		err = router.Start(ctx, clientGen, logger, mgr, args.routerPort, eclient.MakeClient(logger, args.executorUrl))
+		err = router.Start(ctx, clientGen, logger, mgr, args.routerPort, args.routerInternalPort, eclient.MakeClient(logger, args.executorUrl))
 		if err != nil {
 			logger.Error(err, "router exited")
 		}

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -38,6 +38,7 @@ import (
 	mqt "github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/router"
 	"github.com/fission/fission/pkg/storagesvc"
+	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
 	"github.com/fission/fission/pkg/timer"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 	"github.com/fission/fission/pkg/utils/manager"
@@ -256,7 +257,7 @@ func startRequestedService(ctx context.Context, args *CommandLineArgs, clientGen
 	}
 
 	if args.routerPort != 0 {
-		err = router.Start(ctx, clientGen, logger, mgr, args.routerPort, args.routerInternalPort, eclient.MakeClient(logger, args.executorUrl))
+		err = router.Start(ctx, clientGen, logger, mgr, args.routerPort, args.routerInternalPort, eclient.MakeClient(logger, args.executorUrl, storagesvcClient.HMACSecretFromEnv()))
 		if err != nil {
 			logger.Error(err, "router exited")
 		}

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -272,8 +272,18 @@ func startRequestedService(ctx context.Context, args *CommandLineArgs, clientGen
 		return
 	}
 
+	// ROUTER_INTERNAL_URL (set by the chart on internal-publisher pods)
+	// overrides the legacy --routerUrl flag for kubewatcher / timer /
+	// mqtrigger / mqt_keda — they all publish to /fission-function/...,
+	// which after GHSA-3g33-6vg6-27m8 lives only on the router's
+	// internal listener (port 8889 on svc/router-internal).
+	publishURL := args.routerUrl
+	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
+		publishURL = internal
+	}
+
 	if args.kubewatcher {
-		err = kubewatcher.Start(ctx, clientGen, logger, mgr, args.routerUrl)
+		err = kubewatcher.Start(ctx, clientGen, logger, mgr, publishURL)
 		if err != nil {
 			logger.Error(err, "kubewatcher exited")
 		}
@@ -281,7 +291,7 @@ func startRequestedService(ctx context.Context, args *CommandLineArgs, clientGen
 	}
 
 	if args.timer {
-		err = timer.Start(ctx, clientGen, logger, mgr, args.routerUrl)
+		err = timer.Start(ctx, clientGen, logger, mgr, publishURL)
 		if err != nil {
 			logger.Error(err, "timer exited")
 		}
@@ -289,7 +299,7 @@ func startRequestedService(ctx context.Context, args *CommandLineArgs, clientGen
 	}
 
 	if args.mqt {
-		err = mqtrigger.Start(ctx, clientGen, logger, mgr, args.routerUrl)
+		err = mqtrigger.Start(ctx, clientGen, logger, mgr, publishURL)
 		if err != nil {
 			logger.Error(err, "message queue manager exited")
 		}
@@ -297,7 +307,7 @@ func startRequestedService(ctx context.Context, args *CommandLineArgs, clientGen
 	}
 
 	if args.mqt_keda {
-		err = mqt.StartScalerManager(ctx, clientGen, logger, mgr, args.routerUrl)
+		err = mqt.StartScalerManager(ctx, clientGen, logger, mgr, publishURL)
 		if err != nil {
 			logger.Error(err, "mqt scaler manager exited")
 		}

--- a/pkg/builder/client/client.go
+++ b/pkg/builder/client/client.go
@@ -24,12 +24,14 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-retryablehttp"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/net/context/ctxhttp"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/builder"
 	ferror "github.com/fission/fission/pkg/error"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -48,10 +50,28 @@ type (
 	}
 )
 
-func MakeClient(logger logr.Logger, builderUrl string) ClientInterface {
+// MakeClient creates a builder client.
+//
+// masterSecret enables HMAC-SHA256 request signing per the design at
+// docs/internal-auth/00-design.md. The master is the chart-installed
+// fission-internal-auth/secret value; this client derives the
+// per-service signing key for ServiceBuilder internally so a leak of
+// one channel's runtime memory cannot forge requests on a different
+// channel. The builder only enforces signatures when its own copy of
+// the master is set on the server, so passing nil (or empty) here is
+// backwards compatible with installs that have internalAuth disabled.
+//
+// The buildermgr controller pod (the only caller) should pass
+// storagesvcClient.HMACSecretFromEnv(); the same env var
+// (FISSION_INTERNAL_AUTH_SECRET) backs every internal channel.
+func MakeClient(logger logr.Logger, builderUrl string, masterSecret []byte) ClientInterface {
 	hc := retryablehttp.NewClient()
 	hc.ErrorHandler = retryablehttp.PassthroughErrorHandler
-	hc.HTTPClient.Transport = otelhttp.NewTransport(hc.HTTPClient.Transport)
+	var rt http.RoundTripper = otelhttp.NewTransport(hc.HTTPClient.Transport)
+	if len(masterSecret) > 0 {
+		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceBuilder, rt, time.Now)
+	}
+	hc.HTTPClient.Transport = rt
 	return &client{
 		logger:     logger.WithName("builder_client"),
 		url:        strings.TrimSuffix(builderUrl, "/"),

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -34,6 +34,7 @@ import (
 	"github.com/fission/fission/pkg/fetcher"
 	fetcherClient "github.com/fission/fission/pkg/fetcher/client"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
+	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
 )
 
 // buildPackage helps to build source package into deployment package.
@@ -56,8 +57,13 @@ func buildPackage(ctx context.Context, logger logr.Logger, fissionClient version
 
 	svcName := fmt.Sprintf("%s-%s.%s", env.Name, env.ResourceVersion, envBuilderNamespace)
 	srcPkgFilename := fmt.Sprintf("%s-%s", pkg.Name, strings.ToLower(uniuri.NewLen(6)))
-	fetcherC := fetcherClient.MakeClient(logger, fmt.Sprintf("http://%s:8000", svcName))
-	builderC := builderClient.MakeClient(logger, fmt.Sprintf("http://%s:8001", svcName))
+	// HMACSecretFromEnv returns nil when internalAuth is disabled; the
+	// fetcher / builder clients pass-through unsigned in that case,
+	// which matches the corresponding verifier's empty-secret short-
+	// circuit on the server side.
+	masterSecret := storagesvcClient.HMACSecretFromEnv()
+	fetcherC := fetcherClient.MakeClient(logger, fmt.Sprintf("http://%s:8000", svcName), masterSecret)
+	builderC := builderClient.MakeClient(logger, fmt.Sprintf("http://%s:8001", svcName), masterSecret)
 
 	defer func() {
 		logger.Info("cleaning src pkg from builder storage", "source_package", srcPkgFilename)

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -24,11 +24,13 @@ import (
 	"html"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/gorilla/mux"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/client"
 	"github.com/fission/fission/pkg/executor/fscache"
@@ -267,6 +269,27 @@ func (executor *Executor) dumpDebugInfo(w http.ResponseWriter, r *http.Request) 
 // GetHandler returns an http.Handler.
 func (executor *Executor) GetHandler() http.Handler {
 	r := mux.NewRouter()
+	// Register the HMAC verifier middleware before the metrics
+	// middleware so 401 rejections are counted at the same layer as
+	// other auth failures and the metrics middleware sees the post-
+	// verification request. The master secret (when set via
+	// FISSION_INTERNAL_AUTH_SECRET on the executor pod) is derived
+	// per-service for ServiceExecutor so a leak of this executor's
+	// runtime memory cannot forge requests on other Fission internal
+	// channels (storagesvc, fetcher, builder, router-internal). An
+	// empty master means the underlying Verifier short-circuits to
+	// pass-through, preserving backwards compatibility for installs
+	// with internalAuth disabled. /healthz is bypassed so kubelet
+	// probes continue to pass without signing. See
+	// docs/internal-auth/00-design.md.
+	master := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+	masterOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
+	r.Use(hmacauth.ServiceVerifier(master, masterOld, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
+		SkewSec:      60,
+		Bypass:       []string{"/healthz"},
+		MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
+		Logger:       executor.logger.WithName("hmac"),
+	}))
 	r.Use(metrics.HTTPMetricMiddleware)
 	r.HandleFunc("/v2/getServiceForFunction", executor.getServiceForFunctionAPI).Methods("POST")
 	r.HandleFunc("/v2/tapService", executor.tapService).Methods("POST") // for backward compatibility

--- a/pkg/executor/api_auth_test.go
+++ b/pkg/executor/api_auth_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package executor
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// TestExecutorVerifierMiddlewareWiring guards the wiring contract in
+// (*Executor).GetHandler: the HMAC verifier is registered before the
+// metrics middleware, /healthz bypasses signing, and unsigned requests
+// to a non-bypass path are rejected with 401.
+//
+// This mirrors the precedent in pkg/storagesvc/storagesvc_auth_test.go
+// and runs without requiring a full Executor instance.
+func TestExecutorVerifierMiddlewareWiring(t *testing.T) {
+	master := []byte("test-master-must-be-32-bytes-min!!")
+
+	r := mux.NewRouter()
+	r.Use(hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
+		SkewSec:      60,
+		Bypass:       []string{"/healthz"},
+		MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
+	}))
+	r.HandleFunc("/v2/getServiceForFunction", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodPost)
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodGet)
+
+	t.Run("rejects unsigned /v2/getServiceForFunction", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v2/getServiceForFunction", nil)
+		r.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code,
+			"executor must 401 unsigned requests when a master is configured")
+	})
+
+	t.Run("accepts unsigned /healthz", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		r.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code,
+			"executor /healthz must remain unsigned for kubelet probes")
+	})
+
+	t.Run("empty master short-circuits to pass-through", func(t *testing.T) {
+		r2 := mux.NewRouter()
+		r2.Use(hmacauth.ServiceVerifier(nil, nil, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
+			SkewSec:      60,
+			Bypass:       []string{"/healthz"},
+			MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
+		}))
+		r2.HandleFunc("/v2/getServiceForFunction", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}).Methods(http.MethodPost)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/v2/getServiceForFunction", nil)
+		r2.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code,
+			"empty master must short-circuit the verifier and pass requests through")
+	})
+}

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"time"
@@ -32,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	ferror "github.com/fission/fission/pkg/error"
 )
 
@@ -60,9 +62,26 @@ type (
 )
 
 // MakeClient initializes and returns a Client instance.
-func MakeClient(logger logr.Logger, executorURL string) ClientInterface {
+//
+// masterSecret enables HMAC-SHA256 request signing per the design at
+// docs/internal-auth/00-design.md. The master is the chart-installed
+// fission-internal-auth/secret value; this client derives the
+// per-service signing key for ServiceExecutor internally so a leak of
+// one channel's runtime memory cannot forge requests on a different
+// channel. The executor only enforces signatures when its own copy of
+// the master is set on the server, so passing nil (or empty) here is
+// backwards compatible with installs that have internalAuth disabled.
+//
+// The router (the only in-cluster caller) should pass
+// storagesvcClient.HMACSecretFromEnv(); the same env var
+// (FISSION_INTERNAL_AUTH_SECRET) backs every internal channel.
+func MakeClient(logger logr.Logger, executorURL string, masterSecret []byte) ClientInterface {
 	hc := retryablehttp.NewClient()
-	hc.HTTPClient.Transport = otelhttp.NewTransport(hc.HTTPClient.Transport)
+	var rt http.RoundTripper = otelhttp.NewTransport(hc.HTTPClient.Transport)
+	if len(masterSecret) > 0 {
+		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceExecutor, rt, time.Now)
+	}
+	hc.HTTPClient.Transport = rt
 	c := &client{
 		logger:      logger.WithName("executor_client"),
 		executorURL: strings.TrimSuffix(executorURL, "/"),

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -50,6 +50,7 @@ import (
 	fetcherClient "github.com/fission/fission/pkg/fetcher/client"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
+	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/maps"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -460,8 +461,13 @@ func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv
 	logger.Info("specializing pod", "function", fn.Name)
 
 	// Fetcher will download user function to share volume of pod, and
-	// invoke environment specialize api for pod specialization.
-	err := fetcherClient.MakeClient(gp.logger, fetcherURL).Specialize(ctx, &specializeReq)
+	// invoke environment specialize api for pod specialization. The
+	// HMAC master secret (when internalAuth is enabled) is read from
+	// the executor pod's env so each /specialize call to the in-pod
+	// fetcher carries the X-Fission-Auth-* headers required by the
+	// fetcher's verifier; an empty secret is the explicit pass-through
+	// for first-deploy installs.
+	err := fetcherClient.MakeClient(gp.logger, fetcherURL, storagesvcClient.HMACSecretFromEnv()).Specialize(ctx, &specializeReq)
 	if err != nil {
 		return err
 	}

--- a/pkg/fetcher/client/client.go
+++ b/pkg/fetcher/client/client.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fetcher"
 )
@@ -32,8 +33,27 @@ type (
 	}
 )
 
-func MakeClient(logger logr.Logger, fetcherUrl string) ClientInterface {
-	hc := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
+// MakeClient creates a fetcher client.
+//
+// masterSecret enables HMAC-SHA256 request signing per the design at
+// docs/internal-auth/00-design.md. The master is the chart-installed
+// fission-internal-auth/secret value; this client derives the
+// per-service signing key for ServiceFetcher internally so a leak of
+// one channel's runtime memory cannot forge requests on a different
+// channel. The fetcher only enforces signatures when its own copy of
+// the master is set on the server, so passing nil (or empty) here is
+// backwards compatible with installs that have internalAuth disabled.
+//
+// Controller pods (buildermgr, executor) should pass
+// storagesvcClient.HMACSecretFromEnv() — the same env var
+// (FISSION_INTERNAL_AUTH_SECRET) backs every internal channel's
+// signing/verification.
+func MakeClient(logger logr.Logger, fetcherUrl string, masterSecret []byte) ClientInterface {
+	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	if len(masterSecret) > 0 {
+		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceFetcher, rt, time.Now)
+	}
+	hc := &http.Client{Transport: rt}
 	return &client{
 		logger:     logger.WithName("fetcher_client"),
 		url:        strings.TrimSuffix(fetcherUrl, "/"),

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -72,13 +72,6 @@ func NewMqtConsumerGroupHandler(version sarama.KafkaVersion,
 	trigger *fv1.MessageQueueTrigger,
 	producer sarama.SyncProducer,
 	routerUrl string) MqtConsumerGroupHandler {
-	// If ROUTER_INTERNAL_URL is set in the environment, prefer it over
-	// the routerUrl flag — operators wire it to the router's internal
-	// listener (port 8889), where /fission-function/<ns>/<name> lives
-	// after GHSA-3g33-6vg6-27m8.
-	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
-		routerUrl = internal
-	}
 	ch := MqtConsumerGroupHandler{
 		version:    version,
 		logger:     logger,

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"errors"
 
@@ -30,9 +31,23 @@ import (
 	"github.com/go-logr/logr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/utils"
 )
+
+// newKafkaHTTPClient builds the http.Client used to invoke functions
+// through the router. When FISSION_INTERNAL_AUTH_SECRET is set the
+// transport is wrapped with hmacauth.NewSigner, so every
+// /fission-function/<ns>/<name> request carries the X-Fission-Auth-*
+// headers required by the router's internal-listener verifier.
+func newKafkaHTTPClient() *http.Client {
+	rt := http.DefaultTransport
+	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {
+		return &http.Client{Transport: hmacauth.NewSigner([]byte(secret), rt, time.Now)}
+	}
+	return &http.Client{Transport: rt}
+}
 
 type MqtConsumerGroupHandler struct {
 	version        sarama.KafkaVersion
@@ -42,6 +57,10 @@ type MqtConsumerGroupHandler struct {
 	producer       sarama.SyncProducer
 	fnUrl          string
 	ready          chan bool
+	// httpClient invokes the function via the router. It signs each
+	// request when FISSION_INTERNAL_AUTH_SECRET is set, so the
+	// router's internal-listener HMAC verifier accepts it.
+	httpClient *http.Client
 }
 
 func NewMqtConsumerGroupHandler(version sarama.KafkaVersion,
@@ -49,12 +68,20 @@ func NewMqtConsumerGroupHandler(version sarama.KafkaVersion,
 	trigger *fv1.MessageQueueTrigger,
 	producer sarama.SyncProducer,
 	routerUrl string) MqtConsumerGroupHandler {
+	// If ROUTER_INTERNAL_URL is set in the environment, prefer it over
+	// the routerUrl flag — operators wire it to the router's internal
+	// listener (port 8889), where /fission-function/<ns>/<name> lives
+	// after GHSA-3g33-6vg6-27m8.
+	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
+		routerUrl = internal
+	}
 	ch := MqtConsumerGroupHandler{
-		version:  version,
-		logger:   logger,
-		trigger:  trigger,
-		producer: producer,
-		ready:    make(chan bool),
+		version:    version,
+		logger:     logger,
+		trigger:    trigger,
+		producer:   producer,
+		ready:      make(chan bool),
+		httpClient: newKafkaHTTPClient(),
 	}
 	// Support other function ref types
 	if ch.trigger.Spec.FunctionReference.Type != fv1.FunctionReferenceTypeFunctionName {
@@ -165,8 +192,9 @@ func (ch *MqtConsumerGroupHandler) kafkaMsgHandler(msg *sarama.ConsumerMessage) 
 	// Make the request
 	var resp *http.Response
 	for attempt := 0; attempt <= ch.trigger.Spec.MaxRetries; attempt++ {
-		// Make the request
-		resp, err = http.DefaultClient.Do(req)
+		// Make the request via the per-handler client so HMAC
+		// signing (when configured) is applied.
+		resp, err = ch.httpClient.Do(req)
 		if err != nil {
 			ch.logger.Error(err, "sending function invocation request failed", "function_url", ch.fnUrl,
 				"trigger", ch.trigger.Name)

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -193,11 +193,20 @@ func (ch *MqtConsumerGroupHandler) kafkaMsgHandler(msg *sarama.ConsumerMessage) 
 		req.Header.Set(k, v)
 	}
 
-	// Make the request
+	// Make the request via the per-handler client so HMAC
+	// signing (when configured) is applied. Reset the body on every
+	// retry: net/http closes req.Body after each Do() call, AND the
+	// HMAC signing transport reads it for the canonical hash —
+	// without resetting we'd send an empty body on retry and fail
+	// signature verification on the receiving side.
 	var resp *http.Response
 	for attempt := 0; attempt <= ch.trigger.Spec.MaxRetries; attempt++ {
-		// Make the request via the per-handler client so HMAC
-		// signing (when configured) is applied.
+		req.Body = io.NopCloser(strings.NewReader(value))
+		// GetBody is also set so net/http's redirect / retryablehttp
+		// paths can re-read the body if they need to.
+		req.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader(value)), nil
+		}
 		resp, err = ch.httpClient.Do(req)
 		if err != nil {
 			ch.logger.Error(err, "sending function invocation request failed", "function_url", ch.fnUrl,

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -38,13 +38,17 @@ import (
 
 // newKafkaHTTPClient builds the http.Client used to invoke functions
 // through the router. When FISSION_INTERNAL_AUTH_SECRET is set the
-// transport is wrapped with hmacauth.NewSigner, so every
-// /fission-function/<ns>/<name> request carries the X-Fission-Auth-*
-// headers required by the router's internal-listener verifier.
+// transport is wrapped with hmacauth.ServiceSigner for
+// ServiceRouterInternal, so every /fission-function/<ns>/<name>
+// request carries the X-Fission-Auth-* headers required by the
+// router's internal-listener verifier. Using the per-service derived
+// key keeps a leak of this consumer's runtime memory from forging
+// requests on other Fission internal channels (storagesvc, fetcher,
+// builder, executor). See docs/internal-auth/00-design.md.
 func newKafkaHTTPClient() *http.Client {
 	rt := http.DefaultTransport
-	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {
-		return &http.Client{Transport: hmacauth.NewSigner([]byte(secret), rt, time.Now)}
+	if master := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); master != "" {
+		return &http.Client{Transport: hmacauth.ServiceSigner([]byte(master), hmacauth.ServiceRouterInternal, rt, time.Now)}
 	}
 	return &http.Client{Transport: rt}
 }

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -101,21 +101,20 @@ func mqTriggerEventHandlers(ctx context.Context, logger logr.Logger, kubeClient 
 // StartScalerManager watches for changes in MessageQueueTrigger and,
 // Based on changes, it Creates, Updates and Deletes Objects of Kind ScaledObjects, AuthenticationTriggers and Deployments.
 //
-// If ROUTER_INTERNAL_URL is set, it overrides the routerURL flag so the
-// HTTP_ENDPOINT env var on KEDA-managed connector deployments points at
-// the router's internal listener (where /fission-function/... lives
-// after GHSA-3g33-6vg6-27m8). KEDA connector images sourced from
-// upstream do not currently sign their requests, so deployments that
-// enable both KEDA scalers and the HMAC verifier on the router need
-// connector images that have been updated to sign — operators should
-// either keep FISSION_INTERNAL_AUTH_SECRET unset (rely on NetworkPolicy
-// for isolation, which still gates port 8889 to fission-bundle pods
-// only) or build signing-aware connector images. This is a documented
+// routerURL is propagated as the HTTP_ENDPOINT env var on KEDA-managed
+// connector deployments. The fission-bundle entrypoint resolves
+// ROUTER_INTERNAL_URL from the environment before invoking this
+// function, so KEDA connectors point at the router's internal
+// listener (where /fission-function/... lives after
+// GHSA-3g33-6vg6-27m8). KEDA connector images sourced from upstream do
+// not currently sign their requests, so deployments that enable both
+// KEDA scalers and the HMAC verifier on the router need connector
+// images that have been updated to sign — operators should either
+// keep FISSION_INTERNAL_AUTH_SECRET unset (rely on NetworkPolicy for
+// isolation, which still gates port 8889 to fission-bundle pods only)
+// or build signing-aware connector images. This is a documented
 // rollout caveat for advisory 4.
 func StartScalerManager(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, routerURL string) error {
-	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
-		routerURL = internal
-	}
 	fissionClient, err := clientGen.GetFissionClient()
 	if err != nil {
 		return fmt.Errorf("failed to get fission client: %w", err)

--- a/pkg/mqtrigger/scalermanager.go
+++ b/pkg/mqtrigger/scalermanager.go
@@ -99,8 +99,23 @@ func mqTriggerEventHandlers(ctx context.Context, logger logr.Logger, kubeClient 
 }
 
 // StartScalerManager watches for changes in MessageQueueTrigger and,
-// Based on changes, it Creates, Updates and Deletes Objects of Kind ScaledObjects, AuthenticationTriggers and Deployments
+// Based on changes, it Creates, Updates and Deletes Objects of Kind ScaledObjects, AuthenticationTriggers and Deployments.
+//
+// If ROUTER_INTERNAL_URL is set, it overrides the routerURL flag so the
+// HTTP_ENDPOINT env var on KEDA-managed connector deployments points at
+// the router's internal listener (where /fission-function/... lives
+// after GHSA-3g33-6vg6-27m8). KEDA connector images sourced from
+// upstream do not currently sign their requests, so deployments that
+// enable both KEDA scalers and the HMAC verifier on the router need
+// connector images that have been updated to sign — operators should
+// either keep FISSION_INTERNAL_AUTH_SECRET unset (rely on NetworkPolicy
+// for isolation, which still gates port 8889 to fission-bundle pods
+// only) or build signing-aware connector images. This is a documented
+// rollout caveat for advisory 4.
 func StartScalerManager(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, routerURL string) error {
+	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
+		routerURL = internal
+	}
 	fissionClient, err := clientGen.GetFissionClient()
 	if err != nil {
 		return fmt.Errorf("failed to get fission client: %w", err)

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -75,11 +75,12 @@ type (
 // /fission-function/<ns>/<name> after GHSA-3g33-6vg6-27m8.
 //
 // If FISSION_INTERNAL_AUTH_SECRET is set, the publisher's HTTP transport
-// is wrapped with hmacauth.NewSigner so each /fission-function/...
-// invocation carries the X-Fission-Auth-* headers that the router's
-// internal-listener verifier expects. An unset secret leaves the
-// transport unsigned, matching the verifier's pass-through mode for
-// first-deploy installs.
+// is wrapped with hmacauth.ServiceSigner using ServiceRouterInternal,
+// so each /fission-function/... invocation carries the X-Fission-Auth-*
+// headers that the router's internal-listener verifier expects (with
+// the per-service derived key, not the master). An unset secret leaves
+// the transport unsigned, matching the verifier's pass-through mode
+// for first-deploy installs.
 func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher {
 	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
 		baseURL = internal

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -66,13 +66,15 @@ type (
 	}
 )
 
-// MakeWebhookPublisher creates a WebhookPublisher object for the given baseURL.
-//
-// If ROUTER_INTERNAL_URL is set in the environment, baseURL is overridden
-// with that value — this points kubewatcher / timer / mqtrigger at the
-// router's internal listener (port 8889) instead of the public listener
-// (port 8888). The internal listener is the only route registration for
-// /fission-function/<ns>/<name> after GHSA-3g33-6vg6-27m8.
+// MakeWebhookPublisher creates a WebhookPublisher object for the given
+// baseURL. The publisher uses baseURL verbatim; callers that want to
+// override with a router-internal address must resolve it themselves
+// (typically at fission-bundle dispatch time, where the
+// ROUTER_INTERNAL_URL env var is consulted before the routerUrl flag
+// is forwarded into kubewatcher / timer / mqtrigger Start). Keeping
+// MakeWebhookPublisher deterministic lets unit tests construct a
+// publisher against an httptest.Server URL without having to scrub
+// env state.
 //
 // If FISSION_INTERNAL_AUTH_SECRET is set, the publisher's HTTP transport
 // is wrapped with hmacauth.ServiceSigner using ServiceRouterInternal,
@@ -82,9 +84,6 @@ type (
 // the transport unsigned, matching the verifier's pass-through mode
 // for first-deploy installs.
 func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher {
-	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
-		baseURL = internal
-	}
 	p := &WebhookPublisher{
 		logger:         logger.WithName("webhook_publisher"),
 		baseURL:        baseURL,

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -108,10 +108,16 @@ func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher 
 // trace headers are intentionally NOT part of the signed canonical
 // form, which keeps the signature stable across tracing-config
 // changes and avoids re-signing per request retry.
+//
+// The signing key is derived from the master via HKDF-SHA256 for
+// ServiceRouterInternal so a leak of this caller's runtime memory
+// cannot forge requests on other Fission internal channels
+// (storagesvc, fetcher, builder, executor). See
+// docs/internal-auth/00-design.md.
 func newWebhookHTTPClient() *http.Client {
 	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
-	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {
-		rt = hmacauth.NewSigner([]byte(secret), rt, time.Now)
+	if master := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); master != "" {
+		rt = hmacauth.ServiceSigner([]byte(master), hmacauth.ServiceRouterInternal, rt, time.Now)
 	}
 	return &http.Client{Transport: rt}
 }

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -46,6 +48,12 @@ type (
 
 		baseURL string
 		timeout time.Duration
+
+		// httpClient is the per-publisher transport. We keep it on the
+		// struct (rather than reusing the package-level WebhookHttpClient)
+		// so each publisher can carry its own HMAC signer configured at
+		// construction time.
+		httpClient *http.Client
 	}
 	publishRequest struct {
 		ctx        context.Context
@@ -58,11 +66,28 @@ type (
 	}
 )
 
-// MakeWebhookPublisher creates a WebhookPublisher object for the given baseURL
+// MakeWebhookPublisher creates a WebhookPublisher object for the given baseURL.
+//
+// If ROUTER_INTERNAL_URL is set in the environment, baseURL is overridden
+// with that value — this points kubewatcher / timer / mqtrigger at the
+// router's internal listener (port 8889) instead of the public listener
+// (port 8888). The internal listener is the only route registration for
+// /fission-function/<ns>/<name> after GHSA-3g33-6vg6-27m8.
+//
+// If FISSION_INTERNAL_AUTH_SECRET is set, the publisher's HTTP transport
+// is wrapped with hmacauth.NewSigner so each /fission-function/...
+// invocation carries the X-Fission-Auth-* headers that the router's
+// internal-listener verifier expects. An unset secret leaves the
+// transport unsigned, matching the verifier's pass-through mode for
+// first-deploy installs.
 func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher {
+	if internal := os.Getenv("ROUTER_INTERNAL_URL"); internal != "" {
+		baseURL = internal
+	}
 	p := &WebhookPublisher{
 		logger:         logger.WithName("webhook_publisher"),
 		baseURL:        baseURL,
+		httpClient:     newWebhookHTTPClient(),
 		requestChannel: make(chan *publishRequest, 32), // buffered channel
 		// TODO make this configurable
 		timeout: 60 * time.Minute,
@@ -72,6 +97,23 @@ func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher 
 	}
 	go p.svc()
 	return p
+}
+
+// newWebhookHTTPClient constructs the HTTP client used to invoke
+// /fission-function/<ns>/<name> on the router's internal listener. The
+// transport stack is otelhttp -> [hmacauth, when secret set] ->
+// http.DefaultTransport so the signature is computed AFTER OTEL has
+// added its trace headers (otherwise the signed canonical form would
+// not include those headers, but they are not part of the signed
+// canonical anyway — only path/method/body/timestamp are signed, so
+// ordering here is purely about which Transport sees the body buffer
+// in what state).
+func newWebhookHTTPClient() *http.Client {
+	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {
+		rt = hmacauth.NewSigner([]byte(secret), rt, time.Now)
+	}
+	return &http.Client{Transport: rt}
 }
 
 // Publish sends a request to the target with payload having given body and headers
@@ -99,6 +141,9 @@ func (p *WebhookPublisher) svc() {
 	}
 }
 
+// WebhookHttpClient is retained for backwards compatibility with any
+// external callers that may have referenced it. New code should use a
+// *WebhookPublisher (which carries its own per-instance http.Client).
 var WebhookHttpClient = &http.Client{
 	Transport: otelhttp.NewTransport(http.DefaultTransport),
 }
@@ -135,7 +180,7 @@ func (p *WebhookPublisher) makeHTTPRequest(r *publishRequest) {
 	// Make the request
 	ctx, cancel := context.WithTimeoutCause(r.ctx, p.timeout, fmt.Errorf("webhook request timed out (%f)s exceeded ", p.timeout.Seconds()))
 	defer cancel()
-	resp, err := ctxhttp.Do(ctx, WebhookHttpClient, req)
+	resp, err := ctxhttp.Do(ctx, p.httpClient, req)
 	if err != nil {
 		logger = logger.WithValues("request", r)
 	} else {

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -100,14 +100,14 @@ func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher 
 }
 
 // newWebhookHTTPClient constructs the HTTP client used to invoke
-// /fission-function/<ns>/<name> on the router's internal listener. The
-// transport stack is otelhttp -> [hmacauth, when secret set] ->
-// http.DefaultTransport so the signature is computed AFTER OTEL has
-// added its trace headers (otherwise the signed canonical form would
-// not include those headers, but they are not part of the signed
-// canonical anyway — only path/method/body/timestamp are signed, so
-// ordering here is purely about which Transport sees the body buffer
-// in what state).
+// /fission-function/<ns>/<name> on the router's internal listener.
+// The transport stack is hmacauth (outermost, when secret set) ->
+// otelhttp -> http.DefaultTransport: the signer runs first and
+// computes the canonical form over (method, path, body, timestamp);
+// otelhttp then injects trace headers on the inner transport. OTEL
+// trace headers are intentionally NOT part of the signed canonical
+// form, which keeps the signature stable across tracing-config
+// changes and avoids re-signing per request retry.
 func newWebhookHTTPClient() *http.Client {
 	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
 	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -444,10 +444,15 @@ func (ts *HTTPTriggerSet) updateRouter(ctx context.Context) {
 		}
 		ts.functions = allfunctions
 
-		// make a new pair of routers and swap them in atomically. We
-		// rebuild and swap the public listener even when the internal
-		// listener is disabled (nil), so the legacy single-listener
-		// callers keep their original behaviour.
+		// Rebuild both muxes from the same function snapshot then swap
+		// each in turn. The two updateRouter calls are sequential, not
+		// transactional — a request that arrives between the two swaps
+		// could see an updated public mux and a stale internal mux for
+		// a few microseconds, but both muxes derive from the same
+		// `functions` snapshot so the function set served by either
+		// listener is consistent in steady state. True atomicity across
+		// listeners would require a shared atomic.Pointer holding both
+		// muxes; not worth the complexity for this case.
 		public, internal, err := ts.buildMuxes(functionTimeout)
 		if err != nil {
 			ts.logger.Error(err, "error updating router")

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -49,6 +49,12 @@ type HTTPTriggerSet struct {
 	*functionServiceMap
 	*mutableRouter
 
+	// internalMutableRouter is the mutable wrapper for the internal listener.
+	// It is updated in lockstep with mutableRouter (the public listener) on
+	// every trigger / function reconciliation. May be nil in unit-test paths
+	// that only construct the public mux directly.
+	internalMutableRouter *mutableRouter
+
 	logger                     logr.Logger
 	fissionClient              versioned.Interface
 	kubeClient                 kubernetes.Interface
@@ -96,18 +102,25 @@ func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionCli
 	return httpTriggerSet, nil
 }
 
-func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mgr manager.Interface, mr *mutableRouter) error {
+// subscribeRouter wires the public mutable router and (optionally) the
+// internal mutable router. Passing internalMR=nil preserves the legacy
+// single-listener path used by older test scaffolding.
+func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mgr manager.Interface, mr *mutableRouter, internalMR *mutableRouter) error {
 	resolver := makeFunctionReferenceResolver(ts.logger, ts.funcInformer)
 	ts.resolver = resolver
 	ts.mutableRouter = mr
+	ts.internalMutableRouter = internalMR
 
 	if ts.fissionClient == nil {
 		// Used in tests only.
-		router, err := ts.getRouter(nil)
+		public, internal, err := ts.buildMuxes(nil)
 		if err != nil {
 			return err
 		}
-		mr.updateRouter(router)
+		mr.updateRouter(public)
+		if internalMR != nil {
+			internalMR.updateRouter(internal)
+		}
 		ts.logger.Info("skipping continuous trigger updates")
 		return nil
 	}
@@ -143,20 +156,44 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// getRouter builds the public-listener mux router. It is preserved as a
+// thin wrapper over buildMuxes so any in-package caller (notably unit
+// tests) that only needs the public-side router stays unchanged.
 func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router, error) {
+	public, _, err := ts.buildMuxes(fnTimeoutMap)
+	return public, err
+}
 
+// buildMuxes constructs the two mux.Router instances that back the router
+// process: one for the public listener (user HTTPTriggers + healthz +
+// version + optional auth) and one for the internal listener
+// (`/fission-function/<ns>/<name>` and its prefix variant). Splitting
+// the registrations is the core of GHSA-3g33-6vg6-27m8 — internal
+// invocation routes must never be reachable from the public listener,
+// because they bypass HTTPTrigger gates (auth middleware, host/method
+// matching) by design.
+//
+// The internal mux deliberately omits the metrics middleware, the auth
+// middleware, and the GKE-ingress `/` no-op handler: those concerns are
+// public-listener only. Callers wrap the internal mux with
+// hmac.Verifier in the bundle process; the verifier is intentionally
+// not added here so this function stays unit-testable without HMAC env
+// state.
+func (ts *HTTPTriggerSet) buildMuxes(fnTimeoutMap map[types.UID]int) (public, internal *mux.Router, err error) {
 	featureConfig, err := config.GetFeatureConfig(ts.logger)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	muxRouter := mux.NewRouter()
-	muxRouter.Use(metrics.HTTPMetricMiddleware)
+	public = mux.NewRouter()
+	internal = mux.NewRouter()
+
+	public.Use(metrics.HTTPMetricMiddleware)
 	if featureConfig.AuthConfig.IsEnabled {
-		muxRouter.Use(authMiddleware(featureConfig))
+		public.Use(authMiddleware(featureConfig))
 	}
 
-	// HTTP triggers setup by the user
+	// HTTP triggers setup by the user — public listener only.
 	homeHandled := false
 	for i := range ts.triggers {
 		trigger := ts.triggers[i]
@@ -218,19 +255,19 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 		if trigger.Spec.Prefix != nil && *trigger.Spec.Prefix != "" {
 			prefix := *trigger.Spec.Prefix
 			if strings.HasSuffix(prefix, "/") {
-				ht := muxRouter.PathPrefix(prefix).Handler(handler)
+				ht := public.PathPrefix(prefix).Handler(handler)
 				ht.Methods(methods...)
 				if trigger.Spec.Host != "" {
 					ht.Host(trigger.Spec.Host)
 				}
 				ts.logger.V(1).Info("add prefix route for function", "route", prefix, "function", fh.function, "methods", methods)
 			} else {
-				ht1 := muxRouter.Handle(prefix, handler)
+				ht1 := public.Handle(prefix, handler)
 				ht1.Methods(methods...)
 				if trigger.Spec.Host != "" {
 					ht1.Host(trigger.Spec.Host)
 				}
-				ht2 := muxRouter.PathPrefix(prefix + "/").Handler(handler)
+				ht2 := public.PathPrefix(prefix + "/").Handler(handler)
 				ht2.Methods(methods...)
 				if trigger.Spec.Host != "" {
 					ht2.Host(trigger.Spec.Host)
@@ -238,7 +275,7 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 				ts.logger.V(1).Info("add prefix and handler route for function", "route", prefix, "function", fh.function, "methods", methods)
 			}
 		} else {
-			ht := muxRouter.Handle(trigger.Spec.RelativeURL, handler)
+			ht := public.Handle(trigger.Spec.RelativeURL, handler)
 			ht.Methods(methods...)
 			if trigger.Spec.Host != "" {
 				ht.Host(trigger.Spec.Host)
@@ -258,11 +295,13 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 		// want it to be a 404 even if the user doesn't have a function mapped to
 		// this route.
 		//
-		muxRouter.HandleFunc("/", defaultHomeHandler).Methods("GET")
+		public.HandleFunc("/", defaultHomeHandler).Methods("GET")
 	}
 
-	// Internal triggers for each function by name. Non-http
-	// triggers route into these.
+	// Internal triggers for each function by name. Non-http triggers
+	// (timer, kubewatcher, mqtrigger) and the executor's invocation
+	// path land here. These routes live ONLY on the internal mux —
+	// exposing them on the public listener is GHSA-3g33-6vg6-27m8.
 	for i := range ts.functions {
 		fn := ts.functions[i]
 		fh := &functionHandler{
@@ -280,8 +319,8 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 		internalRoute := utils.UrlForFunction(fn.Name, fn.Namespace)
 		internalPrefixRoute := internalRoute + "/"
 		handler := http.HandlerFunc(fh.handler)
-		muxRouter.Handle(internalRoute, handler)
-		muxRouter.PathPrefix(internalPrefixRoute).Handler(handler)
+		internal.Handle(internalRoute, handler)
+		internal.PathPrefix(internalPrefixRoute).Handler(handler)
 		ts.logger.V(1).Info("add internal handler and prefix route for function", "router", internalRoute, "function", fn)
 	}
 
@@ -289,15 +328,17 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router
 
 		path := featureConfig.AuthConfig.AuthUriPath
 		// Auth endpoint for the router.
-		muxRouter.HandleFunc(path, authLoginHandler(featureConfig)).Methods("POST")
+		public.HandleFunc(path, authLoginHandler(featureConfig)).Methods("POST")
 	}
 
-	// Healthz endpoint for the router.
-	muxRouter.HandleFunc("/router-healthz", routerHealthHandler).Methods("GET")
+	// Healthz endpoint for the router. Stays on the public listener so
+	// existing readiness/liveness probes and external monitors keep
+	// working without HMAC credentials.
+	public.HandleFunc("/router-healthz", routerHealthHandler).Methods("GET")
 	// version of application.
-	muxRouter.HandleFunc("/_version", versionHandler).Methods("GET")
+	public.HandleFunc("/_version", versionHandler).Methods("GET")
 
-	return muxRouter, nil
+	return public, internal, nil
 }
 
 func (ts *HTTPTriggerSet) updateTriggerStatusFailed(ht *fv1.HTTPTrigger, err error) {
@@ -411,12 +452,18 @@ func (ts *HTTPTriggerSet) updateRouter(ctx context.Context) {
 		}
 		ts.functions = allfunctions
 
-		// make a new router and use it
-		router, err := ts.getRouter(functionTimeout)
+		// make a new pair of routers and swap them in atomically. We
+		// rebuild and swap the public listener even when the internal
+		// listener is disabled (nil), so the legacy single-listener
+		// callers keep their original behaviour.
+		public, internal, err := ts.buildMuxes(functionTimeout)
 		if err != nil {
 			ts.logger.Error(err, "error updating router")
 			continue
 		}
-		ts.mutableRouter.updateRouter(router)
+		ts.mutableRouter.updateRouter(public)
+		if ts.internalMutableRouter != nil {
+			ts.internalMutableRouter.updateRouter(internal)
+		}
 	}
 }

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -67,13 +67,14 @@ type HTTPTriggerSet struct {
 	updateRouterRequestChannel chan struct{}
 	tsRoundTripperParams       *tsRoundTripperParams
 	isDebugEnv                 bool
+	useEncodedPath             bool
 	svcAddrUpdateThrottler     *throttler.Throttler
 	unTapServiceTimeout        time.Duration
 	syncDebouncer              func(func())
 }
 
 func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionClient versioned.Interface,
-	kubeClient kubernetes.Interface, executor eclient.ClientInterface, params *tsRoundTripperParams, isDebugEnv bool, unTapServiceTimeout time.Duration, actionThrottler *throttler.Throttler) (*HTTPTriggerSet, error) {
+	kubeClient kubernetes.Interface, executor eclient.ClientInterface, params *tsRoundTripperParams, isDebugEnv bool, useEncodedPath bool, unTapServiceTimeout time.Duration, actionThrottler *throttler.Throttler) (*HTTPTriggerSet, error) {
 
 	httpTriggerSet := &HTTPTriggerSet{
 		logger:                     logger.WithName("http_trigger_set"),
@@ -85,6 +86,7 @@ func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionCli
 		updateRouterRequestChannel: make(chan struct{}, 10), // use buffer channel
 		tsRoundTripperParams:       params,
 		isDebugEnv:                 isDebugEnv,
+		useEncodedPath:             useEncodedPath,
 		svcAddrUpdateThrottler:     actionThrottler,
 		unTapServiceTimeout:        unTapServiceTimeout,
 		syncDebouncer:              debounce.New(time.Millisecond * 20),
@@ -179,6 +181,15 @@ func (ts *HTTPTriggerSet) buildMuxes(fnTimeoutMap map[types.UID]int) (public, in
 
 	public = mux.NewRouter()
 	internal = mux.NewRouter()
+	// Honour USE_ENCODED_PATH (see issue #1317) on every reconciliation:
+	// buildMuxes is called repeatedly by updateRouter and the resulting
+	// routers are atomically swapped under the listener handlers. If we
+	// don't apply UseEncodedPath here, the feature works only until the
+	// first reconciliation and then silently turns off.
+	if ts.useEncodedPath {
+		public = public.UseEncodedPath()
+		internal = internal.UseEncodedPath()
+	}
 
 	public.Use(metrics.HTTPMetricMiddleware)
 	if featureConfig.AuthConfig.IsEnabled {

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -156,14 +156,6 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// getRouter builds the public-listener mux router. It is preserved as a
-// thin wrapper over buildMuxes so any in-package caller (notably unit
-// tests) that only needs the public-side router stays unchanged.
-func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) (*mux.Router, error) {
-	public, _, err := ts.buildMuxes(fnTimeoutMap)
-	return public, err
-}
-
 // buildMuxes constructs the two mux.Router instances that back the router
 // process: one for the public listener (user HTTPTriggers + healthz +
 // version + optional auth) and one for the internal listener

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/bep/debounce"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// muxMatches reports whether the gorilla/mux router would dispatch
+// `path` (with `method`) to a registered route. It is used in unit
+// tests to assert route registration without actually running the
+// downstream handler — handlers in this package require additional
+// tsRoundTripperParams plumbing that has no place in a routing test.
+func muxMatches(r *mux.Router, method, path string) bool {
+	req := httptest.NewRequest(method, path, nil)
+	var match mux.RouteMatch
+	return r.Match(req, &match) && match.Handler != nil
+}
+
+// newTestTriggerSet builds an HTTPTriggerSet wired with a minimal
+// resolver and no Kubernetes informers. It is intended only for tests
+// that exercise buildMuxes.
+func newTestTriggerSet(t *testing.T, functions []fv1.Function, triggers []fv1.HTTPTrigger) *HTTPTriggerSet {
+	t.Helper()
+	logger := loggerfactory.GetLogger()
+	ts := &HTTPTriggerSet{
+		logger:                     logger.WithName("test_trigger_set"),
+		functionServiceMap:         makeFunctionServiceMap(logger, time.Minute),
+		triggers:                   triggers,
+		functions:                  functions,
+		updateRouterRequestChannel: make(chan struct{}, 1),
+		syncDebouncer:              debounce.New(time.Millisecond),
+	}
+	// resolver only matters when triggers are present; supply a stub
+	// so resolve() does not panic on an empty trigger list.
+	ts.resolver = makeFunctionReferenceResolver(ts.logger, nil)
+	return ts
+}
+
+// TestPublicMuxDoesNotRegisterInternalFunctionRoute is the GHSA-3g33-6vg6-27m8
+// regression guard: the public listener must NOT have a route
+// registered for /fission-function/<ns>/<name>, while the internal
+// listener MUST. We check route registration via mux.Match rather
+// than driving the handler — the handler relies on tsRoundTripperParams
+// and a live functionService cache, neither of which belong in a unit
+// test for route shape.
+func TestPublicMuxDoesNotRegisterInternalFunctionRoute(t *testing.T) {
+	// Use a non-default namespace so the registered route follows the
+	// /fission-function/<ns>/<name> form (utils.UrlForFunction folds
+	// the default namespace into /fission-function/<name>).
+	fn := fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "myns"},
+	}
+	ts := newTestTriggerSet(t, []fv1.Function{fn}, nil)
+
+	publicMux, internalMux, err := ts.buildMuxes(nil)
+	require.NoError(t, err)
+
+	// Public mux must NOT have the internal-only route.
+	assert.False(t, muxMatches(publicMux, http.MethodGet, "/fission-function/myns/example"),
+		"public listener must not route /fission-function/myns/example")
+	assert.False(t, muxMatches(publicMux, http.MethodPost, "/fission-function/myns/example/sub"),
+		"public listener must not route /fission-function/myns/example/sub")
+
+	// And calling ServeHTTP on the public mux must 404 the internal
+	// path (the gorilla/mux NotFoundHandler defaults to 404 when no
+	// route matches, so this is the user-visible behaviour).
+	rr := httptest.NewRecorder()
+	publicMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/fission-function/myns/example", nil))
+	assert.Equal(t, http.StatusNotFound, rr.Code,
+		"public listener must respond 404 for /fission-function/...")
+
+	// Internal mux must route the same path.
+	assert.True(t, muxMatches(internalMux, http.MethodGet, "/fission-function/myns/example"),
+		"internal listener must route /fission-function/myns/example")
+	assert.True(t, muxMatches(internalMux, http.MethodPost, "/fission-function/myns/example/sub"),
+		"internal listener must route /fission-function/myns/example/sub via the prefix handler")
+}
+
+// TestPublicMuxStillServesHealthAndVersion ensures the listener split
+// did not accidentally move /router-healthz or /_version onto the
+// internal listener; readiness probes and external monitors must still
+// hit them on the public port.
+func TestPublicMuxStillServesHealthAndVersion(t *testing.T) {
+	ts := newTestTriggerSet(t, nil, nil)
+
+	publicMux, internalMux, err := ts.buildMuxes(nil)
+	require.NoError(t, err)
+
+	rr := httptest.NewRecorder()
+	publicMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/router-healthz", nil))
+	assert.Equal(t, http.StatusOK, rr.Code, "/router-healthz must stay on the public listener")
+
+	rr = httptest.NewRecorder()
+	publicMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/_version", nil))
+	assert.Equal(t, http.StatusOK, rr.Code, "/_version must stay on the public listener")
+
+	// Symmetric guard: the internal listener must NOT serve /healthz or
+	// /_version (so cluster monitors can't probe it without HMAC creds
+	// — which would otherwise mask a misconfigured listener).
+	rr = httptest.NewRecorder()
+	internalMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/router-healthz", nil))
+	assert.Equal(t, http.StatusNotFound, rr.Code, "internal listener must not serve /router-healthz")
+}
+
+// TestInternalListenerRejectsUnsignedRequests demonstrates that the
+// HMAC verifier wrapper used by the bundle returns 401 for a
+// /fission-function/... request that arrives without the required
+// X-Fission-Auth-* headers. This guards the integration-test
+// expectation that port 8889 returns 401 for unsigned requests.
+func TestInternalListenerRejectsUnsignedRequests(t *testing.T) {
+	// Use a non-default namespace so the registered route follows the
+	// /fission-function/<ns>/<name> form (utils.UrlForFunction folds
+	// the default namespace into /fission-function/<name>).
+	fn := fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "myns"},
+	}
+	ts := newTestTriggerSet(t, []fv1.Function{fn}, nil)
+
+	_, internalMux, err := ts.buildMuxes(nil)
+	require.NoError(t, err)
+
+	verifier := hmacauth.Verifier(hmacauth.VerifierOpts{
+		Secret:       []byte("test-secret"),
+		SkewSec:      60,
+		MaxBodyBytes: internalListenerMaxBodyBytes,
+	})
+	wrapped := verifier(internalMux)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/fission-function/myns/example", nil)
+	wrapped.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusUnauthorized, rr.Code,
+		"internal listener must 401 unsigned requests when a secret is configured")
+}
+
+// TestInternalListenerPassThroughWithEmptySecret pins the documented
+// rollout behaviour: when FISSION_INTERNAL_AUTH_SECRET is unset the
+// verifier short-circuits and the request is forwarded to the
+// downstream handler. We use a sentinel handler in place of the
+// production functionHandler so the test focuses on the pass-through
+// short-circuit; the functionHandler itself needs additional plumbing
+// that is out of scope for a routing test.
+func TestInternalListenerPassThroughWithEmptySecret(t *testing.T) {
+	// Sanity-pin the env var so the test does not pick up a stale
+	// value from the developer's shell.
+	t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "")
+	require.Empty(t, os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+
+	called := false
+	sentinel := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	verifier := hmacauth.Verifier(hmacauth.VerifierOpts{
+		Secret:       nil,
+		SkewSec:      60,
+		MaxBodyBytes: internalListenerMaxBodyBytes,
+	})
+	wrapped := verifier(sentinel)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/fission-function/myns/example", nil)
+	wrapped.ServeHTTP(rr, req)
+	assert.True(t, called, "empty secret must short-circuit the verifier and call downstream")
+	assert.Equal(t, http.StatusTeapot, rr.Code, "downstream sentinel must respond")
+}

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -142,8 +142,11 @@ func TestInternalListenerRejectsUnsignedRequests(t *testing.T) {
 	_, internalMux, err := ts.buildMuxes(nil)
 	require.NoError(t, err)
 
-	verifier := hmacauth.Verifier(hmacauth.VerifierOpts{
-		Secret:       []byte("test-secret"),
+	// Mirror the production wiring: ServiceVerifier with ServiceRouterInternal
+	// rather than the raw Verifier. A regression in service-key derivation
+	// (e.g. accidentally using a different service id on the signing side)
+	// would surface here in addition to the lower-level keys_test.go suite.
+	verifier := hmacauth.ServiceVerifier([]byte("test-master"), nil, hmacauth.ServiceRouterInternal, hmacauth.VerifierOpts{
 		SkewSec:      60,
 		MaxBodyBytes: internalListenerMaxBodyBytes,
 	})
@@ -175,8 +178,10 @@ func TestInternalListenerPassThroughWithEmptySecret(t *testing.T) {
 		w.WriteHeader(http.StatusTeapot)
 	})
 
-	verifier := hmacauth.Verifier(hmacauth.VerifierOpts{
-		Secret:       nil,
+	// Use ServiceVerifier to match the production wiring; an empty
+	// master propagates to an empty derived key, which the underlying
+	// Verifier short-circuits to pass-through.
+	verifier := hmacauth.ServiceVerifier(nil, nil, hmacauth.ServiceRouterInternal, hmacauth.VerifierOpts{
 		SkewSec:      60,
 		MaxBodyBytes: internalListenerMaxBodyBytes,
 	})

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -117,12 +117,17 @@ func TestPublicMuxStillServesHealthAndVersion(t *testing.T) {
 	publicMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/_version", nil))
 	assert.Equal(t, http.StatusOK, rr.Code, "/_version must stay on the public listener")
 
-	// Symmetric guard: the internal listener must NOT serve /healthz or
-	// /_version (so cluster monitors can't probe it without HMAC creds
-	// — which would otherwise mask a misconfigured listener).
+	// Symmetric guard: the internal listener must NOT serve
+	// /router-healthz or /_version (so cluster monitors can't probe it
+	// without HMAC creds — which would otherwise mask a misconfigured
+	// listener).
 	rr = httptest.NewRecorder()
 	internalMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/router-healthz", nil))
 	assert.Equal(t, http.StatusNotFound, rr.Code, "internal listener must not serve /router-healthz")
+
+	rr = httptest.NewRecorder()
+	internalMux.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/_version", nil))
+	assert.Equal(t, http.StatusNotFound, rr.Code, "internal listener must not serve /_version")
 }
 
 // TestInternalListenerRejectsUnsignedRequests demonstrates that the

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -42,6 +42,7 @@ package router
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -50,6 +51,7 @@ import (
 	"github.com/gorilla/mux"
 	"go.opentelemetry.io/otel"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/crd"
 	eclient "github.com/fission/fission/pkg/executor/client"
 	"github.com/fission/fission/pkg/throttler"
@@ -59,48 +61,110 @@ import (
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
+// DefaultInternalListenerPort is the default port for the internal
+// listener that serves /fission-function/<ns>/<name>. It must match the
+// targetPort used by the chart's router Service "internal" port.
+const DefaultInternalListenerPort = 8889
+
+// internalListenerMaxBodyBytes caps the request body size the HMAC
+// verifier on the internal listener will buffer. 64 MiB is large enough
+// for any realistic JSON / form / small-binary payload that flows from
+// timer / kubewatcher / mqtrigger / executor through
+// /fission-function/<ns>/<name>, while still bounding the cost of a
+// malicious oversized request before the signature check runs. This
+// trims significantly below storagesvc's 256 MiB ceiling because
+// function-invocation bodies are typically small request payloads, not
+// archive uploads.
+const internalListenerMaxBodyBytes int64 = 64 << 20
+
 // request url ---[mux]---> Function(name,uid) ----[fmap]----> k8s service url
 
 // request url ---[trigger]---> Function(name, deployment) ----[deployment]----> Function(name, uid) ----[pool mgr]---> k8s service url
 
-func router(ctx context.Context, logger logr.Logger, mgr manager.Interface, httpTriggerSet *HTTPTriggerSet) (*mutableRouter, error) {
-	var mr *mutableRouter
-	mux := mux.NewRouter()
-	mux.Use(metrics.HTTPMetricMiddleware)
+// router constructs the public and internal mutable routers and wires
+// them to httpTriggerSet's reconciliation loop. Both routers are
+// initialised with empty mux.Router instances; the trigger set fills
+// them in on first sync.
+func router(ctx context.Context, logger logr.Logger, mgr manager.Interface, httpTriggerSet *HTTPTriggerSet) (*mutableRouter, *mutableRouter, error) {
+	publicMux := mux.NewRouter()
+	publicMux.Use(metrics.HTTPMetricMiddleware)
+	internalMux := mux.NewRouter()
 
 	// see issue https://github.com/fission/fission/issues/1317
 	useEncodedPath, err := strconv.ParseBool(os.Getenv("USE_ENCODED_PATH"))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
+	var publicMR, internalMR *mutableRouter
 	if useEncodedPath {
-		mr = newMutableRouter(logger, mux.UseEncodedPath())
+		publicMR = newMutableRouter(logger, publicMux.UseEncodedPath())
+		internalMR = newMutableRouter(logger.WithName("internal"), internalMux.UseEncodedPath())
 	} else {
-		mr = newMutableRouter(logger, mux)
+		publicMR = newMutableRouter(logger, publicMux)
+		internalMR = newMutableRouter(logger.WithName("internal"), internalMux)
 	}
 
-	err = httpTriggerSet.subscribeRouter(ctx, mgr, mr)
+	err = httpTriggerSet.subscribeRouter(ctx, mgr, publicMR, internalMR)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return mr, nil
+	return publicMR, internalMR, nil
 }
 
-func serve(ctx context.Context, logger logr.Logger, mgr manager.Interface, port int,
+func serve(ctx context.Context, logger logr.Logger, mgr manager.Interface, port int, internalPort int,
 	httpTriggerSet *HTTPTriggerSet) error {
-	mr, err := router(ctx, logger, mgr, httpTriggerSet)
+	publicMR, internalMR, err := router(ctx, logger, mgr, httpTriggerSet)
 	if err != nil {
 		return fmt.Errorf("error making router: %w", err)
 	}
-	handler := otelUtils.GetHandlerWithOTEL(mr, "fission-router", otelUtils.UrlsToIgnore("/router-healthz"))
+
+	publicHandler := otelUtils.GetHandlerWithOTEL(publicMR, "fission-router", otelUtils.UrlsToIgnore("/router-healthz"))
 	mgr.Add(ctx, func(ctx context.Context) {
-		httpserver.StartServer(ctx, logger, mgr, "router", fmt.Sprintf("%d", port), handler)
+		httpserver.StartServer(ctx, logger, mgr, "router", fmt.Sprintf("%d", port), publicHandler)
 	})
+
+	// Internal listener for /fission-function/<ns>/<name>. We wrap the
+	// mutable router with the HMAC verifier so an attacker who somehow
+	// reaches port 8889 (NetworkPolicy-locked to executor / kubewatcher
+	// / timer / mqtrigger) without a valid signature is rejected
+	// before reaching the function-handler proxy. An empty
+	// FISSION_INTERNAL_AUTH_SECRET is the explicit pass-through mode
+	// for first-deploy / migration installs and is safe by virtue of
+	// the NetworkPolicy still gating the port.
+	secret := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+	oldSecret := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
+	internalHandlerInner := otelUtils.GetHandlerWithOTEL(internalMR, "fission-router-internal")
+	verifier := hmacauth.Verifier(hmacauth.VerifierOpts{
+		Secret:    secret,
+		OldSecret: oldSecret,
+		SkewSec:   60,
+		// Cap the request body the verifier will buffer before the
+		// signature check; see internalListenerMaxBodyBytes for the
+		// rationale behind 64 MiB.
+		MaxBodyBytes: internalListenerMaxBodyBytes,
+		Logger:       logger.WithName("internal-hmac"),
+	})
+	var internalHandler http.Handler = verifier(internalHandlerInner)
+	mgr.Add(ctx, func(ctx context.Context) {
+		httpserver.StartServer(ctx, logger, mgr, "router-internal", fmt.Sprintf("%d", internalPort), internalHandler)
+	})
+
 	return nil
 }
 
-// Start starts a router
-func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, port int, executor eclient.ClientInterface) error {
+// Start starts a router. internalPort is the listener that serves
+// /fission-function/<ns>/<name> and is wrapped with the HMAC verifier;
+// pass DefaultInternalListenerPort to use the default. A zero
+// internalPort is rejected because the listener is mandatory after
+// GHSA-3g33-6vg6-27m8 — the public listener no longer registers those
+// routes.
+func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, port int, internalPort int, executor eclient.ClientInterface) error {
+	if internalPort <= 0 {
+		internalPort = DefaultInternalListenerPort
+	}
+	if internalPort == port {
+		return fmt.Errorf("router internal port (%d) must differ from public port (%d)", internalPort, port)
+	}
 	fmap := makeFunctionServiceMap(logger, time.Minute)
 
 	fissionClient, err := clientGen.GetFissionClient()
@@ -197,11 +261,11 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		metrics.ServeMetrics(ctx, "router", logger, mgr)
 	})
 
-	logger.Info("starting router", "port", port)
+	logger.Info("starting router", "port", port, "internalPort", internalPort)
 
 	tracer := otel.Tracer("router")
 	ctx, span := tracer.Start(ctx, "router/Start")
 	defer span.End()
 
-	return serve(ctx, logger, mgr, port, triggers)
+	return serve(ctx, logger, mgr, port, internalPort, triggers)
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -42,7 +42,6 @@ package router
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"os"
 	"strconv"
 	"time"
@@ -144,7 +143,7 @@ func serve(ctx context.Context, logger logr.Logger, mgr manager.Interface, port 
 		MaxBodyBytes: internalListenerMaxBodyBytes,
 		Logger:       logger.WithName("internal-hmac"),
 	})
-	var internalHandler http.Handler = verifier(internalHandlerInner)
+	internalHandler := verifier(internalHandlerInner)
 	mgr.Add(ctx, func(ctx context.Context) {
 		httpserver.StartServer(ctx, logger, mgr, "router-internal", fmt.Sprintf("%d", internalPort), internalHandler)
 	})

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -83,27 +83,15 @@ const internalListenerMaxBodyBytes int64 = 64 << 20
 // router constructs the public and internal mutable routers and wires
 // them to httpTriggerSet's reconciliation loop. Both routers are
 // initialised with empty mux.Router instances; the trigger set fills
-// them in on first sync.
+// them in on first sync. The USE_ENCODED_PATH setting (see issue
+// https://github.com/fission/fission/issues/1317) is applied by
+// httpTriggerSet.buildMuxes on every reconciliation rather than here,
+// so that the feature stays on across the atomic mux swaps.
 func router(ctx context.Context, logger logr.Logger, mgr manager.Interface, httpTriggerSet *HTTPTriggerSet) (*mutableRouter, *mutableRouter, error) {
-	publicMux := mux.NewRouter()
-	publicMux.Use(metrics.HTTPMetricMiddleware)
-	internalMux := mux.NewRouter()
+	publicMR := newMutableRouter(logger, mux.NewRouter())
+	internalMR := newMutableRouter(logger.WithName("internal"), mux.NewRouter())
 
-	// see issue https://github.com/fission/fission/issues/1317
-	useEncodedPath, err := strconv.ParseBool(os.Getenv("USE_ENCODED_PATH"))
-	if err != nil {
-		return nil, nil, err
-	}
-	var publicMR, internalMR *mutableRouter
-	if useEncodedPath {
-		publicMR = newMutableRouter(logger, publicMux.UseEncodedPath())
-		internalMR = newMutableRouter(logger.WithName("internal"), internalMux.UseEncodedPath())
-	} else {
-		publicMR = newMutableRouter(logger, publicMux)
-		internalMR = newMutableRouter(logger.WithName("internal"), internalMux)
-	}
-
-	err = httpTriggerSet.subscribeRouter(ctx, mgr, publicMR, internalMR)
+	err := httpTriggerSet.subscribeRouter(ctx, mgr, publicMR, internalMR)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -247,6 +235,12 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 			"default", unTapServiceTimeout)
 	}
 
+	// see issue https://github.com/fission/fission/issues/1317
+	useEncodedPath, err := strconv.ParseBool(os.Getenv("USE_ENCODED_PATH"))
+	if err != nil {
+		return fmt.Errorf("failed to parse USE_ENCODED_PATH: %w", err)
+	}
+
 	triggers, err := makeHTTPTriggerSet(logger.WithName("triggerset"), fmap, fissionClient, kubeClient, executor, &tsRoundTripperParams{
 		timeout:           timeout,
 		timeoutExponent:   timeoutExponent,
@@ -254,7 +248,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		keepAliveTime:     keepAliveTime,
 		maxRetries:        maxRetries,
 		svcAddrRetryCount: svcAddrRetryCount,
-	}, isDebugEnv, unTapServiceTimeout, throttler.MakeThrottler(svcAddrUpdateTimeout))
+	}, isDebugEnv, useEncodedPath, unTapServiceTimeout, throttler.MakeThrottler(svcAddrUpdateTimeout))
 	if err != nil {
 		return fmt.Errorf("error making HTTP trigger set: %w", err)
 	}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -130,13 +130,15 @@ func serve(ctx context.Context, logger logr.Logger, mgr manager.Interface, port 
 	// FISSION_INTERNAL_AUTH_SECRET is the explicit pass-through mode
 	// for first-deploy / migration installs and is safe by virtue of
 	// the NetworkPolicy still gating the port.
-	secret := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
-	oldSecret := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
+	master := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+	masterOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
 	internalHandlerInner := otelUtils.GetHandlerWithOTEL(internalMR, "fission-router-internal")
-	verifier := hmacauth.Verifier(hmacauth.VerifierOpts{
-		Secret:    secret,
-		OldSecret: oldSecret,
-		SkewSec:   60,
+	// Use the per-service derived key for ServiceRouterInternal so a
+	// leak of the router's runtime memory cannot forge requests on
+	// other Fission internal channels (storagesvc, fetcher, builder,
+	// executor). See docs/internal-auth/00-design.md.
+	verifier := hmacauth.ServiceVerifier(master, masterOld, hmacauth.ServiceRouterInternal, hmacauth.VerifierOpts{
+		SkewSec: 60,
 		// Cap the request body the verifier will buffer before the
 		// signature check; see internalListenerMaxBodyBytes for the
 		// rationale behind 64 MiB.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -155,10 +155,11 @@ func serve(ctx context.Context, logger logr.Logger, mgr manager.Interface, port 
 
 // Start starts a router. internalPort is the listener that serves
 // /fission-function/<ns>/<name> and is wrapped with the HMAC verifier;
-// pass DefaultInternalListenerPort to use the default. A zero
-// internalPort is rejected because the listener is mandatory after
-// GHSA-3g33-6vg6-27m8 — the public listener no longer registers those
-// routes.
+// pass DefaultInternalListenerPort to use the default. Zero or
+// negative values are silently substituted with DefaultInternalListenerPort
+// so callers can omit the flag and still get the GHSA-3g33-6vg6-27m8
+// listener split — the public listener no longer registers those
+// routes, so the internal listener is mandatory.
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, port int, internalPort int, executor eclient.ClientInterface) error {
 	if internalPort <= 0 {
 		internalPort = DefaultInternalListenerPort

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -38,10 +38,6 @@ manifests:
           grafana.dashboards.enabled: "false"
           imageTag: ""
           influxdb.enabled: "false"
-          # internalAuth.enabled mirrors the chart default (true) in base
-          # setValues so the kind-ci profile can `replace`-patch it to
-          # exercise the verifier's pass-through mode end-to-end.
-          internalAuth.enabled: "true"
           namespace: fission
           networkPolicy.enabled: "false"
           openTelemetry.otlpCollectorEndpoint: ""
@@ -126,15 +122,6 @@ profiles:
       - op: replace
         path: /manifests/helm/releases/0/setValues/networkPolicy.enabled
         value: true
-      # Disable internalAuth in CI so the test suite exercises the
-      # verifier's pass-through mode (no FISSION_INTERNAL_AUTH_SECRET on
-      # router/fetcher/builder/storagesvc/executor pods, no
-      # fission-internal-auth Secret created). Re-enable here once the
-      # tests are confirmed green to flip CI back to the signed-mode
-      # default.
-      - op: replace
-        path: /manifests/helm/releases/0/setValues/internalAuth.enabled
-        value: false
   - name: kind-ci-old
     patches:
       - op: replace

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -38,6 +38,10 @@ manifests:
           grafana.dashboards.enabled: "false"
           imageTag: ""
           influxdb.enabled: "false"
+          # internalAuth.enabled mirrors the chart default (true) in base
+          # setValues so the kind-ci profile can `replace`-patch it to
+          # exercise the verifier's pass-through mode end-to-end.
+          internalAuth.enabled: "true"
           namespace: fission
           networkPolicy.enabled: "false"
           openTelemetry.otlpCollectorEndpoint: ""
@@ -122,6 +126,15 @@ profiles:
       - op: replace
         path: /manifests/helm/releases/0/setValues/networkPolicy.enabled
         value: true
+      # Disable internalAuth in CI so the test suite exercises the
+      # verifier's pass-through mode (no FISSION_INTERNAL_AUTH_SECRET on
+      # router/fetcher/builder/storagesvc/executor pods, no
+      # fission-internal-auth Secret created). Re-enable here once the
+      # tests are confirmed green to flip CI back to the signed-mode
+      # default.
+      - op: replace
+        path: /manifests/helm/releases/0/setValues/internalAuth.enabled
+        value: false
   - name: kind-ci-old
     patches:
       - op: replace

--- a/test/e2e/fetcher/fetcher_test.go
+++ b/test/e2e/fetcher/fetcher_test.go
@@ -154,7 +154,10 @@ func (f *FetcherTestSuite) SetupSuite() {
 		}
 	})
 
-	f.fetcherClient = client.MakeClient(f.logger, fetcherUrl)
+	// In-process e2e: server and client are in the same process, so the
+	// HMAC master secret (when set on the env) is picked up identically
+	// at both ends via HMACSecretFromEnv.
+	f.fetcherClient = client.MakeClient(f.logger, fetcherUrl, storageClient.HMACSecretFromEnv())
 
 	_, err = cli.ExecCommand(f.framework, ctx, "env", "create", "--name", f.envName, "--image", testEnvImage,
 		"--builder", testBuilderImage)

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -112,16 +112,29 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 	}
 
 	executor := eclient.MakeClient(f.Logger(), fmt.Sprintf("http://localhost:%d", executorPort))
-	err = router.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerPort, executor)
+	internalRouterPort, err := utils.FindFreePort()
+	if err != nil {
+		return fmt.Errorf("error finding unused port for router internal listener: %w", err)
+	}
+	err = router.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerPort, internalRouterPort, executor)
 	if err != nil {
 		return fmt.Errorf("error starting router: %w", err)
 	}
 	f.AddServiceInfo("router", framework.ServiceInfo{Port: routerPort})
+	f.AddServiceInfo("router-internal", framework.ServiceInfo{Port: internalRouterPort})
 	routerURL, err := f.GetServiceURL("router")
 	if err != nil {
 		return fmt.Errorf("error getting router URL: %w", err)
 	}
 	os.Setenv("FISSION_ROUTER_URL", routerURL)
+	// Point internal callers (timer / kubewatcher / mqtrigger) at the
+	// router internal listener so /fission-function/<ns>/<name> reaches
+	// the right port post-GHSA-3g33-6vg6-27m8.
+	internalRouterURL, err := f.GetServiceURL("router-internal")
+	if err != nil {
+		return fmt.Errorf("error getting router internal URL: %w", err)
+	}
+	os.Setenv("ROUTER_INTERNAL_URL", internalRouterURL)
 
 	err = timer.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerURL)
 	if err != nil {

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -14,6 +14,7 @@ import (
 	"github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/router"
 	"github.com/fission/fission/pkg/storagesvc"
+	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
 	"github.com/fission/fission/pkg/timer"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/manager"
@@ -111,7 +112,12 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 		return fmt.Errorf("error toggling metric address: %w", err)
 	}
 
-	executor := eclient.MakeClient(f.Logger(), fmt.Sprintf("http://localhost:%d", executorPort))
+	// E2E framework runs the executor in the same process as its caller,
+	// so any FISSION_INTERNAL_AUTH_SECRET set on the test environment
+	// flows into both ends of this client/verifier pair via
+	// HMACSecretFromEnv (returns nil when unset, leaving the channel
+	// unsigned).
+	executor := eclient.MakeClient(f.Logger(), fmt.Sprintf("http://localhost:%d", executorPort), storagesvcClient.HMACSecretFromEnv())
 	internalRouterPort, err := utils.FindFreePort()
 	if err != nil {
 		return fmt.Errorf("error finding unused port for router internal listener: %w", err)

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -142,19 +142,25 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 	}
 	os.Setenv("ROUTER_INTERNAL_URL", internalRouterURL)
 
-	err = timer.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerURL)
+	// timer / kubewatcher / mqtrigger publish to /fission-function/...,
+	// which after GHSA-3g33-6vg6-27m8 lives only on the router internal
+	// listener. The fission-bundle entrypoint resolves
+	// ROUTER_INTERNAL_URL from the env before forwarding into these
+	// Start functions; this in-process harness has to do the same
+	// resolution explicitly because it bypasses the bundle.
+	err = timer.Start(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL)
 	if err != nil {
 		return fmt.Errorf("error starting timer: %w", err)
 	}
 	f.AddServiceInfo("timer", framework.ServiceInfo{})
 
-	err = mqtrigger.StartScalerManager(ctx, f.ClientGen(), f.Logger(), mgr, routerURL)
+	err = mqtrigger.StartScalerManager(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL)
 	if err != nil {
 		return fmt.Errorf("error starting mqt scaler manager: %w", err)
 	}
 	f.AddServiceInfo("mqtrigger-keda", framework.ServiceInfo{})
 
-	err = kubewatcher.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerURL)
+	err = kubewatcher.Start(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL)
 	if err != nil {
 		return fmt.Errorf("error starting kubewatcher: %w", err)
 	}

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -32,7 +32,21 @@ type Framework struct {
 	kubeClient    kubernetes.Interface
 	images        RuntimeImages
 	router        string
-	logger        logr.Logger
+	// routerInternal is the URL the test framework uses for the
+	// router's internal listener (the one hosting /fission-function/...
+	// after the GHSA-3g33-6vg6-27m8 split). Empty means "fall back to
+	// router" — useful on installations where the listener split is
+	// disabled or the bootstrap hasn't port-forwarded the internal
+	// port yet. Sourced from FISSION_ROUTER_INTERNAL or defaults to
+	// http://127.0.0.1:8889.
+	routerInternal string
+	// internalAuthSecret is the master HMAC key used to sign
+	// /fission-function/... requests on the internal listener.
+	// Sourced from FISSION_INTERNAL_AUTH_SECRET; empty disables
+	// signing (matches the chart's pass-through mode when
+	// internalAuth.enabled=false).
+	internalAuthSecret []byte
+	logger             logr.Logger
 }
 
 var (
@@ -67,13 +81,15 @@ func newFramework() (*Framework, error) {
 		return nil, err
 	}
 	return &Framework{
-		restConfig:    restConfig,
-		clientGen:     clientGen,
-		fissionClient: fissionClient,
-		kubeClient:    kubeClient,
-		images:        loadRuntimeImages(),
-		router:        routerURLFromEnv(),
-		logger:        loggerfactory.GetLogger(),
+		restConfig:         restConfig,
+		clientGen:          clientGen,
+		fissionClient:      fissionClient,
+		kubeClient:         kubeClient,
+		images:             loadRuntimeImages(),
+		router:             routerURLFromEnv(),
+		routerInternal:     routerInternalURLFromEnv(),
+		internalAuthSecret: internalAuthSecretFromEnv(),
+		logger:             loggerfactory.GetLogger(),
 	}, nil
 }
 

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -34,11 +34,11 @@ type Framework struct {
 	router        string
 	// routerInternal is the URL the test framework uses for the
 	// router's internal listener (the one hosting /fission-function/...
-	// after the GHSA-3g33-6vg6-27m8 split). Empty means "fall back to
-	// router" — useful on installations where the listener split is
-	// disabled or the bootstrap hasn't port-forwarded the internal
-	// port yet. Sourced from FISSION_ROUTER_INTERNAL or defaults to
-	// http://127.0.0.1:8889.
+	// after the GHSA-3g33-6vg6-27m8 split). Sourced from
+	// FISSION_ROUTER_INTERNAL and defaults to http://127.0.0.1:8889 to
+	// match the suite-bootstrap port-forward of svc/router-internal.
+	// Always non-empty after framework setup; the RouterClient
+	// unconditionally routes /fission-function/<ns>/<name> here.
 	routerInternal string
 	// internalAuthSecret is the master HMAC key used to sign
 	// /fission-function/... requests on the internal listener.

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -35,10 +35,11 @@ type Framework struct {
 	// routerInternal is the URL the test framework uses for the
 	// router's internal listener (the one hosting /fission-function/...
 	// after the GHSA-3g33-6vg6-27m8 split). Sourced from
-	// FISSION_ROUTER_INTERNAL and defaults to http://127.0.0.1:8889 to
-	// match the suite-bootstrap port-forward of svc/router-internal.
-	// Always non-empty after framework setup; the RouterClient
-	// unconditionally routes /fission-function/<ns>/<name> here.
+	// FISSION_ROUTER_INTERNAL via routerInternalURLFromEnv, which
+	// always returns a non-empty value (defaulting to
+	// http://127.0.0.1:8889 to match the suite-bootstrap port-forward
+	// of svc/router-internal). The RouterClient unconditionally
+	// routes /fission-function/<ns>/<name> here.
 	routerInternal string
 	// internalAuthSecret is the master HMAC key used to sign
 	// /fission-function/... requests on the internal listener.

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -107,3 +107,17 @@ func (f *Framework) Images() RuntimeImages { return f.images }
 
 // Logger returns the framework logger.
 func (f *Framework) Logger() logr.Logger { return f.logger }
+
+// RouterInternalBaseURL returns the framework's URL for the router's
+// internal listener — the one hosting /fission-function/<ns>/<name>
+// after the GHSA-3g33-6vg6-27m8 split. Tests that bypass the
+// `RouterClient` HTTP helpers (e.g. websocket dials done via
+// gorilla/websocket) should compose their URL from this base.
+func (f *Framework) RouterInternalBaseURL() string { return f.routerInternal }
+
+// InternalAuthSecret returns the master HMAC key the framework uses
+// to sign /fission-function/... requests on the internal listener.
+// Empty when internalAuth is disabled in the cluster — callers should
+// emit unsigned requests in that case (the verifier short-circuits to
+// pass-through).
+func (f *Framework) InternalAuthSecret() []byte { return f.internalAuthSecret }

--- a/test/integration/framework/images.go
+++ b/test/integration/framework/images.go
@@ -106,6 +106,33 @@ func routerURLFromEnv() string {
 	return "http://127.0.0.1:8888"
 }
 
+// routerInternalURLFromEnv returns the URL the framework should use
+// for the router's internal listener (post-GHSA-3g33-6vg6-27m8 split).
+// Defaults to http://127.0.0.1:8889 to match the suite-bootstrap
+// port-forward; override via FISSION_ROUTER_INTERNAL when running
+// against a non-default install.
+func routerInternalURLFromEnv() string {
+	if v := os.Getenv("FISSION_ROUTER_INTERNAL"); v != "" {
+		if hasScheme(v) {
+			return v
+		}
+		return "http://" + v
+	}
+	return "http://127.0.0.1:8889"
+}
+
+// internalAuthSecretFromEnv returns the master HMAC key used to sign
+// requests against the router internal listener. Empty when
+// internalAuth is disabled in the cluster — the framework still issues
+// requests, just without auth headers, and the verifier short-circuits
+// to pass-through.
+func internalAuthSecretFromEnv() []byte {
+	if v := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); v != "" {
+		return []byte(v)
+	}
+	return nil
+}
+
 func hasScheme(s string) bool {
 	return len(s) > 7 && (s[:7] == "http://" || s[:8] == "https://")
 }

--- a/test/integration/framework/router.go
+++ b/test/integration/framework/router.go
@@ -21,13 +21,14 @@ import (
 // RouterClient wraps an HTTP client pointed at the Fission router (typically
 // the port-forwarded svc/router on 127.0.0.1:8888 in CI).
 //
-// Requests to /fission-function/... are routed to the internal listener
-// (typically 127.0.0.1:8889) and signed with HMAC-SHA256 because of the
-// GHSA-3g33-6vg6-27m8 listener split — the public listener no longer
-// hosts those routes. The framework reads FISSION_INTERNAL_AUTH_SECRET
-// at startup; an empty secret leaves requests unsigned, which works
-// against clusters where internalAuth.enabled=false (the verifier
-// short-circuits to pass-through).
+// Requests to /fission-function/... are unconditionally routed to the
+// framework's `routerInternal` URL (typically 127.0.0.1:8889) and
+// signed with HMAC-SHA256 because of the GHSA-3g33-6vg6-27m8 listener
+// split — the public listener no longer hosts those routes. The
+// framework reads FISSION_INTERNAL_AUTH_SECRET at startup; an empty
+// secret leaves requests unsigned, which works against clusters where
+// internalAuth.enabled=false (the verifier short-circuits to
+// pass-through).
 type RouterClient struct {
 	baseURL  string
 	internal string
@@ -90,12 +91,13 @@ func (r *RouterClient) Post(ctx context.Context, path, contentType string, body 
 
 func (r *RouterClient) do(ctx context.Context, method, path, contentType string, body []byte) (int, string, error) {
 	// /fission-function/... lives only on the internal listener after
-	// GHSA-3g33-6vg6-27m8. Use the internal base URL when configured;
-	// fall back to the public base URL on installs that haven't
-	// adopted the listener split (older charts, dev clusters).
+	// GHSA-3g33-6vg6-27m8; route to the internal base URL.
+	// `r.internal` is always non-empty after framework setup
+	// (defaults to http://127.0.0.1:8889 from
+	// routerInternalURLFromEnv).
 	base := r.baseURL
 	p := ensureLeadingSlash(path)
-	if strings.HasPrefix(p, "/fission-function/") && r.internal != "" {
+	if strings.HasPrefix(p, "/fission-function/") {
 		base = r.internal
 	}
 	url := base + p

--- a/test/integration/framework/router.go
+++ b/test/integration/framework/router.go
@@ -14,22 +14,63 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 )
 
 // RouterClient wraps an HTTP client pointed at the Fission router (typically
 // the port-forwarded svc/router on 127.0.0.1:8888 in CI).
+//
+// Requests to /fission-function/... are routed to the internal listener
+// (typically 127.0.0.1:8889) and signed with HMAC-SHA256 because of the
+// GHSA-3g33-6vg6-27m8 listener split — the public listener no longer
+// hosts those routes. The framework reads FISSION_INTERNAL_AUTH_SECRET
+// at startup; an empty secret leaves requests unsigned, which works
+// against clusters where internalAuth.enabled=false (the verifier
+// short-circuits to pass-through).
 type RouterClient struct {
-	baseURL string
-	http    *http.Client
+	baseURL  string
+	internal string
+	http     *http.Client
 }
 
 // Router returns an HTTP client targeting FISSION_ROUTER (or 127.0.0.1:8888).
 func (f *Framework) Router(t *testing.T) *RouterClient {
 	t.Helper()
-	return &RouterClient{
-		baseURL: f.router,
-		http:    &http.Client{Timeout: 30 * time.Second},
+	// The persistent http.Client uses a transport that signs requests
+	// to /fission-function/... with the master HMAC key (when
+	// configured). Other paths (HTTPTriggers, /router-healthz) go
+	// through unsigned to match end-user behaviour against the public
+	// listener.
+	rt := http.DefaultTransport
+	if len(f.internalAuthSecret) > 0 {
+		rt = &routerSigningTransport{
+			master: f.internalAuthSecret,
+			inner:  rt,
+		}
 	}
+	return &RouterClient{
+		baseURL:  f.router,
+		internal: f.routerInternal,
+		http:     &http.Client{Timeout: 30 * time.Second, Transport: rt},
+	}
+}
+
+// routerSigningTransport wraps the framework's outbound transport so
+// that any request whose path begins with /fission-function/ is signed
+// with the ServiceRouterInternal HMAC key. Other paths pass through
+// unsigned.
+type routerSigningTransport struct {
+	master []byte
+	inner  http.RoundTripper
+}
+
+func (t *routerSigningTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if !strings.HasPrefix(r.URL.Path, "/fission-function/") {
+		return t.inner.RoundTrip(r)
+	}
+	signer := hmacauth.ServiceSigner(t.master, hmacauth.ServiceRouterInternal, t.inner, time.Now)
+	return signer.RoundTrip(r)
 }
 
 // BaseURL returns the configured router base URL (e.g. "http://127.0.0.1:8888").
@@ -48,7 +89,16 @@ func (r *RouterClient) Post(ctx context.Context, path, contentType string, body 
 }
 
 func (r *RouterClient) do(ctx context.Context, method, path, contentType string, body []byte) (int, string, error) {
-	url := r.baseURL + ensureLeadingSlash(path)
+	// /fission-function/... lives only on the internal listener after
+	// GHSA-3g33-6vg6-27m8. Use the internal base URL when configured;
+	// fall back to the public base URL on installs that haven't
+	// adopted the listener split (older charts, dev clusters).
+	base := r.baseURL
+	p := ensureLeadingSlash(path)
+	if strings.HasPrefix(p, "/fission-function/") && r.internal != "" {
+		base = r.internal
+	}
+	url := base + p
 	var reqBody io.Reader
 	if body != nil {
 		reqBody = bytes.NewReader(body)

--- a/test/integration/suites/common/router_internal_listener_test.go
+++ b/test/integration/suites/common/router_internal_listener_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package common_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRouterInternalListener exercises the listener split introduced
+// for GHSA-3g33-6vg6-27m8: /fission-function/<ns>/<name> must NOT be
+// reachable on the public listener (port 8888 → forwarded to
+// localhost:8888) and the internal listener (port 8889) must reject
+// unsigned requests when the HMAC secret is provisioned, while
+// remaining reachable for healthcheck-style probing.
+//
+// Prerequisites:
+//
+//	kubectl port-forward svc/router 8888:80   -n fission &
+//	kubectl port-forward svc/router 8889:8889 -n fission &
+//
+// (matching the integration-test bootstrap documented in the suite
+// README). The integration suite already requires the public 8888
+// forward; the 8889 forward is new for this advisory.
+
+const (
+	publicRouterURL   = "http://localhost:8888"
+	internalRouterURL = "http://localhost:8889"
+)
+
+// httpClientWithTimeout returns a short-timeout client so a hung
+// listener fails the test fast rather than waiting on the suite-level
+// 30m timeout.
+func httpClientWithTimeout() *http.Client {
+	return &http.Client{Timeout: 10 * time.Second}
+}
+
+// TestPublicRouterReturns404ForInternalRoute pins the GHSA-3g33-6vg6-27m8
+// regression: the public listener must NOT serve /fission-function/...,
+// regardless of whether the function exists.
+func TestPublicRouterReturns404ForInternalRoute(t *testing.T) {
+	client := httpClientWithTimeout()
+	resp, err := client.Get(publicRouterURL + "/fission-function/default/nonexistent")
+	require.NoError(t, err, "public router on 8888 must be reachable")
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode,
+		"public listener must 404 /fission-function/...; body=%s",
+		strings.TrimSpace(string(body)))
+}
+
+// TestInternalRouterRejectsUnsigned checks that the internal listener
+// rejects unsigned requests with 401 when the HMAC verifier is active.
+// This test will skip itself if the cluster is configured in the
+// rollout-friendly pass-through mode (FISSION_INTERNAL_AUTH_SECRET
+// unset on the router pod), because in that mode the verifier
+// short-circuits and the request reaches the function handler.
+func TestInternalRouterRejectsUnsigned(t *testing.T) {
+	client := httpClientWithTimeout()
+	resp, err := client.Get(internalRouterURL + "/fission-function/default/nonexistent")
+	require.NoError(t, err, "internal router on 8889 must be reachable")
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Skipf("internal listener returned %d (expected 401); the router may be in HMAC pass-through mode (FISSION_INTERNAL_AUTH_SECRET unset). body=%s",
+			resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"internal listener must 401 unsigned requests when HMAC is enforced")
+}

--- a/test/integration/suites/common/router_internal_listener_test.go
+++ b/test/integration/suites/common/router_internal_listener_test.go
@@ -20,14 +20,17 @@ import (
 // unsigned requests when the HMAC secret is provisioned, while
 // remaining reachable for healthcheck-style probing.
 //
-// Prerequisites:
+// Prerequisites (matching the integration-test bootstrap in the suite
+// workflow / README — the public listener is on Service `router`, the
+// internal listener is on the separate ClusterIP-only Service
+// `router-internal` so routerServiceType=NodePort/LoadBalancer doesn't
+// expose port 8889 outside the cluster):
 //
-//	kubectl port-forward svc/router 8888:80   -n fission &
-//	kubectl port-forward svc/router 8889:8889 -n fission &
+//	kubectl port-forward svc/router          8888:80   -n fission &
+//	kubectl port-forward svc/router-internal 8889:8889 -n fission &
 //
-// (matching the integration-test bootstrap documented in the suite
-// README). The integration suite already requires the public 8888
-// forward; the 8889 forward is new for this advisory.
+// The integration suite already requires the public 8888 forward;
+// the 8889 forward is new for this advisory.
 
 const (
 	publicRouterURL   = "http://localhost:8888"

--- a/test/integration/suites/common/websocket_test.go
+++ b/test/integration/suites/common/websocket_test.go
@@ -74,8 +74,12 @@ func TestWebsocket(t *testing.T) {
 	}
 
 	// First connect can race the executor specializing the pod; retry
-	// until dial succeeds. Re-sign on every attempt so the timestamp
-	// stays inside the verifier's skew window.
+	// the entire dial + send + receive cycle. On slower clusters
+	// (k8s 1.32+ in CI) the websocket-upgrade handshake can succeed
+	// before the function pod's ws-handler is fully attached, in which
+	// case the first frame back is the router's "Error" placeholder
+	// rather than broadcast.js's echo. Re-establishing the connection
+	// drives the retry through pod warmup.
 	var conn *websocket.Conn
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		hdr := dialHeader
@@ -89,19 +93,32 @@ func TestWebsocket(t *testing.T) {
 		}
 		dctx, dcancel := context.WithTimeout(ctx, 10*time.Second)
 		defer dcancel()
-		var err error
-		conn, _, err = websocket.DefaultDialer.DialContext(dctx, wsURL, hdr)
-		assert.NoErrorf(c, err, "websocket dial %q", wsURL)
+		c2, _, err := websocket.DefaultDialer.DialContext(dctx, wsURL, hdr)
+		if !assert.NoErrorf(c, err, "websocket dial %q", wsURL) {
+			return
+		}
+		if err := c2.SetReadDeadline(time.Now().Add(10 * time.Second)); !assert.NoError(c, err) {
+			_ = c2.Close()
+			return
+		}
+		if err := c2.WriteMessage(websocket.TextMessage, []byte("hello-from-test")); !assert.NoError(c, err, "websocket write") {
+			_ = c2.Close()
+			return
+		}
+		_, msg, err := c2.ReadMessage()
+		if !assert.NoError(c, err, "websocket read") {
+			_ = c2.Close()
+			return
+		}
+		if !assert.Equalf(c, "hello-from-test", string(msg),
+			"broadcast.js should echo the sent frame back to the same client (got %q)", string(msg)) {
+			_ = c2.Close()
+			return
+		}
+		conn = c2
 	}, 90*time.Second, 2*time.Second)
+	require.NotNil(t, conn, "websocket round-trip never succeeded")
 	defer func() { _ = conn.Close() }()
-
-	require.NoError(t, conn.SetReadDeadline(time.Now().Add(15*time.Second)))
-	require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte("hello-from-test")))
-
-	_, msg, err := conn.ReadMessage()
-	require.NoError(t, err, "websocket read")
-	require.Equal(t, "hello-from-test", string(msg),
-		"broadcast.js should echo the sent frame back to the same client")
 
 	// Polite close.
 	_ = conn.WriteMessage(websocket.CloseMessage,

--- a/test/integration/suites/common/websocket_test.go
+++ b/test/integration/suites/common/websocket_test.go
@@ -4,6 +4,8 @@ package common_test
 
 import (
 	"context"
+	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/test/integration/framework"
 )
 
@@ -44,20 +47,50 @@ func TestWebsocket(t *testing.T) {
 		Name: fnName, Env: envName, Code: codePath,
 	})
 
-	// http://127.0.0.1:8888 → ws://127.0.0.1:8888.
-	base := f.Router(t).BaseURL()
+	// /fission-function/<fn> moved off the public listener after
+	// GHSA-3g33-6vg6-27m8 — dial the internal listener instead, and
+	// sign the upgrade-handshake HTTP request with ServiceRouterInternal.
+	// http://127.0.0.1:8889 → ws://127.0.0.1:8889.
+	base := f.RouterInternalBaseURL()
 	require.True(t, strings.HasPrefix(base, "http://"),
-		"router base URL must be http:// for ws rewrite, got %q", base)
-	wsURL := "ws://" + strings.TrimPrefix(base, "http://") + "/fission-function/" + fnName
+		"router internal base URL must be http:// for ws rewrite, got %q", base)
+	path := "/fission-function/" + fnName
+	wsURL := "ws://" + strings.TrimPrefix(base, "http://") + path
+
+	// Build the HMAC-signed upgrade headers. Empty secret leaves the
+	// dial unsigned, which is fine when internalAuth.enabled=false on
+	// the cluster (verifier short-circuits to pass-through).
+	master := f.InternalAuthSecret()
+	dialHeader := http.Header{}
+	if len(master) > 0 {
+		key := hmacauth.DeriveServiceKey(master, hmacauth.ServiceRouterInternal)
+		ts := time.Now().Unix()
+		// gorilla/websocket dials with GET; canonical includes the
+		// request-URI (path + raw query). No body on the upgrade
+		// handshake, so body is nil.
+		sig := hmacauth.Sign(key, http.MethodGet, path, nil, ts)
+		dialHeader.Set(hmacauth.HeaderTimestamp, strconv.FormatInt(ts, 10))
+		dialHeader.Set(hmacauth.HeaderSignature, sig)
+	}
 
 	// First connect can race the executor specializing the pod; retry
-	// until dial succeeds.
+	// until dial succeeds. Re-sign on every attempt so the timestamp
+	// stays inside the verifier's skew window.
 	var conn *websocket.Conn
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		hdr := dialHeader
+		if len(master) > 0 {
+			key := hmacauth.DeriveServiceKey(master, hmacauth.ServiceRouterInternal)
+			ts := time.Now().Unix()
+			sig := hmacauth.Sign(key, http.MethodGet, path, nil, ts)
+			hdr = http.Header{}
+			hdr.Set(hmacauth.HeaderTimestamp, strconv.FormatInt(ts, 10))
+			hdr.Set(hmacauth.HeaderSignature, sig)
+		}
 		dctx, dcancel := context.WithTimeout(ctx, 10*time.Second)
 		defer dcancel()
 		var err error
-		conn, _, err = websocket.DefaultDialer.DialContext(dctx, wsURL, nil)
+		conn, _, err = websocket.DefaultDialer.DialContext(dctx, wsURL, hdr)
 		assert.NoErrorf(c, err, "websocket dial %q", wsURL)
 	}, 90*time.Second, 2*time.Second)
 	defer func() { _ = conn.Close() }()

--- a/test/upgrade_test/fission_objects.sh
+++ b/test/upgrade_test/fission_objects.sh
@@ -59,26 +59,71 @@ create_fission_objects() {
         echo "Function creation failed"
         exit 1
     fi
+
+    echo "Creating HTTPTrigger so the function can be invoked via the public router URL"
+    if fission route create --name hello --url /hello --method GET --function hello; then
+        echo "Successfully created HTTPTrigger"
+    else
+        echo "HTTPTrigger creation failed"
+        exit 1
+    fi
+
     sleep 5
 }
 
 test_fission_objects() {
     doit fission env list
     doit fission function list
+    doit fission httptrigger list
     doit fission check -v 2
     echo "-----------------###############################--------------------"
     echo "                   Running fission object tests"
     echo "-----------------###############################--------------------"
-    if fission function test -v 2 --name hello; then
-        echo "----------------------**********************-------------------------"
-        echo "                           Test success"
-        echo "----------------------**********************-------------------------"
-    else
-        echo "----------------------**********************-------------------------"
-        echo "                            Test failed"
-        echo "----------------------**********************-------------------------"
-        exit 1
-    fi
+    # Invoke via the HTTPTrigger we created in create_fission_objects rather
+    # than via `fission function test`. The CLI's `function test` subcommand
+    # used to invoke /fission-function/<name> directly on the public router,
+    # which is no longer registered there after the GHSA-3g33-6vg6-27m8
+    # listener split. HTTPTriggers are the supported public surface.
+    local pf_log="/tmp/upgrade-test-pf.log"
+    kubectl port-forward svc/router 18888:80 -n "$ns" >"$pf_log" 2>&1 &
+    local pf_pid=$!
+    trap "kill $pf_pid 2>/dev/null || true" RETURN
+
+    # Wait up to 30s for the port-forward to accept connections.
+    local i
+    for i in $(seq 1 30); do
+        if curl -sS --connect-timeout 1 --max-time 2 -o /dev/null "http://127.0.0.1:18888/" 2>/dev/null; then
+            break
+        fi
+        if [ "$i" -eq 30 ]; then
+            echo "router port-forward did not become ready in 30s; pf log:"
+            cat "$pf_log" || true
+            kill $pf_pid 2>/dev/null || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    # Poll the HTTPTrigger URL until the function is invokable. Function
+    # specialization can take a few seconds on a freshly-upgraded router.
+    for i in $(seq 1 30); do
+        if curl -fsS --max-time 5 "http://127.0.0.1:18888/hello" >/tmp/upgrade-test-resp 2>&1; then
+            echo "----------------------**********************-------------------------"
+            echo "                           Test success"
+            echo "----------------------**********************-------------------------"
+            cat /tmp/upgrade-test-resp || true
+            kill $pf_pid 2>/dev/null || true
+            return 0
+        fi
+        sleep 2
+    done
+
+    echo "----------------------**********************-------------------------"
+    echo "                            Test failed"
+    echo "----------------------**********************-------------------------"
+    cat /tmp/upgrade-test-resp || true
+    kill $pf_pid 2>/dev/null || true
+    exit 1
 }
 
 build_docker_images() {

--- a/test/upgrade_test/fission_objects.sh
+++ b/test/upgrade_test/fission_objects.sh
@@ -92,12 +92,25 @@ build_docker_images() {
 }
 
 kind_image_load() {
+    # Re-tag locally-built images to match the registry prefix the chart
+    # resolves to (HELM_VARS_LATEST_RELEASE: ghcr.io/fission/<name>:latest).
+    # Without this, kubelet with pullPolicy=IfNotPresent looks for
+    # `ghcr.io/fission/fission-bundle:latest` and falls through to GHCR,
+    # pulling whatever was last published from main — which won't have
+    # any flags / templates added since that publish.
+    echo "Re-tagging local images to match HELM_VARS_LATEST_RELEASE..."
+    doit docker tag fission-bundle ghcr.io/fission/fission-bundle:latest
+    doit docker tag fetcher ghcr.io/fission/fetcher:latest
+    doit docker tag builder ghcr.io/fission/builder:latest
+    doit docker tag reporter ghcr.io/fission/reporter:latest
+    doit docker tag preupgradechecks ghcr.io/fission/pre-upgrade-checks:latest
+
     echo "Loading Docker images into Kind cluster."
-    doit kind load docker-image fission-bundle --name kind
-    doit kind load docker-image fetcher --name kind
-    doit kind load docker-image builder --name kind
-    doit kind load docker-image reporter --name kind
-    doit kind load docker-image preupgradechecks --name kind
+    doit kind load docker-image ghcr.io/fission/fission-bundle:latest --name kind
+    doit kind load docker-image ghcr.io/fission/fetcher:latest --name kind
+    doit kind load docker-image ghcr.io/fission/builder:latest --name kind
+    doit kind load docker-image ghcr.io/fission/reporter:latest --name kind
+    doit kind load docker-image ghcr.io/fission/pre-upgrade-checks:latest --name kind
 }
 
 install_fission_cli() {


### PR DESCRIPTION
## Description

Builds on PR #3368 (now in `main` as commit `2455fc0c`). Phase 1 wired HMAC application-layer auth to `storagesvc /v1/archive`; this PR extends the same primitive to the four remaining internal HTTP surfaces catalogued in `docs/internal-auth/00-design.md`:

| Service ID | Server | Callers |
|---|---|---|
| `fetcher` | in-pod `cmd/fetcher` `/fetch` `/upload` `/clean` `/specialize` (port 8000) | buildermgr (build pipeline), executor (specialization) |
| `builder` | in-pod `cmd/builder` `/build` (port 8001) | buildermgr |
| `executor` | `pkg/executor` HTTP API (`/v2/getServiceForFunction`, `/v2/tap`, `/v2/error`, etc.) | router, kubewatcher, timer, mqt-fission-kafka, canaryconfig |
| `router-internal` | router's new internal listener (port 8889) hosting `/fission-function/<ns>/<name>` | executor, kubewatcher, timer, mqt-fission-kafka |

All four services use the **same** `pkg/auth/hmac` primitives + `ServiceVerifier` / `ServiceSigner` per-service derivation that landed in #3368, so this PR is mostly mechanical wiring — no new internal-auth Secret and no new internalAuth toggle (one new env var, ROUTER_INTERNAL_URL, on the four trigger-publishing services that now point at the router internal listener). The wire format stays at `fission-internal-v1`.

This PR also closes [GHSA-3g33-6vg6-27m8](https://github.com/fission/fission/security/advisories/GHSA-3g33-6vg6-27m8) (router internal `/fission-function/...` exposure) by splitting the router into two listeners — see "Behavioral change" below.

## What changed

### Server-side wiring (4 new verifiers)

- **`cmd/fetcher/app/server.go`** — registers `ServiceVerifier(master, oldMaster, ServiceFetcher, opts)` before any other middleware. Bypasses `/healthz` and `/readiness-healthz`.
- **`cmd/builder/app/server.go`** — registers `ServiceVerifier(master, oldMaster, ServiceBuilder, opts)`. Bypasses `/healthz`.
- **`pkg/executor/api.go::GetHandler`** — registers `ServiceVerifier(master, oldMaster, ServiceExecutor, opts)` before the metrics middleware. Bypasses `/healthz`.
- **`pkg/router/router.go`** — splits the router into a public listener (port 8888, hosts user HTTPTriggers + `/router-healthz` + `/_version` + the existing `featureConfig.AuthConfig.IsEnabled` JWT auth) and a new internal listener (port 8889, hosts `/fission-function/<ns>/<name>`). The internal listener is wrapped with `ServiceVerifier(..., ServiceRouterInternal, ...)`.

Each verifier inherits the post-Copilot-review behaviour from #3368: V(1) rejection logging with structured reasons (no header values echoed), `http.MaxBytesReader` body cap, early skew check before body buffering, RequestURI canonical signing (path + query bound), constant-time `crypto/hmac.Equal` comparison, empty-master pass-through.

### Client-side wiring (4 new signers)

API signature change: `MakeClient` for the fetcher / builder / executor clients now takes a `masterSecret []byte` parameter. Each client wraps its transport with `ServiceSigner(master, ServiceXxx, rt, time.Now)` when `len(master) > 0`; passing `nil`/empty keeps the previous unsigned behaviour exactly.

- **`pkg/fetcher/client/client.go::MakeClient(logger, url, masterSecret)`** — uses `ServiceSigner(..., ServiceFetcher, ...)`. Two production callers updated: `pkg/buildermgr/common.go` (build pipeline) and `pkg/executor/executortype/poolmgr/gp.go` (specialization).
- **`pkg/builder/client/client.go::MakeClient(logger, url, masterSecret)`** — uses `ServiceSigner(..., ServiceBuilder, ...)`. One production caller (`pkg/buildermgr/common.go`).
- **`pkg/executor/client/client.go::MakeClient(logger, url, masterSecret)`** — uses `ServiceSigner(..., ServiceExecutor, ...)` over the existing `retryablehttp` transport. Two callers (`cmd/fission-bundle/main.go` for the router subcommand, `test/e2e/framework/services/services.go` for in-process E2E).
- **Router-internal callers** — `pkg/publisher/webhookPublisher.go` (used by kubewatcher / timer / canaryconfig), `pkg/mqtrigger/messageQueue/kafka/consumer.go`, and `pkg/mqtrigger/scalermanager.go` (sets the KEDA `HTTP_ENDPOINT` env). All wrap their transport with `ServiceSigner(..., ServiceRouterInternal, ...)` and point at `ROUTER_INTERNAL_URL` (default `http://router.fission.svc:8889`).

All callers feed the master from `storagesvcClient.HMACSecretFromEnv()` (controller pods) — the same env var #3368 already mounts.

### Helm chart

- **New `router.internalPort: 8889`** in `values.yaml`. Drives the Service named-port `internal`, the new `--routerInternalPort` flag on `cmd/fission-bundle`, and the NetworkPolicy `from`-block.
- **`templates/router/svc.yaml`** — exposes the new `internal` port.
- **`templates/router/networkpolicy.yaml`** — restricts the internal port to `executor`, `kubewatcher`, `timer`, `mqtrigger` (fission-kafka), `mqtrigger-keda`, `canaryconfig`, `buildermgr` pod selectors.
- **`templates/router/deployment.yaml`** — adds the `--routerInternalPort` arg and the new `internal` container port.
- **`templates/{kubewatcher,timer,mqt-fission-kafka,mqt-keda}/deployment.yaml`** — adds `ROUTER_INTERNAL_URL` env + (where the deployment signs) the `internalAuth.envs` partial. The mqt-keda manager itself doesn't sign — it just propagates `HTTP_ENDPOINT` into the connector pods it spawns.

No new internal-auth Secret. The new `ROUTER_INTERNAL_URL` env var on kubewatcher / timer / mqt-fission-kafka / mqt-keda deployments points at the router internal Service. The existing `internalAuth.enabled` toggle gates the auth side wholesale.

## Behavioral change

**Router public listener no longer serves `/fission-function/<ns>/<name>`.** This is the GHSA-3g33-6vg6-27m8 fix: previously, anyone who could reach the public router URL (e.g. via Ingress) could invoke any function by guessing its name, bypassing all `HTTPTrigger` host/path/method gates. Now those routes only live on the internal listener (port 8889), gated by NetworkPolicy + (when `internalAuth.enabled=true`) HMAC.

End-user HTTPTrigger flow is unchanged — public listener still serves user HTTPTrigger paths, the existing `featureConfig.AuthConfig.IsEnabled` JWT middleware still applies on the public listener.

**External tooling that today curls `/fission-function/...` on the public router URL will get 404 after this PR.** That's the intended security fix; document it in upgrade notes.

**KEDA connector signing gap (out of scope).** Upstream `fission/kafka-http-connector` images do not yet sign their `/fission-function/...` invocations, so KEDA-driven mqtriggers will receive 401 from the router internal listener when `internalAuth.enabled=true`. Operators have two options:

1. Build signing-aware KEDA connector images (recommended long-term).
2. Run with `internalAuth.enabled=false` and rely on NetworkPolicy alone for the KEDA traffic. The internal listener still hosts `/fission-function/...` but does not enforce signatures.

Documented in `docs/internal-auth/00-design.md` § Limitations.

## Usage

### Default (recommended)

`internalAuth.enabled` defaults to `true`. After this PR merges, every internal channel signs by default:

```bash
helm install fission fission-charts/fission-all -n fission --create-namespace
```

The chart materialises one `Secret/fission-internal-auth` per Fission-using namespace; every controller and dynamic builder/function pod inherits the master via env. Each signer/verifier pair derives its own per-service key via HKDF.

### Disable everywhere

```bash
helm install fission fission-charts/fission-all -n fission \
  --set internalAuth.enabled=false
```

The chart skips the Secret and skips the env mounts. Every signer/verifier short-circuits to pass-through. **Net behavior is identical to `main` after #3368 with internalAuth disabled** — no signature checking on any channel, no signing by any client.

### Master secret rotation

Same flow as #3368 (now applies to all five signed channels atomically because every per-service key is derived from the same master):

```bash
LIVE=$(kubectl -n fission get secret fission-internal-auth -o jsonpath='{.data.secret}' | base64 -d)
helm upgrade fission fission-charts/fission-all -n fission --set internalAuth.oldSecret="$LIVE"
helm upgrade fission fission-charts/fission-all -n fission --set internalAuth.secret="$(openssl rand -base64 32)"
# wait for all pods to roll
helm upgrade fission fission-charts/fission-all -n fission --set internalAuth.oldSecret=""
```

## Net behavior matrix

| Server (verifier) | Client (signer) | Outcome |
|---|---|---|
| **OFF** | **OFF** | All requests pass through unsigned — identical to pre-PR behavior on every channel |
| ON | ON | All signed and verified per-service |
| ON | OFF | Client request returns **401** (only failure mode — toggle applied inconsistently) |
| OFF | ON | Client sends signed headers; server pass-through ignores them — works |

The chart applies the toggle wholesale, so the "ON / OFF" failure mode only surfaces on hand-edited deployments, in-flight upgrades where some pods haven't rolled yet, or external tooling that signed against an unconfigured CLI.

## Tests

- `pkg/executor/api_auth_test.go` (new) — exercises the executor verifier wiring with `ServiceVerifier(..., ServiceExecutor, ...)`; covers signed/unsigned/healthz-bypass.
- `pkg/router/httpTriggers_test.go` (new) — four cases: public mux returns 404 for `/fission-function/...`, internal mux serves it, healthz/version stay public, internal listener 401s unsigned + passes through with empty secret.
- `test/integration/suites/common/router_internal_listener_test.go` (new, `//go:build integration`) — port-forward driven check that the public listener returns 404 and the internal listener returns 401 for unsigned `/fission-function/...`.
- `helm template charts/fission-all -n fission` renders 12 `FISSION_INTERNAL_AUTH_SECRET*` references (was 8 in #3368; the 4 new are kubewatcher/timer × 2 envs each — those services now sign router-internal calls).
- `helm template charts/fission-all -n fission --set internalAuth.enabled=false` renders 0 references — backwards-compat verified.
- `make code-checks` clean.
- `go test -race -count=1` green for `pkg/auth/hmac/...`, `pkg/storagesvc/...`, `pkg/builder/...`, `pkg/executor/...`, `pkg/router/...`, `pkg/publisher/...`, `pkg/mqtrigger/...`, `pkg/fetcher/...`.

## Which issue(s) this PR fixes:

GHSA-3g33-6vg6-27m8 (router `/fission-function/...` exposure on the public listener). The other four channels (`fetcher`, `builder`, `executor`, `router-internal`) are not tied to a CVE on their own — they're the "every other internal HTTP surface" rollout from `docs/internal-auth/00-design.md` § Services.

## Checklist:

- [x] I ran tests as well as code linting locally to verify my changes.
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3369)
<!-- Reviewable:end -->

