### PR TITLE
docs(skill): capture pprof profile analysis workflow in debug-github-ci

### DIFF
--- a/.claude/skills/debug-github-ci/SKILL.md
+++ b/.claude/skills/debug-github-ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug-github-ci
-description: Investigate and fix GitHub Actions CI failures on the Fission repo's PRs efficiently. Use when CI is red on an open PR, when an integration test needs triaging, when the user asks "why is X failing in CI", or after pushing changes to verify CI before claiming work is done. Optimised for the push-fix-monitor loop and the Fission-specific failure patterns we hit repeatedly: builder/fetcher build pipeline, storagesvc archive flow, NetworkPolicy selectors, /packages shared-volume permissions, kind-ci profile patches.
+description: Investigate and fix GitHub Actions CI failures on the Fission repo's PRs efficiently, and analyze the CI-captured pprof profiles for performance/memory work. Use when CI is red on an open PR, when an integration test needs triaging, when the user asks "why is X failing in CI", after pushing changes to verify CI before claiming work is done, or when investigating memory/compute usage in router/executor from the CI heap/goroutine profiles. Optimised for the push-fix-monitor loop and the Fission-specific failure patterns we hit repeatedly: builder/fetcher build pipeline, storagesvc archive flow, NetworkPolicy selectors, /packages shared-volume permissions, kind-ci profile patches, and pprof profile analysis (leak vs. baseline classification, before/after deltas).
 ---
 
 # Debug GitHub CI failures (Fission)
@@ -116,6 +116,8 @@ Match the error string first, then load the matching resource for deeper diagnos
 
 3. **Sanity-test locally** for the affected scope: ```bash make code-checks                                              # lint go test -race -count=1 -timeout 5m ./pkg/<affected>/...       # focused tests helm lint charts/fission-all                                  # if Helm changed helm template charts/fission-all --set <vals> | sed -n '/^kind: <Kind>/,/^---/p'   # render check ```
 
+4. **Performance / memory investigations** (not a failure, but "where is the memory/compute going", or verifying a perf fix): the integration job uploads heap + goroutine pprof artifacts per leg. Pull and read them, classify leak vs. baseline, and quantify before/after — full workflow in `resources/pprof-profile-analysis.md`.
+
 ## Phase 4 — Push and monitor
 
 After pushing the fix, arm the `Monitor` tool with the standard poll loop so terminal-state notifications arrive instead of you polling.
@@ -140,6 +142,7 @@ Full instructions and rationale: `resources/skaffold-kind-ci-profile.md`.
 - `resources/integration-test-framework.md` — Go-test-framework quirks the bash→Go migration uncovered: builder/runtime readiness race (8 layered fixes), pod-label conventions, `ns.CLI` capture limitations, `embed.FS` nested-module skip, spec-test cwd handling, Package CR `/status` subresource gap.
 - `resources/monitor-poll-loop.md` — the canonical `gh pr checks` poll loop for the push-fix-monitor cycle.
 - `resources/gh-commands-cheatsheet.md` — every `gh` invocation we use during a debug session, with notes.
+- `resources/pprof-profile-analysis.md` — pull and read the CI heap/goroutine pprof artifacts; classify leak vs. baseline; quantify a fix's before/after delta; metrics-registration gotchas (the `TestCanary`-stall trap).
 
 ## Out of scope
 

--- a/.claude/skills/debug-github-ci/resources/pprof-profile-analysis.md
+++ b/.claude/skills/debug-github-ci/resources/pprof-profile-analysis.md
@@ -1,0 +1,94 @@
+# Analyzing pprof profiles & performance data from CI
+
+How to pull and read the heap/goroutine profiles the integration-test job captures, separate real leaks from baseline cost, and quantify a fix's before/after delta. This is the workflow used to find and verify the router/executor memory fixes (issue #2775 line of work).
+
+## Where the profiles come from
+
+The integration-test job has a "Collect pprof profiles" step (added with the memory-leak harness) that port-forwards `:6060` on the router and executor pods and curls `/debug/pprof/heap` + `/debug/pprof/goroutine?debug=1` into an artifact.
+
+- Requires `pprof.enabled=true`, which the **kind-ci** skaffold profile sets. So profiles exist on PR/main runs of the `Fission CI` workflow, not on arbitrary branches without that profile.
+- Artifact name: `pprof-dumps-<runId>-v<k8sversion>` (one per matrix leg that ran the step; e.g. `-v1.34.0`, `-v1.28.15`).
+- Contents: `router-heap.pprof`, `router-goroutine.txt`, `executor-heap.pprof`, `executor-goroutine.txt`.
+
+## Download
+
+```bash
+run=$(gh run list --branch <branch> --workflow="Fission CI" --limit 1 --json databaseId -q '.[0].databaseId')
+gh api repos/fission/fission/actions/runs/$run/artifacts --jq '.artifacts[].name' | grep -i pprof
+rm -rf /tmp/pp && mkdir /tmp/pp
+gh run download $run -n pprof-dumps-$run-v1.34.0 -D /tmp/pp
+```
+
+`go tool pprof` is available locally (Go toolchain). The `.pprof` files are standard pprof; the goroutine `.txt` is `debug=1` text format.
+
+## Heap analysis
+
+```bash
+# Top live-heap consumers (flat = allocated by that frame itself)
+go tool pprof -top -inuse_space -nodecount=15 /tmp/pp/router-heap.pprof
+
+# Cumulative — who PULLS the allocations (init chains, GetLogger, etc.)
+go tool pprof -top -inuse_space -cum -nodecount=18 /tmp/pp/executor-heap.pprof
+
+# Is a specific allocator still present? (e.g. confirm a fix removed it)
+go tool pprof -top -inuse_space /tmp/pp/router-heap.pprof | grep -iE 'quantile|newSummary|newStream'
+```
+
+- `-inuse_space` = live heap at capture (what matters for steady-state footprint). `-alloc_space` would show cumulative churn but the harness captures `heap` (inuse).
+- Always run `-cum` too: the flat top is often a leaf like `zapcore.newCounters` or `endpoints.init`; the cumulative view names the caller (`loggerfactory.GetLogger`, `runtime.doInit` → `pkg/webhook.init`) that tells you *why* it's allocated.
+
+## Goroutine analysis
+
+```bash
+head -1 /tmp/pp/executor-goroutine.txt   # "goroutine profile: total N"
+
+# Group goroutines by their top stack frame, count each
+awk '/^[0-9]+ @/ { cnt=$1; getline; sub(/^#[ \t]+0x[0-9a-f]+[ \t]+/,"",$0); gsub(/^[ \t]+/,""); print cnt"\t"$1 }' \
+  /tmp/pp/executor-goroutine.txt | sort -rn | head -12
+
+# Count a specific suspect signature (leak fingerprint)
+grep -c "updateCPUUtilizationSvc" /tmp/pp/executor-goroutine.txt
+```
+
+A leaked goroutine shows up as a high count for one app frame that should be 1-per-something (e.g. `updateCPUUtilizationSvc` was **44** when it leaked per-pool, **1** after the fix).
+
+## Leak vs. baseline — how to classify a top consumer
+
+Not every large heap entry is fixable. Classify before proposing work:
+
+| Pattern | Classification | Action |
+|---|---|---|
+| `prometheus` summary `newStream`/`quantile.newStream`, scales with label cardinality (path/function/ns) | **Reducible** — convert `SummaryVec`→`HistogramVec` | Fix (see #3412, #3414) |
+| `sync.Map`/cache entry count grows with pod/function churn, never deleted | **Leak** | Fix (delete on cleanup path) |
+| App goroutine count grows per pool/function/request, no `ctx.Done()` exit | **Leak** | Fix (bound or cancel) |
+| `*.init` / package-var allocation (`endpoints.init`, `zapcore.newCounters` via package-level `GetLogger()` vars) | **One-time baseline, never freed but constant** | Usually leave; only fixable structurally |
+| k8s scheme registration, protobuf/cbor/regexp init | **Baseline** | Leave |
+
+Key facts that drive the classification:
+- **Go runs `init()` and package-var initializers for ALL imported packages**, regardless of which subsystem the multi-headed `fission-bundle` actually starts. So a `var log = loggerfactory.GetLogger()...` at package scope in e.g. `pkg/webhook` costs *every* process (router, executor, …), not just the webhook one.
+- **A zap logger's sampler pre-allocates `7 levels × 4096 × 16 B ≈ 448 KB`.** N independent `GetLogger()`/`kzap.New` calls ⇒ N × 448 KB, never freed. (Counting samplers: heap-bytes ÷ 448 KB ≈ number of loggers.)
+- **A `SummaryVec` keeps a per-series quantile stream**; cost scales with active label combinations. A histogram uses fixed buckets — far cheaper and aggregatable across replicas.
+- The kind CI cluster is **tiny**, so scale-dependent costs (the 10k-pod informer-cache OOM in #2775) **don't appear** in these profiles. Heap totals here are ~16-20 MB. Absence in this profile ≠ absence at scale; reason about cardinality/pod-count separately.
+
+## Quantify a fix: before/after delta
+
+Download an artifact from a run *before* the fix merged and one *after*, then compare:
+
+```bash
+# goroutine fingerprint before vs after
+grep -c '<leaked-frame>' /tmp/before/executor-goroutine.txt   # e.g. 44
+grep -c '<leaked-frame>' /tmp/after/executor-goroutine.txt    # e.g. 1
+
+# heap top before vs after; confirm the allocator is gone / shrunk
+go tool pprof -top -inuse_space /tmp/before/router-heap.pprof | grep -i '<allocator>'
+go tool pprof -top -inuse_space /tmp/after/router-heap.pprof  | grep -i '<allocator>' || echo "gone"
+```
+
+Compare **composition**, not raw totals: goroutine/heap totals vary run-to-run with cluster activity. "this specific frame went 44→1" or "summary streams no longer present" is the durable signal.
+
+## Gotchas
+
+- **No pprof artifact on the run?** The branch/PR didn't build with `pprof.enabled` — only the kind-ci profile sets it. A branch that doesn't change Go/chart/test paths may also skip the integration job entirely (path filters in `push_pr.yaml`).
+- **A metrics-registration failure silently breaks more than metrics.** `ServeMetrics` does `metrics.Registry.Register(Registry)` as one atomic call and only *logs* on failure — so one colliding collector drops *all* custom metrics. That starves the canary controller (it reads `fission_function_*` from Prometheus) and stalls `TestCanary`. If `TestCanary` fails on a metrics change, grep the router pod log for `failed to register metrics` / `already exists` before assuming a flake. (Root-caused in the #3412/#3414 line.)
+- **controller-runtime already registers Go + process collectors** into the registry `ServeMetrics` serves, so `go_*`/`process_*` are already on `/metrics` — don't re-register them (it panics or collides). That's why the harness adds no runtime collectors of its own.
+- Histogram bucket choice matters: a *lifetime* metric (seconds→hours, e.g. `fission_function_running_seconds`) needs `ExponentialBuckets`, not `DefBuckets` (which top out at 10s and dump everything in `+Inf`). A per-request overhead metric is fine on `DefBuckets`.


### PR DESCRIPTION
## Summary

Captures the pprof profile-analysis workflow used during the recent router/executor memory work (#3410–#3414) into the `debug-github-ci` skill, so it's reusable in future performance/memory investigations.

- **New `resources/pprof-profile-analysis.md`**: where the CI heap/goroutine pprof artifacts come from and how to download them; heap analysis (`-inuse_space` flat **and** `-cum` to find the caller behind a leaf allocator); the `awk` goroutine-grouping one-liner used to fingerprint leaks (e.g. `updateCPUUtilizationSvc` 44→1); a **leak vs. baseline classification table** with the load-bearing facts (Go runs `init()` for all imported packages in the multi-headed binary; the 448KB-per-zap-sampler math; summary-vs-histogram cardinality cost; the kind cluster is too small to surface scale-OOMs); before/after delta comparison; and gotchas — notably the metrics-registration failure that silently drops all custom metrics and **stalls `TestCanary`**.
- **`SKILL.md`**: frontmatter description extended to cover profile analysis (discoverable for "where's the memory going" / "analyze pprof"), a Phase-3 pointer for performance investigations, and the resources list entry.

Docs-only; no code or chart changes.

## Test plan

- [x] Markdown only; no build/test impact
- [x] `lint-dashboards` / integration paths untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3415)
<!-- Reviewable:end -->
