### PR TITLE
perf(metrics): use a histogram for http_requests_duration_seconds

### DIFF
--- a/pkg/utils/metrics/http_metrics.go
+++ b/pkg/utils/metrics/http_metrics.go
@@ -27,11 +27,14 @@ var (
 		},
 		[]string{"path", "method", "code"},
 	)
-	httpRequestDuration = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name:       "http_requests_duration_seconds",
-			Help:       "Time taken to serve the request by path and method.",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	httpRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "http_requests_duration_seconds",
+			Help: "Time taken to serve the request by path and method.",
+			// Histogram instead of Summary: a summary allocates a per-series
+			// quantile stream (the single largest router heap consumer), whereas
+			// histogram buckets are fixed-size and aggregatable across replicas.
+			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"path", "method"},
 	)


### PR DESCRIPTION
## Summary

Phase 2 memory optimization (**B2**), identified from the detection harness's CI heap profiles.

`http_requests_duration_seconds` was a `SummaryVec` with quantile objectives. A summary allocates a per-series quantile stream, which the router heap profile showed as the **single largest consumer (~9MB, 44% of inuse_space)** — and cardinality scales with the `path` label (per-function routes). Switching to a `HistogramVec` with fixed buckets is far cheaper per series and, unlike summaries, is aggregatable across router replicas.

The metric still exposes `_sum` and `_count`, so the only existing consumer (the user dashboard's average-latency panel `…_sum/…_count`) is unaffected. Quantiles are now derived with `histogram_quantile()`.

### Note on B4 (AWS SDK init cost)
The requested B4 (the ~3.5MB `aws-sdk-go/aws/endpoints.init`) is **not bundled here**: it is a link-time cost of the multi-headed `fission-bundle` binary statically including the storagesvc subsystem (`graymeta/stow` → `aws-sdk-go` v1), so every subsystem process pays it. Removing it needs either splitting storagesvc into its own binary or migrating stow off aws-sdk-go v1 — a substantial, risky refactor for a fixed one-time cost (not a leak/growth), so it deserves its own PR.

## Test plan

- [x] `go build ./...`, `go test ./pkg/utils/metrics/...`, `golangci-lint`, gofmt clean
- [x] Confirmed no consumer queries summary quantiles directly (only `_sum/_count` in the dashboard)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3412)
<!-- Reviewable:end -->
