### PR TITLE
chore(claude): add issue-pr-scrub backlog triage skill

### DIFF
--- a/.claude/skills/issue-pr-scrub/SKILL.md
+++ b/.claude/skills/issue-pr-scrub/SKILL.md
@@ -85,7 +85,7 @@ The rule engine, taxonomy, and write playbook are documented in:
 
 Enforced in `apply.py`, every run:
 1. **Dry-run by default.** No `--execute` ⇒ it only prints the gh commands.
-2. **Per-run cap** (`apply.max_per_run`, default 25) + pacing between writes.
+2. **Per-run write cap** (`apply.max_per_run`, default 25 — counts each label/comment/close mutation) + pacing after every write.
 3. **Tier gate.** `--auto` touches only `tier=auto`; `review` items require `--from <curated>`.
 4. **Staleness guard.** Re-fetches each thread's live state immediately before acting; skips if it was closed or *touched since extract* — re-run the pipeline to pick up changes.
 5. **Protected re-check.** Skips anything now carrying a protected label.

--- a/.claude/skills/issue-pr-scrub/SKILL.md
+++ b/.claude/skills/issue-pr-scrub/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: issue-pr-scrub
+description: Use when scrubbing or triaging a GitHub repo's open issue/PR backlog — closing stale/duplicate/already-shipped/EOL items and categorizing the rest (type, area, priority) like a product manager. Use for one-off backlog cleanups or a recurring triage cadence. Backed by gitcrawl (local SQLite mirror, no API-quota burn). Portable across OSS repos via --repo.
+---
+
+# issue-pr-scrub
+
+A repeatable, low-risk pipeline to scrub a long-neglected GitHub backlog. It mirrors all issues/PRs into local SQLite with **gitcrawl**, applies a deterministic rule engine to decide a *disposition* per thread (close-stale / close-duplicate / close-implemented / close-eol / pr-archive / needs-info / keep+categorize), produces a reviewable report, and only then — gated and capped — applies the approved actions to GitHub via `gh`.
+
+**Core principle: decide locally and cheaply (repeatable, no writes); apply to GitHub separately, gated, and capped.** gitcrawl's own `close-thread`/`close-cluster` are LOCAL-only (they hide items from future runs, they never touch GitHub). All real closing/labeling/commenting goes through `gh` in the `apply` stage.
+
+## When to use
+
+- "Scrub / triage / clean up the open issues (and PRs)", especially a backlog years deep.
+- Recurring triage cadence (weekly/monthly) — the pipeline is idempotent and ledger-deduped.
+- Finding duplicates, stale items, and things already fixed in a newer release.
+- Categorizing the living backlog (type/area/priority) for product planning.
+
+Not for: reading a single issue (`gh issue view`), or anything needing GitHub *write* beyond close/label/comment (milestones, transfers — do by hand).
+
+## Prerequisites
+
+`bash scripts/scrub.sh doctor` checks them. You need: **gitcrawl** (`brew install openclaw/tap/gitcrawl` then `gitcrawl init`), **gh** (authenticated), **python3 3.11+**, **sqlite3**. No OpenAI key needed — this skill runs keyword/FTS-only.
+
+## The pipeline
+
+Five idempotent stages, each reading/writing a per-repo workdir (`~/.cache/issue-pr-scrub/<owner>__<repo>/`). Run them via `scripts/scrub.sh`:
+
+| Stage | Command | Writes GitHub? | Output |
+| --- | --- | --- | --- |
+| sync | `scrub.sh sync --repo R [--full]` | no (reads GitHub) | populates gitcrawl SQLite |
+| extract | `scrub.sh extract --repo R` | no | `threads.jsonl` |
+| triage | `scrub.sh triage --repo R` | no | `triage.jsonl` |
+| report | `scrub.sh report --repo R` | no | `report.md`, `triage.csv`, `apply-plan.jsonl` |
+| apply | `scrub.sh apply --repo R --auto|--from F [--execute]` | **yes (gated)** | `ledger.jsonl` |
+
+Plus `scrub.sh protect --repo R [--execute]` — adds `keep-open` to the numbers in `keepers.txt` (gated; dry-run default).
+
+`scrub.sh run --repo R [--full]` chains sync→extract→triage→report (never writes). Use `--full` on the first run (full backfill); omit it after (incremental, with closed-sweep).
+
+**Read the detailed stage contract in `resources/pipeline.md` before running.**
+
+## Typical workflow
+
+```bash
+cd .claude/skills/issue-pr-scrub/scripts
+bash scrub.sh doctor                                   # prerequisites
+bash scrub.sh labels --repo fission/fission            # what labels are missing?
+bash scrub.sh run --repo fission/fission --full        # backfill + triage report (no writes)
+# open ~/.cache/issue-pr-scrub/fission__fission/report.md and review
+bash scrub.sh apply  --repo fission/fission --auto     # DRY-RUN: prints what it would do
+bash scrub.sh apply  --repo fission/fission --auto --execute   # gated auto-tier closes
+```
+
+For `review`-tier items: copy the ones you approve from `apply-plan.jsonl` into `approved.jsonl`, then `apply.py --from approved.jsonl --execute`.
+
+### Re-reviewing the stale pile (don't bulk-close blindly)
+
+`close-stale` is purely age-based and is usually the biggest bucket — treat it as "needs eyes," not "safe to close." Every row is enriched with type/area/priority/engagement, and `report.py` emits **`stale-review.csv`** sorted by signal (highest reactions+comments, feature/bug first) so keepers float to the top.
+
+```bash
+# 1) skim stale-review.csv; put numbers worth keeping into keepers.txt
+#    (one per line, '# notes' allowed)
+# 2) re-run — keepers become skip and drop out of the apply-plan (instant, no re-sync)
+bash scrub.sh triage --repo R && bash scrub.sh report --repo R
+# 3) optional: make the protection visible upstream
+bash scrub.sh protect --repo R --execute       # adds keep-open to keepers.txt items
+# 4) close only what's left
+bash scrub.sh apply --repo R --auto --execute
+```
+
+## Decisions baked in (this deployment)
+
+- **Tiered auto + gated** writes. Only `tier=auto` (deterministic, low-risk) is eligible for `--auto`; everything judgmental is `tier=review` and needs explicit human approval via `--from`. Nothing is ever closed without `--execute`.
+- **Keyword/FTS only** — no OpenAI/embeddings. Duplicate grouping uses deterministic `#ref` cross-references + title-token overlap (in `triage.py`), NOT gitcrawl vector clusters.
+- **Extends existing repo labels.** Taxonomy + the rule→label map live in `resources/labels.md` and `scripts/config.example.toml`. Proposed new labels (`priority/*`, `stale`, `keep-open`) are *proposed*, created only via `labels --create-missing --execute`.
+
+The rule engine, taxonomy, and write playbook are documented in:
+- `resources/triage-rules.md` — every disposition, its heuristic, its tier
+- `resources/labels.md` — full label taxonomy + mapping + proposed extensions
+- `resources/write-actions.md` — gh write playbook, comment templates, safety gates
+- `resources/gitcrawl-reference.md` — the gitcrawl commands + SQLite schema we rely on
+
+## Safety gates (apply stage) — non-negotiable
+
+Enforced in `apply.py`, every run:
+1. **Dry-run by default.** No `--execute` ⇒ it only prints the gh commands.
+2. **Per-run cap** (`apply.max_per_run`, default 25) + pacing between writes.
+3. **Tier gate.** `--auto` touches only `tier=auto`; `review` items require `--from <curated>`.
+4. **Staleness guard.** Re-fetches each thread's live state immediately before acting; skips if it was closed or *touched since extract* — re-run the pipeline to pick up changes.
+5. **Protected re-check.** Skips anything now carrying a protected label.
+6. **Ledger dedup.** A `(number, action)` recorded `ok` is never repeated.
+
+### Rationalization table — STOP if you catch yourself thinking…
+
+| Rationalization | Reality |
+| --- | --- |
+| "The backlog is huge, just bulk-close everything stale." | The cap and tier gate exist precisely for huge backlogs. Run in batches; let the human see the first batch's effect. |
+| "These `review` items are obviously closable, I'll auto them." | `review` means a judgment call the rules couldn't make safely. Curate into `approved.jsonl`; don't promote them to `--auto`. |
+| "Skip the dry-run, I trust the rules." | Dry-run is one command and surfaces mis-tuned thresholds before they post comments on dozens of issues. Always dry-run first. |
+| "The staleness guard is annoying, disable it." | It's the only thing preventing you from closing an issue someone just commented on. Never bypass; re-run the pipeline instead. |
+| "Just create the proposed labels, they're obviously fine." | Labels are repo-wide and visible to everyone. Confirm with a maintainer; `labels --create-missing` requires `--execute` for this reason. |
+| "I'll open a PR with the triage changes." | This skill does not open PRs. It closes/labels/comments via gh only, and only what was approved. |
+
+## Portability
+
+Everything is parameterized by `--repo` and a per-repo `config.<owner>__<repo>.toml` (copy `config.example.toml`). The `[areas]`/`[types]`/`[versions]` tables are the only repo-specific tuning. Copy the whole `issue-pr-scrub/` folder into any OSS project's `.claude/skills/` and point it at a new repo.

--- a/.claude/skills/issue-pr-scrub/resources/gitcrawl-reference.md
+++ b/.claude/skills/issue-pr-scrub/resources/gitcrawl-reference.md
@@ -16,7 +16,8 @@ Requires Go-built binary + a GitHub token (resolved from `GITHUB_TOKEN` or `gh a
 
 | Command | Why | Writes? |
 | --- | --- | --- |
-| `gitcrawl sync R --state all --include-comments` | first-run full backfill | local SQLite only |
+| `gitcrawl sync R --state all` | first-run full backfill (metadata-only by default) | local SQLite only |
+| `gitcrawl sync R --state all --include-comments` | full backfill with comment bodies (opt-in via `scrub.sh sync --with-comments`) | local SQLite only |
 | `gitcrawl sync R` | incremental refresh (open + closed sweep) | local SQLite only |
 | `gitcrawl close-thread R --number <n> --reason ...` | hide a handled item from future runs (LOCAL) | local SQLite only |
 

--- a/.claude/skills/issue-pr-scrub/resources/gitcrawl-reference.md
+++ b/.claude/skills/issue-pr-scrub/resources/gitcrawl-reference.md
@@ -1,0 +1,49 @@
+# gitcrawl reference — what this skill relies on
+
+gitcrawl (https://gitcrawl.sh, `openclaw/gitcrawl`) mirrors a repo's issues/PRs into local SQLite so triage runs offline without burning GitHub API search quota. This skill uses a small, stable slice of it.
+
+## Install / setup
+
+```bash
+brew install openclaw/tap/gitcrawl
+gitcrawl init           # creates ~/.config/gitcrawl/{config.toml,gitcrawl.db,...}
+gitcrawl doctor --json  # confirms github_token_present (uses gh auth token), version
+```
+
+Requires Go-built binary + a GitHub token (resolved from `GITHUB_TOKEN` or `gh auth token`). **No OpenAI key needed** for this skill — we do not embed or cluster.
+
+## Commands we call
+
+| Command | Why | Writes? |
+| --- | --- | --- |
+| `gitcrawl sync R --state all --include-comments` | first-run full backfill | local SQLite only |
+| `gitcrawl sync R` | incremental refresh (open + closed sweep) | local SQLite only |
+| `gitcrawl close-thread R --number <n> --reason ...` | hide a handled item from future runs (LOCAL) | local SQLite only |
+
+We deliberately **do not** use `gitcrawl cluster`/`clusters`: clustering builds a graph over the OpenAI vector store, which is empty in keyword-only mode, so it yields nothing useful. Duplicate detection is done in `triage.py` instead.
+
+`gitcrawl close-thread` / `close-cluster` are **local-only governance** — they set `closed_at_local` in SQLite and never call GitHub. Real closes are done by `apply.py` via `gh`.
+
+## SQLite schema we read (gitcrawl 0.5.0)
+
+DB at `~/.config/gitcrawl/gitcrawl.db` (override `GITCRAWL_DB_PATH`). Relevant tables:
+
+**`repositories`** — `id, owner, name, full_name (unique), …`. We look up `repo_id` by `full_name = owner/repo`.
+
+**`threads`** — one row per issue/PR. Columns we use:
+`number, kind ('issue'|'pull_request'), state, title, body, author_login, author_type, html_url, labels_json (JSON array of GitHub label objects), is_draft, created_at_gh, updated_at_gh, closed_at_gh, merged_at_gh, closed_at_local (local-close marker), raw_json (full GitHub object — we read reactions.total_count)`.
+Unique on `(repo_id, kind, number)`; indexed on `(repo_id, number)`, `(repo_id, state, closed_at_local)`, `(repo_id, updated_at)`.
+
+**`comments`** — `thread_id, comment_type, author_login, is_bot, body, created_at_gh`. We count non-bot comments per thread for engagement/priority.
+
+**`documents` / `documents_fts`** — canonical indexed text + FTS5 virtual table. Available for keyword search; the rule engine works off `threads`/`comments` directly so it doesn't strictly need FTS.
+
+Best-effort (usually empty without vectors): `clusters` (`representative_thread_id, member_count, closed_at_local`), `cluster_members` (`cluster_id, thread_id, score_to_representative`), `cluster_runs`.
+
+## Notes / gotchas
+
+- `labels_json` is the raw GitHub array, e.g. `[{"name":"area-ops",...}]` — parse `.name`. Empty is `[]`.
+- `kind` is `pull_request` in SQLite; we normalize to `pr` in `threads.jsonl`.
+- Timestamps are RFC3339 strings (`…Z`); `common.days_since` handles parsing.
+- A full backfill of a multi-year repo takes minutes and paginates the GitHub API; it honors `Retry-After`/rate-limit headers and resumes. Run it once with `--full`, then incremental.
+- gitcrawl version pinned in this skill's testing: **0.5.0**. If the schema shifts in a future release, `extract.py`'s SELECT is the only thing to adjust.

--- a/.claude/skills/issue-pr-scrub/resources/labels.md
+++ b/.claude/skills/issue-pr-scrub/resources/labels.md
@@ -1,0 +1,63 @@
+# Labels — taxonomy, mapping, and proposed extensions
+
+The skill **extends the repo's existing labels** rather than inventing a parallel scheme. `scrub.sh labels --repo R` reconciles the config's referenced labels against the live repo and reports what's missing. The `[labels]`/`[types]`/`[areas]`/`[priority]` tables in `config.example.toml` are the editable mapping.
+
+## Fission's current labels (captured 2026-05; verify with `gh label list`)
+
+**Type / nature**
+`bug`, `enhancement`, `feature-request`, `question`, `documentation`, `proposal`, `research`, `record-replay`
+
+**Area** (all `0052cc` blue unless noted)
+`area-function`, `area-api`, `area-dev-workflow`, `area-routing`, `area-composition`, `area-events`, `area-ops`, `area-install`, `area-observability`, `area-ux`, `area-performance`, `area-extensibility`, `area-builder`, `area-environment`, `area-executor`, `area-multitenancy`, `area-security`, `area-kubernetes`, `area-test`, `area-fission-cli`, `area-storagesvc`, `area-timetrigger`
+Executor sub-areas: `executor-poolmgr`, `executor-newdeploy`, `executor-container`
+Other component tags: `keda`, `podspec`
+
+**Lifecycle / triage**
+`triage`, `needs-triage`, `needs-reproduction`, `need-user-input`, `duplicate`, `wontfix`, `invalid`, `spam`, `in progress`, `work-in-progress`, `waiting-for-review`, `ready-to-merge`, `hold-off-merging`, `upstream-dependency`, `archive-pr` ("We close PR for timebeing and revisit again in future")
+
+**Size**
+`size/S`, `size/M`, `size/L`, `size/XL`
+
+**PR automation / CI**
+`go`, `docker`, `helm`, `github_actions`, `dependencies`, `no-changelog`, `skip-ci`, `run-old-ci`, `sweep`, `fission-ci/cd/release`
+
+**Community**
+`help wanted`, `good first issue`, `hacktoberfest`, `hacktoberfest-accepted`
+
+## How the rule engine uses them
+
+| Disposition | Label(s) added (`[labels]`) | gh close reason |
+| --- | --- | --- |
+| close-duplicate | `duplicate` | not_planned |
+| close-implemented | _(none)_ | completed |
+| close-eol | `wontfix` | not_planned |
+| close-stale / mark-stale | `stale` * | not_planned (close) |
+| needs-info | `needs-reproduction`, `need-user-input` | _(no close)_ |
+| pr-archive | `archive-pr` | not_planned |
+| keep | `needs-triage` + type + areas + priority * | _(no close)_ |
+
+`*` = references a **proposed** label that does not exist yet (see below).
+
+**Type inference** maps keyword sets to existing type labels (`bug`, `feature-request`, `enhancement`, `documentation`, `question`).
+**Area inference** maps subsystem keywords to `area-*` (+ executor sub-areas / `keda`), capped at the 3 strongest per thread.
+**Protected labels** (`[protected]`) make a thread untouchable: `keep-open`, `help wanted`, `good first issue`, `proposal`, `hold-off-merging`, `in progress`, `work-in-progress`, `ready-to-merge`, `area-security`, `research`.
+
+## Proposed new labels (do NOT exist yet)
+
+The engine references these; they're created only via `scrub.sh labels --create-missing --execute` (after maintainer sign-off — labels are repo-wide and visible to everyone).
+
+| Label | Color | Purpose |
+| --- | --- | --- |
+| `stale` | `ededed` | No activity for a long time; close candidate |
+| `keep-open` | `0e8a16` | Protects an issue from stale automation |
+| `priority/critical` | `b60205` | Drop everything |
+| `priority/high` | `d93f0b` | Address soon |
+| `priority/medium` | `fbca04` | Normal |
+| `priority/low` | `0e8a16` | Nice to have |
+| `eol-version` | `bfd4f2` | Targets an unsupported/EOL version (optional) |
+
+Rationale for additions: Fission has **no priority scheme** and **no stale label** today, both of which a backlog scrub needs. If you'd rather not add `priority/*`, set the four `*_label` keys in `[priority]` to existing labels (or empty) and they'll be skipped.
+
+## Other repos
+
+Run `scrub.sh labels --repo other/repo` first. It lists referenced-but-missing labels so you can either create them or retune `config.<owner>__<repo>.toml` to the repo's existing scheme. The `[areas]`/`[types]` keyword maps are the main thing to localize.

--- a/.claude/skills/issue-pr-scrub/resources/pipeline.md
+++ b/.claude/skills/issue-pr-scrub/resources/pipeline.md
@@ -43,7 +43,7 @@ No network. Safe to re-run any time after a sync.
 
 ## Stage 3 — triage (`triage.py`)
 
-Deterministic rule engine over `threads.jsonl`, config-driven. Triages **open, not-locally-closed** threads only. Builds duplicate groups locally (cross-references + title-token Jaccard ≥ 0.6) — no embeddings. Emits `triage.jsonl`: `disposition, tier, add_labels[], comment_template, context, rationale, type, areas`.
+Deterministic rule engine over `threads.jsonl`, config-driven. Triages **open, not-locally-closed** threads only. Builds duplicate groups locally (same-kind title-token Jaccard ≥ `dup_title_jaccard`, default 0.7; cross-references upgrade confidence) — no embeddings. Emits `triage.jsonl`: `disposition, tier, add_labels[], comment_template, context, rationale, type, areas`.
 
 See `triage-rules.md` for the full rule list. Pure; re-run after tuning config without re-syncing.
 

--- a/.claude/skills/issue-pr-scrub/resources/pipeline.md
+++ b/.claude/skills/issue-pr-scrub/resources/pipeline.md
@@ -1,0 +1,78 @@
+# Pipeline — stage contract & repeated-execution model
+
+Five stages.
+Each is a standalone script under `scripts/`, driven by `scrub.sh`.
+Every stage is keyed by `--repo owner/name` and reads its config via the resolution order in `config.example.toml` (explicit `--config` > `config.<owner>__<repo>.toml` > `config.example.toml`).
+
+## Workdir
+
+All derived artifacts live in `~/.cache/issue-pr-scrub/<owner>__<repo>/` (override via `[paths].workdir`).
+Nothing is written into the target repo, so no `.gitignore` edits are needed and the same machine can scrub many repos.
+
+```
+<workdir>/
+  state.json        timestamps + counts per stage
+  threads.jsonl     normalized issues/PRs (extract)
+  triage.jsonl      disposition/tier/labels/rationale per OPEN thread (triage)
+  apply-plan.jsonl  machine-actionable rows, auto + review (report)
+  report.md         human review, grouped (report)
+  triage.csv        spreadsheet view (report)
+  stale-review.csv  stale items sorted by signal, blank `keep` column (report)
+  keepers.txt       YOU create this: numbers to force-keep (triage skips them)
+  approved.jsonl    YOU create this: curated review-tier rows to apply
+  ledger.jsonl      append-only record of applied gh actions (apply)
+```
+
+## Stage 1 — sync (`scrub.sh sync`)
+
+Wraps gitcrawl. Reads GitHub, writes only local SQLite.
+
+- **First run / full backfill:** `--full` → `gitcrawl sync owner/repo --state all --include-comments`.
+  Pulls every issue + PR and their comments. This is the slow one (minutes for a multi-year repo); it honors GitHub rate limits and resumes cleanly.
+- **Incremental (default):** `gitcrawl sync owner/repo`.
+  Fetches open items plus a recently-closed sweep, so local open-state doesn't rot between runs.
+
+Idempotent: re-running updates changed rows in place (gitcrawl upserts by `(repo, kind, number)`).
+
+## Stage 2 — extract (`extract.py`)
+
+Pure read of the gitcrawl SQLite mirror → `threads.jsonl`, one normalized row per thread:
+`number, kind (issue|pr), state, title, body_excerpt, body_len, author, url, labels[], is_draft, created_at, updated_at, closed_at, merged_at, closed_local, comment_count, reactions (both read from the GitHub object — no comment hydration needed), references[] (parsed #123 / pull/123), cluster_id, cluster_canonical (best-effort, usually null in keyword mode)`.
+
+No network. Safe to re-run any time after a sync.
+
+## Stage 3 — triage (`triage.py`)
+
+Deterministic rule engine over `threads.jsonl`, config-driven. Triages **open, not-locally-closed** threads only. Builds duplicate groups locally (cross-references + title-token Jaccard ≥ 0.6) — no embeddings. Emits `triage.jsonl`: `disposition, tier, add_labels[], comment_template, context, rationale, type, areas`.
+
+See `triage-rules.md` for the full rule list. Pure; re-run after tuning config without re-syncing.
+
+## Stage 4 — report (`report.py`)
+
+Transforms `triage.jsonl` into review artifacts:
+- `report.md` — grouped by tier (auto → review → keep → skip) then disposition, with links + rationale + suggested labels. **This is what a human reads.**
+- `triage.csv` — flat spreadsheet for sorting/filtering.
+- `apply-plan.jsonl` — actionable rows (auto + review tiers) with `action` (close|label), `close_reason`, labels, comment template, context, and `updated_at_at_extract` (for the staleness guard).
+
+Pure. No GitHub writes.
+
+## Stage 5 — apply (`apply.py`) — the only writer
+
+```
+apply.py --repo R --auto                  # dry-run, tier=auto rows
+apply.py --repo R --auto --execute        # perform them (gated, capped)
+apply.py --repo R --from approved.jsonl --execute   # human-approved review items
+```
+
+Per row, in order: ledger-dedup → live re-fetch (staleness + protected guard) → cap check → build gh commands → (dry-run: print | execute: run + ledger + optional `gitcrawl close-thread`).
+See `write-actions.md` for command shapes and the full gate list.
+
+## Repeated-execution model (cadence)
+
+The whole point is cheap re-runs:
+- `scrub.sh run --repo R` (no `--full`) on a schedule → fresh report from an incremental sync.
+- `triage.jsonl`/`report.md` are pure re-derivations, so tuning `config.*.toml` and re-running `triage`+`report` costs nothing (no re-sync).
+- The **ledger** makes `apply` safe to re-run: already-applied actions are skipped, so you can apply in capped batches across multiple invocations until the auto set is drained.
+- Locally closing handled items (`gitcrawl close-thread`, done automatically on a successful GitHub close) drops them from future `triage` runs, so the report shrinks to genuinely-new work each cycle.
+
+To run as an actual cadence, wrap `scrub.sh run` in cron/CI and review the report; keep `apply --execute` a human-in-the-loop step.

--- a/.claude/skills/issue-pr-scrub/resources/pipeline.md
+++ b/.claude/skills/issue-pr-scrub/resources/pipeline.md
@@ -27,8 +27,8 @@ Nothing is written into the target repo, so no `.gitignore` edits are needed and
 
 Wraps gitcrawl. Reads GitHub, writes only local SQLite.
 
-- **First run / full backfill:** `--full` → `gitcrawl sync owner/repo --state all --include-comments`.
-  Pulls every issue + PR and their comments. This is the slow one (minutes for a multi-year repo); it honors GitHub rate limits and resumes cleanly.
+- **First run / full backfill:** `--full` → `gitcrawl sync owner/repo --state all` (metadata-only).
+  Pulls every issue + PR. Comment/reaction counts come from the thread object itself, so the rule engine never needs comment hydration. Add `--with-comments` only if you want comment bodies in the FTS index — that's the slow path; metadata-only is minutes for a multi-year repo, honors rate limits, and resumes cleanly.
 - **Incremental (default):** `gitcrawl sync owner/repo`.
   Fetches open items plus a recently-closed sweep, so local open-state doesn't rot between runs.
 

--- a/.claude/skills/issue-pr-scrub/resources/triage-rules.md
+++ b/.claude/skills/issue-pr-scrub/resources/triage-rules.md
@@ -1,0 +1,66 @@
+# Triage rules — the rule engine
+
+`triage.py` classifies each **open, not-locally-closed** thread with the first matching rule (order matters). Every threshold is in `config.*.toml` under `[triage]`, `[versions]`, `[protected]`. Output per thread: a `disposition`, a `tier`, labels to add, a comment template key, a context dict, and a human rationale.
+
+## Tiers
+
+| Tier | Meaning | How it's applied |
+| --- | --- | --- |
+| `auto` | Deterministic + low-risk. | Eligible for `apply.py --auto` (still gated by dry-run/cap/guards). |
+| `review` | Needs human judgment the rules can't make safely. | Listed in `report.md`; apply only via `--from approved.jsonl`. |
+| `keep` | Active/relevant; categorize only. | Label suggestions only; never closes. |
+| `skip` | Protected. | Never auto-acted. |
+
+## Rule order
+
+**-1. Keepers guard → `skip`.**
+Any number listed in `<workdir>/keepers.txt` (one per line, `#` comments allowed) is force-kept with disposition `keep`, tier `skip`, rationale "manually kept". This wins over every other rule and takes effect immediately — no re-sync. It's how you rescue stale items you've reviewed and want to protect. Optionally push the `keep-open` label upstream with `scrub.sh protect` so the protection is visible on GitHub and survives a DB rebuild.
+
+**0. Protected guard → `keep` / `skip`.**
+If the thread carries any `[protected].labels` (`keep-open`, `help wanted`, `good first issue`, `proposal`, `hold-off-merging`, `in progress`, `work-in-progress`, `ready-to-merge`, `area-security`, `research`), it is untouchable. Rationale records which label protected it.
+
+**1. close-duplicate.**
+Non-canonical member of a locally-detected duplicate group. Group detection (in `build_dup_groups`): union-find over (a) deterministic same-repo cross-references `#123`/`pull/123`/`issues/123` of 2+ digits, and (b) same-kind title-token Jaccard ≥ 0.6 (4+ char tokens, stopwords removed). Canonical = lowest-numbered open member.
+- evidence = cross-reference → `auto`
+- evidence = title-overlap only → `review`
+
+**2. close-implemented → `review`.**
+Body matches `(fixed|resolved|closed|implemented) (in|by|via) #NNN`. Conservative: a human must confirm the referenced PR actually merged (keyword mode can't verify merge state reliably).
+
+**3. close-eol → `auto`.**
+Body/title mentions a version at/below a floor in `[versions]` (`fission_floor`, `k8s_floor`) **and** inactive ≥ `stale_days`. The regexes capture a numeric version; `below_floor` compares tuples.
+
+**4. PR lifecycle (kind == pr).**
+- inactive ≥ `pr_abandoned_days` (default 730) → `pr-archive` / `auto`
+- draft and inactive ≥ `pr_stale_days` (default 365) → `pr-archive` / `review`
+
+**5. close-stale (issues) → `auto`.**
+Open issue, inactive ≥ `stale_days` (default 540 ≈ 18mo), `comment_count ≤ stale_comment_max`.
+If `stale_two_step = true` and not yet labeled `stale`: emits `mark-stale` (label + warning comment, no close) — a later run closes it once it's already labeled stale and still idle.
+
+**6. needs-info → `review`.**
+Issue inferred as `bug`, no reproduction (body shorter than `no_repro_body_chars` or lacking any `repro_markers`), inactive ≥ `needs_info_days`. Adds `needs-reproduction` + `need-user-input`.
+
+**7. keep + categorize → `keep`.**
+Everything else. Adds `needs-triage` plus inferred **type** (`[types]` keyword map → bug/feature-request/enhancement/documentation/question), up to 3 **areas** (`[areas]` keyword map, ranked by hit count over title+body-prefix), and a **priority** (`[priority]`: critical keywords, else engagement score = comments + reactions bucketed high/medium/low).
+
+## Enrichment on every row
+
+`type`, `areas`, `priority`, `engagement` (= reactions + comments), `reactions`, and `comment_count` are computed for **every** triaged thread — including stale/eol/pr-archive rows — so the close piles are reviewable, not opaque. `report.py` uses them to build `stale-review.csv` (sorted by signal) and to annotate the report.
+
+## Stale re-review loop
+
+`close-stale` is purely age-based and intentionally the largest pile. To re-review before closing:
+1. Run the pipeline; open `stale-review.csv` (sorted: highest engagement + feature/bug first).
+2. Decide keepers; put their numbers in `<workdir>/keepers.txt`.
+3. Re-run `triage` + `report` (instant — no re-sync). Keepers are now `skip` and out of the apply-plan.
+4. (Optional) `scrub.sh protect` to add `keep-open` upstream.
+5. `apply --auto --execute` closes the remaining stale items in capped batches.
+
+## Tuning
+
+- Rules are pure re-derivations: edit `config.*.toml`, re-run `scrub.sh triage` + `report` — no re-sync.
+- Too many false stale-closes? Raise `stale_days` / lower `stale_comment_max`.
+- Duplicate groups too greedy? Raise the Jaccard floor (edit `build_dup_groups`, currently 0.6) or rely only on `ref` evidence by treating `title` evidence as keep.
+- Area labels noisy? Tighten `[areas]` keywords or lower the cap (in `infer_areas`).
+- The engine never *removes* labels and never edits closed threads.

--- a/.claude/skills/issue-pr-scrub/resources/triage-rules.md
+++ b/.claude/skills/issue-pr-scrub/resources/triage-rules.md
@@ -20,9 +20,8 @@ Any number listed in `<workdir>/keepers.txt` (one per line, `#` comments allowed
 If the thread carries any `[protected].labels` (`keep-open`, `help wanted`, `good first issue`, `proposal`, `hold-off-merging`, `in progress`, `work-in-progress`, `ready-to-merge`, `area-security`, `research`), it is untouchable. Rationale records which label protected it.
 
 **1. close-duplicate.**
-Non-canonical member of a locally-detected duplicate group. Group detection (in `build_dup_groups`): union-find over (a) deterministic same-repo cross-references `#123`/`pull/123`/`issues/123` of 2+ digits, and (b) same-kind title-token Jaccard ≥ 0.6 (4+ char tokens, stopwords removed). Canonical = lowest-numbered open member.
-- evidence = cross-reference → `auto`
-- evidence = title-overlap only → `review`
+Non-canonical member of a locally-detected duplicate group. Group detection (in `build_dup_groups`): union-find over (a) deterministic same-repo cross-references `#123`/`pull/123`/`issues/123` of 2+ digits, and (b) same-kind title-token Jaccard ≥ `dup_title_jaccard` (default 0.7; 4+ char tokens, stopwords removed). Canonical = lowest-numbered member that is open upstream AND not locally closed.
+- evidence is computed **per member**: a member auto-closes only if it has a direct cross-reference edge to another group member; members joined by title overlap alone stay `review`.
 
 **2. close-implemented → `review`.**
 Body matches `(fixed|resolved|closed|implemented) (in|by|via) #NNN`. Conservative: a human must confirm the referenced PR actually merged (keyword mode can't verify merge state reliably).
@@ -61,6 +60,6 @@ Everything else. Adds `needs-triage` plus inferred **type** (`[types]` keyword m
 
 - Rules are pure re-derivations: edit `config.*.toml`, re-run `scrub.sh triage` + `report` — no re-sync.
 - Too many false stale-closes? Raise `stale_days` / lower `stale_comment_max`.
-- Duplicate groups too greedy? Raise the Jaccard floor (edit `build_dup_groups`, currently 0.6) or rely only on `ref` evidence by treating `title` evidence as keep.
+- Duplicate groups too greedy? Raise `dup_title_jaccard` in `[triage]` (default 0.7), or act only on `ref`-evidence members and leave `title`-only members for manual review.
 - Area labels noisy? Tighten `[areas]` keywords or lower the cap (in `infer_areas`).
 - The engine never *removes* labels and never edits closed threads.

--- a/.claude/skills/issue-pr-scrub/resources/write-actions.md
+++ b/.claude/skills/issue-pr-scrub/resources/write-actions.md
@@ -1,0 +1,68 @@
+# Write actions — the gh playbook & safety gates
+
+`apply.py` is the **only** stage that writes to GitHub. It maps each approved `apply-plan.jsonl` row to `gh` commands. Dry-run prints them; `--execute` runs them.
+
+## Command shapes
+
+For an issue (`gh issue ...`) or PR (`gh pr ...`):
+
+```bash
+# label-only (disposition=keep is never applied; only review/auto labels here)
+gh issue edit  <n> --repo R --add-label "lab1,lab2"
+
+# close (label first if any, then comment, then close)
+gh issue comment <n> --repo R --body "<rendered template>"
+gh issue close   <n> --repo R --reason not_planned   # or completed (issues only)
+gh pr    close   <n> --repo R                          # PRs have no --reason
+```
+
+Close reasons by disposition: `completed` for close-implemented; `not_planned` for close-duplicate / close-eol / close-stale / pr-archive.
+
+After a successful close, `apply.py` runs `gitcrawl close-thread R --number <n>` locally (unless `--no-local-close`) so the item drops out of the next triage run.
+
+## Comment templates
+
+Defaults live in `apply.py` (`TEMPLATES`); override per-repo via a `[templates]` table in config. Placeholders are filled from each row's `context` (`{canonical}`, `{detail}`, `{age_days}`). Keep them courteous and reversible — every one invites reopening.
+
+| Key | Used by | Gist |
+| --- | --- | --- |
+| `duplicate` | close-duplicate | "Closing as a duplicate of #{canonical}… happy to reopen." |
+| `implemented` | close-implemented | "Looks resolved in a more recent release… reopen if it persists." |
+| `eol` | close-eol | "Targets {detail}, past our supported window, idle {age_days}d…" |
+| `stale` | close-stale | "Inactive {age_days}d; scrubbing the backlog… reopen if still relevant." |
+| `stale_warn` | mark-stale | "Inactive {age_days}d; marking stale, will close later unless there's activity." |
+| `pr_archive` | pr-archive | "Archiving for inactivity (`archive-pr`)… rebase & reopen to continue." |
+| `needs_info` | needs-info | "Can't reproduce — please add repro steps, versions, logs." |
+
+## Safety gates (enforced every run)
+
+1. **Dry-run default.** Without `--execute`, `apply.py` prints `would: gh …` and makes no changes.
+2. **Selection is mutually exclusive and explicit.** Exactly one of `--auto` (tier=auto rows from `apply-plan.jsonl`) or `--from FILE.jsonl` (your curated review rows). No "apply everything".
+3. **Per-run cap.** `[apply].max_per_run` (default 25), overridable with `--max`. Stops cleanly; re-run to continue (ledger skips done rows).
+4. **Pacing.** `[apply].sleep_seconds` between writes — gentle on the API and on watchers' notifications.
+5. **Staleness guard.** Immediately before acting, re-fetch live `state`/`updatedAt`/`labels`. Skip if: already closed upstream, or `updatedAt` differs from extract time (someone touched it). Re-run the pipeline to refresh.
+6. **Protected re-check.** Skip if the live labels now include a protected label.
+7. **Ledger dedup.** `ledger.jsonl` records every action with `ok`/`error`; an `ok` `(number, action)` is never repeated.
+8. **Auth.** `--execute` requires a clean `gh auth status`.
+
+## Curating review-tier items
+
+`review` items never run under `--auto`. To act on them:
+
+```bash
+WD=~/.cache/issue-pr-scrub/fission__fission
+# inspect, then keep only the rows you approve:
+jq -c 'select(.tier=="review" and .disposition=="close-duplicate")' "$WD/apply-plan.jsonl" > "$WD/approved.jsonl"
+# edit approved.jsonl by hand to drop any you're unsure about, then:
+bash scrub.sh apply --repo fission/fission --from "$WD/approved.jsonl" --execute
+```
+
+The same gates (cap, staleness, protected, ledger) apply to `--from`.
+
+## What this stage will NOT do
+
+- Open or merge PRs.
+- Edit milestones, assignees, projects, or transfer issues.
+- Remove labels.
+- Touch closed threads.
+- Create labels (that's `labels --create-missing`, a separate gated command).

--- a/.claude/skills/issue-pr-scrub/resources/write-actions.md
+++ b/.claude/skills/issue-pr-scrub/resources/write-actions.md
@@ -1,6 +1,8 @@
 # Write actions — the gh playbook & safety gates
 
-`apply.py` is the **only** stage that writes to GitHub. It maps each approved `apply-plan.jsonl` row to `gh` commands. Dry-run prints them; `--execute` runs them.
+`apply.py` is the stage that applies **triage plan actions** (close/label/comment) to GitHub. It maps each approved `apply-plan.jsonl` row to `gh` commands. Dry-run prints them; `--execute` runs them.
+
+Two other commands also write to GitHub and are likewise gated behind `--execute`: `protect.py` (adds the `keep-open` label to your keepers) and `labels_sync.py --create-missing` (creates the proposed labels). Everything else in the pipeline is read-only.
 
 ## Command shapes
 
@@ -38,7 +40,7 @@ Defaults live in `apply.py` (`TEMPLATES`); override per-repo via a `[templates]`
 
 1. **Dry-run default.** Without `--execute`, `apply.py` prints `would: gh …` and makes no changes.
 2. **Selection is mutually exclusive and explicit.** Exactly one of `--auto` (tier=auto rows from `apply-plan.jsonl`) or `--from FILE.jsonl` (your curated review rows). No "apply everything".
-3. **Per-run cap.** `[apply].max_per_run` (default 25), overridable with `--max`. Stops cleanly; re-run to continue (ledger skips done rows).
+3. **Per-run write cap.** `[apply].max_per_run` (default 25), overridable with `--max`, counts individual GitHub mutations (label/comment/close each count), checked at row boundaries so a row is never left half-applied. Stops cleanly; re-run to continue (per-step ledger skips done steps).
 4. **Pacing.** `[apply].sleep_seconds` between writes — gentle on the API and on watchers' notifications.
 5. **Staleness guard.** Immediately before acting, re-fetch live `state`/`updatedAt`/`labels`. Skip if: already closed upstream, or `updatedAt` differs from extract time (someone touched it). Re-run the pipeline to refresh.
 6. **Protected re-check.** Skip if the live labels now include a protected label.

--- a/.claude/skills/issue-pr-scrub/scripts/.gitignore
+++ b/.claude/skills/issue-pr-scrub/scripts/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+config.*.toml
+!config.example.toml

--- a/.claude/skills/issue-pr-scrub/scripts/apply.py
+++ b/.claude/skills/issue-pr-scrub/scripts/apply.py
@@ -23,7 +23,6 @@ so the item drops out of the next run.
 
 from __future__ import annotations
 
-import argparse
 import time
 
 import common
@@ -192,10 +191,12 @@ def build_commands(slug, kind, action, number, row, cfg) -> list[list[str]]:
     if labels:
         cmds.append(["gh", gk, "edit", str(number), "--repo", slug,
                      "--add-label", ",".join(labels)])
+    # Post the comment for ANY disposition that carries a template, not just
+    # closes — mark-stale and needs-info are label-plus-comment actions.
+    body = render(row.get("comment_template"), cfg, row.get("context", {}))
+    if body:
+        cmds.append(["gh", gk, "comment", str(number), "--repo", slug, "--body", body])
     if action == "close":
-        body = render(row.get("comment_template"), cfg, row.get("context", {}))
-        if body:
-            cmds.append(["gh", gk, "comment", str(number), "--repo", slug, "--body", body])
         close_cmd = ["gh", gk, "close", str(number), "--repo", slug]
         reason = row.get("close_reason")
         if gk == "issue" and reason:

--- a/.claude/skills/issue-pr-scrub/scripts/apply.py
+++ b/.claude/skills/issue-pr-scrub/scripts/apply.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Stage 5 — apply: execute approved triage actions on GitHub via `gh`.
+
+THE ONLY STAGE THAT WRITES TO GITHUB. Dry-run by default — it prints the exact
+gh commands it WOULD run and exits. You must pass --execute to perform writes.
+
+Selection (exactly one required):
+  --auto              act on tier=auto rows from apply-plan.jsonl (gated set)
+  --from FILE.jsonl   act on a curated file of approved rows (for review items)
+
+Safety gates (all enforced here, every run):
+  * dry-run default; --execute required for any mutation
+  * --max N per-run cap (config apply.max_per_run; default 25)
+  * gentle pacing between writes (config apply.sleep_seconds)
+  * ledger dedup: never re-applies a (number, action) already recorded ok
+  * staleness guard: re-fetches each thread's current state/updatedAt/labels
+    immediately before acting; SKIPS if it was closed or touched since extract
+  * protected-label re-check at apply time
+  * requires a clean `gh auth status`
+On a successful GitHub close, optionally runs `gitcrawl close-thread` locally
+so the item drops out of the next run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import common
+
+TEMPLATES = {
+    "duplicate": (
+        "Closing as a duplicate of #{canonical}. Please follow that issue for "
+        "updates; happy to reopen if you think this is meaningfully different."
+    ),
+    "implemented": (
+        "This looks resolved in a more recent release. Closing as completed — "
+        "please reopen with details if you still hit it on a current version."
+    ),
+    "eol": (
+        "This targets {detail}, which is past our supported window, and has been "
+        "inactive for {age_days} days. Closing as not planned — please reopen "
+        "against a currently supported version if it still reproduces."
+    ),
+    "stale": (
+        "This has been inactive for {age_days} days. We're scrubbing the backlog "
+        "and closing stale items to keep it actionable. If this is still relevant, "
+        "please reopen or comment and we'll pick it back up."
+    ),
+    "stale_warn": (
+        "This has been inactive for {age_days} days and is being marked stale. "
+        "It will be closed in a future scrub if there's no further activity. "
+        "Comment to keep it open."
+    ),
+    "pr_archive": (
+        "Archiving this PR for now due to inactivity (see the `archive-pr` label). "
+        "We revisit archived PRs periodically — please rebase and reopen if you'd "
+        "like to continue."
+    ),
+    "needs_info": (
+        "We can't reproduce this from the information provided. Could you add "
+        "reproduction steps, your Fission and Kubernetes versions, and relevant "
+        "logs? Marking as needing more info."
+    ),
+}
+
+
+def render(template_key: str, cfg: dict, context: dict) -> str | None:
+    if not template_key:
+        return None
+    tmpl = cfg.get("templates", {}).get(template_key) or TEMPLATES.get(template_key)
+    if not tmpl:
+        return None
+    safe = {"canonical": "?", "detail": "the targeted version", "age_days": "?"}
+    safe.update({k: v for k, v in context.items() if v is not None})
+    try:
+        return tmpl.format(**safe)
+    except (KeyError, IndexError):
+        return tmpl
+
+
+def gh_kind(kind: str) -> str:
+    return "pr" if kind == "pr" else "issue"
+
+
+def current_state(slug: str, kind: str, number: int) -> dict | None:
+    """Re-fetch live state for the staleness/protection guard."""
+    fields = "state,updatedAt,labels"
+    try:
+        data = common.gh_json(
+            ["pr" if kind == "pr" else "issue", "view", str(number),
+             "--repo", slug, "--json", fields]
+        )
+    except Exception as exc:  # noqa: BLE001 - surface gh failure, skip the item
+        common.info(f"  #{number}: gh view failed ({exc}); skipping")
+        return None
+    return {
+        "state": (data.get("state") or "").lower(),
+        "updated_at": data.get("updatedAt"),
+        "labels": [lb.get("name") for lb in data.get("labels", []) if lb.get("name")],
+    }
+
+
+def main() -> None:
+    ap = common.base_argparser(__doc__)
+    sel = ap.add_mutually_exclusive_group(required=True)
+    sel.add_argument("--auto", action="store_true", help="tier=auto rows from apply-plan.jsonl")
+    sel.add_argument("--from", dest="from_file", help="curated approved rows (.jsonl)")
+    ap.add_argument("--execute", action="store_true", help="actually write (default: dry-run)")
+    ap.add_argument("--max", type=int, default=None, help="override per-run cap")
+    ap.add_argument("--no-local-close", action="store_true", help="skip gitcrawl close-thread")
+    args = ap.parse_args()
+
+    ctx = common.bootstrap(args)
+    wd, slug, cfg = ctx["wd"], ctx["slug"], ctx["cfg"]
+    apply_cfg = cfg.get("apply", {})
+    cap = args.max if args.max is not None else apply_cfg.get("max_per_run", 25)
+    sleep_s = apply_cfg.get("sleep_seconds", 2.0)
+    local_close = apply_cfg.get("local_close", True) and not args.no_local_close
+    protected = set(cfg.get("protected", {}).get("labels", []))
+
+    src = (wd / "apply-plan.jsonl") if args.auto else common.expand_path(args.from_file)
+    rows = list(common.read_jsonl(src))
+    if args.auto:
+        rows = [r for r in rows if r.get("tier") == "auto"]
+    if not rows:
+        common.info(f"no actionable rows in {src}")
+        return
+
+    mode = "EXECUTE" if args.execute else "DRY-RUN"
+    common.info(f"[{mode}] {slug}: {len(rows)} candidate rows (cap {cap})")
+    if args.execute:
+        common.require_gh_auth()
+
+    done = common.ledger_done(wd)
+    applied = 0
+    for r in rows:
+        if applied >= cap:
+            common.info(f"reached per-run cap ({cap}); stop. Re-run to continue.")
+            break
+        number, kind, action = int(r["number"]), r["kind"], r["action"]
+        if (number, action) in done:
+            continue
+
+        live = current_state(slug, kind, number)
+        if live is None:
+            continue
+        if action == "close" and live["state"] != "open":
+            common.info(f"  #{number}: already {live['state']} upstream; skip")
+            continue
+        if set(live["labels"]) & protected:
+            common.info(f"  #{number}: now protected ({set(live['labels']) & protected}); skip")
+            continue
+        if live["updated_at"] and r.get("updated_at_at_extract") and \
+                live["updated_at"] != r["updated_at_at_extract"]:
+            common.info(f"  #{number}: touched since extract ({live['updated_at']}); skip — re-run pipeline")
+            continue
+
+        cmds = build_commands(slug, kind, action, number, r, cfg)
+        for c in cmds:
+            common.info(("  RUN: " if args.execute else "  would: ") + " ".join(_shellish(c)))
+
+        if not args.execute:
+            applied += 1
+            continue
+
+        ok, err = run_commands(cmds)
+        common.ledger_append(wd, {
+            "number": number, "action": action, "disposition": r["disposition"],
+            "status": "ok" if ok else "error", "error": err,
+        })
+        if ok:
+            applied += 1
+            if action == "close" and local_close and common.have("gitcrawl"):
+                common.run(
+                    ["gitcrawl", "close-thread", slug, "--number", str(number),
+                     "--reason", r.get("disposition", "scrub")],
+                    check=False,
+                )
+            time.sleep(sleep_s)
+        else:
+            common.info(f"  #{number}: FAILED — {err}")
+
+    common.info(f"[{mode}] done. {applied} {'applied' if args.execute else 'planned'}.")
+
+
+def build_commands(slug, kind, action, number, row, cfg) -> list[list[str]]:
+    """Return the ordered gh command argv lists for one row."""
+    gk = gh_kind(kind)
+    cmds: list[list[str]] = []
+    labels = row.get("add_labels") or []
+    if labels:
+        cmds.append(["gh", gk, "edit", str(number), "--repo", slug,
+                     "--add-label", ",".join(labels)])
+    if action == "close":
+        body = render(row.get("comment_template"), cfg, row.get("context", {}))
+        if body:
+            cmds.append(["gh", gk, "comment", str(number), "--repo", slug, "--body", body])
+        close_cmd = ["gh", gk, "close", str(number), "--repo", slug]
+        reason = row.get("close_reason")
+        if gk == "issue" and reason:
+            close_cmd += ["--reason", reason]
+        cmds.append(close_cmd)
+    return cmds
+
+
+def run_commands(cmds: list[list[str]]) -> tuple[bool, str]:
+    for c in cmds:
+        cp = common.run(c, check=False)
+        if cp.returncode != 0:
+            return False, (cp.stderr or cp.stdout or "").strip()[:300]
+    return True, ""
+
+
+def _shellish(argv: list[str]) -> list[str]:
+    out = []
+    for a in argv:
+        out.append(f'"{a}"' if " " in a else a)
+    return out
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-pr-scrub/scripts/apply.py
+++ b/.claude/skills/issue-pr-scrub/scripts/apply.py
@@ -137,10 +137,13 @@ def main() -> None:
     done_steps = {(int(e["number"]), e.get("step"))
                   for e in common.read_jsonl(common.ledger_path(wd))
                   if e.get("status") == "ok"}
+    # The cap counts individual GitHub mutations (label/comment/close each
+    # count), checked at row boundaries so a row is never left half-applied.
+    writes = 0
     applied = 0
     for r in rows:
-        if applied >= cap:
-            common.info(f"reached per-run cap ({cap}); stop. Re-run to continue.")
+        if writes >= cap:
+            common.info(f"reached per-run write cap ({cap}); stop. Re-run to continue.")
             break
         number, kind, action = int(r["number"]), r["kind"], r["action"]
         steps = build_commands(slug, kind, action, number, r, cfg)
@@ -166,11 +169,12 @@ def main() -> None:
             common.info(("  RUN: " if args.execute else "  would: ") + " ".join(_shellish(cmd)))
 
         if not args.execute:
+            writes += len(pending)
             applied += 1
             continue
 
         # Run pending steps in order; stop at the first failure so a later run
-        # resumes from exactly the step that failed.
+        # resumes from exactly the step that failed. Pace between each mutation.
         row_ok = True
         closed = False
         for step, cmd in pending:
@@ -183,8 +187,10 @@ def main() -> None:
             })
             if status == "ok":
                 done_steps.add((number, step))
+                writes += 1
                 if step == "close":
                     closed = True
+                time.sleep(sleep_s)
             else:
                 common.info(f"  #{number}: step '{step}' FAILED — {(cp.stderr or '').strip()[:200]}")
                 row_ok = False
@@ -198,7 +204,6 @@ def main() -> None:
             )
         if row_ok:
             applied += 1
-        time.sleep(sleep_s)
 
     common.info(f"[{mode}] done. {applied} {'applied' if args.execute else 'planned'}.")
 

--- a/.claude/skills/issue-pr-scrub/scripts/apply.py
+++ b/.claude/skills/issue-pr-scrub/scripts/apply.py
@@ -150,6 +150,10 @@ def main() -> None:
         pending = [(s, c) for (s, c) in steps if (number, s) not in done_steps]
         if not pending:
             continue
+        # Resuming a partial apply: earlier steps already ran OK, so our OWN
+        # label/comment bumped updated_at. Don't let the staleness guard block
+        # the leftover step on a touch we caused ourselves.
+        resuming = len(pending) < len(steps)
 
         live = current_state(slug, kind, number)
         if live is None:
@@ -160,7 +164,7 @@ def main() -> None:
         if set(live["labels"]) & protected:
             common.info(f"  #{number}: now protected ({set(live['labels']) & protected}); skip")
             continue
-        if live["updated_at"] and r.get("updated_at_at_extract") and \
+        if not resuming and live["updated_at"] and r.get("updated_at_at_extract") and \
                 live["updated_at"] != r["updated_at_at_extract"]:
             common.info(f"  #{number}: touched since extract ({live['updated_at']}); skip — re-run pipeline")
             continue

--- a/.claude/skills/issue-pr-scrub/scripts/apply.py
+++ b/.claude/skills/issue-pr-scrub/scripts/apply.py
@@ -131,14 +131,21 @@ def main() -> None:
     if args.execute:
         common.require_gh_auth()
 
-    done = common.ledger_done(wd)
+    # Ledger dedup is PER STEP (label/comment/close), not per row: a close that
+    # fails after the comment succeeded must not replay the (non-idempotent)
+    # comment on the next run.
+    done_steps = {(int(e["number"]), e.get("step"))
+                  for e in common.read_jsonl(common.ledger_path(wd))
+                  if e.get("status") == "ok"}
     applied = 0
     for r in rows:
         if applied >= cap:
             common.info(f"reached per-run cap ({cap}); stop. Re-run to continue.")
             break
         number, kind, action = int(r["number"]), r["kind"], r["action"]
-        if (number, action) in done:
+        steps = build_commands(slug, kind, action, number, r, cfg)
+        pending = [(s, c) for (s, c) in steps if (number, s) not in done_steps]
+        if not pending:
             continue
 
         live = current_state(slug, kind, number)
@@ -155,62 +162,67 @@ def main() -> None:
             common.info(f"  #{number}: touched since extract ({live['updated_at']}); skip — re-run pipeline")
             continue
 
-        cmds = build_commands(slug, kind, action, number, r, cfg)
-        for c in cmds:
-            common.info(("  RUN: " if args.execute else "  would: ") + " ".join(_shellish(c)))
+        for step, cmd in pending:
+            common.info(("  RUN: " if args.execute else "  would: ") + " ".join(_shellish(cmd)))
 
         if not args.execute:
             applied += 1
             continue
 
-        ok, err = run_commands(cmds)
-        common.ledger_append(wd, {
-            "number": number, "action": action, "disposition": r["disposition"],
-            "status": "ok" if ok else "error", "error": err,
-        })
-        if ok:
+        # Run pending steps in order; stop at the first failure so a later run
+        # resumes from exactly the step that failed.
+        row_ok = True
+        closed = False
+        for step, cmd in pending:
+            cp = common.run(cmd, check=False)
+            status = "ok" if cp.returncode == 0 else "error"
+            common.ledger_append(wd, {
+                "number": number, "step": step, "action": action,
+                "disposition": r["disposition"], "status": status,
+                "error": "" if status == "ok" else (cp.stderr or cp.stdout or "").strip()[:300],
+            })
+            if status == "ok":
+                done_steps.add((number, step))
+                if step == "close":
+                    closed = True
+            else:
+                common.info(f"  #{number}: step '{step}' FAILED — {(cp.stderr or '').strip()[:200]}")
+                row_ok = False
+                break
+
+        if closed and local_close and common.have("gitcrawl"):
+            common.run(
+                ["gitcrawl", "close-thread", slug, "--number", str(number),
+                 "--reason", r.get("disposition", "scrub")],
+                check=False,
+            )
+        if row_ok:
             applied += 1
-            if action == "close" and local_close and common.have("gitcrawl"):
-                common.run(
-                    ["gitcrawl", "close-thread", slug, "--number", str(number),
-                     "--reason", r.get("disposition", "scrub")],
-                    check=False,
-                )
-            time.sleep(sleep_s)
-        else:
-            common.info(f"  #{number}: FAILED — {err}")
+        time.sleep(sleep_s)
 
     common.info(f"[{mode}] done. {applied} {'applied' if args.execute else 'planned'}.")
 
 
-def build_commands(slug, kind, action, number, row, cfg) -> list[list[str]]:
-    """Return the ordered gh command argv lists for one row."""
+def build_commands(slug, kind, action, number, row, cfg) -> list[tuple[str, list[str]]]:
+    """Return ordered (step, argv) pairs for one row; step is the ledger key."""
     gk = gh_kind(kind)
-    cmds: list[list[str]] = []
+    steps: list[tuple[str, list[str]]] = []
     labels = row.get("add_labels") or []
     if labels:
-        cmds.append(["gh", gk, "edit", str(number), "--repo", slug,
-                     "--add-label", ",".join(labels)])
+        steps.append(("label", ["gh", gk, "edit", str(number), "--repo", slug,
+                                "--add-label", ",".join(labels)]))
     # Post the comment for ANY disposition that carries a template, not just
     # closes — mark-stale and needs-info are label-plus-comment actions.
     body = render(row.get("comment_template"), cfg, row.get("context", {}))
     if body:
-        cmds.append(["gh", gk, "comment", str(number), "--repo", slug, "--body", body])
+        steps.append(("comment", ["gh", gk, "comment", str(number), "--repo", slug, "--body", body]))
     if action == "close":
         close_cmd = ["gh", gk, "close", str(number), "--repo", slug]
         reason = row.get("close_reason")
         if gk == "issue" and reason:
             close_cmd += ["--reason", reason]
-        cmds.append(close_cmd)
-    return cmds
-
-
-def run_commands(cmds: list[list[str]]) -> tuple[bool, str]:
-    for c in cmds:
-        cp = common.run(c, check=False)
-        if cp.returncode != 0:
-            return False, (cp.stderr or cp.stdout or "").strip()[:300]
-    return True, ""
+        steps.append(("close", close_cmd))
+    return steps
 
 
 def _shellish(argv: list[str]) -> list[str]:

--- a/.claude/skills/issue-pr-scrub/scripts/common.py
+++ b/.claude/skills/issue-pr-scrub/scripts/common.py
@@ -1,0 +1,228 @@
+"""Shared helpers for the issue-pr-scrub pipeline.
+
+Stdlib-only (Python 3.11+: tomllib, sqlite3, subprocess, argparse). No pip
+installs, so the skill folder is portable: copy it into any OSS project and
+point --repo / --config at the new target.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+
+
+# --------------------------------------------------------------------------- #
+# config + repo                                                               #
+# --------------------------------------------------------------------------- #
+def parse_repo(slug: str) -> tuple[str, str]:
+    slug = slug.strip().removeprefix("https://github.com/").strip("/")
+    if slug.count("/") != 1 or not all(slug.split("/")):
+        die(f"--repo must be owner/name, got {slug!r}")
+    owner, repo = slug.split("/")
+    return owner, repo
+
+
+def find_config(repo_slug: str, explicit: str | None) -> Path:
+    """Resolve a config file: explicit > per-repo > example default."""
+    if explicit:
+        p = Path(explicit).expanduser()
+        if not p.exists():
+            die(f"--config {p} not found")
+        return p
+    owner, repo = parse_repo(repo_slug)
+    per_repo = SCRIPT_DIR / f"config.{owner}__{repo}.toml"
+    if per_repo.exists():
+        return per_repo
+    return SCRIPT_DIR / "config.example.toml"
+
+
+def load_config(path: Path) -> dict:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def expand(path_template: str, owner: str, repo: str) -> Path:
+    return Path(
+        os.path.expanduser(path_template.format(owner=owner, repo=repo))
+    )
+
+
+def expand_path(p: str) -> Path:
+    path = Path(p).expanduser()
+    if not path.exists():
+        die(f"file not found: {path}")
+    return path
+
+
+def workdir(cfg: dict, owner: str, repo: str) -> Path:
+    tmpl = cfg.get("paths", {}).get(
+        "workdir", "~/.cache/issue-pr-scrub/{owner}__{repo}"
+    )
+    d = expand(tmpl, owner, repo)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def gitcrawl_db(cfg: dict) -> Path:
+    # Honor gitcrawl's own override first, then config, then default.
+    env = os.environ.get("GITCRAWL_DB_PATH")
+    if env:
+        return Path(env).expanduser()
+    tmpl = cfg.get("paths", {}).get(
+        "gitcrawl_db", "~/.config/gitcrawl/gitcrawl.db"
+    )
+    return Path(os.path.expanduser(tmpl))
+
+
+# --------------------------------------------------------------------------- #
+# jsonl + state                                                               #
+# --------------------------------------------------------------------------- #
+def write_jsonl(path: Path, rows) -> int:
+    n = 0
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+            n += 1
+    return n
+
+
+def read_jsonl(path: Path):
+    if not path.exists():
+        return
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                yield json.loads(line)
+
+
+def load_state(wd: Path) -> dict:
+    p = wd / "state.json"
+    return json.loads(p.read_text()) if p.exists() else {}
+
+
+def save_state(wd: Path, state: dict) -> None:
+    (wd / "state.json").write_text(json.dumps(state, indent=2))
+
+
+# --------------------------------------------------------------------------- #
+# ledger (apply-time dedup, append-only)                                       #
+# --------------------------------------------------------------------------- #
+def ledger_path(wd: Path) -> Path:
+    return wd / "ledger.jsonl"
+
+
+def ledger_done(wd: Path) -> set[tuple[int, str]]:
+    """Set of (number, action) already applied successfully."""
+    done = set()
+    for row in read_jsonl(ledger_path(wd)):
+        if row.get("status") == "ok":
+            done.add((int(row["number"]), row["action"]))
+    return done
+
+
+def ledger_append(wd: Path, entry: dict) -> None:
+    entry.setdefault("ts", now_iso())
+    with ledger_path(wd).open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+# --------------------------------------------------------------------------- #
+# gh + git wrappers                                                            #
+# --------------------------------------------------------------------------- #
+def run(cmd: list[str], check: bool = True, capture: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+    )
+
+
+def gh_json(args: list[str]):
+    """Run `gh <args>` expecting JSON on stdout."""
+    cp = run(["gh", *args])
+    return json.loads(cp.stdout)
+
+
+def require_gh_auth() -> None:
+    cp = run(["gh", "auth", "status"], check=False)
+    if cp.returncode != 0:
+        die("gh is not authenticated. Run `gh auth login` first.\n" + (cp.stderr or ""))
+
+
+def have(binary: str) -> bool:
+    from shutil import which
+
+    return which(binary) is not None
+
+
+# --------------------------------------------------------------------------- #
+# time                                                                        #
+# --------------------------------------------------------------------------- #
+def now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_ts(value: str | None):
+    if not value:
+        return None
+    v = value.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(v)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def days_since(value: str | None) -> float | None:
+    dt = parse_ts(value)
+    if dt is None:
+        return None
+    return (datetime.now(timezone.utc) - dt).total_seconds() / 86400.0
+
+
+# --------------------------------------------------------------------------- #
+# misc                                                                        #
+# --------------------------------------------------------------------------- #
+def die(msg: str, code: int = 1):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def info(msg: str):
+    print(msg, file=sys.stderr)
+
+
+def base_argparser(description: str) -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description=description)
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--config", default=None, help="path to a config toml")
+    return ap
+
+
+def bootstrap(args) -> dict:
+    """Common setup: resolve repo, config, workdir. Returns a ctx dict."""
+    owner, repo = parse_repo(args.repo)
+    cfg_path = find_config(args.repo, args.config)
+    cfg = load_config(cfg_path)
+    wd = workdir(cfg, owner, repo)
+    return {
+        "owner": owner,
+        "repo": repo,
+        "slug": f"{owner}/{repo}",
+        "cfg": cfg,
+        "cfg_path": cfg_path,
+        "wd": wd,
+    }

--- a/.claude/skills/issue-pr-scrub/scripts/config.example.toml
+++ b/.claude/skills/issue-pr-scrub/scripts/config.example.toml
@@ -1,0 +1,136 @@
+# issue-pr-scrub config — copy to config.<owner>__<repo>.toml and edit.
+# Everything here is portable across OSS projects; only the [labels] and
+# [areas] tables below are Fission-flavored defaults you should retune per repo.
+#
+# Resolution order for a config file (scrub.sh / scripts):
+#   1. --config <path>            (explicit)
+#   2. config.<owner>__<repo>.toml next to this file
+#   3. config.example.toml        (this file, as the fallback default)
+
+[repo]
+# Optional default; --repo on the CLI always wins.
+slug = ""                        # e.g. "fission/fission"
+
+[paths]
+# Workdir for all derived artifacts. {owner}/{repo} are substituted.
+# Default keeps repos clean by living under the user cache dir.
+workdir = "~/.cache/issue-pr-scrub/{owner}__{repo}"
+# gitcrawl SQLite mirror. Leave as-is unless GITCRAWL_DB_PATH is customized.
+gitcrawl_db = "~/.config/gitcrawl/gitcrawl.db"
+
+[sync]
+# Metadata-only is the default and is MUCH faster: comment_count and reaction
+# totals come from the issue/PR object itself, so the rule engine never needs
+# the (slow) per-thread comment hydration. Pass `scrub.sh sync --with-comments`
+# only if you want comment bodies in the FTS index for manual search.
+include_comments = false
+include_pr_details = false       # PR files/commits/checks — heavier, off by default
+
+[triage]
+# --- duplicates ---
+# Same-kind title-token Jaccard floor to call two threads duplicates. Higher =
+# stricter. Cross-references only UPGRADE confidence (title->ref => auto tier);
+# they never create a duplicate on their own (a "fixes #N" link is not a dup).
+dup_title_jaccard = 0.7
+# --- staleness ---
+stale_days = 540                 # ~18mo no activity -> stale candidate
+stale_comment_max = 8            # skip stale-close if more engaged than this
+stale_two_step = false           # true: label `stale` + comment first, close on a later run
+# --- PRs ---
+pr_stale_days = 365              # PR no activity -> archive candidate
+pr_abandoned_days = 730          # >2y abandoned PR -> auto tier
+# --- needs-info ---
+needs_info_days = 365            # bug, no repro, older than this -> needs-info
+# bodies shorter than this (chars) with no repro markers count as "no repro"
+no_repro_body_chars = 120
+repro_markers = ["steps to reproduce", "reproduce", "repro:", "minimal example", "```"]
+
+[versions]
+# close-eol: body mentions a version at/below these floors AND is stale.
+# Regexes are matched case-insensitively against title+body.
+# Capture group 1 must be the numeric version.
+fission_version_re = "fission[^0-9]{0,12}v?([0-9]+\\.[0-9]+)"
+fission_floor = "1.20"           # anything < this is EOL (tune to your support policy)
+k8s_version_re = "(?:kubernetes|k8s)[^0-9]{0,12}v?([0-9]+\\.[0-9]+)"
+k8s_floor = "1.26"
+
+# Labels that make a thread untouchable by any auto/close rule.
+[protected]
+labels = [
+  "keep-open", "help wanted", "good first issue", "proposal",
+  "hold-off-merging", "in progress", "work-in-progress",
+  "ready-to-merge", "area-security", "research",
+]
+
+# Disposition -> label(s) to add when that disposition fires.
+[labels]
+duplicate     = ["duplicate"]
+implemented   = []               # closing as completed; no label needed
+eol           = ["wontfix"]
+stale         = ["stale"]        # NOTE: `stale` does not exist yet — see labels.md
+needs_info    = ["needs-reproduction", "need-user-input"]
+pr_archive    = ["archive-pr"]
+needs_triage  = ["needs-triage"]
+
+# Type inference (first matching keyword set wins). Maps to existing Fission labels.
+[types]
+bug             = ["bug", "panic", "crash", "error", "broken", "fails", "regression"]
+feature-request = ["feature request", "would be nice", "support for", "add support", "proposal to"]
+enhancement     = ["enhancement", "improve", "optimization", "refactor"]
+documentation   = ["docs", "documentation", "readme", "typo in doc"]
+question        = ["question", "how do i", "how to", "is it possible"]
+
+# Area inference: keyword -> label(s). Fission subsystem map (retune per repo).
+[areas]
+"router"        = ["area-routing"]
+"routing"       = ["area-routing"]
+"httptrigger"   = ["area-routing"]
+"executor"      = ["area-executor"]
+"poolmgr"       = ["area-executor", "executor-poolmgr"]
+"newdeploy"     = ["area-executor", "executor-newdeploy"]
+"container"     = ["area-executor", "executor-container"]
+"builder"       = ["area-builder"]
+"package"       = ["area-builder"]
+"environment"   = ["area-environment"]
+"cli"           = ["area-fission-cli"]
+"fission spec"  = ["area-fission-cli"]
+"storage"       = ["area-storagesvc"]
+"storagesvc"    = ["area-storagesvc"]
+"kafka"         = ["area-events", "keda"]
+"nats"          = ["area-events"]
+"keda"          = ["area-events", "keda"]
+"mqtrigger"     = ["area-events"]
+"message queue" = ["area-events"]
+"timer"         = ["area-timetrigger"]
+"cron"          = ["area-timetrigger"]
+"helm"          = ["area-install"]
+"chart"         = ["area-install"]
+"install"       = ["area-install"]
+"metrics"       = ["area-observability"]
+"tracing"       = ["area-observability"]
+"prometheus"    = ["area-observability"]
+"opentelemetry" = ["area-observability"]
+"webhook"       = ["area-kubernetes"]
+"crd"           = ["area-kubernetes"]
+"kubernetes"    = ["area-kubernetes"]
+"multitenan"    = ["area-multitenancy"]
+"namespace"     = ["area-multitenancy"]
+"performance"   = ["area-performance"]
+"latency"       = ["area-performance"]
+
+# Priority heuristic. Score = reactions + comment_count; bumped by keywords.
+[priority]
+critical_keywords = ["data loss", "security", "cve", "production down", "outage"]
+# thresholds on engagement score
+high   = 15
+medium = 5
+# label names per bucket (PROPOSED — do not exist yet, see labels.md)
+critical_label = "priority/critical"
+high_label     = "priority/high"
+medium_label   = "priority/medium"
+low_label      = "priority/low"
+
+[apply]
+max_per_run = 25                 # hard cap on writes per apply invocation
+sleep_seconds = 2.0              # gentle pacing between gh writes
+local_close = true               # gitcrawl close-thread after a successful GitHub close

--- a/.claude/skills/issue-pr-scrub/scripts/config.example.toml
+++ b/.claude/skills/issue-pr-scrub/scripts/config.example.toml
@@ -18,13 +18,12 @@ workdir = "~/.cache/issue-pr-scrub/{owner}__{repo}"
 # gitcrawl SQLite mirror. Leave as-is unless GITCRAWL_DB_PATH is customized.
 gitcrawl_db = "~/.config/gitcrawl/gitcrawl.db"
 
-[sync]
-# Metadata-only is the default and is MUCH faster: comment_count and reaction
-# totals come from the issue/PR object itself, so the rule engine never needs
-# the (slow) per-thread comment hydration. Pass `scrub.sh sync --with-comments`
-# only if you want comment bodies in the FTS index for manual search.
-include_comments = false
-include_pr_details = false       # PR files/commits/checks — heavier, off by default
+# Sync depth is controlled by CLI flags on `scrub.sh sync`, not config:
+#   (default)         metadata-only — comment_count and reaction totals come
+#                     from the issue/PR object, so the rule engine never needs
+#                     the slow per-thread comment hydration.
+#   --with-comments   also fetch comment bodies into the FTS index (slow).
+#   --full            full backfill (--state all) instead of an incremental sync.
 
 [triage]
 # --- duplicates ---

--- a/.claude/skills/issue-pr-scrub/scripts/config.example.toml
+++ b/.claude/skills/issue-pr-scrub/scripts/config.example.toml
@@ -130,6 +130,6 @@ medium_label   = "priority/medium"
 low_label      = "priority/low"
 
 [apply]
-max_per_run = 25                 # hard cap on writes per apply invocation
+max_per_run = 25                 # cap on GitHub mutations/run (label/comment/close each count)
 sleep_seconds = 2.0              # gentle pacing between gh writes
 local_close = true               # gitcrawl close-thread after a successful GitHub close

--- a/.claude/skills/issue-pr-scrub/scripts/config.example.toml
+++ b/.claude/skills/issue-pr-scrub/scripts/config.example.toml
@@ -34,7 +34,10 @@ dup_title_jaccard = 0.7
 # --- staleness ---
 stale_days = 540                 # ~18mo no activity -> stale candidate
 stale_comment_max = 8            # skip stale-close if more engaged than this
-stale_two_step = false           # true: label `stale` + comment first, close on a later run
+stale_two_step = false           # true: ALL stale items get label `stale` + warn first, close on a later run
+# Types that always use the gentle two-step even when stale_two_step is false.
+# e.g. don't hard-close stale feature requests without a heads-up.
+stale_two_step_types = []        # e.g. ["feature-request"]
 # --- PRs ---
 pr_stale_days = 365              # PR no activity -> archive candidate
 pr_abandoned_days = 730          # >2y abandoned PR -> auto tier

--- a/.claude/skills/issue-pr-scrub/scripts/extract.py
+++ b/.claude/skills/issue-pr-scrub/scripts/extract.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Stage 2 — extract: gitcrawl SQLite mirror -> normalized threads.jsonl.
+
+Reads the gitcrawl.db tables (`threads`, `comments`, plus best-effort
+`clusters`/`cluster_members`) and emits one normalized JSON row per issue/PR.
+Pure re-derivation from the local mirror — no network, safe to re-run.
+
+Dup detection note: gitcrawl clustering needs OpenAI vectors. In keyword-only
+mode there are usually none, so we DON'T depend on gitcrawl clusters here; we
+emit parsed cross-references (#123 / pull/123) and let triage.py group dups
+locally. If durable clusters happen to exist, we attach them as a bonus.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+
+import common
+
+# Same-repo issue/PR references. 2+ digits (single digits are too ambiguous).
+REF_HASH = re.compile(r"(?<![\w/])#(\d{2,})\b")
+REF_PATH = re.compile(r"\b(?:issues|pull)/(\d{2,})\b")
+REF_URL = re.compile(r"github\.com/[^/\s]+/[^/\s]+/(?:issues|pull)/(\d{2,})")
+
+BODY_EXCERPT_CHARS = 4000
+
+
+def parse_labels(labels_json: str) -> list[str]:
+    try:
+        arr = json.loads(labels_json or "[]")
+    except json.JSONDecodeError:
+        return []
+    out = []
+    for item in arr:
+        if isinstance(item, dict) and item.get("name"):
+            out.append(item["name"])
+        elif isinstance(item, str):
+            out.append(item)
+    return out
+
+
+def parse_refs(text: str, self_number: int) -> list[int]:
+    if not text:
+        return []
+    found: set[int] = set()
+    for rx in (REF_HASH, REF_PATH, REF_URL):
+        for m in rx.finditer(text):
+            n = int(m.group(1))
+            if n != self_number:
+                found.add(n)
+    return sorted(found)
+
+
+def raw_counts(raw_json: str) -> tuple[int, int]:
+    """(comment_count, reactions_total) straight from the GitHub object.
+
+    Avoids needing the slow --include-comments backfill: the issue/PR object
+    already carries `comments` and `reactions.total_count`.
+    """
+    try:
+        obj = json.loads(raw_json or "{}")
+    except json.JSONDecodeError:
+        return 0, 0
+    comments = int(obj.get("comments", 0) or 0)
+    r = obj.get("reactions")
+    reactions = int(r.get("total_count", 0) or 0) if isinstance(r, dict) else 0
+    return comments, reactions
+
+
+def repo_id(con: sqlite3.Connection, slug: str) -> int:
+    row = con.execute(
+        "select id from repositories where full_name = ?", (slug,)
+    ).fetchone()
+    if row is None:
+        common.die(
+            f"repo {slug} not present in gitcrawl.db — run the sync stage first"
+        )
+    return row[0]
+
+
+def best_effort_clusters(con: sqlite3.Connection, rid: int) -> dict[int, dict]:
+    """Map thread number -> {cluster_id, canonical_number} from latest run.
+
+    Returns {} when no vector-backed clusters exist (the keyword-only norm).
+    """
+    try:
+        run = con.execute(
+            "select id from cluster_runs where repo_id = ? order by id desc limit 1",
+            (rid,),
+        ).fetchone()
+        if not run:
+            return {}
+        run_id = run[0]
+        rows = con.execute(
+            """
+            select c.id, rep.number as canonical, t.number as member
+            from clusters c
+            join cluster_members m on m.cluster_id = c.id
+            join threads t on t.id = m.thread_id
+            left join threads rep on rep.id = c.representative_thread_id
+            where c.cluster_run_id = ? and c.member_count > 1
+            """,
+            (run_id,),
+        ).fetchall()
+    except sqlite3.OperationalError:
+        return {}
+    out: dict[int, dict] = {}
+    for cid, canonical, member in rows:
+        out[member] = {"cluster_id": cid, "canonical_number": canonical}
+    return out
+
+
+def main() -> None:
+    ap = common.base_argparser("extract gitcrawl mirror into threads.jsonl")
+    args = ap.parse_args()
+    ctx = common.bootstrap(args)
+    db = common.gitcrawl_db(ctx["cfg"])
+    if not db.exists():
+        common.die(f"gitcrawl db not found at {db} — run the sync stage first")
+
+    con = sqlite3.connect(f"file:{db}?mode=ro", uri=True)
+    con.row_factory = sqlite3.Row
+    rid = repo_id(con, ctx["slug"])
+    clusters = best_effort_clusters(con, rid)
+
+    rows = con.execute(
+        """
+        select t.number, t.kind, t.state, t.title, t.body, t.author_login,
+               t.author_type, t.html_url, t.labels_json, t.is_draft,
+               t.created_at_gh, t.updated_at_gh, t.closed_at_gh, t.merged_at_gh,
+               t.closed_at_local, t.raw_json
+        from threads t
+        where t.repo_id = ?
+        order by t.number
+        """,
+        (rid,),
+    ).fetchall()
+
+    def emit():
+        for r in rows:
+            body = r["body"] or ""
+            number = r["number"]
+            labels = parse_labels(r["labels_json"])
+            refs = parse_refs(r["title"] + "\n" + body, number)
+            comment_count, reactions = raw_counts(r["raw_json"])
+            cl = clusters.get(number, {})
+            yield {
+                "number": number,
+                "kind": "pr" if r["kind"] == "pull_request" else "issue",
+                "state": r["state"],
+                "title": r["title"],
+                "body_excerpt": body[:BODY_EXCERPT_CHARS],
+                "body_len": len(body),
+                "author": r["author_login"],
+                "author_type": r["author_type"],
+                "url": r["html_url"],
+                "labels": labels,
+                "is_draft": bool(r["is_draft"]),
+                "created_at": r["created_at_gh"],
+                "updated_at": r["updated_at_gh"],
+                "closed_at": r["closed_at_gh"],
+                "merged_at": r["merged_at_gh"],
+                "closed_local": bool(r["closed_at_local"]),
+                "comment_count": comment_count,
+                "reactions": reactions,
+                "references": refs,
+                "cluster_id": cl.get("cluster_id"),
+                "cluster_canonical": cl.get("canonical_number"),
+            }
+
+    out = ctx["wd"] / "threads.jsonl"
+    n = common.write_jsonl(out, emit())
+    con.close()
+
+    state = common.load_state(ctx["wd"])
+    state["extracted_at"] = common.now_iso()
+    state["thread_count"] = n
+    common.save_state(ctx["wd"], state)
+    common.info(f"extracted {n} threads -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-pr-scrub/scripts/labels_sync.py
+++ b/.claude/skills/issue-pr-scrub/scripts/labels_sync.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""labels-sync — reconcile the repo's GitHub labels with the skill taxonomy.
+
+Read-only by default: prints the repo's current labels and which labels the
+triage rules reference but don't yet exist (so you know what to create). With
+--create-missing --execute it creates the missing proposed labels via `gh`.
+
+This is what makes the skill portable: point it at any repo and it tells you
+exactly which labels the config assumes but the repo lacks.
+"""
+
+from __future__ import annotations
+
+import common
+
+# Proposed extensions to a typical OSS label set (created only on request).
+# name -> (hex color without '#', description)
+PROPOSED = {
+    "stale": ("ededed", "No activity for a long time; candidate for closing"),
+    "keep-open": ("0e8a16", "Protected from stale automation"),
+    "priority/critical": ("b60205", "Drop everything"),
+    "priority/high": ("d93f0b", "Should be addressed soon"),
+    "priority/medium": ("fbca04", "Normal priority"),
+    "priority/low": ("0e8a16", "Nice to have"),
+    "eol-version": ("bfd4f2", "Targets an unsupported/EOL version"),
+}
+
+
+def referenced_labels(cfg: dict) -> set[str]:
+    out: set[str] = set()
+    for vals in cfg.get("labels", {}).values():
+        out.update(vals)
+    out.update(cfg.get("types", {}).keys())
+    for vals in cfg.get("areas", {}).values():
+        out.update(vals)
+    prio = cfg.get("priority", {})
+    for key in ("critical_label", "high_label", "medium_label", "low_label"):
+        if prio.get(key):
+            out.add(prio[key])
+    out.update(cfg.get("protected", {}).get("labels", []))
+    return out
+
+
+def main() -> None:
+    ap = common.base_argparser("reconcile repo labels with the triage taxonomy")
+    ap.add_argument("--create-missing", action="store_true",
+                    help="create missing PROPOSED labels")
+    ap.add_argument("--execute", action="store_true", help="actually create (default dry-run)")
+    args = ap.parse_args()
+    ctx = common.bootstrap(args)
+    slug, cfg = ctx["slug"], ctx["cfg"]
+
+    existing = {lb["name"] for lb in common.gh_json(
+        ["label", "list", "--repo", slug, "--limit", "300", "--json", "name"]
+    )}
+    referenced = referenced_labels(cfg)
+    missing = sorted(referenced - existing)
+
+    common.info(f"{slug}: {len(existing)} labels exist; config references {len(referenced)}.")
+    if not missing:
+        common.info("all referenced labels already exist.")
+        return
+
+    common.info(f"\nreferenced but MISSING ({len(missing)}):")
+    for name in missing:
+        tag = "  [proposed]" if name in PROPOSED else "  [unknown — typo? or create manually]"
+        common.info(f"  {name}{tag}")
+
+    if not args.create_missing:
+        common.info("\nrun with --create-missing --execute to create the [proposed] ones.")
+        return
+
+    creatable = [n for n in missing if n in PROPOSED]
+    common.info(f"\n{'creating' if args.execute else 'would create'} {len(creatable)} proposed labels:")
+    if args.execute:
+        common.require_gh_auth()
+    for name in creatable:
+        color, desc = PROPOSED[name]
+        cmd = ["gh", "label", "create", name, "--repo", slug,
+               "--color", color, "--description", desc, "--force"]
+        common.info(("  RUN: " if args.execute else "  would: ") + " ".join(cmd))
+        if args.execute:
+            cp = common.run(cmd, check=False)
+            if cp.returncode != 0:
+                common.info(f"    failed: {(cp.stderr or '').strip()[:200]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-pr-scrub/scripts/protect.py
+++ b/.claude/skills/issue-pr-scrub/scripts/protect.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""protect — push the `keep-open` label upstream for your keepers.
+
+`keepers.txt` already force-keeps items locally (triage skips them with no
+re-sync). This optional step also applies the `keep-open` label on GitHub so
+the protection is visible to everyone and survives a fresh DB rebuild.
+
+Dry-run by default; --execute required. Reads numbers from <workdir>/keepers.txt
+unless --from is given.
+"""
+
+from __future__ import annotations
+
+import common
+
+LABEL = "keep-open"
+
+
+def read_numbers(path) -> list[int]:
+    out: list[int] = []
+    for line in path.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line.isdigit():
+            out.append(int(line))
+    return out
+
+
+def main() -> None:
+    ap = common.base_argparser(__doc__)
+    ap.add_argument("--from", dest="from_file", default=None,
+                    help="file of numbers (default: <workdir>/keepers.txt)")
+    ap.add_argument("--label", default=LABEL, help=f"label to add (default {LABEL})")
+    ap.add_argument("--execute", action="store_true", help="actually label (default dry-run)")
+    args = ap.parse_args()
+    ctx = common.bootstrap(args)
+    slug, wd = ctx["slug"], ctx["wd"]
+
+    src = common.expand_path(args.from_file) if args.from_file else (wd / "keepers.txt")
+    if not src.exists():
+        common.die(f"no keepers file at {src} — add issue/PR numbers, one per line")
+    numbers = read_numbers(src)
+    if not numbers:
+        common.info(f"{src} has no numbers")
+        return
+
+    mode = "EXECUTE" if args.execute else "DRY-RUN"
+    common.info(f"[{mode}] {slug}: labelling {len(numbers)} keepers with `{args.label}`")
+    if args.execute:
+        common.require_gh_auth()
+    for n in numbers:
+        cmd = ["gh", "issue", "edit", str(n), "--repo", slug, "--add-label", args.label]
+        common.info(("  RUN: " if args.execute else "  would: ") + " ".join(cmd))
+        if args.execute:
+            cp = common.run(cmd, check=False)
+            if cp.returncode != 0:
+                common.info(f"    #{n} failed: {(cp.stderr or '').strip()[:200]}")
+    common.info(f"[{mode}] done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-pr-scrub/scripts/report.py
+++ b/.claude/skills/issue-pr-scrub/scripts/report.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Stage 4 — report: triage.jsonl -> report.md + triage.csv + apply-plan.jsonl.
+
+- report.md        human review, grouped by tier then disposition, with links.
+- triage.csv       spreadsheet view of every triaged thread.
+- apply-plan.jsonl  machine-actionable rows (close/label) for apply.py.
+
+Pure re-derivation, safe to re-run. No writes to GitHub.
+"""
+
+from __future__ import annotations
+
+import csv
+
+import common
+
+# Closing dispositions vs label-only.
+CLOSE_DISPOSITIONS = {
+    "close-duplicate", "close-implemented", "close-eol", "close-stale", "pr-archive",
+}
+CLOSE_REASON = {
+    "close-duplicate": "not_planned",
+    "close-implemented": "completed",
+    "close-eol": "not_planned",
+    "close-stale": "not_planned",
+    "pr-archive": "not_planned",
+    "mark-stale": None,
+    "needs-info": None,
+    "keep": None,
+}
+
+TIER_ORDER = ["auto", "review", "keep", "skip"]
+
+
+def plan_rows(triage: list[dict]):
+    """One apply-plan row per actionable thread (auto + review tiers)."""
+    for r in triage:
+        if r["tier"] in ("keep", "skip"):
+            continue
+        action = "close" if r["disposition"] in CLOSE_DISPOSITIONS else "label"
+        yield {
+            "number": r["number"],
+            "kind": r["kind"],
+            "action": action,
+            "disposition": r["disposition"],
+            "tier": r["tier"],
+            "close_reason": CLOSE_REASON.get(r["disposition"]),
+            "add_labels": r["add_labels"],
+            "comment_template": r["comment_template"],
+            "context": r.get("context", {}),
+            "rationale": r["rationale"],
+            "url": r["url"],
+            "title": r["title"],
+            "updated_at_at_extract": r.get("updated_at"),
+        }
+
+
+# Re-review ordering: surface the stale items most likely to be keepers first
+# (high engagement, and feature/bug over question/uncategorized).
+TYPE_RANK = {"feature-request": 0, "enhancement": 1, "bug": 2,
+             "documentation": 3, "question": 4, None: 5}
+
+
+def write_stale_review(path, triage: list[dict]) -> int:
+    rows = [r for r in triage if r["disposition"] in ("close-stale", "mark-stale")]
+    rows.sort(key=lambda r: (-r.get("engagement", 0),
+                             TYPE_RANK.get(r.get("type"), 5),
+                             r.get("age_days", 0)))
+    cols = ["keep", "number", "engagement", "reactions", "comments", "type",
+            "priority", "areas", "age_days", "title", "url"]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(cols)
+        for r in rows:
+            w.writerow([
+                "", r["number"], r.get("engagement", 0), r.get("reactions", 0),
+                r.get("comment_count", 0), r.get("type"), r.get("priority"),
+                "|".join(r.get("areas", [])), int(r.get("age_days") or 0),
+                r["title"], r["url"],
+            ])
+    return len(rows)
+
+
+def write_csv(path, triage: list[dict]):
+    cols = ["number", "kind", "disposition", "tier", "type", "age_days",
+            "add_labels", "areas", "rationale", "url"]
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(cols)
+        for r in triage:
+            w.writerow([
+                r["number"], r["kind"], r["disposition"], r["tier"], r.get("type"),
+                r.get("age_days"), "|".join(r["add_labels"]), "|".join(r.get("areas", [])),
+                r["rationale"], r["url"],
+            ])
+
+
+def write_md(path, slug: str, triage: list[dict]):
+    by_tier: dict[str, dict[str, list[dict]]] = {}
+    for r in triage:
+        by_tier.setdefault(r["tier"], {}).setdefault(r["disposition"], []).append(r)
+
+    lines = [
+        f"# Backlog scrub report — {slug}",
+        "",
+        f"Generated {common.now_iso()} · {len(triage)} open threads triaged.",
+        "",
+        "## Summary",
+        "",
+        "| Tier | Disposition | Count |",
+        "| --- | --- | --- |",
+    ]
+    for tier in TIER_ORDER:
+        for disp in sorted(by_tier.get(tier, {})):
+            lines.append(f"| {tier} | {disp} | {len(by_tier[tier][disp])} |")
+    lines += [
+        "",
+        "**Apply order:** review `auto` items, then run "
+        "`apply.py --auto --execute`. Curate `review` items into "
+        "`approved.jsonl`, then `apply.py --from approved.jsonl --execute`. "
+        "`keep` items are label suggestions only.",
+        "",
+    ]
+
+    titles = {
+        "auto": "## Auto tier — gated, eligible for `apply.py --auto`",
+        "review": "## Review tier — needs your approval",
+        "keep": "## Keep — categorized for the living backlog (label suggestions)",
+        "skip": "## Skipped — protected by label",
+    }
+    for tier in TIER_ORDER:
+        if tier not in by_tier:
+            continue
+        lines += ["", titles[tier], ""]
+        for disp in sorted(by_tier[tier]):
+            rows = sorted(by_tier[tier][disp], key=lambda r: r["number"])
+            lines += [f"### {disp} ({len(rows)})", ""]
+            for r in rows:
+                labels = ", ".join(f"`{lbl}`" for lbl in r["add_labels"]) or "—"
+                meta = " · ".join(filter(None, [
+                    r.get("type"),
+                    r.get("priority"),
+                    f"👍{r['reactions']}/💬{r['comment_count']}" if r.get("engagement") else None,
+                ]))
+                meta = f" [{meta}]" if meta else ""
+                lines.append(
+                    f"- [#{r['number']}]({r['url']}) {r['kind']} · "
+                    f"{int(r.get('age_days') or 0)}d idle{meta} — {r['title']}  \n"
+                    f"  add: {labels} · _{r['rationale']}_"
+                )
+            lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> None:
+    ap = common.base_argparser("build report.md/csv/apply-plan from triage.jsonl")
+    args = ap.parse_args()
+    ctx = common.bootstrap(args)
+    wd = ctx["wd"]
+    triage = list(common.read_jsonl(wd / "triage.jsonl"))
+    if not triage:
+        common.die("no triage.jsonl — run the triage stage first")
+
+    write_md(wd / "report.md", ctx["slug"], triage)
+    write_csv(wd / "triage.csv", triage)
+    n_stale = write_stale_review(wd / "stale-review.csv", triage)
+    n_plan = common.write_jsonl(wd / "apply-plan.jsonl", plan_rows(triage))
+
+    auto = sum(1 for r in triage if r["tier"] == "auto")
+    review = sum(1 for r in triage if r["tier"] == "review")
+    common.info(
+        f"report.md, triage.csv written; apply-plan.jsonl has {n_plan} actionable "
+        f"rows ({auto} auto, {review} review)."
+    )
+    if n_stale:
+        common.info(
+            f"  stale-review.csv: {n_stale} stale items, sorted by signal — mark keepers,"
+            f" add their numbers to {wd / 'keepers.txt'}, then re-run triage+report."
+        )
+    common.info(f"  open {wd / 'report.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-pr-scrub/scripts/report.py
+++ b/.claude/skills/issue-pr-scrub/scripts/report.py
@@ -18,12 +18,14 @@ import common
 CLOSE_DISPOSITIONS = {
     "close-duplicate", "close-implemented", "close-eol", "close-stale", "pr-archive",
 }
+# gh issue close --reason accepts {completed | not planned | duplicate}
+# (note the space — this is the CLI value, not the API's not_planned).
 CLOSE_REASON = {
-    "close-duplicate": "not_planned",
+    "close-duplicate": "duplicate",
     "close-implemented": "completed",
-    "close-eol": "not_planned",
-    "close-stale": "not_planned",
-    "pr-archive": "not_planned",
+    "close-eol": "not planned",
+    "close-stale": "not planned",
+    "pr-archive": "not planned",
     "mark-stale": None,
     "needs-info": None,
     "keep": None,

--- a/.claude/skills/issue-pr-scrub/scripts/report.py
+++ b/.claude/skills/issue-pr-scrub/scripts/report.py
@@ -113,14 +113,13 @@ def write_md(path, slug: str, triage: list[dict]):
     for tier in TIER_ORDER:
         for disp in sorted(by_tier.get(tier, {})):
             lines.append(f"| {tier} | {disp} | {len(by_tier[tier][disp])} |")
-    lines += [
-        "",
+    apply_order = (
         "**Apply order:** review `auto` items, then run "
-        "`apply.py --auto --execute`. Curate `review` items into "
-        "`approved.jsonl`, then `apply.py --from approved.jsonl --execute`. "
-        "`keep` items are label suggestions only.",
-        "",
-    ]
+        + "`apply.py --auto --execute`. Curate `review` items into "
+        + "`approved.jsonl`, then `apply.py --from approved.jsonl --execute`. "
+        + "`keep` items are label suggestions only."
+    )
+    lines += ["", apply_order, ""]
 
     titles = {
         "auto": "## Auto tier — gated, eligible for `apply.py --auto`",

--- a/.claude/skills/issue-pr-scrub/scripts/scrub.sh
+++ b/.claude/skills/issue-pr-scrub/scripts/scrub.sh
@@ -11,8 +11,9 @@
 #   scrub.sh protect --repo owner/name [--from FILE] [--execute]   keep-open keepers
 #   scrub.sh apply  --repo owner/name --auto|--from FILE [--execute] [--max N]
 #
-# Everything except `apply --execute` and `labels --create-missing --execute`
-# is read-only. `run` never writes to GitHub.
+# Read-only EXCEPT the write-capable commands: `apply --execute`,
+# `protect --execute`, and `labels --create-missing --execute`.
+# `run` never writes to GitHub.
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.claude/skills/issue-pr-scrub/scripts/scrub.sh
+++ b/.claude/skills/issue-pr-scrub/scripts/scrub.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# issue-pr-scrub orchestrator. Portable across OSS repos via --repo.
+#
+#   scrub.sh doctor                         prerequisites check
+#   scrub.sh sync   --repo owner/name [--full]   gitcrawl sync into local SQLite
+#   scrub.sh extract --repo owner/name
+#   scrub.sh triage  --repo owner/name
+#   scrub.sh report  --repo owner/name
+#   scrub.sh run    --repo owner/name [--full]   sync -> extract -> triage -> report
+#   scrub.sh labels --repo owner/name [--create-missing --execute]
+#   scrub.sh protect --repo owner/name [--from FILE] [--execute]   keep-open keepers
+#   scrub.sh apply  --repo owner/name --auto|--from FILE [--execute] [--max N]
+#
+# Everything except `apply --execute` and `labels --create-missing --execute`
+# is read-only. `run` never writes to GitHub.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PY="python3"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+# Pull --repo / --full out of the args; pass the rest through to the python stage.
+REPO=""; FULL=0; WITH_COMMENTS=0; PASS=()
+parse_common() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --repo) REPO="$2"; shift 2;;
+      --full) FULL=1; shift;;
+      --with-comments) WITH_COMMENTS=1; shift;;
+      *) PASS+=("$1"); shift;;
+    esac
+  done
+}
+
+need_repo() { [ -n "$REPO" ] || die "--repo owner/name is required"; }
+
+# NB: bash 3.2 (macOS default) errors on "${arr[@]}" when empty under set -u,
+# so guard every array expansion with the "${arr[@]+...}" idiom.
+stage_py() { "$PY" "$HERE/$1" --repo "$REPO" ${PASS[@]+"${PASS[@]}"}; }
+
+cmd_doctor() {
+  echo "== prerequisites =="
+  for b in gitcrawl gh python3 sqlite3; do
+    if command -v "$b" >/dev/null 2>&1; then echo "  ok   $b ($(command -v "$b"))"; else echo "  MISS $b"; fi
+  done
+  echo "== python =="; "$PY" -c 'import sys,tomllib,sqlite3; print("  ok   python", ".".join(map(str,sys.version_info[:3])))' \
+    || echo "  MISS python 3.11+ with tomllib"
+  echo "== gh auth =="; gh auth status 2>&1 | sed 's/^/  /' || echo "  MISS gh not authenticated"
+  echo "== gitcrawl =="; gitcrawl doctor 2>/dev/null | grep -E '"version"|github_token_present|openai_key_present' | sed 's/^/  /' || echo "  (gitcrawl not initialized; run: gitcrawl init)"
+}
+
+cmd_sync() {
+  need_repo
+  command -v gitcrawl >/dev/null || die "gitcrawl not installed (brew install openclaw/tap/gitcrawl)"
+  # Metadata-only by default (fast); add --with-comments to hydrate comment bodies.
+  local comments_flag=""
+  [ "$WITH_COMMENTS" -eq 1 ] && comments_flag="--include-comments"
+  # First-time/full backfill vs incremental (plain sync sweeps recently-closed).
+  if [ "$FULL" -eq 1 ]; then
+    echo ">> full backfill: gitcrawl sync $REPO --state all $comments_flag"
+    gitcrawl sync "$REPO" --state all $comments_flag
+  else
+    echo ">> incremental: gitcrawl sync $REPO $comments_flag"
+    gitcrawl sync "$REPO" $comments_flag
+  fi
+}
+
+cmd_run() {
+  need_repo
+  echo "### scrub run: $REPO"
+  cmd_sync
+  stage_py extract.py
+  stage_py triage.py
+  stage_py report.py
+  echo "### done. Review the report, then: scrub.sh apply --repo $REPO --auto"
+}
+
+main() {
+  [ $# -ge 1 ] || { sed -n '2,20p' "$HERE/scrub.sh" | sed 's/^# \{0,1\}//'; exit 1; }
+  local sub="$1"; shift
+  parse_common "$@"
+  case "$sub" in
+    doctor)  cmd_doctor;;
+    sync)    cmd_sync;;
+    extract) need_repo; stage_py extract.py;;
+    triage)  need_repo; stage_py triage.py;;
+    report)  need_repo; stage_py report.py;;
+    run)     cmd_run;;
+    labels)  need_repo; stage_py labels_sync.py;;
+    protect) need_repo; stage_py protect.py;;
+    apply)   need_repo; stage_py apply.py;;
+    *) die "unknown subcommand: $sub";;
+  esac
+}
+
+main "$@"

--- a/.claude/skills/issue-pr-scrub/scripts/triage.py
+++ b/.claude/skills/issue-pr-scrub/scripts/triage.py
@@ -175,6 +175,10 @@ class Engine:
         self.stale_days = tri.get("stale_days", 540)
         self.stale_comment_max = tri.get("stale_comment_max", 8)
         self.stale_two_step = tri.get("stale_two_step", False)
+        # Types that always get the gentle two-step (label+warn, no close) even
+        # when stale_two_step is off — e.g. feature-requests shouldn't be hard
+        # closed as stale without a heads-up.
+        self.stale_two_step_types = set(tri.get("stale_two_step_types", []))
         self.pr_stale_days = tri.get("pr_stale_days", 365)
         self.pr_abandoned_days = tri.get("pr_abandoned_days", 730)
         self.needs_info_days = tri.get("needs_info_days", 365)
@@ -335,10 +339,11 @@ class Engine:
 
         # 5) stale issue
         if not is_pr and age >= self.stale_days and t["comment_count"] <= self.stale_comment_max:
-            if self.stale_two_step and "stale" not in labels:
+            two_step = self.stale_two_step or (type_label in self.stale_two_step_types)
+            if two_step and "stale" not in labels:
                 return out(
                     "mark-stale", "auto", self.lbl.get("stale", ["stale"]), "stale_warn",
-                    f"inactive {int(age)}d — label stale + warn; close on a later run",
+                    f"inactive {int(age)}d — {type_label or 'item'}: label stale + warn, close on a later run",
                     context={"age_days": int(age)},
                 )
             return out(

--- a/.claude/skills/issue-pr-scrub/scripts/triage.py
+++ b/.claude/skills/issue-pr-scrub/scripts/triage.py
@@ -361,7 +361,8 @@ class Engine:
         for a in area_labels:
             if a not in labels:
                 add.append(a)
-        add.append(priority_label)
+        if priority_label and priority_label not in labels:
+            add.append(priority_label)
         # don't relabel things already triaged with a type+area
         rationale = "active/recent — categorize for the living backlog"
         return out("keep", "keep", add, None, rationale)

--- a/.claude/skills/issue-pr-scrub/scripts/triage.py
+++ b/.claude/skills/issue-pr-scrub/scripts/triage.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python3
+"""Stage 3 — triage: rule engine over threads.jsonl -> triage.jsonl.
+
+Deterministic and config-driven. Ordered, first-match-wins rules assign each
+OPEN thread a disposition, a confidence tier, labels to add, a comment
+template, and a human-readable rationale. Pure re-derivation, safe to re-run.
+
+Tiers:
+  auto   - deterministic + low-risk; eligible for gated auto-apply
+  review - needs human judgment; listed in the report for approval
+  keep   - categorize only, no close
+  skip   - protected, never auto-acted
+
+Closed / locally-closed threads are skipped (nothing to do).
+
+Local dup detection (keyword-only mode): we build duplicate groups from
+deterministic GitHub cross-references (#123) plus normalized title-token
+overlap. No embeddings / OpenAI required.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+
+import common
+
+STOPWORDS = {
+    "the", "a", "an", "to", "of", "in", "on", "for", "and", "or", "is", "are",
+    "with", "when", "not", "no", "fission", "issue", "bug", "error", "support",
+    "add", "use", "using", "via", "feature", "request", "should", "does",
+}
+TOKEN_RE = re.compile(r"[a-z0-9]{4,}")
+
+
+def norm_tokens(title: str) -> set[str]:
+    return {t for t in TOKEN_RE.findall(title.lower()) if t not in STOPWORDS}
+
+
+def load_keepers(wd) -> set[int]:
+    """Numbers the maintainer wants to protect from closing.
+
+    One issue/PR number per line in <workdir>/keepers.txt; '#' starts a comment,
+    and an inline '# note' after a number is allowed. Force-keeps instantly with
+    no re-sync (decoupled from the upstream keep-open label).
+    """
+    path = wd / "keepers.txt"
+    if not path.exists():
+        return set()
+    out: set[int] = set()
+    for line in path.read_text().splitlines():
+        line = line.split("#", 1)[0].strip()
+        if line.isdigit():
+            out.add(int(line))
+    return out
+
+
+def version_tuple(s: str) -> tuple[int, ...]:
+    return tuple(int(p) for p in s.split(".") if p.isdigit())
+
+
+def below_floor(found: str, floor: str) -> bool:
+    return version_tuple(found) < version_tuple(floor)
+
+
+# --------------------------------------------------------------------------- #
+# duplicate grouping                                                          #
+# --------------------------------------------------------------------------- #
+def build_dup_groups(threads: list[dict], jaccard_floor: float = 0.7) -> dict[int, dict]:
+    """Return {number: {"canonical": n, "evidence": "ref"|"title", "members":[...]}}.
+
+    A group's canonical is its oldest still-relevant thread (lowest number).
+    Only OPEN, non-protected members get a dup disposition later; the canonical
+    is whichever member is open with the lowest number (fallback: lowest number).
+    """
+    by_num = {t["number"]: t for t in threads}
+    parent: dict[int, int] = {}
+
+    def find(x: int) -> int:
+        parent.setdefault(x, x)
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[max(ra, rb)] = min(ra, rb)
+
+    # A cross-reference (#123) is NOT duplicate evidence on its own — "PR fixes
+    # #123" or "see also #123" links related work, not duplicates. So duplicates
+    # require SAME-KIND title-token overlap; a same-kind reference between two
+    # already-similar threads only upgrades the evidence (title -> ref => auto).
+    # Cross-kind (issue<->PR) pairs are never treated as duplicates.
+
+    # same-kind reference pairs, for evidence upgrade only
+    ref_pairs: set[frozenset[int]] = set()
+    for t in threads:
+        for ref in t["references"]:
+            other = by_num.get(ref)
+            if other and other["kind"] == t["kind"]:
+                ref_pairs.add(frozenset((t["number"], ref)))
+
+    toks = {t["number"]: norm_tokens(t["title"]) for t in threads}
+    nums = [t["number"] for t in threads if len(toks[t["number"]]) >= 4]
+    bucket: dict[str, list[int]] = defaultdict(list)
+    for n in nums:
+        for tok in toks[n]:
+            bucket[tok].append(n)
+    evidence: dict[frozenset[int], str] = {}
+    seen_pairs: set[frozenset[int]] = set()
+    for members in bucket.values():
+        if len(members) > 40:  # ignore ultra-common tokens
+            continue
+        for i in range(len(members)):
+            for j in range(i + 1, len(members)):
+                a, b = members[i], members[j]
+                key = frozenset((a, b))
+                if key in seen_pairs:
+                    continue
+                seen_pairs.add(key)
+                if by_num[a]["kind"] != by_num[b]["kind"]:
+                    continue
+                ta, tb = toks[a], toks[b]
+                jac = len(ta & tb) / len(ta | tb)
+                if jac >= jaccard_floor:
+                    union(a, b)
+                    evidence[key] = "ref" if key in ref_pairs else "title"
+
+    # collect groups
+    groups: dict[int, list[int]] = defaultdict(list)
+    for t in threads:
+        groups[find(t["number"])].append(t["number"])
+
+    result: dict[int, dict] = {}
+    for members in groups.values():
+        if len(members) < 2:
+            continue
+        members.sort()
+        open_members = [m for m in members if by_num[m]["state"] == "open"]
+        canonical = (open_members or members)[0]
+        # strongest evidence across the title-similar pairs in this group
+        mset = set(members)
+        ev = "title"
+        for pair, kind_ev in evidence.items():
+            if kind_ev == "ref" and pair <= mset:
+                ev = "ref"
+                break
+        for m in members:
+            if m == canonical:
+                continue
+            result[m] = {"canonical": canonical, "evidence": ev, "members": members}
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# rule engine                                                                 #
+# --------------------------------------------------------------------------- #
+class Engine:
+    def __init__(self, cfg: dict, keepers: set[int] | None = None):
+        self.cfg = cfg
+        self.keepers = keepers or set()
+        self.protected = set(cfg.get("protected", {}).get("labels", []))
+        tri = cfg.get("triage", {})
+        self.stale_days = tri.get("stale_days", 540)
+        self.stale_comment_max = tri.get("stale_comment_max", 8)
+        self.stale_two_step = tri.get("stale_two_step", False)
+        self.pr_stale_days = tri.get("pr_stale_days", 365)
+        self.pr_abandoned_days = tri.get("pr_abandoned_days", 730)
+        self.needs_info_days = tri.get("needs_info_days", 365)
+        self.no_repro_chars = tri.get("no_repro_body_chars", 120)
+        self.repro_markers = [m.lower() for m in tri.get("repro_markers", [])]
+        self.lbl = cfg.get("labels", {})
+        v = cfg.get("versions", {})
+        self.fission_re = re.compile(v["fission_version_re"], re.I) if v.get("fission_version_re") else None
+        self.fission_floor = v.get("fission_floor")
+        self.k8s_re = re.compile(v["k8s_version_re"], re.I) if v.get("k8s_version_re") else None
+        self.k8s_floor = v.get("k8s_floor")
+        self.types = cfg.get("types", {})
+        self.areas = cfg.get("areas", {})
+        self.prio = cfg.get("priority", {})
+
+    # -- inference helpers -------------------------------------------------- #
+    def infer_type(self, text: str) -> str | None:
+        for label, kws in self.types.items():
+            if any(k in text for k in kws):
+                return label
+        return None
+
+    def infer_areas(self, scope: str, limit: int = 3) -> list[str]:
+        # Score each area by how often its keywords appear in the scoped text
+        # (title + body prefix), then keep the strongest few. Avoids slapping
+        # 9 area labels on one long issue.
+        scored: dict[str, int] = {}
+        order: list[str] = []
+        for kw, labels in self.areas.items():
+            hits = scope.count(kw)
+            if hits:
+                for lb in labels:
+                    if lb not in scored:
+                        order.append(lb)
+                    scored[lb] = scored.get(lb, 0) + hits
+        ranked = sorted(order, key=lambda lb: (-scored[lb], order.index(lb)))
+        return ranked[:limit]
+
+    def infer_priority(self, t: dict, text: str) -> str:
+        if any(k in text for k in self.prio.get("critical_keywords", [])):
+            return self.prio.get("critical_label", "priority/critical")
+        score = t["comment_count"] + t["reactions"]
+        if score >= self.prio.get("high", 15):
+            return self.prio.get("high_label", "priority/high")
+        if score >= self.prio.get("medium", 5):
+            return self.prio.get("medium_label", "priority/medium")
+        return self.prio.get("low_label", "priority/low")
+
+    def eol_hit(self, text: str) -> str | None:
+        for rx, floor, name in (
+            (self.fission_re, self.fission_floor, "Fission"),
+            (self.k8s_re, self.k8s_floor, "Kubernetes"),
+        ):
+            if not rx or not floor:
+                continue
+            for m in rx.finditer(text):
+                ver = m.group(1)
+                if below_floor(ver, floor):
+                    return f"{name} {ver} (below supported {floor})"
+        return None
+
+    def has_repro(self, t: dict) -> bool:
+        if t["body_len"] >= self.no_repro_chars:
+            body = t["body_excerpt"].lower()
+            if any(m in body for m in self.repro_markers):
+                return True
+        return False
+
+    # -- main classification ------------------------------------------------ #
+    def classify(self, t: dict, dup: dict | None) -> dict:
+        labels = set(t["labels"])
+        text = (t["title"] + "\n" + t["body_excerpt"]).lower()
+        # Type/area inference uses a tight scope (title weighted + body prefix)
+        # so a long body doesn't accrete every label.
+        scope = (t["title"].lower() + " ") * 3 + t["body_excerpt"][:400].lower()
+        age = common.days_since(t["updated_at"]) or 0.0
+        is_pr = t["kind"] == "pr"
+
+        type_label = self.infer_type(scope)
+        area_labels = self.infer_areas(scope)
+        priority_label = self.infer_priority(t, text)
+        engagement = t["comment_count"] + t["reactions"]
+
+        def out(disp, tier, add, template, rationale, context=None):
+            return {
+                "number": t["number"],
+                "kind": t["kind"],
+                "title": t["title"],
+                "url": t["url"],
+                "state": t["state"],
+                "updated_at": t["updated_at"],
+                "disposition": disp,
+                "tier": tier,
+                "add_labels": sorted(set(add)),
+                "comment_template": template,
+                "rationale": rationale,
+                "context": context or {},
+                "age_days": round(age, 0),
+                "type": type_label,
+                "areas": area_labels,
+                # Enrichment present on EVERY row so the stale pile is reviewable.
+                "priority": priority_label,
+                "engagement": engagement,
+                "reactions": t["reactions"],
+                "comment_count": t["comment_count"],
+            }
+
+        # -1) manually kept (keepers.txt) wins over everything
+        if t["number"] in self.keepers:
+            return out("keep", "skip", [], None, "manually kept (keepers.txt)")
+
+        # 0) protected
+        if labels & self.protected:
+            hit = ", ".join(sorted(labels & self.protected))
+            return out("keep", "skip", [], None, f"protected by label(s): {hit}")
+
+        # 1) duplicate
+        if dup:
+            tier = "auto" if dup["evidence"] == "ref" else "review"
+            return out(
+                "close-duplicate", tier, self.lbl.get("duplicate", ["duplicate"]),
+                "duplicate",
+                f"duplicate of #{dup['canonical']} "
+                f"({'cross-reference' if dup['evidence'] == 'ref' else 'title overlap'} evidence; "
+                f"group {sorted(dup['members'])})",
+                context={"canonical": dup["canonical"], "evidence": dup["evidence"]},
+            )
+
+        # 2) implemented (PR linkage in body): conservative -> review
+        if re.search(r"\b(fixed|resolved|closed|implemented) (?:in|by|via) #?\d{2,}", text):
+            return out(
+                "close-implemented", "review", [], "implemented",
+                "body claims it was fixed/implemented in a referenced PR — verify the PR merged",
+            )
+
+        # 3) EOL version + stale
+        eol = self.eol_hit(text)
+        if eol and age >= self.stale_days:
+            return out(
+                "close-eol", "auto", self.lbl.get("eol", ["wontfix"]), "eol",
+                f"targets {eol} and inactive {int(age)}d",
+                context={"detail": eol, "age_days": int(age)},
+            )
+
+        # 4) PR-specific lifecycle
+        if is_pr:
+            if age >= self.pr_abandoned_days:
+                return out(
+                    "pr-archive", "auto", self.lbl.get("pr_archive", ["archive-pr"]),
+                    "pr_archive", f"PR inactive {int(age)}d (>{self.pr_abandoned_days}d, abandoned)",
+                    context={"age_days": int(age)},
+                )
+            if age >= self.pr_stale_days and t["is_draft"]:
+                return out(
+                    "pr-archive", "review", self.lbl.get("pr_archive", ["archive-pr"]),
+                    "pr_archive", f"draft PR inactive {int(age)}d",
+                )
+
+        # 5) stale issue
+        if not is_pr and age >= self.stale_days and t["comment_count"] <= self.stale_comment_max:
+            if self.stale_two_step and "stale" not in labels:
+                return out(
+                    "mark-stale", "auto", self.lbl.get("stale", ["stale"]), "stale_warn",
+                    f"inactive {int(age)}d — label stale + warn; close on a later run",
+                    context={"age_days": int(age)},
+                )
+            return out(
+                "close-stale", "auto", self.lbl.get("stale", ["stale"]), "stale",
+                f"inactive {int(age)}d, {t['comment_count']} comments",
+                context={"age_days": int(age)},
+            )
+
+        # 6) needs-info (bug, no repro, aging)
+        if not is_pr and type_label == "bug" and not self.has_repro(t) and age >= self.needs_info_days:
+            return out(
+                "needs-info", "review", self.lbl.get("needs_info", ["needs-reproduction"]),
+                "needs_info", f"bug without reproduction steps, inactive {int(age)}d",
+            )
+
+        # 7) keep + categorize
+        add = list(self.lbl.get("needs_triage", ["needs-triage"]))
+        if type_label and type_label not in labels:
+            add.append(type_label)
+        for a in area_labels:
+            if a not in labels:
+                add.append(a)
+        add.append(priority_label)
+        # don't relabel things already triaged with a type+area
+        rationale = "active/recent — categorize for the living backlog"
+        return out("keep", "keep", add, None, rationale)
+
+
+def main() -> None:
+    ap = common.base_argparser("triage threads.jsonl -> triage.jsonl")
+    args = ap.parse_args()
+    ctx = common.bootstrap(args)
+    wd = ctx["wd"]
+    threads = list(common.read_jsonl(wd / "threads.jsonl"))
+    if not threads:
+        common.die("no threads.jsonl — run the extract stage first")
+
+    # Only triage things that are actionable: open and not already locally closed.
+    open_threads = [t for t in threads if t["state"] == "open" and not t["closed_local"]]
+    jac = ctx["cfg"].get("triage", {}).get("dup_title_jaccard", 0.7)
+    dup_map = build_dup_groups(threads, jaccard_floor=jac)  # over all to find canonicals
+    keepers = load_keepers(wd)
+    if keepers:
+        common.info(f"keepers.txt: {len(keepers)} numbers force-kept")
+    engine = Engine(ctx["cfg"], keepers=keepers)
+
+    results = [engine.classify(t, dup_map.get(t["number"])) for t in open_threads]
+    n = common.write_jsonl(wd / "triage.jsonl", results)
+
+    state = common.load_state(wd)
+    state["triaged_at"] = common.now_iso()
+    state["open_count"] = len(open_threads)
+    common.save_state(wd, state)
+
+    # quick stderr histogram
+    hist: dict[str, int] = {}
+    for r in results:
+        key = f"{r['disposition']}/{r['tier']}"
+        hist[key] = hist.get(key, 0) + 1
+    common.info(f"triaged {n} open threads -> {wd / 'triage.jsonl'}")
+    for k in sorted(hist):
+        common.info(f"  {k:28s} {hist[k]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-pr-scrub/scripts/triage.py
+++ b/.claude/skills/issue-pr-scrub/scripts/triage.py
@@ -133,23 +133,32 @@ def build_dup_groups(threads: list[dict], jaccard_floor: float = 0.7) -> dict[in
     for t in threads:
         groups[find(t["number"])].append(t["number"])
 
+    # members each thread has a "ref" edge to (for per-member evidence)
+    ref_neighbors: dict[int, set[int]] = defaultdict(set)
+    for pair, kind_ev in evidence.items():
+        if kind_ev == "ref":
+            a, b = tuple(pair)
+            ref_neighbors[a].add(b)
+            ref_neighbors[b].add(a)
+
     result: dict[int, dict] = {}
     for members in groups.values():
         if len(members) < 2:
             continue
         members.sort()
-        open_members = [m for m in members if by_num[m]["state"] == "open"]
-        canonical = (open_members or members)[0]
-        # strongest evidence across the title-similar pairs in this group
         mset = set(members)
-        ev = "title"
-        for pair, kind_ev in evidence.items():
-            if kind_ev == "ref" and pair <= mset:
-                ev = "ref"
-                break
+        # Canonical must be a thread that is actually visible: open upstream AND
+        # not locally hidden, else we'd close items as duplicates of something
+        # intentionally removed from future runs.
+        visible = [m for m in members
+                   if by_num[m]["state"] == "open" and not by_num[m]["closed_local"]]
+        canonical = (visible or members)[0]
         for m in members:
             if m == canonical:
                 continue
+            # Per-member evidence: auto only if THIS member has a direct ref edge
+            # to another group member; title-only members stay review-tier.
+            ev = "ref" if ref_neighbors[m] & mset else "title"
             result[m] = {"canonical": canonical, "evidence": ev, "members": members}
     return result
 


### PR DESCRIPTION
## Summary

Adds a portable, **gitcrawl-backed** Claude Code skill (`.claude/skills/issue-pr-scrub/`) for scrubbing a long-neglected GitHub issue/PR backlog — closing what's stale / duplicate / already-shipped / EOL, and categorizing the rest (type, area, priority) like a product manager. It mirrors issues/PRs into local SQLite so triage runs offline **without burning GitHub API quota**.

Built for **repeated execution** (idempotent stages, cached workdir, action ledger) and **low risk** (decide locally and cheaply; apply to GitHub separately, gated and capped).

## Pipeline (5 idempotent stages, driven by `scripts/scrub.sh`)

| Stage | Writes GitHub? | Output |
| --- | --- | --- |
| sync (gitcrawl, metadata-only) | no (reads GitHub) | local SQLite mirror |
| extract | no | `threads.jsonl` |
| triage (deterministic rule engine) | no | `triage.jsonl` |
| report | no | `report.md`, `triage.csv`, `stale-review.csv`, `apply-plan.jsonl` |
| apply (`gh`) | **yes — gated** | `ledger.jsonl` |

`scrub.sh run` chains the first four (never writes). `apply` is the only writer.

## Key properties

- **Keyword/FTS-only** — no OpenAI/embeddings, no API key. Duplicates via same-kind title-token overlap + deterministic `#ref` evidence (a "fixes #123" link is *not* treated as a duplicate).
- **Tiered + gated writes** — only `tier=auto` (deterministic, low-risk) is eligible for `--auto`; judgment calls are `tier=review` and need explicit approval. Nothing closes without `--execute`.
- **Safety gates** — dry-run default, per-run cap + pacing, staleness guard (re-checks live state before acting), protected-label re-check, ledger dedup, `gh auth` required.
- **Stale re-review** — stale items are enriched (type/area/priority/engagement) and sorted into `stale-review.csv`; `keepers.txt` force-keeps rescued items (instant, no re-sync); `scrub.sh protect` can push `keep-open` upstream.
- **Extends existing labels** — reuses Fission's taxonomy; proposes `priority/*`, `stale`, `keep-open` (created only on request).
- **Portable** — everything parameterized by `--repo` + a per-repo config; stdlib-only Python (3.11+) and bash (3.2-compatible).

`.claude/` is pruned from the license-check scope, so no SPDX headers are required on these scripts.

## Test plan

Verified end-to-end against the live Fission backlog with **zero GitHub writes**:

- [x] Full metadata backfill: 3274 threads in ~44s
- [x] Triage of 199 open threads; dispositions spot-checked against reality (EOL correctly catches Fission 1.16/1.17 & k8s 1.25; stale items 1600–2900d idle; protected labels skipped)
- [x] Fixed a dup-detection bug (cross-references alone were mis-flagging "fixes #N" as duplicates)
- [x] `apply.py` dry-run renders correct `gh` command sequences; cap, staleness guard, ledger dedup, and tier gate all confirmed firing
- [x] `keepers.txt` force-keep + `stale-review.csv` sorting verified
- [x] `bash -n` + `py_compile` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3408)
<!-- Reviewable:end -->
