### PR TITLE
Bump workflow tool versions (skaffold v2.21.0, goreleaser-action v7.2.2)

### DIFF
--- a/.claude/skills/go-deps-security-upgrade/SKILL.md
+++ b/.claude/skills/go-deps-security-upgrade/SKILL.md
@@ -15,7 +15,7 @@ Skip if the user asks for a single, named dep bump — that's just `go get <pkg>
 
 ## Phase 0 — Baseline
 
-1. Create branch: `git checkout -b deps/security-sweep-<YYYY-MM>` off `main`.
+1. Create branch off `main`. **First check for a stale collision** — a prior month's sweep branch is often still present locally and on `origin` after its PR merged (`git checkout -b deps/security-sweep-<YYYY-MM>` then fails with "branch already exists", and its diff vs `main` looks like a huge *reverse* because `main` moved on). If `git rev-parse --verify deps/security-sweep-<YYYY-MM>` succeeds, run `gh pr list --head <branch> --state all` — if that branch's PR is MERGED, it's leftover; do NOT reuse it (its "upgrades" are now downgrades vs `main`). Use a **date-stamped** name instead: `git checkout main && git checkout -b deps/security-sweep-<YYYY-MM-DD>`.
 2. Install scanner (if missing): `go install golang.org/x/vuln/cmd/govulncheck@latest`.
 3. Capture baseline: `govulncheck ./... | tee /tmp/govulncheck-before.txt`. Extract the "Your code is affected by N vulnerabilities" line and the per-vuln "Fixed in:" versions — those dictate minimum target versions.
 4. List outdated direct deps: `go list -m -u -json all` filtered to entries with both `"Update"` and no `"Indirect": true`. Use this Python one-liner:
@@ -78,13 +78,22 @@ If the group fails, bisect **within** the group: drop one dep at a time from the
 ### KEDA's phantom `require` pins
 `github.com/kedacore/keda/v2` ships go.mod files that declare `require k8s.io/client-go v1.5.2` and `require sigs.k8s.io/controller-runtime v0.23.x` but internally `replace`s them to sane versions (v0.3x.x and v0.22.x). Replace directives are **not** transitive. Consumers inherit the bogus `require` and MVS picks the ancient (v1.5.2) or wrong-minor version, breaking the build.
 
-**Fix**: add `exclude` directives to the Fission `go.mod`:
+**Fix**: drop the bogus high-semver tags with `exclude`, and pin controller-runtime with `replace` (NOT `exclude`):
 ```go.mod
-// KEDA phantom requires — not propagated through their internal `replace`.
-exclude k8s.io/client-go v1.5.2
-exclude sigs.k8s.io/controller-runtime v0.23.1
+// KEDA phantom requires — bogus high-semver tags not propagated through KEDA's
+// internal `replace`. Drop them so MVS falls back to our real direct deps.
+exclude (
+	github.com/prometheus/common v1.20.99   // retracted/bogus tag on the v0.x line (KEDA also pulls this in)
+	k8s.io/client-go v1.5.2                  // ancient v1.x tag, higher semver than the live v0.x line
+)
+// KEDA declares `require controller-runtime v0.23.1` but compiles against v0.22.4
+// via its internal replace. Use `replace`, not `exclude`: a bare exclude resolves
+// UP to the next available version (v0.24.1 now exists), which breaks KEDA's webhooks.
+replace sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.22.4
 ```
-Verify with `go mod graph | grep '<bad-version>'` to confirm which consumer declares the phantom require.
+Verify with `go mod graph | grep '<bad-version>'` to confirm which consumer declares the phantom require, and `go list -m sigs.k8s.io/controller-runtime` to confirm the replace took (`v0.23.1 => v0.22.4`).
+
+**Why `replace` and not `exclude` for controller-runtime (changed 2026-05):** the skill originally documented `exclude sigs.k8s.io/controller-runtime v0.23.1`. That worked only while v0.23.1 was the highest version — `exclude` makes MVS pick the *next higher* version to satisfy KEDA's require. Now that v0.24.0/v0.24.1 exist, excluding v0.23.1 resolves up to v0.24.1 (incompatible). `replace` pins the exact version regardless of requires. (`exclude` is still correct for `client-go v1.5.2` / `prometheus/common v1.20.99`: nothing higher than those bogus tags exists, so MVS falls back to our real direct require.)
 
 ### KEDA ↔ controller-runtime coupling
 KEDA's webhook files (`apis/keda/v1alpha1/*_webhook.go`) are compiled whenever Fission imports KEDA CRD types. If controller-runtime's `NewWebhookManagedBy` signature changed (happened at v0.23), KEDA webhook files written against the old signature won't compile. Symptoms:
@@ -94,6 +103,15 @@ not enough arguments in call to ctrl.NewWebhookManagedBy
     want (manager.Manager, T)
 ```
 **Fix**: pin controller-runtime to the KEDA-compatible version (currently v0.22.4) and defer the bump until KEDA ships a cleanly-compatible release. Document in the deferred-group commit message.
+
+### The KEDA cap also blocks the k8s core group (learned 2026-05)
+Because controller-runtime is pinned to v0.22.4 (KEDA), the **k8s core group is capped too** — they version in lockstep. controller-runtime v0.22.4 only implements the `ResourceEventHandlerRegistration` interface as of k8s v0.35; **k8s v0.36 added `HasSyncedChecker` to that interface**, which only controller-runtime v0.24 implements. So bumping `k8s.io/* → v0.36` while controller-runtime is stuck at v0.22.4 fails to compile (against controller-runtime's *own* cached source, not Fission's):
+```
+sigs.k8s.io/controller-runtime@v0.22.4/pkg/cache/multi_namespace_cache.go: cannot use handles
+    (variable of struct type handlerRegistration) as cache.ResourceEventHandlerRegistration value:
+    handlerRegistration does not implement ...ResourceEventHandlerRegistration (missing method HasSyncedChecker)
+```
+**Decision rule:** if controller-runtime is capped by KEDA at vX, cap k8s core at the highest minor controller-runtime vX supports (currently controller-runtime v0.22.4 ⇒ k8s ≤ v0.35.x). Defer both the k8s-core and controller-runtime groups together with one shared blocker note. The unblock is a single event: KEDA shipping a release built against controller-runtime v0.24, which then lets k8s core, controller-runtime, and KEDA all move together.
 
 ### Retracted module tags (e.g. `prometheus/common v1.20.99`)
 Some transitive deps push accidental high-version tags (`v1.20.99` on a project that's actually on the `v0.x` line). `go get` then picks the retracted tag as "latest". Symptom: `tidy` warns `retracted by module author`.

--- a/.claude/skills/workflow-tool-versions/SKILL.md
+++ b/.claude/skills/workflow-tool-versions/SKILL.md
@@ -43,7 +43,7 @@ SHA-pinned actions usually present:
 
 ## Phase 0 — Baseline
 
-1. Create branch: `git checkout -b ci/tool-versions-<YYYY-MM>` off `main`.
+1. Create branch off `main`. **Check for a stale collision first** — last month's branch is often still present locally and on `origin` after its PR merged, so `git checkout -b ci/tool-versions-<YYYY-MM>` fails with "branch already exists". If it exists, run `gh pr list --head <branch> --state all`; a MERGED PR means it's leftover (its bumps are already in `main`) — don't reuse it. Use a **date-stamped** name: `git checkout main && git checkout -b ci/tool-versions-<YYYY-MM-DD>`. After a recent merged sweep, expect most `*_VERSION:` vars to already be at latest — that's normal, not a discovery failure.
 2. Inventory dynamically — do not trust the snapshot above:
    ```bash
    grep -rnE "^\s*[A-Z_]+_VERSION:" .github/workflows/
@@ -84,9 +84,13 @@ For each tool to bump:
 # upgrade_test separate when it has its own intent.
 $EDITOR .github/workflows/push_pr.yaml .github/workflows/release.yaml
 
-# Sanity-check the YAML still parses (no `yq` required — Python does fine)
-python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" \
+# Sanity-check the YAML still parses. PyYAML is NOT installed on the dev macOS
+# box (python3 -c "import yaml" -> ModuleNotFoundError), so prefer ruby, which ships
+# with macOS and has YAML in stdlib. (For a pure value-only edit on a pre-valid line,
+# YAML validity is preserved by construction — but validate anyway when in doubt.)
+ruby -ryaml -e 'ARGV.each { |f| YAML.load_file(f) }; puts "YAML OK"' \
   .github/workflows/push_pr.yaml .github/workflows/release.yaml
+# Fallback if ruby is absent: python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" <files>
 
 git add .github/workflows/
 git commit -m "Bump <tool> v<old> -> v<new>"
@@ -128,6 +132,14 @@ Skaffold occasionally renames or removes profile keys. The Fission `skaffold.yam
 
 ### Dependabot's grouped github-actions PR
 Dependabot already groups *action* version bumps weekly (`.github/dependabot.yml` declares a `github-actions` group). The `*_VERSION:` env vars are NOT touched by Dependabot — those are runtime downloads, not action versions. So this skill's primary scope (env vars) does not overlap with Dependabot's; the SHA-pinned `uses:` bumps usually arrive via Dependabot, so manually doing them is catch-up if Dependabot is paused or behind.
+
+**Before deciding a SHA-pinned action is "behind," check for an open Dependabot PR:** `gh pr list --author "app/dependabot" --state open`. If there's an open `github-actions` group PR (e.g. it bumps harden-runner/codeql-action/codecov-action/goreleaser-action), that PR already owns those SHA bumps — don't duplicate it in a sweep; flag it in the summary instead.
+
+### Bumping a SHA-pinned action when the user explicitly asks
+The user may name a SHA-pinned action directly ("can we bump goreleaser too") even though it's normally Dependabot's domain. Do it, but:
+1. **Resolve the new tag to its commit SHA** (the pin is a 40-hex SHA, not the tag): `gh api repos/<owner>/<repo>/commits/<tag> --jq '.sha'`. This dereferences annotated tags to the commit. Update both the `@<sha>` and the trailing `# vX.Y.Z` comment.
+2. **One action lives in multiple files** — e.g. `goreleaser/goreleaser-action` is pinned in `push_pr.yaml`, `upgrade_test.yaml`, and `release.yaml` (×2). Replace every occurrence with the identical new `@<sha> # vX.Y.Z` and commit together. `Edit` with `replace_all: true` per file is reliable; a `perl -pi -e "s{...}{...}"` one-liner with the `#`/spaces in shell-expanded vars silently no-ops, so don't trust it without a `grep` re-check.
+3. **Flag the Dependabot overlap** in the PR/summary if an open `github-actions` group PR also bumps it (it usually does), so the user can reconcile (whichever merges first, the other rebases/drops the entry).
 
 ## Out of scope
 

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -91,7 +91,7 @@ jobs:
           skaffold version
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           install-only: true
           version: "~> v2"

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -25,7 +25,7 @@ env:
   HELM_VERSION: v4.2.0
   KIND_VERSION: v0.31.0
   KIND_CLUSTER_NAME: kind
-  SKAFFOLD_VERSION: v2.19.0
+  SKAFFOLD_VERSION: v2.21.0
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -45,7 +45,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           install-only: true
           version: "~> v2"
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run GoReleaser
         id: goreleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           version: "~> v2"
           args: release

--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -70,7 +70,7 @@ jobs:
           cluster_name: ${{ env.KIND_CLUSTER_NAME }}
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
           install-only: true
           version: "~> v2"


### PR DESCRIPTION
## Workflow CLI tool-version refresh (2026-05-25)

Refreshes pinned tool versions used by the `.github/workflows/` CI, plus a docs-only update to the local sweep playbooks.

### Changes
- **`SKAFFOLD_VERSION`** `v2.19.0 → v2.21.0` (`push_pr.yaml`).
  Skaffold v2.20.0 and v2.21.0 are dependency/refactor-only releases — no `skaffold.yaml` schema or profile changes, and the `skaffold/v4beta12` config is unaffected.
- **`goreleaser/goreleaser-action`** SHA-pinned bump `v7.2.1 → v7.2.2` across `push_pr.yaml`, `upgrade_test.yaml`, and `release.yaml` (×2).
  Pinned to commit `5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89` (tag v7.2.2).
- **`.claude/skills/` playbooks** (docs only, no CI/runtime impact): refreshed the `go-deps-security-upgrade` and `workflow-tool-versions` skill playbooks with lessons from this sweep (KEDA controller-runtime `replace`-vs-`exclude`, the k8s-core version cap, ruby-based YAML validation, the SHA-pinned-action bump recipe, and stale/merged-branch handling).

### Already current
`HELM_VERSION` (v4.2.0), `KIND_VERSION` (v0.31.0), `COSIGN_VERSION` (v3.0.6) and `GOLANGCI_LINT_VERSION` (v2.12.2) are all at the latest upstream release (refreshed by the recently merged #3376), so nothing to do there.

### Notes
- The `goreleaser/goreleaser-action` SHA bump overlaps Dependabot's open **#3384** (github-actions group). Whichever merges first, the other rebases/drops the entry.
- Other SHA-pinned actions a patch behind (harden-runner, golangci-lint-action) are left to that same Dependabot group PR.
- The `upgrade_test.yaml` Helm v3/v4 split and the `kindversion` matrix spread (`v1.28.15`, `v1.32.8`, `v1.34.0`) are intentional and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3393)
<!-- Reviewable:end -->
