### PR TITLE
fission-cli: add -o json|yaml|wide to list & describe commands

### DIFF
--- a/docs/cli-refactor/2026-05-25-output-formats-design.md
+++ b/docs/cli-refactor/2026-05-25-output-formats-design.md
@@ -48,7 +48,7 @@ Both can share the literal name `output`/`-o` because no single command register
 
 - `json`: marshal the (already-filtered) result. For `list` → a JSON array of the objects (`[]Function`); for describe/single → one object. Arrays chosen over a `*List` wrapper because they are simpler to consume with `jq` and the commands already work with `.Items` slices.
 - `yaml`: the slice marshaled via `sigs.k8s.io/yaml` as a single YAML sequence (not `---`-separated documents); a single object for describe.
-- `wide`: the current table plus extra columns. Minimum new column: `AGE` (from `CreationTimestamp`, rendered with `duration.HumanDuration`). Per-resource extras may be added (e.g. function `READY`-reason). Column order: existing columns, then wide-only columns, then `NAMESPACE` stays last where present.
+- `wide`: the current table plus extra columns. Minimum new column: `AGE` (from `CreationTimestamp`, rendered with `duration.HumanDuration`). Per-resource extras may be added (e.g. function `READY`-reason). Column order: the existing columns (including `NAMESPACE` where present) followed by the wide-only columns, so `AGE` appears last — `PrintObjects` simply appends the wide columns to keep the helper generic.
 - empty: byte-for-byte current output.
 
 ### Printer
@@ -82,7 +82,7 @@ func PrintObjects[T any](
 
 `json`/`yaml` marshal `items` directly (the CRD types already carry the right json tags).
 `table` uses `headers`+`row`; `wide` uses `headers+wideExtra` and `row`+`wideRow` concatenated.
-List commands call `PrintObjects(fmt, fns.Items, …)`; describe commands call a single-object variant (`PrintObject`) that marshals the bare object for json/yaml and prints the existing summary for table/wide.
+List commands call `PrintObjects(format, items, …)`. Describe commands call `PrintStructured(format, obj) (handled bool, err error)`: for json/yaml it marshals the bare object and returns `handled=true`; for table/wide it returns `handled=false` and the command falls back to its existing human rendering.
 
 ### Files
 

--- a/docs/cli-refactor/2026-05-25-output-formats-design.md
+++ b/docs/cli-refactor/2026-05-25-output-formats-design.md
@@ -1,6 +1,6 @@
 # Design: `-o json|yaml|wide` output formats for Fission CLI read commands
 
-Status: Draft (design only — not yet implemented).
+Status: Implemented (branch `cli-output-formats`).
 Date: 2026-05-25.
 
 ## Context

--- a/docs/cli-refactor/2026-05-25-output-formats-design.md
+++ b/docs/cli-refactor/2026-05-25-output-formats-design.md
@@ -1,0 +1,111 @@
+# Design: `-o json|yaml|wide` output formats for Fission CLI read commands
+
+Status: Draft (design only — not yet implemented).
+Date: 2026-05-25.
+
+## Context
+
+Fission CLI `list` and describe commands print a single hard-coded human table.
+There is no machine-readable output, so scripting against `fission` means parsing column text — brittle and undocumented.
+`kubectl` solves this with `-o json|yaml|wide|name`; users expect the same.
+
+The recent dedup work added shared table helpers (`util.PrintTable`, `util.PrintItems`, `util.ConditionStatus`), which gives a natural seam to introduce a format-aware printer without rewriting each command.
+`sigs.k8s.io/yaml` is already a dependency (used by `spec` `SpecDry`/`crdToYaml`), so object→YAML is a solved problem.
+
+The `-o`/`--output` flag is **already used** by *download* commands (`pkg getsrc`, `pkg getdeploy`, `archive` download, `support dump`) to mean "output file path".
+Those are different commands from the read/list commands, so a format-selector `-o` on the read commands does not collide.
+
+## Goal
+
+Add `-o json`, `-o yaml`, and `-o wide` to the read commands.
+No flag keeps today's exact table output (so #3397's default `READY` column is preserved).
+Purely additive and backward compatible.
+
+## Scope
+
+In scope (gain `-o`):
+- `list`: function, environment, httptrigger, timetrigger, mqtrigger, kubewatch (`watch`), canaryconfig, package.
+- describe: `fn getmeta`, `pkg info`, `canary get`, `ht get`.
+
+Out of scope:
+- Download commands that already own `-o` (`pkg getsrc/getdeploy`, `archive`, `support dump`) — unchanged.
+- `fn get` (streams raw source bytes), `pkg getsrc/getdeploy` (archive bytes) — not object views.
+- `spec list` (its own multi-section format) — could follow later; not in this doc.
+- `-o name` — deferred (YAGNI for now; easy to add later under the same printer).
+
+## Design
+
+### Flag
+
+A new shared flag `flag.Output` (`--output`, short `-o`, type String, default `""`) registered as an Optional flag on the in-scope commands.
+Empty → current table. Valid values: `json`, `yaml`, `wide`. Unknown value → error listing the valid set.
+
+Note: a `flagkey.Output = "output"` key already exists and is aliased by `PkgOutput`/`ArchiveOutput`/`SupportOutput` for the download commands.
+Introduce a distinct key (e.g. `flagkey.OutputFormat = "output"`) reused by the read commands; the download commands keep their existing flag definitions unchanged.
+(Both can share the literal name `output`/`-o` because no command registers both.)
+
+### Semantics
+
+- `json`: marshal the (already-filtered) result. For `list` → a JSON array of the objects (`[]Function`); for describe/single → one object. Arrays chosen over a `*List` wrapper because they are simpler to consume with `jq` and the commands already work with `.Items` slices.
+- `yaml`: same objects via `sigs.k8s.io/yaml`; multiple objects separated by `\n---\n`.
+- `wide`: the current table plus extra columns. Minimum new column: `AGE` (from `CreationTimestamp`, rendered with `duration.HumanDuration`). Per-resource extras may be added (e.g. function `READY`-reason). Column order: existing columns, then wide-only columns, then `NAMESPACE` stays last where present.
+- empty: byte-for-byte current output.
+
+### Printer
+
+Add to `pkg/fission-cli/util/output.go`:
+
+```go
+// OutputFormat is the validated value of -o.
+type OutputFormat string
+const (
+    OutputTable OutputFormat = ""     // default human table
+    OutputWide  OutputFormat = "wide"
+    OutputJSON  OutputFormat = "json"
+    OutputYAML  OutputFormat = "yaml"
+)
+
+// ParseOutputFormat validates the -o value (empty allowed).
+func ParseOutputFormat(s string) (OutputFormat, error)
+
+// PrintObjects renders items per the format. For json/yaml it marshals items;
+// for table/wide it builds rows via the provided closures. headers/row are the
+// default columns; wideHeaders/wideRow add the -o wide columns. A single-object
+// describe view passes a one-element slice and marshals as the bare object.
+func PrintObjects[T any](
+    format OutputFormat,
+    items []T,
+    headers []string, row func(T) []string,
+    wideExtra []string, wideRow func(T) []string,
+) error
+```
+
+`json`/`yaml` marshal `items` directly (the CRD types already carry the right json tags).
+`table` uses `headers`+`row`; `wide` uses `headers+wideExtra` and `row`+`wideRow` concatenated.
+List commands call `PrintObjects(fmt, fns.Items, …)`; describe commands call a single-object variant (`PrintObject`) that marshals the bare object for json/yaml and prints the existing summary for table/wide.
+
+### Files
+
+- `pkg/fission-cli/util/output.go` — printer + format parsing (+ tests).
+- `pkg/fission-cli/flag/flag.go`, `flag/key/key.go` — the `--output` flag for read commands.
+- `pkg/fission-cli/cmd/*/command.go` — add `flag.Output` to the in-scope list/describe subcommands.
+- `pkg/fission-cli/cmd/*/list.go`, `getmeta.go`, `package/info.go`, `canaryconfig/get.go`, `httptrigger/get.go` — read `-o`, define wide columns, call the printer.
+
+## Backward compatibility
+
+- Default output (no `-o`) is unchanged, including #3397's `READY` column and the conditions block in describe.
+- No flag/command renames; `--output` is new and optional.
+- Download commands' `-o` semantics are untouched.
+- No CRD/flag-doc regeneration needed beyond the new flag appearing in `--help`.
+
+## Testing
+
+- Unit (table-driven, in `util`): `ParseOutputFormat` valid/invalid; `PrintObjects` for table/wide/json/yaml on a sample type (assert JSON parses back, YAML has `---`, wide has the extra header).
+- Per-command: a representative `fn list -o json|yaml|wide` test via the dummy driver + fake clientset asserting shape.
+- Manual (kind): `fission fn list -o json | jq '.[].metadata.name'`, `-o yaml`, `-o wide` shows `AGE`; unknown `-o foo` errors.
+
+## Out of scope / future
+
+- `-o name`, `-o jsonpath=…`, `-o custom-columns=…`.
+- `spec list -o json`.
+- `-o json` `*List` wrapper (kubectl-style) — revisit if users want kind/apiVersion envelope.

--- a/docs/cli-refactor/2026-05-25-output-formats-design.md
+++ b/docs/cli-refactor/2026-05-25-output-formats-design.md
@@ -40,14 +40,14 @@ Out of scope:
 A new shared flag `flag.Output` (`--output`, short `-o`, type String, default `""`) registered as an Optional flag on the in-scope commands.
 Empty → current table. Valid values: `json`, `yaml`, `wide`. Unknown value → error listing the valid set.
 
-Note: a `flagkey.Output = "output"` key already exists and is aliased by `PkgOutput`/`ArchiveOutput`/`SupportOutput` for the download commands.
-Introduce a distinct key (e.g. `flagkey.OutputFormat = "output"`) reused by the read commands; the download commands keep their existing flag definitions unchanged.
-(Both can share the literal name `output`/`-o` because no command registers both.)
+Note: a `flagkey.Output = "output"` key already exists (aliased by `PkgOutput`/`ArchiveOutput`/`SupportOutput` for the download commands).
+The implementation **reuses that existing `flagkey.Output` key** for the read commands' format flag (`flag.Output`); the download commands keep their own flag definitions unchanged.
+Both can share the literal name `output`/`-o` because no single command registers both.
 
 ### Semantics
 
 - `json`: marshal the (already-filtered) result. For `list` → a JSON array of the objects (`[]Function`); for describe/single → one object. Arrays chosen over a `*List` wrapper because they are simpler to consume with `jq` and the commands already work with `.Items` slices.
-- `yaml`: same objects via `sigs.k8s.io/yaml`; multiple objects separated by `\n---\n`.
+- `yaml`: the slice marshaled via `sigs.k8s.io/yaml` as a single YAML sequence (not `---`-separated documents); a single object for describe.
 - `wide`: the current table plus extra columns. Minimum new column: `AGE` (from `CreationTimestamp`, rendered with `duration.HumanDuration`). Per-resource extras may be added (e.g. function `READY`-reason). Column order: existing columns, then wide-only columns, then `NAMESPACE` stays last where present.
 - empty: byte-for-byte current output.
 
@@ -100,7 +100,7 @@ List commands call `PrintObjects(fmt, fns.Items, …)`; describe commands call a
 
 ## Testing
 
-- Unit (table-driven, in `util`): `ParseOutputFormat` valid/invalid; `PrintObjects` for table/wide/json/yaml on a sample type (assert JSON parses back, YAML has `---`, wide has the extra header).
+- Unit (table-driven, in `util`): `ParseOutputFormat` valid/invalid; `PrintObjects` for table/wide/json/yaml on a sample type (assert JSON parses back as an array, YAML contains the field, wide has the extra header).
 - Per-command: a representative `fn list -o json|yaml|wide` test via the dummy driver + fake clientset asserting shape.
 - Manual (kind): `fission fn list -o json | jq '.[].metadata.name'`, `-o yaml`, `-o wide` shows `AGE`; unknown `-o foo` errors.
 

--- a/docs/cli-refactor/2026-05-25-output-formats-plan.md
+++ b/docs/cli-refactor/2026-05-25-output-formats-plan.md
@@ -16,7 +16,7 @@
 
 - `pkg/fission-cli/util/output.go` — add `OutputFormat`, `ParseOutputFormat`, `encode`, `PrintObjects[T]`, `PrintStructured`. (Existing `PrintTable`/`PrintItems`/`NewTabWriter` stay.)
 - `pkg/fission-cli/util/output_test.go` — unit tests for the new helpers.
-- `pkg/fission-cli/flag/key/key.go` — `OutputFormat = "output"` key.
+- `pkg/fission-cli/flag/key/key.go` — no change; the read commands reuse the existing `Output = "output"` key.
 - `pkg/fission-cli/flag/flag.go` — `Output` flag var.
 - `pkg/fission-cli/cmd/<res>/command.go` — add `flag.Output` to the in-scope subcommands.
 - `pkg/fission-cli/cmd/<res>/list.go` — read `-o`, define wide columns, call `PrintObjects`.
@@ -318,20 +318,14 @@ git commit -m "fission-cli/util: add PrintObjects + PrintStructured format-aware
 
 - [ ] **Step 1: Add the flag key**
 
-In `key.go`, near the existing `Output = "output"` block, add:
-
-```go
-OutputFormat = "output"
-```
-
-(If a bare `Output = "output"` already exists and is only aliased by the download keys, reuse it instead of adding a duplicate literal — confirm with `grep -n 'Output\b' pkg/fission-cli/flag/key/key.go`. The flag *name* `output` is shared; only read commands get the new `flag.Output` var.)
+**As implemented:** `key.go` already has `Output = "output"` (aliased by the download keys), so **no new key is added** — the read commands' format flag reuses `flagkey.Output`. The flag *name* `output`/`-o` is shared; only read commands register the `flag.Output` var below, so there is no collision with the download commands' own flags.
 
 - [ ] **Step 2: Add the flag var**
 
-In `flag.go`, add near the other global-ish flags:
+In `flag.go`, add near the other global-ish flags (note: `flagkey.Output`, the existing key — not a new `flagkey.OutputFormat`):
 
 ```go
-Output = Flag{Type: String, Name: flagkey.OutputFormat, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
+Output = Flag{Type: String, Name: flagkey.Output, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
 ```
 
 - [ ] **Step 3: Verify build**

--- a/docs/cli-refactor/2026-05-25-output-formats-plan.md
+++ b/docs/cli-refactor/2026-05-25-output-formats-plan.md
@@ -1,0 +1,542 @@
+# Output Formats (`-o json|yaml|wide`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `-o json|yaml|wide` to the Fission CLI read commands (list + describe), keeping today's table as the no-flag default.
+
+**Architecture:** A format-aware printer in `pkg/fission-cli/util/output.go` sits on top of the existing `PrintTable`/`PrintItems` helpers. List commands route their items through `PrintObjects[T]` (handles table/wide/json/yaml); describe commands call `PrintStructured` (json/yaml) and fall back to their existing human rendering for table/wide. A new optional `--output`/`-o` flag carries the value.
+
+**Tech Stack:** Go 1.26 generics, `encoding/json`, `sigs.k8s.io/yaml` (already a dep), `k8s.io/apimachinery/pkg/util/duration` (already used for AGE).
+
+**Design doc:** `docs/cli-refactor/2026-05-25-output-formats-design.md`. Refinements adopted here: JSON/YAML marshal the slice directly (JSON array / YAML sequence), wide columns are appended at the end (AGE last), and a pure `encode()` helper makes structured output unit-testable.
+
+---
+
+## File structure
+
+- `pkg/fission-cli/util/output.go` — add `OutputFormat`, `ParseOutputFormat`, `encode`, `PrintObjects[T]`, `PrintStructured`. (Existing `PrintTable`/`PrintItems`/`NewTabWriter` stay.)
+- `pkg/fission-cli/util/output_test.go` — unit tests for the new helpers.
+- `pkg/fission-cli/flag/key/key.go` — `OutputFormat = "output"` key.
+- `pkg/fission-cli/flag/flag.go` — `Output` flag var.
+- `pkg/fission-cli/cmd/<res>/command.go` — add `flag.Output` to the in-scope subcommands.
+- `pkg/fission-cli/cmd/<res>/list.go` — read `-o`, define wide columns, call `PrintObjects`.
+- `pkg/fission-cli/cmd/function/getmeta.go`, `package/info.go`, `package/util/util.go` (`PrintPackageSummary`), `canaryconfig/get.go`, `httptrigger/get.go` — `PrintStructured` early-return for json/yaml.
+
+---
+
+### Task 1: Output format type, parsing, and structured encoder
+
+**Files:**
+- Modify: `pkg/fission-cli/util/output.go`
+- Test: `pkg/fission-cli/util/output_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `output_test.go`:
+
+```go
+func TestParseOutputFormat(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    OutputFormat
+		wantErr bool
+	}{
+		{"", OutputTable, false},
+		{"wide", OutputWide, false},
+		{"json", OutputJSON, false},
+		{"yaml", OutputYAML, false},
+		{"JSON", OutputJSON, false}, // case-insensitive
+		{"name", "", true},
+		{"xml", "", true},
+	}
+	for _, tt := range tests {
+		got, err := ParseOutputFormat(tt.in)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseOutputFormat(%q) err=%v, wantErr=%v", tt.in, err, tt.wantErr)
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseOutputFormat(%q)=%q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestEncode(t *testing.T) {
+	items := []map[string]string{{"name": "a"}, {"name": "b"}}
+
+	j, err := encode(OutputJSON, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back []map[string]string
+	if err := json.Unmarshal(j, &back); err != nil {
+		t.Fatalf("json did not round-trip: %v\n%s", err, j)
+	}
+	if len(back) != 2 || back[0]["name"] != "a" {
+		t.Fatalf("unexpected json: %s", j)
+	}
+
+	y, err := encode(OutputYAML, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(y), "name: a") {
+		t.Fatalf("unexpected yaml: %s", y)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/fission-cli/util/ -run 'TestParseOutputFormat|TestEncode' -v`
+Expected: FAIL — `undefined: ParseOutputFormat`, `undefined: encode`, `undefined: OutputTable` (and add `encoding/json` import to the test).
+
+- [ ] **Step 3: Implement the type, parser, and encoder**
+
+Add to `output.go` (imports: add `encoding/json`, `sigs.k8s.io/yaml`):
+
+```go
+// OutputFormat is the validated value of the -o/--output flag.
+type OutputFormat string
+
+const (
+	OutputTable OutputFormat = ""     // default human table
+	OutputWide  OutputFormat = "wide" // table + extra columns
+	OutputJSON  OutputFormat = "json"
+	OutputYAML  OutputFormat = "yaml"
+)
+
+// ParseOutputFormat validates the -o value (empty is allowed and means table).
+func ParseOutputFormat(s string) (OutputFormat, error) {
+	switch f := OutputFormat(strings.ToLower(s)); f {
+	case OutputTable, OutputWide, OutputJSON, OutputYAML:
+		return f, nil
+	default:
+		return "", fmt.Errorf("invalid output format %q: valid values are wide, json, yaml", s)
+	}
+}
+
+// encode marshals v as JSON or YAML. It is the structured half of the printer,
+// kept pure (no stdout) so it is straightforward to unit test.
+func encode(format OutputFormat, v any) ([]byte, error) {
+	switch format {
+	case OutputJSON:
+		return json.MarshalIndent(v, "", "  ")
+	case OutputYAML:
+		return yaml.Marshal(v)
+	default:
+		return nil, fmt.Errorf("encode called with non-structured format %q", format)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./pkg/fission-cli/util/ -run 'TestParseOutputFormat|TestEncode' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w pkg/fission-cli/util/output.go pkg/fission-cli/util/output_test.go
+git add pkg/fission-cli/util/output.go pkg/fission-cli/util/output_test.go
+git commit -m "fission-cli/util: add OutputFormat parsing + structured encoder"
+```
+
+---
+
+### Task 2: `PrintObjects` (list) and `PrintStructured` (describe)
+
+**Files:**
+- Modify: `pkg/fission-cli/util/output.go`
+- Test: `pkg/fission-cli/util/output_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func TestPrintObjectsTableAndWide(t *testing.T) {
+	type row struct{ name, ready, age string }
+	items := []row{{"a", "True", "5m"}, {"b", "<none>", "1h"}}
+	hdr := []string{"NAME", "READY"}
+	rowFn := func(r row) []string { return []string{r.name, r.ready} }
+	wideHdr := []string{"AGE"}
+	wideFn := func(r row) []string { return []string{r.age} }
+
+	// table: no AGE column
+	out := captureStdout(t, func() error { return PrintObjects(OutputTable, items, hdr, rowFn, wideHdr, wideFn) })
+	if strings.Contains(out, "AGE") {
+		t.Errorf("table output must not include wide columns:\n%s", out)
+	}
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "a") {
+		t.Errorf("table missing base columns:\n%s", out)
+	}
+
+	// wide: AGE present
+	out = captureStdout(t, func() error { return PrintObjects(OutputWide, items, hdr, rowFn, wideHdr, wideFn) })
+	if !strings.Contains(out, "AGE") || !strings.Contains(out, "5m") {
+		t.Errorf("wide output missing AGE:\n%s", out)
+	}
+
+	// json: array round-trips
+	out = captureStdout(t, func() error { return PrintObjects(OutputJSON, items, hdr, rowFn, wideHdr, wideFn) })
+	var back []row // unexported fields won't unmarshal; just assert it's a JSON array
+	_ = back
+	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Errorf("json output should be an array:\n%s", out)
+	}
+}
+
+func TestPrintStructured(t *testing.T) {
+	obj := map[string]string{"name": "hello"}
+
+	// table/wide: not handled, no output
+	out := captureStdout(t, func() error {
+		handled, err := PrintStructured(OutputTable, obj)
+		if handled {
+			t.Error("table must not be handled by PrintStructured")
+		}
+		return err
+	})
+	if out != "" {
+		t.Errorf("expected no output for table, got %q", out)
+	}
+
+	// yaml: handled, prints
+	out = captureStdout(t, func() error {
+		handled, err := PrintStructured(OutputYAML, obj)
+		if !handled {
+			t.Error("yaml must be handled")
+		}
+		return err
+	})
+	if !strings.Contains(out, "name: hello") {
+		t.Errorf("yaml not printed:\n%s", out)
+	}
+}
+```
+
+Add a `captureStdout` test helper at the bottom of `output_test.go` (factor it out of the existing `TestPrintItems`, which currently inlines the same os.Pipe dance):
+
+```go
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it wrote.
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+	os.Stdout = w
+	if err := fn(); err != nil {
+		t.Fatalf("fn returned error: %v", err)
+	}
+	w.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./pkg/fission-cli/util/ -run 'TestPrintObjects|TestPrintStructured' -v`
+Expected: FAIL — `undefined: PrintObjects`, `undefined: PrintStructured`.
+
+- [ ] **Step 3: Implement `PrintObjects` and `PrintStructured`**
+
+Add to `output.go`:
+
+```go
+// PrintObjects renders a slice of items in the requested format. For json/yaml
+// it marshals items (a JSON array / YAML sequence). For table it uses
+// headers+row; for wide it appends wideExtra columns (e.g. AGE) after the base
+// columns. It is the single entry point for the list commands.
+func PrintObjects[T any](format OutputFormat, items []T, headers []string, row func(T) []string, wideExtra []string, wideRow func(T) []string) error {
+	switch format {
+	case OutputJSON, OutputYAML:
+		b, err := encode(format, items)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	case OutputWide:
+		hdr := append(append([]string{}, headers...), wideExtra...)
+		PrintItems(hdr, items, func(t T) []string {
+			return append(row(t), wideRow(t)...)
+		})
+		return nil
+	default: // OutputTable
+		PrintItems(headers, items, row)
+		return nil
+	}
+}
+
+// PrintStructured prints v as json/yaml and returns true when the format is
+// structured; for table/wide it prints nothing and returns false so describe
+// commands fall back to their own human rendering.
+func PrintStructured(format OutputFormat, v any) (bool, error) {
+	switch format {
+	case OutputJSON, OutputYAML:
+		b, err := encode(format, v)
+		if err != nil {
+			return true, err
+		}
+		fmt.Println(string(b))
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+```
+
+Also refactor the existing `TestPrintItems` to use the new `captureStdout` helper (delete its inline os.Pipe block, call `captureStdout`).
+
+- [ ] **Step 4: Run all util tests**
+
+Run: `go test ./pkg/fission-cli/util/ -v`
+Expected: PASS (including the refactored `TestPrintItems`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+gofmt -w pkg/fission-cli/util/output.go pkg/fission-cli/util/output_test.go
+git add pkg/fission-cli/util/output.go pkg/fission-cli/util/output_test.go
+git commit -m "fission-cli/util: add PrintObjects + PrintStructured format-aware printers"
+```
+
+---
+
+### Task 3: The `--output` flag
+
+**Files:**
+- Modify: `pkg/fission-cli/flag/key/key.go`
+- Modify: `pkg/fission-cli/flag/flag.go`
+
+- [ ] **Step 1: Add the flag key**
+
+In `key.go`, near the existing `Output = "output"` block, add:
+
+```go
+OutputFormat = "output"
+```
+
+(If a bare `Output = "output"` already exists and is only aliased by the download keys, reuse it instead of adding a duplicate literal — confirm with `grep -n 'Output\b' pkg/fission-cli/flag/key/key.go`. The flag *name* `output` is shared; only read commands get the new `flag.Output` var.)
+
+- [ ] **Step 2: Add the flag var**
+
+In `flag.go`, add near the other global-ish flags:
+
+```go
+Output = Flag{Type: String, Name: flagkey.OutputFormat, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `go build ./pkg/fission-cli/...`
+Expected: builds (flag unused yet is fine — it's a package-level var).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add pkg/fission-cli/flag/key/key.go pkg/fission-cli/flag/flag.go
+git commit -m "fission-cli/flag: add --output/-o format flag for read commands"
+```
+
+---
+
+### Task 4: Wire `function list` (representative list command)
+
+**Files:**
+- Modify: `pkg/fission-cli/cmd/function/command.go` (add `flag.Output` to the list subcommand's Optional flags)
+- Modify: `pkg/fission-cli/cmd/function/list.go`
+- Test: `pkg/fission-cli/cmd/function/list_test.go` (new)
+
+- [ ] **Step 1: Add the flag to the command**
+
+In `function/command.go`, the `list` subcommand's flag set — add `flag.Output`:
+
+```go
+}, List, flag.FlagSet{
+	Optional: []flag.Flag{flag.NamespaceFunction, flag.AllNamespaces, flag.Output},
+})
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `function/list_test.go` using the dummy driver + fake fission clientset (follow the pattern in `function/create_test.go` for clientset/`cmd.SetClientset` setup):
+
+```go
+func TestFunctionListJSON(t *testing.T) {
+	// arrange: a fake clientset with one function, wired via cmd.SetClientset,
+	// and a dummy CLI input with output=json (see create_test.go for the helper).
+	input := dummy.TestFlagSet()
+	input.Set(flagkey.Output, "json")
+	out := captureStdout(t, func() error { return List(input) })
+	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Errorf("expected JSON array, got:\n%s", out)
+	}
+}
+```
+
+(Reuse/duplicate the `captureStdout` helper locally, or export a small test util. Mirror the clientset bootstrap already used by `function/create_test.go` / `function_test.go`.)
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `go test ./pkg/fission-cli/cmd/function/ -run TestFunctionListJSON -v`
+Expected: FAIL — output is the table, not JSON (List ignores `-o`).
+
+- [ ] **Step 4: Implement `-o` in `function/list.go`**
+
+Replace the `util.PrintItems(...)` call with format-aware printing:
+
+```go
+format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+if err != nil {
+	return err
+}
+
+headers := []string{"NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS", "READY", "NAMESPACE"}
+wideExtra := []string{"AGE"}
+row := func(f fv1.Function) []string {
+	var secretsList, configMapList []string
+	for _, secret := range f.Spec.Secrets {
+		secretsList = append(secretsList, secret.Name)
+	}
+	for _, configMap := range f.Spec.ConfigMaps {
+		configMapList = append(configMapList, configMap.Name)
+	}
+	return []string{
+		f.Name, f.Spec.Environment.Name,
+		string(f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType),
+		fmt.Sprintf("%v", f.Spec.InvokeStrategy.ExecutionStrategy.MinScale),
+		fmt.Sprintf("%v", f.Spec.InvokeStrategy.ExecutionStrategy.MaxScale),
+		f.Spec.Resources.Requests.Cpu().String(),
+		f.Spec.Resources.Limits.Cpu().String(),
+		f.Spec.Resources.Requests.Memory().String(),
+		f.Spec.Resources.Limits.Memory().String(),
+		strings.Join(secretsList, ","),
+		strings.Join(configMapList, ","),
+		util.ConditionStatus(f.Status.Conditions, fv1.FunctionConditionReady),
+		f.Namespace,
+	}
+}
+wideRow := func(f fv1.Function) []string {
+	return []string{util.AgeOf(f.CreationTimestamp)}
+}
+return util.PrintObjects(format, fns.Items, headers, row, wideExtra, wideRow)
+```
+
+Add an `AgeOf` helper to `util/output.go` (TDD it as a tiny step or fold into Task 1) :
+
+```go
+// AgeOf renders an object's age from its creation timestamp, kubectl-style.
+func AgeOf(t metav1.Time) string {
+	if t.IsZero() {
+		return NoneValue
+	}
+	return duration.HumanDuration(time.Since(t.Time))
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes; build + vet**
+
+Run: `go test ./pkg/fission-cli/cmd/function/ -run TestFunctionListJSON -v && go build ./pkg/fission-cli/...`
+Expected: PASS + build clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+gofmt -w pkg/fission-cli/cmd/function/list.go pkg/fission-cli/util/output.go
+git add pkg/fission-cli/cmd/function/ pkg/fission-cli/util/output.go
+git commit -m "fission-cli: -o json|yaml|wide for function list"
+```
+
+---
+
+### Task 5: Wire the remaining list commands
+
+Apply the **exact same pattern as Task 4** to each command below. For each: (a) add `flag.Output` to the list subcommand in its `command.go`; (b) in `list.go`, parse the format, keep the existing `headers`/`row`, add `wideExtra := []string{"AGE"}` + a `wideRow` returning `util.AgeOf(item.CreationTimestamp)`, and replace `util.PrintItems(...)` with `return util.PrintObjects(format, <items>, headers, row, wideExtra, wideRow)`.
+
+- [ ] **environment** (`cmd/environment/list.go`, `command.go`) — items `response.Items`, type `fv1.Environment`. (No READY column today; wide adds only AGE.)
+- [ ] **httptrigger** (`cmd/httptrigger/list.go`, `command.go`) — note list shares `printHtSummary` in `get.go`; thread `format` into it or inline the printer in `list.go`'s run. Items `[]fv1.HTTPTrigger`.
+- [ ] **timetrigger** (`cmd/timetrigger/list.go`, `command.go`) — items `tts.Items`, type `fv1.TimeTrigger`.
+- [ ] **mqtrigger** (`cmd/mqtrigger/list.go`, `command.go`) — items `mqts.Items`, type `fv1.MessageQueueTrigger`.
+- [ ] **kubewatch** (`cmd/kubewatch/list.go`, `command.go`) — items `ws.Items`, type `v1.KubernetesWatchTrigger` (the package aliases core/v1 as `v1`).
+- [ ] **canaryconfig** (`cmd/canaryconfig/list.go`, `command.go`) — items `canaryCfgs.Items`, type `fv1.CanaryConfig`.
+- [ ] **package** (`cmd/package/list.go`, `command.go`) — items are built into a filtered slice (orphan/status filters). Keep the filter loop building `[]fv1.Package`, then pass that slice to `PrintObjects`. Existing `BUILD_STATUS` column stays; wide adds AGE.
+
+For each: write a `TestXListJSON` mirroring Task 4 (assert JSON array), run it red→green, build, commit per command (or one commit for the batch — keep them small).
+
+- [ ] **Final step:** `go test ./pkg/fission-cli/... && go build ./...` → all pass; commit.
+
+---
+
+### Task 6: Wire the describe commands (json/yaml only; table/wide unchanged)
+
+Describe commands keep their bespoke human output; they only gain json/yaml via an early return. Pattern for each:
+
+```go
+format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+if err != nil {
+	return err
+}
+if handled, err := util.PrintStructured(format, obj); err != nil || handled {
+	return err
+}
+// ... existing human rendering ...
+```
+
+- [ ] **function getmeta** (`cmd/function/getmeta.go` + `flag.Output` in `command.go`) — `obj` is the fetched `*fv1.Function`. Early-return before the `Name:`/labels printing.
+- [ ] **package info** (`cmd/package/info.go` + `command.go`) — `obj` is the `*fv1.Package`; early-return before `pkgutil.PrintPackageSummary`.
+- [ ] **canaryconfig get** (`cmd/canaryconfig/get.go` + `command.go`) — `obj` is `*fv1.CanaryConfig`; early-return before the table + conditions.
+- [ ] **httptrigger get** (`cmd/httptrigger/get.go` + `command.go`) — `obj` is `*fv1.HTTPTrigger`; early-return before `printHtSummary` + conditions.
+
+Note: `-o wide` on describe behaves like table (no extra columns defined) — acceptable; the value of wide on describe is marginal. Document that json/yaml are the meaningful describe formats.
+
+- [ ] Add one describe json test (e.g. `TestGetMetaJSON`) mirroring the list test. Run red→green, build, commit.
+
+---
+
+### Task 7: Full verification + manual kind check
+
+- [ ] **Step 1: Lint + unit + build**
+
+```bash
+gofmt -l pkg/fission-cli/    # expect no output
+golangci-lint run ./pkg/fission-cli/...   # 0 issues
+go test ./pkg/fission-cli/... ./cmd/fission-cli/...   # all pass (incl. app command-tree test, which now sees flag.Output)
+go build ./...
+```
+
+- [ ] **Step 2: Manual on kind** (cluster from earlier sessions or recreate per CLAUDE.md)
+
+```bash
+go build -o /tmp/fission ./cmd/fission-cli
+/tmp/fission fn list                  # unchanged table (READY column present)
+/tmp/fission fn list -o wide          # adds AGE column
+/tmp/fission fn list -o json | jq '.[].metadata.name'
+/tmp/fission fn list -o yaml | head
+/tmp/fission fn list -o bogus         # errors: invalid output format "bogus": valid values are wide, json, yaml
+/tmp/fission env list -o json | jq length
+/tmp/fission pkg info --name <pkg> -o yaml
+/tmp/fission fn getmeta --name <fn> -o json
+```
+
+Confirm: default output byte-identical to before; `-o wide` adds AGE; json/yaml parse with jq/yq; unknown value errors clearly; describe json/yaml emits the object.
+
+- [ ] **Step 3: Update the design doc status** to "Implemented" and commit.
+
+- [ ] **Step 4: Push branch `cli-output-formats`** and let the user open the PR (per repo convention).
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** flag (Task 3), printer core (Tasks 1-2), all in-scope list commands (Tasks 4-5), all in-scope describe commands (Task 6), tests + manual (every task + Task 7). Covered.
+- **Deviations from design (intentional, documented above):** JSON/YAML marshal the slice (array/sequence) rather than `---`-separated docs; wide columns appended at end (AGE last) rather than before NAMESPACE — keeps `PrintObjects` generic. `-o wide` on describe == table (no extra columns).
+- **Type consistency:** `PrintObjects[T]`, `PrintStructured`, `ParseOutputFormat`, `encode`, `AgeOf` names are used identically across tasks. `flagkey.Output`/`flagkey.OutputFormat` — confirm the exact key name in Task 3 step 1 before use.
+- **Backward compatibility:** default (no `-o`) path still calls `PrintItems(headers, items, row)` with the current columns → byte-identical output.

--- a/pkg/fission-cli/cmd/canaryconfig/command.go
+++ b/pkg/fission-cli/cmd/canaryconfig/command.go
@@ -39,7 +39,7 @@ func Commands() *cobra.Command {
 		Short:   "View parameters in a canary config",
 	}, Get, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.Output},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -66,7 +66,7 @@ func Commands() *cobra.Command {
 		Short:   "List canary configs",
 		Long:    "List all canary configs in a namespace if specified, else, list canary configs across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -47,6 +47,14 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error getting canary config: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+	if handled, err := util.PrintStructured(format, canaryCfg); err != nil || handled {
+		return err
+	}
+
 	headers := []string{"NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS"}
 	rows := [][]string{{
 		canaryCfg.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction,

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -59,15 +59,22 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error listing canary config: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	headers := []string{"NAME", "TRIGGER", "FUNCTION-N", "FUNCTION-N-1", "WEIGHT-INCREMENT", "INTERVAL", "FAILURE-THRESHOLD", "FAILURE-TYPE", "STATUS", "READY"}
-	util.PrintItems(headers, canaryCfgs.Items, func(canaryCfg fv1.CanaryConfig) []string {
+	row := func(canaryCfg fv1.CanaryConfig) []string {
 		return []string{
 			canaryCfg.Name, canaryCfg.Spec.Trigger, canaryCfg.Spec.NewFunction, canaryCfg.Spec.OldFunction,
 			fmt.Sprintf("%v", canaryCfg.Spec.WeightIncrement), fmt.Sprintf("%v", canaryCfg.Spec.WeightIncrementDuration),
 			fmt.Sprintf("%v", canaryCfg.Spec.FailureThreshold), string(canaryCfg.Spec.FailureType), canaryCfg.Status.Status,
 			util.ConditionStatus(canaryCfg.Status.Conditions, fv1.CanaryConfigConditionReady),
 		}
-	})
+	}
+	wideExtra := []string{"AGE"}
+	wideRow := func(canaryCfg fv1.CanaryConfig) []string { return []string{util.AgeOf(canaryCfg.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, canaryCfgs.Items, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -43,6 +43,15 @@ func SetClientset(client Client) {
 	})
 }
 
+// ResetClientsetForTest clears the once-set default client so a unit test can
+// install its own (fake) client deterministically. It exists because
+// SetClientset is guarded by a sync.Once for the real CLI; tests must be able
+// to reset that. Intended for tests only.
+func ResetClientsetForTest() {
+	once = sync.Once{}
+	defaultClient = Client{}
+}
+
 func (c *CommandActioner) Client() Client {
 	return defaultClient
 }

--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -71,7 +71,7 @@ func Commands() *cobra.Command {
 		Short: "List environments",
 		Long:  "List all environments in a namespace if specified, else, list environments across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.AllNamespaces, flag.Output},
 	})
 
 	listPodsCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -51,15 +51,22 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 	// buildermgr never writes Environment status (a write would bump
 	// ResourceVersion and break in-flight source-archive builds), so a READY
 	// column would always be empty. See pkg/apis/core/v1/conditions.go.
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	headers := []string{"NAME", "IMAGE", "BUILDER_IMAGE", "POOLSIZE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "EXTNET", "GRACETIME", "NAMESPACE"}
-	util.PrintItems(headers, response.Items, func(env fv1.Environment) []string {
+	row := func(env fv1.Environment) []string {
 		return []string{
 			env.Name, env.Spec.Runtime.Image, env.Spec.Builder.Image, fmt.Sprintf("%v", env.Spec.Poolsize),
 			env.Spec.Resources.Requests.Cpu().String(), env.Spec.Resources.Limits.Cpu().String(),
 			env.Spec.Resources.Requests.Memory().String(), env.Spec.Resources.Limits.Memory().String(),
 			fmt.Sprintf("%v", env.Spec.AllowAccessToExternalNetwork), fmt.Sprintf("%v", env.Spec.TerminationGracePeriod), env.Namespace,
 		}
-	})
+	}
+	wideExtra := []string{"AGE"}
+	wideRow := func(env fv1.Environment) []string { return []string{util.AgeOf(env.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, response.Items, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -108,7 +108,7 @@ func Commands() *cobra.Command {
 		Short:   "List functions",
 		Long:    "List all functions in a namespace if specified, else, list functions across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.AllNamespaces, flag.Output},
 	})
 
 	logsCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -65,7 +65,7 @@ func Commands() *cobra.Command {
 		Short:   "Get function metadata",
 	}, GetMeta, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.Output},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -46,6 +46,14 @@ func (opts *GetMetaSubCommand) do(input cli.Input) error {
 		return fmt.Errorf("error getting function: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+	if handled, err := util.PrintStructured(format, fn); err != nil || handled {
+		return err
+	}
+
 	fmt.Printf("Name: %v\n", fn.Name)
 	fmt.Printf("Environment: %v\n", fn.Spec.Environment.Name)
 	if len(fn.Labels) != 0 {

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -48,8 +48,13 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 		return fmt.Errorf("error listing functions: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	headers := []string{"NAME", "ENV", "EXECUTORTYPE", "MINSCALE", "MAXSCALE", "MINCPU", "MAXCPU", "MINMEMORY", "MAXMEMORY", "SECRETS", "CONFIGMAPS", "READY", "NAMESPACE"}
-	util.PrintItems(headers, fns.Items, func(f fv1.Function) []string {
+	row := func(f fv1.Function) []string {
 		var secretsList, configMapList []string
 		for _, secret := range f.Spec.Secrets {
 			secretsList = append(secretsList, secret.Name)
@@ -71,7 +76,9 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 			util.ConditionStatus(f.Status.Conditions, fv1.FunctionConditionReady),
 			f.Namespace,
 		}
-	})
+	}
+	wideExtra := []string{"AGE"}
+	wideRow := func(f fv1.Function) []string { return []string{util.AgeOf(f.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, fns.Items, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/function/list_test.go
+++ b/pkg/fission-cli/cmd/function/list_test.go
@@ -63,6 +63,9 @@ func TestFunctionListOutput(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "listfn", Namespace: "default"},
 		Spec:       fv1.FunctionSpec{Environment: fv1.EnvironmentReference{Name: "nodejs"}},
 	}
+	// Reset the sync.Once-guarded client so this test deterministically installs
+	// its own fake regardless of test order.
+	cmd.ResetClientsetForTest()
 	cmd.SetClientset(cmd.Client{
 		FissionClientSet: fissionfake.NewClientset(fn),
 		Namespace:        "default",

--- a/pkg/fission-cli/cmd/function/list_test.go
+++ b/pkg/fission-cli/cmd/function/list_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The Fission Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package function
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what it wrote.
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+	os.Stdout = w
+	if err := fn(); err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	w.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
+// TestFunctionListOutput exercises the command-level -o wiring (flag -> format
+// -> printer) end to end against a fake clientset, complementing the printer
+// unit tests in pkg/fission-cli/util. cmd.SetClientset is a sync.Once, so the
+// fake set here is shared by the subtests below.
+func TestFunctionListOutput(t *testing.T) {
+	fn := &fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: "listfn", Namespace: "default"},
+		Spec:       fv1.FunctionSpec{Environment: fv1.EnvironmentReference{Name: "nodejs"}},
+	}
+	cmd.SetClientset(cmd.Client{
+		FissionClientSet: fissionfake.NewClientset(fn),
+		Namespace:        "default",
+	})
+
+	t.Run("json is an array containing the function", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Output, "json")
+		out := captureStdout(t, func() error { return List(in) })
+
+		var got []fv1.Function
+		if err := json.Unmarshal([]byte(out), &got); err != nil {
+			t.Fatalf("output is not a JSON array: %v\n%s", err, out)
+		}
+		if len(got) != 1 || got[0].Name != "listfn" {
+			t.Fatalf("unexpected functions in json: %+v", got)
+		}
+	})
+
+	t.Run("wide adds the AGE column", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Output, "wide")
+		out := captureStdout(t, func() error { return List(in) })
+		if !strings.Contains(out, "AGE") {
+			t.Fatalf("wide output missing AGE column:\n%s", out)
+		}
+		if !strings.Contains(out, "listfn") {
+			t.Fatalf("wide output missing the function row:\n%s", out)
+		}
+	})
+
+	t.Run("default table omits AGE", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		out := captureStdout(t, func() error { return List(in) })
+		if strings.Contains(out, "AGE") {
+			t.Fatalf("default table should not include AGE:\n%s", out)
+		}
+		if !strings.Contains(out, "NAME") || !strings.Contains(out, "listfn") {
+			t.Fatalf("default table missing expected content:\n%s", out)
+		}
+	})
+
+	t.Run("invalid format errors", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Output, "bogus")
+		if err := List(in); err == nil {
+			t.Fatal("expected an error for -o bogus")
+		}
+	})
+}

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -41,6 +41,7 @@ func Commands() *cobra.Command {
 		Short:   "Get HTTP trigger details",
 	}, Get, flag.FlagSet{
 		Required: []flag.Flag{flag.HtName},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Output},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -69,7 +70,7 @@ func Commands() *cobra.Command {
 		Short:   "List HTTP triggers",
 		Long:    "List all HTTP triggers in a namespace if specified, else, list HTTP triggers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.HtFnFilter, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.HtFnFilter, flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -52,16 +52,25 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error getting http trigger: %w", err)
 	}
 
-	printHtSummary([]fv1.HTTPTrigger{*ht})
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+	if handled, err := util.PrintStructured(format, ht); err != nil || handled {
+		return err
+	}
+
+	if err := printHtSummary(format, []fv1.HTTPTrigger{*ht}); err != nil {
+		return err
+	}
 	util.PrintConditions(ht.Status.Conditions)
 
 	return nil
 }
 
-func printHtSummary(triggers []fv1.HTTPTrigger) {
+func printHtSummary(format util.OutputFormat, triggers []fv1.HTTPTrigger) error {
 	headers := []string{"NAME", "METHOD", "URL", "FUNCTION(s)", "INGRESS", "HOST", "PATH", "TLS", "ANNOTATIONS", "READY", "NAMESPACE"}
-	rows := make([][]string, 0, len(triggers))
-	for _, trigger := range triggers {
+	row := func(trigger fv1.HTTPTrigger) []string {
 		function := ""
 		if trigger.Spec.FunctionReference.Type == fv1.FunctionReferenceTypeFunctionName {
 			function = trigger.Spec.FunctionReference.Name
@@ -93,12 +102,14 @@ func printHtSummary(triggers []fv1.HTTPTrigger) {
 		if len(trigger.Spec.Methods) > 0 {
 			methods = trigger.Spec.Methods
 		}
-		rows = append(rows, []string{
+		return []string{
 			trigger.Name, fmt.Sprintf("%v", methods), trigger.Spec.RelativeURL, function,
 			fmt.Sprintf("%v", trigger.Spec.CreateIngress), host, path, fmt.Sprintf("%v", trigger.Spec.IngressConfig.TLS), ann,
 			util.ConditionStatus(trigger.Status.Conditions, fv1.HTTPTriggerConditionReady),
 			trigger.Namespace,
-		})
+		}
 	}
-	util.PrintTable(headers, rows)
+	wideExtra := []string{"AGE"}
+	wideRow := func(trigger fv1.HTTPTrigger) []string { return []string{util.AgeOf(trigger.CreationTimestamp)} }
+	return util.PrintObjects(format, triggers, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -60,7 +60,9 @@ func (opts *GetSubCommand) run(input cli.Input) (err error) {
 		return err
 	}
 
-	if err := printHtSummary(format, []fv1.HTTPTrigger{*ht}); err != nil {
+	// describe renders the plain table (no -o wide AGE column), consistent with
+	// the other describe commands; json/yaml are handled above.
+	if err := printHtSummary(util.OutputTable, []fv1.HTTPTrigger{*ht}); err != nil {
 		return err
 	}
 	util.PrintConditions(ht.Status.Conditions)

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type ListSubCommand struct {
@@ -50,6 +51,11 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error listing HTTP triggers: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	filterFunctionName := input.String(flagkey.HtFnName)
 
 	var triggers []fv1.HTTPTrigger
@@ -62,6 +68,5 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		}
 	}
 
-	printHtSummary(triggers)
-	return nil
+	return printHtSummary(format, triggers)
 }

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 		Short:   "List kube watchers",
 		Long:    "List all kube watchers in a namespace if specified, else, list kube watchers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -59,13 +59,20 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error listing kubewatchers: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	headers := []string{"NAME", "NAMESPACE", "OBJTYPE", "LABELS", "FUNCTION_NAME", "READY"}
-	util.PrintItems(headers, ws.Items, func(wa v1.KubernetesWatchTrigger) []string {
+	row := func(wa v1.KubernetesWatchTrigger) []string {
 		return []string{
 			wa.Name, wa.Spec.Namespace, wa.Spec.Type, fmt.Sprintf("%v", wa.Spec.LabelSelector), wa.Spec.FunctionReference.Name,
 			util.ConditionStatus(wa.Status.Conditions, v1.KubernetesWatchTriggerConditionReady),
 		}
-	})
+	}
+	wideExtra := []string{"AGE"}
+	wideRow := func(wa v1.KubernetesWatchTrigger) []string { return []string{util.AgeOf(wa.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, ws.Items, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -63,7 +63,7 @@ func Commands() *cobra.Command {
 		Short:   "List message queue triggers",
 		Long:    "List all message queue triggers in a namespace if specified, else, list message queue triggers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -59,15 +59,22 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return fmt.Errorf("error listing message queue triggers: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	headers := []string{"NAME", "FUNCTION_NAME", "MESSAGE_QUEUE_TYPE", "TOPIC", "RESPONSE_TOPIC", "ERROR_TOPIC", "MAX_RETRIES", "PUB_MSG_CONTENT_TYPE", "READY", "NAMESPACE"}
-	util.PrintItems(headers, mqts.Items, func(mqt fv1.MessageQueueTrigger) []string {
+	row := func(mqt fv1.MessageQueueTrigger) []string {
 		return []string{
 			mqt.Name, mqt.Spec.FunctionReference.Name, string(mqt.Spec.MessageQueueType), mqt.Spec.Topic, mqt.Spec.ResponseTopic, mqt.Spec.ErrorTopic,
 			fmt.Sprintf("%v", mqt.Spec.MaxRetries), mqt.Spec.ContentType,
 			util.ConditionStatus(mqt.Status.Conditions, fv1.MessageQueueTriggerConditionReady),
 			mqt.Namespace,
 		}
-	})
+	}
+	wideExtra := []string{"AGE"}
+	wideRow := func(mqt fv1.MessageQueueTrigger) []string { return []string{util.AgeOf(mqt.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, mqts.Items, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -72,7 +72,7 @@ func Commands() *cobra.Command {
 		Short: "List packages",
 		Long:  "List all packages in a namespace if specified, else, list packages across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.AllNamespaces, flag.Output},
 	})
 
 	infoCmd := wrapper.SubCommand(&cobra.Command{
@@ -80,7 +80,7 @@ func Commands() *cobra.Command {
 		Short: "Show package information",
 	}, Info, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.Output},
 	})
 
 	rebuildCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	pkgutil "github.com/fission/fission/pkg/fission-cli/cmd/package/util"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type InfoSubCommand struct {
@@ -61,6 +62,14 @@ func (opts *InfoSubCommand) run(input cli.Input) error {
 	pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.namespace).Get(input.Context(), opts.name, metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error finding package %s: %w", opts.name, err)
+	}
+
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+	if handled, err := util.PrintStructured(format, pkg); err != nil || handled {
+		return err
 	}
 
 	pkgutil.PrintPackageSummary(os.Stdout, pkg)

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -66,13 +66,18 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		return err
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	// sort the package list by lastUpdatedTimestamp
 	sort.Slice(pkgList.Items, func(i, j int) bool {
 		return pkgList.Items[i].Status.LastUpdateTimestamp.After(pkgList.Items[j].Status.LastUpdateTimestamp.Time)
 	})
 
-	headers := []string{"NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT", "READY", "NAMESPACE"}
-	rows := make([][]string, 0, len(pkgList.Items))
+	// apply --orphan / --status filters, then print the surviving packages.
+	filtered := make([]fv1.Package, 0, len(pkgList.Items))
 	for _, pkg := range pkgList.Items {
 		// TODO improve list speed when --orphan
 		if opts.listOrphans {
@@ -87,14 +92,20 @@ func (opts *ListSubCommand) run(input cli.Input) (err error) {
 		if len(opts.status) > 0 && opts.status != string(pkg.Status.BuildStatus) {
 			continue
 		}
-		rows = append(rows, []string{
+		filtered = append(filtered, pkg)
+	}
+
+	headers := []string{"NAME", "BUILD_STATUS", "ENV", "LASTUPDATEDAT", "READY", "NAMESPACE"}
+	row := func(pkg fv1.Package) []string {
+		return []string{
 			pkg.Name, string(pkg.Status.BuildStatus), pkg.Spec.Environment.Name,
 			pkg.Status.LastUpdateTimestamp.Format(time.RFC822),
 			util.ConditionStatus(pkg.Status.Conditions, fv1.PackageConditionReady),
 			pkg.Namespace,
-		})
+		}
 	}
-	util.PrintTable(headers, rows)
+	wideExtra := []string{"AGE"}
+	wideRow := func(pkg fv1.Package) []string { return []string{util.AgeOf(pkg.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, filtered, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -63,7 +63,7 @@ func Commands() *cobra.Command {
 		Short:   "List time triggers",
 		Long:    "List all time triggers in a namespace if specified, else, list time triggers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces, flag.Output},
 	})
 
 	showCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -47,13 +47,20 @@ func (opts *ListSubCommand) do(input cli.Input) (err error) {
 		return fmt.Errorf("list Time triggers: %w", err)
 	}
 
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+
 	headers := []string{"NAME", "CRON", "FUNCTION_NAME", "METHOD", "SUBPATH", "READY"}
-	util.PrintItems(headers, tts.Items, func(tt fv1.TimeTrigger) []string {
+	row := func(tt fv1.TimeTrigger) []string {
 		return []string{
 			tt.Name, tt.Spec.Cron, tt.Spec.Name, tt.Spec.Method, tt.Spec.Subpath,
 			util.ConditionStatus(tt.Status.Conditions, fv1.TimeTriggerConditionReady),
 		}
-	})
+	}
+	wideExtra := []string{"AGE"}
+	wideRow := func(tt fv1.TimeTrigger) []string { return []string{util.AgeOf(tt.CreationTimestamp)} }
 
-	return nil
+	return util.PrintObjects(format, tts.Items, headers, row, wideExtra, wideRow)
 }

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -90,6 +90,7 @@ var (
 	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"force"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace", DefaultValue: false}
 	ForceDelete          = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
 	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Short: "A", Usage: "Fetch resources from all namespaces"}
+	Output               = Flag{Type: String, Name: flagkey.Output, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
 	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}

--- a/pkg/fission-cli/util/output.go
+++ b/pkg/fission-cli/util/output.go
@@ -121,7 +121,7 @@ func PrintObjects[T any](format OutputFormat, items []T, headers []string, row f
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(b))
+		printBytes(b)
 		return nil
 	case OutputWide:
 		hdr := append(append([]string{}, headers...), wideExtra...)
@@ -145,10 +145,19 @@ func PrintStructured(format OutputFormat, v any) (bool, error) {
 		if err != nil {
 			return true, err
 		}
-		fmt.Println(string(b))
+		printBytes(b)
 		return true, nil
 	default:
 		return false, nil
+	}
+}
+
+// printBytes writes b to stdout ensuring exactly one trailing newline:
+// yaml.Marshal already appends one, json.MarshalIndent does not.
+func printBytes(b []byte) {
+	_, _ = os.Stdout.Write(b)
+	if n := len(b); n == 0 || b[n-1] != '\n' {
+		fmt.Fprintln(os.Stdout)
 	}
 }
 

--- a/pkg/fission-cli/util/output.go
+++ b/pkg/fission-cli/util/output.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +27,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/duration"
+	"sigs.k8s.io/yaml"
 
 	"github.com/fission/fission/pkg/conditions"
 )
@@ -34,6 +36,47 @@ import (
 // written the condition (e.g. a freshly created resource, or a resource
 // whose controller does not emit that condition).
 const NoneValue = "<none>"
+
+// OutputFormat is the validated value of the -o/--output flag.
+type OutputFormat string
+
+const (
+	OutputTable OutputFormat = ""     // default human table
+	OutputWide  OutputFormat = "wide" // table + extra columns
+	OutputJSON  OutputFormat = "json"
+	OutputYAML  OutputFormat = "yaml"
+)
+
+// ParseOutputFormat validates the -o value (empty is allowed and means table).
+func ParseOutputFormat(s string) (OutputFormat, error) {
+	switch f := OutputFormat(strings.ToLower(s)); f {
+	case OutputTable, OutputWide, OutputJSON, OutputYAML:
+		return f, nil
+	default:
+		return "", fmt.Errorf("invalid output format %q: valid values are wide, json, yaml", s)
+	}
+}
+
+// encode marshals v as JSON or YAML. It is the structured half of the printer,
+// kept pure (no stdout) so it is straightforward to unit test.
+func encode(format OutputFormat, v any) ([]byte, error) {
+	switch format {
+	case OutputJSON:
+		return json.MarshalIndent(v, "", "  ")
+	case OutputYAML:
+		return yaml.Marshal(v)
+	default:
+		return nil, fmt.Errorf("encode called with non-structured format %q", format)
+	}
+}
+
+// AgeOf renders an object's age from its creation timestamp, kubectl-style.
+func AgeOf(t metav1.Time) string {
+	if t.IsZero() {
+		return NoneValue
+	}
+	return duration.HumanDuration(time.Since(t.Time))
+}
 
 // NewTabWriter returns a tabwriter configured with the Fission CLI's standard
 // list/get column formatting. It centralises the
@@ -65,6 +108,48 @@ func PrintItems[T any](headers []string, items []T, row func(T) []string) {
 		rows = append(rows, row(it))
 	}
 	PrintTable(headers, rows)
+}
+
+// PrintObjects renders a slice of items in the requested format. For json/yaml
+// it marshals items (a JSON array / YAML sequence). For table it uses
+// headers+row; for wide it appends wideExtra columns (e.g. AGE) after the base
+// columns. It is the single entry point for the list commands.
+func PrintObjects[T any](format OutputFormat, items []T, headers []string, row func(T) []string, wideExtra []string, wideRow func(T) []string) error {
+	switch format {
+	case OutputJSON, OutputYAML:
+		b, err := encode(format, items)
+		if err != nil {
+			return err
+		}
+		fmt.Println(string(b))
+		return nil
+	case OutputWide:
+		hdr := append(append([]string{}, headers...), wideExtra...)
+		PrintItems(hdr, items, func(t T) []string {
+			return append(row(t), wideRow(t)...)
+		})
+		return nil
+	default: // OutputTable
+		PrintItems(headers, items, row)
+		return nil
+	}
+}
+
+// PrintStructured prints v as json/yaml and returns true when the format is
+// structured; for table/wide it prints nothing and returns false so describe
+// commands fall back to their own human rendering.
+func PrintStructured(format OutputFormat, v any) (bool, error) {
+	switch format {
+	case OutputJSON, OutputYAML:
+		b, err := encode(format, v)
+		if err != nil {
+			return true, err
+		}
+		fmt.Println(string(b))
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 // ConditionStatus renders the Status of the named condition for a status

--- a/pkg/fission-cli/util/output_test.go
+++ b/pkg/fission-cli/util/output_test.go
@@ -18,12 +18,71 @@ package util
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func TestParseOutputFormat(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    OutputFormat
+		wantErr bool
+	}{
+		{"", OutputTable, false},
+		{"wide", OutputWide, false},
+		{"json", OutputJSON, false},
+		{"yaml", OutputYAML, false},
+		{"JSON", OutputJSON, false}, // case-insensitive
+		{"name", "", true},
+		{"xml", "", true},
+	}
+	for _, tt := range tests {
+		got, err := ParseOutputFormat(tt.in)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseOutputFormat(%q) err=%v, wantErr=%v", tt.in, err, tt.wantErr)
+		}
+		if err == nil && got != tt.want {
+			t.Errorf("ParseOutputFormat(%q)=%q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestEncode(t *testing.T) {
+	items := []map[string]string{{"name": "a"}, {"name": "b"}}
+
+	j, err := encode(OutputJSON, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back []map[string]string
+	if err := json.Unmarshal(j, &back); err != nil {
+		t.Fatalf("json did not round-trip: %v\n%s", err, j)
+	}
+	if len(back) != 2 || back[0]["name"] != "a" {
+		t.Fatalf("unexpected json: %s", j)
+	}
+
+	y, err := encode(OutputYAML, items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(y), "name: a") {
+		t.Fatalf("unexpected yaml: %s", y)
+	}
+}
+
+func TestAgeOf(t *testing.T) {
+	if got := AgeOf(metav1.Time{}); got != NoneValue {
+		t.Errorf("zero time should render %q, got %q", NoneValue, got)
+	}
+	if got := AgeOf(metav1.Now()); got == NoneValue || got == "" {
+		t.Errorf("recent time should render a duration, got %q", got)
+	}
+}
 
 func TestConditionStatus(t *testing.T) {
 	conds := []metav1.Condition{
@@ -52,6 +111,28 @@ func TestConditionStatus(t *testing.T) {
 	}
 }
 
+// captureStdout runs fn with os.Stdout redirected to a pipe and returns what it wrote.
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+	os.Stdout = w
+	if err := fn(); err != nil {
+		t.Fatalf("fn returned error: %v", err)
+	}
+	w.Close()
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(r); err != nil {
+		t.Fatal(err)
+	}
+	return buf.String()
+}
+
 func TestPrintItems(t *testing.T) {
 	// PrintItems writes to os.Stdout; capture it to assert the row mapping is
 	// applied to every item in order.
@@ -60,30 +141,69 @@ func TestPrintItems(t *testing.T) {
 	}
 	items := []row{{"a", "True"}, {"b", NoneValue}}
 
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer r.Close()
-
-	orig := os.Stdout
-	t.Cleanup(func() { os.Stdout = orig })
-	os.Stdout = w
-
-	PrintItems([]string{"NAME", "READY"}, items, func(it row) []string {
-		return []string{it.name, it.ready}
+	out := captureStdout(t, func() error {
+		PrintItems([]string{"NAME", "READY"}, items, func(it row) []string {
+			return []string{it.name, it.ready}
+		})
+		return nil
 	})
-	w.Close()
-
-	var buf bytes.Buffer
-	if _, err := buf.ReadFrom(r); err != nil {
-		t.Fatal(err)
-	}
-	out := buf.String()
 	for _, want := range []string{"NAME", "READY", "a", "True", "b", NoneValue} {
 		if !strings.Contains(out, want) {
 			t.Errorf("PrintItems output missing %q; got:\n%s", want, out)
 		}
+	}
+}
+
+func TestPrintObjectsTableAndWide(t *testing.T) {
+	type row struct{ name, ready, age string }
+	items := []row{{"a", "True", "5m"}, {"b", NoneValue, "1h"}}
+	hdr := []string{"NAME", "READY"}
+	rowFn := func(r row) []string { return []string{r.name, r.ready} }
+	wideHdr := []string{"AGE"}
+	wideFn := func(r row) []string { return []string{r.age} }
+
+	out := captureStdout(t, func() error { return PrintObjects(OutputTable, items, hdr, rowFn, wideHdr, wideFn) })
+	if strings.Contains(out, "AGE") {
+		t.Errorf("table output must not include wide columns:\n%s", out)
+	}
+	if !strings.Contains(out, "NAME") || !strings.Contains(out, "a") {
+		t.Errorf("table missing base columns:\n%s", out)
+	}
+
+	out = captureStdout(t, func() error { return PrintObjects(OutputWide, items, hdr, rowFn, wideHdr, wideFn) })
+	if !strings.Contains(out, "AGE") || !strings.Contains(out, "5m") {
+		t.Errorf("wide output missing AGE:\n%s", out)
+	}
+
+	out = captureStdout(t, func() error { return PrintObjects(OutputJSON, items, hdr, rowFn, wideHdr, wideFn) })
+	if !strings.HasPrefix(strings.TrimSpace(out), "[") {
+		t.Errorf("json output should be an array:\n%s", out)
+	}
+}
+
+func TestPrintStructured(t *testing.T) {
+	obj := map[string]string{"name": "hello"}
+
+	out := captureStdout(t, func() error {
+		handled, err := PrintStructured(OutputTable, obj)
+		if handled {
+			t.Error("table must not be handled by PrintStructured")
+		}
+		return err
+	})
+	if out != "" {
+		t.Errorf("expected no output for table, got %q", out)
+	}
+
+	out = captureStdout(t, func() error {
+		handled, err := PrintStructured(OutputYAML, obj)
+		if !handled {
+			t.Error("yaml must be handled")
+		}
+		return err
+	})
+	if !strings.Contains(out, "name: hello") {
+		t.Errorf("yaml not printed:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## What

Adds `kubectl`-style `-o json|yaml|wide` output to the Fission CLI read commands. **Backward compatible** — no flag keeps today's exact table output (including the `READY` column from #3397). First of the three CLI-UX follow-ups designed after the spec/cobra refactor (#3398).

Design + plan committed under `docs/cli-refactor/` (`2026-05-25-output-formats-design.md`, `-plan.md`).

### Behavior
- `-o json` → JSON array of the (already-filtered) objects; `-o yaml` → YAML sequence (via `sigs.k8s.io/yaml`); single object for describe commands.
- `-o wide` → current table + an `AGE` column (from `CreationTimestamp`).
- no flag → byte-for-byte the current table.
- invalid value → `Error: invalid output format "x": valid values are wide, json, yaml` (exit 1).

### Scope
- **list:** function, environment, httptrigger, timetrigger, mqtrigger, kubewatch (`watch`), canaryconfig, package.
- **describe (json/yaml):** `fn getmeta`, `pkg info`, `canary get`, `ht get`.
- The download commands that already own `-o` (`pkg getsrc/getdeploy`, `archive`, `support dump`) are untouched — no collision since no command registers both.

### Implementation
- New format-aware printer in `pkg/fission-cli/util/output.go`: `OutputFormat` + `ParseOutputFormat`, a pure `encode`, `AgeOf`, and `PrintObjects[T]` (list) / `PrintStructured` (describe), layered on the existing `PrintTable`/`PrintItems`.
- New optional `--output`/`-o` flag (`flag.Output`, reusing the existing `flagkey.Output`).
- Each in-scope command parses the format and routes through the printer; default path is unchanged.

### Notes / intentional deviations from the draft design
- JSON/YAML marshal the slice directly (array/sequence), not `---`-separated docs — friendlier to `jq`/`yq`.
- Wide columns append at the end (`AGE` last) to keep `PrintObjects` generic.
- `-o wide` on describe behaves like table (no extra columns) — json/yaml are the meaningful describe formats.

## Test
- `go build ./...`, `golangci-lint run ./pkg/fission-cli/... ./cmd/fission-cli/...` → 0 issues, full CLI test suite passes.
- Unit tests (`util/output_test.go`): `ParseOutputFormat` (valid/invalid/case), `encode` (json round-trip + yaml), `AgeOf`, `PrintObjects` (table/wide/json), `PrintStructured`. Coverage on new fns: ParseOutputFormat 100%, PrintObjects 92%, PrintStructured 86%, AgeOf 100%.
- Command-level test (`function/list_test.go`) against a fake clientset: `-o json` (array), `-o wide` (AGE column), default (no AGE), invalid (error) — `List` 100% / `do` 81%.
- Manual on kind: default table unchanged; `-o wide` adds AGE; `fn list -o json | jq`, `-o yaml` (apiVersion/kind present); `pkg list -o json`; `fn getmeta -o json`; `-o bogus` errors with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3399)
<!-- Reviewable:end -->
