### PR TITLE
fission-cli: add 'spec apply --dry-run'

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -115,8 +115,11 @@ func (opts *ApplySubCommand) run(input cli.Input) error {
 	specIgnore := util.GetSpecIgnore(input)
 	applyCommitLabel := input.Bool(flagkey.SpecApplyCommitLabel)
 	deleteResources := input.Bool(flagkey.SpecDelete)
-	watchResources := input.Bool(flagkey.SpecWatch)
-	waitForBuild := input.Bool(flagkey.SpecWait)
+	dryRun := input.Bool(flagkey.SpecApplyDryRun)
+	// --watch/--wait drive package-build polling, which is meaningless when
+	// nothing is applied, so they are inert under --dry-run.
+	watchResources := input.Bool(flagkey.SpecWatch) && !dryRun
+	waitForBuild := input.Bool(flagkey.SpecWait) && !dryRun
 	validateSpecs := util.GetValidationFlag(input)
 
 	var watcher *fsnotify.Watcher
@@ -181,11 +184,11 @@ func (opts *ApplySubCommand) run(input cli.Input) error {
 		}
 
 		// make changes to the cluster based on the specs
-		pkgMetas, as, err := applyResources(input, opts.Client(), specDir, fr, deleteResources, input.Bool(flagkey.SpecAllowConflicts))
+		pkgMetas, as, err := applyResources(input, opts.Client(), specDir, fr, deleteResources, input.Bool(flagkey.SpecAllowConflicts), dryRun)
 		if err != nil {
 			return fmt.Errorf("error applying specs: %w", err)
 		}
-		printApplyStatus(as)
+		printApplyStatus(as, dryRun)
 
 		if watchResources || waitForBuild {
 			// watch package builds
@@ -291,28 +294,36 @@ func waitForFileWatcherToSettleDown(watcher *fsnotify.Watcher) error {
 
 // printApplyStatus prints a summary of what changed on the
 // cluster as the result of a spec apply operation.
-func printApplyStatus(applyStatus map[string]ResourceApplyStatus) {
+// printApplyStatus prints the per-kind summary of an apply. When dryRun is set
+// the verbs switch to "would be …" and a "(dry run - no changes made)" footer
+// is appended, so the preview is unambiguous.
+func printApplyStatus(applyStatus map[string]ResourceApplyStatus, dryRun bool) {
+	created, updated, deleted := "created", "updated", "deleted"
+	if dryRun {
+		created, updated, deleted = "would be created", "would be updated", "would be deleted"
+	}
+
 	changed := false
 	for typ, ras := range applyStatus {
-		n := len(ras.Created)
-		if n > 0 {
+		if n := len(ras.Created); n > 0 {
 			changed = true
-			fmt.Printf("%v %v created: %v\n", n, pluralize(n, typ), strings.Join(metadataNames(ras.Created), ", "))
+			fmt.Printf("%v %v %v: %v\n", n, pluralize(n, typ), created, strings.Join(metadataNames(ras.Created), ", "))
 		}
-		n = len(ras.Updated)
-		if n > 0 {
+		if n := len(ras.Updated); n > 0 {
 			changed = true
-			fmt.Printf("%v %v updated: %v\n", n, pluralize(n, typ), strings.Join(metadataNames(ras.Updated), ", "))
+			fmt.Printf("%v %v %v: %v\n", n, pluralize(n, typ), updated, strings.Join(metadataNames(ras.Updated), ", "))
 		}
-		n = len(ras.Deleted)
-		if n > 0 {
+		if n := len(ras.Deleted); n > 0 {
 			changed = true
-			fmt.Printf("%v %v deleted: %v\n", n, pluralize(n, typ), strings.Join(metadataNames(ras.Deleted), ", "))
+			fmt.Printf("%v %v %v: %v\n", n, pluralize(n, typ), deleted, strings.Join(metadataNames(ras.Deleted), ", "))
 		}
 	}
 
 	if !changed {
 		fmt.Println("Everything up to date.")
+	}
+	if dryRun {
+		fmt.Println("(dry run - no changes made)")
 	}
 }
 
@@ -334,7 +345,13 @@ func pluralize(num int, word string) string {
 }
 
 // applyArchives figures out the set of archives that need to be uploaded, and uploads them.
-func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources) error {
+// Under dryRun it is a no-op: uploading is a real mutation, and the resolved
+// archive URLs are only needed for an actual create/update, so the spec keeps
+// its archive:// references untouched.
+func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool) error {
+	if dryRun {
+		return nil
+	}
 
 	// archive:// URL -> archive map.
 	archiveFiles := make(map[string]fv1.Archive)
@@ -406,24 +423,25 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 	return nil
 }
 
-// applyResources applies the given set of fission resources.
-func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, map[string]ResourceApplyStatus, error) {
+// applyResources applies the given set of fission resources. When dryRun is set
+// it performs the read-only diff only, making no changes to the cluster.
+func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, map[string]ResourceApplyStatus, error) {
 
 	applyStatus := make(map[string]ResourceApplyStatus)
 
 	// upload archives that need to be uploaded. Changes archive references in fr.Packages.
-	err := applyArchives(input, fclient, specDir, fr)
+	err := applyArchives(input, fclient, specDir, fr, dryRun)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	_, ras, err := applyEnvironments(input.Context(), fclient, fr, delete, specAllowConflicts)
+	_, ras, err := applyEnvironments(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("environment apply failed: %w", err)
 	}
 	applyStatus["environment"] = *ras
 
-	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts)
+	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("package apply failed: %w", err)
 	}
@@ -452,31 +470,31 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 		fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
 	}
 
-	_, ras, err = applyFunctions(input.Context(), fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyFunctions(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("function apply failed: %w", err)
 	}
 	applyStatus["function"] = *ras
 
-	_, ras, err = applyHTTPTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyHTTPTriggers(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("HTTPTrigger apply failed: %w", err)
 	}
 	applyStatus["HTTPTrigger"] = *ras
 
-	_, ras, err = applyKubernetesWatchTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyKubernetesWatchTriggers(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("kubernetesWatchTrigger apply failed: %w", err)
 	}
 	applyStatus["KubernetesWatchTrigger"] = *ras
 
-	_, ras, err = applyTimeTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyTimeTriggers(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("timeTrigger apply failed: %w", err)
 	}
 	applyStatus["TimeTrigger"] = *ras
 
-	_, ras, err = applyMessageQueueTriggers(input.Context(), fclient, fr, delete, specAllowConflicts)
+	_, ras, err = applyMessageQueueTriggers(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("messageQueueTrigger apply failed: %w", err)
 	}
@@ -607,7 +625,7 @@ func waitForPackageBuild(ctx context.Context, fclient cmd.Client, pkg *fv1.Packa
 	}
 }
 
-func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	packages := func(ns string) typedv1.PackageInterface {
 		return fclient.FissionClientSet.CoreV1().Packages(ns)
 	}
@@ -663,10 +681,10 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 		delete: func(ctx context.Context, ns, name string) error {
 			return packages(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
-func applyFunctions(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyFunctions(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	functions := func(ns string) typedv1.FunctionInterface {
 		return fclient.FissionClientSet.CoreV1().Functions(ns)
 	}
@@ -701,10 +719,10 @@ func applyFunctions(ctx context.Context, fclient cmd.Client, fr *FissionResource
 		delete: func(ctx context.Context, ns, name string) error {
 			return functions(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
-func applyEnvironments(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyEnvironments(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	environments := func(ns string) typedv1.EnvironmentInterface {
 		return fclient.FissionClientSet.CoreV1().Environments(ns)
 	}
@@ -739,10 +757,10 @@ func applyEnvironments(ctx context.Context, fclient cmd.Client, fr *FissionResou
 		delete: func(ctx context.Context, ns, name string) error {
 			return environments(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
-func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	triggers := func(ns string) typedv1.HTTPTriggerInterface {
 		return fclient.FissionClientSet.CoreV1().HTTPTriggers(ns)
 	}
@@ -783,10 +801,10 @@ func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResou
 		delete: func(ctx context.Context, ns, name string) error {
 			return triggers(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
-func applyKubernetesWatchTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyKubernetesWatchTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	watches := func(ns string) typedv1.KubernetesWatchTriggerInterface {
 		return fclient.FissionClientSet.CoreV1().KubernetesWatchTriggers(ns)
 	}
@@ -821,10 +839,10 @@ func applyKubernetesWatchTriggers(ctx context.Context, fclient cmd.Client, fr *F
 		delete: func(ctx context.Context, ns, name string) error {
 			return watches(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
-func applyTimeTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyTimeTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	triggers := func(ns string) typedv1.TimeTriggerInterface {
 		return fclient.FissionClientSet.CoreV1().TimeTriggers(ns)
 	}
@@ -859,10 +877,10 @@ func applyTimeTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResou
 		delete: func(ctx context.Context, ns, name string) error {
 			return triggers(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
-func applyMessageQueueTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyMessageQueueTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	triggers := func(ns string) typedv1.MessageQueueTriggerInterface {
 		return fclient.FissionClientSet.CoreV1().MessageQueueTriggers(ns)
 	}
@@ -897,7 +915,7 @@ func applyMessageQueueTriggers(ctx context.Context, fclient cmd.Client, fr *Fiss
 		delete: func(ctx context.Context, ns, name string) error {
 			return triggers(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
-	}, delete, specAllowConflicts)
+	}, delete, specAllowConflicts, dryRun)
 }
 
 func isObjectMetaEqual(existingObj, newObj metav1.ObjectMeta) bool {

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -345,14 +345,12 @@ func pluralize(num int, word string) string {
 }
 
 // applyArchives figures out the set of archives that need to be uploaded, and uploads them.
-// Under dryRun it is a no-op: uploading is a real mutation, and the resolved
-// archive URLs are only needed for an actual create/update, so the spec keeps
-// its archive:// references untouched.
+// Under dryRun the read-only work still runs — local archives are built/checksummed
+// and matched against archives already on the cluster — so the resolved Package
+// specs (and therefore the diff) are accurate for unchanged archives; only the
+// actual upload of a new/changed archive is skipped (such a Package legitimately
+// shows as a would-create/update).
 func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool) error {
-	if dryRun {
-		return nil
-	}
-
 	// archive:// URL -> archive map.
 	archiveFiles := make(map[string]fv1.Archive)
 
@@ -393,6 +391,12 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 			fmt.Printf("archive %v exists, not uploading\n", name)
 			ar.URL = url
 			archiveFiles[name] = ar
+		} else if dryRun {
+			// new/changed archive: a real apply would upload it and the owning
+			// Package would be created/updated. Skip the upload (a mutation) and
+			// leave the local reference so the Package shows as a would-change.
+			fmt.Printf("would upload archive %v\n", name)
+			continue
 		} else {
 			// doesn't exist, upload
 			fmt.Printf("uploading archive %v\n", name)
@@ -450,6 +454,12 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	// Each reference to a package from a function must contain the resource version
 	// of the package. This ensures that various caches can invalidate themselves
 	// when the package changes.
+	//
+	// Under --dry-run the package isn't actually updated, so pkgMeta carries the
+	// package's *current* ResourceVersion. A real apply that updates a package
+	// would bump its RV and thus also update the referencing functions; a dry-run
+	// can therefore under-report those cascaded function updates. This is inherent
+	// to a no-cluster-write preview (the post-update RV can't be known in advance).
 	for i, f := range fr.Functions {
 		if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
 			continue
@@ -777,10 +787,12 @@ func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResou
 		equal: func(e, d *fv1.HTTPTrigger) bool {
 			return isObjectMetaEqual(e.ObjectMeta, d.ObjectMeta) && reflect.DeepEqual(e.Spec, d.Spec)
 		},
+		// read-only duplicate-route check; runs in dry-run too so a preview
+		// surfaces the conflict a real apply would reject.
+		validate: func(ctx context.Context, t *fv1.HTTPTrigger) error {
+			return util.CheckHTTPTriggerDuplicates(ctx, fclient, t)
+		},
 		create: func(ctx context.Context, t *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
-			if err := util.CheckHTTPTriggerDuplicates(ctx, fclient, t); err != nil {
-				return nil, err
-			}
 			n, err := triggers(t.Namespace).Create(ctx, t, metav1.CreateOptions{})
 			if err != nil {
 				return nil, err
@@ -788,9 +800,6 @@ func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResou
 			return &n.ObjectMeta, nil
 		},
 		update: func(ctx context.Context, e, d *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
-			if err := util.CheckHTTPTriggerDuplicates(ctx, fclient, d); err != nil {
-				return nil, err
-			}
 			d.ResourceVersion = e.ResourceVersion
 			n, err := triggers(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
 			if err != nil {

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -455,11 +455,10 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	// of the package. This ensures that various caches can invalidate themselves
 	// when the package changes.
 	//
-	// Under --dry-run the package isn't actually updated, so pkgMeta carries the
-	// package's *current* ResourceVersion. A real apply that updates a package
-	// would bump its RV and thus also update the referencing functions; a dry-run
-	// can therefore under-report those cascaded function updates. This is inherent
-	// to a no-cluster-write preview (the post-update RV can't be known in advance).
+	// Under --dry-run pkgMeta carries the package's current ResourceVersion for
+	// no-op/created packages, and the dryRunResourceVersion sentinel for packages
+	// that would be updated — so a would-be package update correctly cascades into
+	// a would-be update of the functions that reference it, matching a real apply.
 	for i, f := range fr.Functions {
 		if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
 			continue

--- a/pkg/fission-cli/cmd/spec/command.go
+++ b/pkg/fission-cli/cmd/spec/command.go
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 		Short: "Create, update, or delete resources from application specification",
 	}, Apply, flag.FlagSet{
 		Optional: []flag.Flag{flag.SpecDir, flag.SpecIgnore, flag.SpecDelete, flag.SpecWait, flag.SpecWatch,
-			flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.ForceNamespace},
+			flag.SpecValidation, flag.SpecApplyCommitLabel, flag.SpecAllowConflicts, flag.ForceNamespace, flag.SpecApplyDryRun},
 	})
 
 	destroyCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -75,37 +75,37 @@ func forceDeleteResources(ctx context.Context, fclient cmd.Client, fr *FissionRe
 
 	var err error
 
-	_, _, err = applyHTTPTriggers(ctx, fclient, fr, true, false)
+	_, _, err = applyHTTPTriggers(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("HTTPTrigger delete failed: %w", err)
 	}
 
-	_, _, err = applyKubernetesWatchTriggers(ctx, fclient, fr, true, false)
+	_, _, err = applyKubernetesWatchTriggers(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("kubernetesWatchTrigger delete failed: %w", err)
 	}
 
-	_, _, err = applyTimeTriggers(ctx, fclient, fr, true, false)
+	_, _, err = applyTimeTriggers(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("timeTrigger delete failed: %w", err)
 	}
 
-	_, _, err = applyMessageQueueTriggers(ctx, fclient, fr, true, false)
+	_, _, err = applyMessageQueueTriggers(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("messageQueueTrigger delete failed: %w", err)
 	}
 
-	_, _, err = applyFunctions(ctx, fclient, fr, true, false)
+	_, _, err = applyFunctions(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("function delete failed: %w", err)
 	}
 
-	_, _, err = applyPackages(ctx, fclient, fr, true, false)
+	_, _, err = applyPackages(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("package delete failed: %w", err)
 	}
 
-	_, _, err = applyEnvironments(ctx, fclient, fr, true, false)
+	_, _, err = applyEnvironments(ctx, fclient, fr, true, false, false)
 	if err != nil {
 		return fmt.Errorf("environment delete failed: %w", err)
 	}

--- a/pkg/fission-cli/cmd/spec/resourcetype.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype.go
@@ -109,11 +109,15 @@ func applyResourceType[T any, PT Object[T]](
 	}
 
 	// Index the cluster objects this deployment owns, by namespace/name. Keep an
-	// ordered slice too so deletions print in a stable (list) order.
+	// ordered slice too so deletions print in a stable (list) order. allByName
+	// holds every cluster object's name (owned or not) so dry-run can detect the
+	// AlreadyExists conflict a real create would hit (see the create branch).
 	ownedByName := make(map[string]PT)
+	allByName := make(map[string]bool)
 	var owned []PT
 	for i := range clusterObjs {
 		obj := PT(&clusterObjs[i])
+		allByName[k8sCache.MetaObjectToName(obj).String()] = true
 		if allowConflicts || ownedByDeployment(obj, fr) {
 			ownedByName[k8sCache.MetaObjectToName(obj).String()] = obj
 			owned = append(owned, obj)
@@ -167,6 +171,14 @@ func applyResourceType[T any, PT Object[T]](
 				if err := ops.validate(ctx, ptr); err != nil {
 					return nil, nil, err
 				}
+			}
+			// A real apply calls Create here; if an object with this name already
+			// exists but isn't owned by this spec (so it wasn't a `found` update)
+			// and we're not adopting conflicts, the server returns AlreadyExists
+			// and the apply fails. Dry-run skips the call, so surface that conflict
+			// explicitly instead of reporting a would-create that can't happen.
+			if dryRun && !allowConflicts && allByName[name] {
+				return nil, nil, fmt.Errorf("%s already exists on the cluster and is not managed by this spec deployment; a real apply would fail with AlreadyExists (use --allowconflicts to adopt it)", name)
 			}
 			newMeta := ops.meta(ptr)
 			if !dryRun {

--- a/pkg/fission-cli/cmd/spec/resourcetype.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype.go
@@ -74,12 +74,20 @@ func ownedByDeployment(o metav1.Object, fr *FissionResources) bool {
 // are removed. It returns each desired object's metadata keyed by namespace/name
 // so callers can wire up cross-references such as a function's package
 // ResourceVersion.
+//
+// When dryRun is set, the same list/diff is performed read-only: the
+// create/update/delete client calls (and the per-deletion log line) are skipped,
+// but ras and the metadata map are still populated exactly as a real run would
+// report — using the desired object's metadata for would-be-creates and the
+// existing object's for would-be-updates — so the caller's summary and
+// cross-reference wiring stay correct without touching the cluster.
 func applyResourceType[T any, PT Object[T]](
 	ctx context.Context,
 	fr *FissionResources,
 	ops resourceOps[T, PT],
 	deleteStale bool,
 	allowConflicts bool,
+	dryRun bool,
 ) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 
 	clusterObjs, err := ops.list(ctx)
@@ -117,16 +125,26 @@ func applyResourceType[T any, PT Object[T]](
 			// Already up to date; record existing metadata for cross-refs.
 			metadata[name] = *ops.meta(existing)
 		case found:
-			newMeta, err := ops.update(ctx, existing, ptr)
-			if err != nil {
-				return nil, nil, err
+			// would-be update: record the existing metadata (carries the real
+			// ResourceVersion) for cross-refs; only mutate when not a dry run.
+			newMeta := ops.meta(existing)
+			if !dryRun {
+				newMeta, err = ops.update(ctx, existing, ptr)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
 			ras.Updated = append(ras.Updated, newMeta)
 			metadata[name] = *newMeta
 		default:
-			newMeta, err := ops.create(ctx, ptr)
-			if err != nil {
-				return nil, nil, err
+			// would-be create: record the desired metadata (RV empty); only
+			// mutate when not a dry run.
+			newMeta := ops.meta(ptr)
+			if !dryRun {
+				newMeta, err = ops.create(ctx, ptr)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
 			ras.Created = append(ras.Created, newMeta)
 			metadata[name] = *newMeta
@@ -139,11 +157,13 @@ func applyResourceType[T any, PT Object[T]](
 			if desired[name] {
 				continue
 			}
-			if err := ops.delete(ctx, obj.GetNamespace(), obj.GetName()); err != nil {
-				return nil, nil, err
+			if !dryRun {
+				if err := ops.delete(ctx, obj.GetNamespace(), obj.GetName()); err != nil {
+					return nil, nil, err
+				}
+				fmt.Printf("Deleted %v %v\n", obj.GetObjectKind().GroupVersionKind().Kind, name)
 			}
 			ras.Deleted = append(ras.Deleted, ops.meta(obj))
-			fmt.Printf("Deleted %v %v\n", obj.GetObjectKind().GroupVersionKind().Kind, name)
 		}
 	}
 

--- a/pkg/fission-cli/cmd/spec/resourcetype.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype.go
@@ -46,6 +46,14 @@ type resourceOps[T any, PT Object[T]] struct {
 	delete func(ctx context.Context, namespace, name string) error
 }
 
+// dryRunResourceVersion is the synthetic ResourceVersion recorded for a would-be
+// update under --dry-run. A real update bumps the object's ResourceVersion, and a
+// Function embeds the ResourceVersion of the Package it references; recording a
+// sentinel here means such dependents detect and report the would-be change too,
+// instead of appearing as no-ops because they still carry the old RV. It is never
+// written to the cluster — dry-run performs no create/update/delete calls.
+const dryRunResourceVersion = "dry-run-would-update"
+
 // setDeploymentUID stamps the deployment name/UID annotations so future applies
 // can recognise the objects this spec owns.
 func setDeploymentUID(o metav1.Object, fr *FissionResources) {
@@ -81,10 +89,11 @@ func ownedByDeployment(o metav1.Object, fr *FissionResources) bool {
 //
 // When dryRun is set, the same list/diff is performed read-only: the
 // create/update/delete client calls (and the per-deletion log line) are skipped,
-// but ras and the metadata map are still populated exactly as a real run would
-// report — using the desired object's metadata for would-be-creates and the
-// existing object's for would-be-updates — so the caller's summary and
-// cross-reference wiring stay correct without touching the cluster.
+// but ras and the metadata map are still populated as a real run would report —
+// the desired object's metadata for would-be-creates, and the existing object's
+// metadata with a sentinel ResourceVersion (dryRunResourceVersion) for would-be-
+// updates so dependents that embed it detect the change — so the caller's summary
+// and cross-reference wiring stay correct without touching the cluster.
 func applyResourceType[T any, PT Object[T]](
 	ctx context.Context,
 	fr *FissionResources,
@@ -129,16 +138,21 @@ func applyResourceType[T any, PT Object[T]](
 			// Already up to date; record existing metadata for cross-refs.
 			metadata[name] = *ops.meta(existing)
 		case found:
-			// would-be update: validate first (runs in dry-run too), record the
-			// existing metadata (carries the real ResourceVersion) for cross-refs,
-			// and only mutate when not a dry run.
+			// would-be update: validate first (runs in dry-run too), then either
+			// perform the update or, in dry-run, synthesize the metadata a real
+			// update would return (existing meta with a bumped ResourceVersion) so
+			// dependent resources still detect the would-be change.
 			if ops.validate != nil {
 				if err := ops.validate(ctx, ptr); err != nil {
 					return nil, nil, err
 				}
 			}
-			newMeta := ops.meta(existing)
-			if !dryRun {
+			var newMeta *metav1.ObjectMeta
+			if dryRun {
+				m := *ops.meta(existing)
+				m.ResourceVersion = dryRunResourceVersion
+				newMeta = &m
+			} else {
 				newMeta, err = ops.update(ctx, existing, ptr)
 				if err != nil {
 					return nil, nil, err

--- a/pkg/fission-cli/cmd/spec/resourcetype.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype.go
@@ -29,13 +29,17 @@ type Object[T any] interface {
 // client calls and equality, so each kind needs a few lines rather than its own
 // copy of the whole loop. Kind-specific quirks live inside the closures: the
 // Package update closure waits out an in-flight build, and the HTTPTrigger
-// create/update closures reject duplicate routes.
+// validate closure rejects duplicate routes.
 type resourceOps[T any, PT Object[T]] struct {
-	items  func(fr *FissionResources) []T         // desired resources from the spec
-	list   func(ctx context.Context) ([]T, error) // all such resources on the cluster
-	meta   func(PT) *metav1.ObjectMeta            // the object's ObjectMeta
-	equal  func(existing, desired PT) bool        // true => apply is a no-op
-	create func(ctx context.Context, desired PT) (*metav1.ObjectMeta, error)
+	items func(fr *FissionResources) []T         // desired resources from the spec
+	list  func(ctx context.Context) ([]T, error) // all such resources on the cluster
+	meta  func(PT) *metav1.ObjectMeta            // the object's ObjectMeta
+	equal func(existing, desired PT) bool        // true => apply is a no-op
+	// validate, if set, runs read-only admission-style checks before a
+	// create/update (e.g. HTTPTrigger duplicate-route detection). It runs in
+	// dry-run too, so a preview surfaces errors a real apply would hit.
+	validate func(ctx context.Context, desired PT) error
+	create   func(ctx context.Context, desired PT) (*metav1.ObjectMeta, error)
 	// update receives the existing object so it can carry the ResourceVersion
 	// forward (and, for packages, wait out an in-flight build).
 	update func(ctx context.Context, existing, desired PT) (*metav1.ObjectMeta, error)
@@ -125,8 +129,14 @@ func applyResourceType[T any, PT Object[T]](
 			// Already up to date; record existing metadata for cross-refs.
 			metadata[name] = *ops.meta(existing)
 		case found:
-			// would-be update: record the existing metadata (carries the real
-			// ResourceVersion) for cross-refs; only mutate when not a dry run.
+			// would-be update: validate first (runs in dry-run too), record the
+			// existing metadata (carries the real ResourceVersion) for cross-refs,
+			// and only mutate when not a dry run.
+			if ops.validate != nil {
+				if err := ops.validate(ctx, ptr); err != nil {
+					return nil, nil, err
+				}
+			}
 			newMeta := ops.meta(existing)
 			if !dryRun {
 				newMeta, err = ops.update(ctx, existing, ptr)
@@ -137,8 +147,13 @@ func applyResourceType[T any, PT Object[T]](
 			ras.Updated = append(ras.Updated, newMeta)
 			metadata[name] = *newMeta
 		default:
-			// would-be create: record the desired metadata (RV empty); only
-			// mutate when not a dry run.
+			// would-be create: validate first (runs in dry-run too), record the
+			// desired metadata (RV empty), and only mutate when not a dry run.
+			if ops.validate != nil {
+				if err := ops.validate(ctx, ptr); err != nil {
+					return nil, nil, err
+				}
+			}
 			newMeta := ops.meta(ptr)
 			if !dryRun {
 				newMeta, err = ops.create(ctx, ptr)

--- a/pkg/fission-cli/cmd/spec/resourcetype_test.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype_test.go
@@ -82,7 +82,7 @@ func TestApplyResourceType(t *testing.T) {
 	t.Run("create when absent", func(t *testing.T) {
 		store := newFnStore()
 		fr := frWith(fn("a", "nodejs", false))
-		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false)
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -97,7 +97,7 @@ func TestApplyResourceType(t *testing.T) {
 	t.Run("no-op when identical", func(t *testing.T) {
 		store := newFnStore(fn("a", "nodejs", true))
 		fr := frWith(fn("a", "nodejs", false))
-		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false)
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -109,7 +109,7 @@ func TestApplyResourceType(t *testing.T) {
 	t.Run("update when spec differs", func(t *testing.T) {
 		store := newFnStore(fn("a", "nodejs", true))
 		fr := frWith(fn("a", "python", false)) // env changed
-		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false)
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -124,7 +124,7 @@ func TestApplyResourceType(t *testing.T) {
 	t.Run("prune stale owned object when deleteStale", func(t *testing.T) {
 		store := newFnStore(fn("stale", "nodejs", true), fn("keep", "nodejs", true))
 		fr := frWith(fn("keep", "nodejs", false))
-		_, ras, err := applyResourceType(ctx, fr, store.ops(), true, false)
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), true, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -143,7 +143,7 @@ func TestApplyResourceType(t *testing.T) {
 		// An object on the cluster without our deployment UID must not be pruned.
 		store := newFnStore(fn("foreign", "nodejs", false))
 		fr := frWith() // spec is empty
-		_, ras, err := applyResourceType(ctx, fr, store.ops(), true, false)
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), true, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -159,7 +159,7 @@ func TestApplyResourceType(t *testing.T) {
 func TestApplyResourceTypeStampsDeploymentUID(t *testing.T) {
 	store := newFnStore()
 	fr := frWith(fn("a", "nodejs", false))
-	if _, _, err := applyResourceType(context.Background(), fr, store.ops(), false, false); err != nil {
+	if _, _, err := applyResourceType(context.Background(), fr, store.ops(), false, false, false); err != nil {
 		t.Fatal(err)
 	}
 	got := store.objs["default/a"]
@@ -213,7 +213,7 @@ func TestApplyResourceTypeEmptyUIDDeletesNothing(t *testing.T) {
 	// even with deleteStale + !allowConflicts, nothing may be deleted.
 	store := newFnStore(fn("foreign", "nodejs", true), fn("other", "nodejs", false))
 	fr := &FissionResources{} // empty UID, empty spec
-	_, ras, err := applyResourceType(context.Background(), fr, store.ops(), true, false)
+	_, ras, err := applyResourceType(context.Background(), fr, store.ops(), true, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,4 +236,74 @@ func TestSetDeploymentUID(t *testing.T) {
 	if f.Annotations[FISSION_DEPLOYMENT_NAME_KEY] != "demo" {
 		t.Fatalf("name annotation not set: %v", f.Annotations)
 	}
+}
+
+// TestApplyResourceTypeDryRun verifies that dryRun reports the same actions a
+// real run would (create/update/delete) and populates the cross-ref metadata,
+// while making no changes to the store.
+func TestApplyResourceTypeDryRun(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create is previewed but not performed", func(t *testing.T) {
+		store := newFnStore()
+		fr := frWith(fn("a", "nodejs", false))
+		meta, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ras.Created) != 1 {
+			t.Fatalf("expected 1 would-be create, got %d", len(ras.Created))
+		}
+		if len(store.objs) != 0 {
+			t.Fatalf("dry run must not create anything, store has %d", len(store.objs))
+		}
+		if _, ok := meta["default/a"]; !ok {
+			t.Fatal("cross-ref metadata must be recorded for the would-be create")
+		}
+	})
+
+	t.Run("update is previewed but not performed", func(t *testing.T) {
+		store := newFnStore(fn("a", "nodejs", true))
+		fr := frWith(fn("a", "python", false)) // env differs -> would update
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ras.Updated) != 1 {
+			t.Fatalf("expected 1 would-be update, got %d", len(ras.Updated))
+		}
+		if got := store.objs["default/a"].Spec.Environment.Name; got != "nodejs" {
+			t.Fatalf("dry run must not mutate the stored object, env=%q", got)
+		}
+	})
+
+	t.Run("no-op stays a no-op", func(t *testing.T) {
+		store := newFnStore(fn("a", "nodejs", true))
+		fr := frWith(fn("a", "nodejs", false)) // identical spec
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ras.Created)+len(ras.Updated) != 0 {
+			t.Fatalf("identical spec should be a no-op, got C=%d U=%d", len(ras.Created), len(ras.Updated))
+		}
+	})
+
+	t.Run("prune is previewed but not performed", func(t *testing.T) {
+		store := newFnStore(fn("stale", "nodejs", true), fn("keep", "nodejs", true))
+		fr := frWith(fn("keep", "nodejs", false))
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), true, false, true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(ras.Deleted) != 1 {
+			t.Fatalf("expected 1 would-be delete, got %d", len(ras.Deleted))
+		}
+		if _, ok := store.objs["default/stale"]; !ok {
+			t.Fatal("dry run must not delete anything")
+		}
+		if len(store.objs) != 2 {
+			t.Fatalf("store must be untouched, has %d (want 2)", len(store.objs))
+		}
+	})
 }

--- a/pkg/fission-cli/cmd/spec/resourcetype_test.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype_test.go
@@ -6,6 +6,7 @@ package spec
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -304,6 +305,45 @@ func TestApplyResourceTypeDryRun(t *testing.T) {
 		}
 		if len(store.objs) != 2 {
 			t.Fatalf("store must be untouched, has %d (want 2)", len(store.objs))
+		}
+	})
+}
+
+// TestApplyResourceTypeDryRunValidates verifies that the read-only validate hook
+// still runs under dryRun, so a preview surfaces a conflict (e.g. an HTTPTrigger
+// duplicate route) that a real apply would reject — for both would-be creates
+// and would-be updates — without mutating the store.
+func TestApplyResourceTypeDryRunValidates(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("duplicate route")
+
+	rejectingOps := func(s *fnStore) resourceOps[fv1.Function, *fv1.Function] {
+		ops := s.ops()
+		ops.validate = func(context.Context, *fv1.Function) error { return wantErr }
+		return ops
+	}
+
+	t.Run("create preview surfaces validation error", func(t *testing.T) {
+		store := newFnStore()
+		fr := frWith(fn("a", "nodejs", false))
+		_, _, err := applyResourceType(ctx, fr, rejectingOps(store), false, false, true)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected validation error, got %v", err)
+		}
+		if len(store.objs) != 0 {
+			t.Fatalf("failed validation must not create anything, store has %d", len(store.objs))
+		}
+	})
+
+	t.Run("update preview surfaces validation error", func(t *testing.T) {
+		store := newFnStore(fn("a", "nodejs", true))
+		fr := frWith(fn("a", "python", false)) // env differs -> would update
+		_, _, err := applyResourceType(ctx, fr, rejectingOps(store), false, false, true)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("expected validation error, got %v", err)
+		}
+		if got := store.objs["default/a"].Spec.Environment.Name; got != "nodejs" {
+			t.Fatalf("failed validation must not mutate the stored object, env=%q", got)
 		}
 	})
 }

--- a/pkg/fission-cli/cmd/spec/resourcetype_test.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype_test.go
@@ -352,3 +352,32 @@ func TestApplyResourceTypeDryRunValidates(t *testing.T) {
 		}
 	})
 }
+
+// TestApplyResourceTypeDryRunAlreadyExists verifies that a dry-run create whose
+// name collides with an unowned cluster object is reported as the error a real
+// apply would hit (the server's AlreadyExists), rather than a false would-create
+// — unless --allowconflicts adopts the existing object as an update.
+func TestApplyResourceTypeDryRunAlreadyExists(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unowned collision errors without allowconflicts", func(t *testing.T) {
+		store := newFnStore(fn("a", "nodejs", false)) // exists, NOT owned by us
+		fr := frWith(fn("a", "nodejs", false))
+		_, _, err := applyResourceType(ctx, fr, store.ops(), false, false, true)
+		if err == nil {
+			t.Fatal("expected an AlreadyExists-style conflict error, got nil")
+		}
+	})
+
+	t.Run("allowconflicts adopts the object as an update", func(t *testing.T) {
+		store := newFnStore(fn("a", "nodejs", false)) // exists, unowned
+		fr := frWith(fn("a", "python", false))        // differs -> would update
+		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, true, true)
+		if err != nil {
+			t.Fatalf("allowconflicts should adopt the object, got %v", err)
+		}
+		if len(ras.Updated) != 1 || len(ras.Created) != 0 {
+			t.Fatalf("expected 1 would-be update, got C=%d U=%d", len(ras.Created), len(ras.Updated))
+		}
+	})
+}

--- a/pkg/fission-cli/cmd/spec/resourcetype_test.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype_test.go
@@ -266,7 +266,7 @@ func TestApplyResourceTypeDryRun(t *testing.T) {
 	t.Run("update is previewed but not performed", func(t *testing.T) {
 		store := newFnStore(fn("a", "nodejs", true))
 		fr := frWith(fn("a", "python", false)) // env differs -> would update
-		_, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, true)
+		meta, ras, err := applyResourceType(ctx, fr, store.ops(), false, false, true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -275,6 +275,11 @@ func TestApplyResourceTypeDryRun(t *testing.T) {
 		}
 		if got := store.objs["default/a"].Spec.Environment.Name; got != "nodejs" {
 			t.Fatalf("dry run must not mutate the stored object, env=%q", got)
+		}
+		// The cross-ref metadata must carry the sentinel RV so dependents (a
+		// function's package reference) detect the would-be change.
+		if got := meta["default/a"].ResourceVersion; got != dryRunResourceVersion {
+			t.Fatalf("would-be update metadata must carry the dry-run RV sentinel, got %q", got)
 		}
 	})
 

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -209,6 +209,7 @@ var (
 	SpecWatch            = Flag{Type: Bool, Name: flagkey.SpecWatch, Usage: "Watch local files for change, and re-apply specs as necessary"}
 	SpecDelete           = Flag{Type: Bool, Name: flagkey.SpecDelete, Usage: "Allow apply to delete resources that no longer exist in the specification"}
 	SpecDry              = Flag{Type: Bool, Name: flagkey.SpecDry, Usage: "View the generated specs"}
+	SpecApplyDryRun      = Flag{Type: Bool, Name: flagkey.SpecApplyDryRun, Usage: "Preview what apply would create/update/delete without changing the cluster"}
 	SpecValidation       = Flag{Type: String, Name: flagkey.SpecValidate, Usage: "Turns server side validations of Fission objects on/off"}
 	SpecIgnore           = Flag{Type: String, Name: flagkey.SpecIgnore, Usage: fmt.Sprintf("File containing specs to be ignored inside --specdir, defaults to %v", util.SPEC_IGNORE_FILE)}
 	SpecApplyCommitLabel = Flag{Type: Bool, Name: flagkey.SpecApplyCommitLabel, Usage: "Apply commit label to the resources"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -159,6 +159,7 @@ const (
 	SpecWatch            = "watch"
 	SpecDelete           = "delete"
 	SpecDry              = "dry"
+	SpecApplyDryRun      = "dry-run"
 	SpecValidate         = "validation"
 	SpecIgnore           = "specignore"
 	SpecApplyCommitLabel = "commitlabel"

--- a/test/integration/suites/common/spec_dryrun_test.go
+++ b/test/integration/suites/common/spec_dryrun_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestSpecApply_DryRun verifies `fission spec apply --dry-run` previews the
+// would-be changes without touching the cluster, and that a real apply makes
+// the subsequent dry-run stop reporting creates. It uses a --code (literal
+// deploy) function so no builder/runtime image is required — nothing is ever
+// built or specialized, only the spec reconcile/diff is exercised.
+func TestSpecApply_DryRun(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	ns := f.NewTestNamespace(t)
+	fc := f.FissionClient().CoreV1()
+
+	envName := "dryrun-env-" + ns.ID
+	fnName := "dryrun-fn-" + ns.ID
+
+	workdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "hello.js"),
+		[]byte("module.exports = async function(){ return {status:200, body:'hi'} }\n"), 0o644))
+
+	// Build the spec directory (local only — no cluster writes yet).
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "init")
+		ns.CLI(t, ctx, "env", "create", "--spec", "--name", envName, "--image", "fission/node-env")
+		ns.CLI(t, ctx, "fn", "create", "--spec", "--name", fnName, "--env", envName, "--code", "hello.js")
+
+		// 1) Dry-run on a fresh spec previews creates and changes nothing.
+		out := ns.CLICaptureStdout(t, ctx, "spec", "apply", "--dry-run")
+		require.Contains(t, out, "would be created")
+		require.Contains(t, out, "(dry run - no changes made)")
+	})
+
+	// The dry-run must not have created anything on the cluster.
+	_, err := fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "dry-run must not create the function (err=%v)", err)
+	_, err = fc.Environments(ns.Name).Get(ctx, envName, metav1.GetOptions{})
+	require.True(t, apierrors.IsNotFound(err), "dry-run must not create the environment (err=%v)", err)
+
+	// 2) Real apply, then a second dry-run is idempotent w.r.t. creates.
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "apply")
+		t.Cleanup(func() {
+			dctx, dcancel := context.WithTimeout(context.Background(), time.Minute)
+			defer dcancel()
+			ns.WithCWD(t, workdir, func() { _ = ns.CLI(t, dctx, "spec", "destroy") })
+		})
+
+		out := ns.CLICaptureStdout(t, ctx, "spec", "apply", "--dry-run")
+		require.NotContains(t, out, "would be created",
+			"after a real apply, a dry-run should not report creates")
+		require.Contains(t, out, "(dry run - no changes made)")
+	})
+
+	// And the real apply did create the function.
+	_, err = fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+	require.NoError(t, err, "real apply should have created the function")
+}

--- a/test/integration/suites/common/spec_dryrun_test.go
+++ b/test/integration/suites/common/spec_dryrun_test.go
@@ -73,9 +73,20 @@ func TestSpecApply_DryRun(t *testing.T) {
 		require.NotContains(t, out, "would be created",
 			"after a real apply, a dry-run should not report creates")
 		require.Contains(t, out, "(dry run - no changes made)")
+
+		// 3) Edit the function code: the package would be updated, and that change
+		// must cascade to a would-be update of the referencing function (the
+		// function embeds the package ResourceVersion). The cluster stays unchanged.
+		require.NoError(t, os.WriteFile(filepath.Join(workdir, "hello.js"),
+			[]byte("module.exports = async function(){ return {status:200, body:'changed'} }\n"), 0o644))
+		out = ns.CLICaptureStdout(t, ctx, "spec", "apply", "--dry-run")
+		require.Contains(t, out, "package would be updated")
+		require.Contains(t, out, "function would be updated",
+			"a package change must cascade to a would-be function update in dry-run")
 	})
 
-	// And the real apply did create the function.
-	_, err = fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+	// And the real apply did create the function; the cascade dry-run changed nothing.
+	gotFn, err := fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
 	require.NoError(t, err, "real apply should have created the function")
+	require.NotEmpty(t, gotFn.Spec.Package.PackageRef.Name, "function should reference its package")
 }


### PR DESCRIPTION
## What

Adds `fission spec apply --dry-run` — a `kubectl apply --dry-run`-style preview of what an apply *would* create/update/delete, without changing the cluster. Third and final CLI-UX follow-up after #3398/#3399/#3402.

```
$ fission spec apply --dry-run
1 environment would be created: nodejs
1 package would be created: hello-…
1 function would be created: hello
1 HTTPTrigger would be created: t1
(dry run - no changes made)
```

## Implementation
- Threads a `dryRun bool` through `applyResources` → each `applyX` → the generic `applyResourceType`. The read-only **list + diff** runs exactly as a real apply, but under `--dry-run`:
  - the `create`/`update`/`delete` client calls (and the per-deletion log line) are skipped;
  - `ras` (Created/Updated/Deleted) and the cross-ref **metadata map are still populated** so the summary and the function→package `ResourceVersion` wiring stay correct without touching the cluster — desired meta for would-be-creates, and existing meta with a **sentinel `ResourceVersion`** for would-be-updates so a would-be **package** update correctly cascades into a would-be update of the functions that reference it (matching a real apply, which bumps the package RV);
  - read-only **validation still runs** via a `validate` hook on `resourceOps` (e.g. HTTPTrigger duplicate-route detection), so a preview surfaces the same errors a real apply would reject;
  - `applyArchives` still does its read-only work (build/checksum + "resolve if already uploaded" against cluster archives) so the Package diff is accurate; only the actual upload of a new/changed archive is skipped (logged as `would upload archive …`).
- `printApplyStatus` switches verbs to "would be …" and appends "(dry run - no changes made)".
- `--wait`/`--watch` are inert under `--dry-run` (nothing is built).
- New `--dry-run` flag (`flagkey.SpecApplyDryRun`), distinct from the existing per-resource `--dry`/`SpecDry`.

Backward compatible — new flag, default false; real applies are unchanged.

## Test
- Unit (`resourcetype_test.go`): dry-run create / update / no-op / prune report the right actions + metadata while leaving the in-memory store **untouched**; the would-be-update metadata carries the sentinel RV; the `validate` hook still fires under dry-run for both would-be creates and updates.
- Integration (`test/integration/suites/common/spec_dryrun_test.go`): `--dry-run` on a fresh spec previews creates and the cluster stays empty (function/env `IsNotFound`); a real apply then creates them; a second `--dry-run` reports no creates; editing the function code then reports **both** a would-be package and a would-be (cascaded) function update. Uses a `--code` (literal deploy) function so no builder/runtime image is needed.
- `go build ./...`, `golangci-lint` (0 issues), `make license-check` (SPDX on new file), full spec unit tests pass.
- Manual on kind: fresh `--dry-run` → "would be created" + footer, nothing created; real apply; edit function code → second `--dry-run` reports the cascaded package + function would-update; `spec destroy` cleans up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3403)
<!-- Reviewable:end -->
