### PR TITLE
refactor(fetcher,builder): confine shared-volume FS ops with os.Root helpers

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -256,7 +256,7 @@ func (builder *Builder) build(ctx context.Context, command string, args []string
 
 	fi, err := utils.RootStat(builder.sharedVolumePath, srcPkgPath)
 	if err != nil {
-		return "", fmt.Errorf("could not find srcPkgPath: '%s'", srcPkgPath)
+		return "", fmt.Errorf("could not find srcPkgPath '%s': %w", srcPkgPath, err)
 	}
 	if fi.IsDir() {
 		cmd.Dir = srcPkgPath

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -154,14 +153,14 @@ func (builder *Builder) Handler(w http.ResponseWriter, r *http.Request) {
 		"buildCommandLen", len(req.BuildCommand))
 
 	logger.V(1).Info("starting build")
-	srcPkgPath, err := utils.SanitizeFilePath(filepath.Join(builder.sharedVolumePath, req.SrcPkgFilename), builder.sharedVolumePath)
+	srcPkgPath, err := utils.RootJoin(builder.sharedVolumePath, req.SrcPkgFilename)
 	if err != nil {
 		logger.Error(err, "filename", req.SrcPkgFilename)
 		builder.reply(r.Context(), w, "", err.Error(), http.StatusBadRequest)
 		return
 	}
 	deployPkgFilename := fmt.Sprintf("%s-%s", req.SrcPkgFilename, strings.ToLower(uniuri.NewLen(6)))
-	deployPkgPath, err := utils.SanitizeFilePath(filepath.Join(builder.sharedVolumePath, deployPkgFilename), builder.sharedVolumePath)
+	deployPkgPath, err := utils.RootJoin(builder.sharedVolumePath, deployPkgFilename)
 	if err != nil {
 		logger.Error(err, "filename", req.SrcPkgFilename)
 		builder.reply(r.Context(), w, "", err.Error(), http.StatusBadRequest)
@@ -205,7 +204,7 @@ func (builder *Builder) Clean(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	srcPkgFilename := r.URL.Query().Get("name")
-	srcPkgPath, err := utils.SanitizeFilePath(filepath.Join(builder.sharedVolumePath, srcPkgFilename), builder.sharedVolumePath)
+	srcPkgPath, err := utils.RootJoin(builder.sharedVolumePath, srcPkgFilename)
 	if err != nil {
 		logger.Error(err, "rejecting clean request", "source_package", srcPkgFilename)
 		builder.reply(r.Context(), w, srcPkgFilename, fmt.Sprintf("error: invalid name: %s", err.Error()), http.StatusBadRequest)
@@ -255,7 +254,7 @@ func (builder *Builder) build(ctx context.Context, command string, args []string
 
 	cmd := exec.Command(command, args...)
 
-	fi, err := os.Stat(srcPkgPath)
+	fi, err := utils.RootStat(builder.sharedVolumePath, srcPkgPath)
 	if err != nil {
 		return "", fmt.Errorf("could not find srcPkgPath: '%s'", srcPkgPath)
 	}

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -178,10 +178,10 @@ func verifyChecksum(fileChecksum, checksum *fv1.Checksum) error {
 
 func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
 	for key, val := range dataMap {
-		writeFilePath := filepath.Join(dirPath, key)
-		err := os.WriteFile(writeFilePath, val, 0750)
-		if err != nil {
-			return fmt.Errorf("failed to write file %s: %w", writeFilePath, err)
+		// key is a Secret/ConfigMap data key; route through an os.Root rooted
+		// at dirPath so a key cannot write outside it.
+		if err := utils.RootWriteFile(dirPath, key, val, 0750); err != nil {
+			return fmt.Errorf("failed to write file %s in %s: %w", key, dirPath, err)
 		}
 	}
 	return nil
@@ -293,14 +293,14 @@ func (fetcher *Fetcher) SpecializeHandler(w http.ResponseWriter, r *http.Request
 func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req FunctionFetchRequest) (int, error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
 
-	storePath, err := utils.SanitizeFilePath(filepath.Join(fetcher.sharedVolumePath, req.Filename), fetcher.sharedVolumePath)
+	storePath, err := utils.RootJoin(fetcher.sharedVolumePath, req.Filename)
 	if err != nil {
 		logger.Error(err, "filename", req.Filename)
 		return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err, req)
 	}
 
 	// verify first if the file already exists.
-	if _, err := os.Stat(storePath); err == nil {
+	if _, err := utils.RootStat(fetcher.sharedVolumePath, storePath); err == nil {
 		logger.Info("requested file already exists at shared volume - skipping fetch",
 			"requested_file", req.Filename,
 			"shared_volume_path", fetcher.sharedVolumePath)
@@ -308,7 +308,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 		return http.StatusOK, nil
 	}
 
-	tmpPath, err := utils.SanitizeFilePath(storePath+".tmp", fetcher.sharedVolumePath)
+	tmpPath, err := utils.RootJoin(fetcher.sharedVolumePath, storePath+".tmp")
 	if err != nil {
 		logger.Error(err, "filename", req.Filename)
 		return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err, req)
@@ -355,7 +355,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 		// get package data as literal or by url
 		if len(archive.Literal) > 0 {
 			// write pkg.Literal into tmpPath
-			err := os.WriteFile(tmpPath, archive.Literal, 0600)
+			err := utils.RootWriteFile(fetcher.sharedVolumePath, tmpPath, archive.Literal, 0600)
 			if err != nil {
 				e := "failed to write file"
 				logger.Error(err, e, "location", tmpPath)
@@ -447,13 +447,13 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 				return httpCode, errors.New(e)
 			}
 
-			secretDir, err := utils.SanitizeFilePath(filepath.Join(fetcher.sharedSecretPath, secret.Namespace, secret.Name), fetcher.sharedSecretPath)
+			secretDir, err := utils.RootJoin(fetcher.sharedSecretPath, filepath.Join(secret.Namespace, secret.Name))
 			if err != nil {
 				logger.Error(err, "directory", secretDir, "secret_name", secret.Name, "secret_namespace", secret.Namespace)
 				return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err, secret)
 			}
 
-			err = os.MkdirAll(secretDir, os.ModeDir|0750)
+			err = utils.RootMkdirAll(fetcher.sharedSecretPath, secretDir, 0750)
 			if err != nil {
 				e := "failed to create directory for secret"
 				logger.Error(err, e, "directory", secretDir,
@@ -493,14 +493,14 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 				return httpCode, errors.New(e)
 			}
 
-			configDir, err := utils.SanitizeFilePath(filepath.Join(fetcher.sharedConfigPath, config.Namespace, config.Name), fetcher.sharedConfigPath)
+			configDir, err := utils.RootJoin(fetcher.sharedConfigPath, filepath.Join(config.Namespace, config.Name))
 			if err != nil {
 				logger.Error(err, "directory", configDir, "config_map_name", config.Name, "config_map_namespace", config.Namespace)
 				return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err,
 					config)
 			}
 
-			err = os.MkdirAll(configDir, os.ModeDir|0750)
+			err = utils.RootMkdirAll(fetcher.sharedConfigPath, configDir, 0750)
 			if err != nil {
 				e := "failed to create directory for configmap"
 				logger.Error(err, e, "directory", configDir,
@@ -562,13 +562,13 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("fetcher received upload request", "request", req)
 
-	srcFilepath, err := utils.SanitizeFilePath(filepath.Join(fetcher.sharedVolumePath, req.Filename), fetcher.sharedVolumePath)
+	srcFilepath, err := utils.RootJoin(fetcher.sharedVolumePath, req.Filename)
 	if err != nil {
 		logger.Error(err, "error sanitizing file path")
 		http.Error(w, fmt.Sprintf("%s: %v", err, req.Filename), http.StatusBadRequest)
 		return
 	}
-	dstFilepath, err := utils.SanitizeFilePath(filepath.Join(fetcher.sharedVolumePath, req.Filename+".zip"), fetcher.sharedVolumePath)
+	dstFilepath, err := utils.RootJoin(fetcher.sharedVolumePath, req.Filename+".zip")
 	if err != nil {
 		logger.Error(err, "error sanitizing file path")
 		http.Error(w, fmt.Sprintf("%s: %v", err, req.Filename), http.StatusBadRequest)
@@ -592,7 +592,7 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		err = os.Rename(srcFilepath, dstFilepath)
+		err = utils.RootRename(fetcher.sharedVolumePath, srcFilepath, dstFilepath)
 		if err != nil {
 			e := "error renaming the archive"
 			logger.Error(err, e, "source", srcFilepath, "destination", dstFilepath)
@@ -646,7 +646,8 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (fetcher *Fetcher) rename(src string, dst string) error {
-	err := os.Rename(src, dst)
+	// src and dst are always under the shared volume; confine the rename to it.
+	err := utils.RootRename(fetcher.sharedVolumePath, src, dst)
 	if err != nil {
 		return fmt.Errorf("failed to move file: %w", err)
 	}

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -177,10 +177,16 @@ func verifyChecksum(fileChecksum, checksum *fv1.Checksum) error {
 }
 
 func writeSecretOrConfigMap(dataMap map[string][]byte, dirPath string) error {
+	// Open the os.Root once and write every key through it: os.Root confines
+	// each write to dirPath (the keys are Secret/ConfigMap data keys), and
+	// reusing one root avoids an openat per key.
+	root, err := os.OpenRoot(dirPath)
+	if err != nil {
+		return fmt.Errorf("failed to open directory %s: %w", dirPath, err)
+	}
+	defer root.Close()
 	for key, val := range dataMap {
-		// key is a Secret/ConfigMap data key; route through an os.Root rooted
-		// at dirPath so a key cannot write outside it.
-		if err := utils.RootWriteFile(dirPath, key, val, 0750); err != nil {
+		if err := root.WriteFile(key, val, 0750); err != nil {
 			return fmt.Errorf("failed to write file %s in %s: %w", key, dirPath, err)
 		}
 	}

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -53,8 +53,9 @@ func TestMakeVolumeDir(t *testing.T) {
 
 func TestRename(t *testing.T) {
 	t.Parallel()
-	f := &Fetcher{logger: loggerfactory.GetLogger()}
 	dir := t.TempDir()
+	// rename is confined to the shared volume; src and dst live under it.
+	f := &Fetcher{logger: loggerfactory.GetLogger(), sharedVolumePath: dir}
 	src := filepath.Join(dir, "src")
 	dst := filepath.Join(dir, "dst")
 	require.NoError(t, os.WriteFile(src, []byte("x"), 0600))

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// relUnderRoot converts a base-relative or absolute-under-base path into a name
+// relative to base, rejecting absolute-escape and ".." traversal. It mirrors the
+// os.Root relName contract used by pkg/storagesvc and is the validation behind
+// the Root* helpers below.
+func relUnderRoot(base, p string) (string, error) {
+	if base == "" {
+		return "", fmt.Errorf("empty base directory")
+	}
+	name := filepath.FromSlash(p)
+	if filepath.IsAbs(name) {
+		rel, err := filepath.Rel(base, name)
+		if err != nil {
+			return "", fmt.Errorf("path %q is outside base %q", p, base)
+		}
+		name = rel
+	}
+	name = filepath.Clean(name)
+	// ".." (and "../...") escape the base; reject them. "." (the base itself)
+	// is inside the root and is allowed, matching the previous SanitizeFilePath
+	// behavior for an empty/base-resolving path.
+	if name == ".." || strings.HasPrefix(name, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path %q escapes base %q", p, base)
+	}
+	return name, nil
+}
+
+// RootJoin validates that name resolves to a location under base (no absolute
+// escape, no ".." traversal) and returns the cleaned absolute path. It is the
+// os.Root-style replacement for SanitizeFilePath: the returned absolute path can
+// be handed to downstream consumers unchanged.
+func RootJoin(base, name string) (string, error) {
+	rel, err := relUnderRoot(base, name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(base, rel), nil
+}
+
+// RootStat stats path within base through an os.Root, so a traversing path
+// cannot reach a file outside base. path may be base-relative or
+// absolute-under-base.
+func RootStat(base, path string) (os.FileInfo, error) {
+	rel, err := relUnderRoot(base, path)
+	if err != nil {
+		return nil, err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	return root.Stat(rel)
+}
+
+// RootWriteFile writes data to path within base through an os.Root.
+func RootWriteFile(base, path string, data []byte, perm os.FileMode) error {
+	rel, err := relUnderRoot(base, path)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return root.WriteFile(rel, data, perm)
+}
+
+// RootMkdirAll creates path (and parents) within base through an os.Root. perm
+// must be permission bits only (no os.ModeDir), which os.Root.MkdirAll requires.
+func RootMkdirAll(base, path string, perm os.FileMode) error {
+	rel, err := relUnderRoot(base, path)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return root.MkdirAll(rel, perm.Perm())
+}
+
+// RootRename renames oldPath to newPath through an os.Root. Both ends must be
+// under the same base.
+func RootRename(base, oldPath, newPath string) error {
+	relOld, err := relUnderRoot(base, oldPath)
+	if err != nil {
+		return err
+	}
+	relNew, err := relUnderRoot(base, newPath)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return root.Rename(relOld, relNew)
+}

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -38,9 +38,10 @@ func relUnderRoot(base, p string) (string, error) {
 }
 
 // RootJoin validates that name resolves to a location under base (no absolute
-// escape, no ".." traversal) and returns the cleaned absolute path. It is the
-// os.Root-style replacement for SanitizeFilePath: the returned absolute path can
-// be handed to downstream consumers unchanged.
+// escape, no ".." traversal) and returns the joined, cleaned path under base —
+// absolute when base is absolute, as it always is for the callers here. It is
+// the os.Root-style replacement for SanitizeFilePath: the result can be handed
+// to downstream consumers unchanged.
 func RootJoin(base, name string) (string, error) {
 	rel, err := relUnderRoot(base, name)
 	if err != nil {

--- a/pkg/utils/root_test.go
+++ b/pkg/utils/root_test.go
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRelUnderRoot(t *testing.T) {
+	t.Parallel()
+	base := filepath.Clean("/packages")
+
+	ok := []struct{ in, want string }{
+		{"file.txt", "file.txt"},
+		{"sub/file.txt", filepath.Join("sub", "file.txt")},
+		{"/packages/file.txt", "file.txt"},
+		{"/packages/sub/file.txt", filepath.Join("sub", "file.txt")},
+		{"foo/../bar", "bar"}, // resolves to an in-base path; not traversal
+		{".", "."},            // the base itself is allowed
+		{"/packages", "."},    // base by absolute path
+	}
+	for _, c := range ok {
+		got, err := relUnderRoot(base, c.in)
+		require.NoError(t, err, "input %q", c.in)
+		assert.Equal(t, c.want, got, "input %q", c.in)
+	}
+
+	bad := []string{"../escape", "../../escape", "/etc/passwd", "sub/../../escape"}
+	for _, in := range bad {
+		_, err := relUnderRoot(base, in)
+		assert.Error(t, err, "input %q should be rejected", in)
+	}
+}
+
+func TestRootHelpersConfineToBase(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write/stat/rename happy path", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+
+		require.NoError(t, RootWriteFile(base, "a.txt", []byte("alpha"), 0o600))
+		fi, err := RootStat(base, "a.txt")
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), fi.Size())
+
+		// absolute-under-base form also works (parent created first, since
+		// RootWriteFile does not create parents — same as os.WriteFile)
+		require.NoError(t, RootMkdirAll(base, "nested", 0o755))
+		require.NoError(t, RootWriteFile(base, filepath.Join(base, "nested", "b.txt"), []byte("beta"), 0o600))
+		require.NoError(t, RootMkdirAll(base, "d1/d2", 0o755))
+
+		require.NoError(t, RootRename(base, "a.txt", "renamed.txt"))
+		_, err = RootStat(base, "a.txt")
+		assert.Error(t, err)
+		fi, err = RootStat(base, "renamed.txt")
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), fi.Size())
+	})
+
+	t.Run("escapes are rejected and leave the filesystem untouched", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		base := filepath.Join(root, "base")
+		require.NoError(t, os.MkdirAll(base, 0o755))
+		sentinel := filepath.Join(root, "sentinel")
+		require.NoError(t, os.WriteFile(sentinel, []byte("intact"), 0o600))
+
+		assert.Error(t, RootWriteFile(base, "../sentinel", []byte("pwned"), 0o600))
+		assert.Error(t, RootWriteFile(base, sentinel, []byte("pwned"), 0o600))
+		assert.Error(t, RootMkdirAll(base, "../evil", 0o755))
+		_, err := RootStat(base, "../sentinel")
+		assert.Error(t, err)
+		assert.Error(t, RootRename(base, "../sentinel", "x"))
+
+		// sentinel outside base is untouched, and no escape dir was created
+		got, err := os.ReadFile(sentinel)
+		require.NoError(t, err)
+		assert.Equal(t, "intact", string(got))
+		assert.NoDirExists(t, filepath.Join(root, "evil"))
+	})
+
+	t.Run("RootJoin returns validated absolute path", func(t *testing.T) {
+		t.Parallel()
+		base := filepath.Clean("/packages")
+		got, err := RootJoin(base, "sub/file.txt")
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(base, "sub", "file.txt"), got)
+		_, err = RootJoin(base, "../escape")
+		assert.Error(t, err)
+	})
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -289,6 +289,11 @@ func IsOwnerReferencesEnabled() bool {
 }
 
 // SanitizeFilePath checks if the path is valid to prevent directory traversal attacks.
+//
+// Deprecated: prefer RootJoin (to validate a path) or the Root* helpers (to
+// perform an os.Root-confined operation). Those validate via os.Root semantics
+// and are recognized by static analysis (CodeQL go/path-injection) as a
+// traversal barrier, which this Clean+HasPrefix check is not.
 func SanitizeFilePath(path string, safedir string) (string, error) {
 	if len(path) == 0 {
 		return "", errors.New("invalid path")


### PR DESCRIPTION
## What

Follow-up to the zip-slip fix (#3444): routes the **fetcher** and **builder** request-derived filesystem operations through `os.Root`, replacing the ad-hoc `SanitizeFilePath` (`filepath.Clean` + `HasPrefix`) guard.

This is mostly **defense-in-depth** — those sites were already validated by `SanitizeFilePath`, so they were not vulnerable — plus one site that gains genuinely new protection (see below). It also makes the traversal barrier one that static analysis recognizes: `os.Root` cleared CodeQL `go/path-injection` in the storagesvc (#3443) and zip-slip (#3444) work, where `Clean`+`HasPrefix` did not.

## How

New `pkg/utils/root.go`:
- `RootJoin(base, name)` — validates that `name` resolves under `base` (no absolute escape, no `..`) and returns the cleaned absolute path; the drop-in replacement for `SanitizeFilePath`.
- `RootStat` / `RootWriteFile` / `RootMkdirAll` / `RootRename` — each performs a single `os.Root`-confined operation rooted at `base`.

These mirror the per-op `os.Root` idiom merged in storagesvc.

Migrations:
- **fetcher** — `storePath`/`tmpPath` stat+write, `secretDir`/`configDir` mkdir, and the rename operations now go through the helpers rooted at the shared volume / secret / config dirs.
  `writeSecretOrConfigMap` routes the Secret/ConfigMap **data key** through an `os.Root` rooted at the per-resource dir — **the one site that gains new protection** (the key was previously `filepath.Join`-ed unchecked; Kubernetes constrains data keys to `[-._a-zA-Z0-9]+`, so this is belt-and-suspenders).
- **builder** — `srcPkg`/`deployPkg` path validation and the `srcPkg` stat go through the helpers; the absolute paths are retained unchanged for the build subprocess env (`SRC_PKG`/`DEPLOY_PKG`), which is not a Go FS sink.

`SanitizeFilePath` is marked `// Deprecated` (kept for compatibility; all in-tree callers migrated). A later PR can convert `DeleteOldPackages`/`DownloadUrl` and remove it.

## Behavior notes

- `relUnderRoot` allows `.` (the base directory itself), matching `SanitizeFilePath`'s prior behavior for an empty/base-resolving path — so an empty filename still resolves to the base, not an error (the builder `Clean` unit test relies on this).
- `os.Root.MkdirAll` requires permission-only modes; the helpers strip any type bits (the previous `os.ModeDir|0750` is passed as `0750`).

## Verification

- New `pkg/utils/root_test.go`: `relUnderRoot` accept/reject table (incl. `foo/../bar` allowed, `../escape` / absolute rejected) and an `os.Root` confinement test asserting an escape attempt leaves a sentinel outside the base untouched.
- Existing `pkg/fetcher` (`TestRename`, `TestWriteSecretOrConfigMap`, `TestMakeVolumeDir`) and `pkg/builder` tests pass (the one `TestRename` update reflects that rename is now confined to the shared volume).
- `go test -race ./pkg/utils/... ./pkg/fetcher/... ./pkg/builder/...`, `make code-checks` (0 issues), `make license-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3445)
<!-- Reviewable:end -->
