### PR TITLE
fix: allow equals in ingress trigger parsing

### DIFF
--- a/pkg/fission-cli/cmd/httptrigger/parse.go
+++ b/pkg/fission-cli/cmd/httptrigger/parse.go
@@ -95,7 +95,7 @@ func getIngressAnnotations(annotations []string) (remove bool, anns map[string]s
 			// remove all annotations
 			return true, nil, nil
 		}
-		v := strings.Split(ann, "=")
+		v := strings.SplitN(ann, "=", 2)
 		if len(v) != 2 {
 			return false, nil, fmt.Errorf("illegal ingress annotation: %v", ann)
 		}
@@ -115,7 +115,7 @@ func getIngressHostRule(rule string, fallbackPath string) (empty bool, host stri
 	if rule == "-" {
 		return false, "*", fallbackPath, nil
 	}
-	v := strings.Split(rule, "=")
+	v := strings.SplitN(rule, "=", 2)
 	if len(v) != 2 {
 		return false, "", "", fmt.Errorf("illegal ingress rule: %v", rule)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/parse_test.go
+++ b/pkg/fission-cli/cmd/httptrigger/parse_test.go
@@ -152,15 +152,21 @@ func Test_GetIngressConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "wrong-annotations-value-2",
+			name: "annotation-value-with-equals",
 			args: args{
 				ingressConfig:       nil,
 				annotations:         []string{"a=b=c"},
 				rule:                "-",
 				fallbackRelativeURL: "/test",
 			},
-			want:    nil,
-			wantErr: true,
+			want: &fv1.IngressConfig{
+				Annotations: map[string]string{
+					"a": "b=c",
+				},
+				Host: "*",
+				Path: "/test",
+			},
+			wantErr: false,
 		},
 		{
 			name: "wrong-rule-value-1",
@@ -178,7 +184,7 @@ func Test_GetIngressConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "wrong-rule-value-2",
+			name: "rule-path-with-equals",
 			args: args{
 				ingressConfig: &fv1.IngressConfig{
 					Annotations: map[string]string{
@@ -186,11 +192,18 @@ func Test_GetIngressConfig(t *testing.T) {
 					},
 				},
 				annotations:         []string{"a=b"},
-				rule:                "a=b=c",
+				rule:                "a=/b=c",
 				fallbackRelativeURL: "/test",
 			},
-			want:    nil,
-			wantErr: true,
+			want: &fv1.IngressConfig{
+				Annotations: map[string]string{
+					"hello": "world",
+					"a":     "b",
+				},
+				Host: "a",
+				Path: "/b=c",
+			},
+			wantErr: false,
 		},
 		{
 			name: "ingressconfog-with-only-fallback-rul",
@@ -384,6 +397,17 @@ func Test_getIngressAnnotations(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "annotation-value-with-equals",
+			args: args{
+				annotations: []string{"nginx.ingress.kubernetes.io/rewrite-target=/api?token=a=b"},
+			},
+			wantRemove: false,
+			wantAnns: map[string]string{
+				"nginx.ingress.kubernetes.io/rewrite-target": "/api?token=a=b",
+			},
+			wantErr: false,
+		},
+		{
 			name: "remove-all-annotations",
 			args: args{
 				annotations: []string{"-", "c=d"},
@@ -395,7 +419,7 @@ func Test_getIngressAnnotations(t *testing.T) {
 		{
 			name: "incorrect-annotation",
 			args: args{
-				annotations: []string{"a==b"},
+				annotations: []string{"a"},
 			},
 			wantRemove: false,
 			wantAnns:   nil,
@@ -459,6 +483,17 @@ func Test_getIngressHostRule(t *testing.T) {
 			wantEmpty: false,
 			wantHost:  "a",
 			wantPath:  "b",
+			wantErr:   false,
+		},
+		{
+			name: "path-with-equals",
+			args: args{
+				rule:         "example.com=/search?q=a=b",
+				fallbackPath: "/foo",
+			},
+			wantEmpty: false,
+			wantHost:  "example.com",
+			wantPath:  "/search?q=a=b",
 			wantErr:   false,
 		},
 		{


### PR DESCRIPTION
Small CLI papercut fix, ngl.

Repro before patch:

```bash
fission httptrigger create --name t --function fn --url /x --ingress --ingressannotation 'a=b=c'
fission httptrigger create --name t --function fn --url /x --ingress --ingressrule 'example.com=/search?q=a=b'
```

Both get rejected because the parser splits on every `=`. Kinda rough for query strings and annotation values.

Fix is tiny: split only on the first `=`.

Tested:

```bash
go test ./pkg/fission-cli/cmd/httptrigger ./pkg/utils ./pkg/apis/core/v1
go test -count=1 ./pkg/fission-cli/cmd/httptrigger
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3370)
<!-- Reviewable:end -->
