### PR TITLE
fission-cli: add 'wait --for=condition' to condition-bearing resources

### DIFF
--- a/pkg/fission-cli/cmd/canaryconfig/command.go
+++ b/pkg/fission-cli/cmd/canaryconfig/command.go
@@ -63,7 +63,15 @@ func Commands() *cobra.Command {
 		Short:   "Create, Update and manage canary configs",
 	}
 
-	command.AddCommand(createCmd, getCmd, updateCmd, deleteCmd, listCmd)
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a canary config to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.CanaryName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespaceCanary, flag.WaitTimeout},
+	})
+
+	command.AddCommand(createCmd, getCmd, updateCmd, deleteCmd, listCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/canaryconfig/wait.go
+++ b/pkg/fission-cli/cmd/canaryconfig/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package canaryconfig
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the CanaryConfig reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.CanaryName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		obj, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return obj.Status.Conditions, nil
+	}
+	return util.RunWait(input, "CanaryConfig", name, get)
+}

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -180,13 +180,21 @@ func Commands() *cobra.Command {
 		Optional: []flag.Flag{flag.NamespaceFunction},
 	})
 
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a function to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.FnName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespaceFunction, flag.WaitTimeout},
+	})
+
 	command := &cobra.Command{
 		Use:     "function",
 		Aliases: []string{"fn"},
 		Short:   "Create, update and manage functions",
 	}
 	command.AddCommand(createCmd, getCmd, getmetaCmd, updateCmd, deleteCmd, listCmd, logsCmd, testCmd,
-		runContainerCmd, updateContainerCmd, listPodsCmd)
+		runContainerCmd, updateContainerCmd, listPodsCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/function/wait.go
+++ b/pkg/fission-cli/cmd/function/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package function
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the function reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.FnName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		fn, err := opts.Client().FissionClientSet.CoreV1().Functions(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return fn.Status.Conditions, nil
+	}
+	return util.RunWait(input, "Function", name, get)
+}

--- a/pkg/fission-cli/cmd/function/wait_test.go
+++ b/pkg/fission-cli/cmd/function/wait_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package function
+
+import (
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+func TestFunctionWait(t *testing.T) {
+	ready := &fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: "rdy", Namespace: "default"},
+		Status: fv1.FunctionStatus{Conditions: []metav1.Condition{
+			{Type: fv1.FunctionConditionReady, Status: metav1.ConditionTrue},
+		}},
+	}
+	notReady := &fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: "notrdy", Namespace: "default"},
+		Status: fv1.FunctionStatus{Conditions: []metav1.Condition{
+			{Type: fv1.FunctionConditionReady, Status: metav1.ConditionFalse},
+		}},
+	}
+	cmd.ResetClientsetForTest()
+	cmd.SetClientset(cmd.Client{
+		FissionClientSet: fissionfake.NewClientset(ready, notReady),
+		Namespace:        "default",
+	})
+
+	t.Run("returns when condition already met", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.FnName, "rdy")
+		in.Set(flagkey.WaitFor, "condition=Ready")
+		in.Set(flagkey.WaitTimeout, 2*time.Second)
+		if err := Wait(in); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+
+	t.Run("times out when condition not met", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.FnName, "notrdy")
+		in.Set(flagkey.WaitFor, "condition=Ready")
+		in.Set(flagkey.WaitTimeout, 30*time.Millisecond)
+		if err := Wait(in); err == nil {
+			t.Fatal("expected a timeout error")
+		}
+	})
+}

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -69,7 +69,7 @@ func Commands() *cobra.Command {
 
 	waitCmd := wrapper.SubCommand(&cobra.Command{
 		Use:   "wait",
-		Short: "Wait for a HTTP trigger to reach a status condition",
+		Short: "Wait for an HTTP trigger to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.HtName, flag.WaitFor},
 		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -67,7 +67,15 @@ func Commands() *cobra.Command {
 		Short:   "Create, update and manage HTTP triggers",
 	}
 
-	command.AddCommand(createCmd, getCmd, updateCmd, deleteCmd, listCmd)
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a HTTP trigger to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.HtName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+	})
+
+	command.AddCommand(createCmd, getCmd, updateCmd, deleteCmd, listCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/httptrigger/wait.go
+++ b/pkg/fission-cli/cmd/httptrigger/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httptrigger
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the HTTPTrigger reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.HtName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		obj, err := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return obj.Status.Conditions, nil
+	}
+	return util.RunWait(input, "HTTPTrigger", name, get)
+}

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -46,7 +46,15 @@ func Commands() *cobra.Command {
 		Short:   "Create, update and manage kube watcher",
 	}
 
-	command.AddCommand(createCmd, deleteCmd, listCmd)
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a kube watcher to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.KwName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+	})
+
+	command.AddCommand(createCmd, deleteCmd, listCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/kubewatch/wait.go
+++ b/pkg/fission-cli/cmd/kubewatch/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package kubewatch
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the KubernetesWatchTrigger reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.KwName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		obj, err := opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return obj.Status.Conditions, nil
+	}
+	return util.RunWait(input, "KubernetesWatchTrigger", name, get)
+}

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -60,7 +60,15 @@ func Commands() *cobra.Command {
 		Short:   "Create, update and manage message queue triggers",
 	}
 
-	command.AddCommand(createCmd, updateCmd, deleteCmd, listCmd)
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a message queue trigger to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.MqtName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+	})
+
+	command.AddCommand(createCmd, updateCmd, deleteCmd, listCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/mqtrigger/wait.go
+++ b/pkg/fission-cli/cmd/mqtrigger/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mqtrigger
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the MessageQueueTrigger reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.MqtName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		obj, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return obj.Status.Conditions, nil
+	}
+	return util.RunWait(input, "MessageQueueTrigger", name, get)
+}

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -85,7 +85,15 @@ func Commands() *cobra.Command {
 		Short:   "Create, update and manage packages",
 	}
 
-	command.AddCommand(createCmd, getSrcCmd, getDeployCmd, updateCmd, deleteCmd, listCmd, infoCmd, rebuildCmd)
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a package to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.PkgName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespacePackage, flag.WaitTimeout},
+	})
+
+	command.AddCommand(createCmd, getSrcCmd, getDeployCmd, updateCmd, deleteCmd, listCmd, infoCmd, rebuildCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/package/wait.go
+++ b/pkg/fission-cli/cmd/package/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package _package
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the Package reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.PkgName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		obj, err := opts.Client().FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return obj.Status.Conditions, nil
+	}
+	return util.RunWait(input, "Package", name, get)
+}

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -68,7 +68,15 @@ func Commands() *cobra.Command {
 		Short:   "Create, update and manage time triggers",
 	}
 
-	command.AddCommand(createCmd, updateCmd, deleteCmd, listCmd, showCmd)
+	waitCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "wait",
+		Short: "Wait for a time trigger to reach a status condition",
+	}, Wait, flag.FlagSet{
+		Required: []flag.Flag{flag.TtName, flag.WaitFor},
+		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+	})
+
+	command.AddCommand(createCmd, updateCmd, deleteCmd, listCmd, showCmd, waitCmd)
 
 	return command
 }

--- a/pkg/fission-cli/cmd/timetrigger/wait.go
+++ b/pkg/fission-cli/cmd/timetrigger/wait.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package timetrigger
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+type WaitSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Wait blocks until the TimeTrigger reaches the --for condition or the timeout.
+func Wait(input cli.Input) error {
+	return (&WaitSubCommand{}).do(input)
+}
+
+func (opts *WaitSubCommand) do(input cli.Input) error {
+	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	if err != nil {
+		return err
+	}
+	name := input.String(flagkey.TtName)
+
+	get := func(ctx context.Context) ([]metav1.Condition, error) {
+		obj, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+		return obj.Status.Conditions, nil
+	}
+	return util.RunWait(input, "TimeTrigger", name, get)
+}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -80,7 +80,7 @@ var (
 	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Short: "A", Usage: "Fetch resources from all namespaces"}
 	Output               = Flag{Type: String, Name: flagkey.Output, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
 	WaitFor              = Flag{Type: String, Name: flagkey.WaitFor, Usage: "Condition to wait for, e.g. condition=Ready or condition=Ready=False"}
-	WaitTimeout          = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: 60 * time.Second, Usage: "Maximum time to wait for the condition before giving up"}
+	WaitTimeout          = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: util.DefaultWaitTimeout, Usage: "Maximum time to wait for the condition before giving up"}
 	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -79,6 +79,8 @@ var (
 	ForceDelete          = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
 	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Short: "A", Usage: "Fetch resources from all namespaces"}
 	Output               = Flag{Type: String, Name: flagkey.Output, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
+	WaitFor              = Flag{Type: String, Name: flagkey.WaitFor, Usage: "Condition to wait for, e.g. condition=Ready or condition=Ready=False"}
+	WaitTimeout          = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: 60 * time.Second, Usage: "Maximum time to wait for the condition before giving up"}
 	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
 	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -179,5 +179,8 @@ const (
 	ArchiveID     = "id"
 	ArchiveOutput = Output
 
+	WaitFor     = "for"
+	WaitTimeout = "timeout"
+
 	DefaultSpecOutputDir = "fission-dump"
 )

--- a/pkg/fission-cli/util/wait.go
+++ b/pkg/fission-cli/util/wait.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/conditions"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+// defaultWaitTimeout is used when --timeout is unset or non-positive.
+const defaultWaitTimeout = 60 * time.Second
+
+// ParseForCondition parses a --for value of the form "condition=<Type>" or
+// "condition=<Type>=<Status>". The status defaults to True. It mirrors
+// `kubectl wait --for=condition=...`.
+func ParseForCondition(s string) (condType string, want metav1.ConditionStatus, err error) {
+	rest, ok := strings.CutPrefix(s, "condition=")
+	if !ok || rest == "" {
+		return "", "", fmt.Errorf("invalid --for %q: expected condition=<Type> or condition=<Type>=<Status>", s)
+	}
+	typ, status, hasStatus := strings.Cut(rest, "=")
+	if typ == "" {
+		return "", "", fmt.Errorf("invalid --for %q: empty condition type", s)
+	}
+	want = metav1.ConditionTrue
+	if hasStatus {
+		switch metav1.ConditionStatus(status) {
+		case metav1.ConditionTrue, metav1.ConditionFalse, metav1.ConditionUnknown:
+			want = metav1.ConditionStatus(status)
+		default:
+			return "", "", fmt.Errorf("invalid --for %q: status must be True, False or Unknown", s)
+		}
+	}
+	return typ, want, nil
+}
+
+// WaitForCondition polls get until the named condition reaches want, or ctx is
+// done. A not-found result keeps polling (the resource may appear within the
+// deadline); any other get error is returned immediately. On timeout it reports
+// the last observed status. interval is the poll period.
+func WaitForCondition(ctx context.Context, get func(context.Context) ([]metav1.Condition, error), condType string, want metav1.ConditionStatus, interval time.Duration) error {
+	lastSeen := "<none>"
+	for {
+		conds, err := get(ctx)
+		switch {
+		case err == nil:
+			if c := conditions.Find(conds, condType); c != nil {
+				lastSeen = string(c.Status)
+				if c.Status == want {
+					return nil
+				}
+			}
+		case IsNotFound(err):
+			lastSeen = "NotFound"
+		default:
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out waiting for condition %q=%q (last seen %q): %w", condType, want, lastSeen, ctx.Err())
+		case <-time.After(interval):
+		}
+	}
+}
+
+// RunWait is the shared glue for every resource's `wait` subcommand: it parses
+// --for / --timeout, polls get until the condition is met (or the deadline),
+// and prints the outcome. get fetches the target resource's Status.Conditions.
+func RunWait(input cli.Input, kind, name string, get func(context.Context) ([]metav1.Condition, error)) error {
+	condType, want, err := ParseForCondition(input.String(flagkey.WaitFor))
+	if err != nil {
+		return err
+	}
+	timeout := input.Duration(flagkey.WaitTimeout)
+	if timeout <= 0 {
+		timeout = defaultWaitTimeout
+	}
+
+	ctx, cancel := context.WithTimeout(input.Context(), timeout)
+	defer cancel()
+
+	if err := WaitForCondition(ctx, get, condType, want, time.Second); err != nil {
+		return fmt.Errorf("%s/%s: %w", kind, name, err)
+	}
+	fmt.Printf("%s/%s condition met: %s=%s\n", kind, name, condType, want)
+	return nil
+}

--- a/pkg/fission-cli/util/wait.go
+++ b/pkg/fission-cli/util/wait.go
@@ -18,8 +18,10 @@ import (
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 )
 
-// defaultWaitTimeout is used when --timeout is unset or non-positive.
-const defaultWaitTimeout = 60 * time.Second
+// DefaultWaitTimeout is the wait timeout used when --timeout is unset or
+// non-positive. It is also the declared default of the --timeout flag, so both
+// the flag definition and the runtime fallback share this single source.
+const DefaultWaitTimeout = 60 * time.Second
 
 // ParseForCondition parses a --for value of the form "condition=<Type>" or
 // "condition=<Type>=<Status>". The status defaults to True. It mirrors
@@ -102,7 +104,7 @@ func RunWait(input cli.Input, kind, name string, get func(context.Context) ([]me
 	}
 	timeout := input.Duration(flagkey.WaitTimeout)
 	if timeout <= 0 {
-		timeout = defaultWaitTimeout
+		timeout = DefaultWaitTimeout
 	}
 
 	ctx, cancel := context.WithTimeout(input.Context(), timeout)

--- a/pkg/fission-cli/util/wait.go
+++ b/pkg/fission-cli/util/wait.go
@@ -6,6 +6,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -46,10 +47,13 @@ func ParseForCondition(s string) (condType string, want metav1.ConditionStatus, 
 
 // WaitForCondition polls get until the named condition reaches want, or ctx is
 // done. A not-found result keeps polling (the resource may appear within the
-// deadline); any other get error is returned immediately. On timeout it reports
-// the last observed status. interval is the poll period.
+// deadline); a get error caused by ctx ending is folded into the wait result so
+// the last-seen status is still reported; any other get error is returned
+// immediately. interval is the poll period.
 func WaitForCondition(ctx context.Context, get func(context.Context) ([]metav1.Condition, error), condType string, want metav1.ConditionStatus, interval time.Duration) error {
-	lastSeen := "<none>"
+	lastSeen := NoneValue
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
 	for {
 		conds, err := get(ctx)
 		switch {
@@ -62,16 +66,30 @@ func WaitForCondition(ctx context.Context, get func(context.Context) ([]metav1.C
 			}
 		case IsNotFound(err):
 			lastSeen = "NotFound"
+		case ctx.Err() != nil:
+			// The wait deadline/cancellation interrupted the in-flight get;
+			// fall through to the ctx.Done() branch so we report the outcome
+			// (and last-seen status) consistently rather than the raw error.
 		default:
 			return err
 		}
 
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timed out waiting for condition %q=%q (last seen %q): %w", condType, want, lastSeen, ctx.Err())
-		case <-time.After(interval):
+			return waitTimeoutError(ctx, condType, want, lastSeen)
+		case <-ticker.C:
 		}
 	}
+}
+
+// waitTimeoutError formats the terminal wait error, distinguishing a deadline
+// from an explicit cancellation so the message is accurate.
+func waitTimeoutError(ctx context.Context, condType string, want metav1.ConditionStatus, lastSeen string) error {
+	verb := "timed out"
+	if errors.Is(ctx.Err(), context.Canceled) {
+		verb = "canceled while"
+	}
+	return fmt.Errorf("%s waiting for condition %q=%q (last seen %q): %w", verb, condType, want, lastSeen, ctx.Err())
 }
 
 // RunWait is the shared glue for every resource's `wait` subcommand: it parses

--- a/pkg/fission-cli/util/wait_test.go
+++ b/pkg/fission-cli/util/wait_test.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+func TestParseForCondition(t *testing.T) {
+	tests := []struct {
+		in       string
+		wantType string
+		wantSt   metav1.ConditionStatus
+		wantErr  bool
+	}{
+		{"condition=Ready", "Ready", metav1.ConditionTrue, false},
+		{"condition=Ready=True", "Ready", metav1.ConditionTrue, false},
+		{"condition=Ready=False", "Ready", metav1.ConditionFalse, false},
+		{"condition=BuildSucceeded=Unknown", "BuildSucceeded", metav1.ConditionUnknown, false},
+		{"", "", "", true},
+		{"Ready", "", "", true},                 // missing condition= prefix
+		{"condition=", "", "", true},            // empty type
+		{"condition=Ready=Maybe", "", "", true}, // bad status
+	}
+	for _, tt := range tests {
+		typ, st, err := ParseForCondition(tt.in)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("ParseForCondition(%q) err=%v wantErr=%v", tt.in, err, tt.wantErr)
+			continue
+		}
+		if err == nil && (typ != tt.wantType || st != tt.wantSt) {
+			t.Errorf("ParseForCondition(%q) = (%q,%q), want (%q,%q)", tt.in, typ, st, tt.wantType, tt.wantSt)
+		}
+	}
+}
+
+func conds(status metav1.ConditionStatus) []metav1.Condition {
+	return []metav1.Condition{{Type: "Ready", Status: status}}
+}
+
+func TestWaitForCondition(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("met immediately", func(t *testing.T) {
+		get := func(context.Context) ([]metav1.Condition, error) { return conds(metav1.ConditionTrue), nil }
+		if err := WaitForCondition(ctx, get, "Ready", metav1.ConditionTrue, time.Millisecond); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+
+	t.Run("met after a few polls", func(t *testing.T) {
+		n := 0
+		get := func(context.Context) ([]metav1.Condition, error) {
+			n++
+			if n < 3 {
+				return conds(metav1.ConditionFalse), nil
+			}
+			return conds(metav1.ConditionTrue), nil
+		}
+		if err := WaitForCondition(ctx, get, "Ready", metav1.ConditionTrue, time.Millisecond); err != nil {
+			t.Fatalf("expected eventual success, got %v", err)
+		}
+		if n < 3 {
+			t.Fatalf("expected at least 3 polls, got %d", n)
+		}
+	})
+
+	t.Run("keeps polling through NotFound", func(t *testing.T) {
+		n := 0
+		get := func(context.Context) ([]metav1.Condition, error) {
+			n++
+			if n < 2 {
+				return nil, fmt.Errorf("functions.fission.io %q not found", "x")
+			}
+			return conds(metav1.ConditionTrue), nil
+		}
+		if err := WaitForCondition(ctx, get, "Ready", metav1.ConditionTrue, time.Millisecond); err != nil {
+			t.Fatalf("not-found should not abort the wait, got %v", err)
+		}
+	})
+
+	t.Run("timeout reports last seen", func(t *testing.T) {
+		tctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+		defer cancel()
+		get := func(context.Context) ([]metav1.Condition, error) { return conds(metav1.ConditionFalse), nil }
+		err := WaitForCondition(tctx, get, "Ready", metav1.ConditionTrue, time.Millisecond)
+		if err == nil || !strings.Contains(err.Error(), "last seen \"False\"") {
+			t.Fatalf("expected timeout mentioning last seen False, got %v", err)
+		}
+	})
+
+	t.Run("non-notfound error returned immediately", func(t *testing.T) {
+		get := func(context.Context) ([]metav1.Condition, error) { return nil, fmt.Errorf("boom") }
+		if err := WaitForCondition(ctx, get, "Ready", metav1.ConditionTrue, time.Millisecond); err == nil || err.Error() != "boom" {
+			t.Fatalf("expected the raw error, got %v", err)
+		}
+	})
+}
+
+func TestRunWait(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.WaitFor, "condition=Ready")
+		in.Set(flagkey.WaitTimeout, 2*time.Second)
+		get := func(context.Context) ([]metav1.Condition, error) { return conds(metav1.ConditionTrue), nil }
+		if err := RunWait(in, "Function", "hello", get); err != nil {
+			t.Fatalf("expected success, got %v", err)
+		}
+	})
+
+	t.Run("invalid --for", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.WaitFor, "Ready")
+		get := func(context.Context) ([]metav1.Condition, error) { return conds(metav1.ConditionTrue), nil }
+		if err := RunWait(in, "Function", "hello", get); err == nil {
+			t.Fatal("expected an error for invalid --for")
+		}
+	})
+
+	t.Run("timeout wraps kind/name", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.WaitFor, "condition=Ready")
+		in.Set(flagkey.WaitTimeout, 20*time.Millisecond)
+		get := func(context.Context) ([]metav1.Condition, error) { return conds(metav1.ConditionFalse), nil }
+		err := RunWait(in, "Function", "hello", get)
+		if err == nil || !strings.Contains(err.Error(), "Function/hello") {
+			t.Fatalf("expected timeout error mentioning Function/hello, got %v", err)
+		}
+	})
+}

--- a/test/integration/suites/common/wait_test.go
+++ b/test/integration/suites/common/wait_test.go
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestWait_FunctionCondition exercises the `fission fn wait --for=condition=...`
+// command end to end against the apiserver. It writes a uniquely-typed smoke
+// condition via UpdateStatus (so the assertion stays stable regardless of which
+// conditions controllers populate), then verifies:
+//   - wait returns success once the condition holds the requested status, and
+//   - wait fails (non-zero exit) when the requested status is never reached.
+//
+// It reuses minimalFunction / smokeConditionType from conditions_test.go.
+func TestWait_FunctionCondition(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	f := framework.Connect(t)
+	ns := f.NewTestNamespace(t)
+	fc := f.FissionClient().CoreV1()
+
+	name := "wait-fn-" + ns.ID
+	_, err := fc.Functions(ns.Name).Create(ctx, minimalFunction(name, ns.Name), metav1.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = fc.Functions(ns.Name).Delete(context.Background(), name, metav1.DeleteOptions{})
+	})
+
+	// Drive the smoke condition to True via the status subresource.
+	fn, err := fc.Functions(ns.Name).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
+		Type:               smokeConditionType,
+		Status:             metav1.ConditionTrue,
+		Reason:             "WaitSmoke",
+		LastTransitionTime: metav1.Now(),
+		ObservedGeneration: fn.Generation,
+	})
+	_, err = fc.Functions(ns.Name).UpdateStatus(ctx, fn, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	// Already True → wait returns success and prints the "condition met" line.
+	out := ns.CLICaptureStdout(t, ctx, "fn", "wait", "--name", name,
+		"--for=condition="+smokeConditionType, "--timeout=15s")
+	require.Contains(t, out, "condition met")
+
+	// Requesting a status the condition never reaches must time out (error).
+	_, err = ns.CLICaptureStdoutBestEffort(t, ctx, "fn", "wait", "--name", name,
+		"--for=condition="+smokeConditionType+"=False", "--timeout=2s")
+	require.Error(t, err, "wait for an unreached condition status must fail")
+}


### PR DESCRIPTION
## What

Adds a `kubectl wait`-style subcommand so scripts/CI/GitOps can block until a resource reaches a status condition. Second of the CLI-UX follow-ups built on RFC-0003 conditions + #3397.

```
fission <res> wait --name <name> --for=condition=<Type>[=<Status>] [--timeout=<dur>]
```

- `fission fn wait --name hello --for=condition=Ready --timeout=2m`
- `fission pkg wait --name p1 --for=condition=BuildSucceeded`
- `fission ht wait --name r1 --for=condition=Ready`

Available on the 7 resources that write conditions: **function, package, httptrigger, timetrigger, mqtrigger, watch (kubewatch), canaryconfig**. Environment is omitted (it intentionally writes no conditions, so a wait could never succeed).

### Behavior
- `--for=condition=<Type>` (status defaults to `True`) or `condition=<Type>=<Status>` (True/False/Unknown).
- Polls the resource (~1s) until the condition matches or `--timeout` (default 60s) elapses. A not-found result keeps polling (the resource may appear); other Get errors return immediately.
- Success: `<Kind>/<name> condition met: <Type>=<Status>` (exit 0). Timeout: descriptive error with last-seen status (**non-zero exit** for CI).

### Implementation
- Shared, dependency-light core in `pkg/fission-cli/util/wait.go`: `ParseForCondition`, `WaitForCondition` (poll loop, reuses `pkg/conditions.Find`; not-found tolerant via `util.IsNotFound`), and `RunWait` CLI glue. Poll (not watch) — consistent with the existing `spec waitForPackageBuild`.
- New `--for` / `--timeout` flags.
- Each resource gets a thin `wait.go` (resolve ns+name, build a `func(ctx) ([]metav1.Condition, error)` closure over its typed client, call `util.RunWait`) + a registered `wait` subcommand.

Backward compatible — new subcommand + flags only.

## Test
- `go build ./...`, `golangci-lint` (0 issues), full CLI test suite pass; SPDX headers on all new files (`make license-check` clean on the tracked tree).
- Unit: `util/wait_test.go` — `ParseForCondition` (valid/invalid/status), `WaitForCondition` (met immediately / after N polls / tolerates NotFound / timeout reports last-seen / non-notfound error surfaced), `RunWait` (success / invalid --for / timeout wraps kind/name). `function/wait_test.go` — `Wait` against a fake clientset (condition met → success; not met + tiny timeout → error).
- Manual on kind: `ht wait`/`timer wait --for=condition=Ready` → `condition met: Ready=True` (exit 0); `fn wait --timeout=2s` on a never-served function → timeout error, **exit 1**; invalid `--for=Ready` rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3402)
<!-- Reviewable:end -->
