### PR TITLE
refactor: retire finformerFactory + fix TestGoEnv router resolver staleness

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -149,7 +149,7 @@ type executorControllers struct {
 	api            *Executor
 	executorTypes  map[fv1.ExecutorType]executortype.ExecutorType
 	startFactories func(stopCh <-chan struct{})
-	waitForSync    func(stopCh <-chan struct{}) bool
+	waitForSync    func(ctx context.Context) bool
 	adoptResources bool
 }
 
@@ -181,7 +181,7 @@ func (c *executorControllers) Start(ctx context.Context) error {
 
 	c.api.isLeader.Store(true)
 	go func() {
-		if c.waitForSync(ctx.Done()) {
+		if c.waitForSync(ctx) {
 			c.api.cachesSynced.Store(true)
 			c.logger.Info("executor caches synced; ready to serve")
 		}
@@ -534,12 +534,13 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 			factory.Start(stopCh)
 		}
 	}
-	waitForSync := func(stopCh <-chan struct{}) bool {
+	waitForSync := func(syncCtx context.Context) bool {
 		// The executor's Function/Environment/ConfigMap/Secret/Pod/ReplicaSet reads
 		// all go through the Manager cache now; it's ready once that has synced.
 		// controller-runtime syncs the cache before starting this (non-cache)
-		// runnable, so this returns ~immediately.
-		return crMgr.GetCache().WaitForCacheSync(ctx)
+		// runnable, so this returns ~immediately. syncCtx is the runnable's context,
+		// so the wait is cancelled on shutdown or leadership loss.
+		return crMgr.GetCache().WaitForCacheSync(syncCtx)
 	}
 
 	utils.CreateMissingPermissionForSA(ctx, kubernetesClient, logger)

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -44,7 +44,6 @@ import (
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
 	fissionmetrics "github.com/fission/fission/pkg/utils/metrics"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -423,18 +422,13 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 
 	logger.Info("Starting executor", "instanceID", executorInstanceID)
 
-	finformerFactory := make(map[string]genInformer.SharedInformerFactory, 0)
-	for _, ns := range utils.DefaultNSResolver().FissionResourceNS {
-		finformerFactory[ns] = genInformer.NewSharedInformerFactoryWithOptions(fissionClient, time.Minute*30, genInformer.WithNamespace(ns))
-	}
-
-	// poolmgr reads pods through the executor Manager cache now, so it no longer
-	// needs a dedicated pod informer factory.
+	// Function and Environment reads go through the executor Manager cache now, so
+	// no dedicated fission informer factory is needed.
 	gpm, err := poolmgr.MakeGenericPoolManager(ctx,
 		logger,
 		fissionClient, kubernetesClient, metricsClient,
 		fetcherConfig, executorInstanceID,
-		finformerFactory, podSpecPatch)
+		podSpecPatch)
 	if err != nil {
 		return fmt.Errorf("pool manager creation failed: %w", err)
 	}
@@ -448,7 +442,6 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 		logger,
 		fissionClient, kubernetesClient,
 		fetcherConfig, executorInstanceID,
-		finformerFactory,
 		ndmInformerFactory, podSpecPatch)
 	if err != nil {
 		return fmt.Errorf("new deploy manager creation failed: %w", err)
@@ -462,7 +455,7 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	cnm, err := container.MakeContainer(
 		ctx, logger,
 		fissionClient, kubernetesClient,
-		executorInstanceID, finformerFactory,
+		executorInstanceID,
 		cnmInformerFactory)
 	if err != nil {
 		return fmt.Errorf("container manager creation failed: %w", err)
@@ -534,9 +527,6 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	}
 
 	startFactories := func(stopCh <-chan struct{}) {
-		for _, factory := range finformerFactory {
-			factory.Start(stopCh)
-		}
 		for _, factory := range ndmInformerFactory {
 			factory.Start(stopCh)
 		}
@@ -545,15 +535,11 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 		}
 	}
 	waitForSync := func(stopCh <-chan struct{}) bool {
-		synced := true
-		for _, factory := range finformerFactory {
-			for _, ok := range factory.WaitForCacheSync(stopCh) {
-				if !ok {
-					synced = false
-				}
-			}
-		}
-		return synced
+		// The executor's Function/Environment/ConfigMap/Secret/Pod/ReplicaSet reads
+		// all go through the Manager cache now; it's ready once that has synced.
+		// controller-runtime syncs the cache before starting this (non-cache)
+		// runnable, so this returns ~immediately.
+		return crMgr.GetCache().WaitForCacheSync(ctx)
 	}
 
 	utils.CreateMissingPermissionForSA(ctx, kubernetesClient, logger)

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -38,7 +38,6 @@ import (
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/maps"
@@ -89,7 +88,6 @@ func MakeContainer(
 	fissionClient versioned.Interface,
 	kubernetesClient kubernetes.Interface,
 	instanceID string,
-	finformerFactory map[string]genInformer.SharedInformerFactory,
 	cnmInformerFactory map[string]k8sInformers.SharedInformerFactory,
 ) (executortype.ExecutorType, error) {
 	enableIstio := false

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -41,7 +41,6 @@ import (
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/maps"
@@ -95,7 +94,6 @@ func MakeNewDeploy(
 	kubernetesClient kubernetes.Interface,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	finformerFactory map[string]genInformer.SharedInformerFactory,
 	ndmInformerFactory map[string]k8sInformers.SharedInformerFactory,
 	podSpecPatch *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
@@ -143,7 +141,6 @@ func MakeNewDeploy(
 	}
 	// The Function and Environment watches are controller-runtime reconcilers now
 	// (see reconciler.go / RegisterReconcilers), wired on the executor Manager.
-	// finformerFactory stays a parameter because poolmgr still drives off it.
 	return nd, nil
 }
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr_test.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr_test.go
@@ -23,7 +23,6 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	fClient "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 	"github.com/fission/fission/pkg/utils/uuid"
@@ -47,8 +46,6 @@ func TestRefreshFuncPods(t *testing.T) {
 	// Hitting issue https://github.com/kubernetes/kubernetes/issues/126850
 	// so using NewSimpleClientset instead of NewClientset here, until that is resolved.
 	fissionClient := fClient.NewSimpleClientset() // nolint:staticcheck
-	factory := make(map[string]genInformer.SharedInformerFactory, 0)
-	factory[metav1.NamespaceDefault] = genInformer.NewSharedInformerFactoryWithOptions(fissionClient, time.Minute*30, genInformer.WithNamespace(metav1.NamespaceDefault))
 
 	executorLabel, err := utils.GetInformerLabelByExecutor(fv1.ExecutorTypeNewdeploy)
 	require.NoError(t, err, "Error creating labels for informer")
@@ -60,7 +57,7 @@ func TestRefreshFuncPods(t *testing.T) {
 	require.NoError(t, err, "Error creating fetcher config")
 
 	executor, err := MakeNewDeploy(ctx, logger, fissionClient, kubernetesClient, fetcherConfig, "test",
-		factory, ndmInformerFactory, nil)
+		ndmInformerFactory, nil)
 	require.NoError(t, err, "new deploy manager creation failed")
 
 	ndm := executor.(*NewDeploy)
@@ -78,9 +75,6 @@ func TestRefreshFuncPods(t *testing.T) {
 	})
 	t.Log("New deploy manager started")
 
-	for _, f := range factory {
-		f.Start(ctx.Done())
-	}
 	for _, informerFactory := range ndmInformerFactory {
 		informerFactory.Start(ctx.Done())
 	}

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -43,7 +43,6 @@ import (
 	executorUtils "github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
@@ -115,7 +114,6 @@ func MakeGenericPoolManager(ctx context.Context,
 	metricsClient metricsclient.Interface,
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
-	finformerFactory map[string]genInformer.SharedInformerFactory,
 	podSpecPatch *apiv1.PodSpec,
 ) (executortype.ExecutorType, error) {
 

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_test.go
@@ -23,7 +23,6 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
 	fClient "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
-	genInformer "github.com/fission/fission/pkg/generated/informers/externalversions"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -48,9 +47,6 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 	kubernetesClient := fake.NewClientset(pod)
 	crClient := crfake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(pod).Build()
 	fissionClient := fClient.NewClientset()
-	factory := map[string]genInformer.SharedInformerFactory{
-		metav1.NamespaceDefault: genInformer.NewSharedInformerFactoryWithOptions(fissionClient, time.Minute*30, genInformer.WithNamespace(metav1.NamespaceDefault)),
-	}
 
 	ppc := NewPoolPodController(logger, kubernetesClient)
 
@@ -63,7 +59,7 @@ func TestPoolPodControllerPodCleanup(t *testing.T) {
 		logger,
 		fissionClient, kubernetesClient, metricsClient,
 		fetcherConfig, executorInstanceID,
-		factory, nil)
+		nil)
 	require.NoError(t, err, "Error creating generic pool manager")
 	gpm := executor.(*GenericPoolManager)
 	gpm.crClient = crClient

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -667,9 +667,11 @@ func (fh functionHandler) getServiceEntryFromExecutor(ctx context.Context) (serv
 		return nil, err
 	}
 	// parse the address into url
-	svcURL, err := url.Parse(fmt.Sprintf("http://%v", service))
+	rawURL := fmt.Sprintf("http://%v", service)
+	svcURL, err := url.Parse(rawURL)
 	if err != nil {
-		logger.Error(err, "error parsing service url", "service_url", svcURL.String())
+		// svcURL is nil on a parse error — log the raw string, not svcURL.String().
+		logger.Error(err, "error parsing service url", "service_url", rawURL)
 		return nil, err
 	}
 	return svcURL, err

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-logr/logr"
 
@@ -44,8 +45,12 @@ const (
 
 type (
 	functionHandler struct {
-		logger                   logr.Logger
-		fmap                     *functionServiceMap
+		logger logr.Logger
+		fmap   *functionServiceMap
+		// reader is the Manager's cache-backed client, used to re-read the current
+		// Function before asking the executor to specialize it (the resolved
+		// `function` snapshot can be stale — see getServiceEntryFromExecutor).
+		reader                   client.Reader
 		executor                 eclient.ClientInterface
 		function                 *fv1.Function
 		httpTrigger              *fv1.HTTPTrigger
@@ -621,12 +626,31 @@ func (fh functionHandler) removeServiceEntryFromCache() {
 
 func (fh functionHandler) getServiceEntryFromExecutor(ctx context.Context) (serviceUrl *url.URL, err error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, fh.logger)
+
+	// The executor specializes a pod from exactly this function's package spec. The
+	// resolved `function` snapshot can be stale: the resolver caches the resolved
+	// function keyed by the *trigger's* ResourceVersion, so a `fission fn update
+	// --pkg` (which changes the function but not the trigger) doesn't invalidate
+	// it. For poolmgr — which specializes on demand from the function we pass —
+	// that means the executor would keep serving the old package. Re-read the
+	// current Function from the Manager cache so the latest spec is specialized.
+	fn := fh.function
+	if fh.reader != nil {
+		fresh := &fv1.Function{}
+		if gerr := fh.reader.Get(ctx, k8stypes.NamespacedName{Namespace: fn.Namespace, Name: fn.Name}, fresh); gerr == nil {
+			fn = fresh
+		} else {
+			logger.V(1).Info("could not re-read current function; using resolved snapshot",
+				"function", fn.Name, "namespace", fn.Namespace, "error", gerr)
+		}
+	}
+
 	// send a request to executor to specialize a new pod
-	fh.logger.V(1).Info("function timeout specified", "timeout", fh.function.Spec.FunctionTimeout)
+	fh.logger.V(1).Info("function timeout specified", "timeout", fn.Spec.FunctionTimeout)
 
 	var fContext context.Context
-	if fh.function.Spec.FunctionTimeout > 0 {
-		timeout := time.Second * time.Duration(fh.function.Spec.FunctionTimeout)
+	if fn.Spec.FunctionTimeout > 0 {
+		timeout := time.Second * time.Duration(fn.Spec.FunctionTimeout)
 		f, cancel := context.WithTimeoutCause(ctx, timeout, fmt.Errorf("function service entry timeout (%f)s exceeded", timeout.Seconds()))
 		fContext = f
 		defer cancel()
@@ -634,11 +658,11 @@ func (fh functionHandler) getServiceEntryFromExecutor(ctx context.Context) (serv
 		fContext = ctx
 	}
 
-	service, err := fh.executor.GetServiceForFunction(fContext, fh.function)
+	service, err := fh.executor.GetServiceForFunction(fContext, fn)
 	if err != nil {
 		statusCode, errMsg := ferror.GetHTTPError(err)
 		logger.Error(err, "error from GetServiceForFunction", "error_message", errMsg,
-			"function", fh.function,
+			"function", fn,
 			"status_code", statusCode)
 		return nil, err
 	}

--- a/pkg/router/functionHandler_test.go
+++ b/pkg/router/functionHandler_test.go
@@ -9,13 +9,17 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -49,4 +53,57 @@ func TestProxyErrorHandler(t *testing.T) {
 	respRecorder = httptest.NewRecorder()
 	errHandler(respRecorder, req, errors.New("dummy"))
 	require.Equal(t, http.StatusInternalServerError, respRecorder.Code)
+}
+
+// recordingExecutor implements eclient.ClientInterface and records the Function
+// passed to GetServiceForFunction.
+type recordingExecutor struct{ gotFn *fv1.Function }
+
+func (r *recordingExecutor) GetServiceForFunction(_ context.Context, fn *fv1.Function) (string, error) {
+	r.gotFn = fn
+	return "10.0.0.1:8888", nil
+}
+func (r *recordingExecutor) TapService(metav1.ObjectMeta, fv1.ExecutorType, url.URL) {}
+func (r *recordingExecutor) UnTapService(context.Context, metav1.ObjectMeta, fv1.ExecutorType, *url.URL) error {
+	return nil
+}
+
+func fnWithPkg(rv, pkg string) *fv1.Function {
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "default", ResourceVersion: rv}}
+	fn.Spec.Package.PackageRef.Name = pkg
+	return fn
+}
+
+// TestGetServiceEntryFromExecutorReReadsCurrentFunction guards the TestGoEnv fix:
+// the executor must be specialized with the current Function (re-read from the
+// Manager cache), not the resolver's stale snapshot — otherwise a poolmgr function
+// keeps serving the old package after `fn update --pkg`.
+func TestGetServiceEntryFromExecutorReReadsCurrentFunction(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	stale := fnWithPkg("1", "pkg-v1") // the resolver snapshot the handler captured
+	fresh := fnWithPkg("2", "pkg-v2") // what the Manager cache now holds
+
+	reader := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(fresh).Build()
+	exec := &recordingExecutor{}
+	fh := functionHandler{logger: logger, function: stale, reader: reader, executor: exec}
+
+	_, err := fh.getServiceEntryFromExecutor(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, exec.gotFn)
+	assert.Equal(t, "pkg-v2", exec.gotFn.Spec.Package.PackageRef.Name, "executor must get the re-read function, not the stale snapshot")
+	assert.Equal(t, "2", exec.gotFn.ResourceVersion)
+}
+
+// TestGetServiceEntryFromExecutorFallsBackToSnapshot: with no reader the captured
+// snapshot is used.
+func TestGetServiceEntryFromExecutorFallsBackToSnapshot(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	snap := fnWithPkg("1", "pkg-v1")
+	exec := &recordingExecutor{}
+	fh := functionHandler{logger: logger, function: snap, executor: exec} // reader nil
+
+	_, err := fh.getServiceEntryFromExecutor(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, exec.gotFn)
+	assert.Equal(t, "pkg-v1", exec.gotFn.Spec.Package.PackageRef.Name)
 }

--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -186,14 +186,17 @@ func (frr *functionReferenceResolver) delete(namespace string, triggerName, trig
 // function from the cache. Used by the function reconciler when a Function's
 // spec changes. Returns true if an entry was invalidated.
 func (frr *functionReferenceResolver) invalidateForFunction(namespace, name, resourceVersion string) bool {
+	invalidated := false
 	for key, rr := range frr.refCache.Copy() {
 		if key.namespace == namespace &&
 			rr.functionMap[name] != nil &&
 			rr.functionMap[name].ResourceVersion != resourceVersion {
-			frr.logger.V(1).Info("invalidating resolver cache", "function", name, "namespace", namespace)
+			frr.logger.V(1).Info("invalidating resolver cache", "function", name, "namespace", namespace, "trigger", key.triggerName)
 			frr.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
-			return true
+			invalidated = true
+			// Don't stop at the first match: the same function can back multiple
+			// triggers (and multiple cached trigger-RV entries), all now stale.
 		}
 	}
-	return false
+	return invalidated
 }

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -271,6 +271,7 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 		fh := &functionHandler{
 			logger:                   ts.logger.WithName(trigger.Name),
 			fmap:                     ts.functionServiceMap,
+			reader:                   ts.resolver.reader,
 			executor:                 ts.executor,
 			httpTrigger:              &trigger,
 			functionMap:              rr.functionMap,
@@ -380,6 +381,7 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 		fh := &functionHandler{
 			logger:                 ts.logger.WithName(fn.Name),
 			fmap:                   ts.functionServiceMap,
+			reader:                 ts.resolver.reader,
 			function:               &fn,
 			executor:               ts.executor,
 			tsRoundTripperParams:   ts.tsRoundTripperParams,

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -117,16 +117,6 @@ func GetInformerFactoryByExecutor(client kubernetes.Interface, labels labels.Sel
 	return informerFactory
 }
 
-func GetInformerFactoryByReadyPod(client kubernetes.Interface, namespace string, labelSelector *metav1.LabelSelector) (k8sInformers.SharedInformerFactory, error) {
-	informerFactory := k8sInformers.NewSharedInformerFactoryWithOptions(client, 0,
-		k8sInformers.WithNamespace(namespace),
-		k8sInformers.WithTweakListOptions(func(options *metav1.ListOptions) {
-			options.LabelSelector = labels.Set(labelSelector.MatchLabels).AsSelector().String()
-			options.FieldSelector = "status.phase=Running"
-		}))
-	return informerFactory, nil
-}
-
 func GetInformerLabelByExecutor(executorType fv1.ExecutorType) (labels.Selector, error) {
 	executorLabel, err := labels.NewRequirement(fv1.EXECUTOR_TYPE, selection.DoubleEquals, []string{string(executorType)})
 	if err != nil {


### PR DESCRIPTION
Two changes (the router fix is piggybacked per maintainer request):

## 1. Retire finformerFactory

The Function/Environment watches are controller-runtime reconcilers now, so the
per-namespace fission informer factory is fully redundant. Removed: its creation
in `executor.go`, the (unused) parameter from `MakeGenericPoolManager` /
`MakeNewDeploy` / `MakeContainer`, and its `startFactories`/`waitForSync` wiring.
The `/readyz` gate (`cachesSynced`) now waits on `crMgr.GetCache().WaitForCacheSync`
(a strict superset), using the runnable's context so it cancels on shutdown /
leadership loss.

## 2. Fix the TestGoEnv flake (router resolver staleness)

**Root cause** (structured debug of CI artifacts): after `fission fn update --pkg`,
a poolmgr function keeps being specialized with the **old** package. For poolmgr,
`getServiceEntry` always calls the executor with the mux handler's captured
function snapshot (`fh.function`) — no `functionServiceMap` shortcut — so the
executor specializes exactly that snapshot. The resolver caches the resolved
function keyed by the **trigger's** ResourceVersion; a function-only update
doesn't change the trigger RV, so `resolve` returns the stale function and the
handler keeps serving the old package. (Confirmed: the poolmgr Go pod
re-specialized with `go-pkg-v1` minutes after the update; newdeploy, which re-rolls
its own deployment, was unaffected.)

**Fix:** `getServiceEntryFromExecutor` now re-reads the current Function from the
Manager cache (via the resolver's reader) and specializes that — always the latest
spec. Also fixes `invalidateForFunction` to invalidate **all** matching cache
entries (a function can back multiple triggers), not just the first.

## Tests

Local gates green: `go build ./...`, `golangci-lint` (0 issues),
`make license-check`, `go test -race` (executor + router packages), e2e suite.
The real validation is the integration suite — **TestGoEnv** should now be stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3438)
<!-- Reviewable:end -->
