### PR TITLE
ci: bump integration-test kind k8s versions to v1.32.11 / v1.34.3 / v1.35.1

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kindversion: ["v1.28.15", "v1.32.8", "v1.34.0"]
+        kindversion: ["v1.32.11", "v1.34.3", "v1.35.1"]
         os: [ubuntu-24.04]
     steps:
       - name: Harden Runner
@@ -112,7 +112,7 @@ jobs:
           # (via goreleaser) but ignored by go subcommands that don't know the
           # flag (e.g. `go mod tidy`). Never set in release.yaml, so published
           # images are never instrumented.
-          GOFLAGS: ${{ matrix.kindversion == 'v1.32.8' && '-cover -coverpkg=github.com/fission/fission/...' || '' }}
+          GOFLAGS: ${{ matrix.kindversion == 'v1.32.11' && '-cover -coverpkg=github.com/fission/fission/...' || '' }}
         run: |
           kubectl create ns fission
           make create-crds
@@ -224,7 +224,7 @@ jobs:
           # the collect step. Other legs run uninstrumented.
           COVER_FLAGS=()
           COVER_ARGS=()
-          if [ "${{ matrix.kindversion }}" = "v1.32.8" ]; then
+          if [ "${{ matrix.kindversion }}" = "v1.32.11" ]; then
             mkdir -p "$PWD/covdata-cli"
             COVER_FLAGS=(-cover -coverpkg=github.com/fission/fission/...)
             COVER_ARGS=(-args -test.gocoverdir="$PWD/covdata-cli")
@@ -234,7 +234,7 @@ jobs:
 
       - name: Collect integration coverage
         # Only the instrumented leg produced coverage; collect there.
-        if: ${{ matrix.kindversion == 'v1.32.8' }}
+        if: ${{ matrix.kindversion == 'v1.32.11' }}
         timeout-minutes: 5
         run: |
           # Graceful delete (foreground cascade) sends SIGTERM and waits for
@@ -263,7 +263,7 @@ jobs:
           fi
 
       - name: Upload integration coverage to CodeCov
-        if: ${{ matrix.kindversion == 'v1.32.8' && hashFiles('integration-coverage.txt') != '' }}
+        if: ${{ matrix.kindversion == 'v1.32.11' && hashFiles('integration-coverage.txt') != '' }}
         continue-on-error: true
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -11,6 +11,7 @@ on:
       - "test/**"
       - go.mod
       - go.sum
+      - .github/workflows/push_pr.yaml
   pull_request:
     branches:
       - main
@@ -20,6 +21,7 @@ on:
       - "test/**"
       - go.mod
       - go.sum
+      - .github/workflows/push_pr.yaml
 
 env:
   HELM_VERSION: v4.2.0


### PR DESCRIPTION
## What

Bumps the Fission CI integration-test matrix (`.github/workflows/push_pr.yaml`)
from `v1.28.15 / v1.32.8 / v1.34.0` to **`v1.32.11 / v1.34.3 / v1.35.1`** — current
patch releases plus k8s 1.35.
The coverage leg (GOFLAGS, coverage upload + PR comment) moves from `v1.32.8` to
`v1.32.11`.

## Why

Two reasons:
- Keep the integration matrix on supported, current k8s patch versions and start
  exercising 1.35.
- Investigating the **TestGoEnv flake** — the poolmgr Go function serves a stale
  package after `fn update --pkg` because the router resolver caches the function
  snapshot keyed by the *trigger's* ResourceVersion (a function-only update can't
  invalidate it), so the executor keeps specializing the old package.
  The thesis is that the resolver-staleness window widens on newer k8s
  (watch-event / cache-sync timing), so this matrix also runs 1.34.3 / 1.35.1 to
  gather data.

## Note

`KIND_VERSION` is pinned to `v0.31.0`. All three `kindest/node` image tags exist,
but if v1.35.1 cluster creation fails on this kind release, the pin needs a bump
to a kind version that ships the v1.35 node image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3437)
<!-- Reviewable:end -->
