### PR TITLE
feat: RFC-0005 WS3 — executor on controller-runtime Manager

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -222,7 +222,7 @@ func (executor *Executor) healthHandler(w http.ResponseWriter, r *http.Request) 
 // standby is ready to take over the moment it wins the lease. /healthz stays a
 // cheap liveness check.
 func (executor *Executor) readyzHandler(w http.ResponseWriter, r *http.Request) {
-	if executor.leaderElection && (executor.elector == nil || !executor.elector.IsLeader()) {
+	if executor.leaderElection && !executor.isLeader.Load() {
 		http.Error(w, "not leader", http.StatusServiceUnavailable)
 		return
 	}

--- a/pkg/executor/api_readyz_test.go
+++ b/pkg/executor/api_readyz_test.go
@@ -5,52 +5,31 @@
 package executor
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/client-go/kubernetes/fake"
-
-	"github.com/fission/fission/pkg/utils/leaderelection"
 )
 
-func TestAwaitLeading(t *testing.T) {
-	t.Run("returns true when leadership acquired", func(t *testing.T) {
-		leading := make(chan struct{})
-		close(leading)
-		assert.True(t, awaitLeading(context.Background(), leading))
-	})
-
-	t.Run("returns false when ctx ends first", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		assert.False(t, awaitLeading(ctx, make(chan struct{})))
-	})
-}
-
 func TestReadyzHandler(t *testing.T) {
-	// An enabled-but-not-yet-leader elector (Run never called) reports
-	// IsLeader() == false.
-	notLeader := leaderelection.New(true, fake.NewSimpleClientset(), "ns", "lock", "id", logr.Discard())
-
 	tests := []struct {
 		name           string
 		leaderElection bool
-		elector        *leaderelection.Elector
+		isLeader       bool
 		cachesSynced   bool
 		want           int
 	}{
-		{"LE disabled and synced -> ready", false, nil, true, http.StatusOK},
-		{"LE disabled and not synced -> 503", false, nil, false, http.StatusServiceUnavailable},
-		{"LE enabled and not leader -> 503", true, notLeader, true, http.StatusServiceUnavailable},
-		{"LE enabled and nil elector -> 503", true, nil, true, http.StatusServiceUnavailable},
+		{"LE disabled and synced -> ready", false, false, true, http.StatusOK},
+		{"LE disabled and not synced -> 503", false, false, false, http.StatusServiceUnavailable},
+		{"LE enabled, leader, synced -> ready", true, true, true, http.StatusOK},
+		{"LE enabled and not leader -> 503", true, false, true, http.StatusServiceUnavailable},
+		{"LE enabled, leader, not synced -> 503", true, true, false, http.StatusServiceUnavailable},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			e := &Executor{leaderElection: tc.leaderElection, elector: tc.elector}
+			e := &Executor{leaderElection: tc.leaderElection}
+			e.isLeader.Store(tc.isLeader)
 			e.cachesSynced.Store(tc.cachesSynced)
 
 			rec := httptest.NewRecorder()
@@ -58,4 +37,22 @@ func TestReadyzHandler(t *testing.T) {
 			assert.Equal(t, tc.want, rec.Code)
 		})
 	}
+}
+
+func TestRunnableLeaderElection(t *testing.T) {
+	assert.True(t, (&executorControllers{}).NeedLeaderElection(),
+		"controllers must run on the leader only")
+	assert.False(t, (&executorAPIServer{}).NeedLeaderElection(),
+		"the API server must run on every replica so /readyz answers everywhere")
+}
+
+func TestBindAddr(t *testing.T) {
+	t.Setenv("METRICS_ADDR", "")
+	assert.Equal(t, ":8080", bindAddr("METRICS_ADDR", "8080"))
+
+	t.Setenv("METRICS_ADDR", "9090")
+	assert.Equal(t, ":9090", bindAddr("METRICS_ADDR", "8080"))
+
+	t.Setenv("METRICS_ADDR", "0.0.0.0:9090")
+	assert.Equal(t, "0.0.0.0:9090", bindAddr("METRICS_ADDR", "8080"))
 }

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -6,6 +6,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -16,7 +17,11 @@ import (
 
 	"github.com/dchest/uniuri"
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	k8sCache "k8s.io/client-go/tools/cache"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
@@ -29,11 +34,12 @@ import (
 	"github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/leaderelection"
 	"github.com/fission/fission/pkg/utils/manager"
-	"github.com/fission/fission/pkg/utils/metrics"
+	fissionmetrics "github.com/fission/fission/pkg/utils/metrics"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -54,8 +60,10 @@ type (
 		// leader (or leader election is disabled) AND informer caches have
 		// synced, so non-leaders are kept out of the Service endpoints and a
 		// just-elected leader is not advertised before its caches are warm.
+		// isLeader is set by the leader-only controllers runnable under the
+		// controller-runtime Manager.
 		leaderElection bool
-		elector        *leaderelection.Elector
+		isLeader       atomic.Bool
 		cachesSynced   atomic.Bool
 	}
 	createFuncServiceRequest struct {
@@ -70,29 +78,12 @@ type (
 	}
 )
 
-// awaitLeading blocks until leadership is acquired (leadingCh is closed) or ctx
-// is cancelled. Returns true if leadership was acquired, false if ctx ended
-// first. When leader election is disabled the caller passes a pre-closed
-// channel, so this returns true immediately.
-func awaitLeading(ctx context.Context, leadingCh <-chan struct{}) bool {
-	select {
-	case <-leadingCh:
-		return true
-	case <-ctx.Done():
-		return false
-	}
-}
-
-// MakeExecutor returns an Executor for given ExecutorType(s). All mutating
-// background work (configmap/secret informers that drive re-specialization,
-// the per-type controllers and reapers, and the function-service serializer)
-// is gated on leadership via leadingCh so it runs only on the elected leader.
-// leadingCh is pre-closed when leader election is disabled, preserving the
-// historical single-replica behaviour.
-func MakeExecutor(ctx context.Context, logger logr.Logger, mgr manager.Interface, cms *cms.ConfigSecretController,
-	fissionClient versioned.Interface, types map[fv1.ExecutorType]executortype.ExecutorType,
-	leadingCh <-chan struct{}, informers ...k8sCache.SharedIndexInformer) (*Executor, error) {
-	executor := &Executor{
+// MakeExecutor returns an Executor for the given ExecutorType(s). It only builds
+// the object; the mutating controllers are started by executorControllers (a
+// leader-only runnable) under the controller-runtime Manager.
+func MakeExecutor(logger logr.Logger, cms *cms.ConfigSecretController,
+	fissionClient versioned.Interface, types map[fv1.ExecutorType]executortype.ExecutorType) *Executor {
+	return &Executor{
 		logger:        logger.WithName("executor"),
 		cms:           cms,
 		fissionClient: fissionClient,
@@ -100,32 +91,101 @@ func MakeExecutor(ctx context.Context, logger logr.Logger, mgr manager.Interface
 
 		requestChan: make(chan *createFuncServiceRequest),
 	}
+}
 
-	// Run all informers (leader only)
-	for _, informer := range informers {
-		mgr.Add(ctx, func(ctx context.Context) {
-			if !awaitLeading(ctx, leadingCh) {
-				return
-			}
-			informer.Run(ctx.Done())
-		})
-	}
+// executorControllers runs the executor's mutating controllers on the elected
+// leader only (NeedLeaderElection). When leader election is disabled the Manager
+// runs it unconditionally, preserving single-replica behaviour. Non-leaders
+// therefore never start it, so /readyz (served by the API server on every
+// replica) reports not-ready and the Service excludes them.
+type executorControllers struct {
+	logger           logr.Logger
+	api              *Executor
+	executorTypes    map[fv1.ExecutorType]executortype.ExecutorType
+	fissionInformers []k8sCache.SharedIndexInformer
+	startFactories   func(stopCh <-chan struct{})
+	waitForSync      func(stopCh <-chan struct{}) bool
+	adoptResources   bool
+}
 
-	for _, et := range types {
-		mgr.Add(ctx, func(ctx context.Context) {
-			if !awaitLeading(ctx, leadingCh) {
-				return
-			}
-			et.Run(ctx, mgr)
-		})
+func (c *executorControllers) NeedLeaderElection() bool { return true }
+
+func (c *executorControllers) Start(ctx context.Context) error {
+	gm := manager.New()
+
+	// Read-only executortype informer factories (listers used by et.Run).
+	c.startFactories(ctx.Done())
+
+	// ConfigMap/Secret informers drive re-specialization (mutating), so they
+	// run on the leader only.
+	for _, informer := range c.fissionInformers {
+		gm.Add(ctx, func(ic context.Context) { informer.Run(ic.Done()) })
 	}
-	mgr.Add(ctx, func(ctx context.Context) {
-		if !awaitLeading(ctx, leadingCh) {
-			return
+	for _, et := range c.executorTypes {
+		gm.Add(ctx, func(ic context.Context) { et.Run(ic, gm) })
+	}
+	gm.Add(ctx, func(ic context.Context) { c.api.serveCreateFuncServices(ic) })
+
+	runAdoptCleanup(ctx, c.executorTypes, c.adoptResources)
+
+	c.api.isLeader.Store(true)
+	go func() {
+		if c.waitForSync(ctx.Done()) {
+			c.api.cachesSynced.Store(true)
+			c.logger.Info("executor caches synced; ready to serve")
 		}
-		executor.serveCreateFuncServices(ctx)
-	})
-	return executor, nil
+	}()
+
+	<-ctx.Done()
+	c.api.isLeader.Store(false)
+	gm.Wait()
+	return nil
+}
+
+// executorAPIServer serves the executor HTTP API (getServiceForFunction plus the
+// /healthz and /readyz probes) on every replica, so non-leaders report
+// not-ready and are kept out of the Service endpoints.
+type executorAPIServer struct {
+	api  *Executor
+	port int
+}
+
+func (a *executorAPIServer) NeedLeaderElection() bool { return false }
+
+func (a *executorAPIServer) Start(ctx context.Context) error {
+	gm := manager.New()
+	a.api.Serve(ctx, gm, a.port)
+	gm.Wait()
+	return nil
+}
+
+// runAdoptCleanup adopts pre-existing resources (optional) and cleans up stale
+// executor objects with a hard timeout. Runs on the leader.
+func runAdoptCleanup(ctx context.Context, executorTypes map[fv1.ExecutorType]executortype.ExecutorType, adopt bool) {
+	wg := &sync.WaitGroup{}
+	for _, et := range executorTypes {
+		wg.Go(func() {
+			if adopt {
+				et.AdoptExistingResources(ctx)
+			}
+			et.CleanupOldExecutorObjects(ctx)
+		})
+	}
+	// TODO: use context to control the waiting time once kubernetes client supports it.
+	util.WaitTimeout(wg, 30*time.Second)
+}
+
+// bindAddr resolves a server bind address from env, defaulting to def and
+// prefixing ":" when only a port is given.
+func bindAddr(env, def string) string {
+	addr := os.Getenv(env)
+	if addr == "" {
+		addr = def
+	}
+	if !strings.Contains(addr, ":") {
+		addr = ":" + addr
+	}
+	return addr
 }
 
 // All non-cached function service requests go through this goroutine
@@ -287,6 +347,10 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	if err != nil {
 		logger.Error(err, "error making the metrics client")
 	}
+	restConfig, err := clientGen.GetRestConfig()
+	if err != nil {
+		return fmt.Errorf("error getting rest config: %w", err)
+	}
 
 	err = crd.WaitForFunctionCRDs(ctx, logger, fissionClient)
 	if err != nil {
@@ -363,58 +427,10 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 
 	adoptExistingResources, _ := strconv.ParseBool(os.Getenv("ADOPT_EXISTING_RESOURCES"))
 
-	// Leader election (opt-in via LEADER_ELECTION_ENABLED). Disabled by
-	// default: the elector reports itself leader immediately, so every gated
-	// path below runs exactly as it did historically. When enabled, only the
-	// elected leader runs the mutating controllers/reapers and is advertised
-	// Ready; on losing leadership we cancel runCtx so the process drains and
-	// restarts (the standby then takes over). Informer factories run on every
-	// replica so a standby keeps warm caches for fast failover.
-	leaderElectionEnabled, _ := strconv.ParseBool(os.Getenv("LEADER_ELECTION_ENABLED"))
-	runCtx, cancelRun := context.WithCancel(ctx)
-	leNamespace := leaderelection.Namespace()
-	if leaderElectionEnabled && leNamespace == "" {
-		cancelRun()
-		return fmt.Errorf("leader election enabled but pod namespace is unknown; set POD_NAMESPACE")
-	}
-	elector := leaderelection.New(leaderElectionEnabled, kubernetesClient, leNamespace,
-		"fission-executor", leaderelection.Identity(), logger,
-		leaderelection.WithOnStoppedLeading(cancelRun))
-	mgr.Add(ctx, func(context.Context) {
-		elector.Run(runCtx)
-	})
-	leadingCh := elector.Leading()
-
-	runAdoptCleanup := func(ctx context.Context) {
-		wg := &sync.WaitGroup{}
-		for _, et := range executorTypes {
-			wg.Go(func() {
-				if adoptExistingResources {
-					et.AdoptExistingResources(ctx)
-				}
-				et.CleanupOldExecutorObjects(ctx)
-			})
-		}
-		// set hard timeout for resource adoption
-		// TODO: use context to control the waiting time once kubernetes client supports it.
-		util.WaitTimeout(wg, 30*time.Second)
-	}
-	if leaderElectionEnabled {
-		// Can't block startup waiting for an election; defer to the leader.
-		mgr.Add(runCtx, func(ctx context.Context) {
-			if awaitLeading(ctx, leadingCh) {
-				runAdoptCleanup(ctx)
-			}
-		})
-	} else {
-		runAdoptCleanup(ctx)
-	}
-
 	configMapInformer := utils.GetK8sInformersForNamespaces(kubernetesClient, time.Minute*30, fv1.ConfigMaps)
 	secretInformer := utils.GetK8sInformersForNamespaces(kubernetesClient, time.Minute*30, fv1.Secrets)
-	cms, err := cms.MakeConfigSecretController(ctx, logger, fissionClient, kubernetesClient, executorTypes, configMapInformer, secretInformer)
+	cmsController, err := cms.MakeConfigSecretController(ctx, logger, fissionClient, kubernetesClient, executorTypes, configMapInformer, secretInformer)
 	if err != nil {
-		cancelRun()
 		return fmt.Errorf("error creating configmap and secret controller: %w", err)
 	}
 
@@ -425,61 +441,92 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	for _, informer := range secretInformer {
 		fissionInformers = append(fissionInformers, informer)
 	}
-	// Informer factories run on every replica (read-only watches) so a standby
-	// keeps warm caches; runCtx stops them if this leader loses its lease.
-	for _, factory := range finformerFactory {
-		factory.Start(runCtx.Done())
-	}
-	for _, informerFactory := range gpmInformerFactory {
-		informerFactory.Start(runCtx.Done())
-	}
-	for _, informerFactory := range ndmInformerFactory {
-		informerFactory.Start(runCtx.Done())
-	}
-	for _, informerFactory := range cnmInformerFactory {
-		informerFactory.Start(runCtx.Done())
+
+	// Leader election is owned by the controller-runtime Manager (native),
+	// opt-in via LEADER_ELECTION_ENABLED. When disabled the Manager runs every
+	// runnable unconditionally, so single-replica behaviour is unchanged. On
+	// lease loss the Manager stops and the API server's /healthz (port 8888)
+	// goes down, so the kubelet restarts the pod and it rejoins as a standby.
+	leaderElectionEnabled, _ := strconv.ParseBool(os.Getenv("LEADER_ELECTION_ENABLED"))
+	leNamespace := leaderelection.Namespace()
+	if leaderElectionEnabled && leNamespace == "" {
+		return fmt.Errorf("leader election enabled but pod namespace is unknown; set POD_NAMESPACE")
 	}
 
-	api, err := MakeExecutor(runCtx, logger, mgr, cms, fissionClient, executorTypes,
-		leadingCh, fissionInformers...,
-	)
-	if err != nil {
-		cancelRun()
-		return err
-	}
+	api := MakeExecutor(logger, cmsController, fissionClient, executorTypes)
 	api.leaderElection = leaderElectionEnabled
-	api.elector = elector
 
-	// Flip readiness on once we are the leader (or election is disabled) and
-	// the function informers have synced, so /readyz only reports Ready when
-	// this replica can actually serve.
-	mgr.Add(runCtx, func(ctx context.Context) {
-		if !awaitLeading(ctx, leadingCh) {
-			return
+	// Fission's collectors register into controller-runtime's global registry;
+	// the Manager's metrics server then serves them on METRICS_ADDR (:8080).
+	var alreadyRegistered prometheus.AlreadyRegisteredError
+	if err := ctrlmetrics.Registry.Register(fissionmetrics.Registry); err != nil && !errors.As(err, &alreadyRegistered) {
+		logger.Error(err, "failed to register fission metrics collectors")
+	}
+
+	metricsBind := bindAddr("METRICS_ADDR", "8080")
+	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
+		// In-process e2e harness: bind an ephemeral metrics port to avoid clashes.
+		metricsBind = ":0"
+	}
+
+	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+		Scheme:                        scheme.Scheme,
+		Metrics:                       metricsserver.Options{BindAddress: metricsBind},
+		HealthProbeBindAddress:        "0", // /healthz + /readyz stay on the API mux (port)
+		LeaderElection:                leaderElectionEnabled,
+		LeaderElectionID:              "fission-executor",
+		LeaderElectionNamespace:       leNamespace,
+		LeaderElectionReleaseOnCancel: true,
+		Logger:                        logger,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to set up executor manager: %w", err)
+	}
+
+	startFactories := func(stopCh <-chan struct{}) {
+		for _, factory := range finformerFactory {
+			factory.Start(stopCh)
 		}
+		for _, factory := range gpmInformerFactory {
+			factory.Start(stopCh)
+		}
+		for _, factory := range ndmInformerFactory {
+			factory.Start(stopCh)
+		}
+		for _, factory := range cnmInformerFactory {
+			factory.Start(stopCh)
+		}
+	}
+	waitForSync := func(stopCh <-chan struct{}) bool {
 		synced := true
 		for _, factory := range finformerFactory {
-			for _, ok := range factory.WaitForCacheSync(ctx.Done()) {
+			for _, ok := range factory.WaitForCacheSync(stopCh) {
 				if !ok {
 					synced = false
 				}
 			}
 		}
-		if synced {
-			api.cachesSynced.Store(true)
-			logger.Info("executor caches synced; ready to serve")
-		}
-	})
+		return synced
+	}
 
 	utils.CreateMissingPermissionForSA(ctx, kubernetesClient, logger)
 
-	mgr.Add(runCtx, func(ctx context.Context) {
-		metrics.ServeMetrics(ctx, "executor", logger, mgr)
-	})
+	controllers := &executorControllers{
+		logger:           logger,
+		api:              api,
+		executorTypes:    executorTypes,
+		fissionInformers: fissionInformers,
+		startFactories:   startFactories,
+		waitForSync:      waitForSync,
+		adoptResources:   adoptExistingResources,
+	}
+	if err := crMgr.Add(controllers); err != nil {
+		return fmt.Errorf("unable to add executor controllers: %w", err)
+	}
+	if err := crMgr.Add(&executorAPIServer{api: api, port: port}); err != nil {
+		return fmt.Errorf("unable to add executor api server: %w", err)
+	}
 
-	mgr.Add(runCtx, func(ctx context.Context) {
-		api.Serve(ctx, mgr, port)
-	})
-
-	return nil
+	logger.Info("starting executor manager", "instanceID", executorInstanceID, "leaderElection", leaderElectionEnabled)
+	return crMgr.Start(ctx)
 }

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -28,6 +28,12 @@ import (
 
 func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Interface) error {
 	os.Setenv("DEBUG_ENV", "true")
+	// The executor and buildermgr run under controller-runtime Managers whose
+	// metrics/health servers bind hard (unlike the fail-soft ServeMetrics the
+	// other in-process services use). In this single-process harness
+	// METRICS_ADDR is shared and racy, so tell them to bind ephemeral ports.
+	// Set once and never mutated, so their goroutines read it deterministically.
+	os.Setenv("FISSION_TEST_EPHEMERAL_SERVERS", "true")
 	env := f.GetEnv()
 	webhookPort := env.WebhookInstallOptions.LocalServingPort
 	err := f.ToggleMetricAddr()
@@ -66,10 +72,15 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 	}
 
 	os.Setenv("POD_READY_TIMEOUT", "300s")
-	err = executor.StartExecutor(ctx, f.ClientGen(), f.Logger(), mgr, executorPort)
-	if err != nil {
-		return fmt.Errorf("error starting executor: %w", err)
-	}
+	// executor now runs under a controller-runtime Manager, so StartExecutor
+	// blocks (like webhook.Start). Run it in a goroutine so the remaining
+	// services still come up.
+	mgr.Add(ctx, func(ctx context.Context) {
+		if err := executor.StartExecutor(ctx, f.ClientGen(), f.Logger(), mgr, executorPort); err != nil {
+			f.Logger().Error(err, "error starting executor")
+			os.Exit(1)
+		}
+	})
 	f.AddServiceInfo("executor", framework.ServiceInfo{Port: executorPort})
 
 	os.Setenv("PRUNE_ENABLED", "true")
@@ -90,15 +101,9 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 		return err
 	}
 
-	// buildermgr runs under a controller-runtime Manager whose metrics/health
-	// servers bind hard (unlike the fail-soft ServeMetrics other in-process
-	// services use). In this single-process harness METRICS_ADDR is shared and
-	// racy, so tell buildermgr to bind ephemeral ports. Set once and never
-	// mutated, so its goroutine reads it deterministically.
-	os.Setenv("FISSION_TEST_EPHEMERAL_SERVERS", "true")
-
-	// buildermgr's Start blocks (like webhook.Start) until the context is
-	// cancelled, so run it in a goroutine so the remaining services come up.
+	// buildermgr's Start blocks (controller-runtime Manager), so run it in a
+	// goroutine; FISSION_TEST_EPHEMERAL_SERVERS (set at the top) makes its
+	// Manager servers bind ephemeral ports.
 	storageSvcURL := fmt.Sprintf("http://localhost:%d", storageSvcPort)
 	mgr.Add(ctx, func(ctx context.Context) {
 		if err := buildermgr.Start(ctx, f.ClientGen(), f.Logger(), mgr, storageSvcURL); err != nil {

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -29,10 +29,12 @@ import (
 func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Interface) error {
 	os.Setenv("DEBUG_ENV", "true")
 	// The executor and buildermgr run under controller-runtime Managers whose
-	// metrics/health servers bind hard (unlike the fail-soft ServeMetrics the
-	// other in-process services use). In this single-process harness
-	// METRICS_ADDR is shared and racy, so tell them to bind ephemeral ports.
-	// Set once and never mutated, so their goroutines read it deterministically.
+	// metrics server binds hard (and buildermgr's health-probe server too;
+	// the executor keeps health on its API mux), unlike the fail-soft
+	// ServeMetrics the other in-process services use. In this single-process
+	// harness METRICS_ADDR is shared and racy, so tell them to bind ephemeral
+	// ports. Set once and never mutated, so their goroutines read it
+	// deterministically.
 	os.Setenv("FISSION_TEST_EPHEMERAL_SERVERS", "true")
 	env := f.GetEnv()
 	webhookPort := env.WebhookInstallOptions.LocalServingPort


### PR DESCRIPTION
## Summary

Second PR of **RFC-0005 WS3** (controller-runtime modernization), applying the
buildermgr template (#3417) to the **executor** and replacing its client-go
leader election with the Manager's **native** leader election. Fully backward
compatible; no Reconciler rewrite yet.

### What changed

- **Lifecycle**: `StartExecutor` builds a controller-runtime Manager (native LE,
  `LeaderElectionID: "fission-executor"`, from `LEADER_ELECTION_ENABLED`,
  `ReleaseOnCancel`); `mgr.Start(ctx)` replaces the GroupManager wiring. The
  client-go elector / `leadingCh` / `awaitLeading` machinery is removed.
- **Two runnables**:
  - *leader-only* (`NeedLeaderElection`): per-type controllers, cms
    config/secret informers, the function-service serializer, adopt/cleanup;
    sets `isLeader` + `cachesSynced`.
  - *all-replica*: the executor HTTP API server (`getServiceForFunction` +
    `/healthz` + `/readyz`) so non-leaders report not-ready and are excluded
    from the Service.
- **Health/readiness stay on the API mux (8888)** — chart probes unchanged;
  Manager health server disabled. On lease loss the Manager stops → `/healthz`
  goes down → kubelet restarts the pod → rejoins as standby (**fixes the
  no-auto-rejoin limitation**).
- **Metrics** served by the Manager (Fission collectors registered into the
  global registry); `/readyz` reads the `isLeader` atomic set by the leader
  runnable.
- **No chart change**: the executor already has `leases` + `events` RBAC and
  its `/readyz`/`LEADER_ELECTION_ENABLED` wiring from #3416.
- **e2e harness**: run `StartExecutor` in a goroutine (Manager `Start` blocks)
  and bind ephemeral Manager metrics ports via `FISSION_TEST_EPHEMERAL_SERVERS`.

Default (LE disabled, single replica) behaves exactly as before.

## Test plan

- [x] `go test ./pkg/executor/...` (incl. envtest) — readyz matrix, runnable
  leader-election flags, `bindAddr`, existing poolmgr/newdeploy/container/cms tests
- [x] `./test/e2e/fetcher` and `./test/e2e/cli` pass locally (run before push)
- [x] `go build ./...`, `golangci-lint`, `helm template`/`lint`
- [ ] CI green
- [ ] Multi-replica failover on a live cluster (follow-up)

Next: replicate to the **router** (the last of the three core components).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3418)
<!-- Reviewable:end -->
