### PR TITLE
perf(executor): free pod cache maps and bound idle-reaper concurrency

### DIFF
--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -649,6 +649,14 @@ func (gpm *GenericPoolManager) doIdleObjectReaper(ctx context.Context) {
 		return
 	}
 
+	// Bound concurrency: a traffic drop can leave thousands of pods idle at
+	// once, and one cleanup goroutine each would spike goroutines and hammer
+	// the API server. The semaphore caps in-flight reaps; wait.UntilWithContext
+	// won't start the next reaper pass until this one returns.
+	const maxConcurrentReaps = 10
+	sem := make(chan struct{}, maxConcurrentReaps)
+	var wg sync.WaitGroup
+
 	for i := range funcSvcs {
 		fsvc := funcSvcs[i]
 
@@ -682,7 +690,11 @@ func (gpm *GenericPoolManager) doIdleObjectReaper(ctx context.Context) {
 			continue
 		}
 
+		wg.Add(1)
+		sem <- struct{}{}
 		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
 			deleted, err := gpm.fsCache.DeleteOldPoolCache(ctx, fsvc, idlePodReapTime)
 			if err != nil {
 				gpm.logger.Error(err, "error deleting Kubernetes objects for function service", "service", fsvc)
@@ -701,6 +713,7 @@ func (gpm *GenericPoolManager) doIdleObjectReaper(ctx context.Context) {
 			}
 		}()
 	}
+	wg.Wait()
 }
 
 // WebsocketStartEventChecker checks if the pod has emitted a websocket connection start event

--- a/pkg/executor/fscache/delete_pod_maps_test.go
+++ b/pkg/executor/fscache/delete_pod_maps_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fscache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// TestDeleteFunctionSvcCleansPodMaps guards against the leak where PodToFsvc
+// and WebsocketFsvc (keyed by pod name) accumulated one entry per specialized
+// pod and were never removed. DeleteFunctionSvc, on the path of both poolmgr
+// cleanup routes, must drop those entries.
+func TestDeleteFunctionSvcCleansPodMaps(t *testing.T) {
+	fsc := MakeFunctionServiceCache(loggerfactory.GetLogger())
+	require.NotNil(t, fsc)
+
+	fsvc := &FuncSvc{
+		Name:     "poolmgr-env-default-1-abcde",
+		Function: &metav1.ObjectMeta{Name: "fn", Namespace: "default", UID: "uid-1"},
+		Address:  "10.0.0.1",
+	}
+
+	fsc.PodToFsvc.Store(fsvc.Name, fsvc)
+	fsc.WebsocketFsvc.Store(fsvc.Name, true)
+
+	fsc.DeleteFunctionSvc(t.Context(), fsvc)
+
+	_, ok := fsc.PodToFsvc.Load(fsvc.Name)
+	assert.False(t, ok, "PodToFsvc entry should be removed after DeleteFunctionSvc")
+	_, ok = fsc.WebsocketFsvc.Load(fsvc.Name)
+	assert.False(t, ok, "WebsocketFsvc entry should be removed after DeleteFunctionSvc")
+}

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -326,6 +326,13 @@ func (fsc *FunctionServiceCache) DeleteFunctionSvc(ctx context.Context, fsvc *Fu
 			"address", fsvc.Address,
 		)
 	}
+	// PodToFsvc and WebsocketFsvc are keyed by pod name (== fsvc.Name) and were
+	// never cleaned up, leaking one entry per specialized pod as pods churn.
+	// Both poolmgr cleanup paths (idle reaper and specialized-pod cleanup) route
+	// through here, so removing them once covers both. Delete is a no-op for
+	// executors that never populate these maps.
+	fsc.PodToFsvc.Delete(fsvc.Name)
+	fsc.WebsocketFsvc.Delete(fsvc.Name)
 }
 
 // DeleteOld deletes aged function service entries from cache.


### PR DESCRIPTION
## Summary

Two poolmgr memory/compute optimizations found during the Phase 2 profiling pass for #2775. Both are executor-side and verified safe.

**1. Memory leak — `PodToFsvc` / `WebsocketFsvc` never freed.**
These `sync.Map`s (keyed by pod name) get one entry per specialized pod (`gp.go:654`) but were never deleted, so they grow unbounded as pods churn. `DeleteFunctionSvc` is on the path of both poolmgr cleanup routes (the idle reaper via `DeleteOldPoolCache`, and specialized-pod cleanup in `poolpodcontroller`), so the entries are dropped there. `fsvc.Name == pod.Name` is the map key, and `Delete` is a no-op for executors that never populate these maps. Active-websocket pods are skipped by the reaper, so entries aren't removed while a connection is live.

**2. Compute spike — unbounded idle-reaper goroutine fan-out.**
`doIdleObjectReaper` launched one cleanup goroutine per idle pod with no limit. A traffic drop leaving thousands of idle pods would spike goroutine count and hammer the API server (each goroutine deletes K8s objects). Now capped with a semaphore (10 in-flight) and waited on. Since the reaper runs via `wait.UntilWithContext`, the next pass won't start until this one returns, so this also prevents overlapping reaper runs.

## Test plan

- [x] New `TestDeleteFunctionSvcCleansPodMaps`: asserts both maps are emptied after `DeleteFunctionSvc`
- [x] `go test -race ./pkg/executor/fscache/... ./pkg/executor/executortype/poolmgr/...` pass; gofmt + `golangci-lint` clean
- [x] Reaping behavior preserved (still reaps all idle pods, just bounded) — covered by the existing `idle_objects_reaper` integration test
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3413)
<!-- Reviewable:end -->
