### PR TITLE
feat: RFC-0005 WS3 (D/poolmgr-lifecycle) — poolmgr Environment + Function reconcilers

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -513,8 +513,10 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	}
 
 	// Each executor type registers its Function/Environment reconcilers on the
-	// Manager (replacing its informer event handlers). Types still on the
-	// informer-handler path (newdeploy and poolmgr) return nil.
+	// Manager (replacing its informer event handlers): container (Function),
+	// newdeploy (Function + Environment), poolmgr (Function + Environment). The
+	// remaining poolmgr watches (ReplicaSet → specialized-pod cleanup) stay on
+	// poolpodcontroller's informers.
 	for _, et := range executorTypes {
 		if err := et.RegisterReconcilers(crMgr); err != nil {
 			return fmt.Errorf("error registering reconcilers for executor type %s: %w", et.GetTypeName(ctx), err)

--- a/pkg/executor/executortype/poolmgr/funchandlers.go
+++ b/pkg/executor/executortype/poolmgr/funchandlers.go
@@ -11,10 +11,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/kubernetes"
-	k8sCache "k8s.io/client-go/tools/cache"
-
-	"github.com/go-logr/logr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/utils"
@@ -26,100 +22,73 @@ func getIstioServiceLabels(fnName string) map[string]string {
 	}
 }
 
-// FunctionEventHandlers provides handlers for function resource events.
-// Based on function create/update/delete event, we create role binding
-// for the secret/configmap access which is used by fetcher component.
-// If istio is enabled, we create a service for the function.
-func FunctionEventHandlers(ctx context.Context, logger logr.Logger, kubernetesClient kubernetes.Interface, fissionfnNamespace string, istioEnabled bool) k8sCache.ResourceEventHandlerFuncs {
-	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			fn := obj.(*fv1.Function)
+// createIstioServiceForFunction creates the per-function ClusterIP Service that
+// istio needs (istio only routes traffic through k8s services, so a poolmgr
+// function — whose pod lives in the warm pool — needs a stable service in front
+// of it). It is idempotent: an already-existing service is treated as success.
+// Driven by the Function reconciler on create; replaces the old istio AddFunc
+// handler.
+func (gpm *GenericPoolManager) createIstioServiceForFunction(ctx context.Context, fn *fv1.Function) error {
+	sel := map[string]string{
+		"functionName": fn.Name,
+		"functionUid":  string(fn.UID),
+	}
+	svcName := utils.GetFunctionIstioServiceName(fn.Name, fn.Namespace)
+	envNs := gpm.nsResolver.GetFunctionNS(fn.Spec.Environment.Namespace)
 
-			// Since istio only allows accessing pod through k8s service,
-			// for the functions with executor type "poolmgr" we need to
-			// create a service for sending requests to pod in pool.
-			// Functions with executor type "Newdeploy" is specialized at
-			// pod starts. In this case, just ignore such functions.
-			fnExecutorType := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
-
-			// In some cases, user may not enter the executorType explicitly, for example in his spec.yaml.
-			// we assume it to be of type poolmgr
-			if fnExecutorType != "" && fnExecutorType != fv1.ExecutorTypePoolmgr {
-				return
-			}
-
-			if istioEnabled {
-				// create a same name service for function
-				// since istio only allows the traffic to service
-				sel := map[string]string{
-					"functionName": fn.Name,
-					"functionUid":  string(fn.UID),
-				}
-
-				svcName := utils.GetFunctionIstioServiceName(fn.Name, fn.Namespace)
-				envNs := utils.DefaultNSResolver().GetFunctionNS(fn.Spec.Environment.Namespace)
-
-				// service for accepting user traffic
-				svc := apiv1.Service{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: envNs,
-						Name:      svcName,
-						Labels:    getIstioServiceLabels(fn.Name),
-					},
-					Spec: apiv1.ServiceSpec{
-						Type: apiv1.ServiceTypeClusterIP,
-						Ports: []apiv1.ServicePort{
-							// Service port name should begin with a recognized prefix, or the traffic will be
-							// treated as TCP traffic. (https://istio.io/docs/setup/kubernetes/additional-setup/requirements/)
-							{
-								Name:       "http-fetcher",
-								Protocol:   apiv1.ProtocolTCP,
-								Port:       8000,
-								TargetPort: intstr.FromInt(8000),
-							},
-							{
-								Name:       "http-env",
-								Protocol:   apiv1.ProtocolTCP,
-								Port:       8888,
-								TargetPort: intstr.FromInt(8888),
-							},
-						},
-						Selector: sel,
-					},
-				}
-
-				// create function istio service if it does not exist
-				_, err := kubernetesClient.CoreV1().Services(envNs).Create(ctx, &svc, metav1.CreateOptions{})
-				if err != nil && !kerrors.IsAlreadyExists(err) {
-					logger.Error(err, "error creating istio service for function",
-						"service_name", svcName,
-						"function_name", fn.Name,
-						"selectors", sel)
-				}
-			}
+	svc := apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: envNs,
+			Name:      svcName,
+			Labels:    getIstioServiceLabels(fn.Name),
 		},
-
-		DeleteFunc: func(obj any) {
-			fn := obj.(*fv1.Function)
-
-			fnExecutorType := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
-			if fnExecutorType != "" && fnExecutorType != fv1.ExecutorTypePoolmgr {
-				return
-			}
-
-			if istioEnabled {
-				envNs := utils.DefaultNSResolver().GetFunctionNS(fn.Spec.Environment.Namespace)
-
-				svcName := utils.GetFunctionIstioServiceName(fn.Name, fn.Namespace)
-				// delete function istio service
-				err := kubernetesClient.CoreV1().Services(envNs).Delete(ctx, svcName, metav1.DeleteOptions{})
-				if err != nil && !kerrors.IsNotFound(err) {
-					logger.Error(err, "error deleting istio service for function", "service_name", svcName,
-						"function_name", fn.Name)
-
-				}
-			}
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				// Service port name should begin with a recognized prefix, or the traffic will be
+				// treated as TCP traffic. (https://istio.io/docs/setup/kubernetes/additional-setup/requirements/)
+				{
+					Name:       "http-fetcher",
+					Protocol:   apiv1.ProtocolTCP,
+					Port:       8000,
+					TargetPort: intstr.FromInt(8000),
+				},
+				{
+					Name:       "http-env",
+					Protocol:   apiv1.ProtocolTCP,
+					Port:       8888,
+					TargetPort: intstr.FromInt(8888),
+				},
+			},
+			Selector: sel,
 		},
 	}
 
+	_, err := gpm.kubernetesClient.CoreV1().Services(envNs).Create(ctx, &svc, metav1.CreateOptions{})
+	if err != nil && !kerrors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// deleteIstioServiceForFunction removes the per-function istio Service. Idempotent
+// (a missing service is success). Driven by the Function reconciler on delete;
+// replaces the old istio DeleteFunc handler.
+func (gpm *GenericPoolManager) deleteIstioServiceForFunction(ctx context.Context, fn *fv1.Function) error {
+	envNs := gpm.nsResolver.GetFunctionNS(fn.Spec.Environment.Namespace)
+	svcName := utils.GetFunctionIstioServiceName(fn.Name, fn.Namespace)
+	err := gpm.kubernetesClient.CoreV1().Services(envNs).Delete(ctx, svcName, metav1.DeleteOptions{})
+	if err != nil && !kerrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// refreshFuncPods deletes the function's specialized pods so the next request
+// re-specializes a warm pod with the function's current package/config. The
+// Function reconciler calls it on a spec change: poolmgr otherwise has no
+// function-update path, so a stale specialized pod (old package) could keep being
+// routed to until the idle reaper happens to recycle it.
+func (gpm *GenericPoolManager) refreshFuncPods(ctx context.Context, fn *fv1.Function) error {
+	return gpm.RefreshFuncPods(ctx, gpm.logger, *fn)
 }

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -28,6 +28,7 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	k8sCache "k8s.io/client-go/tools/cache"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 
@@ -72,6 +73,11 @@ type (
 		fsCache        *fscache.FunctionServiceCache
 		instanceID     string
 		requestChannel chan *request
+
+		// crClient is the executor Manager's cache-backed client, used by
+		// getFunctionEnv to resolve a function's Environment (replacing
+		// poolpodcontroller's informer lister). Set in RegisterReconcilers.
+		crClient client.Client
 
 		enableIstio   bool
 		fetcherConfig *fetcherConfig.Config
@@ -125,8 +131,7 @@ func MakeGenericPoolManager(ctx context.Context,
 		enableIstio = istio
 	}
 
-	poolPodC, err := NewPoolPodController(ctx, gpmLogger, kubernetesClient,
-		enableIstio, finformerFactory, gpmInformerFactory)
+	poolPodC, err := NewPoolPodController(ctx, gpmLogger, kubernetesClient, gpmInformerFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -573,6 +578,49 @@ func (gpm *GenericPoolManager) cleanupPool(ctx context.Context, env *fv1.Environ
 	}
 }
 
+// markFuncDeleted marks a function's pool service entries deleted in the fsCache
+// so the idle reaper recycles its specialized pods. Driven by the Function
+// reconciler on delete.
+func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyURG) {
+	gpm.fsCache.MarkFuncDeleted(key)
+}
+
+// reconcileEnvPool brings an environment's warm pool to its desired state:
+// ensure the pool exists, destroy it if the pool size is zero, otherwise update
+// the pool deployment. Driven by the Environment reconciler on create/update
+// (replacing poolpodcontroller's envCreateUpdateQueue handler).
+func (gpm *GenericPoolManager) reconcileEnvPool(ctx context.Context, env *fv1.Environment) error {
+	log := gpm.logger.WithValues("env", env.Name, "namespace", env.Namespace)
+	pool, created, err := gpm.getPool(ctx, env)
+	if err != nil {
+		return err
+	}
+	if created {
+		log.Info("created pool for the environment")
+		return nil
+	}
+	if getEnvPoolSize(env) == 0 {
+		log.Info("pool size is zero, cleaning up pool")
+		gpm.cleanupPool(ctx, env)
+		return nil
+	}
+	if err := pool.updatePoolDeployment(ctx, env); err != nil {
+		return err
+	}
+	// Any specialized pods are recycled by the ReplicaSet → cleanup path.
+	return nil
+}
+
+// cleanupEnvPool destroys an environment's pool and reaps its specialized pods.
+// Driven by the Environment reconciler on delete (replacing the envDeleteQueue
+// handler); it uses the last-seen Environment since the live object is gone.
+func (gpm *GenericPoolManager) cleanupEnvPool(ctx context.Context, env *fv1.Environment) {
+	gpm.logger.V(1).Info("env delete: destroying pool and reaping specialized pods",
+		"env", env.Name, "namespace", env.Namespace)
+	gpm.cleanupPool(ctx, env)
+	gpm.poolPodC.cleanupSpecializedPodsForEnv(ctx, env)
+}
+
 func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Function) (*fv1.Environment, error) {
 	var env *fv1.Environment
 	otelUtils.SpanTrackEvent(ctx, "getFunctionEnv", otelUtils.GetAttributesForFunction(fn)...)
@@ -593,12 +641,12 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 		return result, nil
 	}
 
-	// Get env from controller
-	envLister, err := gpm.poolPodC.getEnvLister(fn.Spec.Environment.Namespace)
-	if err != nil {
-		return nil, err
-	}
-	env, err = envLister.Environments(fn.Spec.Environment.Namespace).Get(fn.Spec.Environment.Name)
+	// Resolve the environment from the executor Manager cache.
+	env = &fv1.Environment{}
+	err = gpm.crClient.Get(ctx, client.ObjectKey{
+		Namespace: fn.Spec.Environment.Namespace,
+		Name:      fn.Spec.Environment.Name,
+	}, env)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -6,7 +6,6 @@ package poolmgr
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -28,29 +27,26 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
-	flisterv1 "github.com/fission/fission/pkg/generated/listers/core/v1"
 	"github.com/fission/fission/pkg/utils"
 )
 
+// PoolPodController watches ReplicaSets and reaps a pool's specialized pods when
+// the pool scales to zero (a ReplicaSet with zero replicas) or its Environment is
+// deleted. The Function and Environment watches it used to host are now
+// controller-runtime reconcilers on the executor Manager (see reconciler.go);
+// this controller keeps only the k8s-native pod machinery, which is tightly
+// coupled to the gpm actor and migrated separately.
 type (
 	PoolPodController struct {
 		logger           logr.Logger
 		kubernetesClient kubernetes.Interface
-		enableIstio      bool
 		nsResolver       *utils.NamespaceResolver
-
-		envLister       map[string]flisterv1.EnvironmentLister
-		envListerSynced map[string]k8sCache.InformerSynced
 
 		// podLister can list/get pods from the shared informer's store
 		podLister map[string]corelisters.PodLister
 
 		// podListerSynced returns true if the pod store has been synced at least once.
 		podListerSynced map[string]k8sCache.InformerSynced
-
-		envCreateUpdateQueue workqueue.TypedRateLimitingInterface[string]
-		envDeleteQueue       workqueue.TypedRateLimitingInterface[*fv1.Environment]
 
 		spCleanupPodQueue workqueue.TypedRateLimitingInterface[string]
 
@@ -60,46 +56,15 @@ type (
 
 func NewPoolPodController(ctx context.Context, logger logr.Logger,
 	kubernetesClient kubernetes.Interface,
-	enableIstio bool,
-	finformerFactory map[string]genInformer.SharedInformerFactory,
 	gpmInformerFactory map[string]k8sInformers.SharedInformerFactory) (*PoolPodController, error) {
 	logger = logger.WithName("pool_pod_controller")
 	p := &PoolPodController{
-		logger:               logger,
-		nsResolver:           utils.DefaultNSResolver(),
-		kubernetesClient:     kubernetesClient,
-		enableIstio:          enableIstio,
-		envLister:            make(map[string]flisterv1.EnvironmentLister, 0),
-		envListerSynced:      make(map[string]k8sCache.InformerSynced, 0),
-		podLister:            make(map[string]corelisters.PodLister),
-		podListerSynced:      make(map[string]k8sCache.InformerSynced),
-		envCreateUpdateQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "EnvAddUpdateQueue"}),
-		envDeleteQueue:       workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[*fv1.Environment](), workqueue.TypedRateLimitingQueueConfig[*fv1.Environment]{Name: "EnvDeleteQueue"}),
-		spCleanupPodQueue:    workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "SpecializedPodCleanupQueue"}),
-	}
-	if p.enableIstio {
-		for _, factory := range finformerFactory {
-			_, err := factory.Core().V1().Functions().Informer().AddEventHandler(FunctionEventHandlers(ctx, p.logger, p.kubernetesClient, p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace), p.enableIstio))
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-	// Function deletion (marking the fsCache entry deleted so the reaper recycles
-	// specialized pods) is now a controller-runtime reconciler on the executor
-	// Manager (see reconciler.go). The Environment + ReplicaSet watches below stay
-	// on informers for now.
-	for ns, informer := range finformerFactory {
-		_, err := informer.Core().V1().Environments().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			AddFunc:    p.enqueueEnvAdd,
-			UpdateFunc: p.enqueueEnvUpdate,
-			DeleteFunc: p.enqueueEnvDelete,
-		})
-		if err != nil {
-			return nil, err
-		}
-		p.envLister[ns] = informer.Core().V1().Environments().Lister()
-		p.envListerSynced[ns] = informer.Core().V1().Environments().Informer().HasSynced
+		logger:            logger,
+		nsResolver:        utils.DefaultNSResolver(),
+		kubernetesClient:  kubernetesClient,
+		podLister:         make(map[string]corelisters.PodLister),
+		podListerSynced:   make(map[string]k8sCache.InformerSynced),
+		spCleanupPodQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "SpecializedPodCleanupQueue"}),
 	}
 	for ns, informerFactory := range gpmInformerFactory {
 		_, err := informerFactory.Apps().V1().ReplicaSets().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
@@ -197,40 +162,41 @@ func (p *PoolPodController) handleRSDelete(obj any) {
 	p.processRS(rs)
 }
 
-func (p *PoolPodController) enqueueEnvAdd(obj any) {
-	key, err := k8sCache.MetaNamespaceKeyFunc(obj)
-	if err != nil {
-		p.logger.Error(nil, "error retrieving key from object in poolPodController", "obj", obj)
-		return
-	}
-	p.logger.V(1).Info("enqueue env add", "key", key)
-	p.envCreateUpdateQueue.Add(key)
-}
-
-func (p *PoolPodController) enqueueEnvUpdate(oldObj, newObj any) {
-	key, err := k8sCache.MetaNamespaceKeyFunc(newObj)
-	if err != nil {
-		p.logger.Error(nil, "error retrieving key from object in poolPodController", "obj", key)
-		return
-	}
-	p.logger.V(1).Info("enqueue env update", "key", key)
-	p.envCreateUpdateQueue.Add(key)
-}
-
-func (p *PoolPodController) enqueueEnvDelete(obj any) {
-	env, ok := obj.(*fv1.Environment)
+// cleanupSpecializedPodsForEnv enqueues an environment's specialized pods for
+// cleanup. Called by the Environment reconciler on delete (via the gpm actor's
+// cleanupEnvPool), after the warm pool itself has been destroyed.
+func (p *PoolPodController) cleanupSpecializedPodsForEnv(ctx context.Context, env *fv1.Environment) {
+	specializePodLabels := getSpecializedPodLabels(env)
+	ns := p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace)
+	podLister, ok := p.podLister[ns]
 	if !ok {
-		p.logger.Error(nil, "unexpected type when deleting env to pool pod controller", "obj", obj)
+		p.logger.Error(nil, "no pod lister found for namespace", "namespace", ns)
 		return
 	}
-	p.logger.V(1).Info("enqueue env delete", "env", env)
-	p.envDeleteQueue.Add(env)
+	specializedPods, err := podLister.Pods(ns).List(labels.SelectorFromSet(specializePodLabels))
+	if err != nil {
+		p.logger.Error(err, "failed to list specialized pods")
+		return
+	}
+	if len(specializedPods) == 0 {
+		return
+	}
+	p.logger.Info("specialized pods identified for cleanup after env delete", "env", env.Name, "namespace", env.Namespace, "count", len(specializedPods))
+	for _, pod := range specializedPods {
+		if !IsPodActive(pod) {
+			continue
+		}
+		key, err := k8sCache.MetaNamespaceKeyFunc(pod)
+		if err != nil {
+			p.logger.Error(err, "Failed to get key for pod")
+			continue
+		}
+		p.spCleanupPodQueue.Add(key)
+	}
 }
 
 func (p *PoolPodController) Run(ctx context.Context, stopCh <-chan struct{}, mgr *errgroup.Group) {
 	defer utilruntime.HandleCrash()
-	defer p.envCreateUpdateQueue.ShutDown()
-	defer p.envDeleteQueue.ShutDown()
 	defer p.spCleanupPodQueue.ShutDown()
 	// Wait for the caches to be synced before starting workers
 	p.logger.Info("Waiting for informer caches to sync")
@@ -239,25 +205,12 @@ func (p *PoolPodController) Run(ctx context.Context, stopCh <-chan struct{}, mgr
 	for _, synced := range p.podListerSynced {
 		waitSynced = append(waitSynced, synced)
 	}
-	for _, synced := range p.envListerSynced {
-		waitSynced = append(waitSynced, synced)
-	}
 	if ok := k8sCache.WaitForCacheSync(stopCh, waitSynced...); !ok {
 		// Usually means the context was cancelled (shutdown or loss of
 		// leadership). Stop cleanly instead of taking the whole process down.
 		p.logger.Info("failed to wait for caches to sync; stopping pool pod controller")
 		return
 	}
-	for range 4 {
-		mgr.Go(func() error {
-			wait.Until(p.workerRun(ctx, "envCreateUpdate", p.envCreateUpdateQueueProcessFunc), time.Second, stopCh)
-			return nil
-		})
-	}
-	mgr.Go(func() error {
-		wait.Until(p.workerRun(ctx, "envDeleteQueue", p.envDeleteQueueProcessFunc), time.Second, stopCh)
-		return nil
-	})
 	mgr.Go(func() error {
 		wait.Until(p.workerRun(ctx, "spCleanupPodQueue", p.spCleanupPodQueueProcessFunc), time.Second, stopCh)
 		return nil
@@ -277,143 +230,6 @@ func (p *PoolPodController) workerRun(ctx context.Context, name string, processF
 			}
 		}
 	}
-}
-
-func (p *PoolPodController) getEnvLister(namespace string) (flisterv1.EnvironmentLister, error) {
-	lister, ok := p.envLister[namespace]
-	if ok {
-		return lister, nil
-	}
-	for ns, lister := range p.envLister {
-		if ns == namespace {
-			return lister, nil
-		}
-	}
-	p.logger.Error(nil, "no environment lister found for namespace", "namespace", namespace)
-	return nil, fmt.Errorf("no environment lister found for namespace %s", namespace)
-}
-
-func (p *PoolPodController) envCreateUpdateQueueProcessFunc(ctx context.Context) bool {
-	maxRetries := 3
-	handleEnv := func(ctx context.Context, env *fv1.Environment) error {
-		log := p.logger.WithValues("env", env.Name, "namespace", env.Namespace)
-		log.V(1).Info("env reconsile request processing")
-		pool, created, err := p.gpm.getPool(ctx, env)
-		if err != nil {
-			log.Error(err, "error getting pool")
-			return err
-		}
-		if created {
-			log.Info("created pool for the environment")
-			return nil
-		}
-		poolsize := getEnvPoolSize(env)
-		if poolsize == 0 {
-			log.Info("pool size is zero")
-			p.gpm.cleanupPool(ctx, env)
-			return nil
-		}
-		err = pool.updatePoolDeployment(ctx, env)
-		if err != nil {
-			log.Error(err, "error updating pool")
-			return err
-		}
-		// If any specialized pods are running, those would be
-		// deleted by replicaSet controller.
-		return nil
-	}
-
-	key, quit := p.envCreateUpdateQueue.Get()
-	if quit {
-		return true
-	}
-	defer p.envCreateUpdateQueue.Done(key)
-
-	namespace, name, err := k8sCache.SplitMetaNamespaceKey(key)
-	if err != nil {
-		p.logger.Error(err, "error splitting key")
-		p.envCreateUpdateQueue.Forget(key)
-		return false
-	}
-	envLister, err := p.getEnvLister(namespace)
-	if err != nil {
-		p.logger.Error(err, "error getting environment lister")
-		p.envCreateUpdateQueue.Forget(key)
-		return false
-	}
-	env, err := envLister.Environments(namespace).Get(name)
-	if apierrors.IsNotFound(err) {
-		p.logger.Info("env not found", "key", key)
-		p.envCreateUpdateQueue.Forget(key)
-		return false
-	}
-
-	if err != nil {
-		if p.envCreateUpdateQueue.NumRequeues(key) < maxRetries {
-			p.envCreateUpdateQueue.AddRateLimited(key)
-			p.logger.Error(err, "error getting env, retrying")
-		} else {
-			p.envCreateUpdateQueue.Forget(key)
-			p.logger.Error(err, "error getting env, retrying, max retries reached")
-		}
-		return false
-	}
-
-	err = handleEnv(ctx, env)
-	if err != nil {
-		if p.envCreateUpdateQueue.NumRequeues(key) < maxRetries {
-			p.envCreateUpdateQueue.AddRateLimited(key)
-			p.logger.Error(err, "error handling env from envInformer, retrying", "key", key)
-		} else {
-			p.envCreateUpdateQueue.Forget(key)
-			p.logger.Error(err, "error handling env from envInformer, max retries reached", "key", key)
-		}
-		return false
-	}
-	p.envCreateUpdateQueue.Forget(key)
-	return false
-}
-
-func (p *PoolPodController) envDeleteQueueProcessFunc(ctx context.Context) bool {
-	env, quit := p.envDeleteQueue.Get()
-	if quit {
-		return true
-	}
-	defer p.envDeleteQueue.Done(env)
-	p.logger.V(1).Info("env delete request processing")
-	p.gpm.cleanupPool(ctx, env)
-	specializePodLables := getSpecializedPodLabels(env)
-	ns := p.nsResolver.ResolveNamespace(p.nsResolver.FunctionNamespace)
-	podLister, ok := p.podLister[ns]
-	if !ok {
-		p.logger.Error(nil, "no pod lister found for namespace", "namespace", ns)
-		p.envDeleteQueue.Forget(env)
-		return false
-	}
-	specializedPods, err := podLister.Pods(ns).List(labels.SelectorFromSet(specializePodLables))
-	if err != nil {
-		p.logger.Error(err, "failed to list specialized pods")
-		p.envDeleteQueue.Forget(env)
-		return false
-	}
-	if len(specializedPods) == 0 {
-		p.envDeleteQueue.Forget(env)
-		return false
-	}
-	p.logger.Info("specialized pods identified for cleanup after env delete", "env", env.Name, "namespace", env.Namespace, "count", len(specializedPods))
-	for _, pod := range specializedPods {
-		if !IsPodActive(pod) {
-			continue
-		}
-		key, err := k8sCache.MetaNamespaceKeyFunc(pod)
-		if err != nil {
-			p.logger.Error(err, "Failed to get key for pod")
-			continue
-		}
-		p.spCleanupPodQueue.Add(key)
-	}
-	p.envDeleteQueue.Forget(env)
-	return false
 }
 
 func (p *PoolPodController) spCleanupPodQueueProcessFunc(ctx context.Context) bool {

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
@@ -40,8 +40,7 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 	require.NoError(t, err, "Error creating labels for informer")
 	gpmInformerFactory := utils.GetInformerFactoryByExecutor(kubernetesClient, executorLabel, time.Minute*30)
 
-	ppc, err := NewPoolPodController(ctx, logger, kubernetesClient, false,
-		factory, gpmInformerFactory)
+	ppc, err := NewPoolPodController(ctx, logger, kubernetesClient, gpmInformerFactory)
 	require.NoError(t, err, "Error creating pool pod controller")
 
 	executorInstanceID := strings.ToLower(uniuri.NewLen(8))

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -7,6 +7,7 @@ package poolmgr
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -18,36 +19,56 @@ import (
 	"github.com/fission/fission/pkg/crd"
 )
 
-// funcDeleter is the slice of *GenericPoolManager the reconciler needs — an
-// interface so the delete routing is unit-testable with a fake.
-type funcDeleter interface {
+// envResyncPeriod re-reconciles each Environment periodically so the pool
+// deployment is kept in sync even without a spec change — replacing the 30m
+// informer resync the env workqueue used to get.
+const envResyncPeriod = 30 * time.Minute
+
+// funcManager is the subset of *GenericPoolManager the Function reconciler drives.
+// An interface so the reconcile routing is unit-testable with a fake.
+type funcManager interface {
 	markFuncDeleted(crd.CacheKeyURG)
+	refreshFuncPods(ctx context.Context, fn *fv1.Function) error
+	createIstioServiceForFunction(ctx context.Context, fn *fv1.Function) error
+	deleteIstioServiceForFunction(ctx context.Context, fn *fv1.Function) error
 }
 
-// markFuncDeleted marks a function's pool service entries deleted in the fsCache.
-func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyURG) {
-	gpm.fsCache.MarkFuncDeleted(key)
+// poolManager is the subset of *GenericPoolManager the Environment reconciler
+// drives (pool lifecycle), also an interface for testing.
+type poolManager interface {
+	reconcileEnvPool(ctx context.Context, env *fv1.Environment) error
+	cleanupEnvPool(ctx context.Context, env *fv1.Environment)
 }
 
-// functionReconciler marks a function's pool-manager service entries deleted in
-// the fsCache when the Function is removed, so the idle reaper recycles its
-// specialized pods. It replaces poolpodcontroller's Function delete handler.
+// isPoolmgrType reports whether the pool manager should handle this function.
+// Poolmgr is the default executor, so an empty executor type counts as poolmgr —
+// matching the old istio/handler filter (`type != "" && type != poolmgr → skip`).
+func isPoolmgrType(fn *fv1.Function) bool {
+	t := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
+	return t == "" || t == fv1.ExecutorTypePoolmgr
+}
+
+// functionReconciler manages the pool manager's per-Function concerns, replacing
+// poolpodcontroller's istio Function handler and #3432's delete-only reconciler:
 //
-// MarkFuncDeleted matches fsCache entries by the function's UID (and records its
-// Generation), which a reconciler does not have once the live object is gone, so
-// the reconciler keeps the last-seen Function per key to supply it on delete.
-// GenerationChangedPredicate is fine: the UID is stable and the Generation is
-// captured on every spec change, and the executor's own status writes (which
-// leave Generation unchanged) don't need to churn the cache.
+//   - create: create the per-function istio Service (when istio is enabled).
+//   - update: refresh (delete) the function's specialized pods so the next
+//     request re-specializes a warm pod with the new package/config. Poolmgr had
+//     no function-update path before, so a stale specialized pod (old package)
+//     could keep being routed to until the idle reaper recycled it.
+//   - delete: mark the fsCache entries deleted (so the reaper recycles pods) and
+//     remove the istio Service.
 //
-// Note: the environment (pool lifecycle), replicaset, and specialized-pod
-// cleanup watches remain on poolpodcontroller's informers — they are k8s-native
-// pod machinery tightly coupled to the gpm actor, migrated in a later step.
+// updateFunction-style diffing is unnecessary: GenerationChangedPredicate means a
+// reconcile of a cached function is always a spec change, and the istio Service is
+// keyed on the (stable) function name/uid so it only needs create/delete. The
+// last-seen Function supplies the object for cleanup once the live one is gone.
 type functionReconciler struct {
-	logger   logr.Logger
-	client   client.Client
-	deleter  funcDeleter
-	lastSeen sync.Map // client.ObjectKey -> *fv1.Function
+	logger      logr.Logger
+	client      client.Client
+	mgr         funcManager
+	enableIstio bool
+	lastSeen    sync.Map // client.ObjectKey -> *fv1.Function
 }
 
 func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -55,31 +76,130 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
 		if apierrors.IsNotFound(err) {
 			if old, ok := r.lastSeen.LoadAndDelete(req.NamespacedName); ok {
-				r.deleter.markFuncDeleted(crd.CacheKeyURGFromMeta(&old.(*fv1.Function).ObjectMeta))
+				if err := r.cleanupFunction(ctx, old.(*fv1.Function)); err != nil {
+					return ctrl.Result{}, err
+				}
 			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
 	}
-	// A delete followed by a quick recreate of the same name can coalesce into a
-	// single reconcile (the workqueue only carries namespace/name): if the cached
-	// function has a different UID, mark the old one deleted before caching the
-	// new one, so its fsCache entry isn't orphaned and its pods are reaped.
-	if old, ok := r.lastSeen.Load(req.NamespacedName); ok && old.(*fv1.Function).UID != fn.UID {
-		r.deleter.markFuncDeleted(crd.CacheKeyURGFromMeta(&old.(*fv1.Function).ObjectMeta))
+
+	old, seen := r.lastSeen.Load(req.NamespacedName)
+	if !seen {
+		// First sight. Only manage poolmgr-type functions.
+		if !isPoolmgrType(fn) {
+			return ctrl.Result{}, nil
+		}
+		if r.enableIstio {
+			if err := r.mgr.createIstioServiceForFunction(ctx, fn); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
+		return ctrl.Result{}, nil
+	}
+
+	oldFn := old.(*fv1.Function)
+	// A delete+recreate of the same name, or a switch away from poolmgr, can
+	// coalesce into one reconcile (the workqueue carries only namespace/name).
+	// If the cached function is no longer the one we should manage, clean it up.
+	if oldFn.UID != fn.UID || !isPoolmgrType(fn) {
+		if err := r.cleanupFunction(ctx, oldFn); err != nil {
+			return ctrl.Result{}, err
+		}
+		if !isPoolmgrType(fn) {
+			r.lastSeen.Delete(req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+		// New incarnation is still poolmgr: treat as a fresh create.
+		if r.enableIstio {
+			if err := r.mgr.createIstioServiceForFunction(ctx, fn); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
+		return ctrl.Result{}, nil
+	}
+
+	// Genuine spec change of a managed function: re-specialize its pods so the new
+	// package/config is served. The istio Service is keyed on the stable function
+	// name/uid, so it needs no change here.
+	if err := r.mgr.refreshFuncPods(ctx, fn); err != nil {
+		return ctrl.Result{}, err
 	}
 	r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
 	return ctrl.Result{}, nil
 }
 
-// RegisterReconcilers registers the pool manager's Function reconciler on the
-// executor Manager. The environment, replicaset, and specialized-pod-cleanup
-// watches remain on poolpodcontroller's informers for now.
-func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
-	r := &functionReconciler{
-		logger:  gpm.logger.WithName("function_reconciler"),
-		client:  mgr.GetClient(),
-		deleter: gpm,
+// cleanupFunction marks the function's fsCache entries deleted and removes its
+// istio Service (when enabled).
+func (r *functionReconciler) cleanupFunction(ctx context.Context, fn *fv1.Function) error {
+	r.mgr.markFuncDeleted(crd.CacheKeyURGFromMeta(&fn.ObjectMeta))
+	if r.enableIstio {
+		if err := r.mgr.deleteIstioServiceForFunction(ctx, fn); err != nil {
+			return err
+		}
 	}
-	return controller.Register(mgr, &fv1.Function{}, r, "poolmgr-function")
+	return nil
+}
+
+// environmentReconciler manages the warm pool for each Environment, replacing
+// poolpodcontroller's env create/update/delete workqueues. It drives the gpm
+// actor (getPool/cleanupPool/updatePoolDeployment) — which stays as the
+// serializer shared with the hot GetFuncSvc path — and keeps the last-seen
+// Environment so a delete can still destroy the pool and reap specialized pods.
+type environmentReconciler struct {
+	logger   logr.Logger
+	client   client.Client
+	mgr      poolManager
+	lastSeen sync.Map // client.ObjectKey -> *fv1.Environment
+}
+
+func (r *environmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	env := &fv1.Environment{}
+	if err := r.client.Get(ctx, req.NamespacedName, env); err != nil {
+		if apierrors.IsNotFound(err) {
+			if old, ok := r.lastSeen.LoadAndDelete(req.NamespacedName); ok {
+				r.mgr.cleanupEnvPool(ctx, old.(*fv1.Environment))
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if err := r.mgr.reconcileEnvPool(ctx, env); err != nil {
+		return ctrl.Result{}, err
+	}
+	r.lastSeen.Store(req.NamespacedName, env.DeepCopy())
+	// Periodically re-reconcile to keep the pool deployment in sync even without a
+	// spec change (the old env workqueue got this from the 30m informer resync).
+	return ctrl.Result{RequeueAfter: envResyncPeriod}, nil
+}
+
+// RegisterReconcilers registers the pool manager's Function and Environment
+// reconcilers on the executor Manager, replacing poolpodcontroller's Function and
+// Environment informer handlers. The ReplicaSet → specialized-pod-cleanup watch
+// stays on poolpodcontroller (k8s pod machinery).
+func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
+	// getFunctionEnv (hot path) reads Environments from the Manager cache instead
+	// of poolpodcontroller's informer lister now.
+	gpm.crClient = mgr.GetClient()
+
+	fr := &functionReconciler{
+		logger:      gpm.logger.WithName("function_reconciler"),
+		client:      mgr.GetClient(),
+		mgr:         gpm,
+		enableIstio: gpm.enableIstio,
+	}
+	if err := controller.Register(mgr, &fv1.Function{}, fr, "poolmgr-function"); err != nil {
+		return err
+	}
+
+	er := &environmentReconciler{
+		logger: gpm.logger.WithName("environment_reconciler"),
+		client: mgr.GetClient(),
+		mgr:    gpm,
+	}
+	return controller.Register(mgr, &fv1.Environment{}, er, "poolmgr-environment")
 }

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -5,6 +5,7 @@
 package poolmgr
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -21,59 +22,180 @@ import (
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 )
 
-type fakeDeleter struct{ deleted []crd.CacheKeyURG }
+type fakeFuncMgr struct {
+	deleted      []crd.CacheKeyURG
+	refreshed    []string
+	istioCreated []string
+	istioDeleted []string
+}
 
-func (f *fakeDeleter) markFuncDeleted(k crd.CacheKeyURG) { f.deleted = append(f.deleted, k) }
+func (f *fakeFuncMgr) markFuncDeleted(k crd.CacheKeyURG) { f.deleted = append(f.deleted, k) }
+func (f *fakeFuncMgr) refreshFuncPods(_ context.Context, fn *fv1.Function) error {
+	f.refreshed = append(f.refreshed, fn.Name)
+	return nil
+}
+func (f *fakeFuncMgr) createIstioServiceForFunction(_ context.Context, fn *fv1.Function) error {
+	f.istioCreated = append(f.istioCreated, fn.Name)
+	return nil
+}
+func (f *fakeFuncMgr) deleteIstioServiceForFunction(_ context.Context, fn *fv1.Function) error {
+	f.istioDeleted = append(f.istioDeleted, fn.Name)
+	return nil
+}
+
+type fakePoolMgr struct {
+	reconciled []string
+	cleaned    []string
+}
+
+func (f *fakePoolMgr) reconcileEnvPool(_ context.Context, env *fv1.Environment) error {
+	f.reconciled = append(f.reconciled, env.Name)
+	return nil
+}
+func (f *fakePoolMgr) cleanupEnvPool(_ context.Context, env *fv1.Environment) {
+	f.cleaned = append(f.cleaned, env.Name)
+}
 
 func crClient(objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
 }
 
+func poolmgrFn(name string, et fv1.ExecutorType) *fv1.Function {
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: "u1", ResourceVersion: "9", Generation: 2}}
+	fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType = et
+	return fn
+}
+
 func TestPoolmgrFunctionReconciler(t *testing.T) {
 	key := types.NamespacedName{Name: "fn", Namespace: "default"}
 	req := ctrl.Request{NamespacedName: key}
-	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "default", UID: "u1", ResourceVersion: "9", Generation: 2}}
 
-	t.Run("existing function is cached, not marked deleted", func(t *testing.T) {
-		d := &fakeDeleter{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fn), deleter: d}
+	t.Run("first sight of poolmgr function creates istio service and caches", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", fv1.ExecutorTypePoolmgr)), mgr: m, enableIstio: true}
 		_, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
-		assert.Empty(t, d.deleted)
+		assert.Equal(t, []string{"fn"}, m.istioCreated)
+		assert.Empty(t, m.deleted)
 		_, cached := r.lastSeen.Load(key)
-		assert.True(t, cached, "live function must be cached so its URG is available on delete")
+		assert.True(t, cached)
 	})
 
-	t.Run("deleted function is marked deleted with its cached URG", func(t *testing.T) {
-		d := &fakeDeleter{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(), deleter: d} // empty client -> NotFound
-		r.lastSeen.Store(key, fn.DeepCopy())
+	t.Run("istio disabled: no istio service on create", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", "")), mgr: m, enableIstio: false}
 		_, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
-		require.Len(t, d.deleted, 1)
-		assert.Equal(t, crd.CacheKeyURGFromMeta(&fn.ObjectMeta), d.deleted[0])
+		assert.Empty(t, m.istioCreated)
+		_, cached := r.lastSeen.Load(key)
+		assert.True(t, cached, "empty executor type defaults to poolmgr and is managed")
+	})
+
+	t.Run("non-poolmgr function on first sight is ignored", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", fv1.ExecutorTypeNewdeploy)), mgr: m, enableIstio: true}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, m.istioCreated)
 		_, cached := r.lastSeen.Load(key)
 		assert.False(t, cached)
 	})
 
-	t.Run("delete of an unseen function is a no-op", func(t *testing.T) {
-		d := &fakeDeleter{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(), deleter: d}
+	t.Run("spec change of a managed function refreshes its pods", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", fv1.ExecutorTypePoolmgr)), mgr: m, enableIstio: true}
+		r.lastSeen.Store(key, poolmgrFn("fn", fv1.ExecutorTypePoolmgr))
 		_, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
-		assert.Empty(t, d.deleted)
+		assert.Equal(t, []string{"fn"}, m.refreshed, "package/config change must re-specialize pods")
+		assert.Empty(t, m.istioCreated, "istio service is stable across spec updates")
 	})
 
-	t.Run("delete+recreate with a new UID marks the old UID deleted", func(t *testing.T) {
-		d := &fakeDeleter{}
-		recreated := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "default", UID: "u2", ResourceVersion: "3", Generation: 1}}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(recreated), deleter: d}
-		r.lastSeen.Store(key, fn.DeepCopy()) // old UID u1
+	t.Run("deleted function is marked deleted and its istio service removed", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(), mgr: m, enableIstio: true} // empty client -> NotFound
+		cached := poolmgrFn("fn", fv1.ExecutorTypePoolmgr)
+		r.lastSeen.Store(key, cached)
 		_, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
-		require.Len(t, d.deleted, 1)
-		assert.Equal(t, crd.CacheKeyURGFromMeta(&fn.ObjectMeta), d.deleted[0], "old UID must be marked deleted")
-		cached, _ := r.lastSeen.Load(key)
-		assert.Equal(t, recreated.UID, cached.(*fv1.Function).UID, "cache now holds the recreated function")
+		require.Len(t, m.deleted, 1)
+		assert.Equal(t, crd.CacheKeyURGFromMeta(&cached.ObjectMeta), m.deleted[0])
+		assert.Equal(t, []string{"fn"}, m.istioDeleted)
+		_, ok := r.lastSeen.Load(key)
+		assert.False(t, ok)
+	})
+
+	t.Run("delete of an unseen function is a no-op", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(), mgr: m, enableIstio: true}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, m.deleted)
+	})
+
+	t.Run("delete+recreate with a new UID cleans the old and creates the new", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		old := poolmgrFn("fn", fv1.ExecutorTypePoolmgr) // UID u1
+		recreated := poolmgrFn("fn", fv1.ExecutorTypePoolmgr)
+		recreated.UID = "u2"
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(recreated), mgr: m, enableIstio: true}
+		r.lastSeen.Store(key, old)
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		require.Len(t, m.deleted, 1)
+		assert.Equal(t, crd.CacheKeyURGFromMeta(&old.ObjectMeta), m.deleted[0])
+		assert.Equal(t, []string{"fn"}, m.istioCreated, "new incarnation gets a fresh istio service")
+		newCached, _ := r.lastSeen.Load(key)
+		assert.Equal(t, types.UID("u2"), newCached.(*fv1.Function).UID)
+	})
+
+	t.Run("transition away from poolmgr cleans up and uncaches", func(t *testing.T) {
+		m := &fakeFuncMgr{}
+		now := poolmgrFn("fn", fv1.ExecutorTypeNewdeploy)
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(now), mgr: m, enableIstio: true}
+		r.lastSeen.Store(key, poolmgrFn("fn", fv1.ExecutorTypePoolmgr))
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		require.Len(t, m.deleted, 1, "old poolmgr incarnation must be cleaned up")
+		assert.Equal(t, []string{"fn"}, m.istioDeleted)
+		_, ok := r.lastSeen.Load(key)
+		assert.False(t, ok)
+	})
+}
+
+func TestPoolmgrEnvironmentReconciler(t *testing.T) {
+	key := types.NamespacedName{Name: "env", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+	env := &fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env", Namespace: "default", UID: "e1"}}
+
+	t.Run("existing environment reconciles its pool and is cached", func(t *testing.T) {
+		m := &fakePoolMgr{}
+		r := &environmentReconciler{logger: logr.Discard(), client: crClient(env), mgr: m}
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"env"}, m.reconciled)
+		assert.Empty(t, m.cleaned)
+		assert.Equal(t, envResyncPeriod, res.RequeueAfter, "should periodically re-reconcile")
+		_, cached := r.lastSeen.Load(key)
+		assert.True(t, cached)
+	})
+
+	t.Run("deleted environment cleans up its pool via the cached object", func(t *testing.T) {
+		m := &fakePoolMgr{}
+		r := &environmentReconciler{logger: logr.Discard(), client: crClient(), mgr: m} // empty -> NotFound
+		r.lastSeen.Store(key, env.DeepCopy())
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"env"}, m.cleaned)
+		_, cached := r.lastSeen.Load(key)
+		assert.False(t, cached)
+	})
+
+	t.Run("delete of an unseen environment is a no-op", func(t *testing.T) {
+		m := &fakePoolMgr{}
+		r := &environmentReconciler{logger: logr.Discard(), client: crClient(), mgr: m}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, m.cleaned)
 	})
 }


### PR DESCRIPTION
## What

Migrates the **pool manager's Environment and Function watches** from
`poolpodcontroller`'s informers to controller-runtime reconcilers on the executor
Manager.
With this, **every Fission CRD watch in the executor is a reconciler** — container
(#3431), newdeploy (#3433), and poolmgr (Function-delete #3432, now Function +
Environment here).
Only `poolpodcontroller`'s **k8s-native** ReplicaSet → specialized-pod-cleanup
watch remains on an informer.

## functionReconciler (full)

Extends #3432's delete-only reconciler into a full last-seen-cache reconciler,
merging three concerns into one:

- **create** → create the per-function istio `Service` (when istio is enabled) —
  absorbs the old `funchandlers.go` istio `AddFunc`.
- **update** → `RefreshFuncPods` on a spec change. **This is the TestGoEnv fix:**
  poolmgr had *no* function-update path, so after `fn update --pkg` a stale
  specialized pod (old package) could keep being routed to until the idle reaper
  recycled it. The reconciler now re-specializes proactively. (Diagnosed from CI
  artifact logs on #3433: the poolmgr Go pod stayed on `go-pkg-v1`.)
- **delete** → `markFuncDeleted` (so the reaper recycles pods) + delete the istio
  `Service`.

Gated to poolmgr-type functions (an empty executor type defaults to poolmgr),
matching the old istio handler's filter.

## environmentReconciler

Replaces the env create/update/delete workqueues. Drives the **gpm actor** (which
stays — it's the serializer shared with the hot `GetFuncSvc` path, not a watch):

- create/update → `reconcileEnvPool`: `getPool` / `cleanupPool` (pool size 0) /
  `updatePoolDeployment`.
- delete → `cleanupEnvPool` from the last-seen Environment: destroy the pool +
  reap specialized pods.
- `RequeueAfter(30m)` replaces the informer resync that kept the pool deployment
  in sync without a spec change.

`gpm.getFunctionEnv` (hot path) now resolves the Environment from the Manager
cache instead of `poolpodcontroller`'s informer lister. `poolpodcontroller`
shrinks to the ReplicaSet watch + specialized-pod cleanup queue.

## Scope / deferred

- The **k8s-native** ReplicaSet and per-pool readyPod watches stay on informers
  (not Fission resource types; tightly coupled to the gpm pod machinery) — a later
  PR.
- `finformerFactory` is now redundant with the Manager cache but is left running
  (its `waitForSync` is a readiness gate); removing it needs a separate readiness
  check.

## Tests

- New `reconciler_test.go`: Function routing (istio create / spec-change refresh /
  delete-with-istio-removal / non-poolmgr ignored / delete+recreate / transition
  away / istio-disabled) and Environment routing (reconcile+requeue / delete
  cleanup / unseen delete) via fakes.
- `TestPoolPodControllerPodCleanup` updated to the trimmed constructor.
- Local gates green: `go build ./...`, `golangci-lint` (0 issues),
  `make license-check`, `go test -race` on the poolmgr package, and the
  **in-process e2e suite** (`test/e2e/cli` + `test/e2e/fetcher`) which starts the
  executor Manager with these reconcilers and serves poolmgr functions through the
  Manager-cache `getFunctionEnv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3434)
<!-- Reviewable:end -->
