### PR TITLE
perf(metrics): convert remaining latency summaries to histograms

### DIFF
--- a/charts/fission-all/dashboards/fission-admin-dashboard.json
+++ b/charts/fission-all/dashboards/fission-admin-dashboard.json
@@ -798,9 +798,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(fission_function_overhead_seconds_bucket[$__rate_interval])) by (le, function_name, method, code))",
+          "expr": "histogram_quantile(0.99, sum(rate(fission_function_overhead_seconds_bucket[$__rate_interval])) by (le, function_namespace, function_name, method, code))",
           "interval": "",
-          "legendFormat": "Function: {{function_name}} {{method}} {{code}} p99",
+          "legendFormat": "Function: {{function_namespace}}/{{function_name}} {{method}} {{code}} p99",
           "range": true,
           "refId": "A"
         }

--- a/charts/fission-all/dashboards/fission-admin-dashboard.json
+++ b/charts/fission-all/dashboards/fission-admin-dashboard.json
@@ -798,9 +798,9 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "fission_function_overhead_seconds",
+          "expr": "histogram_quantile(0.99, sum(rate(fission_function_overhead_seconds_bucket[5m])) by (le, function_name, method, code))",
           "interval": "",
-          "legendFormat": "Function: {{function_name}} {{method}} {{code}} Percentile:{{quantile}}",
+          "legendFormat": "Function: {{function_name}} {{method}} {{code}} p99",
           "range": true,
           "refId": "A"
         }

--- a/charts/fission-all/dashboards/fission-admin-dashboard.json
+++ b/charts/fission-all/dashboards/fission-admin-dashboard.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "links": [],
@@ -1153,7 +1153,7 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": "Data Source",
+        "label": "Data source",
         "multi": false,
         "name": "datasource",
         "options": [],

--- a/charts/fission-all/dashboards/fission-admin-dashboard.json
+++ b/charts/fission-all/dashboards/fission-admin-dashboard.json
@@ -798,7 +798,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(fission_function_overhead_seconds_bucket[5m])) by (le, function_name, method, code))",
+          "expr": "histogram_quantile(0.99, sum(rate(fission_function_overhead_seconds_bucket[$__rate_interval])) by (le, function_name, method, code))",
           "interval": "",
           "legendFormat": "Function: {{function_name}} {{method}} {{code}} p99",
           "range": true,

--- a/charts/fission-all/dashboards/fission-user-dashboard.json
+++ b/charts/fission-all/dashboards/fission-user-dashboard.json
@@ -21,7 +21,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "links": [],
@@ -510,7 +510,7 @@
         },
         "hide": 0,
         "includeAll": false,
-        "label": "Data Source",
+        "label": "Data source",
         "multi": false,
         "name": "datasource",
         "options": [],
@@ -542,7 +542,7 @@
           "query": "label_values(fission_function_calls_total, function_name)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -573,7 +573,7 @@
           "query": "label_values(http_requests_total, path)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -601,7 +601,7 @@
           "query": "label_values(kube_namespace_labels, namespace)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -627,7 +627,7 @@
           "query": "label_values(fission_function_calls_total, namespace)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/hack/lint-dashboards.sh
+++ b/hack/lint-dashboards.sh
@@ -3,13 +3,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+gobin="$(go env GOBIN)"
+gobin="${gobin:-$(go env GOPATH | cut -d: -f1)/bin}"
+export PATH="$PATH:$gobin"
+
 if ! command -v dashboard-linter >/dev/null 2>&1; then
     echo "dashboard-linter is not installed"
     echo "Installing dashboard-linter..."
-    # dashboard-linter v0.1.1, pinned by commit (OSSF Scorecard PinnedDependencies)
-    go install github.com/grafana/dashboard-linter@1be3836b83fbcf9508efcd87af87dfbfbec94279 || exit 1
-    gobin="$(go env GOBIN)"
-    export PATH="$PATH:${gobin:-$(go env GOPATH | cut -d: -f1)/bin}"
+    # dashboard-linter v0.1.1, pinned by commit (OSSF Scorecard PinnedDependencies).
+    # `go install pkg@version` is rejected because this version's go.mod has
+    # replace directives, so clone at the pinned commit and build instead.
+    linter_sha=1be3836b83fbcf9508efcd87af87dfbfbec94279
+    linter_src=$(mktemp -d)
+    trap 'rm -rf "$linter_src"' EXIT
+    git clone --quiet https://github.com/grafana/dashboard-linter "$linter_src" || exit 1
+    git -C "$linter_src" -c advice.detachedHead=false checkout --quiet "$linter_sha" || exit 1
+    mkdir -p "$gobin"
+    (cd "$linter_src" && go build -o "$gobin/dashboard-linter" .) || exit 1
 fi
 BASE_PATH=$(pwd)
 

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -314,7 +314,7 @@ func (fsc *FunctionServiceCache) DeleteEntry(fsvc *FuncSvc) {
 	fsc.byFunction.Delete(crd.CacheKeyURFromMeta(fsvc.Function))
 	fsc.byAddress.Delete(fsvc.Address)
 	fsc.byFunctionUID.Delete(fsvc.Function.UID)
-	metrics.FuncRunningSummary.WithLabelValues(fsvc.Function.Name, fsvc.Function.Namespace).Observe(fsvc.Atime.Sub(fsvc.Ctime).Seconds())
+	metrics.FuncRunningSeconds.WithLabelValues(fsvc.Function.Name, fsvc.Function.Namespace).Observe(fsvc.Atime.Sub(fsvc.Ctime).Seconds())
 }
 
 // DeleteFunctionSvc deletes a function service at key composed of [function][address].

--- a/pkg/executor/metrics/metrics.go
+++ b/pkg/executor/metrics/metrics.go
@@ -27,8 +27,10 @@ var (
 			Name: "fission_function_running_seconds",
 			Help: "The running time (last access - create) in seconds of the function.",
 			// Histogram instead of Summary: avoids the per-series quantile stream
-			// memory; quantiles are derived with histogram_quantile().
-			Buckets: prometheus.DefBuckets,
+			// memory; quantiles are derived with histogram_quantile(). This is a
+			// function lifetime (seconds to hours), so use exponential buckets
+			// from 1s to ~9h rather than DefBuckets (which top out at 10s).
+			Buckets: prometheus.ExponentialBuckets(1, 2, 16),
 		},
 		functionLabels,
 	)

--- a/pkg/executor/metrics/metrics.go
+++ b/pkg/executor/metrics/metrics.go
@@ -22,11 +22,13 @@ var (
 		},
 		functionLabels,
 	)
-	FuncRunningSummary = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name:       "fission_function_running_seconds",
-			Help:       "The running time (last access - create) in seconds of the function.",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	FuncRunningSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "fission_function_running_seconds",
+			Help: "The running time (last access - create) in seconds of the function.",
+			// Histogram instead of Summary: avoids the per-series quantile stream
+			// memory; quantiles are derived with histogram_quantile().
+			Buckets: prometheus.DefBuckets,
 		},
 		functionLabels,
 	)
@@ -42,6 +44,6 @@ var (
 func init() {
 	registry := metrics.Registry
 	registry.MustRegister(ColdStarts)
-	registry.MustRegister(FuncRunningSummary)
+	registry.MustRegister(FuncRunningSeconds)
 	registry.MustRegister(ColdStartsError)
 }

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -34,11 +34,15 @@ var (
 		},
 		labelsStrings,
 	)
-	functionCallOverhead = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name:       "fission_function_overhead_seconds",
-			Help:       "The function call delay caused by fission.",
-			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	functionCallOverhead = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "fission_function_overhead_seconds",
+			Help: "The function call delay caused by fission.",
+			// Histogram instead of Summary: a summary keeps a per-series quantile
+			// stream, and with these high-cardinality labels that was the largest
+			// router heap consumer. Buckets are fixed-size and aggregatable across
+			// replicas. Quantiles are derived with histogram_quantile().
+			Buckets: prometheus.DefBuckets,
 		},
 		labelsStrings,
 	)


### PR DESCRIPTION
## Summary

Follow-up to #3412, found by checking the harness pprof after the recent merges. The router heap was **still ~6.7MB (39% of inuse_space) in summary quantile streams** — #3412 converted only `http_requests_duration_seconds`, but two more `SummaryVec`s remained:

- `fission_function_overhead_seconds` (router) — high cardinality (`function_namespace, function_name, path, method, code`); this is the 6.7MB consumer.
- `fission_function_running_seconds` (executor) — ~2.6MB.

Both are converted to `HistogramVec` (fixed buckets, aggregatable across replicas; summaries are not). Metric names are unchanged, so `_sum`/`_count` queries keep working. The only consumer that queried raw summary quantiles — the admin dashboard's "Function overhead" panel — is updated to `histogram_quantile()`. The canary controller is unaffected (it queries the `_total` counters).

## Verified improvements from already-merged work (same pprof run)

- **B1 goroutine leak**: `updateCPUUtilizationSvc` goroutines **44 → 1** (only the live pool's remains).
- **B2**: `http_requests_duration_seconds` summary streams gone from the router heap.

## Test plan

- [x] `go build ./...`, `go test ./pkg/router/... ./pkg/executor/...`, `golangci-lint`, gofmt clean
- [x] `helm lint charts/fission-all` passes (dashboard JSON valid)
- [x] Confirmed no consumer needs raw summary quantiles except the one updated panel; canary uses counters
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3414)
<!-- Reviewable:end -->
