### PR TITLE
feat: RFC-0005 WS3 — mqtrigger as a controller-runtime Reconciler

### DIFF
--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -10,21 +10,24 @@ import (
 	"os"
 	"path"
 	"strings"
-	"time"
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/crd"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/mqtrigger/factory"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/kafka"
-	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/crmanager"
+	"github.com/fission/fission/pkg/utils/metrics"
 )
+
+// mqtReconcileConcurrency lets independent MessageQueueTriggers subscribe in
+// parallel, matching the throughput of the previous 4 create/update workers.
+const mqtReconcileConcurrency = 4
 
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, _ *errgroup.Group, routerUrl string) error {
 	fissionClient, err := clientGen.GetFissionClient()
@@ -66,50 +69,40 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		routerUrl,
 	)
 	if err != nil {
-		logger.Error(err, "failed to connect to remote message queue server")
-
-		os.Exit(1)
-	}
-
-	finformerFactory := make(map[string]genInformer.SharedInformerFactory, 0)
-	for _, ns := range utils.DefaultNSResolver().FissionResourceNS {
-		finformerFactory[ns] = genInformer.NewSharedInformerFactoryWithOptions(fissionClient, time.Minute*30, genInformer.WithNamespace(ns))
-	}
-
-	mqtMgr, err := mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, finformerFactory, mq)
-	if err != nil {
-		return err
+		return fmt.Errorf("failed to connect to remote message queue server: %w", err)
 	}
 
 	// Active-passive HA via native controller-runtime leader election: only the
 	// elected leader consumes the message queue and manages triggers, so two
 	// replicas don't double-consume. No-op when LEADER_ELECTION_ENABLED is unset
-	// (single-replica default).
+	// (single-replica default). The reconciler watches MessageQueueTriggers
+	// through the Manager's namespace-scoped cache and runs only on the leader.
 	crMgr, err := crmanager.NewLeaderElected(restConfig, "fission-mqtrigger", logger)
 	if err != nil {
 		return err
 	}
-	// Warm the trigger informer caches on every replica (not just the leader)
-	// so a standby can take over without a cold cache. The Manager starts this
-	// non-leader runnable before the leader-only one below, so mqtMgr.Run's
-	// WaitForCacheSync sees the already-started factories.
+
+	// Serve the subsystem's custom metrics on every replica (the crmanager
+	// Manager's own metrics server is disabled), so a scrape hits whichever pod.
 	if err := crMgr.Add(crmanager.NonLeaderRunnable(func(c context.Context) error {
-		for _, factory := range finformerFactory {
-			factory.Start(c.Done())
-		}
+		gm := &errgroup.Group{}
+		metrics.ServeMetrics(c, "mqtrigger", logger, gm)
 		<-c.Done()
-		return nil
+		return gm.Wait()
 	})); err != nil {
 		return err
 	}
-	if err := crMgr.Add(crmanager.LeaderRunnable(func(c context.Context) error {
-		gm := &errgroup.Group{}
-		mqtMgr.Run(c, c.Done(), gm)
-		<-c.Done()
-		_ = gm.Wait()
-		return nil
-	})); err != nil {
+
+	// The subscription manager (service() actor) is leader-only: only the leader
+	// holds live queue subscriptions, so a standby doesn't double-consume.
+	mqtMgr := mqtrigger.MakeMessageQueueTriggerManager(ctx, logger, fissionClient, mqType, mq)
+	if err := crMgr.Add(crmanager.LeaderRunnable(mqtMgr.Start)); err != nil {
 		return err
+	}
+
+	r := mqtrigger.NewMessageQueueTriggerReconciler(logger, crMgr.GetClient(), mqtMgr)
+	if err := controller.RegisterWithConcurrency(crMgr, &fv1.MessageQueueTrigger{}, r, "messagequeuetrigger", mqtReconcileConcurrency); err != nil {
+		return fmt.Errorf("error registering messagequeuetrigger reconciler: %w", err)
 	}
 	return crMgr.Start(ctx)
 }

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -95,7 +95,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 
 	// The subscription manager (service() actor) is leader-only: only the leader
 	// holds live queue subscriptions, so a standby doesn't double-consume.
-	mqtMgr := mqtrigger.MakeMessageQueueTriggerManager(ctx, logger, fissionClient, mqType, mq)
+	mqtMgr := mqtrigger.MakeMessageQueueTriggerManager(logger, fissionClient, mqType, mq)
 	if err := crMgr.Add(crmanager.LeaderRunnable(mqtMgr.Start)); err != nil {
 		return err
 	}

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -8,6 +8,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -23,8 +24,21 @@ import (
 // on a leader-elected Manager they run only on the elected replica; on a
 // non-elected Manager (e.g. the router) they run on every replica.
 func Register(mgr ctrl.Manager, obj client.Object, reconciler reconcile.Reconciler, name string) error {
-	return builder.ControllerManagedBy(mgr).
+	return RegisterWithConcurrency(mgr, obj, reconciler, name, 0)
+}
+
+// RegisterWithConcurrency is Register with an explicit MaxConcurrentReconciles.
+// maxConcurrent <= 0 leaves the controller-runtime default (1). A higher value
+// lets a subsystem reconcile independent objects in parallel (e.g. mqtrigger
+// subscribing many triggers at once); controller-runtime still serializes
+// reconciles for the same key, so in-memory state keyed by NamespacedName stays
+// safe.
+func RegisterWithConcurrency(mgr ctrl.Manager, obj client.Object, reconciler reconcile.Reconciler, name string, maxConcurrent int) error {
+	b := builder.ControllerManagedBy(mgr).
 		For(obj, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
-		Named(name).
-		Complete(reconciler)
+		Named(name)
+	if maxConcurrent > 0 {
+		b = b.WithOptions(ctrlcontroller.Options{MaxConcurrentReconciles: maxConcurrent})
+	}
+	return b.Complete(reconciler)
 }

--- a/pkg/mqtrigger/constants.go
+++ b/pkg/mqtrigger/constants.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	// MaxRetries is the default maximum number of retries for queue operations.
-	MaxRetries = 3
-
 	// AuthTriggerSuffix is the suffix appended to trigger names to create authentication trigger names.
 	AuthTriggerSuffix = "-auth-trigger"
 

--- a/pkg/mqtrigger/errors.go
+++ b/pkg/mqtrigger/errors.go
@@ -6,7 +6,6 @@ package mqtrigger
 
 import (
 	"errors"
-	"fmt"
 )
 
 // Sentinel errors for the mqtrigger package.
@@ -23,25 +22,4 @@ var (
 
 	// ErrSubscriptionNil indicates that the subscription returned from the message queue is nil.
 	ErrSubscriptionNil = errors.New("subscription is nil")
-
-	// ErrListerNotFound indicates that no lister was found for the specified namespace.
-	ErrListerNotFound = errors.New("no messagequeuetrigger lister found for namespace")
 )
-
-// ListerNotFoundError provides detailed error information when a lister is not found.
-type ListerNotFoundError struct {
-	Namespace string
-}
-
-func (e *ListerNotFoundError) Error() string {
-	return fmt.Sprintf("%s: %s", ErrListerNotFound.Error(), e.Namespace)
-}
-
-func (e *ListerNotFoundError) Unwrap() error {
-	return ErrListerNotFound
-}
-
-// NewListerNotFoundError creates a new ListerNotFoundError for the given namespace.
-func NewListerNotFoundError(namespace string) error {
-	return &ListerNotFoundError{Namespace: namespace}
-}

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -41,11 +41,16 @@ type (
 		messageQueueType fv1.MessageQueueType
 		messageQueue     messageQueue.MessageQueue
 
-		// ctx is the manager-wide parent context for all subscriptions. It
-		// outlives any single reconcile so a subscription's consumer goroutine
-		// is not torn down when Reconcile returns; it is cancelled when the
-		// controller-runtime Manager stops.
+		// ctx is the leader-scoped parent context for all subscriptions, set by
+		// Start (a leader-only Runnable). It outlives any single reconcile so a
+		// subscription's consumer goroutine isn't torn down when Reconcile
+		// returns, and it is cancelled when this replica loses leadership (or
+		// the Manager stops) so a promoted standby doesn't double-consume.
 		ctx context.Context
+		// ready is closed once ctx is bound and the actor is serving, so a
+		// reconcile that races ahead of Start blocks instead of subscribing
+		// with a nil context.
+		ready chan struct{}
 	}
 
 	triggerSubscription struct {
@@ -64,10 +69,10 @@ type (
 	}
 )
 
-// MakeMessageQueueTriggerManager creates the subscription manager. ctx is the
-// manager-wide context that bounds subscription lifetime (see the ctx field).
-// The caller must run service() (Start does) before issuing trigger requests.
-func MakeMessageQueueTriggerManager(ctx context.Context, logger logr.Logger,
+// MakeMessageQueueTriggerManager creates the subscription manager. The
+// leader-scoped context that bounds subscription lifetime is supplied later by
+// Start; reconciles wait (waitReady) until that context is bound.
+func MakeMessageQueueTriggerManager(logger logr.Logger,
 	fissionClient versioned.Interface,
 	mqType fv1.MessageQueueType,
 	messageQueue messageQueue.MessageQueue) *MessageQueueTriggerManager {
@@ -78,18 +83,40 @@ func MakeMessageQueueTriggerManager(ctx context.Context, logger logr.Logger,
 		fissionClient:    fissionClient,
 		messageQueueType: mqType,
 		messageQueue:     messageQueue,
-		ctx:              ctx,
+		ready:            make(chan struct{}),
 	}
 }
 
-// Start runs the subscription actor. It returns when ctx is cancelled (Manager
-// shutdown), at which point the actor stops serving requests.
+// Start runs the subscription actor as a leader-only Runnable. It binds ctx as
+// the subscription parent (so subscriptions are cancelled on leadership loss)
+// and returns when ctx is cancelled.
 func (mqt *MessageQueueTriggerManager) Start(ctx context.Context) error {
 	mqt.logger.Info("starting message queue trigger manager")
-	go mqt.service()
+	mqt.bind(ctx)
 	<-ctx.Done()
 	mqt.logger.Info("shutting down message queue trigger manager")
 	return nil
+}
+
+// bind records the leader-scoped subscription context and starts the request
+// actor, then signals readiness. Separated from Start so tests can drive it
+// without Start's blocking wait.
+func (mqt *MessageQueueTriggerManager) bind(ctx context.Context) {
+	mqt.ctx = ctx
+	go mqt.service()
+	close(mqt.ready)
+}
+
+// waitReady blocks until bind has run (leader-scoped ctx set, actor serving) or
+// the caller's ctx is cancelled. The reconciler calls this before driving any
+// subscribe so it never calls Subscribe with a nil context.
+func (mqt *MessageQueueTriggerManager) waitReady(ctx context.Context) error {
+	select {
+	case <-mqt.ready:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func (mqt *MessageQueueTriggerManager) service() {

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -6,26 +6,17 @@ package mqtrigger
 
 import (
 	"context"
-	"os"
-	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apimachinery/pkg/types"
 	k8sCache "k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	"github.com/go-logr/logr"
-	"golang.org/x/sync/errgroup"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/conditions"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
-	flisterv1 "github.com/fission/fission/pkg/generated/listers/core/v1"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
-	"github.com/fission/fission/pkg/utils/metrics"
 )
 
 const (
@@ -38,6 +29,10 @@ const (
 type (
 	requestType int
 
+	// MessageQueueTriggerManager owns the live message-queue subscriptions. The
+	// subscription map is mutated only from the single service() goroutine
+	// (serialized via reqChan), so the MessageQueueTriggerReconciler can drive
+	// add/update/delete from multiple concurrent reconciles without locking.
 	MessageQueueTriggerManager struct {
 		logger           logr.Logger
 		reqChan          chan request
@@ -46,14 +41,11 @@ type (
 		messageQueueType fv1.MessageQueueType
 		messageQueue     messageQueue.MessageQueue
 
-		// ctx is the parent context for all subscriptions
+		// ctx is the manager-wide parent context for all subscriptions. It
+		// outlives any single reconcile so a subscription's consumer goroutine
+		// is not torn down when Reconcile returns; it is cancelled when the
+		// controller-runtime Manager stops.
 		ctx context.Context
-
-		mqtLister       map[string]flisterv1.MessageQueueTriggerLister
-		mqtListerSynced map[string]k8sCache.InformerSynced
-
-		mqTriggerCreateUpdateQueue workqueue.TypedRateLimitingInterface[string]
-		mqTriggerDeleteQueue       workqueue.TypedRateLimitingInterface[*fv1.MessageQueueTrigger]
 	}
 
 	triggerSubscription struct {
@@ -72,79 +64,32 @@ type (
 	}
 )
 
-func MakeMessageQueueTriggerManager(logger logr.Logger,
+// MakeMessageQueueTriggerManager creates the subscription manager. ctx is the
+// manager-wide context that bounds subscription lifetime (see the ctx field).
+// The caller must run service() (Start does) before issuing trigger requests.
+func MakeMessageQueueTriggerManager(ctx context.Context, logger logr.Logger,
 	fissionClient versioned.Interface,
 	mqType fv1.MessageQueueType,
-	finformerFactory map[string]genInformer.SharedInformerFactory,
-	messageQueue messageQueue.MessageQueue) (*MessageQueueTriggerManager, error) {
-	mqTriggerMgr := MessageQueueTriggerManager{
-		logger:                     logger.WithName("message_queue_trigger_manager"),
-		reqChan:                    make(chan request),
-		triggers:                   make(map[string]*triggerSubscription),
-		fissionClient:              fissionClient,
-		mqtLister:                  make(map[string]flisterv1.MessageQueueTriggerLister, 0),
-		mqtListerSynced:            make(map[string]k8sCache.InformerSynced, 0),
-		messageQueueType:           mqType,
-		messageQueue:               messageQueue,
-		mqTriggerCreateUpdateQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "MqtAddUpdateQueue"}),
-		mqTriggerDeleteQueue:       workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[*fv1.MessageQueueTrigger](), workqueue.TypedRateLimitingQueueConfig[*fv1.MessageQueueTrigger]{Name: "MqtDeleteQueue"}),
+	messageQueue messageQueue.MessageQueue) *MessageQueueTriggerManager {
+	return &MessageQueueTriggerManager{
+		logger:           logger.WithName("message_queue_trigger_manager"),
+		reqChan:          make(chan request),
+		triggers:         make(map[string]*triggerSubscription),
+		fissionClient:    fissionClient,
+		messageQueueType: mqType,
+		messageQueue:     messageQueue,
+		ctx:              ctx,
 	}
-
-	for ns, informer := range finformerFactory {
-		_, err := informer.Core().V1().MessageQueueTriggers().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			AddFunc:    mqTriggerMgr.enqueueMqtAdd,
-			UpdateFunc: mqTriggerMgr.enqueueMqtUpdate,
-			DeleteFunc: mqTriggerMgr.enqueueMqtDelete,
-		})
-		if err != nil {
-			return nil, err
-		}
-		mqTriggerMgr.mqtLister[ns] = informer.Core().V1().MessageQueueTriggers().Lister()
-		mqTriggerMgr.mqtListerSynced[ns] = informer.Core().V1().MessageQueueTriggers().Informer().HasSynced
-	}
-
-	return &mqTriggerMgr, nil
 }
 
-func (mqt *MessageQueueTriggerManager) Run(ctx context.Context, stopCh <-chan struct{}, mgr *errgroup.Group) {
-	defer utilruntime.HandleCrash()
-	defer mqt.mqTriggerCreateUpdateQueue.ShutDown()
-	defer mqt.mqTriggerDeleteQueue.ShutDown()
-
-	// Store the context for subscription lifetime management
-	mqt.ctx = ctx
-
+// Start runs the subscription actor. It returns when ctx is cancelled (Manager
+// shutdown), at which point the actor stops serving requests.
+func (mqt *MessageQueueTriggerManager) Start(ctx context.Context) error {
+	mqt.logger.Info("starting message queue trigger manager")
 	go mqt.service()
-
-	mqt.logger.Info("Waiting for informer caches to sync")
-
-	waitSynced := make([]k8sCache.InformerSynced, 0)
-	for _, synced := range mqt.mqtListerSynced {
-		waitSynced = append(waitSynced, synced)
-	}
-	if ok := k8sCache.WaitForCacheSync(stopCh, waitSynced...); !ok {
-		mqt.logger.Info("failed to wait for caches to sync")
-		os.Exit(1)
-	}
-
-	for range 4 {
-		mgr.Go(func() error {
-			wait.Until(mqt.workerRun(ctx, "mqTriggerCreateUpdate", mqt.mqTriggerCreateUpdateQueueProcessFunc), time.Second, stopCh)
-			return nil
-		})
-	}
-	mgr.Go(func() error {
-		wait.Until(mqt.workerRun(ctx, "mqTriggerDeleteQueue", mqt.mqTriggerDeleteQueueProcessFunc), time.Second, stopCh)
-		return nil
-	})
-
-	mgr.Go(func() error {
-		metrics.ServeMetrics(ctx, "mqtrigger", mqt.logger, mgr)
-		return nil
-	})
-
-	<-stopCh
-	mqt.logger.Info("Shutting down workers for messageQueueTriggerManager")
+	<-ctx.Done()
+	mqt.logger.Info("shutting down message queue trigger manager")
+	return nil
 }
 
 func (mqt *MessageQueueTriggerManager) service() {
@@ -255,13 +200,16 @@ func (mqt *MessageQueueTriggerManager) updateTrigger(trigger *fv1.MessageQueueTr
 	err = mqt.updateTriggerSubscription(&newTriggerSubscription)
 	if err != nil {
 		mqt.logger.Error(err, "updating message queue trigger failed", "trigger_name", trigger.Name)
-		os.Exit(1)
 		return err
 	}
 	mqt.logger.Info("message queue trigger updated", "trigger_name", trigger.Name)
 	return nil
 }
 
+// RegisterTrigger subscribes to (or re-subscribes, on a spec change) the message
+// queue for trigger and records the subscription. It is the create/update path
+// the reconciler calls; the delete path is unsubscribe. Subscriptions use the
+// manager-wide ctx so they survive the reconcile that created them.
 func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueueTrigger) error {
 	isPresent := mqt.checkTriggerSubscription(trigger)
 	if isPresent {
@@ -292,14 +240,38 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 	err = mqt.addTrigger(&triggerSub)
 	if err != nil {
 		mqt.logger.Error(err, "adding message queue trigger failed", "trigger_name", trigger.Name)
-		os.Exit(1)
+		// Roll back the subscription we just created so we don't leak a consumer
+		// goroutine for a trigger we failed to record; the reconciler requeues.
+		if unsubErr := mqt.messageQueue.Unsubscribe(sub); unsubErr != nil {
+			mqt.logger.Error(unsubErr, "failed to roll back subscription after add failure", "trigger_name", trigger.Name)
+		}
 		return err
 	}
 	mqt.logger.Info("message queue trigger created", "trigger_name", trigger.Name)
 	// Use the manager-wide ctx so dangling status writes cancel on
-	// manager shutdown. The RegisterTrigger call path doesn't carry
-	// a request-scoped ctx (it's driven off an internal workqueue).
+	// manager shutdown.
 	mqt.markMessageQueueTriggerBound(mqt.ctx, trigger)
+	return nil
+}
+
+// unsubscribe tears down the subscription for a deleted MessageQueueTrigger,
+// identified by name (a delete reconcile only has the NamespacedName). It is a
+// no-op if no subscription is recorded for the key.
+func (mqt *MessageQueueTriggerManager) unsubscribe(key types.NamespacedName) error {
+	stub := &fv1.MessageQueueTrigger{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}}
+	sub := mqt.getTriggerSubscription(stub)
+	if sub == nil {
+		return nil
+	}
+	if err := mqt.messageQueue.Unsubscribe(sub.subscription); err != nil {
+		mqt.logger.Error(err, "failed to unsubscribe from message queue trigger", "trigger_name", key.Name)
+		return err
+	}
+	if err := mqt.delTriggerSubscription(stub); err != nil {
+		mqt.logger.Error(err, "error deleting message queue trigger subscription", "trigger_name", key.Name)
+		return err
+	}
+	mqt.logger.Info("message queue trigger deleted", "trigger_name", key.Name)
 	return nil
 }
 
@@ -342,162 +314,4 @@ func (mqt *MessageQueueTriggerManager) markMessageQueueTriggerBound(ctx context.
 	if _, err := mqt.fissionClient.CoreV1().MessageQueueTriggers(trigger.Namespace).UpdateStatus(ctx, cur, metav1.UpdateOptions{}); err != nil {
 		mqt.logger.V(1).Info("mqtrigger status: update failed", "name", trigger.Name, "namespace", trigger.Namespace, "error", err)
 	}
-}
-
-func (mqt *MessageQueueTriggerManager) enqueueMqtAdd(obj any) {
-	key, err := k8sCache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		mqt.logger.Error(nil, "error retrieving key from object in messageQueueTriggerManager", "obj", obj)
-		return
-	}
-	mqt.logger.V(1).Info("enqueue mqt add", "key", key)
-	mqt.mqTriggerCreateUpdateQueue.Add(key)
-}
-
-func (mqt *MessageQueueTriggerManager) enqueueMqtUpdate(oldObj, newObj any) {
-	// Status-subresource writes (e.g., our condition write from
-	// markMessageQueueTriggerBound) bump ResourceVersion only.
-	// Re-enqueuing on those would tear down and recreate the queue
-	// subscription needlessly. Generation only changes when Spec
-	// changes, which is the actual signal we care about here.
-	oldMqt, oldOK := oldObj.(*fv1.MessageQueueTrigger)
-	newMqt, newOK := newObj.(*fv1.MessageQueueTrigger)
-	if oldOK && newOK && oldMqt.Generation == newMqt.Generation {
-		return
-	}
-	key, err := k8sCache.MetaNamespaceKeyFunc(newObj)
-	if err != nil {
-		mqt.logger.Error(err, "error retrieving key from object in messageQueueTriggerManager", "obj", newObj)
-		return
-	}
-	mqt.logger.V(1).Info("enqueue mqt update", "key", key)
-	mqt.mqTriggerCreateUpdateQueue.Add(key)
-}
-
-func (mqt *MessageQueueTriggerManager) enqueueMqtDelete(obj any) {
-	mqTrigger, ok := obj.(*fv1.MessageQueueTrigger)
-	if !ok {
-		mqt.logger.Error(nil, "unexpected type when deleting mqt to messageQueueTriggerManager", "obj", obj)
-		return
-	}
-	mqt.logger.V(1).Info("enqueue mqt delete", "mqTrigger", mqTrigger)
-	mqt.mqTriggerDeleteQueue.Add(mqTrigger)
-}
-
-func (mqt *MessageQueueTriggerManager) workerRun(ctx context.Context, name string, processFunc func(ctx context.Context) bool) func() {
-	return func() {
-		mqt.logger.V(1).Info("Starting worker with func", "name", name)
-		for {
-			if quit := processFunc(ctx); quit {
-				mqt.logger.Info("Shutting down worker", "name", name)
-				return
-			}
-		}
-	}
-}
-
-func (mqt *MessageQueueTriggerManager) getMqtLister(namespace string) (flisterv1.MessageQueueTriggerLister, error) {
-	lister, ok := mqt.mqtLister[namespace]
-	if ok {
-		return lister, nil
-	}
-	mqt.logger.Error(nil, "no messagequeuetrigger lister found for namespace", "namespace", namespace)
-	return nil, NewListerNotFoundError(namespace)
-}
-
-func (mqt *MessageQueueTriggerManager) mqTriggerCreateUpdateQueueProcessFunc(ctx context.Context) bool {
-	key, quit := mqt.mqTriggerCreateUpdateQueue.Get()
-	if quit {
-		return false
-	}
-	defer mqt.mqTriggerCreateUpdateQueue.Done(key)
-
-	namespace, name, err := k8sCache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		mqt.logger.Error(err, "error splitting key")
-		mqt.mqTriggerCreateUpdateQueue.Forget(key)
-		return false
-	}
-	mqTriggerLister, err := mqt.getMqtLister(namespace)
-	if err != nil {
-		mqt.logger.Error(err, "error getting messagequeuetrigger lister")
-		mqt.mqTriggerCreateUpdateQueue.Forget(key)
-		return false
-	}
-	mqTrigger, err := mqTriggerLister.MessageQueueTriggers(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		mqt.logger.Info("mqt not found", "key", key)
-		mqt.mqTriggerCreateUpdateQueue.Forget(key)
-		return false
-	}
-
-	if err != nil {
-		if mqt.mqTriggerCreateUpdateQueue.NumRequeues(key) < MaxRetries {
-			mqt.mqTriggerCreateUpdateQueue.AddRateLimited(key)
-			mqt.logger.Error(err, "error getting mqt, retrying")
-		} else {
-			mqt.mqTriggerCreateUpdateQueue.Forget(key)
-			mqt.logger.Error(err, "error getting mqt, max retries reached")
-		}
-		return false
-	}
-
-	mqt.logger.V(1).Info("Added mqt", "trigger", mqTrigger.ObjectMeta)
-	err = mqt.RegisterTrigger(mqTrigger)
-	if err != nil {
-		if mqt.mqTriggerCreateUpdateQueue.NumRequeues(key) < MaxRetries {
-			mqt.mqTriggerCreateUpdateQueue.AddRateLimited(key)
-			mqt.logger.Error(err, "error handling mqt from mqtInformer, retrying", "key", key)
-		} else {
-			mqt.mqTriggerCreateUpdateQueue.Forget(key)
-			mqt.logger.Error(err, "error handling mqt from mqtInformer, max retries reached", "key", key)
-		}
-		return false
-	}
-	mqt.mqTriggerCreateUpdateQueue.Forget(key)
-	return false
-}
-
-func (mqt *MessageQueueTriggerManager) mqTriggerDeleteQueueProcessFunc(ctx context.Context) bool {
-	mqTrigger, quit := mqt.mqTriggerDeleteQueue.Get()
-	if quit {
-		return false
-	}
-	defer mqt.mqTriggerDeleteQueue.Done(mqTrigger)
-
-	mqt.logger.V(1).Info("Delete mqt", "trigger", mqTrigger.ObjectMeta)
-	triggerSubscription := mqt.getTriggerSubscription(mqTrigger)
-	if triggerSubscription == nil {
-		mqt.logger.Info("Unsubscribe failed", "trigger_name", mqTrigger.Name)
-		mqt.mqTriggerDeleteQueue.Forget(mqTrigger)
-		return false
-	}
-
-	err := mqt.messageQueue.Unsubscribe(triggerSubscription.subscription)
-	if err != nil {
-		if mqt.mqTriggerDeleteQueue.NumRequeues(mqTrigger) < MaxRetries {
-			mqt.mqTriggerDeleteQueue.AddRateLimited(mqTrigger)
-			mqt.logger.Error(err, "failed to unsubscribe from message queue trigger, retrying", "trigger_name", mqTrigger.Name)
-		} else {
-			mqt.mqTriggerDeleteQueue.Forget(mqTrigger)
-			mqt.logger.Error(err, "failed to unsubscribe from message queue trigger, max retries reached")
-		}
-		return false
-	}
-
-	err = mqt.delTriggerSubscription(mqTrigger)
-	if err != nil {
-		if mqt.mqTriggerDeleteQueue.NumRequeues(mqTrigger) < MaxRetries {
-			mqt.mqTriggerDeleteQueue.AddRateLimited(mqTrigger)
-			mqt.logger.Error(err, "error deleting mqt, retrying", "obj", mqTrigger)
-		} else {
-			mqt.mqTriggerDeleteQueue.Forget(mqTrigger)
-			mqt.logger.Error(err, "deleting message queue trigger failed, max retries reached", "trigger_name", mqTrigger.Name)
-		}
-		return false
-	}
-
-	mqt.mqTriggerDeleteQueue.Forget(mqTrigger)
-	mqt.logger.Info("message queue trigger deleted", "trigger_name", mqTrigger.Name)
-	return false
 }

--- a/pkg/mqtrigger/mqtmanager_test.go
+++ b/pkg/mqtrigger/mqtmanager_test.go
@@ -69,9 +69,9 @@ func TestMqtManager(t *testing.T) {
 	logger := loggerfactory.GetLogger()
 	msgQueue := fakeMessageQueue{}
 	ctx := t.Context()
-	mgr := MakeMessageQueueTriggerManager(ctx, logger, nil, fv1.MessageQueueTypeKafka, msgQueue)
+	mgr := MakeMessageQueueTriggerManager(logger, nil, fv1.MessageQueueTypeKafka, msgQueue)
+	mgr.bind(ctx)
 
-	go mgr.service()
 	trigger := fv1.MessageQueueTrigger{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
@@ -156,8 +156,8 @@ func TestMessageQueueTriggerReconciler(t *testing.T) {
 
 	// nil fissionClient → markMessageQueueTriggerBound is a no-op, keeping the
 	// test focused on subscription state.
-	mgr := MakeMessageQueueTriggerManager(ctx, logger, nil, fv1.MessageQueueTypeKafka, fakeMessageQueue{})
-	go mgr.service()
+	mgr := MakeMessageQueueTriggerManager(logger, nil, fv1.MessageQueueTypeKafka, fakeMessageQueue{})
+	mgr.bind(ctx)
 
 	r := NewMessageQueueTriggerReconciler(logger, c, mgr)
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "mqt1"}}

--- a/pkg/mqtrigger/mqtmanager_test.go
+++ b/pkg/mqtrigger/mqtmanager_test.go
@@ -7,14 +7,16 @@ package mqtrigger
 import (
 	"context"
 	"testing"
-	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	fClient "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
@@ -66,16 +68,8 @@ func (f fakeMessageQueue) Unsubscribe(sub messageQueue.Subscription) error {
 func TestMqtManager(t *testing.T) {
 	logger := loggerfactory.GetLogger()
 	msgQueue := fakeMessageQueue{}
-	fissionClient := fClient.NewClientset()
-	factory := make(map[string]genInformer.SharedInformerFactory, 0)
-	factory[metav1.NamespaceDefault] = genInformer.NewSharedInformerFactoryWithOptions(fissionClient, time.Minute*30, genInformer.WithNamespace(metav1.NamespaceDefault))
-	mgr, err := MakeMessageQueueTriggerManager(logger, nil, fv1.MessageQueueTypeKafka, factory, msgQueue)
-	require.NoError(t, err, "Error creating messageQueueTriggerManagesr")
-
 	ctx := t.Context()
-
-	// Set the context for the manager (normally done in Run)
-	mgr.ctx = ctx
+	mgr := MakeMessageQueueTriggerManager(ctx, logger, nil, fv1.MessageQueueTypeKafka, msgQueue)
 
 	go mgr.service()
 	trigger := fv1.MessageQueueTrigger{
@@ -145,4 +139,46 @@ func TestMqtManager(t *testing.T) {
 	if mgr.checkTriggerSubscription(&trigger) {
 		t.Errorf("checkTrigger should return false")
 	}
+}
+
+func TestMessageQueueTriggerReconciler(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	ctx := t.Context()
+	mqt := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "mqt1", Namespace: metav1.NamespaceDefault, Generation: 1},
+		Spec:       fv1.MessageQueueTriggerSpec{Topic: "topic-a"},
+	}
+	c := crfake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(mqt).
+		WithStatusSubresource(&fv1.MessageQueueTrigger{}).
+		Build()
+
+	// nil fissionClient → markMessageQueueTriggerBound is a no-op, keeping the
+	// test focused on subscription state.
+	mgr := MakeMessageQueueTriggerManager(ctx, logger, nil, fv1.MessageQueueTypeKafka, fakeMessageQueue{})
+	go mgr.service()
+
+	r := NewMessageQueueTriggerReconciler(logger, c, mgr)
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "mqt1"}}
+
+	// Create: subscribes and records the trigger.
+	_, err := r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, mgr.checkTriggerSubscription(mqt), "subscription should exist after reconcile")
+
+	// Reconcile again is idempotent (update path; still subscribed).
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, mgr.checkTriggerSubscription(mqt))
+
+	// Delete: a NotFound get tears the subscription down.
+	require.NoError(t, c.Delete(ctx, mqt))
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	assert.False(t, mgr.checkTriggerSubscription(mqt), "subscription should be gone after delete")
+
+	// Unsubscribing an unknown trigger is a no-op, not an error.
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
 }

--- a/pkg/mqtrigger/reconciler.go
+++ b/pkg/mqtrigger/reconciler.go
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mqtrigger
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// MessageQueueTriggerReconciler keeps the live message-queue subscriptions in
+// sync with the MessageQueueTrigger CRDs. It replaces the previous informer +
+// two rate-limited workqueues + 4+1 wait.Until workers: controller-runtime
+// delivers add/update/delete through its own rate-limited workqueue
+// (MaxConcurrentReconciles lets independent triggers reconcile in parallel),
+// the GenerationChangedPredicate (in controller.Register) drops the status-only
+// updates the old enqueueMqtUpdate filtered by generation, and a failed
+// subscribe/unsubscribe is retried via the returned error instead of os.Exit.
+//
+// Reads go through the Manager's cache-backed client; the actual subscribe/
+// unsubscribe side effects and the in-memory subscription map live in
+// MessageQueueTriggerManager, whose service() actor serializes the map so
+// concurrent reconciles are safe.
+type MessageQueueTriggerReconciler struct {
+	logger logr.Logger
+	client client.Client
+	mqtMgr *MessageQueueTriggerManager
+}
+
+// NewMessageQueueTriggerReconciler builds the reconciler. client is the
+// Manager's cache-backed client; mqtMgr owns the live subscriptions.
+func NewMessageQueueTriggerReconciler(logger logr.Logger, client client.Client, mqtMgr *MessageQueueTriggerManager) *MessageQueueTriggerReconciler {
+	return &MessageQueueTriggerReconciler{
+		logger: logger.WithName("messagequeuetrigger_reconciler"),
+		client: client,
+		mqtMgr: mqtMgr,
+	}
+}
+
+func (r *MessageQueueTriggerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	mqt := &fv1.MessageQueueTrigger{}
+	if err := r.client.Get(ctx, req.NamespacedName, mqt); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Deleted: tear down the subscription. Identified by name only —
+			// the object is already gone.
+			if err := r.mqtMgr.unsubscribe(req.NamespacedName); err != nil {
+				return ctrl.Result{}, err
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	// RegisterTrigger subscribes on first sight and re-subscribes on a spec
+	// change (it checks the in-memory map). A failure returns an error so the
+	// workqueue requeues with backoff.
+	if err := r.mqtMgr.RegisterTrigger(mqt); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}

--- a/pkg/mqtrigger/reconciler.go
+++ b/pkg/mqtrigger/reconciler.go
@@ -45,6 +45,13 @@ func NewMessageQueueTriggerReconciler(logger logr.Logger, client client.Client, 
 }
 
 func (r *MessageQueueTriggerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// The subscription manager binds its leader-scoped context and starts its
+	// actor in a sibling leader Runnable; block until that's done so we never
+	// subscribe with a nil context or send on the actor channel before it serves.
+	if err := r.mqtMgr.waitReady(ctx); err != nil {
+		return ctrl.Result{}, err
+	}
+
 	mqt := &fv1.MessageQueueTrigger{}
 	if err := r.client.Get(ctx, req.NamespacedName, mqt); err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
## What

Part of **RFC-0005 WS3** — migrating Fission's hand-rolled informer controllers to controller-runtime native Reconcilers.
Follows the timer (#3422), kubewatcher (#3423), and canaryconfig (#3424) migrations.

Migrates the `MessageQueueTrigger` controller (the `--mqt` / Kafka path) off its informer + two rate-limited workqueues + 4+1 `wait.Until` workers onto a `MessageQueueTriggerReconciler`.

## Changes

- **New `pkg/mqtrigger/reconciler.go`** — `Reconcile` reads the MQT via the Manager's cache-backed client; a found object goes through `RegisterTrigger` (subscribe / re-subscribe on spec change), a `NotFound` tears the subscription down via the new `unsubscribe(NamespacedName)`.
  controller-runtime's workqueue replaces both custom queues; `GenerationChangedPredicate` (in `controller.Register`) replaces the by-hand generation filter that `enqueueMqtUpdate` did.
- **`mqtmanager.go`** — keeps the `service()` subscription actor and the `addTrigger`/`updateTrigger`/`RegisterTrigger`/`markMessageQueueTriggerBound` logic; drops the informers, listers, workqueues, enqueue funcs, worker loops, and `Run()`.
  `MakeMessageQueueTriggerManager` now takes the manager-wide `ctx` (which bounds subscription lifetime) and no longer builds informers; `Start()` runs the actor as a leader-only `Runnable`.
- **`os.Exit(1)` removed**: the cache-sync exit is gone (the Manager owns cache sync); `updateTrigger` returns its error; `RegisterTrigger` now rolls back the subscription it just created if recording it fails (no leaked consumer goroutine) and returns the error to requeue; `factory.Create` failure returns an error.
- **Entry point** — builds the leader-elected Manager, registers the reconciler with `MaxConcurrentReconciles=4` (parity with the old 4 create/update workers) via the new `controller.RegisterWithConcurrency`, and serves the subsystem's custom metrics on every replica via a `NonLeaderRunnable`.
- Removes the now-dead lister-error helpers and `MaxRetries` constant.

`MessageQueueTrigger` already has the `/status` subresource and `messagequeuetriggers/status` RBAC, so **no CRD or Helm chart change is needed**.

## Behavior notes

- The subscription actor and reconciler are leader-only, so a standby doesn't double-consume — unchanged from before. Metrics now serve on every replica (previously leader-only), so scrapes hit any pod.
- Per-object reconciles are still serialized by key, so the in-memory subscription map (mutated only by the `service()` actor) stays safe under `MaxConcurrentReconciles=4`.

## Testing

- `go build ./...`, `go vet`, `golangci-lint` (0 issues).
- `go test -race ./pkg/mqtrigger/...` — existing `TestMqtManager` (actor) plus a new `TestMessageQueueTriggerReconciler` covering create→subscribe, idempotent re-reconcile (update path), delete→unsubscribe, and unsubscribe-of-unknown (no-op) using a fake `client.Client` + fake `MessageQueue`.
- Both in-process e2e suites (`test/e2e/fetcher`, `test/e2e/cli`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3425)
<!-- Reviewable:end -->
