### PR TITLE
fix(executor): apply executor-type label filter on informers (#2775)

### DIFF
--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
@@ -72,6 +72,9 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-pod",
 			Namespace: metav1.NamespaceDefault,
+			// Real poolmgr pods carry this label; the executor informer filters
+			// on it, so the fixture must set it to be tracked by the controller.
+			Labels: map[string]string{fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypePoolmgr)},
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodRunning,

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -132,11 +132,15 @@ func GetInformerLabelByExecutor(executorType fv1.ExecutorType) (labels.Selector,
 	if err != nil {
 		return nil, err
 	}
-	labelSelector := labels.NewSelector()
-	labelSelector.Add(*executorLabel)
+	// labels.Selector.Add returns a new selector and does not mutate the
+	// receiver, so the result must be assigned back. Dropping it left an empty
+	// selector that matched every pod cluster-wide, so the executor informers
+	// cached all pods and OOMed at scale (issue #2775).
+	labelSelector := labels.NewSelector().Add(*executorLabel)
 
 	return labelSelector, nil
 }
+
 func SupportedMetricsAPIVersionAvailable(discoveredAPIGroups *metav1.APIGroupList) bool {
 	var supportedMetricsAPIVersions = []string{
 		"v1beta1",

--- a/pkg/utils/informer_test.go
+++ b/pkg/utils/informer_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// TestGetInformerLabelByExecutor guards against the regression where the
+// returned selector was empty (labels.Selector.Add's result was discarded),
+// so executor informers matched every pod cluster-wide and OOMed at scale
+// (issue #2775). The selector must be non-empty and match only pods carrying
+// the executor-type label.
+func TestGetInformerLabelByExecutor(t *testing.T) {
+	selector, err := GetInformerLabelByExecutor(fv1.ExecutorTypePoolmgr)
+	require.NoError(t, err)
+
+	assert.False(t, selector.Empty(), "selector must filter by executor type, not match everything")
+	assert.Equal(t, fv1.EXECUTOR_TYPE+"=="+string(fv1.ExecutorTypePoolmgr), selector.String())
+
+	assert.True(t, selector.Matches(labels.Set{fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypePoolmgr)}),
+		"must match a pod with the matching executor-type label")
+	assert.False(t, selector.Matches(labels.Set{fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypeNewdeploy)}),
+		"must not match a pod with a different executor type")
+	assert.False(t, selector.Matches(labels.Set{}),
+		"must not match an unlabelled pod")
+}


### PR DESCRIPTION
## Summary

Root-cause fix for **#2775** (executor OOM with 10,000+ pods), identified during the Phase 2 memory-bottleneck pass.

`GetInformerLabelByExecutor` built a label selector but discarded the result of `labels.Selector.Add` — which returns a *new* selector and does not mutate the receiver. It returned an empty selector, so the poolmgr/newdeploy/container **pod, deployment, and service** informer factories (`pkg/executor/executor.go`) matched *all* resources cluster-wide and cached every pod object. In a cluster with thousands of pods this is the dominant executor memory consumer and the reported OOM.

The one-line fix assigns the `Add` result back so informers filter to executor-owned objects.

## Test plan

- [x] New `TestGetInformerLabelByExecutor`: selector is non-empty, equals `executorType==poolmgr`, matches a pod with that label, and rejects other/unlabelled pods (fails before the fix — empty selector matched everything)
- [x] `go build ./...`, `golangci-lint`, gofmt clean
- [ ] CI integration tests green (functional no-op for small clusters; the memory delta only manifests at scale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3411)
<!-- Reviewable:end -->
