### PR TITLE
feat: RFC-0005 WS3 (D/poolmgr-rs) — poolmgr ReplicaSet reconciler

### DIFF
--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -17,6 +17,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/sync/errgroup"
+	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -583,6 +584,13 @@ func (gpm *GenericPoolManager) cleanupPool(ctx context.Context, env *fv1.Environ
 // reconciler on delete.
 func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyURG) {
 	gpm.fsCache.MarkFuncDeleted(key)
+}
+
+// processReplicaSet reaps a pool's specialized pods when its ReplicaSet has
+// scaled to zero. Driven by the ReplicaSet reconciler; delegates to the pool pod
+// controller, which owns the specialized-pod cleanup queue.
+func (gpm *GenericPoolManager) processReplicaSet(rs *appsv1.ReplicaSet) {
+	gpm.poolPodC.processRS(rs)
 }
 
 // reconcileEnvPool brings an environment's warm pool to its desired state:

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -67,19 +67,11 @@ func NewPoolPodController(ctx context.Context, logger logr.Logger,
 		spCleanupPodQueue: workqueue.NewTypedRateLimitingQueueWithConfig(workqueue.DefaultTypedControllerRateLimiter[string](), workqueue.TypedRateLimitingQueueConfig[string]{Name: "SpecializedPodCleanupQueue"}),
 	}
 	for ns, informerFactory := range gpmInformerFactory {
-		_, err := informerFactory.Apps().V1().ReplicaSets().Informer().AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
-			AddFunc:    p.handleRSAdd,
-			UpdateFunc: p.handleRSUpdate,
-			DeleteFunc: p.handleRSDelete,
-		})
-		if err != nil {
-			return nil, err
-		}
 		p.podListerSynced[ns] = informerFactory.Core().V1().Pods().Informer().HasSynced
 		p.podLister[ns] = informerFactory.Core().V1().Pods().Lister()
 	}
 
-	p.logger.Info("pool pod controller handlers registered")
+	p.logger.Info("pool pod controller pod lister registered")
 	return p, nil
 }
 
@@ -125,41 +117,6 @@ func (p *PoolPodController) processRS(rs *apps.ReplicaSet) {
 		}
 		p.spCleanupPodQueue.Add(key)
 	}
-}
-
-func (p *PoolPodController) handleRSAdd(obj any) {
-	rs, ok := obj.(*apps.ReplicaSet)
-	if !ok {
-		p.logger.Info("unexpected type when adding rs to pool pod controller", "obj", obj)
-		return
-	}
-	p.processRS(rs)
-}
-
-func (p *PoolPodController) handleRSUpdate(oldObj any, newObj any) {
-	rs, ok := newObj.(*apps.ReplicaSet)
-	if !ok {
-		p.logger.Error(nil, "unexpected type when updating rs to pool pod controller", "obj", newObj)
-		return
-	}
-	p.processRS(rs)
-}
-
-func (p *PoolPodController) handleRSDelete(obj any) {
-	rs, ok := obj.(*apps.ReplicaSet)
-	if !ok {
-		tombstone, ok := obj.(k8sCache.DeletedFinalStateUnknown)
-		if !ok {
-			p.logger.Error(nil, "couldn't get object from tombstone", "obj", obj)
-			return
-		}
-		rs, ok = tombstone.Obj.(*apps.ReplicaSet)
-		if !ok {
-			p.logger.Error(nil, "tombstone contained object that is not a replicaset", "obj", obj)
-			return
-		}
-	}
-	p.processRS(rs)
 }
 
 // cleanupSpecializedPodsForEnv enqueues an environment's specialized pods for

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -10,9 +10,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/controller"
@@ -39,6 +41,41 @@ type poolManager interface {
 	reconcileEnvPool(ctx context.Context, env *fv1.Environment) error
 	cleanupEnvPool(ctx context.Context, env *fv1.Environment)
 }
+
+// rsCleaner is the subset of *GenericPoolManager the ReplicaSet reconciler drives.
+type rsCleaner interface {
+	processReplicaSet(rs *appsv1.ReplicaSet)
+}
+
+// replicaSetReconciler reaps a pool's specialized pods when its ReplicaSet scales
+// to zero (the pool was destroyed). It replaces poolpodcontroller's ReplicaSet
+// informer handler. processReplicaSet is a no-op unless replicas == 0, and the
+// scale-to-zero is a spec change (caught by GenerationChangedPredicate) that
+// always precedes the ReplicaSet's deletion, so a NotFound needs no handling.
+type replicaSetReconciler struct {
+	logger  logr.Logger
+	client  client.Client
+	cleaner rsCleaner
+}
+
+func (r *replicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	rs := &appsv1.ReplicaSet{}
+	if err := r.client.Get(ctx, req.NamespacedName, rs); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+	r.cleaner.processReplicaSet(rs)
+	return ctrl.Result{}, nil
+}
+
+// poolmgrReplicaSetPredicate keeps the ReplicaSet reconciler to pool-manager
+// ReplicaSets only (the executor cache also sees newdeploy/container ones), the
+// same filter the old executor-labelled informer applied.
+var poolmgrReplicaSetPredicate = predicate.NewPredicateFuncs(func(obj client.Object) bool {
+	return obj.GetLabels()[fv1.EXECUTOR_TYPE] == string(fv1.ExecutorTypePoolmgr)
+})
 
 // isPoolmgrType reports whether the pool manager should handle this function.
 // Poolmgr is the default executor, so an empty executor type counts as poolmgr —
@@ -177,10 +214,11 @@ func (r *environmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	return ctrl.Result{RequeueAfter: envResyncPeriod}, nil
 }
 
-// RegisterReconcilers registers the pool manager's Function and Environment
-// reconcilers on the executor Manager, replacing poolpodcontroller's Function and
-// Environment informer handlers. The ReplicaSet → specialized-pod-cleanup watch
-// stays on poolpodcontroller (k8s pod machinery).
+// RegisterReconcilers registers the pool manager's Function, Environment, and
+// ReplicaSet reconcilers on the executor Manager, replacing poolpodcontroller's
+// informer handlers. poolpodcontroller now only owns the specialized-pod cleanup
+// queue (fed by the ReplicaSet reconciler and the Environment reconciler) and the
+// pod lister.
 func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
 	// getFunctionEnv (hot path) reads Environments from the Manager cache instead
 	// of poolpodcontroller's informer lister now.
@@ -201,5 +239,15 @@ func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
 		client: mgr.GetClient(),
 		mgr:    gpm,
 	}
-	return controller.Register(mgr, &fv1.Environment{}, er, "poolmgr-environment")
+	if err := controller.Register(mgr, &fv1.Environment{}, er, "poolmgr-environment"); err != nil {
+		return err
+	}
+
+	rr := &replicaSetReconciler{
+		logger:  gpm.logger.WithName("replicaset_reconciler"),
+		client:  mgr.GetClient(),
+		cleaner: gpm,
+	}
+	return controller.RegisterWithPredicates(mgr, &appsv1.ReplicaSet{}, rr, "poolmgr-replicaset", 0,
+		poolmgrReplicaSetPredicate, predicate.GenerationChangedPredicate{})
 }

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	appsv1 "k8s.io/api/apps/v1"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -17,6 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	appsv1 "k8s.io/api/apps/v1"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
@@ -41,6 +44,12 @@ func (f *fakeFuncMgr) createIstioServiceForFunction(_ context.Context, fn *fv1.F
 func (f *fakeFuncMgr) deleteIstioServiceForFunction(_ context.Context, fn *fv1.Function) error {
 	f.istioDeleted = append(f.istioDeleted, fn.Name)
 	return nil
+}
+
+type fakeRSCleaner struct{ processed []string }
+
+func (f *fakeRSCleaner) processReplicaSet(rs *appsv1.ReplicaSet) {
+	f.processed = append(f.processed, rs.Name)
 }
 
 type fakePoolMgr struct {
@@ -197,5 +206,31 @@ func TestPoolmgrEnvironmentReconciler(t *testing.T) {
 		_, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
 		assert.Empty(t, m.cleaned)
+	})
+}
+
+func crClientK8s(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(objs...).Build()
+}
+
+func TestPoolmgrReplicaSetReconciler(t *testing.T) {
+	key := types.NamespacedName{Name: "rs", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+	rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "rs", Namespace: "default"}}
+
+	t.Run("existing replicaset is handed to the cleaner", func(t *testing.T) {
+		c := &fakeRSCleaner{}
+		r := &replicaSetReconciler{logger: logr.Discard(), client: crClientK8s(rs), cleaner: c}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"rs"}, c.processed, "the zero-replica check lives in processReplicaSet")
+	})
+
+	t.Run("deleted replicaset is a no-op", func(t *testing.T) {
+		c := &fakeRSCleaner{}
+		r := &replicaSetReconciler{logger: logr.Discard(), client: crClientK8s(), cleaner: c}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, c.processed, "scale-to-zero precedes deletion, so a missing RS needs no cleanup")
 	})
 }


### PR DESCRIPTION
## What

Migrates `poolpodcontroller`'s **last informer event handler** — the ReplicaSet
watch that reaps a pool's specialized pods when its ReplicaSet scales to zero (the
pool was destroyed) — to a controller-runtime reconciler on the executor Manager.

After this, `poolpodcontroller` registers **no informer event handlers** at all:
it owns only the specialized-pod cleanup queue (fed by the ReplicaSet and
Environment reconcilers) and the pod lister.

## How

`replicaSetReconciler` watches ReplicaSets filtered to pool-manager ones — a label
predicate on `EXECUTOR_TYPE=poolmgr` (matching the old executor-labelled informer)
plus `GenerationChangedPredicate` (the scale-to-zero is a `spec.replicas` change).
It delegates to `gpm.processReplicaSet` → `poolpodcontroller.processRS`, preserving
the exact behavior: a no-op unless `replicas == 0`, otherwise enqueue the
specialized pods to the `spCleanupPodQueue`.

A `NotFound` ReplicaSet needs no handling — the scale-to-zero update always
precedes deletion, so the pods are already enqueued by the time the RS is gone.

## RBAC

No change: the executor Role already grants `apps/replicasets` `list`+`watch` (the
old informer used it), so the Manager cache's ReplicaSet watch is already
permitted (verified in `charts/.../_fission-kubernetes-roles.tpl`).

## Scope

The **per-pool readyPod informer** — the cold-start hot path (`choosePod` blocks
on a per-pool `readyPodQueue` fed by a dynamically-scoped per-pool Pod informer) —
is intentionally **left for a separate, focused PR**. It's the one remaining
`Informer().AddEventHandler` in the executor, and converting it touches the path
every poolmgr function cold-start goes through, so it warrants isolated review.

## Tests

- `reconciler_test.go`: ReplicaSet routing (existing RS handed to the cleaner;
  deleted RS is a no-op) via a fake cleaner + a k8s-scheme fake client.
- Local gates green: `go build ./...`, `golangci-lint` (0 issues),
  `make license-check`, `go test -race` on the poolmgr package, and the in-process
  e2e suite (`test/e2e/cli` + `test/e2e/fetcher`), which starts the executor
  Manager with the new ReplicaSet watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3435)
<!-- Reviewable:end -->
