### PR TITLE
feat: RFC-0005 WS3 (D1) — shared executor idle reaper

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/fission/fission/pkg/executor/executortype/newdeploy"
 	"github.com/fission/fission/pkg/executor/executortype/poolmgr"
 	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/executor/reaper/idle"
 	"github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
@@ -123,6 +124,17 @@ func (c *executorControllers) Start(ctx context.Context) error {
 	for _, et := range c.executorTypes {
 		gm.Go(func() error { et.Run(ctx, gm); return nil })
 	}
+
+	// One shared idle reaper drives every executor type's idle-reaping strategy
+	// (replacing the three per-type reaper goroutines). It runs on the leader
+	// only, inheriting this leader-elected runnable's context.
+	strategies := make([]idle.Strategy, 0, len(c.executorTypes))
+	for _, et := range c.executorTypes {
+		strategies = append(strategies, et.IdleStrategy())
+	}
+	idleReaper := idle.NewReaper(c.logger, strategies...)
+	gm.Go(func() error { idleReaper.Start(ctx); return nil })
+
 	gm.Go(func() error { c.api.serveCreateFuncServices(ctx); return nil })
 
 	runAdoptCleanup(ctx, c.executorTypes, c.adoptResources)

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	k8sInformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
@@ -35,6 +34,7 @@ import (
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/metrics"
 	"github.com/fission/fission/pkg/executor/reaper"
+	"github.com/fission/fission/pkg/executor/reaper/idle"
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
@@ -157,10 +157,6 @@ func (caaf *Container) Run(ctx context.Context, mgr *errgroup.Group) {
 		caaf.logger.Error(nil, "failed to wait for caches to sync; stopping container manager")
 		return
 	}
-	mgr.Go(func() error {
-		caaf.idleObjectReaper(ctx)
-		return nil
-	})
 }
 
 // GetTypeName returns the executor type name.
@@ -706,83 +702,12 @@ func (caaf *Container) updateStatus(fn *fv1.Function, err error, message string)
 	caaf.logger.Error(err, "function status update", "function", fn, "message", message)
 }
 
-// idleObjectReaper reaps objects after certain idle time
-func (caaf *Container) idleObjectReaper(ctx context.Context) {
-	// calling function doIdleObjectReaper() repeatedly at given interval of time
-	wait.UntilWithContext(ctx, caaf.doIdleObjectReaper, caaf.objectReaperIntervalSecond)
-}
-
-func (caaf *Container) doIdleObjectReaper(ctx context.Context) {
-	funcSvcs, err := caaf.fsCache.ListOld(time.Second * 5)
-	if err != nil {
-		caaf.logger.Error(err, "error reaping idle pods")
-		return
-	}
-
-	for i := range funcSvcs {
-		fsvc := funcSvcs[i]
-
-		if fsvc.Executor != fv1.ExecutorTypeContainer {
-			continue
-		}
-
-		fn, err := caaf.fissionClient.CoreV1().Functions(fsvc.Function.Namespace).Get(ctx, fsvc.Function.Name, metav1.GetOptions{})
-		if err != nil {
-			// CaaF manager handles the function delete event and clean cache/kubeobjs itself,
-			// so we ignore the not found error for functions with CaaF executor type here.
-			if k8sErrs.IsNotFound(err) && fsvc.Executor == fv1.ExecutorTypeContainer {
-				continue
-			}
-			caaf.logger.Error(err, "error getting function", "function", fsvc.Function.Name)
-			continue
-		}
-
-		idlePodReapTime := caaf.defaultIdlePodReapTime
-		if fn.Spec.IdleTimeout != nil {
-			idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
-		}
-
-		if time.Since(fsvc.Atime) < idlePodReapTime {
-			continue
-		}
-
-		go func() {
-			deployObj := getDeploymentObj(fsvc.KubernetesObjects)
-			if deployObj == nil {
-				caaf.logger.Error(err, "error finding function deployment", "function", fsvc.Function.Name)
-				return
-			}
-
-			currentDeploy, err := caaf.kubernetesClient.AppsV1().
-				Deployments(deployObj.Namespace).Get(ctx, deployObj.Name, metav1.GetOptions{})
-			if err != nil {
-				caaf.logger.Error(err, "error getting function deployment", "function", fsvc.Function.Name)
-				return
-			}
-
-			minScale := int32(fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale)
-
-			// do nothing if the current replicas is already lower than minScale
-			if *currentDeploy.Spec.Replicas <= minScale {
-				return
-			}
-
-			err = caaf.scaleDeployment(ctx, deployObj.Namespace, deployObj.Name, minScale)
-			if err != nil {
-				caaf.logger.Error(err, "error scaling down function deployment", "function", fsvc.Function.Name)
-			}
-		}()
-	}
-}
-
-func getDeploymentObj(kubeobjs []apiv1.ObjectReference) *apiv1.ObjectReference {
-	for _, kubeobj := range kubeobjs {
-		switch strings.ToLower(kubeobj.Kind) {
-		case "deployment":
-			return &kubeobj
-		}
-	}
-	return nil
+// IdleStrategy returns the container idle-reaping strategy (scale the function
+// deployment down to MinScale), run by the shared idle reaper. checkEnv is
+// false: the container executor never inspected the environment list.
+func (caaf *Container) IdleStrategy() idle.Strategy {
+	return idle.NewScaleDownStrategy(caaf.logger, fv1.ExecutorTypeContainer, caaf.fissionClient,
+		caaf.fsCache, caaf.kubernetesClient, caaf.defaultIdlePodReapTime, caaf.objectReaperIntervalSecond, false)
 }
 
 func (caaf *Container) DumpDebugInfo(ctx context.Context) error {

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -14,11 +14,16 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/executor/reaper/idle"
 )
 
 type ExecutorType interface {
 	// Run runs background job.
 	Run(context.Context, *errgroup.Group)
+
+	// IdleStrategy returns this executor type's idle-reaping strategy, driven by
+	// the shared idle reaper instead of a per-type goroutine.
+	IdleStrategy() idle.Strategy
 
 	// GetTypeName returns the name of executor type
 	GetTypeName(context.Context) fv1.ExecutorType

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -21,7 +21,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	k8sInformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	appslisters "k8s.io/client-go/listers/apps/v1"
@@ -36,6 +35,7 @@ import (
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/metrics"
 	"github.com/fission/fission/pkg/executor/reaper"
+	"github.com/fission/fission/pkg/executor/reaper/idle"
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
@@ -171,10 +171,6 @@ func (deploy *NewDeploy) Run(ctx context.Context, mgr *errgroup.Group) {
 		deploy.logger.Info("failed to wait for caches to sync; stopping newdeploy manager")
 		return
 	}
-	mgr.Go(func() error {
-		deploy.idleObjectReaper(ctx)
-		return nil
-	})
 }
 
 // GetTypeName returns the executor type name.
@@ -783,106 +779,13 @@ func (deploy *NewDeploy) updateStatus(fn *fv1.Function, err error, message strin
 	deploy.logger.Error(nil, "function status update", "function", fn, "message", message)
 }
 
-// idleObjectReaper reaps objects after certain idle time
-func (deploy *NewDeploy) idleObjectReaper(ctx context.Context) {
-	// calling function doIdleObjectReaper() repeatedly at given interval of time
-	wait.UntilWithContext(ctx, deploy.doIdleObjectReaper, deploy.objectReaperIntervalSecond)
-}
-
-func (deploy *NewDeploy) doIdleObjectReaper(ctx context.Context) {
-	envList := make(map[k8sTypes.UID]struct{})
-	for _, namespace := range utils.DefaultNSResolver().FissionResourceNS {
-		envs, err := deploy.fissionClient.CoreV1().Environments(namespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			// Skip this reaper pass rather than crashing the process; an
-			// incomplete env list could otherwise reap live deployments. The
-			// reaper runs on a ticker and retries on the next interval.
-			deploy.logger.Error(err, "failed to get environment list; skipping this reaper pass", "namespace", namespace)
-			return
-		}
-
-		for _, env := range envs.Items {
-			envList[env.UID] = struct{}{}
-		}
-	}
-
-	funcSvcs, err := deploy.fsCache.ListOld(time.Second * 5)
-	if err != nil {
-		deploy.logger.Error(err, "error reaping idle pods")
-		return
-	}
-
-	for i := range funcSvcs {
-		fsvc := funcSvcs[i]
-		if fsvc.Executor != fv1.ExecutorTypeNewdeploy {
-			continue
-		}
-
-		// For function with the environment that no longer exists, executor
-		// scales down the deployment as usual and prints log to notify user.
-		if _, ok := envList[fsvc.Environment.UID]; !ok {
-			deploy.logger.Info("function environment no longer exists",
-				"environment", fsvc.Environment.Name,
-				"function", fsvc.Name)
-		}
-
-		fn, err := deploy.fissionClient.CoreV1().Functions(fsvc.Function.Namespace).Get(ctx, fsvc.Function.Name, metav1.GetOptions{})
-		if err != nil {
-			// Newdeploy manager handles the function delete event and clean cache/kubeobjs itself,
-			// so we ignore the not found error for functions with newdeploy executor type here.
-			if k8sErrs.IsNotFound(err) && fsvc.Executor == fv1.ExecutorTypeNewdeploy {
-				continue
-			}
-			deploy.logger.Error(err, "error getting function", "function", fsvc.Function.Name)
-			continue
-		}
-
-		idlePodReapTime := deploy.defaultIdlePodReapTime
-		if fn.Spec.IdleTimeout != nil {
-			idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
-		}
-
-		if time.Since(fsvc.Atime) < idlePodReapTime {
-			continue
-		}
-
-		go func() {
-			deployObj := getDeploymentObj(fsvc.KubernetesObjects)
-			if deployObj == nil {
-				deploy.logger.Error(err, "error finding function deployment", "function", fsvc.Function.Name)
-				return
-			}
-
-			currentDeploy, err := deploy.kubernetesClient.AppsV1().
-				Deployments(deployObj.Namespace).Get(ctx, deployObj.Name, metav1.GetOptions{})
-			if err != nil {
-				deploy.logger.Error(err, "error getting function deployment", "function", fsvc.Function.Name)
-				return
-			}
-
-			minScale := int32(fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale)
-
-			// do nothing if the current replicas is already lower than minScale
-			if *currentDeploy.Spec.Replicas <= minScale {
-				return
-			}
-
-			err = deploy.scaleDeployment(ctx, deployObj.Namespace, deployObj.Name, minScale)
-			if err != nil {
-				deploy.logger.Error(err, "error scaling down function deployment", "function", fsvc.Function.Name)
-			}
-		}()
-	}
-}
-
-func getDeploymentObj(kubeobjs []apiv1.ObjectReference) *apiv1.ObjectReference {
-	for _, kubeobj := range kubeobjs {
-		switch strings.ToLower(kubeobj.Kind) {
-		case "deployment":
-			return &kubeobj
-		}
-	}
-	return nil
+// IdleStrategy returns the newdeploy idle-reaping strategy (scale the function
+// deployment down to MinScale), run by the shared idle reaper. checkEnv is true
+// so it mirrors the previous behaviour of logging function services whose
+// environment was deleted and skipping the pass on an environment-list error.
+func (deploy *NewDeploy) IdleStrategy() idle.Strategy {
+	return idle.NewScaleDownStrategy(deploy.logger, fv1.ExecutorTypeNewdeploy, deploy.fissionClient,
+		deploy.fsCache, deploy.kubernetesClient, deploy.defaultIdlePodReapTime, deploy.objectReaperIntervalSecond, true)
 }
 
 func (deploy *NewDeploy) scaleDeployment(ctx context.Context, deplNS string, deplName string, replicas int32) error {

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -38,6 +38,7 @@ import (
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/metrics"
 	"github.com/fission/fission/pkg/executor/reaper"
+	"github.com/fission/fission/pkg/executor/reaper/idle"
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
@@ -185,10 +186,6 @@ func (gpm *GenericPoolManager) Run(ctx context.Context, mgr *errgroup.Group) {
 		if err != nil {
 			gpm.logger.Error(err, "error in checking inactive event from pod: ")
 		}
-		return nil
-	})
-	mgr.Go(func() error {
-		gpm.idleObjectReaper(ctx)
 		return nil
 	})
 	mgr.Go(func() error {
@@ -617,109 +614,11 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 	return env, nil
 }
 
-// idleObjectReaper reaps objects after certain idle time
-func (gpm *GenericPoolManager) idleObjectReaper(ctx context.Context) {
-	// calling function doIdleObjectReaper() repeatedly at given interval of time
-	wait.UntilWithContext(ctx, gpm.doIdleObjectReaper, gpm.objectReaperIntervalSecond)
-}
-
-func (gpm *GenericPoolManager) doIdleObjectReaper(ctx context.Context) {
-	envList := make(map[k8sTypes.UID]struct{})
-	for _, namespace := range utils.DefaultNSResolver().FissionResourceNS {
-		envs, err := gpm.fissionClient.CoreV1().Environments(namespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			gpm.logger.Error(err, "failed to get environment list", "namespace", namespace)
-			return
-		}
-
-		for _, env := range envs.Items {
-			envList[env.UID] = struct{}{}
-		}
-	}
-
-	fnList := make(map[k8sTypes.UID]fv1.Function)
-	for _, namespace := range utils.DefaultNSResolver().FissionResourceNS {
-		fns, err := gpm.fissionClient.CoreV1().Functions(namespace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			gpm.logger.Error(err, "failed to get environment list", "namespace", namespace)
-			return
-		}
-		for i, fn := range fns.Items {
-			fnList[fn.UID] = fns.Items[i]
-		}
-	}
-
-	funcSvcs, err := gpm.fsCache.ListOldForPool(time.Second * 5)
-	if err != nil {
-		gpm.logger.Error(err, "error reaping idle pods")
-		return
-	}
-
-	// Bound concurrency: a traffic drop can leave thousands of pods idle at
-	// once, and one cleanup goroutine each would spike goroutines and hammer
-	// the API server. The semaphore caps in-flight reaps; wait.UntilWithContext
-	// won't start the next reaper pass until this one returns.
-	const maxConcurrentReaps = 10
-	sem := make(chan struct{}, maxConcurrentReaps)
-	var wg sync.WaitGroup
-
-	for i := range funcSvcs {
-		fsvc := funcSvcs[i]
-
-		if fsvc.Executor != fv1.ExecutorTypePoolmgr {
-			continue
-		}
-
-		if _, ok := gpm.fsCache.WebsocketFsvc.Load(fsvc.Name); ok {
-			continue
-		}
-		// For function with the environment that no longer exists, executor
-		// cleanups the idle pod as usual and prints log to notify user.
-		if _, ok := envList[fsvc.Environment.UID]; !ok {
-			gpm.logger.Error(nil, "function environment no longer exists",
-				"environment", fsvc.Environment.Name,
-				"function", fsvc.Name)
-		}
-
-		if fsvc.Environment.Spec.AllowedFunctionsPerContainer == fv1.AllowedFunctionsPerContainerInfinite {
-			continue
-		}
-
-		idlePodReapTime := gpm.defaultIdlePodReapTime
-		if fn, ok := fnList[fsvc.Function.UID]; ok {
-			if fn.Spec.IdleTimeout != nil {
-				idlePodReapTime = time.Duration(*fn.Spec.IdleTimeout) * time.Second
-			}
-		}
-
-		if time.Since(fsvc.Atime) < idlePodReapTime {
-			continue
-		}
-
-		wg.Add(1)
-		sem <- struct{}{}
-		go func() {
-			defer wg.Done()
-			defer func() { <-sem }()
-			deleted, err := gpm.fsCache.DeleteOldPoolCache(ctx, fsvc, idlePodReapTime)
-			if err != nil {
-				gpm.logger.Error(err, "error deleting Kubernetes objects for function service", "service", fsvc)
-			}
-			if deleted {
-				for i := range fsvc.KubernetesObjects {
-					gpm.logger.Info("release idle function resources",
-						"function", fsvc.Function.Name,
-						"address", fsvc.Address,
-						"executor", string(fsvc.Executor),
-						"pod", fsvc.Name,
-					)
-					reaper.CleanupKubeObject(ctx, gpm.logger, gpm.kubernetesClient, &fsvc.KubernetesObjects[i])
-					time.Sleep(50 * time.Millisecond)
-				}
-			}
-		}()
-	}
-	wg.Wait()
+// IdleStrategy returns the poolmgr idle-reaping strategy (delete idle warm
+// pods), run by the shared idle reaper.
+func (gpm *GenericPoolManager) IdleStrategy() idle.Strategy {
+	return idle.NewPoolDeleteStrategy(gpm.logger, gpm.fissionClient, gpm.fsCache, gpm.kubernetesClient,
+		gpm.defaultIdlePodReapTime, gpm.objectReaperIntervalSecond)
 }
 
 // WebsocketStartEventChecker checks if the pod has emitted a websocket connection start event

--- a/pkg/executor/reaper/idle/idle.go
+++ b/pkg/executor/reaper/idle/idle.go
@@ -1,0 +1,354 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package idle consolidates the executor's idle-pod reaping. It replaces the
+// three near-identical idleObjectReaper goroutines (poolmgr, newdeploy,
+// container) with one leader-only Runnable that drives a per-executor-type
+// Strategy. Each strategy ticks on its own interval; every strategy's reaps are
+// bounded to maxConcurrentReaps (previously only poolmgr was bounded — a
+// traffic drop could otherwise spawn one goroutine per idle deployment).
+package idle
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apiv1 "k8s.io/api/core/v1"
+	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/executor/reaper"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
+	"github.com/fission/fission/pkg/utils"
+)
+
+// maxConcurrentReaps bounds in-flight reaps per strategy: a traffic drop can
+// leave thousands of function services idle at once, and one reap goroutine
+// each would spike goroutines and hammer the API server.
+const maxConcurrentReaps = 10
+
+// idleListAge is the coarse pre-filter the cache applies before a strategy's
+// per-function idle threshold is evaluated.
+const idleListAge = 5 * time.Second
+
+// Strategy is one executor type's idle-reaping behaviour.
+type Strategy interface {
+	// Name identifies the strategy in logs.
+	Name() string
+	// ExecutorType is the executor type whose function services this strategy
+	// reaps; the Reaper filters candidates to this type.
+	ExecutorType() fv1.ExecutorType
+	// Interval is how often this strategy runs.
+	Interval() time.Duration
+	// ListIdle returns the candidate function services (those idle past the
+	// coarse cache pre-filter).
+	ListIdle() ([]*fscache.FuncSvc, error)
+	// Prepare runs once per tick before any candidate is processed. Returning an
+	// error skips the whole tick — used when an incomplete environment list
+	// could otherwise reap live objects.
+	Prepare(ctx context.Context) error
+	// Reap evaluates one candidate (already filtered to ExecutorType) and
+	// performs the idle action if it is past its per-function idle threshold and
+	// not otherwise skipped (websocket, Infinite, deleted function, ...).
+	Reap(ctx context.Context, fsvc *fscache.FuncSvc) error
+}
+
+// Reaper periodically reaps idle function services across all strategies.
+type Reaper struct {
+	logger     logr.Logger
+	strategies []Strategy
+}
+
+// NewReaper builds a reaper over the given strategies.
+func NewReaper(logger logr.Logger, strategies ...Strategy) *Reaper {
+	return &Reaper{logger: logger.WithName("idle_reaper"), strategies: strategies}
+}
+
+// Start launches one ticker per strategy and blocks until ctx is cancelled
+// (leadership loss or shutdown). Its signature matches errgroup.Group.Go usage
+// in the executor controllers.
+func (r *Reaper) Start(ctx context.Context) {
+	var wg sync.WaitGroup
+	for _, s := range r.strategies {
+		wg.Go(func() {
+			r.logger.Info("starting idle reaper", "strategy", s.Name(), "interval", s.Interval())
+			wait.UntilWithContext(ctx, func(ctx context.Context) { r.reapOnce(ctx, s) }, s.Interval())
+		})
+	}
+	wg.Wait()
+}
+
+func (r *Reaper) reapOnce(ctx context.Context, s Strategy) {
+	if err := s.Prepare(ctx); err != nil {
+		r.logger.Error(err, "skipping idle reaper pass", "strategy", s.Name())
+		return
+	}
+	funcSvcs, err := s.ListIdle()
+	if err != nil {
+		r.logger.Error(err, "error listing idle function services", "strategy", s.Name())
+		return
+	}
+
+	sem := make(chan struct{}, maxConcurrentReaps)
+	var wg sync.WaitGroup
+	for i := range funcSvcs {
+		fsvc := funcSvcs[i]
+		if fsvc.Executor != s.ExecutorType() {
+			continue
+		}
+		sem <- struct{}{}
+		wg.Go(func() {
+			defer func() { <-sem }()
+			if err := s.Reap(ctx, fsvc); err != nil {
+				r.logger.Error(err, "error reaping idle function service", "strategy", s.Name(), "function", fsvc.Function.Name)
+			}
+		})
+	}
+	wg.Wait()
+}
+
+// idleThreshold returns the per-function idle reap duration: the function's
+// IdleTimeout if set, otherwise the strategy default.
+func idleThreshold(fn *fv1.Function, def time.Duration) time.Duration {
+	if fn != nil && fn.Spec.IdleTimeout != nil {
+		return time.Duration(*fn.Spec.IdleTimeout) * time.Second
+	}
+	return def
+}
+
+// listEnvUIDs returns the set of Environment UIDs across the Fission resource
+// namespaces, used to detect function services whose environment was deleted.
+func listEnvUIDs(ctx context.Context, fissionClient versioned.Interface) (map[k8sTypes.UID]struct{}, error) {
+	envUIDs := make(map[k8sTypes.UID]struct{})
+	for _, namespace := range utils.DefaultNSResolver().FissionResourceNS {
+		envs, err := fissionClient.CoreV1().Environments(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		for _, env := range envs.Items {
+			envUIDs[env.UID] = struct{}{}
+		}
+	}
+	return envUIDs, nil
+}
+
+// listFunctionsByUID returns all functions across the Fission resource
+// namespaces keyed by UID.
+func listFunctionsByUID(ctx context.Context, fissionClient versioned.Interface) (map[k8sTypes.UID]fv1.Function, error) {
+	fnByUID := make(map[k8sTypes.UID]fv1.Function)
+	for _, namespace := range utils.DefaultNSResolver().FissionResourceNS {
+		fns, err := fissionClient.CoreV1().Functions(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		for i := range fns.Items {
+			fnByUID[fns.Items[i].UID] = fns.Items[i]
+		}
+	}
+	return fnByUID, nil
+}
+
+func getDeploymentObj(kubeobjs []apiv1.ObjectReference) *apiv1.ObjectReference {
+	for i := range kubeobjs {
+		if kubeobjs[i].Kind == "Deployment" || kubeobjs[i].Kind == "deployment" {
+			return &kubeobjs[i]
+		}
+	}
+	return nil
+}
+
+func scaleDeploymentToMinScale(ctx context.Context, logger logr.Logger, kubeClient kubernetes.Interface, namespace, name string, replicas int32) error {
+	logger.Info("scaling down idle deployment", "deployment", name, "namespace", namespace, "replicas", replicas)
+	_, err := kubeClient.AppsV1().Deployments(namespace).UpdateScale(ctx, name, &autoscalingv1.Scale{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       autoscalingv1.ScaleSpec{Replicas: replicas},
+	}, metav1.UpdateOptions{})
+	return err
+}
+
+// PoolDeleteStrategy reaps poolmgr function services by deleting their idle
+// pods (the generic-pool warm-pod path). It skips function services with an
+// active websocket connection or an environment configured for an infinite
+// number of functions per container.
+type PoolDeleteStrategy struct {
+	logger        logr.Logger
+	fissionClient versioned.Interface
+	fsCache       *fscache.FunctionServiceCache
+	kubeClient    kubernetes.Interface
+	reapTime      time.Duration
+	interval      time.Duration
+
+	// Per-tick state populated by Prepare. Ticks for a strategy never overlap
+	// (wait.UntilWithContext), and Reap goroutines only read these maps.
+	envUIDs map[k8sTypes.UID]struct{}
+	fnByUID map[k8sTypes.UID]fv1.Function
+}
+
+func NewPoolDeleteStrategy(logger logr.Logger, fissionClient versioned.Interface, fsCache *fscache.FunctionServiceCache, kubeClient kubernetes.Interface, reapTime, interval time.Duration) *PoolDeleteStrategy {
+	return &PoolDeleteStrategy{
+		logger:        logger,
+		fissionClient: fissionClient,
+		fsCache:       fsCache,
+		kubeClient:    kubeClient,
+		reapTime:      reapTime,
+		interval:      interval,
+	}
+}
+
+func (s *PoolDeleteStrategy) Name() string                   { return string(fv1.ExecutorTypePoolmgr) }
+func (s *PoolDeleteStrategy) ExecutorType() fv1.ExecutorType { return fv1.ExecutorTypePoolmgr }
+func (s *PoolDeleteStrategy) Interval() time.Duration        { return s.interval }
+
+func (s *PoolDeleteStrategy) ListIdle() ([]*fscache.FuncSvc, error) {
+	return s.fsCache.ListOldForPool(idleListAge)
+}
+
+func (s *PoolDeleteStrategy) Prepare(ctx context.Context) error {
+	envUIDs, err := listEnvUIDs(ctx, s.fissionClient)
+	if err != nil {
+		return err
+	}
+	fnByUID, err := listFunctionsByUID(ctx, s.fissionClient)
+	if err != nil {
+		return err
+	}
+	s.envUIDs, s.fnByUID = envUIDs, fnByUID
+	return nil
+}
+
+func (s *PoolDeleteStrategy) Reap(ctx context.Context, fsvc *fscache.FuncSvc) error {
+	if _, ok := s.fsCache.WebsocketFsvc.Load(fsvc.Name); ok {
+		return nil
+	}
+	// For a function whose environment no longer exists, reap the idle pod as
+	// usual but log to notify the user.
+	if _, ok := s.envUIDs[fsvc.Environment.UID]; !ok {
+		s.logger.Error(nil, "function environment no longer exists", "environment", fsvc.Environment.Name, "function", fsvc.Name)
+	}
+	if fsvc.Environment.Spec.AllowedFunctionsPerContainer == fv1.AllowedFunctionsPerContainerInfinite {
+		return nil
+	}
+
+	reapTime := s.reapTime
+	if fn, ok := s.fnByUID[fsvc.Function.UID]; ok {
+		reapTime = idleThreshold(&fn, s.reapTime)
+	}
+	if time.Since(fsvc.Atime) < reapTime {
+		return nil
+	}
+
+	deleted, err := s.fsCache.DeleteOldPoolCache(ctx, fsvc, reapTime)
+	if err != nil {
+		return err
+	}
+	if deleted {
+		for i := range fsvc.KubernetesObjects {
+			s.logger.Info("release idle function resources",
+				"function", fsvc.Function.Name,
+				"address", fsvc.Address,
+				"executor", string(fsvc.Executor),
+				"pod", fsvc.Name,
+			)
+			reaper.CleanupKubeObject(ctx, s.logger, s.kubeClient, &fsvc.KubernetesObjects[i])
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	return nil
+}
+
+// ScaleDownStrategy reaps newdeploy/container function services by scaling
+// their deployment down to the function's MinScale. checkEnv mirrors the
+// newdeploy behaviour of logging (and gating the tick on) the environment list;
+// the container executor leaves it false.
+type ScaleDownStrategy struct {
+	logger        logr.Logger
+	execType      fv1.ExecutorType
+	fissionClient versioned.Interface
+	fsCache       *fscache.FunctionServiceCache
+	kubeClient    kubernetes.Interface
+	reapTime      time.Duration
+	interval      time.Duration
+	checkEnv      bool
+
+	envUIDs map[k8sTypes.UID]struct{} // per-tick, only when checkEnv
+}
+
+func NewScaleDownStrategy(logger logr.Logger, execType fv1.ExecutorType, fissionClient versioned.Interface, fsCache *fscache.FunctionServiceCache, kubeClient kubernetes.Interface, reapTime, interval time.Duration, checkEnv bool) *ScaleDownStrategy {
+	return &ScaleDownStrategy{
+		logger:        logger,
+		execType:      execType,
+		fissionClient: fissionClient,
+		fsCache:       fsCache,
+		kubeClient:    kubeClient,
+		reapTime:      reapTime,
+		interval:      interval,
+		checkEnv:      checkEnv,
+	}
+}
+
+func (s *ScaleDownStrategy) Name() string                   { return string(s.execType) }
+func (s *ScaleDownStrategy) ExecutorType() fv1.ExecutorType { return s.execType }
+func (s *ScaleDownStrategy) Interval() time.Duration        { return s.interval }
+
+func (s *ScaleDownStrategy) ListIdle() ([]*fscache.FuncSvc, error) {
+	return s.fsCache.ListOld(idleListAge)
+}
+
+func (s *ScaleDownStrategy) Prepare(ctx context.Context) error {
+	if !s.checkEnv {
+		return nil
+	}
+	envUIDs, err := listEnvUIDs(ctx, s.fissionClient)
+	if err != nil {
+		return err
+	}
+	s.envUIDs = envUIDs
+	return nil
+}
+
+func (s *ScaleDownStrategy) Reap(ctx context.Context, fsvc *fscache.FuncSvc) error {
+	fn, err := s.fissionClient.CoreV1().Functions(fsvc.Function.Namespace).Get(ctx, fsvc.Function.Name, metav1.GetOptions{})
+	if err != nil {
+		// The deploy managers handle the function delete event and clean up the
+		// cache/objects themselves, so a missing function is not an error here.
+		if k8sErrs.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	if s.checkEnv {
+		if _, ok := s.envUIDs[fsvc.Environment.UID]; !ok {
+			s.logger.Info("function environment no longer exists", "environment", fsvc.Environment.Name, "function", fsvc.Name)
+		}
+	}
+
+	if time.Since(fsvc.Atime) < idleThreshold(fn, s.reapTime) {
+		return nil
+	}
+
+	deployObj := getDeploymentObj(fsvc.KubernetesObjects)
+	if deployObj == nil {
+		return fmt.Errorf("no deployment found in kubernetes objects for function %q", fsvc.Function.Name)
+	}
+	currentDeploy, err := s.kubeClient.AppsV1().Deployments(deployObj.Namespace).Get(ctx, deployObj.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	minScale := int32(fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale)
+	// Do nothing if the current replica count is already at or below MinScale.
+	if currentDeploy.Spec.Replicas != nil && *currentDeploy.Spec.Replicas <= minScale {
+		return nil
+	}
+	return scaleDeploymentToMinScale(ctx, s.logger, s.kubeClient, deployObj.Namespace, deployObj.Name, minScale)
+}

--- a/pkg/executor/reaper/idle/idle_test.go
+++ b/pkg/executor/reaper/idle/idle_test.go
@@ -1,0 +1,228 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package idle
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+func TestGetDeploymentObj(t *testing.T) {
+	t.Parallel()
+	objs := []apiv1.ObjectReference{
+		{Kind: "Service", Name: "svc"},
+		{Kind: "Deployment", Name: "depl", Namespace: "ns"},
+	}
+	got := getDeploymentObj(objs)
+	require.NotNil(t, got)
+	assert.Equal(t, "depl", got.Name)
+
+	assert.Nil(t, getDeploymentObj([]apiv1.ObjectReference{{Kind: "Service"}}), "no deployment returns nil")
+}
+
+func TestIdleThreshold(t *testing.T) {
+	t.Parallel()
+	def := 2 * time.Minute
+	assert.Equal(t, def, idleThreshold(nil, def), "nil function uses default")
+
+	fn := &fv1.Function{}
+	assert.Equal(t, def, idleThreshold(fn, def), "unset IdleTimeout uses default")
+
+	timeout := 30
+	fn.Spec.IdleTimeout = &timeout
+	assert.Equal(t, 30*time.Second, idleThreshold(fn, def), "IdleTimeout overrides default")
+}
+
+// fakeStrategy records which function services Reap was invoked on.
+type fakeStrategy struct {
+	execType fv1.ExecutorType
+	idle     []*fscache.FuncSvc
+	prepErr  error
+
+	mu     sync.Mutex
+	reaped []string
+}
+
+func (f *fakeStrategy) Name() string                          { return "fake" }
+func (f *fakeStrategy) ExecutorType() fv1.ExecutorType        { return f.execType }
+func (f *fakeStrategy) Interval() time.Duration               { return time.Hour }
+func (f *fakeStrategy) ListIdle() ([]*fscache.FuncSvc, error) { return f.idle, nil }
+func (f *fakeStrategy) Prepare(_ context.Context) error       { return f.prepErr }
+func (f *fakeStrategy) Reap(_ context.Context, fsvc *fscache.FuncSvc) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.reaped = append(f.reaped, fsvc.Name)
+	return nil
+}
+
+func fsvc(name string, executor fv1.ExecutorType) *fscache.FuncSvc {
+	return &fscache.FuncSvc{
+		Name:     name,
+		Executor: executor,
+		Function: &metav1.ObjectMeta{Name: name, Namespace: "default"},
+	}
+}
+
+func TestReaperReapOnce_FiltersByExecutorType(t *testing.T) {
+	t.Parallel()
+	s := &fakeStrategy{
+		execType: fv1.ExecutorTypeNewdeploy,
+		idle: []*fscache.FuncSvc{
+			fsvc("nd1", fv1.ExecutorTypeNewdeploy),
+			fsvc("pool1", fv1.ExecutorTypePoolmgr),
+			fsvc("nd2", fv1.ExecutorTypeNewdeploy),
+		},
+	}
+	r := NewReaper(logr.Discard(), s)
+	r.reapOnce(t.Context(), s)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sort.Strings(s.reaped)
+	assert.Equal(t, []string{"nd1", "nd2"}, s.reaped, "only matching executor type is reaped")
+}
+
+func TestReaperReapOnce_SkipsTickOnPrepareError(t *testing.T) {
+	t.Parallel()
+	s := &fakeStrategy{
+		execType: fv1.ExecutorTypeNewdeploy,
+		idle:     []*fscache.FuncSvc{fsvc("nd1", fv1.ExecutorTypeNewdeploy)},
+		prepErr:  assert.AnError,
+	}
+	r := NewReaper(logr.Discard(), s)
+	r.reapOnce(t.Context(), s)
+	assert.Empty(t, s.reaped, "a Prepare error skips the whole tick")
+}
+
+func TestPoolDeleteStrategy_Skips(t *testing.T) {
+	t.Parallel()
+	newStrategy := func() (*PoolDeleteStrategy, *fscache.FunctionServiceCache) {
+		fc := fscache.MakeFunctionServiceCache(logr.Discard())
+		s := NewPoolDeleteStrategy(logr.Discard(), nil, fc, k8sfake.NewSimpleClientset(), 2*time.Minute, 5*time.Second)
+		s.envUIDs = map[types.UID]struct{}{}
+		s.fnByUID = map[types.UID]fv1.Function{}
+		return s, fc
+	}
+
+	idleFsvc := func() *fscache.FuncSvc {
+		return &fscache.FuncSvc{
+			Name:        "p",
+			Executor:    fv1.ExecutorTypePoolmgr,
+			Function:    &metav1.ObjectMeta{Name: "fn", Namespace: "default"},
+			Environment: &fv1.Environment{},
+			Atime:       time.Now().Add(-time.Hour),
+		}
+	}
+
+	t.Run("websocket connection is skipped", func(t *testing.T) {
+		s, fc := newStrategy()
+		f := idleFsvc()
+		fc.WebsocketFsvc.Store(f.Name, true)
+		require.NoError(t, s.Reap(t.Context(), f))
+	})
+
+	t.Run("infinite functions-per-container is skipped", func(t *testing.T) {
+		s, _ := newStrategy()
+		f := idleFsvc()
+		f.Environment.Spec.AllowedFunctionsPerContainer = fv1.AllowedFunctionsPerContainerInfinite
+		require.NoError(t, s.Reap(t.Context(), f))
+	})
+
+	t.Run("not-yet-idle is skipped", func(t *testing.T) {
+		s, _ := newStrategy()
+		f := idleFsvc()
+		f.Atime = time.Now() // fresh
+		require.NoError(t, s.Reap(t.Context(), f))
+	})
+}
+
+func TestScaleDownStrategy_Reap(t *testing.T) {
+	t.Parallel()
+	const ns, deplName, fnName = "default", "fn-depl", "fn"
+
+	makeFn := func(minScale int) *fv1.Function {
+		fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: fnName, Namespace: ns}}
+		fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale = minScale
+		return fn
+	}
+	makeFsvc := func() *fscache.FuncSvc {
+		return &fscache.FuncSvc{
+			Name:        "p",
+			Executor:    fv1.ExecutorTypeNewdeploy,
+			Function:    &metav1.ObjectMeta{Name: fnName, Namespace: ns},
+			Environment: &fv1.Environment{},
+			Atime:       time.Now().Add(-time.Hour),
+			KubernetesObjects: []apiv1.ObjectReference{
+				{Kind: "Deployment", Name: deplName, Namespace: ns},
+			},
+		}
+	}
+	deployWithReplicas := func(r int32) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: deplName, Namespace: ns},
+			Spec:       appsv1.DeploymentSpec{Replicas: &r},
+		}
+	}
+	// captureScale records the replica count of any scale update.
+	captureScale := func(kc *k8sfake.Clientset, got *int32) {
+		kc.PrependReactor("update", "deployments", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if action.GetSubresource() != "scale" {
+				return false, nil, nil
+			}
+			sc := action.(k8stesting.UpdateAction).GetObject().(*autoscalingv1.Scale)
+			*got = sc.Spec.Replicas
+			return true, sc, nil
+		})
+	}
+
+	t.Run("scales an idle deployment down to MinScale", func(t *testing.T) {
+		kc := k8sfake.NewSimpleClientset(deployWithReplicas(3))
+		var scaled int32 = -1
+		captureScale(kc, &scaled)
+		s := NewScaleDownStrategy(logr.Discard(), fv1.ExecutorTypeNewdeploy,
+			fissionfake.NewClientset(makeFn(1)), fscache.MakeFunctionServiceCache(logr.Discard()), kc, 2*time.Minute, 5*time.Second, true)
+
+		require.NoError(t, s.Reap(t.Context(), makeFsvc()))
+		assert.Equal(t, int32(1), scaled, "deployment scaled to MinScale")
+	})
+
+	t.Run("no scale when already at or below MinScale", func(t *testing.T) {
+		kc := k8sfake.NewSimpleClientset(deployWithReplicas(1))
+		var scaled int32 = -1
+		captureScale(kc, &scaled)
+		s := NewScaleDownStrategy(logr.Discard(), fv1.ExecutorTypeNewdeploy,
+			fissionfake.NewClientset(makeFn(1)), fscache.MakeFunctionServiceCache(logr.Discard()), kc, 2*time.Minute, 5*time.Second, true)
+
+		require.NoError(t, s.Reap(t.Context(), makeFsvc()))
+		assert.Equal(t, int32(-1), scaled, "no scale issued when already at MinScale")
+	})
+
+	t.Run("missing function is not an error", func(t *testing.T) {
+		kc := k8sfake.NewSimpleClientset(deployWithReplicas(3))
+		s := NewScaleDownStrategy(logr.Discard(), fv1.ExecutorTypeNewdeploy,
+			fissionfake.NewClientset(), fscache.MakeFunctionServiceCache(logr.Discard()), kc, 2*time.Minute, 5*time.Second, true)
+
+		require.NoError(t, s.Reap(t.Context(), makeFsvc()), "a deleted function is handled by the deploy manager, not the reaper")
+	})
+}


### PR DESCRIPTION
## What

Part of **RFC-0005 WS3** (executor sub-step **D1**), following the timer (#3422), kubewatcher (#3423), canary (#3424), and mqtrigger (#3425) reconciler migrations.

Consolidates the three near-identical `idleObjectReaper` goroutines (poolmgr, newdeploy, container) into **one leader-only Runnable** driven by a per-executor-type `Strategy`, in the new `pkg/executor/reaper/idle` package.

## Changes

- **`idle.Reaper`** ticks each `Strategy` on its own interval and **bounds every strategy's concurrent reaps to 10**. Previously only poolmgr was bounded; newdeploy/container spawned one *unbounded* goroutine per idle deployment, so a traffic drop could spike goroutines and hammer the API server.
- **`PoolDeleteStrategy`** deletes idle warm pods — preserving the websocket skip, the `AllowedFunctionsPerContainer=Infinite` skip, and the environment-existence log.
- **`ScaleDownStrategy`** scales newdeploy/container deployments down to `MinScale`. The two executors differed only by reap interval/time and a newdeploy-only environment-list check (`checkEnv`), so they now share one implementation.
- Each executor type exposes **`IdleStrategy()`** (added to the `ExecutorType` interface) instead of its own reaper goroutine; `executor.go` starts a single `idle.Reaper` over all three. The three `idleObjectReaper`/`doIdleObjectReaper` methods, the duplicated `getDeploymentObj`, and the three `mgr.Go` reaper starts are removed. `scaleDeployment` stays on newdeploy/container (still used by their deploy-creation path).

Net: ~290 lines removed from the executor types, replaced by one shared package.

## Behavior notes

- **Only behavior change:** newdeploy/container reaps are now concurrency-bounded (to 10), matching poolmgr. Reap intervals, per-function `IdleTimeout` overrides, the `MinScale` floor, the skip conditions, and leader-only execution are all preserved.
- This is a periodic poll over `fscache` idleness (not a CRD watch), so it stays a `Runnable`, not a Reconciler — no `/status`, no CRD or RBAC change.

## Testing

- `go build ./...`, `go vet`, `golangci-lint` (0 issues).
- New `pkg/executor/reaper/idle` unit tests (`-race`): executor-type filtering, Prepare-error skips the tick, pool websocket/Infinite/not-idle skips, scale-down to MinScale, MinScale floor (no-op), and missing-function tolerance — using fake kube + fission clients.
- All existing executor unit tests pass; both in-process e2e suites (`test/e2e/fetcher`, `test/e2e/cli`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3426)
<!-- Reviewable:end -->
