### PR TITLE
feat: RFC-0005 WS3 — router on controller-runtime Manager

### DIFF
--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -29,25 +29,50 @@ package router
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/crd"
 	eclient "github.com/fission/fission/pkg/executor/client"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils/httpsecurity"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/manager"
-	"github.com/fission/fission/pkg/utils/metrics"
+	fissionmetrics "github.com/fission/fission/pkg/utils/metrics"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
+
+// runnableFunc adapts a function to a controller-runtime manager.Runnable.
+type runnableFunc func(context.Context) error
+
+func (f runnableFunc) Start(ctx context.Context) error { return f(ctx) }
+
+// bindAddr resolves a server bind address from env, defaulting to def and
+// prefixing ":" when only a port is given.
+func bindAddr(env, def string) string {
+	addr := os.Getenv(env)
+	if addr == "" {
+		addr = def
+	}
+	if !strings.Contains(addr, ":") {
+		addr = ":" + addr
+	}
+	return addr
+}
 
 // DefaultInternalListenerPort is the default port for the internal
 // listener that serves /fission-function/<ns>/<name>. It must match the
@@ -172,6 +197,10 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	if err != nil {
 		return fmt.Errorf("error making the kube client: %w", err)
 	}
+	restConfig, err := clientGen.GetRestConfig()
+	if err != nil {
+		return fmt.Errorf("error getting rest config: %w", err)
+	}
 
 	err = crd.WaitForFunctionCRDs(ctx, logger, fissionClient)
 	if err != nil {
@@ -260,15 +289,53 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return fmt.Errorf("error making HTTP trigger set: %w", err)
 	}
 
-	mgr.Add(ctx, func(ctx context.Context) {
-		metrics.ServeMetrics(ctx, "router", logger, mgr)
+	// The router runs under a controller-runtime Manager for lifecycle
+	// consistency with the rest of the control plane and to set up the future
+	// HTTPTrigger Reconciler. It is stateless and replica-independent, so it
+	// uses NO leader election (every replica serves). The Manager owns the
+	// metrics server and graceful shutdown; /healthz + /readyz stay on the
+	// public listener, so the Manager's own health server is disabled.
+	var alreadyRegistered prometheus.AlreadyRegisteredError
+	if err := ctrlmetrics.Registry.Register(fissionmetrics.Registry); err != nil && !errors.As(err, &alreadyRegistered) {
+		logger.Error(err, "failed to register fission metrics collectors")
+	}
+
+	metricsBind := bindAddr("METRICS_ADDR", "8080")
+	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
+		// In-process e2e harness: bind an ephemeral metrics port to avoid clashes.
+		metricsBind = ":0"
+	}
+
+	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+		Scheme:                 scheme.Scheme,
+		Metrics:                metricsserver.Options{BindAddress: metricsBind},
+		HealthProbeBindAddress: "0", // /router-healthz + /readyz stay on the public listener
+		LeaderElection:         false,
+		Logger:                 logger,
 	})
+	if err != nil {
+		return fmt.Errorf("unable to set up router manager: %w", err)
+	}
 
 	logger.Info("starting router", "port", port, "internalPort", internalPort)
 
-	tracer := otel.Tracer("router")
-	ctx, span := tracer.Start(ctx, "router/Start")
-	defer span.End()
+	// The trigger watching + the public/internal listeners run on an internal
+	// GroupManager, hosted by a single Manager runnable.
+	err = crMgr.Add(runnableFunc(func(rctx context.Context) error {
+		gm := manager.New()
+		tracer := otel.Tracer("router")
+		rctx, span := tracer.Start(rctx, "router/serve")
+		defer span.End()
+		if err := serve(rctx, logger, gm, port, internalPort, triggers); err != nil {
+			return err
+		}
+		<-rctx.Done()
+		gm.Wait()
+		return nil
+	}))
+	if err != nil {
+		return fmt.Errorf("unable to add router runnable: %w", err)
+	}
 
-	return serve(ctx, logger, mgr, port, internalPort, triggers)
+	return crMgr.Start(ctx)
 }

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -145,10 +145,15 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr manager.Inte
 	if err != nil {
 		return fmt.Errorf("error finding unused port for router internal listener: %w", err)
 	}
-	err = router.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerPort, internalRouterPort, executor)
-	if err != nil {
-		return fmt.Errorf("error starting router: %w", err)
-	}
+	// router now runs under a controller-runtime Manager, so Start blocks. Run
+	// it in a goroutine so the harness can continue; FISSION_TEST_EPHEMERAL_SERVERS
+	// (set at the top) makes its Manager metrics server bind an ephemeral port.
+	mgr.Add(ctx, func(ctx context.Context) {
+		if err := router.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerPort, internalRouterPort, executor); err != nil {
+			f.Logger().Error(err, "error starting router")
+			os.Exit(1)
+		}
+	})
 	f.AddServiceInfo("router", framework.ServiceInfo{Port: routerPort})
 	f.AddServiceInfo("router-internal", framework.ServiceInfo{Port: internalRouterPort})
 	routerURL, err := f.GetServiceURL("router")


### PR DESCRIPTION
## Summary

Third and final core component of **RFC-0005 WS3** (controller-runtime
modernization): the **router**, completing builder (#3417) + executor (#3418) +
router. Fully backward compatible; no Reconciler rewrite yet.

The router is stateless and replica-independent, so — unlike the executor and
buildermgr — it uses **no leader election** (every replica serves). The cr
Manager provides lifecycle consistency, the metrics server, graceful shutdown,
and the foundation for a future HTTPTrigger Reconciler.

### What changed

- `router.Start` builds a controller-runtime Manager (`LeaderElection: false`);
  `mgr.Start(ctx)` replaces the GroupManager startup.
- The trigger watching + the public/internal listeners (`serve()`) run as a
  single Manager runnable backed by an internal GroupManager — the
  **dual-listener split, internal-listener HMAC, and `/readyz` cache-sync
  gating are unchanged**.
- Health/readiness stay on the **public listener (8888)** → chart probes
  unchanged; Manager health server disabled.
- Metrics served by the Manager (Fission collectors registered into the global
  registry); the inline `ServeMetrics` is removed.
- **No chart change** (no leader election → no Lease/RBAC; probes/metrics ports
  unchanged).
- e2e harness: run `router.Start` in a goroutine (Manager `Start` blocks),
  ephemeral Manager metrics port via `FISSION_TEST_EPHEMERAL_SERVERS`.

Default behaviour is unchanged.

## Test plan

- [x] `go test -race ./pkg/router/...`
- [x] `./test/e2e/fetcher` and `./test/e2e/cli` pass locally (run before push)
- [x] `go build ./...`, `golangci-lint`, `helm template`/`lint`
- [ ] CI green

With this, all three core components (router, executor, buildermgr) run under
controller-runtime Managers — the foundation for converting their controllers
to Reconcilers in later PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3419)
<!-- Reviewable:end -->
