### PR TITLE
fission-cli: surface CRD status conditions in list/get + dedup printers

### DIFF
--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -18,14 +18,13 @@ package canaryconfig
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -48,12 +47,14 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error getting canary config: %w", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS")
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-		canaryCfg.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction, canaryCfg.Spec.WeightIncrement, canaryCfg.Spec.WeightIncrementDuration,
-		canaryCfg.Spec.FailureThreshold, canaryCfg.Spec.FailureType, canaryCfg.Status.Status)
+	headers := []string{"NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS"}
+	rows := [][]string{{
+		canaryCfg.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction,
+		fmt.Sprintf("%v", canaryCfg.Spec.WeightIncrement), fmt.Sprintf("%v", canaryCfg.Spec.WeightIncrementDuration),
+		fmt.Sprintf("%v", canaryCfg.Spec.FailureThreshold), string(canaryCfg.Spec.FailureType), canaryCfg.Status.Status,
+	}}
+	util.PrintTable(headers, rows)
+	util.PrintConditions(canaryCfg.Status.Conditions)
 
-	w.Flush()
 	return nil
 }

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -18,14 +18,14 @@ package canaryconfig
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -46,7 +46,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	opts.namespace, err = opts.ResolveNamespace(input, flagkey.NamespaceCanary)
 	if err != nil {
 		return fmt.Errorf("error in listing canary config: %w", err)
 	}
@@ -54,24 +54,22 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-
-	if input.Bool(flagkey.AllNamespaces) {
-		opts.namespace = metav1.NamespaceAll
-	}
 	canaryCfgs, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.namespace).List(input.Context(), metav1.ListOptions{})
-
 	if err != nil {
 		return fmt.Errorf("error listing canary config: %w", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS")
+	headers := []string{"NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS", "READY"}
+	rows := make([][]string, 0, len(canaryCfgs.Items))
 	for _, canaryCfg := range canaryCfgs.Items {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			canaryCfg.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction, canaryCfg.Spec.WeightIncrement, canaryCfg.Spec.WeightIncrementDuration,
-			canaryCfg.Spec.FailureThreshold, canaryCfg.Spec.FailureType, canaryCfg.Status.Status)
+		rows = append(rows, []string{
+			canaryCfg.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction,
+			fmt.Sprintf("%v", canaryCfg.Spec.WeightIncrement), fmt.Sprintf("%v", canaryCfg.Spec.WeightIncrementDuration),
+			fmt.Sprintf("%v", canaryCfg.Spec.FailureThreshold), string(canaryCfg.Spec.FailureType), canaryCfg.Status.Status,
+			util.ConditionStatus(canaryCfg.Status.Conditions, fv1.CanaryConfigConditionReady),
+		})
 	}
+	util.PrintTable(headers, rows)
 
-	w.Flush()
 	return nil
 }

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"sync"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
@@ -67,4 +69,20 @@ func (c *CommandActioner) GetResourceNamespace(input cli.Input, deprecatedFlag s
 
 	console.Verbose(2, "Namespace for resource %s ", currentNS)
 	return namespace, currentNS, nil
+}
+
+// ResolveNamespace returns the namespace a list command should operate in. It
+// applies the same precedence as GetResourceNamespace, then collapses to
+// metav1.NamespaceAll when --all-namespaces is set. This replaces the
+// GetResourceNamespace + AllNamespaces block that was duplicated across every
+// list command.
+func (c *CommandActioner) ResolveNamespace(input cli.Input, deprecatedFlag string) (string, error) {
+	_, namespace, err := c.GetResourceNamespace(input, deprecatedFlag)
+	if err != nil {
+		return "", err
+	}
+	if input.Bool(flagkey.AllNamespaces) {
+		namespace = metav1.NamespaceAll
+	}
+	return namespace, nil
 }

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -18,14 +18,13 @@ package environment
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -37,14 +36,9 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
-
-	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	currentNS, err := opts.ResolveNamespace(input, flagkey.NamespaceEnvironment)
 	if err != nil {
-		return fmt.Errorf("error creating environment: %w", err)
-	}
-
-	if input.Bool(flagkey.AllNamespaces) {
-		currentNS = metav1.NamespaceAll
+		return fmt.Errorf("error listing environments: %w", err)
 	}
 
 	response, err := opts.Client().FissionClientSet.CoreV1().Environments(currentNS).List(input.Context(), metav1.ListOptions{})
@@ -52,19 +46,21 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 		return fmt.Errorf("error listing environments: %w", err)
 	}
 
-	envs := response.Items
-
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "IMAGE", "BUILDER_IMAGE", "POOLSIZE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "EXTNET", "GRACETIME", "NAMESPACE")
-	for _, env := range envs {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			env.Name, env.Spec.Runtime.Image, env.Spec.Builder.Image, env.Spec.Poolsize,
-			env.Spec.Resources.Requests.Cpu(), env.Spec.Resources.Limits.Cpu(),
-			env.Spec.Resources.Requests.Memory(), env.Spec.Resources.Limits.Memory(),
-			env.Spec.AllowAccessToExternalNetwork, env.Spec.TerminationGracePeriod, env.Namespace,
-		)
+	// Environment.Status.Conditions is intentionally not surfaced here: the
+	// buildermgr never writes Environment status (a write would bump
+	// ResourceVersion and break in-flight source-archive builds), so a READY
+	// column would always be empty. See pkg/apis/core/v1/conditions.go.
+	headers := []string{"NAME", "IMAGE", "BUILDER_IMAGE", "POOLSIZE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "EXTNET", "GRACETIME", "NAMESPACE"}
+	rows := make([][]string, 0, len(response.Items))
+	for _, env := range response.Items {
+		rows = append(rows, []string{
+			env.Name, env.Spec.Runtime.Image, env.Spec.Builder.Image, fmt.Sprintf("%v", env.Spec.Poolsize),
+			env.Spec.Resources.Requests.Cpu().String(), env.Spec.Resources.Limits.Cpu().String(),
+			env.Spec.Resources.Requests.Memory().String(), env.Spec.Resources.Limits.Memory().String(),
+			fmt.Sprintf("%v", env.Spec.AllowAccessToExternalNetwork), fmt.Sprintf("%v", env.Spec.TerminationGracePeriod), env.Namespace,
+		})
 	}
-	w.Flush()
+	util.PrintTable(headers, rows)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetMetaSubCommand struct {
@@ -59,6 +60,7 @@ func (opts *GetMetaSubCommand) do(input cli.Input) error {
 			fmt.Printf("  %s=%s\n", k, v)
 		}
 	}
+	util.PrintConditions(fn.Status.Conditions)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -18,15 +18,15 @@ package function
 
 import (
 	"fmt"
-	"os"
 	"strings"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -38,48 +38,43 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	namespace, err := opts.ResolveNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
 		return fmt.Errorf("error in listing function : %w", err)
 	}
 
-	if input.Bool(flagkey.AllNamespaces) {
-		namespace = metav1.NamespaceAll
-	}
 	fns, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).List(input.Context(), metav1.ListOptions{})
-
 	if err != nil {
 		return fmt.Errorf("error listing functions: %w", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS", "NAMESPACE")
+	headers := []string{"NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS", "READY", "NAMESPACE"}
+	rows := make([][]string, 0, len(fns.Items))
 	for _, f := range fns.Items {
-		secrets := f.Spec.Secrets
-		configMaps := f.Spec.ConfigMaps
 		var secretsList, configMapList []string
-		for _, secret := range secrets {
+		for _, secret := range f.Spec.Secrets {
 			secretsList = append(secretsList, secret.Name)
 		}
-		for _, configMap := range configMaps {
+		for _, configMap := range f.Spec.ConfigMaps {
 			configMapList = append(configMapList, configMap.Name)
 		}
 
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
+		rows = append(rows, []string{
 			f.Name, f.Spec.Environment.Name,
-			f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType,
-			f.Spec.InvokeStrategy.ExecutionStrategy.MinScale,
-			f.Spec.InvokeStrategy.ExecutionStrategy.MaxScale,
+			string(f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType),
+			fmt.Sprintf("%v", f.Spec.InvokeStrategy.ExecutionStrategy.MinScale),
+			fmt.Sprintf("%v", f.Spec.InvokeStrategy.ExecutionStrategy.MaxScale),
 			f.Spec.Resources.Requests.Cpu().String(),
 			f.Spec.Resources.Limits.Cpu().String(),
 			f.Spec.Resources.Requests.Memory().String(),
 			f.Spec.Resources.Limits.Memory().String(),
 			strings.Join(secretsList, ","),
 			strings.Join(configMapList, ","),
-			f.Namespace)
+			util.ConditionStatus(f.Status.Conditions, fv1.FunctionConditionReady),
+			f.Namespace,
+		})
 	}
-	w.Flush()
+	util.PrintTable(headers, rows)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -18,9 +18,7 @@ package httptrigger
 
 import (
 	"fmt"
-	"os"
 	"strings"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,6 +26,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type GetSubCommand struct {
@@ -45,7 +44,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
 	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
 	if err != nil {
-		return fmt.Errorf("error in deleting function : %w", err)
+		return fmt.Errorf("error in getting HTTP trigger: %w", err)
 	}
 
 	ht, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).Get(input.Context(), input.String(flagkey.HtName), metav1.GetOptions{})
@@ -54,13 +53,14 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 	}
 
 	printHtSummary([]fv1.HTTPTrigger{*ht})
+	util.PrintConditions(ht.Status.Conditions)
 
 	return nil
 }
 
 func printHtSummary(triggers []fv1.HTTPTrigger) {
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n", "NAME", "METHOD", "URL", "FUNCTION(s)", "INGRESS", "HOST", "PATH", "TLS", "ANNOTATIONS", "NAMESPACE")
+	headers := []string{"NAME", "METHOD", "URL", "FUNCTION(s)", "INGRESS", "HOST", "PATH", "TLS", "ANNOTATIONS", "READY", "NAMESPACE"}
+	rows := make([][]string, 0, len(triggers))
 	for _, trigger := range triggers {
 		function := ""
 		if trigger.Spec.FunctionReference.Type == fv1.FunctionReferenceTypeFunctionName {
@@ -93,8 +93,12 @@ func printHtSummary(triggers []fv1.HTTPTrigger) {
 		if len(trigger.Spec.Methods) > 0 {
 			methods = trigger.Spec.Methods
 		}
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			trigger.Name, methods, trigger.Spec.RelativeURL, function, trigger.Spec.CreateIngress, host, path, trigger.Spec.IngressConfig.TLS, ann, trigger.Namespace)
+		rows = append(rows, []string{
+			trigger.Name, fmt.Sprintf("%v", methods), trigger.Spec.RelativeURL, function,
+			fmt.Sprintf("%v", trigger.Spec.CreateIngress), host, path, fmt.Sprintf("%v", trigger.Spec.IngressConfig.TLS), ann,
+			util.ConditionStatus(trigger.Status.Conditions, fv1.HTTPTriggerConditionReady),
+			trigger.Namespace,
+		})
 	}
-	w.Flush()
+	util.PrintTable(headers, rows)
 }

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -42,7 +42,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return fmt.Errorf("error in getting HTTP trigger: %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -40,17 +40,12 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	namespace, err := opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
-		return fmt.Errorf("error in deleting function : %w", err)
+		return fmt.Errorf("error in listing HTTP triggers: %w", err)
 	}
 
-	if input.Bool(flagkey.AllNamespaces) {
-		namespace = v1.NamespaceAll
-	}
 	hts, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).List(input.Context(), v1.ListOptions{})
-
 	if err != nil {
 		return fmt.Errorf("error listing HTTP triggers: %w", err)
 	}

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -18,8 +18,6 @@ package kubewatch
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -27,6 +25,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -47,7 +46,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	opts.namespace, err = opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
 		return fmt.Errorf("error listing kubewatchers: %w", err)
 	}
@@ -55,25 +54,20 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-	var ws *v1.KubernetesWatchTriggerList
-	if input.Bool(flagkey.AllNamespaces) {
-		opts.namespace = metav1.NamespaceAll
-	}
-	ws, err = opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
-
+	ws, err := opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
 	if err != nil {
 		return fmt.Errorf("error listing kubewatchers: %w", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
-		"NAME", "NAMESPACE", "OBJTYPE", "LABELS", "FUNCTION_NAME")
+	headers := []string{"NAME", "NAMESPACE", "OBJTYPE", "LABELS", "FUNCTION_NAME", "READY"}
+	rows := make([][]string, 0, len(ws.Items))
 	for _, wa := range ws.Items {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
-			wa.Name, wa.Spec.Namespace, wa.Spec.Type, wa.Spec.LabelSelector, wa.Spec.FunctionReference.Name)
+		rows = append(rows, []string{
+			wa.Name, wa.Spec.Namespace, wa.Spec.Type, fmt.Sprintf("%v", wa.Spec.LabelSelector), wa.Spec.FunctionReference.Name,
+			util.ConditionStatus(wa.Status.Conditions, v1.KubernetesWatchTriggerConditionReady),
+		})
 	}
-	w.Flush()
+	util.PrintTable(headers, rows)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -18,14 +18,14 @@ package mqtrigger
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -46,33 +46,30 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	opts.namespace, err = opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
-		return fmt.Errorf("error in deleting function : %w", err)
+		return fmt.Errorf("error in listing message queue triggers: %w", err)
 	}
 	return nil
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-
-	if input.Bool(flagkey.AllNamespaces) {
-		opts.namespace = metav1.NamespaceAll
-	}
 	mqts, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.namespace).List(input.Context(), metav1.ListOptions{})
-
 	if err != nil {
 		return fmt.Errorf("error listing message queue triggers: %w", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-		"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE", "NAMESPACE")
+	headers := []string{"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE", "READY", "NAMESPACE"}
+	rows := make([][]string, 0, len(mqts.Items))
 	for _, mqt := range mqts.Items {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\t%v\n",
-			mqt.Name, mqt.Spec.FunctionReference.Name, mqt.Spec.MessageQueueType, mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic, mqt.Spec.MaxRetries, mqt.Spec.ContentType, mqt.Namespace)
+		rows = append(rows, []string{
+			mqt.Name, mqt.Spec.FunctionReference.Name, string(mqt.Spec.MessageQueueType), mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic,
+			fmt.Sprintf("%v", mqt.Spec.MaxRetries), mqt.Spec.ContentType,
+			util.ConditionStatus(mqt.Status.Conditions, fv1.MessageQueueTriggerConditionReady),
+			mqt.Namespace,
+		})
 	}
-	w.Flush()
+	util.PrintTable(headers, rows)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -18,9 +18,7 @@ package _package
 
 import (
 	"fmt"
-	"os"
 	"sort"
-	"text/tabwriter"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,6 +27,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -54,20 +53,15 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	// option for the user to list all orphan packages (not referenced by any function)
 	opts.listOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.status = input.String(flagkey.PkgStatus)
-	_, opts.pkgNamespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	opts.pkgNamespace, err = opts.ResolveNamespace(input, flagkey.NamespacePackage)
 	if err != nil {
-		return fv1.AggregateValidationErrors("Environment", err)
+		return fv1.AggregateValidationErrors("Package", err)
 	}
 	return nil
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-
-	if input.Bool(flagkey.AllNamespaces) {
-		opts.pkgNamespace = v1.NamespaceAll
-	}
 	pkgList, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.pkgNamespace).List(input.Context(), v1.ListOptions{})
-
 	if err != nil {
 		return err
 	}
@@ -77,11 +71,9 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return pkgList.Items[i].Status.LastUpdateTimestamp.After(pkgList.Items[j].Status.LastUpdateTimestamp.Time)
 	})
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", "NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT", "NAMESPACE")
-
+	headers := []string{"NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT", "READY", "NAMESPACE"}
+	rows := make([][]string, 0, len(pkgList.Items))
 	for _, pkg := range pkgList.Items {
-		show := true
 		// TODO improve list speed when --orphan
 		if opts.listOrphans {
 			fnList, err := GetFunctionsByPackage(input.Context(), opts.Client(), pkg.Name, pkg.Namespace)
@@ -89,18 +81,20 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 				return fmt.Errorf("get functions sharing package %v: %w", pkg.Name, err)
 			}
 			if len(fnList) > 0 {
-				show = false
+				continue
 			}
 		}
 		if len(opts.status) > 0 && opts.status != string(pkg.Status.BuildStatus) {
-			show = false
+			continue
 		}
-		if show {
-			fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", pkg.Name, pkg.Status.BuildStatus, pkg.Spec.Environment.Name, pkg.Status.LastUpdateTimestamp.Format(time.RFC822), pkg.Namespace)
-		}
+		rows = append(rows, []string{
+			pkg.Name, string(pkg.Status.BuildStatus), pkg.Spec.Environment.Name,
+			pkg.Status.LastUpdateTimestamp.Format(time.RFC822),
+			util.ConditionStatus(pkg.Status.Conditions, fv1.PackageConditionReady),
+			pkg.Namespace,
+		})
 	}
-
-	w.Flush()
+	util.PrintTable(headers, rows)
 
 	return nil
 }

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"text/tabwriter"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
@@ -235,16 +234,17 @@ func WriteArchiveToFile(fileName string, reader io.Reader) error {
 	return nil
 }
 
-// PrintPackageSummary prints package information and build logs.
+// PrintPackageSummary prints package information, conditions and build logs.
 func PrintPackageSummary(writer io.Writer, pkg *fv1.Package) {
 	// replace escaped line breaker character
 	buildlog := strings.ReplaceAll(pkg.Status.BuildLog, `\n`, "\n")
-	w := tabwriter.NewWriter(writer, 0, 0, 1, ' ', 0)
+	w := util.NewTabWriter(writer)
 	fmt.Fprintf(w, "%v\t%v\n", "Name:", pkg.Name)
 	fmt.Fprintf(w, "%v\t%v\n", "Environment:", pkg.Spec.Environment.Name)
 	fmt.Fprintf(w, "%v\t%v\n", "Status:", pkg.Status.BuildStatus)
-	fmt.Fprintf(w, "%v\n%v", "Build Logs:", buildlog)
 	w.Flush()
+	util.PrintConditionsTo(writer, pkg.Status.Conditions)
+	fmt.Fprintf(writer, "%v\n%v", "Build Logs:", buildlog)
 }
 
 // validArchiveURL checks if the given URL is a valid archive URL

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -18,14 +18,14 @@ package timetrigger
 
 import (
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -37,28 +37,25 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
-	_, ttNs, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	ttNs, err := opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
 	if err != nil {
-		return fmt.Errorf("error in deleting function : %w", err)
+		return fmt.Errorf("error in listing time triggers: %w", err)
 	}
 
-	if input.Bool(flagkey.AllNamespaces) {
-		ttNs = metav1.NamespaceAll
-	}
 	tts, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(ttNs).List(input.Context(), metav1.ListOptions{})
-
 	if err != nil {
 		return fmt.Errorf("list Time triggers: %w", err)
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 1, ' ', 0)
-
-	fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", "NAME", "CRON", "FUNCTION_NAME", "METHOD", "SUBPATH")
+	headers := []string{"NAME", "CRON", "FUNCTION_NAME", "METHOD", "SUBPATH", "READY"}
+	rows := make([][]string, 0, len(tts.Items))
 	for _, tt := range tts.Items {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n",
-			tt.Name, tt.Spec.Cron, tt.Spec.Name, tt.Spec.Method, tt.Spec.Subpath)
+		rows = append(rows, []string{
+			tt.Name, tt.Spec.Cron, tt.Spec.Name, tt.Spec.Method, tt.Spec.Subpath,
+			util.ConditionStatus(tt.Status.Conditions, fv1.TimeTriggerConditionReady),
+		})
 	}
-	w.Flush()
+	util.PrintTable(headers, rows)
 
 	return nil
 }

--- a/pkg/fission-cli/util/output.go
+++ b/pkg/fission-cli/util/output.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+
+	"github.com/fission/fission/pkg/conditions"
+)
+
+// NoneValue is rendered in a status column when a controller has not yet
+// written the condition (e.g. a freshly created resource, or a resource
+// whose controller does not emit that condition).
+const NoneValue = "<none>"
+
+// NewTabWriter returns a tabwriter configured with the Fission CLI's standard
+// list/get column formatting. It centralises the
+// tabwriter.NewWriter(w, 0, 0, 1, ' ', 0) literal that was duplicated across
+// every list and get command.
+func NewTabWriter(w io.Writer) *tabwriter.Writer {
+	return tabwriter.NewWriter(w, 0, 0, 1, ' ', 0)
+}
+
+// PrintTable writes a tab-separated header row followed by data rows to stdout
+// using NewTabWriter, flushing before it returns. Callers build rows as
+// [][]string; fmt.Sprintf("%v", x) at the call site preserves the existing
+// rendering of ints, resource.Quantity, []string, etc.
+func PrintTable(headers []string, rows [][]string) {
+	w := NewTabWriter(os.Stdout)
+	fmt.Fprintln(w, strings.Join(headers, "\t"))
+	for _, row := range rows {
+		fmt.Fprintln(w, strings.Join(row, "\t"))
+	}
+	w.Flush()
+}
+
+// ConditionStatus renders the Status of the named condition for a status
+// column: "True", "False" or "Unknown", or NoneValue when the controller has
+// not written that condition yet.
+func ConditionStatus(conds []metav1.Condition, conditionType string) string {
+	c := conditions.Find(conds, conditionType)
+	if c == nil {
+		return NoneValue
+	}
+	return string(c.Status)
+}
+
+// PrintConditions writes a CONDITIONS table to stdout for describe-style
+// commands. It is a no-op when conds is empty, so callers can invoke it
+// unconditionally.
+func PrintConditions(conds []metav1.Condition) {
+	PrintConditionsTo(os.Stdout, conds)
+}
+
+// PrintConditionsTo writes a CONDITIONS table (TYPE / STATUS / REASON /
+// MESSAGE / LASTTRANSITION) to w. It is a no-op when conds is empty.
+func PrintConditionsTo(out io.Writer, conds []metav1.Condition) {
+	if len(conds) == 0 {
+		return
+	}
+	w := NewTabWriter(out)
+	fmt.Fprintln(w, "\nCONDITIONS:")
+	fmt.Fprintln(w, "TYPE\tSTATUS\tREASON\tMESSAGE\tLASTTRANSITION")
+	for _, c := range conds {
+		age := NoneValue
+		if !c.LastTransitionTime.IsZero() {
+			age = duration.HumanDuration(time.Since(c.LastTransitionTime.Time))
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", c.Type, c.Status, c.Reason, c.Message, age)
+	}
+	w.Flush()
+}

--- a/pkg/fission-cli/util/output_test.go
+++ b/pkg/fission-cli/util/output_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestConditionStatus(t *testing.T) {
+	conds := []metav1.Condition{
+		{Type: "Ready", Status: metav1.ConditionTrue},
+		{Type: "BuildSucceeded", Status: metav1.ConditionFalse},
+	}
+
+	tests := []struct {
+		name     string
+		conds    []metav1.Condition
+		condType string
+		want     string
+	}{
+		{"true condition", conds, "Ready", "True"},
+		{"false condition", conds, "BuildSucceeded", "False"},
+		{"missing condition", conds, "Progressing", NoneValue},
+		{"nil conditions", nil, "Ready", NoneValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ConditionStatus(tt.conds, tt.condType); got != tt.want {
+				t.Errorf("ConditionStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintConditionsTo(t *testing.T) {
+	t.Run("empty is a no-op", func(t *testing.T) {
+		var buf bytes.Buffer
+		PrintConditionsTo(&buf, nil)
+		if buf.Len() != 0 {
+			t.Errorf("expected no output for empty conditions, got %q", buf.String())
+		}
+	})
+
+	t.Run("renders rows", func(t *testing.T) {
+		var buf bytes.Buffer
+		PrintConditionsTo(&buf, []metav1.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue, Reason: "Available", Message: "backend serving"},
+		})
+		out := buf.String()
+		for _, want := range []string{"CONDITIONS:", "TYPE", "Ready", "True", "Available", "backend serving"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("output missing %q; got:\n%s", want, out)
+			}
+		}
+	})
+}
+
+func TestPrintTableRowsAlign(t *testing.T) {
+	// PrintTable writes to os.Stdout; here we exercise the same shaping the
+	// list commands rely on (header + string rows) via NewTabWriter so the
+	// formatting contract is covered without capturing global stdout.
+	var buf bytes.Buffer
+	w := NewTabWriter(&buf)
+	headers := []string{"NAME", "READY"}
+	rows := [][]string{{"hello", "True"}, {"world", NoneValue}}
+	if _, err := w.Write([]byte(strings.Join(headers, "\t") + "\n")); err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range rows {
+		if _, err := w.Write([]byte(strings.Join(r, "\t") + "\n")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{"NAME", "READY", "hello", "True", "world", NoneValue} {
+		if !strings.Contains(out, want) {
+			t.Errorf("table output missing %q; got:\n%s", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## What

RFC-0003 Phase 1 wired `Status.Conditions` onto every Fission CRD, and the controllers now write a standard `Ready` condition (plus resource-specific ones). This PR surfaces that in the CLI and de-duplicates the list/get printing code along the way.

### Status reporting
- **`READY` column added by default** to the lists whose controllers write a `Ready` condition: `function`, `package`, `httptrigger`, `kubewatch`, `timetrigger`, `mqtrigger`, `canaryconfig`. Renders `True` / `False` / `Unknown`, or `<none>` before the controller has written anything.
  - `package` keeps `BUILD_STATUS` and `canaryconfig` keeps `STATUS` (legacy fields) — `READY` is added alongside, not replacing them.
- **`CONDITIONS` table added to describe-style commands**: `fn getmeta`, `pkg info`, `canary get`, `ht get` (TYPE / STATUS / REASON / MESSAGE / LASTTRANSITION).
  - `fn get` / `pkg getsrc|getdeploy` are deliberately untouched — they stream source/archive bytes, not object detail.
- **Environment is intentionally skipped**: the buildermgr never writes Environment status (a write would bump `ResourceVersion` and break in-flight source-archive builds — see `pkg/apis/core/v1/conditions.go`), so a `READY` column would always be empty.

### De-duplication
- New `pkg/fission-cli/util/output.go`:
  - `NewTabWriter` / `PrintTable` replace the `tabwriter.NewWriter(os.Stdout, 0,0,1,' ',0)` + manual `Fprintf` loop boilerplate copy-pasted across ~9 commands.
  - `ConditionStatus` / `PrintConditions(To)` reuse the existing `pkg/conditions.Find` helper instead of reimplementing condition lookup.
- New `CommandActioner.ResolveNamespace` collapses the repeated `GetResourceNamespace(...) + if AllNamespaces { NamespaceAll }` block into one call. Threading the lists through it also fixes copy-pasted wrong error strings (`"error in deleting function"` on list/get paths).

No new CLI flags, so no flag/CLI-ref-docs regeneration is required.

## Test
- `go build ./...`, `go test ./pkg/fission-cli/...`, `golangci-lint run ./pkg/fission-cli/...` all pass.
- Added unit tests for the new helpers in `pkg/fission-cli/util/output_test.go`.
- Verified against a local kind cluster (`SKAFFOLD_PROFILE=kind`): after creating an HTTP trigger and a time trigger, `httptrigger list` and `timetrigger list` show `READY  True`; `ht get` renders the `CONDITIONS` table (`RouteAdmitted=True`, `Ready=True`) with a human-readable age; `pkg list` shows both `BUILD_STATUS` and `READY`; `env list` correctly has no `READY` column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3397)
<!-- Reviewable:end -->
