### PR TITLE
feat(crd): validate CRDs in the API server with CEL + server-side-apply markers

### DIFF
--- a/crds/v1/fission.io_environments.yaml
+++ b/crds/v1/fission.io_environments.yaml
@@ -53,6 +53,9 @@ spec:
                   Available value:
                   - single
                   - infinite
+                enum:
+                - single
+                - infinite
                 type: string
               builder:
                 description: |-
@@ -10078,6 +10081,7 @@ spec:
                 type: boolean
               poolsize:
                 description: The initial pool size for environment
+                minimum: 0
                 type: integer
               resources:
                 description: |-
@@ -20162,6 +20166,7 @@ spec:
                   The grace time for pod to perform connection draining before termination. The unit is in seconds.
                   (Optional) defaults to 360 seconds
                 format: int64
+                minimum: 0
                 type: integer
               version:
                 description: |-
@@ -20173,7 +20178,12 @@ spec:
                   Version "2" supports downloading and compiling user function if source archive is not empty.
 
                   Version "3" is almost the same with v2, but you're able to control the size of pre-warm pool of the environment.
+                maximum: 3
+                minimum: 1
                 type: integer
+                x-kubernetes-validations:
+                - message: spec.version is immutable
+                  rule: self == oldSelf
             required:
             - runtime
             - version

--- a/crds/v1/fission.io_functions.yaml
+++ b/crds/v1/fission.io_functions.yaml
@@ -9314,6 +9314,46 @@ spec:
             - environment
             - package
             type: object
+            x-kubernetes-validations:
+            - message: executor type container requires a pod spec (spec.podspec)
+              rule: '!(has(self.InvokeStrategy.ExecutionStrategy) && self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''container'') || has(self.podspec)'
+            - message: minimum scale must be greater than or equal to 0 for newdeploy/container
+                executors
+              rule: '!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''newdeploy'' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''container'')) || !has(self.InvokeStrategy.ExecutionStrategy.MinScale)
+                || self.InvokeStrategy.ExecutionStrategy.MinScale >= 0'
+            - message: maximum scale must be greater than 0 for newdeploy/container
+                executors
+              rule: '!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''newdeploy'' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''container'')) || (has(self.InvokeStrategy.ExecutionStrategy.MaxScale)
+                && self.InvokeStrategy.ExecutionStrategy.MaxScale > 0)'
+            - message: maximum scale must be greater than or equal to minimum scale
+                for newdeploy/container executors
+              rule: '!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''newdeploy'' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''container'')) || !has(self.InvokeStrategy.ExecutionStrategy.MaxScale)
+                || self.InvokeStrategy.ExecutionStrategy.MaxScale >= (has(self.InvokeStrategy.ExecutionStrategy.MinScale)
+                ? self.InvokeStrategy.ExecutionStrategy.MinScale : 0)'
+            - message: TargetCPUPercent must be a value between 0 and 100 for newdeploy/container
+                executors
+              rule: '!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''newdeploy'' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''container'')) || !has(self.InvokeStrategy.ExecutionStrategy.TargetCPUPercent)
+                || (self.InvokeStrategy.ExecutionStrategy.TargetCPUPercent >= 0 &&
+                self.InvokeStrategy.ExecutionStrategy.TargetCPUPercent <= 100)'
+            - message: InvokeStrategy.StrategyType must be 'execution'
+              rule: '!has(self.InvokeStrategy.StrategyType) || self.InvokeStrategy.StrategyType
+                == '''' || self.InvokeStrategy.StrategyType == ''execution'''
+            - message: ExecutionStrategy.ExecutorType must be one of poolmgr, newdeploy,
+                container
+              rule: '!has(self.InvokeStrategy.ExecutionStrategy) || !has(self.InvokeStrategy.ExecutionStrategy.ExecutorType)
+                || self.InvokeStrategy.ExecutionStrategy.ExecutorType == '''' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''poolmgr'' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''newdeploy'' || self.InvokeStrategy.ExecutionStrategy.ExecutorType
+                == ''container'''
           status:
             description: FunctionStatus describes the observed state of a Function.
             properties:

--- a/crds/v1/fission.io_httptriggers.yaml
+++ b/crds/v1/fission.io_httptriggers.yaml
@@ -98,6 +98,11 @@ spec:
                       time.ParseDuration. Empty means the header is omitted.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: corsConfig.allowOrigins=["*"] cannot be combined with allowCredentials=true;
+                    browsers refuse the response
+                  rule: '!(has(self.allowCredentials) && self.allowCredentials &&
+                    has(self.allowOrigins) && ''*'' in self.allowOrigins)'
               createingress:
                 description: If CreateIngress is true, router will create an ingress
                   definition.
@@ -126,15 +131,24 @@ spec:
                       Available value:
                       - name
                       - function-weights
+                    enum:
+                    - name
+                    - function-weights
                     type: string
                 required:
                 - name
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: functionref.name must be a valid DNS1123 label (lowercase
+                    alphanumeric or '-', start/end alphanumeric, max 63 chars) when
+                    type is 'name'
+                  rule: self.type != 'name' || (self.name.size() <= 63 && self.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
               host:
                 description: |-
                   Deprecated: the original idea of this field is not for setting Ingress.
                   Since we have IngressConfig now, remove Host after couple releases.
+                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?$
                 type: string
               ingressconfig:
                 description: IngressConfig for router to set up Ingress.
@@ -164,6 +178,14 @@ spec:
                       key and crt must match the value of Host field.
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: ingressconfig.path must be an absolute path (start with
+                    '/')
+                  rule: '!has(self.path) || self.path == '''' || self.path.startsWith(''/'')'
+                - message: ingressconfig.host must be empty, '*', a valid DNS1123
+                    subdomain, or a wildcard DNS1123 subdomain (e.g. *.example.com)
+                  rule: '!has(self.host) || self.host == '''' || self.host == ''*''
+                    || self.host.matches(r''^(\*\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'')'
               keepPrefix:
                 description: |-
                   When function is exposed with Prefix based path,
@@ -173,10 +195,31 @@ spec:
                 description: |-
                   Use Methods instead of Method. This field is going to be deprecated in a future release
                   HTTP method to access a function.
+                enum:
+                - ""
+                - GET
+                - HEAD
+                - POST
+                - PUT
+                - PATCH
+                - DELETE
+                - CONNECT
+                - OPTIONS
+                - TRACE
                 type: string
               methods:
                 description: HTTP methods to access a function
                 items:
+                  enum:
+                  - GET
+                  - HEAD
+                  - POST
+                  - PUT
+                  - PATCH
+                  - DELETE
+                  - CONNECT
+                  - OPTIONS
+                  - TRACE
                   type: string
                 type: array
                 x-kubernetes-list-type: set

--- a/crds/v1/fission.io_kuberneteswatchtriggers.yaml
+++ b/crds/v1/fission.io_kuberneteswatchtriggers.yaml
@@ -66,21 +66,35 @@ spec:
                       Available value:
                       - name
                       - function-weights
+                    enum:
+                    - name
+                    - function-weights
                     type: string
                 required:
                 - name
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: functionref.name must be a valid DNS1123 label (lowercase
+                    alphanumeric or '-', start/end alphanumeric, max 63 chars) when
+                    type is 'name'
+                  rule: self.type != 'name' || (self.name.size() <= 63 && self.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
               labelselector:
                 additionalProperties:
                   type: string
                 description: Resource labels
                 type: object
               namespace:
+                maxLength: 63
+                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                 type: string
               type:
                 description: Type of resource to watch (Pod, Service, etc.)
                 type: string
+                x-kubernetes-validations:
+                - message: spec.type must be one of POD, SERVICE, REPLICATIONCONTROLLER,
+                    JOB (case-insensitive)
+                  rule: self.upperAscii() in ['POD','SERVICE','REPLICATIONCONTROLLER','JOB']
             required:
             - functionref
             - namespace

--- a/crds/v1/fission.io_messagequeuetriggers.yaml
+++ b/crds/v1/fission.io_messagequeuetriggers.yaml
@@ -79,11 +79,19 @@ spec:
                       Available value:
                       - name
                       - function-weights
+                    enum:
+                    - name
+                    - function-weights
                     type: string
                 required:
                 - name
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: functionref.name must be a valid DNS1123 label (lowercase
+                    alphanumeric or '-', start/end alphanumeric, max 63 chars) when
+                    type is 'name'
+                  rule: self.type != 'name' || (self.name.size() <= 63 && self.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
               maxReplicaCount:
                 description: Maximum number of replicas KEDA will scale the deployment
                   up to

--- a/crds/v1/fission.io_packages.yaml
+++ b/crds/v1/fission.io_packages.yaml
@@ -63,6 +63,11 @@ spec:
                           sha256, used for a checksum.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: checksum must be empty, or its type must be 'sha256'
+                        (the only supported checksum type)
+                      rule: ((!has(self.type) || self.type == '') && (!has(self.sum)
+                        || self.sum == '')) || self.type == 'sha256'
                   literal:
                     description: |-
                       Literal contents of the package. Can be used for
@@ -75,6 +80,10 @@ spec:
                       Available value:
                        - literal
                        - url
+                    enum:
+                    - ""
+                    - literal
+                    - url
                     type: string
                   url:
                     description: URL references a package.
@@ -111,6 +120,11 @@ spec:
                           sha256, used for a checksum.
                         type: string
                     type: object
+                    x-kubernetes-validations:
+                    - message: checksum must be empty, or its type must be 'sha256'
+                        (the only supported checksum type)
+                      rule: ((!has(self.type) || self.type == '') && (!has(self.sum)
+                        || self.sum == '')) || self.type == 'sha256'
                   literal:
                     description: |-
                       Literal contents of the package. Can be used for
@@ -123,6 +137,10 @@ spec:
                       Available value:
                        - literal
                        - url
+                    enum:
+                    - ""
+                    - literal
+                    - url
                     type: string
                   url:
                     description: URL references a package.
@@ -140,6 +158,13 @@ spec:
               buildstatus:
                 default: pending
                 description: BuildStatus is the package build status.
+                enum:
+                - ""
+                - pending
+                - running
+                - succeeded
+                - failed
+                - none
                 type: string
               conditions:
                 description: Conditions represent the latest observations of the package's

--- a/crds/v1/fission.io_timetriggers.yaml
+++ b/crds/v1/fission.io_timetriggers.yaml
@@ -68,11 +68,19 @@ spec:
                       Available value:
                       - name
                       - function-weights
+                    enum:
+                    - name
+                    - function-weights
                     type: string
                 required:
                 - name
                 - type
                 type: object
+                x-kubernetes-validations:
+                - message: functionref.name must be a valid DNS1123 label (lowercase
+                    alphanumeric or '-', start/end alphanumeric, max 63 chars) when
+                    type is 'name'
+                  rule: self.type != 'name' || (self.name.size() <= 63 && self.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
               method:
                 default: POST
                 description: 'HTTP Method for trigger, ex : GET, POST, PUT, DELETE,

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -230,6 +230,7 @@ type (
 		//  - literal
 		//  - url
 		// +optional
+		// +kubebuilder:validation:Enum="";literal;url
 		Type ArchiveType `json:"type,omitempty"`
 
 		// Literal contents of the package. Can be used for
@@ -244,6 +245,7 @@ type (
 		// Checksum ensures the integrity of packages
 		// referenced by URL. Ignored for literals.
 		// +optional
+		// +kubebuilder:validation:XValidation:rule="((!has(self.type) || self.type == '') && (!has(self.sum) || self.sum == '')) || self.type == 'sha256'",message="checksum must be empty, or its type must be 'sha256' (the only supported checksum type)"
 		Checksum Checksum `json:"checksum,omitempty"`
 	}
 
@@ -297,6 +299,7 @@ type (
 
 		// BuildStatus is the package build status.
 		// +kubebuilder:default:="pending"
+		// +kubebuilder:validation:Enum="";pending;running;succeeded;failed;none
 		BuildStatus BuildStatus `json:"buildstatus,omitempty"`
 
 		// BuildLog stores build log during the compilation.
@@ -355,6 +358,13 @@ type (
 	StrategyType string
 
 	// FunctionSpec describes the contents of the function.
+	// +kubebuilder:validation:XValidation:rule="!(has(self.InvokeStrategy.ExecutionStrategy) && self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'container') || has(self.podspec)",message="executor type container requires a pod spec (spec.podspec)"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'newdeploy' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'container')) || !has(self.InvokeStrategy.ExecutionStrategy.MinScale) || self.InvokeStrategy.ExecutionStrategy.MinScale >= 0",message="minimum scale must be greater than or equal to 0 for newdeploy/container executors"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'newdeploy' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'container')) || (has(self.InvokeStrategy.ExecutionStrategy.MaxScale) && self.InvokeStrategy.ExecutionStrategy.MaxScale > 0)",message="maximum scale must be greater than 0 for newdeploy/container executors"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'newdeploy' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'container')) || !has(self.InvokeStrategy.ExecutionStrategy.MaxScale) || self.InvokeStrategy.ExecutionStrategy.MaxScale >= (has(self.InvokeStrategy.ExecutionStrategy.MinScale) ? self.InvokeStrategy.ExecutionStrategy.MinScale : 0)",message="maximum scale must be greater than or equal to minimum scale for newdeploy/container executors"
+	// +kubebuilder:validation:XValidation:rule="!(has(self.InvokeStrategy.ExecutionStrategy) && (self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'newdeploy' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'container')) || !has(self.InvokeStrategy.ExecutionStrategy.TargetCPUPercent) || (self.InvokeStrategy.ExecutionStrategy.TargetCPUPercent >= 0 && self.InvokeStrategy.ExecutionStrategy.TargetCPUPercent <= 100)",message="TargetCPUPercent must be a value between 0 and 100 for newdeploy/container executors"
+	// +kubebuilder:validation:XValidation:rule="!has(self.InvokeStrategy.StrategyType) || self.InvokeStrategy.StrategyType == '' || self.InvokeStrategy.StrategyType == 'execution'",message="InvokeStrategy.StrategyType must be 'execution'"
+	// +kubebuilder:validation:XValidation:rule="!has(self.InvokeStrategy.ExecutionStrategy) || !has(self.InvokeStrategy.ExecutionStrategy.ExecutorType) || self.InvokeStrategy.ExecutionStrategy.ExecutorType == '' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'poolmgr' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'newdeploy' || self.InvokeStrategy.ExecutionStrategy.ExecutorType == 'container'",message="ExecutionStrategy.ExecutorType must be one of poolmgr, newdeploy, container"
 	FunctionSpec struct {
 		// Environment is the build and runtime environment that this function is
 		// associated with. An Environment with this name should exist, otherwise the
@@ -503,6 +513,7 @@ type (
 	FunctionReferenceType string
 
 	// FunctionReference refers to a function
+	// +kubebuilder:validation:XValidation:rule="self.type != 'name' || (self.name.size() <= 63 && self.name.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))",message="functionref.name must be a valid DNS1123 label (lowercase alphanumeric or '-', start/end alphanumeric, max 63 chars) when type is 'name'"
 	FunctionReference struct {
 		// Type indicates whether this function reference is by name or selector. For now,
 		// the only supported reference type is by "name".  Future reference types:
@@ -512,6 +523,7 @@ type (
 		// Available value:
 		// - name
 		// - function-weights
+		// +kubebuilder:validation:Enum=name;function-weights
 		Type FunctionReferenceType `json:"type"`
 
 		// Name of the function.
@@ -608,6 +620,9 @@ type (
 		// Version "2" supports downloading and compiling user function if source archive is not empty.
 		//
 		// Version "3" is almost the same with v2, but you're able to control the size of pre-warm pool of the environment.
+		// +kubebuilder:validation:Minimum=1
+		// +kubebuilder:validation:Maximum=3
+		// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="spec.version is immutable"
 		Version int `json:"version"`
 
 		// Runtime is configuration for running function, like container image etc.
@@ -629,6 +644,7 @@ type (
 		// - single
 		// - infinite
 		// +optional
+		// +kubebuilder:validation:Enum=single;infinite
 		AllowedFunctionsPerContainer AllowedFunctionsPerContainer `json:"allowedFunctionsPerContainer,omitempty"`
 
 		// Istio default blocks all egress traffic for safety.
@@ -644,11 +660,13 @@ type (
 
 		// The initial pool size for environment
 		// +optional
+		// +kubebuilder:validation:Minimum=0
 		Poolsize int `json:"poolsize,omitempty"`
 
 		// The grace time for pod to perform connection draining before termination. The unit is in seconds.
 		// (Optional) defaults to 360 seconds
 		// +optional
+		// +kubebuilder:validation:Minimum=0
 		TerminationGracePeriod int64 `json:"terminationGracePeriod,omitempty"`
 
 		// KeepArchive is used by fetcher to determine if the extracted archive
@@ -675,6 +693,7 @@ type (
 		// Deprecated: the original idea of this field is not for setting Ingress.
 		// Since we have IngressConfig now, remove Host after couple releases.
 		// +optional
+		// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*)?$`
 		Host string `json:"host"`
 
 		// RelativeURL is the exposed URL for external client to access a function with.
@@ -696,11 +715,13 @@ type (
 		// Use Methods instead of Method. This field is going to be deprecated in a future release
 		// HTTP method to access a function.
 		// +optional
+		// +kubebuilder:validation:Enum="";GET;HEAD;POST;PUT;PATCH;DELETE;CONNECT;OPTIONS;TRACE
 		Method string `json:"method"`
 
 		// HTTP methods to access a function
 		// +optional
 		// +listType=set
+		// +kubebuilder:validation:items:Enum=GET;HEAD;POST;PUT;PATCH;DELETE;CONNECT;OPTIONS;TRACE
 		Methods []string `json:"methods,omitempty"`
 
 		// FunctionReference is a reference to the target function.
@@ -731,6 +752,7 @@ type (
 	// middleware to the trigger's route. Triggers without a CorsConfig
 	// receive no Access-Control-* response headers and therefore deny
 	// cross-origin browser reads at the Same-Origin Policy layer.
+	// +kubebuilder:validation:XValidation:rule="!(has(self.allowCredentials) && self.allowCredentials && has(self.allowOrigins) && '*' in self.allowOrigins)",message="corsConfig.allowOrigins=[\"*\"] cannot be combined with allowCredentials=true; browsers refuse the response"
 	HTTPTriggerCorsConfig struct {
 		// AllowOrigins is the list of allowed origins (scheme + host +
 		// port). Use ["*"] to allow any origin. Mixing "*" with
@@ -772,6 +794,8 @@ type (
 	}
 
 	// IngressConfig is for router to set up Ingress.
+	// +kubebuilder:validation:XValidation:rule="!has(self.path) || self.path == '' || self.path.startsWith('/')",message="ingressconfig.path must be an absolute path (start with '/')"
+	// +kubebuilder:validation:XValidation:rule="!has(self.host) || self.host == '' || self.host == '*' || self.host.matches(r'^(\\*\\.)?[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')",message="ingressconfig.host must be empty, '*', a valid DNS1123 subdomain, or a wildcard DNS1123 subdomain (e.g. *.example.com)"
 	IngressConfig struct {
 		// Annotations will be added to metadata when creating Ingress.
 		// +optional
@@ -798,9 +822,12 @@ type (
 
 	// KubernetesWatchTriggerSpec defines spec of KuberenetesWatchTrigger
 	KubernetesWatchTriggerSpec struct {
+		// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+		// +kubebuilder:validation:MaxLength=63
 		Namespace string `json:"namespace"`
 
 		// Type of resource to watch (Pod, Service, etc.)
+		// +kubebuilder:validation:XValidation:rule="self.upperAscii() in ['POD','SERVICE','REPLICATIONCONTROLLER','JOB']",message="spec.type must be one of POD, SERVICE, REPLICATIONCONTROLLER, JOB (case-insensitive)"
 		Type string `json:"type"`
 
 		// Resource labels

--- a/test/cel/cel_validation_test.go
+++ b/test/cel/cel_validation_test.go
@@ -1,0 +1,198 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cel verifies that the CRD-level CEL (x-kubernetes-validations) and
+// server-side-apply markers added in pkg/apis/core/v1/types.go are enforced by
+// the Kubernetes API server itself.
+//
+// Scope note: the cross-namespace and podspec/container security checks (the
+// GHSA fixes) are NOT expressible as CRD CEL — cross-namespace rules need
+// metadata.namespace (not exposed to CRD CEL) and the embedded PodSpec list
+// rules blow the apiserver CEL cost budget. Those remain enforced by the
+// admission webhook (pkg/webhook) and validation.go. The cases here only cover
+// the field-level CEL rules that DO compile and stay under the cost budget:
+// enum/range scalar rules and SSA immutability.
+//
+// These tests need the envtest control-plane binaries; they skip cleanly when
+// KUBEBUILDER_ASSETS is unset (e.g. a plain `go test ./...` without the
+// harness). `make test-run` sets it. The envtest control plane is started once
+// per package (TestMain) and the client is reused across cases; every test
+// object uses a unique name so a shared API server stays isolated.
+package cel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/crd"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
+)
+
+const ns = "default"
+
+// fissionClient is the shared client against the single envtest API server
+// started by TestMain. It is nil when KUBEBUILDER_ASSETS is unset.
+var fissionClient versioned.Interface
+
+func TestMain(m *testing.M) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		// envtest binaries unavailable; each test skips individually.
+		os.Exit(m.Run())
+	}
+	ctrllog.SetLogger(logr.Discard())
+
+	env := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "crds", "v1")},
+		ErrorIfCRDPathMissing: true,
+		CRDInstallOptions:     envtest.CRDInstallOptions{MaxTime: 60 * time.Second},
+		BinaryAssetsDirectory: os.Getenv("KUBEBUILDER_ASSETS"),
+	}
+	// A successful Start() means every CRD — with all its CEL rules — installed
+	// cleanly, which is itself the apiserver CEL cost-budget proof: an
+	// over-budget or non-compiling x-kubernetes-validations rule is rejected at
+	// CRD apply time.
+	cfg, err := env.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envtest start failed (CRDs did not install — check CEL rules): %v\n", err)
+		os.Exit(1)
+	}
+
+	fc, err := crd.NewClientGeneratorWithRestConfig(cfg).GetFissionClient()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fission client: %v\n", err)
+		_ = env.Stop()
+		os.Exit(1)
+	}
+	fissionClient = fc
+
+	code := m.Run()
+
+	if err := env.Stop(); err != nil {
+		// Surface (don't hide) shutdown failures so leaked envtest
+		// processes/ports are diagnosable in CI logs.
+		fmt.Fprintf(os.Stderr, "envtest stop failed: %v\n", err)
+	}
+	os.Exit(code)
+}
+
+func client(t *testing.T) versioned.Interface {
+	t.Helper()
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Skip("KUBEBUILDER_ASSETS not set; run via `make test-run` or set it with setup-envtest")
+	}
+	return fissionClient
+}
+
+func TestCELFunctionValidation(t *testing.T) {
+	fc := client(t)
+
+	fn := func(name string, mut func(*fv1.Function)) *fv1.Function {
+		f := &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec: fv1.FunctionSpec{
+				Environment:    fv1.EnvironmentReference{Name: "env", Namespace: ns},
+				InvokeStrategy: fv1.InvokeStrategy{ExecutionStrategy: fv1.ExecutionStrategy{ExecutorType: fv1.ExecutorTypePoolmgr}},
+			},
+		}
+		if mut != nil {
+			mut(f)
+		}
+		return f
+	}
+
+	cases := []struct {
+		name    string
+		fn      *fv1.Function
+		wantErr string // empty => expect accept
+	}{
+		{"valid poolmgr", fn("f-valid", nil), ""},
+		{"invalid executor type enum", fn("f-bad-executor", func(f *fv1.Function) {
+			f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType = fv1.ExecutorType("bogus")
+		}), "ExecutorType"},
+		{"executor container requires podspec", fn("f-container-nopodspec", func(f *fv1.Function) {
+			f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType = fv1.ExecutorTypeContainer
+		}), "pod spec"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := fc.CoreV1().Functions(ns).Create(t.Context(), tc.fn, metav1.CreateOptions{})
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err, "apiserver should reject")
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+func TestCELEnvironmentValidation(t *testing.T) {
+	fc := client(t)
+
+	env := func(name string, mut func(*fv1.Environment)) *fv1.Environment {
+		e := &fv1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			Spec:       fv1.EnvironmentSpec{Version: 1, Runtime: fv1.Runtime{Image: "img"}},
+		}
+		if mut != nil {
+			mut(e)
+		}
+		return e
+	}
+
+	cases := []struct {
+		name    string
+		env     *fv1.Environment
+		wantErr string // empty => expect accept
+	}{
+		{"valid v1", env("e-valid", nil), ""},
+		{"version above maximum", env("e-ver-high", func(e *fv1.Environment) { e.Spec.Version = 4 }), "spec.version"},
+		{"version below minimum", env("e-ver-low", func(e *fv1.Environment) { e.Spec.Version = 0 }), "spec.version"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := fc.CoreV1().Environments(ns).Create(t.Context(), tc.env, metav1.CreateOptions{})
+			if tc.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			// version range message comes from the structural schema (Minimum/Maximum);
+			// accept either the field path or the lowercased message text.
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				assert.Contains(t, strings.ToLower(err.Error()), strings.ToLower(tc.wantErr))
+			}
+		})
+	}
+}
+
+func TestCELEnvironmentVersionImmutable(t *testing.T) {
+	fc := client(t)
+
+	created, err := fc.CoreV1().Environments(ns).Create(t.Context(),
+		&fv1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: "e-immutable", Namespace: ns},
+			Spec:       fv1.EnvironmentSpec{Version: 1, Runtime: fv1.Runtime{Image: "img"}},
+		}, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	created.Spec.Version = 2
+	_, err = fc.CoreV1().Environments(ns).Update(t.Context(), created, metav1.UpdateOptions{})
+	require.Error(t, err, "spec.version should be immutable")
+	assert.Contains(t, err.Error(), "immutable")
+}

--- a/test/integration/suites/common/cors_test.go
+++ b/test/integration/suites/common/cors_test.go
@@ -117,8 +117,8 @@ func TestCORS_RouterSecurity(t *testing.T) {
 //     even when called cross-origin (browser SOP enforces deny).
 //   - allowlist (CorsConfig set) echoes the configured origin on
 //     preflight + actual request, and 403s mismatched preflights.
-//   - admission (CorsConfig invalid) is rejected by the validating
-//     webhook so a broken trigger never reconciles.
+//   - admission (CorsConfig invalid) is rejected at admission so a
+//     broken trigger never reconciles.
 func TestCORS_HTTPTrigger(t *testing.T) {
 	t.Parallel()
 
@@ -275,9 +275,9 @@ func TestCORS_HTTPTrigger(t *testing.T) {
 	})
 
 	t.Run("admission rejects CorsConfig with wildcard + credentials", func(t *testing.T) {
-		// HTTPTriggerCorsConfig.Validate panics in code but the validating
-		// webhook converts that into an admission rejection. The trigger
-		// must never reconcile into a broken state.
+		// The API server's CEL validation (x-kubernetes-validations) rejects
+		// this combination at admission, so the trigger never reconciles into
+		// a broken state.
 		bad := &fv1.HTTPTrigger{
 			ObjectMeta: metav1.ObjectMeta{Name: "bad-cors-" + ns.ID, Namespace: ns.Name},
 			Spec: fv1.HTTPTriggerSpec{
@@ -294,15 +294,16 @@ func TestCORS_HTTPTrigger(t *testing.T) {
 			},
 		}
 		_, err := f.FissionClient().CoreV1().HTTPTriggers(ns.Name).Create(ctx, bad, metav1.CreateOptions{})
-		require.Error(t, err, "admission webhook should reject CorsConfig with wildcard + credentials")
-		// The webhook surfaces a 4xx; either Invalid or generic admission
-		// failure depending on apiserver version. Just confirm it isn't
-		// a NotFound (no webhook installed) and the error message names
-		// the offending field so future regressions surface clearly.
+		require.Error(t, err, "API server should reject CorsConfig with wildcard + credentials")
+		// The API server surfaces a 4xx Invalid from the CEL rule. Confirm it
+		// isn't a NotFound (which would mean the CRD validation isn't installed)
+		// and that the error names the offending field so future regressions
+		// surface clearly.
 		assert.Falsef(t, apierrors.IsNotFound(err), "expected validation rejection, got NotFound: %v", err)
+		msg := strings.ToLower(err.Error())
 		assert.Truef(t,
-			strings.Contains(err.Error(), "AllowCredentials") || strings.Contains(err.Error(), "CorsConfig"),
-			"rejection error should mention AllowCredentials or CorsConfig (got %v)", err)
+			strings.Contains(msg, "corsconfig") || strings.Contains(msg, "allowcredentials") || strings.Contains(msg, "credentials"),
+			"rejection error should mention the CORS config / credentials (got %v)", err)
 	})
 
 	t.Run("admission rejects CorsConfig with origin containing path", func(t *testing.T) {


### PR DESCRIPTION
## What

Adds Kubernetes-native CEL validation (`x-kubernetes-validations`) and server-side-apply markers to the Fission CRDs, so the API server validates resources directly — the rules apply even if the admission webhook is not running, and GitOps tools (Argo CD, Flux) and `kubectl explain` can see them.

### Field rules now enforced by the API server
- Executor type/strategy enums and autoscale bounds (min/max scale, target CPU %).
- Archive / checksum / build-status enums.
- Environment version range; pool-size and termination-grace bounds.
- HTTPTrigger HTTP-method enums (the deprecated singular `method` may still be empty), host / CORS / ingress-path rules.
- FunctionReference name (DNS-1123) validation.
- Immutability of `Environment.spec.version`.

## Admission webhook

The admission webhook is **retained** for the checks CEL cannot express: cross-namespace references and pod-spec security (the API server does not expose `metadata.namespace` to CRD validation rules, and validating an embedded `PodSpec` exceeds the CEL cost budget), plus the package archive literal-size limit. No behavior change for those checks.

## Tests

`test/cel` exercises the new rules against a real API server (envtest): valid objects are admitted; invalid enums/ranges and immutable-field updates are rejected by the API server itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3449)
<!-- Reviewable:end -->
