### PR TITLE
feat: RFC-0005 WS3 (D/poolmgr) — pool manager Function reconciler

### DIFF
--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -27,7 +27,6 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/executor/fscache"
 	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	flisterv1 "github.com/fission/fission/pkg/generated/listers/core/v1"
@@ -86,14 +85,10 @@ func NewPoolPodController(ctx context.Context, logger logr.Logger,
 			}
 		}
 	}
-	for _, factory := range finformerFactory {
-		_, err := factory.Core().V1().Functions().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			DeleteFunc: p.handleFuncDelete,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
+	// Function deletion (marking the fsCache entry deleted so the reaper recycles
+	// specialized pods) is now a controller-runtime reconciler on the executor
+	// Manager (see reconciler.go). The Environment + ReplicaSet watches below stay
+	// on informers for now.
 	for ns, informer := range finformerFactory {
 		_, err := informer.Core().V1().Environments().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
 			AddFunc:    p.enqueueEnvAdd,
@@ -131,11 +126,6 @@ func IsPodActive(p *v1.Pod) bool {
 	return v1.PodSucceeded != p.Status.Phase &&
 		v1.PodFailed != p.Status.Phase &&
 		p.DeletionTimestamp == nil
-}
-
-func (p *PoolPodController) handleFuncDelete(obj any) {
-	fn := obj.(*fv1.Function)
-	p.gpm.fsCache.MarkFuncDeleted(crd.CacheKeyURGFromMeta(&fn.ObjectMeta))
 }
 
 func (p *PoolPodController) processRS(rs *apps.ReplicaSet) {

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -33,12 +33,12 @@ func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyURG) {
 // the fsCache when the Function is removed, so the idle reaper recycles its
 // specialized pods. It replaces poolpodcontroller's Function delete handler.
 //
-// MarkFuncDeleted keys on the function's UID+ResourceVersion+Generation, which a
-// reconciler does not have once the live object is gone, so the reconciler keeps
-// the last-seen Function per key. It watches every event (no
-// GenerationChangedPredicate) so the cached copy carries the latest
-// ResourceVersion that MarkFuncDeleted needs — the cost is a cheap cache store
-// per function event.
+// MarkFuncDeleted matches fsCache entries by the function's UID (and records its
+// Generation), which a reconciler does not have once the live object is gone, so
+// the reconciler keeps the last-seen Function per key to supply it on delete.
+// GenerationChangedPredicate is fine: the UID is stable and the Generation is
+// captured on every spec change, and the executor's own status writes (which
+// leave Generation unchanged) don't need to churn the cache.
 //
 // Note: the environment (pool lifecycle), replicaset, and specialized-pod
 // cleanup watches remain on poolpodcontroller's informers — they are k8s-native
@@ -81,5 +81,5 @@ func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
 		client:  mgr.GetClient(),
 		deleter: gpm,
 	}
-	return controller.RegisterWithPredicates(mgr, &fv1.Function{}, r, "poolmgr-function", 0)
+	return controller.Register(mgr, &fv1.Function{}, r, "poolmgr-function")
 }

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -4,11 +4,75 @@
 
 package poolmgr
 
-import ctrl "sigs.k8s.io/controller-runtime"
+import (
+	"context"
+	"sync"
 
-// RegisterReconcilers is a no-op: the pool manager still drives off informer
-// event handlers (poolpodcontroller + readyPodController). It migrates to
-// controller-runtime reconcilers in a later WS3 step.
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller"
+	"github.com/fission/fission/pkg/crd"
+)
+
+// funcDeleter is the slice of *GenericPoolManager the reconciler needs — an
+// interface so the delete routing is unit-testable with a fake.
+type funcDeleter interface {
+	markFuncDeleted(crd.CacheKeyURG)
+}
+
+// markFuncDeleted marks a function's pool service entries deleted in the fsCache.
+func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyURG) {
+	gpm.fsCache.MarkFuncDeleted(key)
+}
+
+// functionReconciler marks a function's pool-manager service entries deleted in
+// the fsCache when the Function is removed, so the idle reaper recycles its
+// specialized pods. It replaces poolpodcontroller's Function delete handler.
+//
+// MarkFuncDeleted keys on the function's UID+ResourceVersion+Generation, which a
+// reconciler does not have once the live object is gone, so the reconciler keeps
+// the last-seen Function per key. It watches every event (no
+// GenerationChangedPredicate) so the cached copy carries the latest
+// ResourceVersion that MarkFuncDeleted needs — the cost is a cheap cache store
+// per function event.
+//
+// Note: the environment (pool lifecycle), replicaset, and specialized-pod
+// cleanup watches remain on poolpodcontroller's informers — they are k8s-native
+// pod machinery tightly coupled to the gpm actor, migrated in a later step.
+type functionReconciler struct {
+	logger   logr.Logger
+	client   client.Client
+	deleter  funcDeleter
+	lastSeen sync.Map // client.ObjectKey -> *fv1.Function
+}
+
+func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	fn := &fv1.Function{}
+	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
+		if apierrors.IsNotFound(err) {
+			if old, ok := r.lastSeen.LoadAndDelete(req.NamespacedName); ok {
+				r.deleter.markFuncDeleted(crd.CacheKeyURGFromMeta(&old.(*fv1.Function).ObjectMeta))
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
+	return ctrl.Result{}, nil
+}
+
+// RegisterReconcilers registers the pool manager's Function reconciler on the
+// executor Manager. The environment, replicaset, and specialized-pod-cleanup
+// watches remain on poolpodcontroller's informers for now.
 func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
-	return nil
+	r := &functionReconciler{
+		logger:  gpm.logger.WithName("function_reconciler"),
+		client:  mgr.GetClient(),
+		deleter: gpm,
+	}
+	return controller.RegisterWithPredicates(mgr, &fv1.Function{}, r, "poolmgr-function", 0)
 }

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -61,6 +61,13 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		return ctrl.Result{}, err
 	}
+	// A delete followed by a quick recreate of the same name can coalesce into a
+	// single reconcile (the workqueue only carries namespace/name): if the cached
+	// function has a different UID, mark the old one deleted before caching the
+	// new one, so its fsCache entry isn't orphaned and its pods are reaped.
+	if old, ok := r.lastSeen.Load(req.NamespacedName); ok && old.(*fv1.Function).UID != fn.UID {
+		r.deleter.markFuncDeleted(crd.CacheKeyURGFromMeta(&old.(*fv1.Function).ObjectMeta))
+	}
 	r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
 	return ctrl.Result{}, nil
 }

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package poolmgr
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/crd"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
+)
+
+type fakeDeleter struct{ deleted []crd.CacheKeyURG }
+
+func (f *fakeDeleter) markFuncDeleted(k crd.CacheKeyURG) { f.deleted = append(f.deleted, k) }
+
+func crClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
+}
+
+func TestPoolmgrFunctionReconciler(t *testing.T) {
+	key := types.NamespacedName{Name: "fn", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "default", UID: "u1", ResourceVersion: "9", Generation: 2}}
+
+	t.Run("existing function is cached, not marked deleted", func(t *testing.T) {
+		d := &fakeDeleter{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(fn), deleter: d}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, d.deleted)
+		_, cached := r.lastSeen.Load(key)
+		assert.True(t, cached, "live function must be cached so its URG is available on delete")
+	})
+
+	t.Run("deleted function is marked deleted with its cached URG", func(t *testing.T) {
+		d := &fakeDeleter{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(), deleter: d} // empty client -> NotFound
+		r.lastSeen.Store(key, fn.DeepCopy())
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		require.Len(t, d.deleted, 1)
+		assert.Equal(t, crd.CacheKeyURGFromMeta(&fn.ObjectMeta), d.deleted[0])
+		_, cached := r.lastSeen.Load(key)
+		assert.False(t, cached)
+	})
+
+	t.Run("delete of an unseen function is a no-op", func(t *testing.T) {
+		d := &fakeDeleter{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(), deleter: d}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, d.deleted)
+	})
+}

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -63,4 +63,17 @@ func TestPoolmgrFunctionReconciler(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, d.deleted)
 	})
+
+	t.Run("delete+recreate with a new UID marks the old UID deleted", func(t *testing.T) {
+		d := &fakeDeleter{}
+		recreated := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "default", UID: "u2", ResourceVersion: "3", Generation: 1}}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(recreated), deleter: d}
+		r.lastSeen.Store(key, fn.DeepCopy()) // old UID u1
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		require.Len(t, d.deleted, 1)
+		assert.Equal(t, crd.CacheKeyURGFromMeta(&fn.ObjectMeta), d.deleted[0], "old UID must be marked deleted")
+		cached, _ := r.lastSeen.Load(key)
+		assert.Equal(t, recreated.UID, cached.(*fv1.Function).UID, "cache now holds the recreated function")
+	})
 }


### PR DESCRIPTION
> **Stacked on #3431** (`ws3-executor-deployexec`). Review/merge that first; this PR's diff is poolmgr-only.

## What

Migrates the **pool manager's Function-delete watch** from `poolpodcontroller`'s
informer handler to a controller-runtime reconciler on the executor Manager.
Together with #3431 (container), the container and pool-manager Function watches
are now reconcilers (newdeploy is descoped to a later PR — see #3431).

`handleFuncDelete` marked the function's `fsCache` entry deleted (so the idle
reaper recycles its specialized pods). `MarkFuncDeleted` matches entries by the
function's **UID** (and records its **Generation**) — not ResourceVersion. A
reconciler has no live object on a delete, so it keeps a **last-seen Function**
per key to supply that UID/Generation. `GenerationChangedPredicate` (the
repository default via `controller.Register`) is therefore sufficient: the UID is
stable and the Generation is captured on every spec change, while the executor's
own status writes (Generation unchanged) don't need to churn the cache.

## Scope (deliberately bounded)

This is the **cleanly-separable Function watch only**. The **Environment** (pool
lifecycle), **ReplicaSet**, and **specialized-pod-cleanup** watches — plus the
**gpm actor** and **readyPodController** — remain on `poolpodcontroller`'s
informers. They are k8s-native pod machinery tightly coupled to the gpm actor
(the env-delete path *feeds* the specialized-pod-cleanup queue), and warrant a
dedicated, review-driven PR rather than an unsupervised pass on the **default
executor**. `poolpodcontroller` keeps running for those.

## Tests

Delete routing is unit-tested via a `funcDeleter` interface (the fake records the
URG passed to `markFuncDeleted`). Local gates green: `go build ./...`,
`golangci-lint` (0 issues), `make license-check`, `go test -race` across the
executor packages, and the **in-process e2e suite** (`test/e2e/cli` +
`test/e2e/fetcher`) — which starts the executor with the new reconciler.

## Remaining executor work (a future PR)

The Environment pool-lifecycle reconciler (`getPool`/`cleanupPool`/
`updatePoolDeployment`), the ReplicaSet → specialized-pod-cleanup flow, the
`readyPodController`, and the gpm channel-RPC actor. These are the most intricate
+ highest-blast-radius pieces and should be migrated with review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3432)
<!-- Reviewable:end -->

