### PR TITLE
refactor(executor): context-bound adopt/cleanup wait + de-duplicate adopt/cleanup

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -210,8 +210,15 @@ func (a *executorAPIServer) Start(ctx context.Context) error {
 	return nil
 }
 
+// adoptCleanupMaxWait caps how long startup readiness waits for the adopt +
+// cleanup pass before proceeding. It's a safety bound only: the pass itself is
+// context-bound and continues in the background if it outlasts this, and
+// CleanupOldExecutorObjects runs after AdoptExistingResources within each
+// goroutine regardless, so it never reaps objects adopt hasn't re-stamped.
+const adoptCleanupMaxWait = 30 * time.Second
+
 // runAdoptCleanup adopts pre-existing resources (optional) and cleans up stale
-// executor objects with a hard timeout. Runs on the leader.
+// executor objects. Runs on the leader.
 func runAdoptCleanup(ctx context.Context, executorTypes map[fv1.ExecutorType]executortype.ExecutorType, adopt bool) {
 	wg := &sync.WaitGroup{}
 	for _, et := range executorTypes {
@@ -222,8 +229,19 @@ func runAdoptCleanup(ctx context.Context, executorTypes map[fv1.ExecutorType]exe
 			et.CleanupOldExecutorObjects(ctx)
 		})
 	}
-	// TODO: use context to control the waiting time once kubernetes client supports it.
-	util.WaitTimeout(wg, 30*time.Second)
+	// Wait for the pass, but honour ctx (executor shutdown / leader-lease loss)
+	// rather than blocking on a fixed timer that ignores it — the adopt/cleanup
+	// calls are themselves ctx-bound and return promptly on cancellation. The
+	// cap bounds startup readiness if a call wedges.
+	done := make(chan struct{})
+	go func() { defer close(done); wg.Wait() }()
+	timer := time.NewTimer(adoptCleanupMaxWait)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-ctx.Done():
+	case <-timer.C:
+	}
 }
 
 // bindAddr resolves a server bind address from env, defaulting to def and

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -272,70 +271,23 @@ func (caaf *Container) RefreshFuncPods(ctx context.Context, logger logr.Logger, 
 	return nil
 }
 
-// AdoptExistingResources attempts to adopt resources for functions in all namespaces.
+// AdoptExistingResources re-claims the function objects this executor type left
+// behind on a previous run. It routes through the throttled createFunction (not
+// fnCreate directly), so the adopt pass and the Function reconciler — which also
+// re-stamps existing objects on its initial sync — single-flight per function
+// UID instead of racing on the in-place Update (which previously produced
+// resourceVersion conflicts that tripped fnCreate's destroy-on-error path).
 func (caaf *Container) AdoptExistingResources(ctx context.Context) {
-	wg := &sync.WaitGroup{}
-
-	for _, namepsace := range utils.DefaultNSResolver().FissionResourceNS {
-		fnList, err := caaf.fissionClient.CoreV1().Functions(namepsace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			caaf.logger.Error(err, "error getting function list")
-			return
-		}
-
-		for i := range fnList.Items {
-			fn := &fnList.Items[i]
-			if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
-				wg.Go(func() {
-					// Route through createFunction (throttled) rather than calling
-					// fnCreate directly: the Function reconciler also re-stamps existing
-					// objects on its initial sync, so going through the per-UID throttler
-					// makes adopt and reconcile single-flight instead of racing each other
-					// on the in-place Update (which previously produced resourceVersion
-					// conflicts that tripped fnCreate's destroy-on-error path). The local
-					// err also avoids a data race on the err variable from the enclosing
-					// scope, which every adopt goroutine previously wrote.
-					if _, err := caaf.createFunction(ctx, fn); err != nil {
-						caaf.logger.Error(err, "failed to adopt resources for function", "function", fn.Name)
-						return
-					}
-					caaf.logger.Info("adopted resources for function", "function", fn.Name)
-				})
-			}
-		}
-	}
-
-	wg.Wait()
+	executorUtils.AdoptFunctions(ctx, caaf.logger, caaf.fissionClient, fv1.ExecutorTypeContainer,
+		func(ctx context.Context, fn *fv1.Function) error {
+			_, err := caaf.createFunction(ctx, fn)
+			return err
+		})
 }
 
 // CleanupOldExecutorObjects cleans orphaned resources.
 func (caaf *Container) CleanupOldExecutorObjects(ctx context.Context) {
-	caaf.logger.Info("CaaF starts to clean orphaned resources", "instanceID", caaf.instanceID)
-
-	var errs error
-	listOpts := metav1.ListOptions{
-		LabelSelector: labels.Set(map[string]string{fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypeContainer)}).AsSelector().String(),
-	}
-
-	err := reaper.CleanupHpa(ctx, caaf.logger, caaf.kubernetesClient, caaf.instanceID, listOpts)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
-
-	err = reaper.CleanupDeployments(ctx, caaf.logger, caaf.kubernetesClient, caaf.instanceID, listOpts)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
-
-	err = reaper.CleanupServices(ctx, caaf.logger, caaf.kubernetesClient, caaf.instanceID, listOpts)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
-
-	if errs != nil {
-		// TODO retry reaper; logged and ignored for now
-		caaf.logger.Error(errs, "Failed to cleanup old executor objects")
-	}
+	reaper.CleanupExecutorObjects(ctx, caaf.logger, caaf.kubernetesClient, caaf.instanceID, fv1.ExecutorTypeContainer)
 }
 
 func (caaf *Container) createFunction(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -291,70 +290,23 @@ func (deploy *NewDeploy) RefreshFuncPods(ctx context.Context, logger logr.Logger
 	return nil
 }
 
-// AdoptExistingResources attempts to adopt resources for functions in all namespaces.
+// AdoptExistingResources re-claims the function objects this executor type left
+// behind on a previous run. It routes through the throttled createFunction (not
+// fnCreate directly), so the adopt pass and the Function reconciler — which also
+// re-stamps existing objects on its initial sync — single-flight per function
+// UID instead of racing on the in-place Update (which previously produced
+// resourceVersion conflicts that tripped fnCreate's destroy-on-error path).
 func (deploy *NewDeploy) AdoptExistingResources(ctx context.Context) {
-	wg := &sync.WaitGroup{}
-
-	for _, namepsace := range utils.DefaultNSResolver().FissionResourceNS {
-		fnList, err := deploy.fissionClient.CoreV1().Functions(namepsace).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			deploy.logger.Error(err, "error getting function list")
-			return
-		}
-
-		for i := range fnList.Items {
-			fn := &fnList.Items[i]
-			if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy {
-				wg.Go(func() {
-					// Route through createFunction (throttled) rather than calling
-					// fnCreate directly: the Function reconciler also re-stamps existing
-					// objects on its initial sync, so going through the per-UID throttler
-					// makes adopt and reconcile single-flight instead of racing each other
-					// on the in-place Update (which previously produced resourceVersion
-					// conflicts that tripped fnCreate's destroy-on-error path). The local
-					// err also avoids a data race on the err variable from the enclosing
-					// scope, which every adopt goroutine previously wrote.
-					if _, err := deploy.createFunction(ctx, fn); err != nil {
-						deploy.logger.Error(err, "failed to adopt resources for function", "function", fn.Name)
-						return
-					}
-					deploy.logger.Info("adopted resources for function", "function", fn.Name)
-				})
-			}
-		}
-	}
-
-	wg.Wait()
+	executorUtils.AdoptFunctions(ctx, deploy.logger, deploy.fissionClient, fv1.ExecutorTypeNewdeploy,
+		func(ctx context.Context, fn *fv1.Function) error {
+			_, err := deploy.createFunction(ctx, fn)
+			return err
+		})
 }
 
 // CleanupOldExecutorObjects cleans orphaned resources.
 func (deploy *NewDeploy) CleanupOldExecutorObjects(ctx context.Context) {
-	deploy.logger.Info("Newdeploy starts to clean orphaned resources", "instanceID", deploy.instanceID)
-
-	var errs error
-	listOpts := metav1.ListOptions{
-		LabelSelector: labels.Set(map[string]string{fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypeNewdeploy)}).AsSelector().String(),
-	}
-
-	err := reaper.CleanupHpa(ctx, deploy.logger, deploy.kubernetesClient, deploy.instanceID, listOpts)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
-
-	err = reaper.CleanupDeployments(ctx, deploy.logger, deploy.kubernetesClient, deploy.instanceID, listOpts)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
-
-	err = reaper.CleanupServices(ctx, deploy.logger, deploy.kubernetesClient, deploy.instanceID, listOpts)
-	if err != nil {
-		errs = errors.Join(errs, err)
-	}
-
-	if errs != nil {
-		// TODO retry reaper; logged and ignored for now
-		deploy.logger.Error(err, "Failed to cleanup old executor objects")
-	}
+	reaper.CleanupExecutorObjects(ctx, deploy.logger, deploy.kubernetesClient, deploy.instanceID, fv1.ExecutorTypeNewdeploy)
 }
 
 func (deploy *NewDeploy) getEnvFunctions(ctx context.Context, m *metav1.ObjectMeta) []fv1.Function {

--- a/pkg/executor/reaper/reaper.go
+++ b/pkg/executor/reaper/reaper.go
@@ -6,11 +6,13 @@ package reaper
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	apiv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/go-logr/logr"
@@ -18,6 +20,28 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/utils"
 )
+
+// CleanupExecutorObjects reaps the HorizontalPodAutoscaler, Deployment and
+// Service objects of the given executor type whose executorInstanceId annotation
+// no longer matches instanceID (orphans left by a previous executor instance).
+// It's the shared body of the newdeploy and container managers'
+// CleanupOldExecutorObjects; errors are logged and swallowed, matching the
+// best-effort reaping the callers previously did inline.
+func CleanupExecutorObjects(ctx context.Context, logger logr.Logger, client kubernetes.Interface, instanceID string, executorType fv1.ExecutorType) {
+	logger.Info("starting to clean orphaned executor resources", "executorType", executorType, "instanceID", instanceID)
+	listOpts := metav1.ListOptions{
+		LabelSelector: labels.Set{fv1.EXECUTOR_TYPE: string(executorType)}.AsSelector().String(),
+	}
+	errs := errors.Join(
+		CleanupHpa(ctx, logger, client, instanceID, listOpts),
+		CleanupDeployments(ctx, logger, client, instanceID, listOpts),
+		CleanupServices(ctx, logger, client, instanceID, listOpts),
+	)
+	if errs != nil {
+		// TODO retry reaper; logged and ignored for now
+		logger.Error(errs, "failed to cleanup old executor objects", "executorType", executorType)
+	}
+}
 
 var (
 	deletePropagation = metav1.DeletePropagationBackground

--- a/pkg/executor/util/adopt_test.go
+++ b/pkg/executor/util/adopt_test.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	fakeFission "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+// TestAdoptFunctionsFiltersByExecutorType verifies the shared adopt body calls
+// create only for functions of the requested executor type (so the newdeploy
+// and container managers don't adopt each other's — or poolmgr's — functions).
+func TestAdoptFunctionsFiltersByExecutorType(t *testing.T) {
+	ctx := t.Context()
+	client := fakeFission.NewSimpleClientset() // nolint:staticcheck
+
+	// DefaultNSResolver().FissionResourceNS defaults to {"default"} with no env,
+	// so create the functions there for AdoptFunctions to find them.
+	mk := func(name string, et fv1.ExecutorType) {
+		_, err := client.CoreV1().Functions(metav1.NamespaceDefault).Create(ctx, &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault, UID: types.UID(name)},
+			Spec: fv1.FunctionSpec{
+				InvokeStrategy: fv1.InvokeStrategy{
+					ExecutionStrategy: fv1.ExecutionStrategy{ExecutorType: et},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoErrorf(t, err, "create function %s", name)
+	}
+	mk("nd1", fv1.ExecutorTypeNewdeploy)
+	mk("nd2", fv1.ExecutorTypeNewdeploy)
+	mk("ctr1", fv1.ExecutorTypeContainer)
+	mk("pm1", fv1.ExecutorTypePoolmgr)
+
+	var mu sync.Mutex
+	created := map[string]bool{}
+	create := func(_ context.Context, fn *fv1.Function) error {
+		mu.Lock()
+		defer mu.Unlock()
+		created[fn.Name] = true
+		return nil
+	}
+
+	AdoptFunctions(ctx, logr.Discard(), client, fv1.ExecutorTypeNewdeploy, create)
+
+	require.Equal(t, map[string]bool{"nd1": true, "nd2": true}, created,
+		"AdoptFunctions must call create only for functions of the requested executor type")
+}
+
+// TestAdoptFunctionsToleratesCreateErrors verifies a per-function create failure
+// is contained (logged) and doesn't stop the other functions from being adopted.
+func TestAdoptFunctionsToleratesCreateErrors(t *testing.T) {
+	ctx := t.Context()
+	client := fakeFission.NewSimpleClientset() // nolint:staticcheck
+
+	for _, name := range []string{"a", "b", "c"} {
+		_, err := client.CoreV1().Functions(metav1.NamespaceDefault).Create(ctx, &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: metav1.NamespaceDefault, UID: types.UID(name)},
+			Spec: fv1.FunctionSpec{
+				InvokeStrategy: fv1.InvokeStrategy{
+					ExecutionStrategy: fv1.ExecutionStrategy{ExecutorType: fv1.ExecutorTypeNewdeploy},
+				},
+			},
+		}, metav1.CreateOptions{})
+		require.NoErrorf(t, err, "create function %s", name)
+	}
+
+	var mu sync.Mutex
+	attempted := map[string]bool{}
+	create := func(_ context.Context, fn *fv1.Function) error {
+		mu.Lock()
+		defer mu.Unlock()
+		attempted[fn.Name] = true
+		if fn.Name == "b" {
+			return context.DeadlineExceeded // one function fails to adopt
+		}
+		return nil
+	}
+
+	AdoptFunctions(ctx, logr.Discard(), client, fv1.ExecutorTypeNewdeploy, create)
+
+	require.Equal(t, map[string]bool{"a": true, "b": true, "c": true}, attempted,
+		"a single create failure must not stop the other functions from being adopted")
+}

--- a/pkg/executor/util/util.go
+++ b/pkg/executor/util/util.go
@@ -20,12 +20,47 @@ import (
 	"sigs.k8s.io/yaml"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
 	"github.com/fission/fission/pkg/utils"
 )
 
 const (
 	dumpFileName string = "fission-dump"
 )
+
+// AdoptFunctions lists every Function of executorType across the executor's
+// resource namespaces and (re)creates it via create, concurrently — the shared
+// body of the newdeploy and container managers' AdoptExistingResources. It runs
+// at executor startup to re-stamp pre-existing objects with the new instance ID;
+// pass the executor type's *throttled* createFunction so adopt single-flights
+// with the Function reconciler rather than racing it. A list error in one
+// namespace is logged and skipped rather than aborting the whole sweep.
+func AdoptFunctions(ctx context.Context, logger logr.Logger, fissionClient versioned.Interface,
+	executorType fv1.ExecutorType, create func(context.Context, *fv1.Function) error) {
+	wg := &sync.WaitGroup{}
+	for _, namespace := range utils.DefaultNSResolver().FissionResourceNS {
+		fnList, err := fissionClient.CoreV1().Functions(namespace).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			logger.Error(err, "error listing functions to adopt", "namespace", namespace)
+			continue
+		}
+		for i := range fnList.Items {
+			fn := &fnList.Items[i]
+			if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != executorType {
+				continue
+			}
+			wg.Go(func() {
+				if err := create(ctx, fn); err != nil {
+					logger.Error(err, "failed to adopt resources for function",
+						"function", fn.Name, "namespace", fn.Namespace)
+					return
+				}
+				logger.Info("adopted resources for function", "function", fn.Name, "namespace", fn.Namespace)
+			})
+		}
+	}
+	wg.Wait()
+}
 
 // ApplyImagePullSecret applies image pull secret to the give pod spec.
 // It's intentional not to check the existence of secret here.


### PR DESCRIPTION
## What

Follow-up to #3450 — the "safe wins" of the adopt reliability/maintainability work (#5 + de-dup; the riskier reaper-semantics and chart-default changes were intentionally left out).

## Changes

**1. Context-bound adopt/cleanup wait (`runAdoptCleanup`).** It waited on a fixed 30s timer (`util.WaitTimeout`) that ignores `ctx`, so executor shutdown / leader-lease loss could be delayed up to 30s even though the adopt/cleanup calls are themselves `ctx`-bound. Now it waits on the WaitGroup, `ctx`, **and** a safety cap, and the stale TODO is gone. The cap is only a startup-readiness bound — the pass continues in the background if it outlasts it, and `CleanupOldExecutorObjects` always runs *after* `AdoptExistingResources` within each goroutine, so it never reaps objects adopt hasn't re-stamped.

**2. De-duplicate the triplicated adopt/cleanup code.**
- `reaper.CleanupExecutorObjects` composes the HPA + Deployment + Service reaping that the newdeploy and container managers each did inline.
- `executor/util.AdoptFunctions` is the shared "list functions of my type, (re)create each via the throttled `createFunction`" body both managers duplicated. It also **continues past a per-namespace list error** instead of aborting the whole sweep (minor robustness improvement).

`newdeploy`/`container` `AdoptExistingResources` + `CleanupOldExecutorObjects` are now thin wrappers. `poolmgr` keeps its own (structurally different — env pools + pod re-stamping) implementations. Net **−19 lines**; no behavior change beyond the list-error-continue.

## Test plan

- `go build ./...`, `go vet ./pkg/executor/...` ✅
- `go test ./pkg/executor/...` — all packages incl. reaper/util/newdeploy/container ✅
- `golangci-lint run ./pkg/executor/...` → 0 issues; `make license-check` ✅
- `go build -tags=integration ./test/integration/...` ✅ (adopt integration test unchanged; still validates the end-to-end behavior in CI)

> Stacked conceptually on #3450 (merged); independent of the test/RBAC PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3451)
<!-- Reviewable:end -->
