### PR TITLE
feat: RFC-0005 WS3 (B1) — Package /status subresource + split status writers

### DIFF
--- a/charts/fission-all/templates/_fission-component-roles.tpl
+++ b/charts/fission-all/templates/_fission-component-roles.tpl
@@ -16,12 +16,13 @@ rules:
   - delete
 - apiGroups:
   - fission.io
-  # Packages have no status subresource — main-resource update
-  # covers their writes. functions/status is needed because the
-  # buildermgr propagates package build outcome onto dependent
-  # functions via markFunctionsForPackage.
+  # packages/status: the buildermgr writes the package BuildStatus and
+  # build conditions through the /status subresource. functions/status is
+  # needed because the buildermgr propagates package build outcome onto
+  # dependent functions via markFunctionsForPackage.
   resources:
   - functions/status
+  - packages/status
   verbs:
   - get
   - update

--- a/crds/v1/fission.io_packages.yaml
+++ b/crds/v1/fission.io_packages.yaml
@@ -217,3 +217,5 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -34,6 +34,7 @@ type (
 	// Package Think of these as function-level images.
 	// +genclient
 	// +kubebuilder:object:root=true
+	// +kubebuilder:subresource:status
 	// +kubebuilder:resource:singular="package",scope="Namespaced",shortName={pkg}
 	Package struct {
 		metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -243,7 +243,12 @@ func (sts PackageStatus) Validate() error {
 	var errs error
 
 	switch sts.BuildStatus {
-	case BuildStatusPending, BuildStatusRunning, BuildStatusSucceeded, BuildStatusFailed, BuildStatusNone: // no op
+	// "" (empty) is the not-yet-processed state: with the Package /status
+	// subresource, the apiserver strips the status set by the defaulting webhook
+	// on create, so a package is admitted with an empty BuildStatus and the
+	// buildermgr fills it in (setInitialBuildStatus). Reject only genuinely
+	// unknown values.
+	case "", BuildStatusPending, BuildStatusRunning, BuildStatusSucceeded, BuildStatusFailed, BuildStatusNone: // no op
 	default:
 		errs = errors.Join(errs, MakeValidationErr(ErrorUnsupportedType, "PackageStatus.BuildStatus", sts.BuildStatus, "not a valid build status"))
 	}

--- a/pkg/apis/core/v1/validation_validators_test.go
+++ b/pkg/apis/core/v1/validation_validators_test.go
@@ -72,6 +72,9 @@ func TestReferenceValidate(t *testing.T) {
 func TestPackageStatusValidate(t *testing.T) {
 	t.Parallel()
 	require.NoError(t, PackageStatus{BuildStatus: BuildStatusSucceeded}.Validate())
+	// Empty BuildStatus is the not-yet-processed state admitted on create once
+	// the /status subresource strips the defaulting webhook's status.
+	require.NoError(t, PackageStatus{}.Validate())
 	require.Error(t, PackageStatus{BuildStatus: "weird"}.Validate())
 }
 

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -146,21 +146,11 @@ func updatePackage(ctx context.Context, logger logr.Logger, fissionClient versio
 	pkg *fv1.Package, status fv1.BuildStatus, buildLogs string,
 	uploadResp *fetcher.ArchiveUploadResponse) (*fv1.Package, error) {
 
-	// Preserve existing Conditions across the status replacement so
-	// transitions aren't accidentally wiped when build outcome changes.
-	existingConds := pkg.Status.Conditions
-	pkg.Status = fv1.PackageStatus{
-		BuildStatus:         status,
-		BuildLog:            buildLogs,
-		LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
-		Conditions:          existingConds,
-	}
-	setPackageBuildCondition(&pkg.Status, status, buildLogs, pkg.Generation)
-	desiredStatus := pkg.Status
-
 	// A successful build also writes the deployment archive onto the spec. With
 	// the /status subresource enabled, the apiserver ignores status on a
-	// main-resource Update, so the spec and status are persisted in two calls.
+	// main-resource Update, so persist the spec first (it may bump
+	// metadata.generation) and build the status afterwards, so the conditions'
+	// ObservedGeneration is stamped from the post-update generation.
 	if uploadResp != nil {
 		pkg.Spec.Deployment = fv1.Archive{
 			Type:     fv1.ArchiveTypeUrl,
@@ -173,11 +163,19 @@ func updatePackage(ctx context.Context, logger logr.Logger, fissionClient versio
 			logger.Error(err, e)
 			return nil, fmt.Errorf("%s: %w", e, err)
 		}
-		// Update returns the server object with its own (unchanged) status;
-		// re-apply the status we want before persisting it below.
 		pkg = updated
-		pkg.Status = desiredStatus
 	}
+
+	// Preserve existing Conditions across the status replacement so
+	// transitions aren't accidentally wiped when build outcome changes.
+	existingConds := pkg.Status.Conditions
+	pkg.Status = fv1.PackageStatus{
+		BuildStatus:         status,
+		BuildLog:            buildLogs,
+		LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
+		Conditions:          existingConds,
+	}
+	setPackageBuildCondition(&pkg.Status, status, buildLogs, pkg.Generation)
 
 	pkg, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -156,19 +156,32 @@ func updatePackage(ctx context.Context, logger logr.Logger, fissionClient versio
 		Conditions:          existingConds,
 	}
 	setPackageBuildCondition(&pkg.Status, status, buildLogs, pkg.Generation)
+	desiredStatus := pkg.Status
 
+	// A successful build also writes the deployment archive onto the spec. With
+	// the /status subresource enabled, the apiserver ignores status on a
+	// main-resource Update, so the spec and status are persisted in two calls.
 	if uploadResp != nil {
 		pkg.Spec.Deployment = fv1.Archive{
 			Type:     fv1.ArchiveTypeUrl,
 			URL:      uploadResp.ArchiveDownloadUrl,
 			Checksum: uploadResp.Checksum,
 		}
+		updated, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
+		if err != nil {
+			e := "error updating package spec"
+			logger.Error(err, e)
+			return nil, fmt.Errorf("%s: %w", e, err)
+		}
+		// Update returns the server object with its own (unchanged) status;
+		// re-apply the status we want before persisting it below.
+		pkg = updated
+		pkg.Status = desiredStatus
 	}
 
-	// update package spec
-	pkg, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
+	pkg, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
 	if err != nil {
-		e := "error updating package"
+		e := "error updating package status"
 		logger.Error(err, e)
 		return nil, fmt.Errorf("%s: %w", e, err)
 	}

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dchest/uniuri"
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/builder"
@@ -146,39 +147,57 @@ func updatePackage(ctx context.Context, logger logr.Logger, fissionClient versio
 	pkg *fv1.Package, status fv1.BuildStatus, buildLogs string,
 	uploadResp *fetcher.ArchiveUploadResponse) (*fv1.Package, error) {
 
+	packages := fissionClient.CoreV1().Packages(pkg.Namespace)
+	name := pkg.Name
+
 	// A successful build also writes the deployment archive onto the spec. With
 	// the /status subresource enabled, the apiserver ignores status on a
 	// main-resource Update, so persist the spec first (it may bump
 	// metadata.generation) and build the status afterwards, so the conditions'
-	// ObservedGeneration is stamped from the post-update generation.
+	// ObservedGeneration is stamped from the post-update generation. Both writes
+	// re-get on conflict, since other actors (a concurrent reconcile, a CLI
+	// rebuild) may update the package between our read and write.
 	if uploadResp != nil {
-		pkg.Spec.Deployment = fv1.Archive{
+		deployment := fv1.Archive{
 			Type:     fv1.ArchiveTypeUrl,
 			URL:      uploadResp.ArchiveDownloadUrl,
 			Checksum: uploadResp.Checksum,
 		}
-		updated, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
-		if err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			fresh, gerr := packages.Get(ctx, name, metav1.GetOptions{})
+			if gerr != nil {
+				return gerr
+			}
+			fresh.Spec.Deployment = deployment
+			var uerr error
+			pkg, uerr = packages.Update(ctx, fresh, metav1.UpdateOptions{})
+			return uerr
+		}); err != nil {
 			e := "error updating package spec"
 			logger.Error(err, e)
 			return nil, fmt.Errorf("%s: %w", e, err)
 		}
-		pkg = updated
 	}
 
-	// Preserve existing Conditions across the status replacement so
-	// transitions aren't accidentally wiped when build outcome changes.
-	existingConds := pkg.Status.Conditions
-	pkg.Status = fv1.PackageStatus{
-		BuildStatus:         status,
-		BuildLog:            buildLogs,
-		LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
-		Conditions:          existingConds,
-	}
-	setPackageBuildCondition(&pkg.Status, status, buildLogs, pkg.Generation)
-
-	pkg, err := fissionClient.CoreV1().Packages(pkg.ObjectMeta.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
-	if err != nil {
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, gerr := packages.Get(ctx, name, metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		// Preserve existing Conditions across the status replacement so
+		// transitions aren't accidentally wiped when build outcome changes.
+		existingConds := fresh.Status.Conditions
+		fresh.Status = fv1.PackageStatus{
+			BuildStatus:         status,
+			BuildLog:            buildLogs,
+			LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
+			Conditions:          existingConds,
+		}
+		setPackageBuildCondition(&fresh.Status, status, buildLogs, fresh.Generation)
+		var uerr error
+		pkg, uerr = packages.UpdateStatus(ctx, fresh, metav1.UpdateOptions{})
+		return uerr
+	}); err != nil {
 		e := "error updating package status"
 		logger.Error(err, e)
 		return nil, fmt.Errorf("%s: %w", e, err)

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	k8sCache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/cache"
@@ -340,25 +341,42 @@ func (pkgw *packageWatcher) Run(ctx context.Context, mgr *errgroup.Group) error 
 // This normally occurs when the user applies package YAML files that have no status field
 // through kubectl.
 func setInitialBuildStatus(ctx context.Context, fissionClient versioned.Interface, pkg *fv1.Package) (*fv1.Package, error) {
-	// Preserve any Conditions a previous reconcile may have written.
-	existingConds := pkg.Status.Conditions
-	pkg.Status = fv1.PackageStatus{
-		LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
-		Conditions:          existingConds,
-	}
-	if !pkg.Spec.Deployment.IsEmpty() {
-		// if the deployment archive is not empty,
-		// we assume it's a deployable package no matter
-		// the source archive is empty or not.
-		pkg.Status.BuildStatus = fv1.BuildStatusNone
-	} else if !pkg.Spec.Source.IsEmpty() {
-		pkg.Status.BuildStatus = fv1.BuildStatusPending
-	} else {
-		// mark package failed since we cannot do anything with it.
-		pkg.Status.BuildStatus = fv1.BuildStatusFailed
-		pkg.Status.BuildLog = "Both deploy and source archive are empty"
-	}
-	setPackageBuildCondition(&pkg.Status, pkg.Status.BuildStatus, pkg.Status.BuildLog, pkg.Generation)
+	packages := fissionClient.CoreV1().Packages(pkg.Namespace)
+	name := pkg.Name
 
-	return fissionClient.CoreV1().Packages(pkg.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
+	// Re-get on conflict: a fast user/CLI update can race this initial status
+	// write. The derived status is a pure function of the spec archives, so a
+	// retry on the fresh object is idempotent.
+	var out *fv1.Package
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, gerr := packages.Get(ctx, name, metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		// Preserve any Conditions a previous reconcile may have written.
+		fresh.Status = fv1.PackageStatus{
+			LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
+			Conditions:          fresh.Status.Conditions,
+		}
+		if !fresh.Spec.Deployment.IsEmpty() {
+			// if the deployment archive is not empty,
+			// we assume it's a deployable package no matter
+			// the source archive is empty or not.
+			fresh.Status.BuildStatus = fv1.BuildStatusNone
+		} else if !fresh.Spec.Source.IsEmpty() {
+			fresh.Status.BuildStatus = fv1.BuildStatusPending
+		} else {
+			// mark package failed since we cannot do anything with it.
+			fresh.Status.BuildStatus = fv1.BuildStatusFailed
+			fresh.Status.BuildLog = "Both deploy and source archive are empty"
+		}
+		setPackageBuildCondition(&fresh.Status, fresh.Status.BuildStatus, fresh.Status.BuildLog, fresh.Generation)
+		var uerr error
+		out, uerr = packages.UpdateStatus(ctx, fresh, metav1.UpdateOptions{})
+		return uerr
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/pkg/buildermgr/pkgwatcher.go
+++ b/pkg/buildermgr/pkgwatcher.go
@@ -360,6 +360,5 @@ func setInitialBuildStatus(ctx context.Context, fissionClient versioned.Interfac
 	}
 	setPackageBuildCondition(&pkg.Status, pkg.Status.BuildStatus, pkg.Status.BuildLog, pkg.Generation)
 
-	// TODO: use UpdateStatus to update status
-	return fissionClient.CoreV1().Packages(pkg.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
+	return fissionClient.CoreV1().Packages(pkg.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
 }

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -183,14 +183,28 @@ func UpdatePackage(input cli.Input, client cmd.Client, specFile string, pkg *fv1
 		return &pkg.ObjectMeta, nil
 	}
 
-	newPkgMeta, err := client.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(input.Context(), pkg, metav1.UpdateOptions{})
+	newPkg, err := client.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(input.Context(), pkg, metav1.UpdateOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("update package: %w", err)
 	}
 
-	fmt.Printf("Package '%v' updated\n", newPkgMeta.GetName())
+	// The rebuild trigger (BuildStatusPending) is a status write; with the
+	// /status subresource the spec Update above ignores it, so persist it
+	// separately through UpdateStatus.
+	if needToRebuild {
+		newPkg.Status = fv1.PackageStatus{
+			BuildStatus:         fv1.BuildStatusPending,
+			LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
+		}
+		newPkg, err = client.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).UpdateStatus(input.Context(), newPkg, metav1.UpdateOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("update package status: %w", err)
+		}
+	}
 
-	return &newPkgMeta.ObjectMeta, err
+	fmt.Printf("Package '%v' updated\n", newPkg.GetName())
+
+	return &newPkg.ObjectMeta, nil
 }
 
 func UpdateFunctionPackageResourceVersion(ctx context.Context, client cmd.Client, pkgMeta *metav1.ObjectMeta, fnList ...fv1.Function) error {
@@ -215,7 +229,7 @@ func updatePackageStatus(ctx context.Context, client cmd.Client, pkg *fv1.Packag
 			BuildStatus:         status,
 			LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
 		}
-		pkg, err := client.FissionClientSet.CoreV1().Packages(pkg.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
+		pkg, err := client.FissionClientSet.CoreV1().Packages(pkg.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
 		return &pkg.ObjectMeta, err
 	}
 	return nil, errors.New("unknown package status")

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -245,7 +245,7 @@ func UpdateFunctionPackageResourceVersion(ctx context.Context, client cmd.Client
 
 func updatePackageStatus(ctx context.Context, client cmd.Client, pkg *fv1.Package, status fv1.BuildStatus) (*metav1.ObjectMeta, error) {
 	switch status {
-	case fv1.BuildStatusNone, fv1.BuildStatusPending, fv1.BuildStatusRunning, fv1.BuildStatusSucceeded, fv1.CanaryConfigStatusAborted:
+	case fv1.BuildStatusNone, fv1.BuildStatusPending, fv1.BuildStatusRunning, fv1.BuildStatusSucceeded, fv1.BuildStatusFailed:
 		packages := client.FissionClientSet.CoreV1().Packages(pkg.Namespace)
 		var out *fv1.Package
 		// Re-get on conflict: the buildermgr can update the package status

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -246,12 +246,24 @@ func UpdateFunctionPackageResourceVersion(ctx context.Context, client cmd.Client
 func updatePackageStatus(ctx context.Context, client cmd.Client, pkg *fv1.Package, status fv1.BuildStatus) (*metav1.ObjectMeta, error) {
 	switch status {
 	case fv1.BuildStatusNone, fv1.BuildStatusPending, fv1.BuildStatusRunning, fv1.BuildStatusSucceeded, fv1.CanaryConfigStatusAborted:
-		pkg.Status = fv1.PackageStatus{
-			BuildStatus:         status,
-			LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
+		packages := client.FissionClientSet.CoreV1().Packages(pkg.Namespace)
+		var out *fv1.Package
+		// Re-get on conflict: the buildermgr can update the package status
+		// concurrently.
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			fresh, gerr := packages.Get(ctx, pkg.Name, metav1.GetOptions{})
+			if gerr != nil {
+				return gerr
+			}
+			fresh.Status.BuildStatus = status
+			fresh.Status.LastUpdateTimestamp = metav1.Time{Time: time.Now().UTC()}
+			var uerr error
+			out, uerr = packages.UpdateStatus(ctx, fresh, metav1.UpdateOptions{})
+			return uerr
+		}); err != nil {
+			return nil, err
 		}
-		pkg, err := client.FissionClientSet.CoreV1().Packages(pkg.Namespace).UpdateStatus(ctx, pkg, metav1.UpdateOptions{})
-		return &pkg.ObjectMeta, err
+		return &out.ObjectMeta, nil
 	}
 	return nil, errors.New("unknown package status")
 }

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -183,21 +184,41 @@ func UpdatePackage(input cli.Input, client cmd.Client, specFile string, pkg *fv1
 		return &pkg.ObjectMeta, nil
 	}
 
-	newPkg, err := client.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).Update(input.Context(), pkg, metav1.UpdateOptions{})
-	if err != nil {
+	packages := client.FissionClientSet.CoreV1().Packages(pkg.Namespace)
+
+	// Apply the desired spec, re-getting on conflict: the buildermgr writes a
+	// package's initial build status shortly after create, which bumps the
+	// ResourceVersion between our Get and this Update.
+	desiredSpec := pkg.Spec
+	var newPkg *fv1.Package
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, gerr := packages.Get(input.Context(), pkg.Name, metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		fresh.Spec = desiredSpec
+		var uerr error
+		newPkg, uerr = packages.Update(input.Context(), fresh, metav1.UpdateOptions{})
+		return uerr
+	}); err != nil {
 		return nil, fmt.Errorf("update package: %w", err)
 	}
 
 	// The rebuild trigger (BuildStatusPending) is a status write; with the
 	// /status subresource the spec Update above ignores it, so persist it
-	// separately through UpdateStatus.
+	// separately through UpdateStatus (also conflict-retried).
 	if needToRebuild {
-		newPkg.Status = fv1.PackageStatus{
-			BuildStatus:         fv1.BuildStatusPending,
-			LastUpdateTimestamp: metav1.Time{Time: time.Now().UTC()},
-		}
-		newPkg, err = client.FissionClientSet.CoreV1().Packages(pkg.ObjectMeta.Namespace).UpdateStatus(input.Context(), newPkg, metav1.UpdateOptions{})
-		if err != nil {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			fresh, gerr := packages.Get(input.Context(), pkg.Name, metav1.GetOptions{})
+			if gerr != nil {
+				return gerr
+			}
+			fresh.Status.BuildStatus = fv1.BuildStatusPending
+			fresh.Status.LastUpdateTimestamp = metav1.Time{Time: time.Now().UTC()}
+			var uerr error
+			newPkg, uerr = packages.UpdateStatus(input.Context(), fresh, metav1.UpdateOptions{})
+			return uerr
+		}); err != nil {
 			return nil, fmt.Errorf("update package status: %w", err)
 		}
 	}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -669,25 +669,28 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 			return &n.ObjectMeta, nil
 		},
 		update: func(ctx context.Context, existing, desired *fv1.Package) (*metav1.ObjectMeta, error) {
-			desired.ResourceVersion = existing.ResourceVersion
 			// We may be racing the package builder (a previous version might be
-			// building), so wait for a non-running build status first.
-			pkg, err := waitForPackageBuild(ctx, fclient, desired)
+			// building), so wait for a non-running build status first. Decide
+			// from the live object (existing): desired comes from the spec file
+			// and carries no status, so the wait/re-trigger must read the real
+			// BuildStatus.
+			current, err := waitForPackageBuild(ctx, fclient, existing)
 			if err != nil {
 				console.Warn(fmt.Sprintf("Error waiting for package '%v' build, ignoring", desired.Name))
-				pkg = desired
+				current = existing
 			}
-			// Re-trigger a build if the previous one failed. This is a status
-			// write; with the /status subresource it must go through
-			// UpdateStatus, separately from the spec Update below.
-			retrigger := pkg.Status.BuildStatus == fv1.BuildStatusFailed
-			n, err := packages(pkg.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
+			// Apply the spec from desired, on top of the post-wait version.
+			desired.ResourceVersion = current.ResourceVersion
+			n, err := packages(desired.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
 			if err != nil {
 				return nil, err
 			}
-			if retrigger {
+			// Re-trigger a build if the previous one failed. This is a status
+			// write; with the /status subresource it must go through
+			// UpdateStatus, separately from the spec Update above.
+			if current.Status.BuildStatus == fv1.BuildStatusFailed {
 				n.Status.BuildStatus = fv1.BuildStatusPending
-				n, err = packages(pkg.Namespace).UpdateStatus(ctx, n, metav1.UpdateOptions{})
+				n, err = packages(desired.Namespace).UpdateStatus(ctx, n, metav1.UpdateOptions{})
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -677,13 +677,20 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 				console.Warn(fmt.Sprintf("Error waiting for package '%v' build, ignoring", desired.Name))
 				pkg = desired
 			}
-			// Re-trigger a build if the previous one failed.
-			if pkg.Status.BuildStatus == fv1.BuildStatusFailed {
-				pkg.Status.BuildStatus = fv1.BuildStatusPending
-			}
+			// Re-trigger a build if the previous one failed. This is a status
+			// write; with the /status subresource it must go through
+			// UpdateStatus, separately from the spec Update below.
+			retrigger := pkg.Status.BuildStatus == fv1.BuildStatusFailed
 			n, err := packages(pkg.Namespace).Update(ctx, pkg, metav1.UpdateOptions{})
 			if err != nil {
 				return nil, err
+			}
+			if retrigger {
+				n.Status.BuildStatus = fv1.BuildStatusPending
+				n, err = packages(pkg.Namespace).UpdateStatus(ctx, n, metav1.UpdateOptions{})
+				if err != nil {
+					return nil, err
+				}
 			}
 			return &n.ObjectMeta, nil
 		},

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -657,9 +657,14 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 					!reflect.DeepEqual(existing.Spec.Source, fv1.Archive{}) &&
 					reflect.DeepEqual(existing.Spec.Source, desired.Spec.Source) &&
 					existing.Spec.BuildCommand == desired.Spec.BuildCommand)
+			// "none" (a deploy-archive package needing no build) is as ready a
+			// terminal state as "succeeded"; treating only the latter as ready
+			// would re-apply unchanged deploy packages on every run.
+			ready := existing.Status.BuildStatus == fv1.BuildStatusSucceeded ||
+				existing.Status.BuildStatus == fv1.BuildStatusNone
 			return specMatches &&
 				isObjectMetaEqual(existing.ObjectMeta, desired.ObjectMeta) &&
-				existing.Status.BuildStatus == fv1.BuildStatusSucceeded
+				ready
 		},
 		create: func(ctx context.Context, p *fv1.Package) (*metav1.ObjectMeta, error) {
 			n, err := packages(p.Namespace).Create(ctx, p, metav1.CreateOptions{})

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sCache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -684,19 +685,39 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 				console.Warn(fmt.Sprintf("Error waiting for package '%v' build, ignoring", desired.Name))
 				current = existing
 			}
-			// Apply the spec from desired, on top of the post-wait version.
-			desired.ResourceVersion = current.ResourceVersion
-			n, err := packages(desired.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
-			if err != nil {
+			retrigger := current.Status.BuildStatus == fv1.BuildStatusFailed
+
+			// Apply the spec, re-getting on conflict: the buildermgr writes a
+			// package's build status concurrently, which can bump the
+			// ResourceVersion between our read and this Update.
+			var n *fv1.Package
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				live, gerr := packages(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+				if gerr != nil {
+					return gerr
+				}
+				desired.ResourceVersion = live.ResourceVersion
+				var uerr error
+				n, uerr = packages(desired.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
+				return uerr
+			}); err != nil {
 				return nil, err
 			}
 			// Re-trigger a build if the previous one failed. This is a status
 			// write; with the /status subresource it must go through
-			// UpdateStatus, separately from the spec Update above.
-			if current.Status.BuildStatus == fv1.BuildStatusFailed {
-				n.Status.BuildStatus = fv1.BuildStatusPending
-				n, err = packages(desired.Namespace).UpdateStatus(ctx, n, metav1.UpdateOptions{})
-				if err != nil {
+			// UpdateStatus, separately from the spec Update above (also
+			// conflict-retried).
+			if retrigger {
+				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					live, gerr := packages(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+					if gerr != nil {
+						return gerr
+					}
+					live.Status.BuildStatus = fv1.BuildStatusPending
+					var uerr error
+					n, uerr = packages(desired.Namespace).UpdateStatus(ctx, live, metav1.UpdateOptions{})
+					return uerr
+				}); err != nil {
 					return nil, err
 				}
 			}

--- a/test/e2e/fetcher/fetcher_test.go
+++ b/test/e2e/fetcher/fetcher_test.go
@@ -213,7 +213,10 @@ func (f *FetcherTestSuite) TestFetcherDeploymentType() {
 		}
 
 		for _, pkg := range pkgs.Items {
-			if pkg.Name == testDeployPkg && pkg.Status.BuildStatus == fv1.BuildStatusSucceeded {
+			// A deploy-archive package needs no build: the buildermgr marks it
+			// "none" (no build required), which is an equally-ready state as
+			// "succeeded" (see fetcher build-status gate). Accept either.
+			if pkg.Name == testDeployPkg && (pkg.Status.BuildStatus == fv1.BuildStatusSucceeded || pkg.Status.BuildStatus == fv1.BuildStatusNone) {
 				return true, nil
 			} else if pkg.Name == testDeployPkg && pkg.Status.BuildStatus == fv1.BuildStatusFailed {
 				return true, fmt.Errorf("build failed for package:%s", pkg.Name)
@@ -264,7 +267,10 @@ func (f *FetcherTestSuite) TestFetcherURLType() {
 		}
 
 		for _, pkg := range pkgs.Items {
-			if pkg.Name == testDeployPkg && pkg.Status.BuildStatus == fv1.BuildStatusSucceeded {
+			// A deploy-archive package needs no build: the buildermgr marks it
+			// "none" (no build required), which is an equally-ready state as
+			// "succeeded" (see fetcher build-status gate). Accept either.
+			if pkg.Name == testDeployPkg && (pkg.Status.BuildStatus == fv1.BuildStatusSucceeded || pkg.Status.BuildStatus == fv1.BuildStatusNone) {
 				return true, nil
 			} else if pkg.Name == testDeployPkg && pkg.Status.BuildStatus == fv1.BuildStatusFailed {
 				return true, fmt.Errorf("build failed for package:%s", pkg.Name)
@@ -385,7 +391,10 @@ func (f *FetcherTestSuite) TestFetcherSpecialize() {
 		}
 
 		for _, pkg := range pkgs.Items {
-			if pkg.Name == testDeployPkg && pkg.Status.BuildStatus == fv1.BuildStatusSucceeded {
+			// A deploy-archive package needs no build: the buildermgr marks it
+			// "none" (no build required), which is an equally-ready state as
+			// "succeeded" (see fetcher build-status gate). Accept either.
+			if pkg.Name == testDeployPkg && (pkg.Status.BuildStatus == fv1.BuildStatusSucceeded || pkg.Status.BuildStatus == fv1.BuildStatusNone) {
 				return true, nil
 			} else if pkg.Name == testDeployPkg && pkg.Status.BuildStatus == fv1.BuildStatusFailed {
 				return true, fmt.Errorf("build failed for package:%s", pkg.Name)

--- a/test/integration/framework/package.go
+++ b/test/integration/framework/package.go
@@ -17,6 +17,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
@@ -208,10 +209,19 @@ func (ns *TestNamespace) waitForPackageBuildStatus(t *testing.T, ctx context.Con
 				transientRetries++
 				t.Logf("package %q transient build failure (retry %d/%d): %s",
 					pkgName, transientRetries, maxTransientRetries, p.Status.BuildLog)
-				p.Status.BuildStatus = fv1.BuildStatusPending
-				// Status write goes through the /status subresource.
-				if _, uerr := ns.f.fissionClient.CoreV1().Packages(ns.Name).UpdateStatus(c, p, metav1.UpdateOptions{}); uerr != nil {
-					return false, fmt.Errorf("transient retry: reset package status to pending: %w", uerr)
+				// Status write goes through the /status subresource, re-getting
+				// on conflict since the buildermgr updates package status
+				// concurrently.
+				if rerr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+					fresh, gerr := ns.f.fissionClient.CoreV1().Packages(ns.Name).Get(c, pkgName, metav1.GetOptions{})
+					if gerr != nil {
+						return gerr
+					}
+					fresh.Status.BuildStatus = fv1.BuildStatusPending
+					_, uerr := ns.f.fissionClient.CoreV1().Packages(ns.Name).UpdateStatus(c, fresh, metav1.UpdateOptions{})
+					return uerr
+				}); rerr != nil {
+					return false, fmt.Errorf("transient retry: reset package status to pending: %w", rerr)
 				}
 				return false, nil
 			}

--- a/test/integration/framework/package.go
+++ b/test/integration/framework/package.go
@@ -193,6 +193,13 @@ func (ns *TestNamespace) waitForPackageBuildStatus(t *testing.T, ctx context.Con
 		switch p.Status.BuildStatus {
 		case want:
 			return true, nil
+		case fv1.BuildStatusNone:
+			// A package needing no build (deploy archive / no source) reports
+			// "none" — an equally-ready terminal state as "succeeded".
+			if want == fv1.BuildStatusSucceeded {
+				return true, nil
+			}
+			return false, nil
 		case fv1.BuildStatusFailed:
 			if want == fv1.BuildStatusFailed {
 				return false, nil
@@ -202,7 +209,8 @@ func (ns *TestNamespace) waitForPackageBuildStatus(t *testing.T, ctx context.Con
 				t.Logf("package %q transient build failure (retry %d/%d): %s",
 					pkgName, transientRetries, maxTransientRetries, p.Status.BuildLog)
 				p.Status.BuildStatus = fv1.BuildStatusPending
-				if _, uerr := ns.f.fissionClient.CoreV1().Packages(ns.Name).Update(c, p, metav1.UpdateOptions{}); uerr != nil {
+				// Status write goes through the /status subresource.
+				if _, uerr := ns.f.fissionClient.CoreV1().Packages(ns.Name).UpdateStatus(c, p, metav1.UpdateOptions{}); uerr != nil {
 					return false, fmt.Errorf("transient retry: reset package status to pending: %w", uerr)
 				}
 				return false, nil

--- a/test/integration/suites/common/conditions_test.go
+++ b/test/integration/suites/common/conditions_test.go
@@ -93,11 +93,6 @@ func TestConditions_FunctionStatusSubresource(t *testing.T) {
 	require.Equal(t, "ConditionsSmoke", c.Reason)
 }
 
-// TestConditions_PackageMainResource verifies the additive change to
-// PackageStatus: Conditions can be written via the existing main-resource
-// Update path (no status subresource on Package), and round-trips cleanly.
-// This is the canary that PackageStatus changes did NOT silently flip the
-// subresource on Package, which would have broken pkg/buildermgr writes.
 // TestConditions_PackageStatusSubresource verifies that Package now carries a
 // /status subresource: a spec change submitted through UpdateStatus must be
 // dropped by the apiserver. (Package gained +kubebuilder:subresource:status in

--- a/test/integration/suites/common/conditions_test.go
+++ b/test/integration/suites/common/conditions_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/conditions"
@@ -97,7 +98,12 @@ func TestConditions_FunctionStatusSubresource(t *testing.T) {
 // Update path (no status subresource on Package), and round-trips cleanly.
 // This is the canary that PackageStatus changes did NOT silently flip the
 // subresource on Package, which would have broken pkg/buildermgr writes.
-func TestConditions_PackageMainResource(t *testing.T) {
+// TestConditions_PackageStatusSubresource verifies that Package now carries a
+// /status subresource: a spec change submitted through UpdateStatus must be
+// dropped by the apiserver. (Package gained +kubebuilder:subresource:status in
+// the buildermgr /status migration; this replaces the earlier test that
+// asserted the opposite.)
+func TestConditions_PackageStatusSubresource(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
@@ -108,10 +114,11 @@ func TestConditions_PackageMainResource(t *testing.T) {
 	fc := f.FissionClient().CoreV1()
 
 	name := "conds-pkg-" + ns.ID
+	const envName = "conds-smoke-fake"
 	pkg := &fv1.Package{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns.Name},
 		Spec: fv1.PackageSpec{
-			Environment: fv1.EnvironmentReference{Name: "conds-smoke-fake", Namespace: ns.Name},
+			Environment: fv1.EnvironmentReference{Name: envName, Namespace: ns.Name},
 			Deployment:  fv1.Archive{Type: fv1.ArchiveTypeLiteral, Literal: []byte("// noop")},
 		},
 		Status: fv1.PackageStatus{BuildStatus: fv1.BuildStatusNone},
@@ -122,25 +129,24 @@ func TestConditions_PackageMainResource(t *testing.T) {
 		_ = fc.Packages(ns.Name).Delete(context.Background(), name, metav1.DeleteOptions{})
 	})
 
-	got, err := fc.Packages(ns.Name).Get(ctx, name, metav1.GetOptions{})
-	require.NoError(t, err)
-	got.Status.Conditions = append(got.Status.Conditions, metav1.Condition{
-		Type:               smokeConditionType,
-		Status:             metav1.ConditionTrue,
-		Reason:             "ConditionsSmoke",
-		Message:            "set by TestConditions_PackageMainResource",
-		LastTransitionTime: metav1.Now(),
-		ObservedGeneration: got.Generation,
+	// Submit a spec change via UpdateStatus; the subresource must drop it. Retry
+	// on conflict because the buildermgr also writes this package's initial
+	// status (setInitialBuildStatus) shortly after create.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		got, gerr := fc.Packages(ns.Name).Get(ctx, name, metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		got.Spec.Environment.Name = "conds-tampered"
+		_, uerr := fc.Packages(ns.Name).UpdateStatus(ctx, got, metav1.UpdateOptions{})
+		return uerr
 	})
-	// Main-resource Update writes Spec AND Status together — proves we did
-	// NOT add +kubebuilder:subresource:status to Package.
-	_, err = fc.Packages(ns.Name).Update(ctx, got, metav1.UpdateOptions{})
-	require.NoError(t, err, "Update on Package main resource must persist Status.Conditions")
+	require.NoError(t, err)
 
-	refetched := ns.GetPackageConditions(t, ctx, name)
-	c := conditions.Find(refetched, smokeConditionType)
-	require.NotNil(t, c, "smoke condition must round-trip through the main-resource Update (got %v)", refetched)
-	require.EqualValues(t, "True", c.Status)
+	after, err := fc.Packages(ns.Name).Get(ctx, name, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Equal(t, envName, after.Spec.Environment.Name,
+		"spec change submitted via UpdateStatus must be dropped — Package now has a /status subresource")
 }
 
 // TestConditions_SSAListMapKey is the core SSA correctness test for

--- a/test/integration/suites/common/kubectl_test.go
+++ b/test/integration/suites/common/kubectl_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/test/integration/framework"
@@ -86,23 +87,32 @@ func TestKubectlApply(t *testing.T) {
 	// have the latest ResourceVersion, then update Spec.Source.URL.
 	//
 	// Critical: the buildermgr only triggers a (re)build when
-	// Status.BuildStatus == "pending" (see pkg/buildermgr/pkgwatcher.go:259-262
-	// and the long-standing TODO above it about /status subresource).
-	// A plain Spec-only Update would leave status at "failed" and the
-	// controller would skip the new build. Bash uses `kubectl replace`
-	// which round-trips the whole object including Status; we mimic
-	// that by explicitly resetting BuildStatus to pending before Update.
-	current, err := f.FissionClient().CoreV1().Packages(ns.Name).Get(ctx, pkgName, metav1.GetOptions{})
+	// Status.BuildStatus == "pending". We point Spec.Source.URL at the good URL
+	// (spec Update) and then reset BuildStatus to pending through the /status
+	// subresource (UpdateStatus). Both writes are conflict-retried because the
+	// buildermgr updates the package status concurrently.
+	pkgs := f.FissionClient().CoreV1().Packages(ns.Name)
+	current, err := pkgs.Get(ctx, pkgName, metav1.GetOptions{})
 	require.NoError(t, err)
 	since := current.Status.LastUpdateTimestamp
-	current.Spec.Source.URL = goodURL
-	updated, err := f.FissionClient().CoreV1().Packages(ns.Name).Update(ctx, current, metav1.UpdateOptions{})
-	require.NoError(t, err, "update package %q spec to good URL", pkgName)
-	// The rebuild trigger (BuildStatus=pending) is a status write; with the
-	// Package /status subresource it must go through UpdateStatus.
-	updated.Status.BuildStatus = fv1.BuildStatusPending
-	_, err = f.FissionClient().CoreV1().Packages(ns.Name).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
-	require.NoError(t, err, "reset package %q build status to pending", pkgName)
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, gerr := pkgs.Get(ctx, pkgName, metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		fresh.Spec.Source.URL = goodURL
+		_, uerr := pkgs.Update(ctx, fresh, metav1.UpdateOptions{})
+		return uerr
+	}), "update package %q spec to good URL", pkgName)
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fresh, gerr := pkgs.Get(ctx, pkgName, metav1.GetOptions{})
+		if gerr != nil {
+			return gerr
+		}
+		fresh.Status.BuildStatus = fv1.BuildStatusPending
+		_, uerr := pkgs.UpdateStatus(ctx, fresh, metav1.UpdateOptions{})
+		return uerr
+	}), "reset package %q build status to pending", pkgName)
 
 	ns.WaitForPackageRebuiltSince(t, ctx, pkgName, since)
 

--- a/test/integration/suites/common/kubectl_test.go
+++ b/test/integration/suites/common/kubectl_test.go
@@ -96,9 +96,13 @@ func TestKubectlApply(t *testing.T) {
 	require.NoError(t, err)
 	since := current.Status.LastUpdateTimestamp
 	current.Spec.Source.URL = goodURL
-	current.Status.BuildStatus = fv1.BuildStatusPending
-	_, err = f.FissionClient().CoreV1().Packages(ns.Name).Update(ctx, current, metav1.UpdateOptions{})
-	require.NoError(t, err, "update package %q to good URL + pending", pkgName)
+	updated, err := f.FissionClient().CoreV1().Packages(ns.Name).Update(ctx, current, metav1.UpdateOptions{})
+	require.NoError(t, err, "update package %q spec to good URL", pkgName)
+	// The rebuild trigger (BuildStatus=pending) is a status write; with the
+	// Package /status subresource it must go through UpdateStatus.
+	updated.Status.BuildStatus = fv1.BuildStatusPending
+	_, err = f.FissionClient().CoreV1().Packages(ns.Name).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+	require.NoError(t, err, "reset package %q build status to pending", pkgName)
 
 	ns.WaitForPackageRebuiltSince(t, ctx, pkgName, since)
 


### PR DESCRIPTION
## What

First half of the **buildermgr** migration (RFC-0005 WS3 stream B), split out to isolate the risky schema change. This PR adds the **Package `/status` subresource** and routes every Package status write through it, **keeping the informer watchers unchanged** so the build loop behaves identically. The reconciler rewrite (B2) will build on this.

## Changes

- Add `// +kubebuilder:subresource:status` to `Package` (regenerated CRD); grant **`packages/status`** (get/update/patch) to the buildermgr role.
- **Split every Package status writer** — the apiserver now ignores status on a main-resource `Update`:
  - `buildermgr/common.go` `updatePackage`: spec (Deployment archive) via `Update`, status (BuildStatus/conditions) via `UpdateStatus`.
  - `buildermgr/pkgwatcher.go` `setInitialBuildStatus` → `UpdateStatus`.
  - CLI `package/update.go` (rebuild-trigger `BuildStatus=pending`) and `spec/apply.go` (failed→pending re-trigger): spec via `Update`, status via `UpdateStatus`.
- **Allow empty `PackageStatus.BuildStatus`** in validation: with `/status` the apiserver strips the defaulting webhook's status on create, so a package is admitted with an empty `BuildStatus` and the buildermgr fills it in (`setInitialBuildStatus`).

## Behavior notes

- A **deploy-archive** (pre-built, no source) package now reports its accurate **`none`** (`NoBuildRequired`) `BuildStatus` from the buildermgr, instead of the CLI's legacy create-time `succeeded`. The two are an **equivalent ready state** (see the fetcher's build-status gate, which accepts both). The e2e fetcher test now accepts either — this was the one behavior surfaced by making the buildermgr's status authoritative.
- **CLI RBAC:** the CLI status writes run as the invoking user, so a user with a *custom* role granting only `packages` will also need `packages/status` for `fission package update` / `fission spec apply` rebuild triggers. (cluster-admins — the common case — are unaffected.)

## Testing

- `go build ./...`, `go vet`, `golangci-lint` (0 issues), `make codegen`/`generate-crds` (no drift).
- `-race` unit tests for buildermgr, package/spec CLI, `apis/core/v1` (incl. a new empty-`BuildStatus`-is-valid assertion), and webhook.
- Both in-process e2e suites (`test/e2e/fetcher` — the real build-loop, runs buildermgr in-process — and `test/e2e/cli`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3427)
<!-- Reviewable:end -->
