### PR TITLE
fix(utils): confine zip extraction with os.Root (zip-slip / CWE-22)

### DIFF
--- a/pkg/utils/zip.go
+++ b/pkg/utils/zip.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mholt/archives"
 )
@@ -74,7 +75,13 @@ func Archive(ctx context.Context, src string, dst string) error {
 	return err
 }
 
-// Unarchive is a function that unzips a zip file to destination
+// Unarchive unzips the zip file at src into dst.
+//
+// Extraction is confined to dst through an os.Root: the archive entry name
+// arrives from a user-supplied package, so a crafted name (e.g. "../../etc/x"
+// or an absolute path) must not write outside dst. os.Root enforces that in the
+// kernel; we also reject escaping names and symlink entries up front for a
+// clear error (zip-slip / CWE-22).
 func Unarchive(ctx context.Context, src string, dst string) error {
 	var format archives.Zip
 	file, err := os.Open(src)
@@ -83,20 +90,46 @@ func Unarchive(ctx context.Context, src string, dst string) error {
 	}
 	defer file.Close()
 
+	// The destination must exist before we can open a root on it. Mode 0o755 is
+	// required so that other containers in the same pod (running under
+	// different UIDs / GIDs — fetcher sidecar at UID 10001 vs. builder
+	// running as root) can read this shared /packages volume. Tighter
+	// modes break cross-container access for the v2 builder flow.
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return fmt.Errorf("failed to create destination directory: %w", err)
+	}
+	root, err := os.OpenRoot(dst)
+	if err != nil {
+		return fmt.Errorf("failed to open destination root: %w", err)
+	}
+	defer root.Close()
+
 	return format.Extract(ctx, file, func(ctx context.Context, f archives.FileInfo) error {
-		destPath := filepath.Join(dst, f.NameInArchive)
-		// check if the file is a directory
-		if f.IsDir() {
-			return os.MkdirAll(destPath, f.Mode())
+		// Confine the archive entry to dst.
+		name := filepath.Clean(filepath.FromSlash(f.NameInArchive))
+		if name == "." {
+			return nil // archive root; dst already exists
+		}
+		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(os.PathSeparator)) {
+			return fmt.Errorf("archive entry %q escapes destination", f.NameInArchive)
+		}
+		// Refuse symlink entries: function packages have no need for them, and
+		// they are an avenue for escaping the extraction root.
+		if f.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("archive entry %q is a symlink; refusing to extract", f.NameInArchive)
 		}
 
-		// check if parent directory exists for the file. Mode 0o755 is
-		// required so that other containers in the same pod (running under
-		// different UIDs / GIDs — fetcher sidecar at UID 10001 vs. builder
-		// running as root) can read this shared /packages volume. Tighter
-		// modes break cross-container access for the v2 builder flow.
-		if err := os.MkdirAll(filepath.Dir(destPath), os.ModeDir|0o755); err != nil {
-			return fmt.Errorf("failed to create parent directory: %w", err)
+		// check if the file is a directory
+		if f.IsDir() {
+			return root.MkdirAll(name, f.Mode().Perm())
+		}
+
+		// Create the parent directory at 0o755 for the same cross-container
+		// access reason as the destination root above.
+		if dir := filepath.Dir(name); dir != "." {
+			if err := root.MkdirAll(dir, 0o755); err != nil {
+				return fmt.Errorf("failed to create parent directory: %w", err)
+			}
 		}
 
 		// Open file in archive
@@ -109,7 +142,7 @@ func Unarchive(ctx context.Context, src string, dst string) error {
 		// Create file in destination with the archive entry's mode applied
 		// at create time, so a concurrent observer never sees a wider mode.
 		// Same overwrite semantics as os.Create.
-		destFile, err := os.OpenFile(destPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
+		destFile, err := root.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_TRUNC, f.Mode().Perm())
 		if err != nil {
 			return fmt.Errorf("failed to create file in destination: %w", err)
 		}

--- a/pkg/utils/zip_test.go
+++ b/pkg/utils/zip_test.go
@@ -5,12 +5,110 @@
 package utils
 
 import (
+	"archive/zip"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type rawZipEntry struct {
+	name string
+	mode os.FileMode
+	body string
+}
+
+// writeRawZip writes a zip whose entry names and modes are set verbatim,
+// bypassing any archive-time sanitization so that malicious names (the kind an
+// attacker-supplied package can contain) reach the extractor unchanged.
+func writeRawZip(t *testing.T, path string, entries ...rawZipEntry) {
+	t.Helper()
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	for _, e := range entries {
+		hdr := &zip.FileHeader{Name: e.name, Method: zip.Deflate}
+		hdr.SetMode(e.mode)
+		w, err := zw.CreateHeader(hdr)
+		require.NoError(t, err)
+		_, err = w.Write([]byte(e.body))
+		require.NoError(t, err)
+	}
+	require.NoError(t, zw.Close())
+}
+
+// TestUnarchiveZipSlip verifies that a malicious archive entry cannot write
+// outside the destination directory (zip-slip / CWE-22) and that symlink
+// entries are refused, while benign archives still extract.
+func TestUnarchiveZipSlip(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	t.Run("parent traversal is refused", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		sentinel := filepath.Join(tmp, "sentinel")
+		require.NoError(t, os.WriteFile(sentinel, []byte("intact"), 0o600))
+
+		zipPath := filepath.Join(tmp, "evil.zip")
+		writeRawZip(t, zipPath, rawZipEntry{name: "../escape.txt", mode: 0o644, body: "pwned"})
+
+		err := Unarchive(ctx, zipPath, filepath.Join(tmp, "dst"))
+		assert.Error(t, err)
+		assert.NoFileExists(t, filepath.Join(tmp, "escape.txt"))
+
+		got, err := os.ReadFile(sentinel)
+		require.NoError(t, err)
+		assert.Equal(t, "intact", string(got))
+	})
+
+	t.Run("absolute path is refused", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		abs := filepath.Join(tmp, "abs-escape.txt")
+		zipPath := filepath.Join(tmp, "evil.zip")
+		writeRawZip(t, zipPath, rawZipEntry{name: abs, mode: 0o644, body: "pwned"})
+
+		err := Unarchive(ctx, zipPath, filepath.Join(tmp, "dst"))
+		assert.Error(t, err)
+		assert.NoFileExists(t, abs)
+	})
+
+	t.Run("symlink entry is refused", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		zipPath := filepath.Join(tmp, "evil.zip")
+		writeRawZip(t, zipPath, rawZipEntry{name: "link", mode: 0o777 | os.ModeSymlink, body: "/etc/passwd"})
+
+		dst := filepath.Join(tmp, "dst")
+		err := Unarchive(ctx, zipPath, dst)
+		assert.Error(t, err)
+		_, lerr := os.Lstat(filepath.Join(dst, "link"))
+		assert.True(t, os.IsNotExist(lerr), "no symlink should be created")
+	})
+
+	t.Run("benign archive still extracts", func(t *testing.T) {
+		t.Parallel()
+		tmp := t.TempDir()
+		zipPath := filepath.Join(tmp, "ok.zip")
+		writeRawZip(t, zipPath,
+			rawZipEntry{name: "a.txt", mode: 0o644, body: "alpha"},
+			rawZipEntry{name: "sub/b.txt", mode: 0o644, body: "beta"},
+		)
+		dst := filepath.Join(tmp, "dst")
+		require.NoError(t, Unarchive(ctx, zipPath, dst))
+
+		got, err := os.ReadFile(filepath.Join(dst, "a.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "alpha", string(got))
+		got, err = os.ReadFile(filepath.Join(dst, "sub", "b.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "beta", string(got))
+	})
+}
 
 func TestIsZip(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## What

Fixes a **zip-slip path traversal (CWE-22)** in `pkg/utils/zip.go:Unarchive()`.

The extractor built each output path as `filepath.Join(dst, f.NameInArchive)` and wrote it with no sanitization of the archive entry name.
`f.NameInArchive` comes from a user-supplied package archive, so an entry named `../../etc/x` (or an absolute path) wrote **outside** `dst`.

This is reachable server-side: the **fetcher** sidecar calls `Unarchive` when it extracts a Package's source/deployment archive (`pkg/fetcher/fetcher.go`), so any user who can create a Package can craft a malicious archive.

## How

Extraction now runs through an [`os.Root`](https://pkg.go.dev/os#Root) (Go 1.24+) opened on `dst`.
`os.Root` confines every `MkdirAll`/`OpenFile` to the destination **in the kernel** — it rejects absolute paths and `..` traversal — so a crafted entry name cannot escape.
Escaping entry names and symlink entries are additionally rejected up front for a clear error.
This mirrors the `os.Root` approach already merged in storagesvc (#3443), which also cleared CodeQL `go/path-injection`.

The load-bearing **`0o755` cross-container directory mode** and the per-file create-with-mode behavior are preserved (the shared `/packages` volume is read by other-UID containers — fetcher UID 10001 vs. builder root).

## Behavior change

A **symlink** archive entry is now **rejected** with an error.
Previously it was silently written as a regular file containing the link-target string (it fell through to the file branch).
Function packages are not expected to contain symlinks, so real-world impact should be nil — but flagging it.

## Verification

- New `TestUnarchiveZipSlip`: builds malicious zips with `archive/zip` (raw entry names `../escape.txt`, an absolute path, and a symlink), asserts `Unarchive` errors and that **nothing is written outside `dst`** (sentinel sibling file untouched), plus a benign archive that still extracts.
- Existing `TestArchiveUnarchive` / `TestArchiveOverwrite` / `TestIsZip` still pass (round-trip + 0o755/0o644 perm preservation).
- `go test -race ./pkg/utils/...`, `make code-checks` (0 issues), `make license-check` all pass.

This is the first of a short series hardening Fission's server-side filesystem calls with `os.Root`; follow-ups will migrate the fetcher/builder sinks off `SanitizeFilePath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3444)
<!-- Reviewable:end -->
