### PR TITLE
fix(executor): make AdoptExistingResources resilient to concurrent re-stamping

### DIFF
--- a/pkg/executor/executortype/container/adopt_test.go
+++ b/pkg/executor/executortype/container/adopt_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestDestroyOnCreateError guards the gate that keeps a transient fnCreate
+// failure from tearing down a function's resources. A Conflict / AlreadyExists
+// means the object exists and was concurrently modified (adopt racing a
+// reconcile), so it must NOT be destroyed; genuine failures still warrant
+// cleanup of a half-created new function.
+func TestDestroyOnCreateError(t *testing.T) {
+	t.Parallel()
+	gr := schema.GroupResource{Group: "apps", Resource: "deployments"}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"conflict is transient — keep", k8sErrs.NewConflict(gr, "fn", errors.New("object has been modified")), false},
+		{"already exists is transient — keep", k8sErrs.NewAlreadyExists(gr, "fn"), false},
+		{"not found is genuine — clean up", k8sErrs.NewNotFound(gr, "fn"), true},
+		{"forbidden is genuine — clean up", k8sErrs.NewForbidden(gr, "fn", errors.New("rbac")), true},
+		{"opaque error is genuine — clean up", errors.New("quota exceeded"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, destroyOnCreateError(tc.err))
+		})
+	}
+}

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -293,7 +293,8 @@ func (caaf *Container) AdoptExistingResources(ctx context.Context) {
 					// makes adopt and reconcile single-flight instead of racing each other
 					// on the in-place Update (which previously produced resourceVersion
 					// conflicts that tripped fnCreate's destroy-on-error path). The local
-					// err also avoids a data race on the shared loop variable.
+					// err also avoids a data race on the err variable from the enclosing
+					// scope, which every adopt goroutine previously wrote.
 					if _, err := caaf.createFunction(ctx, fn); err != nil {
 						caaf.logger.Error(err, "failed to adopt resources for function", "function", fn.Name)
 						return

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -287,12 +287,18 @@ func (caaf *Container) AdoptExistingResources(ctx context.Context) {
 			fn := &fnList.Items[i]
 			if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
 				wg.Go(func() {
-					_, err = caaf.fnCreate(ctx, fn)
-					if err != nil {
-						caaf.logger.Error(err, "failed to adopt resources for function")
+					// Route through createFunction (throttled) rather than calling
+					// fnCreate directly: the Function reconciler also re-stamps existing
+					// objects on its initial sync, so going through the per-UID throttler
+					// makes adopt and reconcile single-flight instead of racing each other
+					// on the in-place Update (which previously produced resourceVersion
+					// conflicts that tripped fnCreate's destroy-on-error path). The local
+					// err also avoids a data race on the shared loop variable.
+					if _, err := caaf.createFunction(ctx, fn); err != nil {
+						caaf.logger.Error(err, "failed to adopt resources for function", "function", fn.Name)
 						return
 					}
-					caaf.logger.Info("adopt resources for function", "function", fn.Name)
+					caaf.logger.Info("adopted resources for function", "function", fn.Name)
 				})
 			}
 		}
@@ -370,6 +376,17 @@ func (caaf *Container) deleteFunction(ctx context.Context, fn *fv1.Function) err
 	return err
 }
 
+// destroyOnCreateError reports whether a fnCreate failure warrants tearing down
+// the function's partial resources. A Conflict or AlreadyExists means the object
+// exists and was concurrently modified (e.g. the adopt pass racing a reconcile,
+// or two reconciles), so deleting it would turn a transient blip into a cold
+// recreate — leave it for the next reconcile to converge instead. Genuine
+// creation failures (quota, invalid spec, API errors) still trigger cleanup so a
+// brand-new function doesn't leak half-created objects.
+func destroyOnCreateError(err error) bool {
+	return !k8sErrs.IsConflict(err) && !k8sErrs.IsAlreadyExists(err)
+}
+
 func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	cleanupFunc := func(ns string, name string) {
 		err := caaf.cleanupContainer(ctx, ns, name)
@@ -396,7 +413,9 @@ func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache
 	svc, err := caaf.createOrGetSvc(ctx, fn, deployLabels, deployAnnotations, objName, ns)
 	if err != nil {
 		caaf.logger.Error(err, "error creating service", "service", objName)
-		go cleanupFunc(ns, objName)
+		if destroyOnCreateError(err) {
+			go cleanupFunc(ns, objName)
+		}
 		return nil, fmt.Errorf("error creating service %s: %w", objName, err)
 	}
 	svcAddress := fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
@@ -404,14 +423,18 @@ func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache
 	depl, err := caaf.createOrGetDeployment(ctx, fn, objName, deployLabels, deployAnnotations, ns)
 	if err != nil {
 		caaf.logger.Error(err, "error creating deployment", "deployment", objName)
-		go cleanupFunc(ns, objName)
+		if destroyOnCreateError(err) {
+			go cleanupFunc(ns, objName)
+		}
 		return nil, fmt.Errorf("error creating deployment %s: %w", objName, err)
 	}
 
 	hpa, err := caaf.hpaops.CreateOrGetHpa(ctx, fn, objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
 	if err != nil {
 		caaf.logger.Error(err, "error creating HPA", "hpa", objName)
-		go cleanupFunc(ns, objName)
+		if destroyOnCreateError(err) {
+			go cleanupFunc(ns, objName)
+		}
 		return nil, fmt.Errorf("error creating HPA %s: %w", objName, err)
 	}
 

--- a/pkg/executor/executortype/newdeploy/adopt_test.go
+++ b/pkg/executor/executortype/newdeploy/adopt_test.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package newdeploy
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// TestDestroyOnCreateError guards the gate that keeps a transient fnCreate
+// failure from tearing down a function's resources. A Conflict / AlreadyExists
+// means the object exists and was concurrently modified (adopt racing a
+// reconcile), so it must NOT be destroyed; genuine failures still warrant
+// cleanup of a half-created new function.
+func TestDestroyOnCreateError(t *testing.T) {
+	t.Parallel()
+	gr := schema.GroupResource{Group: "apps", Resource: "deployments"}
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"conflict is transient — keep", k8sErrs.NewConflict(gr, "fn", errors.New("object has been modified")), false},
+		{"already exists is transient — keep", k8sErrs.NewAlreadyExists(gr, "fn"), false},
+		{"not found is genuine — clean up", k8sErrs.NewNotFound(gr, "fn"), true},
+		{"forbidden is genuine — clean up", k8sErrs.NewForbidden(gr, "fn", errors.New("rbac")), true},
+		{"opaque error is genuine — clean up", errors.New("quota exceeded"), true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, destroyOnCreateError(tc.err))
+		})
+	}
+}

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -306,12 +306,18 @@ func (deploy *NewDeploy) AdoptExistingResources(ctx context.Context) {
 			fn := &fnList.Items[i]
 			if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy {
 				wg.Go(func() {
-					_, err = deploy.fnCreate(ctx, fn)
-					if err != nil {
-						deploy.logger.Error(err, "failed to adopt resources for function")
+					// Route through createFunction (throttled) rather than calling
+					// fnCreate directly: the Function reconciler also re-stamps existing
+					// objects on its initial sync, so going through the per-UID throttler
+					// makes adopt and reconcile single-flight instead of racing each other
+					// on the in-place Update (which previously produced resourceVersion
+					// conflicts that tripped fnCreate's destroy-on-error path). The local
+					// err also avoids a data race on the shared loop variable.
+					if _, err := deploy.createFunction(ctx, fn); err != nil {
+						deploy.logger.Error(err, "failed to adopt resources for function", "function", fn.Name)
 						return
 					}
-					deploy.logger.Info("adopt resources for function", "function", fn.Name)
+					deploy.logger.Info("adopted resources for function", "function", fn.Name)
 				})
 			}
 		}
@@ -429,6 +435,17 @@ func (deploy *NewDeploy) deleteFunction(ctx context.Context, fn *fv1.Function) e
 	return nil
 }
 
+// destroyOnCreateError reports whether a fnCreate failure warrants tearing down
+// the function's partial resources. A Conflict or AlreadyExists means the object
+// exists and was concurrently modified (e.g. the adopt pass racing a reconcile,
+// or two reconciles), so deleting it would turn a transient blip into a cold
+// recreate — leave it for the next reconcile to converge instead. Genuine
+// creation failures (quota, invalid spec, API errors) still trigger cleanup so a
+// brand-new function doesn't leak half-created objects.
+func destroyOnCreateError(err error) bool {
+	return !k8sErrs.IsConflict(err) && !k8sErrs.IsAlreadyExists(err)
+}
+
 func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	// Defence in depth for GHSA-cvw6-gfvv-953q — primary defence is the
 	// admission webhook in pkg/webhook/function.go, but a stale Function
@@ -470,7 +487,9 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 	svc, err := deploy.createOrGetSvc(ctx, fn, deployLabels, deployAnnotations, objName, ns)
 	if err != nil {
 		deploy.logger.Error(err, "error creating service", "service", objName)
-		go cleanupFunc(context.Background(), ns, objName)
+		if destroyOnCreateError(err) {
+			go cleanupFunc(context.Background(), ns, objName)
+		}
 		return nil, fmt.Errorf("error creating service %s: %w", objName, err)
 	}
 	svcAddress := fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
@@ -478,14 +497,18 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 	depl, err := deploy.createOrGetDeployment(ctx, fn, env, objName, deployLabels, deployAnnotations, ns)
 	if err != nil {
 		deploy.logger.Error(err, "error creating deployment", "deployment", objName)
-		go cleanupFunc(context.Background(), ns, objName)
+		if destroyOnCreateError(err) {
+			go cleanupFunc(context.Background(), ns, objName)
+		}
 		return nil, fmt.Errorf("error creating deployment %s: %w", objName, err)
 	}
 
 	hpa, err := deploy.hpaops.CreateOrGetHpa(ctx, fn, objName, &fn.Spec.InvokeStrategy.ExecutionStrategy, depl, deployLabels, deployAnnotations)
 	if err != nil {
 		deploy.logger.Error(err, "error creating HPA", "hpa", objName)
-		go cleanupFunc(context.Background(), ns, objName)
+		if destroyOnCreateError(err) {
+			go cleanupFunc(context.Background(), ns, objName)
+		}
 		return nil, fmt.Errorf("error creating HPA %s: %w", objName, err)
 	}
 

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -312,7 +312,8 @@ func (deploy *NewDeploy) AdoptExistingResources(ctx context.Context) {
 					// makes adopt and reconcile single-flight instead of racing each other
 					// on the in-place Update (which previously produced resourceVersion
 					// conflicts that tripped fnCreate's destroy-on-error path). The local
-					// err also avoids a data race on the shared loop variable.
+					// err also avoids a data race on the err variable from the enclosing
+					// scope, which every adopt goroutine previously wrote.
 					if _, err := deploy.createFunction(ctx, fn); err != nil {
 						deploy.logger.Error(err, "failed to adopt resources for function", "function", fn.Name)
 						return

--- a/test/integration/suites/serial/adopt_existing_test.go
+++ b/test/integration/suites/serial/adopt_existing_test.go
@@ -35,20 +35,17 @@ import (
 // reaper (which deletes objects whose annotation != the current ID) leaves it
 // alone instead of deleting it and forcing a cold recreate.
 //
-//   - poolmgr: the env-scoped warm-pool Deployment (createPoolDeployment adopt
-//     branch) is re-stamped exactly once via the serialized getPool path, so we
-//     make the strong claim there — adopted in place (same UID + creationTimestamp)
-//     with the annotation flipped — and assert the function keeps serving.
-//   - newdeploy / container: created and invoked so the restart exercises their
-//     AdoptExistingResources branches (createOrGetService/createOrGetDeployment —
-//     coverage). We do NOT assert on their per-function Deployments afterward: adopt
-//     races the Function reconciler on them, so that Deployment can be deleted and
-//     recreated (or briefly absent) around a restart independently of adopt, which
-//     would make any identity/existence assertion flaky.
+// For all three types — the per-function newdeploy/container Deployment and the
+// env-scoped poolmgr pool Deployment — we assert the strong invariant: same UID +
+// creationTimestamp (adopted, not deleted-and-recreated) with the annotation
+// flipped to the new executor, plus the function keeps serving. This is reliable
+// for the per-function Deployments because adopt now runs through the throttled
+// createFunction (single-flighting with the Function reconciler) and a transient
+// conflict no longer tears the resources down.
 //
 // The services `update` RBAC the newdeploy/container adopt path depends on — the
-// gap this suite first surfaced — is asserted directly and deterministically via
-// a SubjectAccessReview, so a regression fails cleanly instead of only flaking.
+// gap this suite first surfaced — is also asserted directly and deterministically
+// via a SubjectAccessReview, so an RBAC regression fails cleanly.
 //
 // This test lives in the serial suite because restarting the single,
 // cluster-wide executor is incompatible with the parallel common suite.
@@ -124,14 +121,18 @@ func TestAdoptExistingResources(t *testing.T) {
 	instIDOf := func(d *appsv1.Deployment) string { return d.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] }
 	anyDeployment := func(*appsv1.Deployment) bool { return true }
 
-	// Snapshot the poolmgr warm-pool Deployment and the executor instance ID that
-	// owns it. This is the one backing object we can make a deterministic in-place
-	// adoption claim on (see below).
+	// Snapshot each backing Deployment and the executor instance ID that owns it.
+	ndBefore := ns.WaitForFunctionDeployment(t, ctx, ndFn, anyDeployment,
+		"newdeploy Deployment exists before adopt", 90*time.Second)
+	ctrBefore := ns.WaitForFunctionDeployment(t, ctx, ctrFn, anyDeployment,
+		"container Deployment exists before adopt", 90*time.Second)
 	poolBefore := ns.WaitForPoolDeployment(t, ctx, envName, anyDeployment,
 		"poolmgr pool Deployment exists before adopt", 90*time.Second)
-	require.NotEmptyf(t, instIDOf(poolBefore),
-		"pool Deployment %q should carry an executor instance ID before adopt", poolBefore.Name)
-	oldPool := instIDOf(poolBefore)
+	for _, d := range []*appsv1.Deployment{ndBefore, ctrBefore, poolBefore} {
+		require.NotEmptyf(t, instIDOf(d),
+			"deployment %q should carry an executor instance ID before adopt", d.Name)
+	}
+	oldND, oldCTR, oldPool := instIDOf(ndBefore), instIDOf(ctrBefore), instIDOf(poolBefore)
 
 	// Enable adopt and restart the executor. Once the new pod reports ready its
 	// adopt pass has run for all three executor types (newdeploy, container,
@@ -140,35 +141,47 @@ func TestAdoptExistingResources(t *testing.T) {
 	t.Cleanup(restore)
 	f.WaitForExecutorRollout(t, ctx, gen, 5*time.Minute)
 
-	// poolmgr: getPool is serialized through the pool manager's request channel, so
-	// the env-scoped pool Deployment is re-stamped exactly once, in place — adopt
-	// can't race the environment reconciler on it. Assert the strong adoption
-	// invariant here: same UID + creationTimestamp (not deleted-and-recreated) with
-	// the instance-ID annotation flipped to the new executor.
-	//
-	// We deliberately do NOT assert on the newdeploy/container *per-function*
-	// Deployments. Adopt calls fnCreate directly while the Function reconciler also
-	// (re)creates via its throttled path, and the two race: that Deployment can be
-	// deleted and recreated — or briefly absent — around a restart independently of
-	// adopt, so asserting its identity or existence is inherently flaky. Their adopt
-	// code paths are still exercised by the restart (coverage), and the services
-	// `update` RBAC they depend on is asserted deterministically by the
-	// SubjectAccessReview above.
+	// reStamped matches a Deployment whose instance-ID annotation has flipped to a
+	// new, non-empty value — i.e. the new executor adopted it.
 	reStamped := func(oldID string) func(*appsv1.Deployment) bool {
 		return func(d *appsv1.Deployment) bool {
 			id := instIDOf(d)
 			return id != "" && id != oldID
 		}
 	}
+	// Each backing object must be adopted *in place*: same UID + creationTimestamp
+	// (not deleted-and-recreated) with the instance-ID annotation flipped to the
+	// new executor. This holds for the per-function newdeploy/container Deployments
+	// too — not just the env-scoped poolmgr pool — because adopt now runs through
+	// the throttled createFunction (single-flighting with the Function reconciler
+	// instead of racing it) and a transient conflict no longer tears the resources
+	// down. (Before those fixes, the per-function Deployment could be recreated
+	// around a restart, so this assertion was scoped to poolmgr only.)
+	assertAdoptedInPlace := func(kind string, before, after *appsv1.Deployment, oldID string) {
+		t.Helper()
+		require.Equalf(t, before.UID, after.UID,
+			"%s Deployment %q must be adopted in place (same UID), not recreated", kind, before.Name)
+		require.Equalf(t, before.CreationTimestamp, after.CreationTimestamp,
+			"%s Deployment %q must keep its creationTimestamp (adopted, not recreated)", kind, before.Name)
+		require.NotEqualf(t, oldID, instIDOf(after),
+			"%s Deployment %q instance-ID annotation should be re-stamped to the new executor", kind, before.Name)
+	}
+
+	ndAfter := ns.WaitForFunctionDeployment(t, ctx, ndFn, reStamped(oldND),
+		"newdeploy Deployment re-stamped with the new executor instance ID", 5*time.Minute)
+	assertAdoptedInPlace("newdeploy", ndBefore, ndAfter, oldND)
+
+	ctrAfter := ns.WaitForFunctionDeployment(t, ctx, ctrFn, reStamped(oldCTR),
+		"container Deployment re-stamped with the new executor instance ID", 5*time.Minute)
+	assertAdoptedInPlace("container", ctrBefore, ctrAfter, oldCTR)
+
 	poolAfter := ns.WaitForPoolDeployment(t, ctx, envName, reStamped(oldPool),
 		"poolmgr pool Deployment re-stamped with the new executor instance ID", 5*time.Minute)
-	require.Equalf(t, poolBefore.UID, poolAfter.UID,
-		"poolmgr pool Deployment %q must be adopted in place (same UID), not recreated", poolBefore.Name)
-	require.Equalf(t, poolBefore.CreationTimestamp, poolAfter.CreationTimestamp,
-		"poolmgr pool Deployment %q must keep its creationTimestamp (adopted, not recreated)", poolBefore.Name)
+	assertAdoptedInPlace("poolmgr", poolBefore, poolAfter, oldPool)
 
-	// The poolmgr function keeps serving after the restart: its specialized pod was
-	// re-adopted into the function-service cache (or re-specialized from the
-	// still-warm pool) with no cold recreate of the pool.
+	// All three functions still serve after the restart: adopt re-stamped the
+	// objects so the orphan reaper kept them, with no cold recreate needed.
 	r.GetEventually(t, ctx, "/"+pmFn, framework.BodyContains("world"))
+	r.GetEventually(t, ctx, "/"+ndFn, framework.BodyContains("world"))
+	r.GetEventually(t, ctx, "/"+ctrFn, is2xx)
 }


### PR DESCRIPTION
## What

Follow-up to #3447. That PR's adopt integration test exposed that `AdoptExistingResources` is unreliable around an executor restart — and the root cause turned out to be a real bug, not test flakiness.

## Root cause

On an adopt-enabled restart, **two code paths re-stamp the same pre-existing objects**: the explicit adopt pass (`AdoptExistingResources` → `fnCreate` **directly**) and the controller-runtime Function reconciler's initial-sync reconcile (`createFunction`, **throttled**). They don't dedupe against each other, so they race on the in-place `Update`. A transient `resourceVersion` conflict from that race propagates out of `fnCreate`, which then runs its **destroy-on-error** path (`go cleanupFunc` → `cleanupNewdeploy`) and **deletes the function's Service + HPA + Deployment**. The reconciler recreates them with a fresh UID — a cold recreate of a healthy function, exactly what adopt is supposed to prevent.

This is why #3447's integration test had to scope its strong in-place assertion to the poolmgr pool Deployment (whose `getPool` is serialized, so it doesn't race).

## Changes

- **Route the adopt pass through the throttled `createFunction`** instead of raw `fnCreate` (newdeploy + container). The reconciler uses the same per-UID throttler, so adopt and reconcile now single-flight per function rather than racing. Also fixes a pre-existing data race on the shared loop variable in the adopt goroutines.
- **Gate `fnCreate`'s destroy-on-error**: a `Conflict`/`AlreadyExists` means the object exists and was concurrently modified, so don't tear it down — let the next reconcile converge. Genuine creation failures (quota, invalid spec, RBAC) still clean up a half-created new function. New `TestDestroyOnCreateError` unit test covers the predicate in both packages.

## Test impact

With the per-function Deployments now adopted in place deterministically, the adopt integration test (`suites/serial`) asserts the strong **same-UID + creationTimestamp** invariant for **all three** executor types (newdeploy, container, poolmgr), not just poolmgr.

## Test plan

- `go test ./pkg/executor/executortype/{newdeploy,container}/...` (incl. new predicate test) ✅
- `go build -tags=integration ./test/integration/...`, `golangci-lint` (both default + integration tags), `make license-check`, `go vet` ✅
- Full integration run (all k8s legs) via CI — the re-tightened serial adopt test is the end-to-end validation.

> Independent of #3447 (already merged) — no file overlap. A follow-up (PR B) will harden the reaper's orphan signal, the 30s adopt/cleanup budget, the rollout-overlap default, and de-duplicate the triplicated adopt/cleanup code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3450)
<!-- Reviewable:end -->
