### PR TITLE
feat: RFC-0005 WS3 — buildermgr on controller-runtime Manager

### DIFF
--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -23,6 +23,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - pods
   - services
   verbs:

--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -72,6 +72,21 @@ spec:
         ports:
           - containerPort: 8080
             name: metrics
+          - containerPort: 8081
+            name: health
+        livenessProbe:
+          httpGet:
+            path: "/healthz"
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: "/readyz"
+            port: 8081
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          failureThreshold: 30
         resources:
           {{- toYaml .Values.buildermgr.resources | nindent 10 }}
         {{- if .Values.terminationMessagePath }}

--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -6,6 +6,7 @@ package buildermgr
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	k8sCache "k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -90,15 +92,28 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 
 	// Fission's custom collectors register into controller-runtime's global
 	// metrics registry; the Manager's metrics server then serves them on
-	// METRICS_ADDR (preserving the existing :8080 scrape).
-	if err := ctrlmetrics.Registry.Register(fissionmetrics.Registry); err != nil {
+	// METRICS_ADDR (preserving the existing :8080 scrape). AlreadyRegistered is
+	// benign — it only happens when another Fission service shares the process
+	// (the e2e harness) and has already registered the same collectors.
+	var alreadyRegistered prometheus.AlreadyRegisteredError
+	if err := ctrlmetrics.Registry.Register(fissionmetrics.Registry); err != nil && !errors.As(err, &alreadyRegistered) {
 		bmLogger.Error(err, "failed to register fission metrics collectors")
+	}
+
+	metricsBind := bindAddr("METRICS_ADDR", "8080")
+	healthBind := bindAddr("HEALTH_PROBE_ADDR", "8081")
+	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
+		// The e2e framework runs every Fission service in one process sharing
+		// METRICS_ADDR, which is fine for the fail-soft ServeMetrics servers but
+		// clashes with the Manager's hard-binding servers. Bind ephemeral ports
+		// (OS-assigned, race-free) in that mode. Never set in production.
+		metricsBind, healthBind = ":0", ":0"
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                        scheme.Scheme,
-		Metrics:                       metricsserver.Options{BindAddress: bindAddr("METRICS_ADDR", "8080")},
-		HealthProbeBindAddress:        bindAddr("HEALTH_PROBE_ADDR", "8081"),
+		Metrics:                       metricsserver.Options{BindAddress: metricsBind},
+		HealthProbeBindAddress:        healthBind,
 		LeaderElection:                leaderElectionEnabled,
 		LeaderElectionID:              leaderElectionID,
 		LeaderElectionNamespace:       leNamespace,

--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -7,22 +7,42 @@ package buildermgr
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
+	k8sCache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/leaderelection"
 	"github.com/fission/fission/pkg/utils/manager"
+	fissionmetrics "github.com/fission/fission/pkg/utils/metrics"
 )
 
-// Start the buildermgr service.
-func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr manager.Interface, storageSvcUrl string) error {
+// leaderElectionID is the name of the Lease the builder manager contends for.
+// Kept identical to the client-go lease name used before the controller-runtime
+// migration so there is no orphaned lease across the upgrade.
+const leaderElectionID = "fission-buildermgr"
+
+// Start runs the builder manager under a controller-runtime Manager. The
+// Manager owns leader election, health/readiness probes, the metrics server and
+// graceful shutdown. The environment/package watchers keep their existing
+// informer-driven logic; they run as a leader-only Manager runnable. The legacy
+// GroupManager argument is unused now that the Manager owns the lifecycle.
+func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, _ manager.Interface, storageSvcUrl string) error {
 	bmLogger := logger.WithName("builder_manager")
 
 	fissionClient, err := clientGen.GetFissionClient()
@@ -33,23 +53,26 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client: %w", err)
 	}
-
-	err = crd.WaitForFunctionCRDs(ctx, logger, fissionClient)
+	restConfig, err := clientGen.GetRestConfig()
 	if err != nil {
+		return fmt.Errorf("failed to get rest config: %w", err)
+	}
+
+	if err := crd.WaitForFunctionCRDs(ctx, bmLogger, fissionClient); err != nil {
 		return fmt.Errorf("error waiting for CRDs: %w", err)
 	}
 
-	fetcherConfig, err := fetcherConfig.MakeFetcherConfig("/packages")
+	fConfig, err := fetcherConfig.MakeFetcherConfig("/packages")
 	if err != nil {
 		return fmt.Errorf("error making fetcher config: %w", err)
 	}
 
 	podSpecPatch, err := util.GetSpecFromConfigMap(fv1.BuilderPodSpecPath)
 	if err != nil && !os.IsNotExist(err) {
-		logger.Error(err, "error reading data for pod spec patch", "path", fv1.BuilderPodSpecPath)
+		bmLogger.Error(err, "error reading data for pod spec patch", "path", fv1.BuilderPodSpecPath)
 	}
 
-	envWatcher, err := makeEnvironmentWatcher(ctx, bmLogger, fissionClient, kubernetesClient, fetcherConfig, podSpecPatch)
+	envWatcher, err := makeEnvironmentWatcher(ctx, bmLogger, fissionClient, kubernetesClient, fConfig, podSpecPatch)
 	if err != nil {
 		return err
 	}
@@ -59,19 +82,115 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		utils.GetK8sInformersForNamespaces(kubernetesClient, time.Minute*30, fv1.Pods),
 		utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.PackagesResource))
 
-	// Active-passive HA: only the elected leader watches environments/packages
-	// and runs builds, so two replicas don't run duplicate/competing builds.
-	// No-op when LEADER_ELECTION_ENABLED is unset (single-replica default).
-	elector, runCtx, err := leaderelection.FromEnv(ctx, kubernetesClient, "fission-buildermgr", bmLogger)
+	leaderElectionEnabled, _ := strconv.ParseBool(os.Getenv("LEADER_ELECTION_ENABLED"))
+	leNamespace := leaderelection.Namespace()
+	if leaderElectionEnabled && leNamespace == "" {
+		return fmt.Errorf("leader election enabled but pod namespace is unknown; set POD_NAMESPACE")
+	}
+
+	// Fission's custom collectors register into controller-runtime's global
+	// metrics registry; the Manager's metrics server then serves them on
+	// METRICS_ADDR (preserving the existing :8080 scrape).
+	if err := ctrlmetrics.Registry.Register(fissionmetrics.Registry); err != nil {
+		bmLogger.Error(err, "failed to register fission metrics collectors")
+	}
+
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+		Scheme:                        scheme.Scheme,
+		Metrics:                       metricsserver.Options{BindAddress: bindAddr("METRICS_ADDR", "8080")},
+		HealthProbeBindAddress:        bindAddr("HEALTH_PROBE_ADDR", "8081"),
+		LeaderElection:                leaderElectionEnabled,
+		LeaderElectionID:              leaderElectionID,
+		LeaderElectionNamespace:       leNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		Logger:                        bmLogger,
+	})
 	if err != nil {
+		return fmt.Errorf("unable to set up builder manager: %w", err)
+	}
+
+	runnable := &watcherRunnable{logger: bmLogger, env: envWatcher, pkg: pkgWatcher}
+	if err := mgr.Add(runnable); err != nil {
+		return fmt.Errorf("unable to add watcher runnable: %w", err)
+	}
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		return fmt.Errorf("unable to add healthz check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("informers-synced", runnable.readyCheck); err != nil {
+		return fmt.Errorf("unable to add readyz check: %w", err)
+	}
+
+	bmLogger.Info("starting builder manager", "leaderElection", leaderElectionEnabled)
+	return mgr.Start(ctx)
+}
+
+// bindAddr resolves a server bind address from env, defaulting to def and
+// prefixing ":" when only a port is given (matching ServeMetrics' convention).
+func bindAddr(env, def string) string {
+	addr := os.Getenv(env)
+	if addr == "" {
+		addr = def
+	}
+	if !strings.Contains(addr, ":") {
+		addr = ":" + addr
+	}
+	return addr
+}
+
+// watcherRunnable runs the environment and package watchers as a leader-only
+// controller-runtime runnable. The existing informer goroutines are hosted on
+// an internal GroupManager; only the elected leader runs them. When leader
+// election is disabled, the Manager runs this runnable unconditionally, so
+// single-replica behaviour is unchanged.
+type watcherRunnable struct {
+	logger logr.Logger
+	env    *environmentWatcher
+	pkg    *packageWatcher
+	ready  atomic.Bool
+}
+
+// NeedLeaderElection makes the Manager run this runnable on the leader only.
+func (w *watcherRunnable) NeedLeaderElection() bool { return true }
+
+// Start launches the watchers and blocks until ctx is cancelled (shutdown or
+// loss of leadership), then drains the informer goroutines.
+func (w *watcherRunnable) Start(ctx context.Context) error {
+	gm := manager.New()
+	w.env.Run(ctx, gm)
+	if err := w.pkg.Run(ctx, gm); err != nil {
 		return err
 	}
-	mgr.Add(ctx, func(context.Context) { elector.Run(runCtx) })
-	mgr.Add(runCtx, elector.Gated(func(c context.Context) { envWatcher.Run(c, mgr) }))
-	mgr.Add(runCtx, elector.Gated(func(c context.Context) {
-		if err := pkgWatcher.Run(c, mgr); err != nil {
-			bmLogger.Error(err, "package watcher stopped")
+	go func() {
+		if w.waitForCacheSync(ctx) {
+			w.ready.Store(true)
+			w.logger.Info("builder manager informer caches synced; ready")
 		}
-	}))
+	}()
+	<-ctx.Done()
+	w.ready.Store(false)
+	gm.Wait()
 	return nil
+}
+
+func (w *watcherRunnable) waitForCacheSync(ctx context.Context) bool {
+	synced := make([]k8sCache.InformerSynced, 0)
+	for _, inf := range w.env.envWatchInformer {
+		synced = append(synced, inf.HasSynced)
+	}
+	for _, inf := range w.pkg.podInformer {
+		synced = append(synced, inf.HasSynced)
+	}
+	for _, inf := range w.pkg.pkgInformer {
+		synced = append(synced, inf.HasSynced)
+	}
+	return k8sCache.WaitForCacheSync(ctx.Done(), synced...)
+}
+
+// readyCheck backs /readyz: ready once the watcher informers have synced (and,
+// under leader election, only after this replica has won the lease).
+func (w *watcherRunnable) readyCheck(_ *http.Request) error {
+	if w.ready.Load() {
+		return nil
+	}
+	return fmt.Errorf("builder manager informers not synced")
 }

--- a/pkg/buildermgr/buildermgr_test.go
+++ b/pkg/buildermgr/buildermgr_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package buildermgr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWatcherRunnableNeedLeaderElection(t *testing.T) {
+	w := &watcherRunnable{}
+	assert.True(t, w.NeedLeaderElection(), "watchers must run on the leader only")
+}
+
+func TestWatcherRunnableReadyCheck(t *testing.T) {
+	w := &watcherRunnable{}
+	assert.Error(t, w.readyCheck(nil), "not ready until informers sync")
+
+	w.ready.Store(true)
+	assert.NoError(t, w.readyCheck(nil), "ready once informers sync")
+}
+
+func TestBindAddr(t *testing.T) {
+	t.Setenv("METRICS_ADDR", "")
+	assert.Equal(t, ":8080", bindAddr("METRICS_ADDR", "8080"))
+
+	t.Setenv("METRICS_ADDR", "9090")
+	assert.Equal(t, ":9090", bindAddr("METRICS_ADDR", "8080"))
+
+	t.Setenv("METRICS_ADDR", "0.0.0.0:9090")
+	assert.Equal(t, "0.0.0.0:9090", bindAddr("METRICS_ADDR", "8080"))
+}

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -7,7 +7,6 @@ package buildermgr
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -23,7 +22,6 @@ import (
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/manager"
-	"github.com/fission/fission/pkg/utils/metrics"
 )
 
 type (
@@ -315,17 +313,13 @@ func (pkgw *packageWatcher) packageInformerHandler(ctx context.Context) k8sCache
 }
 
 func (pkgw *packageWatcher) Run(ctx context.Context, mgr manager.Interface) error {
-
-	mgr.Add(ctx, func(ctx context.Context) {
-		metrics.ServeMetrics(ctx, "buildermgr", pkgw.logger, mgr)
-	})
+	// Metrics are served by the controller-runtime Manager (see buildermgr.go);
+	// the watcher only wires up its informers here.
 	mgr.AddInformers(ctx, pkgw.podInformer)
 	for _, pkgInformer := range pkgw.pkgInformer {
 		_, err := pkgInformer.AddEventHandler(pkgw.packageInformerHandler(ctx))
 		if err != nil {
-			pkgw.logger.Error(err, "error adding package informer handler")
-			os.Exit(1)
-			return err
+			return fmt.Errorf("error adding package informer handler: %w", err)
 		}
 	}
 	mgr.AddInformers(ctx, pkgw.pkgInformer)

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -90,10 +90,22 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 		return err
 	}
 
-	err = buildermgr.Start(ctx, f.ClientGen(), f.Logger(), mgr, fmt.Sprintf("http://localhost:%d", storageSvcPort))
-	if err != nil {
-		return fmt.Errorf("error starting builder manager: %w", err)
-	}
+	// buildermgr runs under a controller-runtime Manager whose metrics/health
+	// servers bind hard (unlike the fail-soft ServeMetrics other in-process
+	// services use). In this single-process harness METRICS_ADDR is shared and
+	// racy, so tell buildermgr to bind ephemeral ports. Set once and never
+	// mutated, so its goroutine reads it deterministically.
+	os.Setenv("FISSION_TEST_EPHEMERAL_SERVERS", "true")
+
+	// buildermgr's Start blocks (like webhook.Start) until the context is
+	// cancelled, so run it in a goroutine so the remaining services come up.
+	storageSvcURL := fmt.Sprintf("http://localhost:%d", storageSvcPort)
+	mgr.Add(ctx, func(ctx context.Context) {
+		if err := buildermgr.Start(ctx, f.ClientGen(), f.Logger(), mgr, storageSvcURL); err != nil {
+			f.Logger().Error(err, "error starting builder manager")
+			os.Exit(1)
+		}
+	})
 	f.AddServiceInfo("buildermgr", framework.ServiceInfo{})
 
 	os.Setenv("ROUTER_ROUND_TRIP_TIMEOUT", "50ms")


### PR DESCRIPTION
## Summary

First PR of **RFC-0005 WS3** (controller-runtime modernization). Migrates
**buildermgr** onto a controller-runtime Manager as the proven template;
executor and router follow in later PRs. Builds on the merged Phase-1
foundation (#3416). Fully backward compatible.

### What changed

- **Lifecycle**: `buildermgr.Start` now builds a controller-runtime Manager
  (mirroring `pkg/webhook`) that owns leader election, health/readiness, the
  metrics server, and graceful shutdown. `mgr.Start(ctx)` replaces the
  GroupManager-driven startup.
- **Native leader election** replaces the client-go barrier helper for
  buildermgr (`LeaderElectionID: fission-buildermgr`, from
  `LEADER_ELECTION_ENABLED`, `ReleaseOnCancel`). On lease loss the Manager
  stops → `/healthz` fails → the pod restarts and rejoins — **fixing the
  no-auto-rejoin limitation** of the barrier approach. (The client-go helper
  stays for the not-yet-migrated components.)
- **Watchers unchanged — no Reconciler rewrite yet**: `envWatcher`/`pkgWatcher`
  keep their informer logic and run as a leader-only Manager runnable
  (`NeedLeaderElection`), hosted on an internal GroupManager.
- **Health/readiness**: `/healthz` (ping) + `/readyz` (gated on watcher
  informer cache sync); Helm gains a health port + liveness/readiness probes
  (buildermgr had none).
- **Metrics**: served by the Manager — Fission's collectors register into
  controller-runtime's global registry, so the `:8080` scrape is unchanged;
  the in-watcher `ServeMetrics` is removed.
- Removed the remaining `os.Exit(1)` in `packageWatcher.Run`.
- RBAC: `events` create/patch for the Manager's LE event recorder (leases
  already granted in #3416).

Default (LE disabled, single replica) behaves exactly as before.

## Test plan

- [x] `go test -race ./pkg/buildermgr/...` (incl. envtest) — runnable
  leader-gating, `/readyz` check, `bindAddr`, existing env/pkg watcher tests
- [x] `go build ./...`, `golangci-lint`, `helm template` + `helm lint`
  (buildermgr renders health probes + leases/events RBAC; default unchanged)
- [ ] CI green
- [ ] Multi-replica failover validated on a live cluster (follow-up)

Next: replicate the pattern to executor, then router; later, convert the
watchers to Reconcilers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3417)
<!-- Reviewable:end -->
