### PR TITLE
feat: RFC-0005 WS3 (C) — router HTTPTrigger + Function reconcilers

### DIFF
--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -5,11 +5,13 @@
 package router
 
 import (
+	"context"
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	k8sCache "k8s.io/client-go/tools/cache"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 
@@ -22,10 +24,13 @@ type (
 	// reference into a resolveResult
 	functionReferenceResolver struct {
 		// FunctionReference -> function metadata
-		refCache     *cache.Cache[namespacedTriggerReference, resolveResult]
-		funcInformer map[string]k8sCache.SharedIndexInformer
-		logger       logr.Logger
-		// store    k8sCache.Store
+		refCache *cache.Cache[namespacedTriggerReference, resolveResult]
+		// reader is the Manager's cache-backed client. Function lookups go
+		// through it (in-memory cache reads), replacing the per-namespace
+		// SharedIndexInformer stores the resolver used before the
+		// controller-runtime migration.
+		reader client.Reader
+		logger logr.Logger
 	}
 
 	resolveResultType int
@@ -59,17 +64,17 @@ const (
 	resolveResultMultipleFunctions
 )
 
-func makeFunctionReferenceResolver(logger logr.Logger, funcInformer map[string]k8sCache.SharedIndexInformer) *functionReferenceResolver {
+func makeFunctionReferenceResolver(logger logr.Logger, reader client.Reader) *functionReferenceResolver {
 	frr := &functionReferenceResolver{
-		refCache:     cache.MakeCache[namespacedTriggerReference, resolveResult](time.Minute, 0),
-		funcInformer: funcInformer,
-		logger:       logger.WithName("function_ref_resolver"),
+		refCache: cache.MakeCache[namespacedTriggerReference, resolveResult](time.Minute, 0),
+		reader:   reader,
+		logger:   logger.WithName("function_ref_resolver"),
 	}
 	return frr
 }
 
 // resolve translates a trigger's function reference to a resolveResult.
-func (frr *functionReferenceResolver) resolve(trigger fv1.HTTPTrigger) (*resolveResult, error) {
+func (frr *functionReferenceResolver) resolve(ctx context.Context, trigger fv1.HTTPTrigger) (*resolveResult, error) {
 	nfr := namespacedTriggerReference{
 		namespace:              trigger.Namespace,
 		triggerName:            trigger.Name,
@@ -87,13 +92,13 @@ func (frr *functionReferenceResolver) resolve(trigger fv1.HTTPTrigger) (*resolve
 
 	switch trigger.Spec.FunctionReference.Type {
 	case fv1.FunctionReferenceTypeFunctionName:
-		rr, err = frr.resolveByName(nfr.namespace, trigger.Spec.FunctionReference.Name)
+		rr, err = frr.resolveByName(ctx, nfr.namespace, trigger.Spec.FunctionReference.Name)
 		if err != nil {
 			return nil, err
 		}
 
 	case fv1.FunctionReferenceTypeFunctionWeights:
-		rr, err = frr.resolveByFunctionWeights(nfr.namespace, &trigger.Spec.FunctionReference)
+		rr, err = frr.resolveByFunctionWeights(ctx, nfr.namespace, &trigger.Spec.FunctionReference)
 		if err != nil {
 			return nil, err
 		}
@@ -108,73 +113,47 @@ func (frr *functionReferenceResolver) resolve(trigger fv1.HTTPTrigger) (*resolve
 	return rr, nil
 }
 
-func (frr *functionReferenceResolver) getInformerByNamespace(namespace string) (k8sCache.SharedIndexInformer, error) {
-	if informer, ok := frr.funcInformer[namespace]; ok {
-		return informer, nil
-	}
-	return nil, fmt.Errorf("informer for namespace %s not found", namespace)
-}
-
-// resolveByName simply looks up function by name in a namespace.
-func (frr *functionReferenceResolver) resolveByName(namespace, name string) (*resolveResult, error) {
-	// get function from cache
-	informer, err := frr.getInformerByNamespace(namespace)
-	if err != nil {
-		return nil, err
-	}
-	obj, isExist, err := informer.GetStore().Get(&fv1.Function{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: namespace,
-			Name:      name,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	if !isExist {
+// getFunction reads a Function from the Manager's cache.
+func (frr *functionReferenceResolver) getFunction(ctx context.Context, namespace, name string) (*fv1.Function, error) {
+	f := &fv1.Function{}
+	err := frr.reader.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, f)
+	if apierrors.IsNotFound(err) {
 		frr.logger.Error(nil, "function does not exists", "name", name, "namespace", namespace)
 		return nil, fmt.Errorf("function %s/%s does not exist", namespace, name)
 	}
-	f := obj.(*fv1.Function)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
 
-	functionMap := map[string]*fv1.Function{
-		f.Name: f,
+// resolveByName simply looks up function by name in a namespace.
+func (frr *functionReferenceResolver) resolveByName(ctx context.Context, namespace, name string) (*resolveResult, error) {
+	f, err := frr.getFunction(ctx, namespace, name)
+	if err != nil {
+		return nil, err
 	}
 
 	rr := resolveResult{
 		resolveResultType: resolveResultSingleFunction,
-		functionMap:       functionMap,
+		functionMap: map[string]*fv1.Function{
+			f.Name: f,
+		},
 	}
 
 	return &rr, nil
 }
 
-func (frr *functionReferenceResolver) resolveByFunctionWeights(namespace string, fr *fv1.FunctionReference) (*resolveResult, error) {
-
+func (frr *functionReferenceResolver) resolveByFunctionWeights(ctx context.Context, namespace string, fr *fv1.FunctionReference) (*resolveResult, error) {
 	functionMap := make(map[string]*fv1.Function)
 	fnWtDistrList := make([]functionWeightDistribution, 0)
 	sumPrefix := 0
 
 	for functionName, functionWeight := range fr.FunctionWeights {
-		// get function from cache
-		informer, err := frr.getInformerByNamespace(namespace)
+		f, err := frr.getFunction(ctx, namespace, functionName)
 		if err != nil {
 			return nil, err
 		}
-		obj, isExist, err := informer.GetStore().Get(&fv1.Function{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: namespace,
-				Name:      functionName,
-			},
-		})
-		if err != nil {
-			return nil, err
-		}
-		if !isExist {
-			frr.logger.Error(nil, "function does not exists", "name", functionName, "namespace", namespace)
-			return nil, fmt.Errorf("function %s/%s does not exist", namespace, functionName)
-		}
-		f := obj.(*fv1.Function)
 		functionMap[f.Name] = f
 		sumPrefix = sumPrefix + functionWeight
 		fnWtDistrList = append(fnWtDistrList, functionWeightDistribution{
@@ -202,6 +181,19 @@ func (frr *functionReferenceResolver) delete(namespace string, triggerName, trig
 	frr.refCache.Delete(nfr)
 }
 
-func (frr *functionReferenceResolver) copy() map[namespacedTriggerReference]resolveResult {
-	return frr.refCache.Copy()
+// invalidateForFunction drops any cached resolve result that references the
+// named function in the given namespace, so the next resolve re-reads the
+// function from the cache. Used by the function reconciler when a Function's
+// spec changes. Returns true if an entry was invalidated.
+func (frr *functionReferenceResolver) invalidateForFunction(namespace, name, resourceVersion string) bool {
+	for key, rr := range frr.refCache.Copy() {
+		if key.namespace == namespace &&
+			rr.functionMap[name] != nil &&
+			rr.functionMap[name].ResourceVersion != resourceVersion {
+			frr.logger.V(1).Info("invalidating resolver cache", "function", name, "namespace", namespace)
+			frr.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/bep/debounce"
@@ -20,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
-	k8sCache "k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/conditions"
@@ -46,15 +47,18 @@ type HTTPTriggerSet struct {
 	// that only construct the public mux directly.
 	internalMutableRouter *mutableRouter
 
-	logger                     logr.Logger
-	fissionClient              versioned.Interface
-	kubeClient                 kubernetes.Interface
+	logger        logr.Logger
+	fissionClient versioned.Interface
+	kubeClient    kubernetes.Interface
+	// client is the Manager's cache-backed client. The trigger/function
+	// reconcilers and updateRouter read HTTPTriggers + Functions through it,
+	// replacing the per-namespace SharedIndexInformers the router used before
+	// the controller-runtime migration.
+	client                     client.Client
 	executor                   eclient.ClientInterface
 	resolver                   *functionReferenceResolver
 	triggers                   []fv1.HTTPTrigger
-	triggerInformer            map[string]k8sCache.SharedIndexInformer
 	functions                  []fv1.Function
-	funcInformer               map[string]k8sCache.SharedIndexInformer
 	updateRouterRequestChannel chan struct{}
 	tsRoundTripperParams       *tsRoundTripperParams
 	isDebugEnv                 bool
@@ -62,10 +66,18 @@ type HTTPTriggerSet struct {
 	svcAddrUpdateThrottler     *throttler.Throttler
 	unTapServiceTimeout        time.Duration
 	syncDebouncer              func(func())
+	// ready flips true after the first successful mux build; routerReadinessHandler
+	// gates /readyz on it so a starting/rolling pod stays out of the
+	// Service endpoints until its mux is populated.
+	ready atomic.Bool
 }
 
+// makeHTTPTriggerSet builds the trigger set. cl is the Manager's cache-backed
+// client (mgr.GetClient()); it backs both the trigger/function reconcilers and
+// the resolver. A nil cl is the unit-test path that drives buildMuxes directly
+// without a Manager.
 func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionClient versioned.Interface,
-	kubeClient kubernetes.Interface, executor eclient.ClientInterface, params *tsRoundTripperParams, isDebugEnv bool, useEncodedPath bool, unTapServiceTimeout time.Duration, actionThrottler *throttler.Throttler) (*HTTPTriggerSet, error) {
+	kubeClient kubernetes.Interface, cl client.Client, executor eclient.ClientInterface, params *tsRoundTripperParams, isDebugEnv bool, useEncodedPath bool, unTapServiceTimeout time.Duration, actionThrottler *throttler.Throttler) (*HTTPTriggerSet, error) {
 
 	httpTriggerSet := &HTTPTriggerSet{
 		logger:                     logger.WithName("http_trigger_set"),
@@ -73,6 +85,7 @@ func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionCli
 		triggers:                   []fv1.HTTPTrigger{},
 		fissionClient:              fissionClient,
 		kubeClient:                 kubeClient,
+		client:                     cl,
 		executor:                   executor,
 		updateRouterRequestChannel: make(chan struct{}, 10), // use buffer channel
 		tsRoundTripperParams:       params,
@@ -82,16 +95,7 @@ func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionCli
 		unTapServiceTimeout:        unTapServiceTimeout,
 		syncDebouncer:              debounce.New(time.Millisecond * 20),
 	}
-	httpTriggerSet.triggerInformer = utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.HttpTriggerResource)
-	httpTriggerSet.funcInformer = utils.GetInformersForNamespaces(fissionClient, time.Minute*30, fv1.FunctionResource)
-	err := httpTriggerSet.addTriggerHandlers()
-	if err != nil {
-		return nil, err
-	}
-	err = httpTriggerSet.addFunctionHandlers()
-	if err != nil {
-		return nil, err
-	}
+	httpTriggerSet.resolver = makeFunctionReferenceResolver(logger, cl)
 	return httpTriggerSet, nil
 }
 
@@ -99,14 +103,12 @@ func makeHTTPTriggerSet(logger logr.Logger, fmap *functionServiceMap, fissionCli
 // internal mutable router. Passing internalMR=nil preserves the legacy
 // single-listener path used by older test scaffolding.
 func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mgr *errgroup.Group, mr *mutableRouter, internalMR *mutableRouter) error {
-	resolver := makeFunctionReferenceResolver(ts.logger, ts.funcInformer)
-	ts.resolver = resolver
 	ts.mutableRouter = mr
 	ts.internalMutableRouter = internalMR
 
 	if ts.fissionClient == nil {
 		// Used in tests only.
-		public, internal, err := ts.buildMuxes(nil)
+		public, internal, err := ts.buildMuxes(ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -117,23 +119,14 @@ func (ts *HTTPTriggerSet) subscribeRouter(ctx context.Context, mgr *errgroup.Gro
 		ts.logger.Info("skipping continuous trigger updates")
 		return nil
 	}
+	// The trigger/function reconcilers (registered on the Manager) signal mux
+	// rebuilds through updateRouterRequestChannel; this goroutine consumes them.
+	// The Manager owns the informer caches, so there are no informers to Run
+	// here. The initial mux build is kicked off by Start once the cache syncs.
 	mgr.Go(func() error {
 		ts.updateRouter(ctx)
 		return nil
 	})
-	ts.syncTriggers()
-	for _, informer := range ts.funcInformer {
-		mgr.Go(func() error {
-			informer.Run(ctx.Done())
-			return nil
-		})
-	}
-	for _, informer := range ts.triggerInformer {
-		mgr.Go(func() error {
-			informer.Run(ctx.Done())
-			return nil
-		})
-	}
 	return nil
 }
 
@@ -145,23 +138,18 @@ func routerHealthHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// routerReadinessHandler reports 200 only once the trigger and function
-// informer caches have synced. The kubelet keeps a freshly started or rolling
-// router pod out of the Service endpoints until its mux is populated, avoiding
-// 404s for valid triggers during startup and rolling updates. /router-healthz
-// stays a cheap liveness check.
+// routerReadinessHandler reports 200 only once the first mux build has
+// succeeded (which happens after the Manager's trigger + function caches sync).
+// The kubelet keeps a freshly started or rolling router pod out of the Service
+// endpoints until its mux is populated, avoiding 404s for valid triggers during
+// startup and rolling updates. /router-healthz stays a cheap liveness check.
 func (ts *HTTPTriggerSet) routerReadinessHandler(w http.ResponseWriter, r *http.Request) {
-	for _, inf := range ts.triggerInformer {
-		if !inf.HasSynced() {
-			http.Error(w, "trigger informer cache not synced", http.StatusServiceUnavailable)
-			return
-		}
-	}
-	for _, inf := range ts.funcInformer {
-		if !inf.HasSynced() {
-			http.Error(w, "function informer cache not synced", http.StatusServiceUnavailable)
-			return
-		}
+	// ready flips true after the first successful mux build, which only happens
+	// once the Manager's trigger + function caches have synced. Until then the
+	// mux has no user routes, so report 503 to stay out of the Service endpoints.
+	if !ts.ready.Load() {
+		http.Error(w, "router mux not yet built", http.StatusServiceUnavailable)
+		return
 	}
 	w.WriteHeader(http.StatusOK)
 }
@@ -227,7 +215,7 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 // hmac.Verifier in the bundle process; the verifier is intentionally
 // not added here so this function stays unit-testable without HMAC env
 // state.
-func (ts *HTTPTriggerSet) buildMuxes(fnTimeoutMap map[types.UID]int) (public, internal *mux.Router, err error) {
+func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types.UID]int) (public, internal *mux.Router, err error) {
 	featureConfig, err := config.GetFeatureConfig(ts.logger)
 	if err != nil {
 		return nil, nil, err
@@ -261,7 +249,7 @@ func (ts *HTTPTriggerSet) buildMuxes(fnTimeoutMap map[types.UID]int) (public, in
 		trigger := ts.triggers[i]
 
 		// resolve function reference
-		rr, err := ts.resolver.resolve(trigger)
+		rr, err := ts.resolver.resolve(ctx, trigger)
 		if err != nil {
 			// Unresolvable function reference. Report the error via
 			// the trigger's status.
@@ -517,88 +505,6 @@ func (ts *HTTPTriggerSet) markTriggerCondition(ctx context.Context, trigger *fv1
 	}
 }
 
-func (ts *HTTPTriggerSet) addTriggerHandlers() error {
-	for _, triggerInformer := range ts.triggerInformer {
-		_, err := triggerInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj any) {
-				trigger := obj.(*fv1.HTTPTrigger)
-				go createIngress(context.Background(), ts.logger, trigger, ts.kubeClient)
-				ts.syncTriggers()
-			},
-			DeleteFunc: func(obj any) {
-				ts.syncTriggers()
-				trigger := obj.(*fv1.HTTPTrigger)
-				go deleteIngress(context.Background(), ts.logger, trigger, ts.kubeClient)
-			},
-			UpdateFunc: func(oldObj any, newObj any) {
-				oldTrigger := oldObj.(*fv1.HTTPTrigger)
-				newTrigger := newObj.(*fv1.HTTPTrigger)
-
-				// Skip status-only updates: our own markTriggerCondition
-				// writes bump RV but leave Generation untouched. If we
-				// re-synced on every status-only update we'd loop on our
-				// own writes (mux rebuild → status write → informer
-				// fires → mux rebuild).
-				if oldTrigger.Generation == newTrigger.Generation {
-					return
-				}
-
-				go updateIngress(context.Background(), ts.logger, oldTrigger, newTrigger, ts.kubeClient)
-				ts.syncTriggers()
-			},
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (ts *HTTPTriggerSet) addFunctionHandlers() error {
-	for _, funcInformer := range ts.funcInformer {
-
-		_, err := funcInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			AddFunc: func(obj any) {
-				ts.syncTriggers()
-			},
-			DeleteFunc: func(obj any) {
-				ts.syncTriggers()
-			},
-			UpdateFunc: func(oldObj any, newObj any) {
-				oldFn := oldObj.(*fv1.Function)
-				fn := newObj.(*fv1.Function)
-
-				// Generation-based comparison filters out status-only
-				// updates (executor's FunctionConditionReady writes go
-				// through the status subresource and don't bump
-				// Generation). Without this, every cold-start specialization
-				// would invalidate the resolver cache and force a full
-				// mux rebuild on the next request.
-				if oldFn.Generation == fn.Generation {
-					return
-				}
-
-				// update resolver function reference cache
-				for key, rr := range ts.resolver.copy() {
-					if key.namespace == fn.Namespace &&
-						rr.functionMap[fn.Name] != nil &&
-						rr.functionMap[fn.Name].ResourceVersion != fn.ResourceVersion {
-						// invalidate resolver cache
-						ts.logger.V(1).Info("invalidating resolver cache")
-						ts.resolver.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
-						break
-					}
-				}
-				ts.syncTriggers()
-			},
-		})
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func (ts *HTTPTriggerSet) syncTriggers() {
 	ts.syncDebouncer(func() {
 		ts.updateRouterRequestChannel <- struct{}{}
@@ -612,28 +518,27 @@ func (ts *HTTPTriggerSet) updateRouter(ctx context.Context) {
 			return
 		case <-ts.updateRouterRequestChannel:
 		}
-		// get triggers
-		alltriggers := make([]fv1.HTTPTrigger, 0)
-		for _, triggerInformer := range ts.triggerInformer {
-			latestTriggers := triggerInformer.GetStore().List()
-			for _, t := range latestTriggers {
-				alltriggers = append(alltriggers, *t.(*fv1.HTTPTrigger))
-			}
+		// get triggers + functions from the Manager's cache (scoped to the
+		// Fission-watched namespaces via FissionCacheOptions).
+		var triggerList fv1.HTTPTriggerList
+		if err := ts.client.List(ctx, &triggerList); err != nil {
+			ts.logger.Error(err, "error listing http triggers; skipping mux rebuild")
+			continue
 		}
-		ts.triggers = alltriggers
+		ts.triggers = triggerList.Items
 
-		// get functions
-		allfunctions := make([]fv1.Function, 0)
-		functionTimeout := make(map[types.UID]int, 0)
-		for _, funcInformer := range ts.funcInformer {
-			latestFunctions := funcInformer.GetStore().List()
-			for _, f := range latestFunctions {
-				fn := *f.(*fv1.Function)
-				functionTimeout[fn.UID] = fn.Spec.FunctionTimeout
-				allfunctions = append(allfunctions, fn)
-			}
+		var functionList fv1.FunctionList
+		if err := ts.client.List(ctx, &functionList); err != nil {
+			ts.logger.Error(err, "error listing functions; skipping mux rebuild")
+			continue
+		}
+		allfunctions := functionList.Items
+		functionTimeout := make(map[types.UID]int, len(allfunctions))
+		for i := range allfunctions {
+			functionTimeout[allfunctions[i].UID] = allfunctions[i].Spec.FunctionTimeout
 		}
 		ts.functions = allfunctions
+		alltriggers := ts.triggers
 
 		// Rebuild both muxes from the same function snapshot then swap
 		// each in turn. The two updateRouter calls are sequential, not
@@ -644,7 +549,7 @@ func (ts *HTTPTriggerSet) updateRouter(ctx context.Context) {
 		// listener is consistent in steady state. True atomicity across
 		// listeners would require a shared atomic.Pointer holding both
 		// muxes; not worth the complexity for this case.
-		public, internal, err := ts.buildMuxes(functionTimeout)
+		public, internal, err := ts.buildMuxes(ctx, functionTimeout)
 		if err != nil {
 			ts.logger.Error(err, "error updating router")
 			// Flip every trigger to Ready=False so consumers polling
@@ -662,6 +567,8 @@ func (ts *HTTPTriggerSet) updateRouter(ctx context.Context) {
 		if ts.internalMutableRouter != nil {
 			ts.internalMutableRouter.updateRouter(internal)
 		}
+		// The mux now serves user routes — report ready (gates /readyz).
+		ts.ready.Store(true)
 
 		// Mark each trigger admitted now that its routes are live. We
 		// do this after the swap so the condition reflects observable

--- a/pkg/router/httpTriggers_test.go
+++ b/pkg/router/httpTriggers_test.go
@@ -70,7 +70,7 @@ func TestPublicMuxDoesNotRegisterInternalFunctionRoute(t *testing.T) {
 	}
 	ts := newTestTriggerSet(t, []fv1.Function{fn}, nil)
 
-	publicMux, internalMux, err := ts.buildMuxes(nil)
+	publicMux, internalMux, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 
 	// Public mux must NOT have the internal-only route.
@@ -101,7 +101,7 @@ func TestPublicMuxDoesNotRegisterInternalFunctionRoute(t *testing.T) {
 func TestPublicMuxStillServesHealthAndVersion(t *testing.T) {
 	ts := newTestTriggerSet(t, nil, nil)
 
-	publicMux, internalMux, err := ts.buildMuxes(nil)
+	publicMux, internalMux, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
@@ -139,7 +139,7 @@ func TestInternalListenerRejectsUnsignedRequests(t *testing.T) {
 	}
 	ts := newTestTriggerSet(t, []fv1.Function{fn}, nil)
 
-	_, internalMux, err := ts.buildMuxes(nil)
+	_, internalMux, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 
 	// Mirror the production wiring: ServiceVerifier with ServiceRouterInternal
@@ -201,7 +201,7 @@ func TestInternalListenerPassThroughWithEmptySecret(t *testing.T) {
 // router.go's wrap surfaces here.
 func TestPublicListener_SecurityHeadersPresentOnRouterOwnedRoutes(t *testing.T) {
 	ts := newTestTriggerSet(t, nil, nil)
-	publicMux, _, err := ts.buildMuxes(nil)
+	publicMux, _, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 	wrapped := httpsecurity.SecurityHeaders(publicMux)
 
@@ -219,7 +219,7 @@ func TestPublicListener_SecurityHeadersPresentOnRouterOwnedRoutes(t *testing.T) 
 // preflight to the wrapped DenyAllCORS handler, which returns 403.
 func TestPublicListener_RouterOwnedRoutesRejectCrossOriginPreflight(t *testing.T) {
 	ts := newTestTriggerSet(t, nil, nil)
-	publicMux, _, err := ts.buildMuxes(nil)
+	publicMux, _, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 
 	for _, path := range []string{"/router-healthz", "/_version", "/"} {
@@ -289,7 +289,7 @@ func TestInternalListener_RejectsCrossOriginPreflight(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "example", Namespace: "myns"},
 	}
 	ts := newTestTriggerSet(t, []fv1.Function{fn}, nil)
-	_, internalMux, err := ts.buildMuxes(nil)
+	_, internalMux, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 
 	// Mirror the production wrap chain from router.go:Start: HMAC

--- a/pkg/router/ingress.go
+++ b/pkg/router/ingress.go
@@ -29,91 +29,63 @@ func init() {
 	}
 }
 
-func createIngress(ctx context.Context, logger logr.Logger, trigger *fv1.HTTPTrigger, kubeClient kubernetes.Interface) {
+// reconcileIngress brings the Ingress for a trigger to its desired state
+// (level-based, called from the HTTPTrigger reconciler): create it when
+// Spec.CreateIngress is set and it is missing, update it when its spec drifts,
+// and delete it when CreateIngress is unset. The Ingress lives in podNamespace
+// and is named after the trigger.
+func reconcileIngress(ctx context.Context, logger logr.Logger, trigger *fv1.HTTPTrigger, kubeClient kubernetes.Interface) {
 	if !trigger.Spec.CreateIngress {
-		return
-	}
-	_, err := kubeClient.NetworkingV1().Ingresses(podNamespace).Create(ctx, util.GetIngressSpec(podNamespace, trigger), v1.CreateOptions{})
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		logger.Error(err, "failed to create ingress")
-		return
-	}
-	logger.V(1).Info("created ingress successfully for trigger", "trigger", trigger.Name)
-}
-
-func deleteIngress(ctx context.Context, logger logr.Logger, trigger *fv1.HTTPTrigger, kubeClient kubernetes.Interface) {
-	if !trigger.Spec.CreateIngress {
+		// Ensure no Ingress lingers (e.g. CreateIngress was toggled off).
+		deleteIngressByName(ctx, logger, trigger.Name, kubeClient)
 		return
 	}
 
-	ingress, err := kubeClient.NetworkingV1().Ingresses(podNamespace).Get(ctx, trigger.Name, v1.GetOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		logger.Error(err, "failed to get ingress when deleting trigger", "trigger", trigger.Name)
-		return
-	}
-
-	err = kubeClient.NetworkingV1().Ingresses(podNamespace).Delete(ctx, ingress.Name, v1.DeleteOptions{})
-	if err != nil && !k8serrors.IsNotFound(err) {
-		logger.Error(err, "failed to delete ingress for trigger", "ingress", ingress,
-			"trigger", trigger.Name)
-	}
-}
-
-func updateIngress(ctx context.Context, logger logr.Logger, oldT *fv1.HTTPTrigger, newT *fv1.HTTPTrigger, kubeClient kubernetes.Interface) {
-	if !oldT.Spec.CreateIngress && !newT.Spec.CreateIngress {
-		return
-	}
-
-	if !oldT.Spec.CreateIngress && newT.Spec.CreateIngress {
-		createIngress(ctx, logger, newT, kubeClient)
-		return
-	}
-
-	if !newT.Spec.CreateIngress && oldT.Spec.CreateIngress {
-		deleteIngress(ctx, logger, oldT, kubeClient)
-		return
-	}
-
-	oldIngress, err := kubeClient.NetworkingV1().Ingresses(podNamespace).Get(ctx, oldT.Name, v1.GetOptions{})
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			createIngress(ctx, logger, newT, kubeClient)
-		}
-		logger.Error(err, "failed to get ingress when updating trigger", "trigger", oldT.Name)
-		return
-	}
-	newIngress := util.GetIngressSpec(podNamespace, newT)
-
-	changes := false
-
-	if !reflect.DeepEqual(oldIngress.Annotations, newIngress.Annotations) {
-		logger.V(1).Info("ingress annotation",
-			"old_trigger", oldIngress.Annotations, "new_trigger", newIngress.Annotations)
-
-		if oldIngress.Annotations == nil || newIngress.Annotations == nil {
-			oldIngress.Annotations = newIngress.Annotations
-		} else {
-			maps.Copy(oldIngress.Annotations, newIngress.Annotations)
-		}
-		changes = true
-	}
-
-	if !reflect.DeepEqual(oldIngress.Spec, newIngress.Spec) {
-		logger.V(1).Info("ingress spec",
-			"old_trigger", oldIngress.Spec, "new_trigger", newIngress.Spec)
-
-		oldIngress.Spec = newIngress.Spec
-		changes = true
-	}
-
-	if changes {
-		_, err = kubeClient.NetworkingV1().Ingresses(podNamespace).Update(ctx, oldIngress, v1.UpdateOptions{})
-		if err != nil {
-			logger.Error(err, "failed to update ingress for trigger", "trigger", oldT.Name)
+	desired := util.GetIngressSpec(podNamespace, trigger)
+	existing, err := kubeClient.NetworkingV1().Ingresses(podNamespace).Get(ctx, trigger.Name, v1.GetOptions{})
+	if k8serrors.IsNotFound(err) {
+		_, err := kubeClient.NetworkingV1().Ingresses(podNamespace).Create(ctx, desired, v1.CreateOptions{})
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			logger.Error(err, "failed to create ingress", "trigger", trigger.Name)
 			return
 		}
+		logger.V(1).Info("created ingress successfully for trigger", "trigger", trigger.Name)
+		return
+	}
+	if err != nil {
+		logger.Error(err, "failed to get ingress when reconciling trigger", "trigger", trigger.Name)
+		return
+	}
 
-		logger.V(1).Info("updated ingress successfully for trigger",
-			"old_trigger", oldT.Name, "new_trigger", newT.Name)
+	changes := false
+	if !reflect.DeepEqual(existing.Annotations, desired.Annotations) {
+		if existing.Annotations == nil || desired.Annotations == nil {
+			existing.Annotations = desired.Annotations
+		} else {
+			maps.Copy(existing.Annotations, desired.Annotations)
+		}
+		changes = true
+	}
+	if !reflect.DeepEqual(existing.Spec, desired.Spec) {
+		existing.Spec = desired.Spec
+		changes = true
+	}
+	if changes {
+		if _, err := kubeClient.NetworkingV1().Ingresses(podNamespace).Update(ctx, existing, v1.UpdateOptions{}); err != nil {
+			logger.Error(err, "failed to update ingress for trigger", "trigger", trigger.Name)
+			return
+		}
+		logger.V(1).Info("updated ingress successfully for trigger", "trigger", trigger.Name)
+	}
+}
+
+// deleteIngressByName removes the Ingress with the given name from podNamespace.
+// Idempotent: a missing Ingress is not an error, so this is safe to call for a
+// trigger that never had CreateIngress set (e.g. on the reconciler's delete
+// path, where the trigger object is already gone).
+func deleteIngressByName(ctx context.Context, logger logr.Logger, name string, kubeClient kubernetes.Interface) {
+	err := kubeClient.NetworkingV1().Ingresses(podNamespace).Delete(ctx, name, v1.DeleteOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		logger.Error(err, "failed to delete ingress", "ingress", name)
 	}
 }

--- a/pkg/router/lifecycle_test.go
+++ b/pkg/router/lifecycle_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
-	k8sCache "k8s.io/client-go/tools/cache"
 
 	config "github.com/fission/fission/pkg/featureconfig"
 )
@@ -63,34 +62,23 @@ func TestPanicRecoveryMiddleware(t *testing.T) {
 	})
 }
 
-// fakeInformer embeds the SharedIndexInformer interface (nil) and overrides
-// only HasSynced, which is all routerReadinessHandler calls.
-type fakeInformer struct {
-	k8sCache.SharedIndexInformer
-	synced bool
-}
-
-func (f fakeInformer) HasSynced() bool { return f.synced }
-
+// TestRouterReadinessHandler pins the readiness gate: /readyz reports
+// 200 only after the first successful mux build flips ready, keeping a
+// freshly started or rolling pod out of the Service endpoints until its mux is
+// populated.
 func TestRouterReadinessHandler(t *testing.T) {
-	synced := func(b bool) map[string]k8sCache.SharedIndexInformer {
-		return map[string]k8sCache.SharedIndexInformer{"ns": fakeInformer{synced: b}}
-	}
-
 	tests := []struct {
-		name    string
-		trigger map[string]k8sCache.SharedIndexInformer
-		fn      map[string]k8sCache.SharedIndexInformer
-		want    int
+		name  string
+		ready bool
+		want  int
 	}{
-		{"all synced", synced(true), synced(true), http.StatusOK},
-		{"trigger not synced", synced(false), synced(true), http.StatusServiceUnavailable},
-		{"function not synced", synced(true), synced(false), http.StatusServiceUnavailable},
-		{"empty maps ready", map[string]k8sCache.SharedIndexInformer{}, map[string]k8sCache.SharedIndexInformer{}, http.StatusOK},
+		{"mux built -> ready", true, http.StatusOK},
+		{"mux not built -> unavailable", false, http.StatusServiceUnavailable},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ts := &HTTPTriggerSet{triggerInformer: tc.trigger, funcInformer: tc.fn}
+			ts := &HTTPTriggerSet{}
+			ts.ready.Store(tc.ready)
 			rec := httptest.NewRecorder()
 			ts.routerReadinessHandler(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 			assert.Equal(t, tc.want, rec.Code)

--- a/pkg/router/reconciler.go
+++ b/pkg/router/reconciler.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// httpTriggerReconciler and functionReconciler replace the router's HTTPTrigger
+// and Function informers + event handlers. Both are thin: the heavy lifting (a
+// debounced full mux rebuild from the Manager cache) already lived behind the
+// updateRouterRequestChannel, so each reconcile just performs its per-object
+// side effect (ingress reconciliation / resolver-cache invalidation) and signals
+// a rebuild. Many concurrent events collapse into one rebuild via the existing
+// syncDebouncer — this is the single-key coalescing pattern.
+//
+// Both are registered with GenerationChangedPredicate (via controller.Register),
+// so status-only writes are dropped: the router's own HTTPTrigger condition
+// writes and the executor's Function readiness writes do not trigger spurious
+// rebuilds, matching the old generation-based informer filters.
+
+// httpTriggerReconciler reconciles a trigger's Ingress and rebuilds the mux.
+type httpTriggerReconciler struct {
+	logger logr.Logger
+	client client.Client
+	ts     *HTTPTriggerSet
+}
+
+func (r *httpTriggerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	trigger := &fv1.HTTPTrigger{}
+	if err := r.client.Get(ctx, req.NamespacedName, trigger); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Deleted: drop any Ingress it owned (idempotent by name) and
+			// rebuild the mux without it.
+			deleteIngressByName(ctx, r.logger, req.Name, r.ts.kubeClient)
+			r.ts.syncTriggers()
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	reconcileIngress(ctx, r.logger, trigger, r.ts.kubeClient)
+	r.ts.syncTriggers()
+	return ctrl.Result{}, nil
+}
+
+// functionReconciler invalidates the resolver cache for a changed Function and
+// rebuilds the mux (function spec changes can alter routing / weights).
+type functionReconciler struct {
+	logger logr.Logger
+	client client.Client
+	ts     *HTTPTriggerSet
+}
+
+func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	fn := &fv1.Function{}
+	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Deleted: nothing to invalidate by ResourceVersion; rebuild so the
+			// function's routes drop out.
+			r.ts.syncTriggers()
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	if r.ts.resolver != nil {
+		r.ts.resolver.invalidateForFunction(fn.Namespace, fn.Name, fn.ResourceVersion)
+	}
+	r.ts.syncTriggers()
+	return ctrl.Result{}, nil
+}

--- a/pkg/router/reconciler_test.go
+++ b/pkg/router/reconciler_test.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"testing"
+	"time"
+
+	"github.com/bep/debounce"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+func newReconcilerTS(t *testing.T, crObjs ...client.Object) (*HTTPTriggerSet, client.Client, *k8sfake.Clientset) {
+	t.Helper()
+	logger := loggerfactory.GetLogger()
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(crObjs...).Build()
+	kc := k8sfake.NewClientset()
+	ts := &HTTPTriggerSet{
+		logger:                     logger,
+		kubeClient:                 kc,
+		client:                     cl,
+		updateRouterRequestChannel: make(chan struct{}, 10),
+		syncDebouncer:              debounce.New(time.Millisecond),
+		resolver:                   makeFunctionReferenceResolver(logger, cl),
+	}
+	return ts, cl, kc
+}
+
+// requireRebuildSignal asserts the debounced syncTriggers pushed a rebuild
+// request onto the channel.
+func requireRebuildSignal(t *testing.T, ts *HTTPTriggerSet) {
+	t.Helper()
+	select {
+	case <-ts.updateRouterRequestChannel:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("expected a mux rebuild signal, got none")
+	}
+}
+
+func TestHTTPTriggerReconcilerIngressLifecycle(t *testing.T) {
+	trigger := &fv1.HTTPTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "t1", Namespace: "default"},
+		Spec: fv1.HTTPTriggerSpec{
+			CreateIngress: true,
+			RelativeURL:   "/t1",
+			Methods:       []string{"GET"},
+		},
+	}
+	ts, cl, kc := newReconcilerTS(t, trigger)
+	r := &httpTriggerReconciler{logger: ts.logger, client: cl, ts: ts}
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "t1", Namespace: "default"}}
+
+	// Present + CreateIngress -> ingress created, rebuild signalled.
+	_, err := r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	_, err = kc.NetworkingV1().Ingresses(podNamespace).Get(t.Context(), "t1", metav1.GetOptions{})
+	require.NoError(t, err, "ingress must be created for a CreateIngress trigger")
+	requireRebuildSignal(t, ts)
+
+	// Deleted -> ingress removed, rebuild signalled.
+	require.NoError(t, cl.Delete(t.Context(), trigger))
+	_, err = r.Reconcile(t.Context(), req)
+	require.NoError(t, err)
+	_, err = kc.NetworkingV1().Ingresses(podNamespace).Get(t.Context(), "t1", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "ingress must be removed when the trigger is deleted")
+	requireRebuildSignal(t, ts)
+}
+
+func TestHTTPTriggerReconcilerNoIngressStillRebuilds(t *testing.T) {
+	trigger := &fv1.HTTPTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "t2", Namespace: "default"},
+		Spec:       fv1.HTTPTriggerSpec{RelativeURL: "/t2", Methods: []string{"GET"}},
+	}
+	ts, cl, kc := newReconcilerTS(t, trigger)
+	r := &httpTriggerReconciler{logger: ts.logger, client: cl, ts: ts}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "t2", Namespace: "default"}})
+	require.NoError(t, err)
+	_, err = kc.NetworkingV1().Ingresses(podNamespace).Get(t.Context(), "t2", metav1.GetOptions{})
+	assert.True(t, apierrors.IsNotFound(err), "no ingress should exist for a non-CreateIngress trigger")
+	requireRebuildSignal(t, ts)
+}
+
+func TestFunctionReconcilerInvalidatesAndRebuilds(t *testing.T) {
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn1", Namespace: "default", ResourceVersion: "5"}}
+	ts, cl, _ := newReconcilerTS(t, fn)
+	r := &functionReconciler{logger: ts.logger, client: cl, ts: ts}
+
+	// Seed a resolver entry that references fn1 at an older ResourceVersion.
+	ts.resolver.refCache.Upsert(
+		namespacedTriggerReference{namespace: "default", triggerName: "trig", triggerResourceVersion: "1"},
+		resolveResult{
+			resolveResultType: resolveResultSingleFunction,
+			functionMap:       map[string]*fv1.Function{"fn1": {ObjectMeta: metav1.ObjectMeta{Name: "fn1", Namespace: "default", ResourceVersion: "4"}}},
+		},
+	)
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "fn1", Namespace: "default"}})
+	require.NoError(t, err)
+
+	_, gerr := ts.resolver.refCache.Get(namespacedTriggerReference{namespace: "default", triggerName: "trig", triggerResourceVersion: "1"})
+	assert.Error(t, gerr, "stale resolver entry must be invalidated when the function changes")
+	requireRebuildSignal(t, ts)
+}
+
+func TestFunctionReconcilerDeletedRebuilds(t *testing.T) {
+	ts, cl, _ := newReconcilerTS(t)
+	r := &functionReconciler{logger: ts.logger, client: cl, ts: ts}
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "gone", Namespace: "default"}})
+	require.NoError(t, err)
+	requireRebuildSignal(t, ts)
+}
+
+func TestResolverResolveByNameViaCache(t *testing.T) {
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "default"}}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(fn).Build()
+	frr := makeFunctionReferenceResolver(loggerfactory.GetLogger(), cl)
+
+	trigger := fv1.HTTPTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "t", Namespace: "default", ResourceVersion: "1"},
+		Spec: fv1.HTTPTriggerSpec{
+			FunctionReference: fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "hello"},
+		},
+	}
+	rr, err := frr.resolve(t.Context(), trigger)
+	require.NoError(t, err)
+	require.NotNil(t, rr.functionMap["hello"])
+	assert.Equal(t, "hello", rr.functionMap["hello"].Name)
+
+	// Missing function resolves to an error.
+	missing := trigger
+	missing.Spec.FunctionReference.Name = "nope"
+	missing.ResourceVersion = "2"
+	_, err = frr.resolve(t.Context(), missing)
+	assert.Error(t, err)
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -45,11 +45,14 @@ import (
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/crd"
 	eclient "github.com/fission/fission/pkg/executor/client"
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/throttler"
+	"github.com/fission/fission/pkg/utils/crmanager"
 	"github.com/fission/fission/pkg/utils/httpsecurity"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	fissionmetrics "github.com/fission/fission/pkg/utils/metrics"
@@ -279,24 +282,13 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return fmt.Errorf("failed to parse USE_ENCODED_PATH: %w", err)
 	}
 
-	triggers, err := makeHTTPTriggerSet(logger.WithName("triggerset"), fmap, fissionClient, kubeClient, executor, &tsRoundTripperParams{
-		timeout:           timeout,
-		timeoutExponent:   timeoutExponent,
-		disableKeepAlive:  disableKeepAlive,
-		keepAliveTime:     keepAliveTime,
-		maxRetries:        maxRetries,
-		svcAddrRetryCount: svcAddrRetryCount,
-	}, isDebugEnv, useEncodedPath, unTapServiceTimeout, throttler.MakeThrottler(svcAddrUpdateTimeout))
-	if err != nil {
-		return fmt.Errorf("error making HTTP trigger set: %w", err)
-	}
-
 	// The router runs under a controller-runtime Manager for lifecycle
-	// consistency with the rest of the control plane and to set up the future
-	// HTTPTrigger Reconciler. It is stateless and replica-independent, so it
-	// uses NO leader election (every replica serves). The Manager owns the
-	// metrics server and graceful shutdown; /healthz + /readyz stay on the
-	// public listener, so the Manager's own health server is disabled.
+	// consistency with the rest of the control plane and to host the HTTPTrigger
+	// + Function reconcilers. It is stateless and replica-independent, so it
+	// uses NO leader election (every replica serves and reconciles its own mux).
+	// The Manager owns the metrics server and graceful shutdown; /router-healthz
+	// + /readyz stay on the public listener, so the Manager's own health
+	// server is disabled.
 	var alreadyRegistered prometheus.AlreadyRegisteredError
 	if err := ctrlmetrics.Registry.Register(fissionmetrics.Registry); err != nil && !errors.As(err, &alreadyRegistered) {
 		logger.Error(err, "failed to register fission metrics collectors")
@@ -309,7 +301,13 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	}
 
 	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:                 scheme.Scheme,
+		Scheme: scheme.Scheme,
+		// Scope the shared cache to the Fission-watched namespaces. The
+		// reconcilers and updateRouter read HTTPTriggers + Functions through it,
+		// and the router's RBAC is per-namespace Roles (not a ClusterRole) — a
+		// cluster-wide cache's list/watch is forbidden, so its sync would time out
+		// and the manager would exit. See crmanager.FissionCacheOptions.
+		Cache:                  crmanager.FissionCacheOptions(),
 		Metrics:                metricsserver.Options{BindAddress: metricsBind},
 		HealthProbeBindAddress: "0", // /router-healthz + /readyz stay on the public listener
 		LeaderElection:         false,
@@ -319,10 +317,36 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return fmt.Errorf("unable to set up router manager: %w", err)
 	}
 
+	triggers, err := makeHTTPTriggerSet(logger.WithName("triggerset"), fmap, fissionClient, kubeClient, crMgr.GetClient(), executor, &tsRoundTripperParams{
+		timeout:           timeout,
+		timeoutExponent:   timeoutExponent,
+		disableKeepAlive:  disableKeepAlive,
+		keepAliveTime:     keepAliveTime,
+		maxRetries:        maxRetries,
+		svcAddrRetryCount: svcAddrRetryCount,
+	}, isDebugEnv, useEncodedPath, unTapServiceTimeout, throttler.MakeThrottler(svcAddrUpdateTimeout))
+	if err != nil {
+		return fmt.Errorf("error making HTTP trigger set: %w", err)
+	}
+
+	// Register the trigger + function reconcilers. Each signals a debounced mux
+	// rebuild; GenerationChangedPredicate drops status-only writes so the
+	// router's own HTTPTrigger condition writes don't loop.
+	if err := controller.Register(crMgr, &fv1.HTTPTrigger{},
+		&httpTriggerReconciler{logger: logger.WithName("httptrigger_reconciler"), client: crMgr.GetClient(), ts: triggers},
+		"router-httptrigger"); err != nil {
+		return fmt.Errorf("error registering httptrigger reconciler: %w", err)
+	}
+	if err := controller.Register(crMgr, &fv1.Function{},
+		&functionReconciler{logger: logger.WithName("function_reconciler"), client: crMgr.GetClient(), ts: triggers},
+		"router-function"); err != nil {
+		return fmt.Errorf("error registering function reconciler: %w", err)
+	}
+
 	logger.Info("starting router", "port", port, "internalPort", internalPort)
 
-	// The trigger watching + the public/internal listeners run on an internal
-	// GroupManager, hosted by a single Manager runnable.
+	// The public/internal listeners run on an internal GroupManager, hosted by a
+	// single Manager runnable.
 	err = crMgr.Add(runnableFunc(func(rctx context.Context) error {
 		gm := &errgroup.Group{}
 		tracer := otel.Tracer("router")
@@ -330,6 +354,13 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		defer span.End()
 		if err := serve(rctx, logger, gm, port, internalPort, triggers); err != nil {
 			return err
+		}
+		// Kick the initial mux build once the cache has synced, so router-owned
+		// routes (healthz/version/auth) are installed even with zero triggers.
+		// The reconcilers also fire for every existing object; the debouncer
+		// coalesces these into a single rebuild.
+		if crMgr.GetCache().WaitForCacheSync(rctx) {
+			triggers.syncTriggers()
 		}
 		<-rctx.Done()
 		_ = gm.Wait()


### PR DESCRIPTION
## What

Migrates the **router**'s HTTPTrigger + Function informers (and their event
handlers) to native controller-runtime reconcilers on the router's existing
non-leader Manager. The request-serving path is untouched — `buildMuxes`, the
`functionHandler` proxy, the atomic mux swap, and the public/internal listeners
are unchanged. Only the rebuild **trigger** (informers → reconcilers) and the
**reads** (informer stores → Manager cache) change.

## Changes

- **`reconciler.go` (new)** — `httpTriggerReconciler` reconciles a trigger's
  Ingress (level-based: ensure on `CreateIngress`, delete otherwise; idempotent
  by name on the delete path) and signals a mux rebuild. `functionReconciler`
  invalidates the resolver cache for a changed Function and signals a rebuild.
  Both are thin: the debounced full rebuild already lived behind
  `updateRouterRequestChannel`, so many events coalesce into one rebuild
  (single-key coalescing). Registered with `GenerationChangedPredicate` so
  status-only writes (the router's own HTTPTrigger conditions, the executor's
  Function readiness) don't loop — matching the old generation-based filters.
- **`httpTriggers.go`** — drop the informer maps + `addTrigger/FunctionHandlers`;
  `updateRouter` lists from the Manager cache; the resolver reads Functions
  through the cache-backed client (build-time, still in-memory). Readiness is
  gated on a `ready` flag flipped after the first successful mux build.
- **`router.go`** — the Manager sets `Cache: crmanager.FissionCacheOptions()`.
  Router RBAC is **per-namespace Roles**, so a cluster-wide cache's list/watch
  would be forbidden and the manager would crashloop on cache-sync timeout (the
  lesson from the buildermgr B2 migration). The reconcilers are registered, and
  the initial mux build is kicked off once the cache syncs so router-owned
  routes are installed even with zero triggers.
- **`ingress.go`** — edge-based create/update/delete become level-based
  `reconcileIngress` + idempotent `deleteIngressByName`.

## Notes

- **RBAC unchanged** — `httptriggers` + `functions` list/watch and
  `httptriggers/status` are already granted.
- **Readiness/liveness** verified against the chart: liveness `/router-healthz`
  has `initialDelaySeconds: 35` and readiness `/readyz` tolerates ~30s, both
  comfortably covering cache-sync + first build.
- Non-leader (every replica serves + reconciles its own mux) — unchanged.

## Tests

New unit tests: reconcilers (ingress lifecycle, rebuild signalling, resolver
invalidation), resolve-via-cache, and the readiness gate. Local gates green:
`go build ./...`, `golangci-lint` (0 issues), `make license-check`,
`go test -race`, integration compiles. The common integration suite is the
end-to-end router test (every invocation routes through it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3429)
<!-- Reviewable:end -->
