### PR TITLE
Bump Helm chart version to 1.24.0 for next release

### DIFF
--- a/charts/fission-all/Chart.yaml
+++ b/charts/fission-all/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: fission-all
-version: 1.23.0
-appVersion: v1.23.0
+version: 1.24.0
+appVersion: v1.24.0
 description: Fission is a fast serverless framework for Kubernetes.
 kubeVersion: ">=1.28.0-0"
 home: https://fission.io/

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -25,7 +25,7 @@ image: fission/fission-bundle
 ## It is also used by the chart to identify version of the few more images apart from fission-bundle.
 ## Keep it empty for using latest tag.
 ##
-imageTag: v1.23.0
+imageTag: v1.24.0
 
 ## pullPolicy represents the pull policy to use for images in the chart.
 ##
@@ -124,7 +124,7 @@ fetcher:
   ## image represents the image of the fetcher component.
   image: fission/fetcher
   ## imageTag represents the tag of the image of the fetcher component.
-  imageTag: v1.23.0
+  imageTag: v1.24.0
 
   ## Fetcher is only for to downloading or uploading archive.
   ## Normally, you don't need to change the value here, unless necessary.
@@ -714,7 +714,7 @@ preUpgradeChecks:
   image: fission/pre-upgrade-checks
   ## pre-install/pre-upgrade checks image version
   ##
-  imageTag: v1.23.0
+  imageTag: v1.24.0
 
 ## Fission post-install/post-upgrade reporting live in this image
 ##


### PR DESCRIPTION
## Bump Helm chart version to 1.24.0 for the next release

Prepares the chart for the next tagged release (`v1.24.0`), following the current `v1.23.0`.

### Changes
- `charts/fission-all/Chart.yaml`: `version` `1.23.0 → 1.24.0`, `appVersion` `v1.23.0 → v1.24.0`.
- `charts/fission-all/values.yaml`: `imageTag` `v1.23.0 → v1.24.0` for the fission-bundle base image, the fetcher, and the pre-upgrade-checks image.

The CLI/binary version is injected at build time via goreleaser ldflags (`GORELEASER_CURRENT_TAG`), so there is no hard-coded version constant to update.

`helm lint charts/fission-all/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3396)
<!-- Reviewable:end -->
