### PR TITLE
fix(executor): stop updateCPUUtilizationSvc goroutine on pool destroy

### DIFF
--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -63,6 +63,7 @@ type (
 		fissionClient            versioned.Interface
 		fetcherConfig            *fetcherConfig.Config
 		stopReadyPodControllerCh chan struct{}
+		cancelPoolCtx            context.CancelFunc
 		readyPodLister           corelisters.PodLister
 		readyPodListerSynced     cache.InformerSynced
 		readyPodQueue            workqueue.TypedDelayingInterface[string]
@@ -140,7 +141,12 @@ func (gp *GenericPool) setup(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	go gp.updateCPUUtilizationSvc(ctx)
+	// updateCPUUtilizationSvc runs for the lifetime of the pool, so it gets a
+	// context tied to the pool (cancelled in destroy) rather than the
+	// request-scoped ctx, which would cancel once the triggering request ends.
+	poolCtx, cancel := context.WithCancel(context.Background())
+	gp.cancelPoolCtx = cancel
+	go gp.updateCPUUtilizationSvc(poolCtx)
 	return nil
 }
 
@@ -212,13 +218,18 @@ func (gp *GenericPool) updateCPUUtilizationSvc(ctx context.Context) {
 		}
 	}
 
-	for range ticker.C {
-		if metricsApiAvailabe {
-			serviceFunc(ctx)
-		} else {
-			if gp.checkMetricsApi() {
-				metricsApiAvailabe = true
-				ticker.Reset(30 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if metricsApiAvailabe {
+				serviceFunc(ctx)
+			} else {
+				if gp.checkMetricsApi() {
+					metricsApiAvailabe = true
+					ticker.Reset(30 * time.Second)
+				}
 			}
 		}
 	}
@@ -666,6 +677,9 @@ func (gp *GenericPool) destroy(ctx context.Context) error {
 	gp.lock.Lock()
 	defer gp.lock.Unlock()
 	close(gp.stopReadyPodControllerCh)
+	if gp.cancelPoolCtx != nil {
+		gp.cancelPoolCtx()
+	}
 
 	deletePropagation := metav1.DeletePropagationBackground
 	delOpt := metav1.DeleteOptions{

--- a/pkg/executor/executortype/poolmgr/gp_cpu_util_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_cpu_util_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package poolmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metricsfake "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// TestUpdateCPUUtilizationSvcStopsOnContextCancel guards against the goroutine
+// leak where updateCPUUtilizationSvc looped on the ticker forever and ignored
+// context cancellation, so it outlived the pool (one leaked goroutine per pool
+// ever created). It must return promptly once its context is cancelled.
+func TestUpdateCPUUtilizationSvcStopsOnContextCancel(t *testing.T) {
+	gp := &GenericPool{
+		logger:        loggerfactory.GetLogger(),
+		metricsClient: metricsfake.NewSimpleClientset(),
+		fnNamespace:   "fission-function",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		gp.updateCPUUtilizationSvc(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("updateCPUUtilizationSvc did not return after its context was cancelled")
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 memory fix (#2775 follow-up), identified from the detection harness's CI pprof profiles.

`GenericPool.updateCPUUtilizationSvc` looped on `for range ticker.C` and never observed context cancellation. `destroy()` only closed `stopReadyPodControllerCh`, so the goroutine outlived the pool — **one leaked goroutine per pool ever created**, each also issuing a `PodMetrics` LIST every 30s. The executor goroutine profile from a CI run showed **44 live instances** of this goroutine.

The fix gives the goroutine a pool-lifetime context (cancelled in `destroy()`) and `select`s on `ctx.Done()`, so it exits cleanly when the pool is torn down. The request-scoped ctx was the wrong lifetime — it would cancel once the triggering request ended.

## Test plan

- [x] `go test -race -run TestUpdateCPUUtilizationSvcStopsOnContextCancel ./pkg/executor/executortype/poolmgr/...` — new test hangs/fails before the fix (ticker is 30–180s), returns promptly after
- [x] full `pkg/executor/executortype/poolmgr` package tests pass; `golangci-lint` + gofmt clean
- [ ] CI integration tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3410)
<!-- Reviewable:end -->
