### PR TITLE
ci: cache goreleaser dist/ output to skip skaffold-prebuild on hit

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -106,6 +106,28 @@ jobs:
           helm install prometheus prometheus-community/kube-prometheus-stack -n monitoring \
           --version 45.28.0 --set grafana.enabled=false --set alertmanager.enabled=false
 
+      # Cache the goreleaser dist/ output keyed on the inputs that affect
+      # the linux/amd64 binaries: go.sum, production Go source (no tests),
+      # the goreleaser config, the per-binary Dockerfiles, and the Makefile
+      # (build flags / ldflags). A cache hit lets us skip ~5-8min of
+      # `goreleaser build --snapshot` work per matrix entry — skaffold
+      # still builds the small container images from the cached binaries.
+      #
+      # The key also carries a cover/plain segment: only the GOFLAGS leg
+      # (see below) builds Go binary-coverage-instrumented binaries, so
+      # instrumented and plain dist/ outputs must live in separate cache
+      # namespaces — otherwise a plain cache hit would feed uninstrumented
+      # binaries to the coverage leg and silently empty the coverage report.
+      #
+      # Exact-key match only (no restore-keys fallback) — we never want to
+      # test against binaries built from different source.
+      - name: Restore goreleaser dist/ cache
+        id: cache-dist
+        uses: actions/cache@v4
+        with:
+          path: dist
+          key: dist-linux-amd64-${{ matrix.kindversion == 'v1.32.11' && 'cover' || 'plain' }}-${{ hashFiles('go.sum', 'go.mod', '.goreleaser.yml', 'Makefile', 'cmd/**/*.go', '!cmd/**/*_test.go', 'pkg/**/*.go', '!pkg/**/*_test.go', 'cmd/**/Dockerfile') }}
+
       - name: Build and Install Fission
         timeout-minutes: 10
         env:
@@ -127,7 +149,38 @@ jobs:
           # and leave it empty.
           docker exec kind-control-plane sh -c \
             'mkdir -p /fission-coverage && chown 10001:10001 /fission-coverage && chmod 0700 /fission-coverage'
-          SKAFFOLD_PROFILE=kind-ci make skaffold-deploy
+          # On cache hit dist/ already contains the per-binary build
+          # contexts (binary + Dockerfile). Skip `make skaffold-deploy`'s
+          # prebuild step and invoke skaffold directly so goreleaser does
+          # not re-run. Skaffold itself produces the container images from
+          # these cached binaries — fast since the COPY layer is tiny.
+          #
+          # Sanity-check every context the kind-ci profile actually builds
+          # (skaffold.yaml artifacts: fission-bundle, fetcher,
+          # pre-upgrade-checks, reporter — note: NOT builder). A partially
+          # saved cache that's missing any of these would otherwise
+          # green-light `skaffold run` and fail confusingly mid-build
+          # instead of cleanly falling back to the full prebuild.
+          dist_complete=true
+          if [ "${{ steps.cache-dist.outputs.cache-hit }}" = "true" ]; then
+            for bin in fission-bundle fetcher pre-upgrade-checks reporter; do
+              if [ ! -x "dist/${bin}_linux_amd64_v1/${bin}" ] \
+                  || [ ! -f "dist/${bin}_linux_amd64_v1/Dockerfile" ]; then
+                echo "dist/ cache hit but ${bin} context incomplete"
+                dist_complete=false
+                break
+              fi
+            done
+          else
+            dist_complete=false
+          fi
+          if [ "$dist_complete" = "true" ]; then
+            echo "dist/ cache hit — skipping skaffold-prebuild (goreleaser)"
+            skaffold run -p kind-ci
+          else
+            echo "dist/ cache miss — running full skaffold-prebuild"
+            SKAFFOLD_PROFILE=kind-ci make skaffold-deploy
+          fi
 
       # Port-forward is started inside the Go test step rather than as a
       # standalone step, because background processes started with `&` may


### PR DESCRIPTION
The integration-test job runs three k8s matrix entries, each spending 5-8 minutes on `make skaffold-prebuild` (goreleaser snapshot build of fission-bundle / fetcher / builder / pre-upgrade-checks / reporter). For PRs that don't touch production Go source, those rebuilds are wasted — the linux/amd64 binaries are functionally identical between runs.

Add an actions/cache step keyed on the inputs that actually affect the binary output:
- go.mod / go.sum (deps + toolchain)
- production Go source under cmd/ and pkg/ (excluding _test.go)
- .goreleaser.yml (build config)
- Makefile (build flags / ldflags)
- Per-binary Dockerfiles in cmd/*/Dockerfile

On cache hit the build step skips `make skaffold-deploy` (which chains skaffold-prebuild) and invokes `skaffold run -p kind-ci` directly, letting skaffold build the small container images from the cached binaries. On cache miss the full prebuild runs as before and populates the cache for subsequent runs.

Exact-key match only (no restore-keys fallback) — we must never run integration tests against binaries built from different source.

Limitations:
- Binaries embed BuildDate / GitCommit via ldflags, so cached binaries will report the commit that populated the cache. This is fine for tests; the dev-loop release path doesn't use this cache.
- _test.go files are excluded from the hash; PRs that only change test code still get a cache hit, which is the intended outcome.

<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
<!--- Describe your changes in detail. -->
<!-- Typically try to give details of what, why and how of the PR changes. -->

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

## Testing
<!--- Please describe in detail how you tested your changes. -->

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [ ] I ran tests as well as code linting locally to verify my changes. 
- [ ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3380)
<!-- Reviewable:end -->
