### PR TITLE
logger: migrate --logger pod watch to a controller-runtime reconciler

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -237,23 +237,26 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	return nil
 }
 
-// loggerCacheOptions scopes the Manager's Pod cache to pods on this node when
-// NODE_NAME is set (a spec.nodeName field selector), so the per-node DaemonSet
-// pod only mirrors its own node's pods rather than every pod in the cluster —
-// matching the per-node filtering isValidFunctionPodOnNode applied. When
-// NODE_NAME is unset (e.g. tests, or an install that doesn't inject it) the
-// cache watches all pods and isValidFunctionPodOnNode filters in the reconciler.
-// The cache is cluster-wide (DefaultNamespaces unset) because function pods can
-// live in any namespace; the logger's RBAC already grants pods list/watch.
+// loggerCacheOptions scopes the Manager's Pod cache to the Fission namespaces the
+// old per-namespace pod informers (GetK8sInformersForNamespaces) watched. The
+// fission-fluentbit ServiceAccount has pods list/watch only via per-namespace
+// Roles (no ClusterRole), so a cluster-wide cache would be forbidden and crashloop
+// on cache-sync. Within those namespaces, when NODE_NAME is set the Pod watch is
+// further scoped to this node (a per-node DaemonSet only needs its own node's
+// pods); isValidFunctionPodOnNode still filters in the reconciler.
 func loggerCacheOptions() crcache.Options {
-	if nodeName == "" {
-		return crcache.Options{}
+	resolver := utils.DefaultNSResolver()
+	nsConfig := map[string]crcache.Config{}
+	for _, ns := range resolver.FissionNSWithOptions(utils.WithBuilderNs(), utils.WithFunctionNs(), utils.WithDefaultNs()) {
+		nsConfig[ns] = crcache.Config{}
 	}
-	return crcache.Options{
-		ByObject: map[client.Object]crcache.ByObject{
+	opts := crcache.Options{DefaultNamespaces: nsConfig}
+	if nodeName != "" {
+		opts.ByObject = map[client.Object]crcache.ByObject{
 			&corev1.Pod{}: {
 				Field: fields.OneTermEqualSelector("spec.nodeName", nodeName),
 			},
-		},
+		}
 	}
+	return opts
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -12,16 +12,31 @@ import (
 	"strings"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
-	k8sCache "k8s.io/client-go/tools/cache"
-
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/utils"
 )
+
+// loggerScheme registers the Kubernetes built-in types (Pods) the logger's
+// reconciler watches.
+var loggerScheme = runtime.NewScheme()
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(loggerScheme))
+}
 
 var nodeName = os.Getenv("NODE_NAME")
 
@@ -32,36 +47,39 @@ var (
 	fissionSymlinkPath       = "/var/log/fission"
 )
 
-func podInformerHandlers(zapLogger logr.Logger) k8sCache.ResourceEventHandler {
-	return k8sCache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			pod := obj.(*corev1.Pod)
-			if !isValidFunctionPodOnNode(pod) || !utils.IsReadyPod(pod) {
-				return
-			}
-			err := createLogSymlinks(zapLogger, pod)
-			if err != nil {
-				funcName := pod.Labels[fv1.FUNCTION_NAME]
-				zapLogger.Error(err, "error creating symlink",
-					"function", funcName)
-			}
-		},
-		UpdateFunc: func(_, obj any) {
-			pod := obj.(*corev1.Pod)
-			if !isValidFunctionPodOnNode(pod) || !utils.IsReadyPod(pod) {
-				return
-			}
-			err := createLogSymlinks(zapLogger, pod)
-			if err != nil {
-				funcName := pod.Labels[fv1.FUNCTION_NAME]
-				zapLogger.Error(err, "error creating symlink",
-					"function", funcName)
-			}
-		},
-		DeleteFunc: func(obj any) {
-			// Do nothing here, let symlink reaper to recycle orphan symlink file
-		},
+// podReconciler creates log symlinks for valid, ready function pods scheduled on
+// this node, replacing the Pod informer's Add/Update handlers. It reacts to pod
+// STATUS changes (container IDs appear in Status.ContainerStatuses), so it must
+// NOT use GenerationChangedPredicate — that drops status-only updates and the
+// symlinks would never be created. A delete needs no handling here: the
+// symlinkReaper goroutine recycles orphan symlinks, so a NotFound (the pod is
+// gone) is a no-op, mirroring the old DeleteFunc.
+type podReconciler struct {
+	logger logr.Logger
+	client client.Client
+}
+
+func (r *podReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	pod := &corev1.Pod{}
+	if err := r.client.Get(ctx, req.NamespacedName, pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Pod gone; symlinkReaper reaps any orphan symlink.
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
 	}
+	// Mirror the old Add/Update handlers: only act on valid function pods on this
+	// node that are ready. The cache is already scoped to this node by field
+	// selector when NODE_NAME is set, but isValidFunctionPodOnNode re-checks the
+	// node defensively (and is the only filter when NODE_NAME is unset).
+	if !isValidFunctionPodOnNode(pod) || !utils.IsReadyPod(pod) {
+		return ctrl.Result{}, nil
+	}
+	if err := createLogSymlinks(r.logger, pod); err != nil {
+		r.logger.Error(err, "error creating symlink", "function", pod.Labels[fv1.FUNCTION_NAME])
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
 }
 
 func createLogSymlinks(zapLogger logr.Logger, pod *corev1.Pod) error {
@@ -178,21 +196,64 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	}
 	go symlinkReaper(logger)
 
-	kubernetesClient, err := clientGen.GetKubernetesClient()
+	restConfig, err := clientGen.GetRestConfig()
 	if err != nil {
 		return err
 	}
 
-	var wg wait.Group
-	for _, podInformer := range utils.GetK8sInformersForNamespaces(kubernetesClient, time.Minute*30, fv1.Pods) {
-		_, err := podInformer.AddEventHandler(podInformerHandlers(logger))
-		if err != nil {
-			return err
-		}
-		wg.StartWithChannel(ctx.Done(), podInformer.Run)
+	// The logger is a DaemonSet (one pod per node). Each node's logger MUST
+	// process its OWN pods, so the Manager MUST NOT use leader election — with
+	// leader election only one node's logger would run and logging would break on
+	// every other node. Build a non-leader-elected Manager whose every runnable
+	// (here the Pod reconciler) runs on this replica unconditionally.
+	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+		Scheme: loggerScheme,
+		Cache:  loggerCacheOptions(),
+		// No Manager-owned metrics/health servers: the logger serves none.
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		LeaderElection:         false,
+		Logger:                 logger,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to set up logger manager: %w", err)
 	}
-	wg.Wait()
+
+	pr := &podReconciler{
+		logger: logger.WithName("pod_reconciler"),
+		client: mgr.GetClient(),
+	}
+	// React to pod STATUS changes (container IDs appear in status), so do NOT use
+	// GenerationChangedPredicate. Pass no predicates to watch every pod event.
+	if err := controller.RegisterWithPredicates(mgr, &corev1.Pod{}, pr, "logger-pod", 0); err != nil {
+		return fmt.Errorf("unable to register pod reconciler: %w", err)
+	}
+
+	if err := mgr.Start(ctx); err != nil {
+		return fmt.Errorf("error running logger manager: %w", err)
+	}
 
 	logger.Error(nil, "Stop watching pod changes")
 	return nil
+}
+
+// loggerCacheOptions scopes the Manager's Pod cache to pods on this node when
+// NODE_NAME is set (a spec.nodeName field selector), so the per-node DaemonSet
+// pod only mirrors its own node's pods rather than every pod in the cluster —
+// matching the per-node filtering isValidFunctionPodOnNode applied. When
+// NODE_NAME is unset (e.g. tests, or an install that doesn't inject it) the
+// cache watches all pods and isValidFunctionPodOnNode filters in the reconciler.
+// The cache is cluster-wide (DefaultNamespaces unset) because function pods can
+// live in any namespace; the logger's RBAC already grants pods list/watch.
+func loggerCacheOptions() crcache.Options {
+	if nodeName == "" {
+		return crcache.Options{}
+	}
+	return crcache.Options{
+		ByObject: map[client.Object]crcache.ByObject{
+			&corev1.Pod{}: {
+				Field: fields.OneTermEqualSelector("spec.nodeName", nodeName),
+			},
+		},
+	}
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
@@ -191,13 +195,10 @@ func TestReapStaleSymlinks(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "symlink with a missing target should be removed")
 }
 
-func TestPodInformerHandlers(t *testing.T) {
+func TestPodReconciler(t *testing.T) {
 	origNode := nodeName
 	nodeName = "this-node"
 	t.Cleanup(func() { nodeName = origNode })
-
-	handler := podInformerHandlers(logr.Discard())
-	require.NotNil(t, handler)
 
 	readyPod := func() *corev1.Pod {
 		pod := podWithContainerStatuses(
@@ -207,43 +208,64 @@ func TestPodInformerHandlers(t *testing.T) {
 		return pod
 	}
 
-	t.Run("AddFunc creates a symlink for a valid ready pod", func(t *testing.T) {
+	// reconcileFor builds a fake-client-backed reconciler seeded with pod and
+	// reconciles it once.
+	reconcileFor := func(t *testing.T, pod *corev1.Pod) error {
+		t.Helper()
+		c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(pod).Build()
+		r := &podReconciler{logger: logr.Discard(), client: c}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name},
+		})
+		return err
+	}
+
+	t.Run("creates a symlink for a valid ready pod", func(t *testing.T) {
 		symlinkDir, _ := redirectLogPaths(t)
 		pod := readyPod()
 
-		handler.OnAdd(pod, false)
+		require.NoError(t, reconcileFor(t, pod))
 
 		link := getLogPath(symlinkDir, pod.Name, pod.Namespace, "c1", "ready-uid")
 		_, err := os.Lstat(link)
-		assert.NoError(t, err, "AddFunc should create the symlink")
+		assert.NoError(t, err, "reconcile should create the symlink")
 	})
 
-	t.Run("AddFunc ignores a pod scheduled elsewhere", func(t *testing.T) {
+	t.Run("ignores a pod scheduled elsewhere", func(t *testing.T) {
 		symlinkDir, _ := redirectLogPaths(t)
 		pod := readyPod()
 		pod.Spec.NodeName = "other-node"
 
-		handler.OnAdd(pod, false)
+		require.NoError(t, reconcileFor(t, pod))
 
 		entries, err := os.ReadDir(symlinkDir)
 		require.NoError(t, err)
 		assert.Empty(t, entries)
 	})
 
-	t.Run("UpdateFunc creates a symlink for a valid ready pod", func(t *testing.T) {
+	t.Run("ignores a non-ready pod", func(t *testing.T) {
 		symlinkDir, _ := redirectLogPaths(t)
-		pod := readyPod()
+		pod := podWithContainerStatuses(
+			corev1.ContainerStatus{Name: "c1", ContainerID: "docker://not-ready", Ready: false},
+		)
 
-		handler.OnUpdate(nil, pod)
+		require.NoError(t, reconcileFor(t, pod))
 
-		link := getLogPath(symlinkDir, pod.Name, pod.Namespace, "c1", "ready-uid")
-		_, err := os.Lstat(link)
-		assert.NoError(t, err, "UpdateFunc should create the symlink")
+		entries, err := os.ReadDir(symlinkDir)
+		require.NoError(t, err)
+		assert.Empty(t, entries)
 	})
 
-	t.Run("DeleteFunc is a no-op", func(t *testing.T) {
+	t.Run("NotFound is a no-op", func(t *testing.T) {
 		symlinkDir, _ := redirectLogPaths(t)
-		handler.OnDelete(readyPod())
+		c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).Build()
+		r := &podReconciler{logger: logr.Discard(), client: c}
+
+		_, err := r.Reconcile(t.Context(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: "fission-function", Name: "gone"},
+		})
+		require.NoError(t, err)
+
 		entries, err := os.ReadDir(symlinkDir)
 		require.NoError(t, err)
 		assert.Empty(t, entries)


### PR DESCRIPTION
Replaces the raw Pod informer + event handler in `pkg/logger` with a controller-runtime Pod reconciler.

## DaemonSet specifics (the important bits)
The `--logger` subsystem is a per-node DaemonSet, so each node's logger must process its own pods.
The Manager is built with **`LeaderElection: false`** — leader election would let only one node's logger run and break logging on every other node.
The reconciler reacts to pod **status** changes (container IDs appear in `Status.ContainerStatuses`), so it registers with **no predicates** — in particular *not* `GenerationChangedPredicate`, which would drop status-only updates.
It mirrors the old Add/Update handlers: for a valid, ready function pod on this node it calls the idempotent `createLogSymlinks`. A NotFound is a no-op; the existing `symlinkReaper` goroutine still recycles orphan symlinks.

## Cache scope (RBAC)
The Manager cache is scoped to the **Fission namespaces** the old `GetK8sInformersForNamespaces` informers watched (`FissionNSWithOptions`) — the `fission-fluentbit` ServiceAccount has pods list/watch only via per-namespace Roles (no ClusterRole), so a cluster-wide cache would be forbidden and crashloop on cache-sync. Within those namespaces the Pod watch is further scoped to this node via a `spec.nodeName` field selector when `NODE_NAME` is set.
RBAC is unchanged.

`Start`'s signature is unchanged: `Start(ctx, clientGen, logger) error`. `TestPodInformerHandlers` is replaced by `TestPodReconciler`.

## Verification
`go build ./...`, `golangci-lint run ./pkg/logger/...` (0 issues), `go test ./pkg/logger/...`, `make license-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3440)
<!-- Reviewable:end -->
