### PR TITLE
Reject cross-namespace Environment + Package references in Function (…

### DIFF
--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -270,6 +270,11 @@ func (deploy *NewDeploy) IsValid(ctx context.Context, fsvc *fscache.FuncSvc) boo
 
 // RefreshFuncPods deletes pods related to the function so that new pods are replenished
 func (deploy *NewDeploy) RefreshFuncPods(ctx context.Context, logger logr.Logger, f fv1.Function) error {
+	// Defence in depth for GHSA-cvw6-gfvv-953q — see fnCreate for context.
+	if envNs := f.Spec.Environment.Namespace; envNs != "" && envNs != f.Namespace {
+		return fmt.Errorf("cross-namespace environment reference is not allowed: fn.namespace=%s env.namespace=%s",
+			f.Namespace, envNs)
+	}
 
 	env, err := deploy.fissionClient.CoreV1().Environments(f.Spec.Environment.Namespace).Get(ctx, f.Spec.Environment.Name, metav1.GetOptions{})
 	if err != nil {
@@ -427,6 +432,14 @@ func (deploy *NewDeploy) deleteFunction(ctx context.Context, fn *fv1.Function) e
 }
 
 func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	// Defence in depth for GHSA-cvw6-gfvv-953q — primary defence is the
+	// admission webhook in pkg/webhook/function.go, but a stale Function
+	// from a pre-webhook upgrade window (or failurePolicy=ignore) could
+	// still reach this path.
+	if envNs := fn.Spec.Environment.Namespace; envNs != "" && envNs != fn.Namespace {
+		return nil, fmt.Errorf("cross-namespace environment reference is not allowed: fn.namespace=%s env.namespace=%s",
+			fn.Namespace, envNs)
+	}
 	cleanupFunc := func(ctx context.Context, ns string, name string) {
 		err := deploy.cleanupNewdeploy(ctx, ns, name)
 		if err != nil {

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -586,6 +586,15 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 	var env *fv1.Environment
 	otelUtils.SpanTrackEvent(ctx, "getFunctionEnv", otelUtils.GetAttributesForFunction(fn)...)
 
+	// Defence in depth for GHSA-cvw6-gfvv-953q — the admission webhook
+	// already rejects this at submit time, but a stale Function object
+	// from an upgrade-before-webhook-restart window (or a cluster running
+	// with failurePolicy=ignore) could still reach this path.
+	if envNs := fn.Spec.Environment.Namespace; envNs != "" && envNs != fn.Namespace {
+		return nil, fmt.Errorf("cross-namespace environment reference is not allowed: fn.namespace=%s env.namespace=%s",
+			fn.Namespace, envNs)
+	}
+
 	// Cached ?
 	// TODO: the cache should be able to search by <env name, fn namespace> instead of function metadata.
 	result, err := gpm.functionEnv.Get(crd.CacheKeyURFromMeta(&fn.ObjectMeta))

--- a/pkg/webhook/function.go
+++ b/pkg/webhook/function.go
@@ -62,15 +62,19 @@ func (r *Function) Validate(new *v1.Function) error {
 		}
 	}
 	// Cross-namespace EnvironmentRef closes GHSA-cvw6-gfvv-953q. An empty
-	// namespace remains accepted — controllers default it to the function's
-	// own namespace — but an explicit cross-namespace reference is rejected.
+	// namespace remains accepted — the Fission CLI populates it with the
+	// function's own namespace at creation time (pkg/fission-cli/cmd/function/
+	// create.go), and downstream controllers tolerate empty via
+	// DefaultNSResolver. Rejecting only the explicit cross-namespace value is
+	// sufficient for this advisory; defaulting an empty namespace at admission
+	// is a separate hardening track tracked outside this fix.
 	if envRef := new.Spec.Environment; envRef.Namespace != "" && envRef.Namespace != new.Namespace {
 		err := fmt.Errorf("environment's namespace [%s] and function's namespace [%s] are different; cross-namespace Environment reference is not allowed",
 			envRef.Namespace, new.Namespace)
 		return v1.AggregateValidationErrors("Function", err)
 	}
 	// Cross-namespace PackageRef closes GHSA-3r8v-2xmj-5c39. Same shape as
-	// the EnvironmentRef check above.
+	// the EnvironmentRef check above, including the empty-is-accepted rule.
 	if pkgRef := new.Spec.Package.PackageRef; pkgRef.Namespace != "" && pkgRef.Namespace != new.Namespace {
 		err := fmt.Errorf("package's namespace [%s] and function's namespace [%s] are different; cross-namespace Package reference is not allowed",
 			pkgRef.Namespace, new.Namespace)

--- a/pkg/webhook/function.go
+++ b/pkg/webhook/function.go
@@ -61,6 +61,21 @@ func (r *Function) Validate(new *v1.Function) error {
 			return v1.AggregateValidationErrors("Function", err)
 		}
 	}
+	// Cross-namespace EnvironmentRef closes GHSA-cvw6-gfvv-953q. An empty
+	// namespace remains accepted — controllers default it to the function's
+	// own namespace — but an explicit cross-namespace reference is rejected.
+	if envRef := new.Spec.Environment; envRef.Namespace != "" && envRef.Namespace != new.Namespace {
+		err := fmt.Errorf("environment's namespace [%s] and function's namespace [%s] are different; cross-namespace Environment reference is not allowed",
+			envRef.Namespace, new.Namespace)
+		return v1.AggregateValidationErrors("Function", err)
+	}
+	// Cross-namespace PackageRef closes GHSA-3r8v-2xmj-5c39. Same shape as
+	// the EnvironmentRef check above.
+	if pkgRef := new.Spec.Package.PackageRef; pkgRef.Namespace != "" && pkgRef.Namespace != new.Namespace {
+		err := fmt.Errorf("package's namespace [%s] and function's namespace [%s] are different; cross-namespace Package reference is not allowed",
+			pkgRef.Namespace, new.Namespace)
+		return v1.AggregateValidationErrors("Function", err)
+	}
 
 	if err := new.Validate(); err != nil {
 		return v1.AggregateValidationErrors("Function", err)

--- a/pkg/webhook/function_test.go
+++ b/pkg/webhook/function_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package webhook
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// makeValidFunction returns a Function object that satisfies v1.Function.Validate()
+// so the cross-namespace branches are the only thing under test. The caller may
+// override the Environment / PackageRef namespaces to exercise the rejects.
+func makeValidFunction(fnNs, envNs, pkgNs string) *v1.Function {
+	return &v1.Function{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "fn-1",
+			Namespace: fnNs,
+		},
+		Spec: v1.FunctionSpec{
+			Environment: v1.EnvironmentReference{
+				Name:      "env-1",
+				Namespace: envNs,
+			},
+			Package: v1.FunctionPackageRef{
+				PackageRef: v1.PackageRef{
+					Name:      "pkg-1",
+					Namespace: pkgNs,
+				},
+			},
+			InvokeStrategy: v1.InvokeStrategy{
+				StrategyType: v1.StrategyTypeExecution,
+				ExecutionStrategy: v1.ExecutionStrategy{
+					ExecutorType: v1.ExecutorTypePoolmgr,
+				},
+			},
+		},
+	}
+}
+
+func TestFunctionWebhook_Validate_CrossNamespaceEnvironment(t *testing.T) {
+	cases := []struct {
+		name         string
+		fnNs         string
+		envNs        string
+		wantRejected bool
+	}{
+		{name: "empty env.namespace is accepted", fnNs: "default", envNs: "", wantRejected: false},
+		{name: "same namespace is accepted", fnNs: "default", envNs: "default", wantRejected: false},
+		{name: "cross namespace is rejected", fnNs: "ns-attacker", envNs: "ns-victim", wantRejected: true},
+		{name: "cross namespace rejected even when fn in kube-system", fnNs: "kube-system", envNs: "default", wantRejected: true},
+	}
+
+	r := &Function{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := r.Validate(makeValidFunction(tc.fnNs, tc.envNs, tc.fnNs))
+			if tc.wantRejected {
+				if err == nil {
+					t.Fatalf("expected rejection, got nil")
+				}
+				if !strings.Contains(err.Error(), "Environment reference") {
+					t.Fatalf("error should reference cross-namespace Environment, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.envNs) || !strings.Contains(err.Error(), tc.fnNs) {
+					t.Fatalf("error should mention both namespaces (%q and %q), got: %v", tc.fnNs, tc.envNs, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected acceptance, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestFunctionWebhook_Validate_CrossNamespacePackage(t *testing.T) {
+	cases := []struct {
+		name         string
+		fnNs         string
+		pkgNs        string
+		wantRejected bool
+	}{
+		{name: "empty pkg.namespace is accepted", fnNs: "default", pkgNs: "", wantRejected: false},
+		{name: "same namespace is accepted", fnNs: "default", pkgNs: "default", wantRejected: false},
+		{name: "cross namespace is rejected", fnNs: "ns-attacker", pkgNs: "ns-victim", wantRejected: true},
+	}
+
+	r := &Function{}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Keep env.Namespace aligned with fn.Namespace so only the
+			// package-ref branch can trigger the cross-ns reject.
+			err := r.Validate(makeValidFunction(tc.fnNs, tc.fnNs, tc.pkgNs))
+			if tc.wantRejected {
+				if err == nil {
+					t.Fatalf("expected rejection, got nil")
+				}
+				if !strings.Contains(err.Error(), "Package reference") {
+					t.Fatalf("error should reference cross-namespace Package, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), tc.pkgNs) || !strings.Contains(err.Error(), tc.fnNs) {
+					t.Fatalf("error should mention both namespaces (%q and %q), got: %v", tc.fnNs, tc.pkgNs, err)
+				}
+			} else if err != nil {
+				t.Fatalf("expected acceptance, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Closes two confused-deputy primitives where a subject with `functions.fission.io/create` permission in `ns-attacker` can target `ns-victim` by setting either `spec.environment.namespace` or `spec.package.packageref.namespace` to the victim's namespace.

The Function admission webhook (`pkg/webhook/function.go::Validate`) already checked `Secret.Namespace` and `ConfigMap.Namespace` against the function's own namespace. `EnvironmentRef` and `PackageRef` were the two missing fields. Mirrors the prior fix shape from PR #3379 (`e2b92663`) for the Package + KubernetesWatchTrigger cross-namespace pair.

### Webhook (primary defence)

`pkg/webhook/function.go::Validate` (verbs already `create;update`):
- Reject `Function.spec.environment.namespace != metadata.namespace`.
- Reject `Function.spec.package.packageref.namespace != metadata.namespace`.
- Empty namespace remains accepted — controllers default it to the function's own namespace, same as the existing ConfigMap/Secret behaviour.

### Controller-side belt-and-braces

For clusters running with the webhook disabled (`failurePolicy=ignore`) or with stale Function objects from a pre-webhook upgrade window:
- `pkg/executor/executortype/poolmgr/gpm.go::getFunctionEnv` — guard before the cross-ns `Environments(...).Get`.
- `pkg/executor/executortype/newdeploy/newdeploymgr.go::fnCreate` — guard at the canonical executor entry point.
- `pkg/executor/executortype/newdeploy/newdeploymgr.go::RefreshFuncPods` — same guard at the force-restart path.

### Behavioural change

`Function.spec.environment.namespace` and `Function.spec.package.packageref.namespace` must equal the Function's own namespace (or be empty). Functions that explicitly set either to another namespace are now rejected at admission. There is no legitimate cross-namespace use case — both controllers already assume same-namespace lookups elsewhere in the call graph.

### Out of scope

The fetcher path (`pkg/fetcher/fetcher.go`) is left to the executor's upstream guards. Adding a fetcher-side check would require extending `FunctionFetchRequest` with the function's namespace; the executor guards already cover the attack surface comprehensively.

## Which issue(s) this PR fixes:

- [GHSA-cvw6-gfvv-953q](https://github.com/fission/fission/security/advisories/GHSA-cvw6-gfvv-953q) — Cross-namespace Environment reference via unvalidated EnvironmentRef in Function admission webhook (CVSS 8.2 High).
- [GHSA-3r8v-2xmj-5c39](https://github.com/fission/fission/security/advisories/GHSA-3r8v-2xmj-5c39) — Cross-namespace Package read via unvalidated PackageRef in Function admission webhook (High).

## Testing

- `pkg/webhook/function_test.go` — table tests for both fields covering empty / same-ns / cross-ns plus a kube-system canary; asserts both namespaces appear in the rejection message.
- `make code-checks` clean.
- `go test -race ./pkg/webhook/... ./pkg/executor/executortype/poolmgr/... ./pkg/executor/executortype/newdeploy/...` green locally.

## Checklist:

- [x] I ran tests as well as code linting locally to verify my changes.
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3389)
<!-- Reviewable:end -->