### PR TITLE
fix(security): validate Runtime/Builder Container SecurityContext (GHSA-m63v)

### DIFF
--- a/pkg/apis/core/v1/podspec_safety.go
+++ b/pkg/apis/core/v1/podspec_safety.go
@@ -69,37 +69,59 @@ func ValidatePodSpecSafety(fieldPath string, ps *apiv1.PodSpec) error {
 		}
 	}
 
-	checkContainer := func(group string, c apiv1.Container) error {
-		var cerrs error
-		sc := c.SecurityContext
-		if sc == nil {
-			return nil
-		}
-		if sc.Privileged != nil && *sc.Privileged {
-			cerrs = errors.Join(cerrs, fmt.Errorf(
-				"%s.%s[%s].securityContext.privileged=true is not allowed", fieldPath, group, c.Name))
-		}
-		if sc.AllowPrivilegeEscalation != nil && *sc.AllowPrivilegeEscalation {
-			cerrs = errors.Join(cerrs, fmt.Errorf(
-				"%s.%s[%s].securityContext.allowPrivilegeEscalation=true is not allowed", fieldPath, group, c.Name))
-		}
-		if sc.Capabilities != nil {
-			for _, cap := range sc.Capabilities.Add {
-				if _, bad := dangerousCapabilities[cap]; bad {
-					cerrs = errors.Join(cerrs, fmt.Errorf(
-						"%s.%s[%s].securityContext.capabilities.add[%q] is not allowed", fieldPath, group, c.Name, cap))
-				}
+	for i := range ps.Containers {
+		group := fmt.Sprintf("%s.containers[%s]", fieldPath, ps.Containers[i].Name)
+		errs = errors.Join(errs, ValidateContainerSafety(group, &ps.Containers[i]))
+	}
+	for i := range ps.InitContainers {
+		group := fmt.Sprintf("%s.initContainers[%s]", fieldPath, ps.InitContainers[i].Name)
+		errs = errors.Join(errs, ValidateContainerSafety(group, &ps.InitContainers[i]))
+	}
+
+	return errs
+}
+
+// ValidateContainerSafety rejects the SecurityContext fields of a single
+// container that would let a low-privilege tenant escape the container
+// sandbox: privileged=true, allowPrivilegeEscalation=true, and dangerous
+// Linux capabilities.
+//
+// It exists as a standalone check because the Environment CRD exposes
+// `spec.runtime.container` and `spec.builder.container` — a bare
+// *apiv1.Container that is merged into the runtime/builder pod but is
+// NOT part of any PodSpec, so ValidatePodSpecSafety never reaches it.
+// Leaving the Container SecurityContext unchecked is a bypass of the
+// PodSpec hardening (GHSA-gx55-f84r-v3r7 / GHSA-wmgg-3p4h-48x7 /
+// GHSA-v455-mv2v-5g92) — closes GHSA-m63v-2g9w-2w6v.
+//
+// ValidatePodSpecSafety calls this for each (init)container, and
+// Environment.Validate calls it directly for Runtime.Container /
+// Builder.Container. A nil container is accepted (the field is optional).
+//
+// The fieldPath argument is used as a prefix in error messages so the
+// caller can identify which container failed (e.g.
+// "Environment.spec.runtime.container").
+func ValidateContainerSafety(fieldPath string, c *apiv1.Container) error {
+	if c == nil || c.SecurityContext == nil {
+		return nil
+	}
+	var errs error
+	sc := c.SecurityContext
+	if sc.Privileged != nil && *sc.Privileged {
+		errs = errors.Join(errs, fmt.Errorf(
+			"%s.securityContext.privileged=true is not allowed", fieldPath))
+	}
+	if sc.AllowPrivilegeEscalation != nil && *sc.AllowPrivilegeEscalation {
+		errs = errors.Join(errs, fmt.Errorf(
+			"%s.securityContext.allowPrivilegeEscalation=true is not allowed", fieldPath))
+	}
+	if sc.Capabilities != nil {
+		for _, cap := range sc.Capabilities.Add {
+			if _, bad := dangerousCapabilities[cap]; bad {
+				errs = errors.Join(errs, fmt.Errorf(
+					"%s.securityContext.capabilities.add[%q] is not allowed", fieldPath, cap))
 			}
 		}
-		return cerrs
 	}
-
-	for _, c := range ps.Containers {
-		errs = errors.Join(errs, checkContainer("containers", c))
-	}
-	for _, c := range ps.InitContainers {
-		errs = errors.Join(errs, checkContainer("initContainers", c))
-	}
-
 	return errs
 }

--- a/pkg/apis/core/v1/podspec_safety_test.go
+++ b/pkg/apis/core/v1/podspec_safety_test.go
@@ -169,6 +169,65 @@ func TestValidatePodSpecSafety_DangerousFields(t *testing.T) {
 	}
 }
 
+// TestValidateContainerSafety covers the standalone-container check used for
+// Environment Runtime.Container / Builder.Container. Closes GHSA-m63v-2g9w-2w6v.
+func TestValidateContainerSafety(t *testing.T) {
+	on := true
+	off := false
+
+	t.Run("nil container is accepted", func(t *testing.T) {
+		if err := ValidateContainerSafety("Environment.spec.runtime.container", nil); err != nil {
+			t.Fatalf("nil container must be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("nil securityContext is accepted", func(t *testing.T) {
+		c := &apiv1.Container{Name: "py", Image: "fission/python-env:latest"}
+		if err := ValidateContainerSafety("Environment.spec.runtime.container", c); err != nil {
+			t.Fatalf("container without securityContext must be accepted, got: %v", err)
+		}
+	})
+
+	t.Run("benign securityContext is accepted", func(t *testing.T) {
+		c := &apiv1.Container{
+			Name: "py",
+			SecurityContext: &apiv1.SecurityContext{
+				AllowPrivilegeEscalation: &off,
+				Capabilities:             &apiv1.Capabilities{Add: []apiv1.Capability{"NET_BIND_SERVICE"}},
+			},
+		}
+		if err := ValidateContainerSafety("Environment.spec.runtime.container", c); err != nil {
+			t.Fatalf("benign container must be accepted, got: %v", err)
+		}
+	})
+
+	cases := []struct {
+		name      string
+		sc        *apiv1.SecurityContext
+		wantInErr string
+	}{
+		{"privileged", &apiv1.SecurityContext{Privileged: &on}, "privileged"},
+		{"allowPrivilegeEscalation", &apiv1.SecurityContext{AllowPrivilegeEscalation: &on}, "allowPrivilegeEscalation"},
+		{"SYS_ADMIN", &apiv1.SecurityContext{Capabilities: &apiv1.Capabilities{Add: []apiv1.Capability{"SYS_ADMIN"}}}, "SYS_ADMIN"},
+		{"NET_ADMIN", &apiv1.SecurityContext{Capabilities: &apiv1.Capabilities{Add: []apiv1.Capability{"NET_ADMIN"}}}, "NET_ADMIN"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &apiv1.Container{Name: "py", SecurityContext: tc.sc}
+			err := ValidateContainerSafety("Environment.spec.runtime.container", c)
+			if err == nil {
+				t.Fatalf("expected rejection for %s, got nil", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantInErr) {
+				t.Fatalf("error must mention %q, got: %v", tc.wantInErr, err)
+			}
+			if !strings.Contains(err.Error(), "Environment.spec.runtime.container") {
+				t.Fatalf("error must include the field prefix, got: %v", err)
+			}
+		})
+	}
+}
+
 // TestValidatePodSpecSafety_BenignCapability asserts that NET_BIND_SERVICE
 // (and other non-dangerous capabilities) flow through. The denylist is
 // intentionally narrow so legitimate function workloads can still bind to

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -662,6 +662,14 @@ func (e *Environment) Validate() error {
 	// GHSA-wmgg-3p4h-48x7.
 	errs = errors.Join(errs, ValidatePodSpecSafety("Environment.spec.runtime.podspec", e.Spec.Runtime.PodSpec))
 	errs = errors.Join(errs, ValidatePodSpecSafety("Environment.spec.builder.podspec", e.Spec.Builder.PodSpec))
+	// The standalone Runtime.Container / Builder.Container fields are merged
+	// into the runtime / builder pod without going through any PodSpec, so
+	// ValidatePodSpecSafety above does not reach them. Validate their
+	// SecurityContext directly — otherwise a tenant could set
+	// spec.runtime.container.securityContext.privileged=true and bypass the
+	// PodSpec hardening. Closes GHSA-m63v-2g9w-2w6v.
+	errs = errors.Join(errs, ValidateContainerSafety("Environment.spec.runtime.container", e.Spec.Runtime.Container))
+	errs = errors.Join(errs, ValidateContainerSafety("Environment.spec.builder.container", e.Spec.Builder.Container))
 	return errs
 }
 

--- a/pkg/executor/util/merge.go
+++ b/pkg/executor/util/merge.go
@@ -39,6 +39,17 @@ func MergeContainer(dst *apiv1.Container, src *apiv1.Container) (*apiv1.Containe
 		checkSliceConflicts("Name", dstC.VolumeMounts),
 		checkSliceConflicts("Name", dstC.VolumeDevices))
 
+	// mergo.WithOverride copies src.SecurityContext onto the merged result,
+	// so a tenant-supplied Environment Runtime.Container / Builder.Container
+	// with privileged=true / allowPrivilegeEscalation=true / dangerous caps
+	// would otherwise reach the running pod. The admission webhook
+	// (ValidateContainerSafety) is the primary defence; this strips the
+	// dangerous bits at the merge layer so a webhook-bypass cluster
+	// (failurePolicy=Ignore or stale objects from a pre-webhook upgrade)
+	// is still protected. Closes GHSA-m63v-2g9w-2w6v (the Container-field
+	// sibling of GHSA-gx55 / GHSA-wmgg / GHSA-v455).
+	sanitizeContainerSecurityContext(&dstC)
+
 	return &dstC, errs
 }
 

--- a/pkg/executor/util/merge_test.go
+++ b/pkg/executor/util/merge_test.go
@@ -156,6 +156,61 @@ func Test_mergeContainer(t *testing.T) {
 	}
 }
 
+// TestMergeContainer_SanitizesSecurityContext pins the GHSA-m63v-2g9w-2w6v
+// invariant: MergeContainer is the path for the Environment Runtime.Container /
+// Builder.Container fields, which do not go through any PodSpec and so are not
+// reached by MergePodSpec's sanitizer. A tenant-supplied container with
+// privileged=true / allowPrivilegeEscalation=true / dangerous caps must be
+// sanitized in the merged result, while the caller's source container must not
+// be mutated (it is typically env.Spec.Runtime.Container from an informer
+// cache).
+func TestMergeContainer_SanitizesSecurityContext(t *testing.T) {
+	on := true
+	dst := &apiv1.Container{Name: "py", Image: "fission/python-env:latest"}
+	src := &apiv1.Container{
+		Name: "py",
+		SecurityContext: &apiv1.SecurityContext{
+			Privileged:               &on,
+			AllowPrivilegeEscalation: &on,
+			Capabilities: &apiv1.Capabilities{
+				Add: []apiv1.Capability{"SYS_ADMIN", "NET_BIND_SERVICE", "NET_ADMIN"},
+			},
+		},
+	}
+
+	out, err := MergeContainer(dst, src)
+	if err != nil {
+		t.Fatalf("MergeContainer error: %v", err)
+	}
+	if out.SecurityContext == nil {
+		t.Fatalf("merged container must keep a SecurityContext")
+	}
+	if out.SecurityContext.Privileged != nil && *out.SecurityContext.Privileged {
+		t.Errorf("Privileged=true must be sanitized to false")
+	}
+	if out.SecurityContext.AllowPrivilegeEscalation != nil && *out.SecurityContext.AllowPrivilegeEscalation {
+		t.Errorf("AllowPrivilegeEscalation=true must be sanitized to false")
+	}
+	gotCaps := map[apiv1.Capability]bool{}
+	for _, c := range out.SecurityContext.Capabilities.Add {
+		gotCaps[c] = true
+	}
+	if gotCaps["SYS_ADMIN"] || gotCaps["NET_ADMIN"] {
+		t.Errorf("dangerous capabilities must be stripped, got %v", out.SecurityContext.Capabilities.Add)
+	}
+	if !gotCaps["NET_BIND_SERVICE"] {
+		t.Errorf("benign capability NET_BIND_SERVICE must flow through")
+	}
+
+	// The caller's source container must not be mutated by the merge.
+	if src.SecurityContext.Privileged == nil || !*src.SecurityContext.Privileged {
+		t.Errorf("source container Privileged must be left untouched (deep copy expected)")
+	}
+	if len(src.SecurityContext.Capabilities.Add) != 3 {
+		t.Errorf("source container capabilities must be left untouched, got %v", src.SecurityContext.Capabilities.Add)
+	}
+}
+
 func Test_mergeVolumeLists(t *testing.T) {
 	type args struct {
 		dst []apiv1.Volume

--- a/pkg/webhook/environment_test.go
+++ b/pkg/webhook/environment_test.go
@@ -109,6 +109,40 @@ func TestEnvironmentWebhook_Validate_RejectsDangerousPodSpec(t *testing.T) {
 			},
 			wantInErr: "serviceAccountName",
 		},
+		// Runtime.Container / Builder.Container are a separate injection path
+		// from the PodSpec cases above. Closes GHSA-m63v-2g9w-2w6v.
+		{
+			name: "runtime container privileged",
+			mutate: func(e *v1.Environment) {
+				e.Spec.Runtime.Container = &apiv1.Container{
+					Name:            "py",
+					SecurityContext: &apiv1.SecurityContext{Privileged: &on},
+				}
+			},
+			wantInErr: "privileged",
+		},
+		{
+			name: "runtime container SYS_ADMIN capability",
+			mutate: func(e *v1.Environment) {
+				e.Spec.Runtime.Container = &apiv1.Container{
+					Name: "py",
+					SecurityContext: &apiv1.SecurityContext{
+						Capabilities: &apiv1.Capabilities{Add: []apiv1.Capability{"SYS_ADMIN"}},
+					},
+				}
+			},
+			wantInErr: "SYS_ADMIN",
+		},
+		{
+			name: "builder container allowPrivilegeEscalation",
+			mutate: func(e *v1.Environment) {
+				e.Spec.Builder.Container = &apiv1.Container{
+					Name:            "py-builder",
+					SecurityContext: &apiv1.SecurityContext{AllowPrivilegeEscalation: &on},
+				}
+			},
+			wantInErr: "allowPrivilegeEscalation",
+		},
 	}
 
 	r := &Environment{}


### PR DESCRIPTION
## Summary

Closes **GHSA-m63v-2g9w-2w6v** (critical, CVSS 9.9) — a follow-up bypass of the round-4 PodSpec hardening (GHSA-gx55-f84r-v3r7 / GHSA-wmgg-3p4h-48x7 / GHSA-v455-mv2v-5g92, PR #3391).

The round-4 fix validates and sanitizes dangerous fields on the **PodSpec**.
But the Environment CRD also exposes `spec.runtime.container` and `spec.builder.container` — a standalone `*corev1.Container` merged into the runtime/builder pod **without going through any PodSpec**.
Its `SecurityContext` was never inspected at admission, and the merge-layer `sanitizeContainerSecurityContext` ran only inside `MergePodSpec` (never in `MergeContainer`).
So an Environment with `spec.runtime.container.securityContext.privileged: true` was admitted and produced a privileged pool pod — node escape via the executor's high-privilege service account.

PoC (reporter-verified on the v1.23.0 chart / kind v1.32.2):

```yaml
apiVersion: fission.io/v1
kind: Environment
metadata:
  name: priv-escape-test
spec:
  version: 3
  runtime:
    image: "ghcr.io/fission/python-env:latest"
    container:
      name: priv-escape-test
      securityContext:
        privileged: true
  poolsize: 1
```

## Changes

**Admission layer (primary defence)** — `pkg/apis/core/v1`:
- Extract `ValidateContainerSafety(fieldPath string, c *apiv1.Container)` from `ValidatePodSpecSafety` (privileged / allowPrivilegeEscalation / dangerous caps). No behaviour change for the existing PodSpec path — it now calls the extracted helper per (init)container.
- Wire `ValidateContainerSafety` into `Environment.Validate()` for `Runtime.Container` and `Builder.Container`.

**Merge layer (defence in depth)** — `pkg/executor/util/merge.go`:
- Call `sanitizeContainerSecurityContext` on the result of `MergeContainer` unconditionally, covering the three call sites (`poolmgr/gp_deployment.go`, `newdeploy/newdeploy.go`, `buildermgr/envwatcher.go`). This protects webhook-bypass clusters (`failurePolicy=Ignore` or stale pre-webhook objects). The helper already deep-copies before mutating, so the informer-cached source container is not mutated.

**Function** needs no change: `FunctionSpec` has no standalone `Container` field; its container-executor path uses `spec.podspec`, already covered by round 4.

## Tests

- `pkg/apis/core/v1`: `TestValidateContainerSafety` — nil container / nil SecurityContext / benign accepted; privileged, allowPrivilegeEscalation, SYS_ADMIN, NET_ADMIN rejected with field-prefixed errors. Existing `ValidatePodSpecSafety` tests still pass (refactor is behaviour-preserving).
- `pkg/webhook`: `TestEnvironmentWebhook_Validate_RejectsDangerousPodSpec` extended with `Runtime.Container` privileged + SYS_ADMIN and `Builder.Container` allowPrivilegeEscalation cases.
- `pkg/executor/util`: `TestMergeContainer_SanitizesSecurityContext` — dangerous bits stripped from the merged result, benign caps (NET_BIND_SERVICE) flow through, and the caller's source container is left unmutated (deep-copy check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3406)
<!-- Reviewable:end -->
