### PR TITLE
perf(logger): memoize base zap logger and lazy-init webhook loggers

### DIFF
--- a/pkg/utils/loggerfactory/loggerfactory.go
+++ b/pkg/utils/loggerfactory/loggerfactory.go
@@ -7,6 +7,7 @@ package loggerfactory
 import (
 	"os"
 	"strconv"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"go.uber.org/zap"
@@ -14,7 +15,14 @@ import (
 	kzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-func GetLogger() logr.Logger {
+var (
+	baseLogger     logr.Logger
+	baseLoggerOnce sync.Once
+)
+
+// buildLogger constructs the controller-runtime zap logger. DEBUG_ENV is read
+// here, at first construction time, and decides Debug vs Info level.
+func buildLogger() logr.Logger {
 	encConfOpt := func(o *kzap.Options) {
 		encTimeFunc := func(encConfig *zapcore.EncoderConfig) {
 			encConfig.EncodeTime = zapcore.ISO8601TimeEncoder
@@ -28,4 +36,16 @@ func GetLogger() logr.Logger {
 		level = kzap.Level(zap.DebugLevel)
 	}
 	return kzap.New(level, encConfOpt)
+}
+
+// GetLogger returns a process-wide shared base logger. The underlying zap core
+// (including its sampler) is constructed exactly once and memoized, so every
+// caller shares a single sampler instead of allocating a fresh one per call.
+// Callers may chain .WithName()/.WithValues(); those derive cheaply without
+// allocating a new sampler.
+func GetLogger() logr.Logger {
+	baseLoggerOnce.Do(func() {
+		baseLogger = buildLogger()
+	})
+	return baseLogger
 }

--- a/pkg/utils/loggerfactory/loggerfactory_test.go
+++ b/pkg/utils/loggerfactory/loggerfactory_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package loggerfactory
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGetLoggerMemoized asserts that GetLogger() returns a logger backed by the
+// same underlying sink across calls, proving the base zap core/sampler is
+// constructed once and shared rather than re-allocated per call.
+func TestGetLoggerMemoized(t *testing.T) {
+	a := GetLogger()
+	b := GetLogger()
+
+	sinkA := a.GetSink()
+	sinkB := b.GetSink()
+	require.NotNil(t, sinkA)
+	require.NotNil(t, sinkB)
+
+	assert.Equal(t,
+		reflect.ValueOf(sinkA).Pointer(),
+		reflect.ValueOf(sinkB).Pointer(),
+		"GetLogger() should return a logger backed by the same memoized sink",
+	)
+}
+
+// TestGetLoggerLogsWithoutPanic is a basic smoke test ensuring the memoized
+// logger is usable.
+func TestGetLoggerLogsWithoutPanic(t *testing.T) {
+	logger := GetLogger().WithName("smoke").WithValues("k", "v")
+	assert.NotPanics(t, func() {
+		logger.Info("smoke test message", "field", "value")
+		logger.V(1).Info("debug-ish message")
+	})
+}

--- a/pkg/webhook/canaryconfig.go
+++ b/pkg/webhook/canaryconfig.go
@@ -16,11 +16,8 @@ type CanaryConfig struct {
 	GenericWebhook[*v1.CanaryConfig]
 }
 
-// log is for logging in this package.
-var canaryConfigLog = loggerfactory.GetLogger().WithName("canaryconfig-resource")
-
 func (r *CanaryConfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = canaryConfigLog
+	r.Logger = loggerfactory.GetLogger().WithName("canaryconfig-resource")
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.CanaryConfig{})
 }
 

--- a/pkg/webhook/environment.go
+++ b/pkg/webhook/environment.go
@@ -16,11 +16,8 @@ type Environment struct {
 	GenericWebhook[*v1.Environment]
 }
 
-// log is for logging in this package.
-var environmentlog = loggerfactory.GetLogger().WithName("environment-resource")
-
 func (r *Environment) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = environmentlog
+	r.Logger = loggerfactory.GetLogger().WithName("environment-resource")
 	r.Validator = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.Environment{})
 }

--- a/pkg/webhook/function.go
+++ b/pkg/webhook/function.go
@@ -18,11 +18,8 @@ type Function struct {
 	GenericWebhook[*v1.Function]
 }
 
-// log is for logging in this package.
-var functionlog = loggerfactory.GetLogger().WithName("function-resource")
-
 func (r *Function) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = functionlog
+	r.Logger = loggerfactory.GetLogger().WithName("function-resource")
 	r.Validator = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.Function{})
 }

--- a/pkg/webhook/httptrigger.go
+++ b/pkg/webhook/httptrigger.go
@@ -16,11 +16,8 @@ type HTTPTrigger struct {
 	GenericWebhook[*v1.HTTPTrigger]
 }
 
-// log is for logging in this package.
-var httptriggerlog = loggerfactory.GetLogger().WithName("httptrigger-resource")
-
 func (r *HTTPTrigger) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = httptriggerlog
+	r.Logger = loggerfactory.GetLogger().WithName("httptrigger-resource")
 	r.Validator = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.HTTPTrigger{})
 }

--- a/pkg/webhook/kuberneteswatchtrigger.go
+++ b/pkg/webhook/kuberneteswatchtrigger.go
@@ -19,11 +19,8 @@ type KubernetesWatchTrigger struct {
 	GenericWebhook[*v1.KubernetesWatchTrigger]
 }
 
-// log is for logging in this package.
-var kuberneteswatchtriggerlog = loggerfactory.GetLogger().WithName("kuberneteswatchtrigger-resource")
-
 func (r *KubernetesWatchTrigger) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = kuberneteswatchtriggerlog
+	r.Logger = loggerfactory.GetLogger().WithName("kuberneteswatchtrigger-resource")
 	r.Validator = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.KubernetesWatchTrigger{})
 }

--- a/pkg/webhook/messagequeuetrigger.go
+++ b/pkg/webhook/messagequeuetrigger.go
@@ -20,11 +20,8 @@ type MessageQueueTrigger struct {
 	GenericWebhook[*v1.MessageQueueTrigger]
 }
 
-// log is for logging in this package.
-var messagequeuetriggerlog = loggerfactory.GetLogger().WithName("messagequeuetrigger-resource")
-
 func (r *MessageQueueTrigger) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = messagequeuetriggerlog
+	r.Logger = loggerfactory.GetLogger().WithName("messagequeuetrigger-resource")
 	r.Validator = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.MessageQueueTrigger{})
 }

--- a/pkg/webhook/package.go
+++ b/pkg/webhook/package.go
@@ -20,11 +20,8 @@ type Package struct {
 	GenericWebhook[*v1.Package]
 }
 
-// log is for logging in this package.
-var packagelog = loggerfactory.GetLogger().WithName("package-resource")
-
 func (r *Package) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = packagelog
+	r.Logger = loggerfactory.GetLogger().WithName("package-resource")
 	r.Validator = r
 	r.Defaulter = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.Package{})

--- a/pkg/webhook/timetrigger.go
+++ b/pkg/webhook/timetrigger.go
@@ -16,11 +16,8 @@ type TimeTrigger struct {
 	GenericWebhook[*v1.TimeTrigger]
 }
 
-// log is for logging in this package.
-var timetriggerlog = loggerfactory.GetLogger().WithName("timetrigger-resource")
-
 func (r *TimeTrigger) SetupWebhookWithManager(mgr ctrl.Manager) error {
-	r.Logger = timetriggerlog
+	r.Logger = loggerfactory.GetLogger().WithName("timetrigger-resource")
 	r.Validator = r
 	return r.GenericWebhook.SetupWebhookWithManager(mgr, &v1.TimeTrigger{})
 }


### PR DESCRIPTION
Profiling of `fission-bundle` showed 7-14 live zap samplers per process (each ~448KB, `zapcore.newCounters`).

Two causes, both fixed here.

`pkg/utils/loggerfactory/GetLogger()` built a fresh `kzap.New` (controller-runtime zap, which wraps a sampler) on every call, with 59 call sites and no memoization.
This change wraps construction in `sync.Once` so every caller shares one underlying zap core/sampler.
`DEBUG_ENV` is read once at first construction (Info by default, Debug when truthy); the `func GetLogger() logr.Logger` signature is unchanged.
Callers that chain `.WithName()` / `.WithValues()` derive cheaply without allocating a new sampler.

`pkg/webhook` had 8 package-level vars of the form `var xlog = loggerfactory.GetLogger().WithName("...-resource")`.
Go runs `init()` for every linked package, and `pkg/webhook` is linked into the single `fission-bundle` binary, so those 8 samplers allocated in every subsystem (router, executor, timer, ...) even when only `--webhookPort` uses them.
Each var is now inlined into its file's `SetupWebhookWithManager` (`r.Logger = loggerfactory.GetLogger().WithName("...-resource")`), so the loggers are only constructed when the webhook server actually starts.
The exact `WithName(...)` strings are preserved.

Added `pkg/utils/loggerfactory/loggerfactory_test.go`: asserts two `GetLogger()` calls return loggers backed by the same sink (memoization) and a logging smoke test.

Note: log sampling throttle is now process-global rather than per-logger.
This is acceptable and arguably preferable, since the goal is one shared sampler.

## Context

This is one of two memory optimizations surfaced by a before/after pprof comparison of the RFC-0005 WS3 reconciler migration.
The companion PR drops `aws-sdk-go` v1 from the binary.
Neither is required by the RFC; both are pre-existing steady-state costs paid by every `fission-bundle` subsystem.

## Verification

- `go build ./...`
- `go test ./pkg/utils/loggerfactory/... ./pkg/webhook/...`
- `make code-checks` (0 issues)
- `make license-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3442)
<!-- Reviewable:end -->
