### PR TITLE
test(fission-cli): raise coverage + dedupe create commands; fix canary status bug

### DIFF
--- a/pkg/fission-cli/cmd/canaryconfig/get_test.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get_test.go
@@ -22,6 +22,7 @@ func captureStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
+	defer r.Close()
 	orig := os.Stdout
 	t.Cleanup(func() { os.Stdout = orig })
 	os.Stdout = w

--- a/pkg/fission-cli/cmd/canaryconfig/get_test.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package canaryconfig
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+	os.Stdout = w
+	runErr := fn()
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	require.NoError(t, runErr)
+	return buf.String()
+}
+
+func TestCanaryGet(t *testing.T) {
+	setCanaryClient(newCanary())
+
+	t.Run("table output names the config", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.CanaryName, "canary")
+		out := captureStdout(t, func() error { return Get(in) })
+		assert.True(t, strings.Contains(out, "canary"), "table output should name the canary config, got: %q", out)
+		assert.Contains(t, out, "NAME")
+	})
+
+	t.Run("json output is structured", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.CanaryName, "canary")
+		in.Set(flagkey.Output, "json")
+		out := captureStdout(t, func() error { return Get(in) })
+		assert.Contains(t, out, "\"name\": \"canary\"")
+	})
+
+	t.Run("missing config errors", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.CanaryName, "absent")
+		require.Error(t, Get(in))
+	})
+}

--- a/pkg/fission-cli/cmd/canaryconfig/list_delete_test.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list_delete_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package canaryconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+func TestCanaryList(t *testing.T) {
+	setCanaryClient(newCanary())
+
+	t.Run("table lists the config", func(t *testing.T) {
+		out := captureStdout(t, func() error { return List(dummy.TestFlagSet()) })
+		assert.Contains(t, out, "NAME")
+		assert.Contains(t, out, "canary")
+	})
+
+	t.Run("json output", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Output, "json")
+		out := captureStdout(t, func() error { return List(in) })
+		assert.Contains(t, out, "canary")
+	})
+
+	t.Run("invalid format errors", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Output, "bogus")
+		require.Error(t, List(in))
+	})
+}
+
+func TestCanaryDelete(t *testing.T) {
+	setCanaryClient(newCanary())
+
+	t.Run("deletes an existing config", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.CanaryName, "canary")
+		_ = captureStdout(t, func() error { return Delete(in) })
+	})
+
+	t.Run("deleting a missing config errors", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.CanaryName, "canary") // already deleted above
+		require.Error(t, Delete(in))
+	})
+
+	t.Run("ignore-not-found swallows the error", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.CanaryName, "canary")
+		in.Set(flagkey.IgnoreNotFound, true)
+		require.NoError(t, Delete(in))
+	})
+}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -58,16 +58,21 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 
 	if incrementStep != canaryCfg.Spec.WeightIncrement {
 		canaryCfg.Spec.WeightIncrement = incrementStep
+		updateNeeded = true
 	}
 
 	if failureThreshold != canaryCfg.Spec.FailureThreshold {
 		canaryCfg.Spec.FailureThreshold = failureThreshold
+		updateNeeded = true
 	}
 
 	if incrementInterval != canaryCfg.Spec.WeightIncrementDuration {
 		canaryCfg.Spec.WeightIncrementDuration = incrementInterval
+		updateNeeded = true
 	}
 
+	// When any spec field changed, re-arm the rollout by resetting the status to
+	// pending so the canary controller re-evaluates from the start.
 	if updateNeeded {
 		canaryCfg.Status.Status = fv1.CanaryConfigStatusPending
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -39,36 +39,39 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	if err != nil {
 		return fmt.Errorf("error updating canary config: %w", err)
 	}
-	incrementStep := input.Int(flagkey.CanaryWeightIncrement)
-	failureThreshold := input.Int(flagkey.CanaryFailureThreshold)
-	incrementInterval := input.String(flagkey.CanaryIncrementInterval)
-
-	// check for time parsing
-	_, err = time.ParseDuration(incrementInterval)
-	if err != nil {
-		return fmt.Errorf("error parsing time duration: %w", err)
-	}
-
 	canaryCfg, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(ns).Get(input.Context(), input.String(flagkey.CanaryName), metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error getting canary config: %w", err)
 	}
 
+	// Only flags the user actually set should mutate the resource; these flags
+	// have non-zero defaults, so comparing the raw value would clobber stored
+	// fields (and reset status) on an update that never mentioned them.
 	var updateNeeded bool
 
-	if incrementStep != canaryCfg.Spec.WeightIncrement {
-		canaryCfg.Spec.WeightIncrement = incrementStep
-		updateNeeded = true
+	if input.IsSet(flagkey.CanaryWeightIncrement) {
+		if incrementStep := input.Int(flagkey.CanaryWeightIncrement); incrementStep != canaryCfg.Spec.WeightIncrement {
+			canaryCfg.Spec.WeightIncrement = incrementStep
+			updateNeeded = true
+		}
 	}
 
-	if failureThreshold != canaryCfg.Spec.FailureThreshold {
-		canaryCfg.Spec.FailureThreshold = failureThreshold
-		updateNeeded = true
+	if input.IsSet(flagkey.CanaryFailureThreshold) {
+		if failureThreshold := input.Int(flagkey.CanaryFailureThreshold); failureThreshold != canaryCfg.Spec.FailureThreshold {
+			canaryCfg.Spec.FailureThreshold = failureThreshold
+			updateNeeded = true
+		}
 	}
 
-	if incrementInterval != canaryCfg.Spec.WeightIncrementDuration {
-		canaryCfg.Spec.WeightIncrementDuration = incrementInterval
-		updateNeeded = true
+	if input.IsSet(flagkey.CanaryIncrementInterval) {
+		incrementInterval := input.String(flagkey.CanaryIncrementInterval)
+		if _, err := time.ParseDuration(incrementInterval); err != nil {
+			return fmt.Errorf("error parsing time duration: %w", err)
+		}
+		if incrementInterval != canaryCfg.Spec.WeightIncrementDuration {
+			canaryCfg.Spec.WeightIncrementDuration = incrementInterval
+			updateNeeded = true
+		}
 	}
 
 	// When any spec field changed, re-arm the rollout by resetting the status to

--- a/pkg/fission-cli/cmd/canaryconfig/update_test.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package canaryconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/generated/clientset/versioned"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+func newCanary() *fv1.CanaryConfig {
+	return &fv1.CanaryConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "canary", Namespace: "default"},
+		Spec: fv1.CanaryConfigSpec{
+			Trigger:                 "route",
+			NewFunction:             "new",
+			OldFunction:             "old",
+			WeightIncrement:         10,
+			WeightIncrementDuration: "2m",
+			FailureThreshold:        10,
+		},
+		Status: fv1.CanaryConfigStatus{Status: "succeeded"},
+	}
+}
+
+// setCanaryClient installs a fake clientset as the CLI's default client and
+// returns it so the test can read resources back.
+func setCanaryClient(objs ...*fv1.CanaryConfig) versioned.Interface {
+	// NewSimpleClientset (legacy tracker) supports Update without an SSA schema;
+	// NewClientset fails Update for fission CRs (no applyconfigs generated) with a
+	// structured-merge-diff error. See kubernetes/kubernetes#126850.
+	rs := make([]runtime.Object, 0, len(objs))
+	for _, o := range objs {
+		rs = append(rs, o)
+	}
+	fc := fissionfake.NewSimpleClientset(rs...) //nolint:staticcheck
+	cmd.ResetClientsetForTest()
+	cmd.SetClientset(cmd.Client{FissionClientSet: fc, Namespace: "default"})
+	return fc
+}
+
+func TestCanaryUpdateResetsStatusOnChange(t *testing.T) {
+	fc := setCanaryClient(newCanary())
+
+	in := dummy.TestFlagSet()
+	in.Set(flagkey.CanaryName, "canary")
+	in.Set(flagkey.CanaryWeightIncrement, 20) // changed from 10
+	in.Set(flagkey.CanaryFailureThreshold, 10)
+	in.Set(flagkey.CanaryIncrementInterval, "2m")
+
+	require.NoError(t, Update(in))
+
+	got, err := fc.CoreV1().CanaryConfigs("default").Get(t.Context(), "canary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 20, got.Spec.WeightIncrement, "weight increment should be updated")
+	assert.Equal(t, fv1.CanaryConfigStatusPending, got.Status.Status,
+		"a changed canary config must reset status to pending so the controller re-evaluates")
+}
+
+func TestCanaryUpdateNoChangeKeepsStatus(t *testing.T) {
+	fc := setCanaryClient(newCanary())
+
+	in := dummy.TestFlagSet()
+	in.Set(flagkey.CanaryName, "canary")
+	in.Set(flagkey.CanaryWeightIncrement, 10) // same as existing
+	in.Set(flagkey.CanaryFailureThreshold, 10)
+	in.Set(flagkey.CanaryIncrementInterval, "2m")
+
+	require.NoError(t, Update(in))
+
+	got, err := fc.CoreV1().CanaryConfigs("default").Get(t.Context(), "canary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "succeeded", got.Status.Status, "no spec change must leave status untouched")
+}
+
+func TestCanaryUpdateInvalidIntervalErrors(t *testing.T) {
+	setCanaryClient(newCanary())
+
+	in := dummy.TestFlagSet()
+	in.Set(flagkey.CanaryName, "canary")
+	in.Set(flagkey.CanaryIncrementInterval, "not-a-duration")
+
+	require.Error(t, Update(in))
+}
+
+func TestCanaryUpdateMissingConfigErrors(t *testing.T) {
+	setCanaryClient() // empty clientset
+
+	in := dummy.TestFlagSet()
+	in.Set(flagkey.CanaryName, "absent")
+	in.Set(flagkey.CanaryIncrementInterval, "2m")
+
+	require.Error(t, Update(in))
+}

--- a/pkg/fission-cli/cmd/canaryconfig/update_test.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update_test.go
@@ -85,6 +85,23 @@ func TestCanaryUpdateNoChangeKeepsStatus(t *testing.T) {
 	assert.Equal(t, "succeeded", got.Status.Status, "no spec change must leave status untouched")
 }
 
+func TestCanaryUpdateOnlySetFlagsMutate(t *testing.T) {
+	fc := setCanaryClient(newCanary()) // step=10, threshold=10, duration=2m
+
+	in := dummy.TestFlagSet()
+	in.Set(flagkey.CanaryName, "canary")
+	in.Set(flagkey.CanaryFailureThreshold, 5) // only this flag is provided
+
+	require.NoError(t, Update(in))
+
+	got, err := fc.CoreV1().CanaryConfigs("default").Get(t.Context(), "canary", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, 5, got.Spec.FailureThreshold, "the set flag should change")
+	assert.Equal(t, 10, got.Spec.WeightIncrement, "an unset flag must not be clobbered with its default")
+	assert.Equal(t, "2m", got.Spec.WeightIncrementDuration, "an unset flag must not be clobbered with its default")
+	assert.Equal(t, fv1.CanaryConfigStatusPending, got.Status.Status)
+}
+
 func TestCanaryUpdateInvalidIntervalErrors(t *testing.T) {
 	setCanaryClient(newCanary())
 

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -67,29 +67,13 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 			len(envList.Items), opts.env.Namespace)
 	}
 
-	// if we're writing a spec, don't call the API
-	// save to spec file or display the spec to console
-	if input.Bool(flagkey.SpecDry) {
-		err = opts.env.Validate()
-		if err != nil {
+	// if we're writing a spec, don't call the API; validate then save/print.
+	if input.Bool(flagkey.SpecDry) || input.Bool(flagkey.SpecSave) {
+		if err = opts.env.Validate(); err != nil {
 			return fv1.AggregateValidationErrors("Environment", err)
 		}
-
-		return spec.SpecDry(*opts.env)
-	}
-
-	if input.Bool(flagkey.SpecSave) {
-		err = opts.env.Validate()
-		if err != nil {
-			return fv1.AggregateValidationErrors("Environment", err)
-		}
-
-		specFile := fmt.Sprintf("env-%v.yaml", opts.env.Name)
-		err = spec.SpecSave(*opts.env, specFile, false)
-		if err != nil {
-			return fmt.Errorf("error saving environment spec: %w", err)
-		}
-		return nil
+		_, err = spec.SaveOrDry(input, *opts.env, fmt.Sprintf("env-%v.yaml", opts.env.Name))
+		return err
 	}
 
 	opts.env.Namespace = currentNS

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -58,6 +58,16 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 	// we use user provided NS in spec. While creating actual record we use the current context's NS.
 	opts.env.Namespace = userDefinedNS
 
+	// if we're writing a spec, don't call the API; validate then save/print.
+	// Handled before any API call so `--spec`/`--spec-dry` works without a cluster.
+	if input.Bool(flagkey.SpecDry) || input.Bool(flagkey.SpecSave) {
+		if err = opts.env.Validate(); err != nil {
+			return fv1.AggregateValidationErrors("Environment", err)
+		}
+		_, err = spec.SaveOrDry(input, *opts.env, fmt.Sprintf("env-%v.yaml", opts.env.Name))
+		return err
+	}
+
 	envList, err := opts.Client().FissionClientSet.CoreV1().Environments(opts.env.ObjectMeta.Namespace).List(input.Context(), metav1.ListOptions{})
 	if err != nil {
 		return err
@@ -65,15 +75,6 @@ func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 		console.Verbose(2, "%d environment(s) are present in the %s namespace.  "+
 			"These environments are not isolated from each other; use separate namespaces if you need isolation.",
 			len(envList.Items), opts.env.Namespace)
-	}
-
-	// if we're writing a spec, don't call the API; validate then save/print.
-	if input.Bool(flagkey.SpecDry) || input.Bool(flagkey.SpecSave) {
-		if err = opts.env.Validate(); err != nil {
-			return fv1.AggregateValidationErrors("Environment", err)
-		}
-		_, err = spec.SaveOrDry(input, *opts.env, fmt.Sprintf("env-%v.yaml", opts.env.Name))
-		return err
 	}
 
 	opts.env.Namespace = currentNS

--- a/pkg/fission-cli/cmd/environment/update_test.go
+++ b/pkg/fission-cli/cmd/environment/update_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package environment
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+func baseEnv() *fv1.Environment {
+	return &fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default"},
+		Spec: fv1.EnvironmentSpec{
+			Version: 2,
+			Runtime: fv1.Runtime{Image: "old-image", Container: &v1.Container{Name: "e"}},
+		},
+	}
+}
+
+func TestUpdateExistingEnvironmentWithCmd(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates scalar fields", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.EnvImage, "new-image")
+		in.Set(flagkey.EnvPoolsize, 5)
+		in.Set(flagkey.EnvGracePeriod, int64(42))
+		in.Set(flagkey.EnvKeeparchive, true)
+		in.Set(flagkey.EnvImagePullSecret, "regcred")
+
+		got, err := updateExistingEnvironmentWithCmd(baseEnv(), in)
+		require.NoError(t, err)
+		assert.Equal(t, "new-image", got.Spec.Runtime.Image)
+		assert.Equal(t, 5, got.Spec.Poolsize)
+		assert.Equal(t, int64(42), got.Spec.TerminationGracePeriod)
+		assert.True(t, got.Spec.KeepArchive)
+		assert.Equal(t, "regcred", got.Spec.ImagePullSecret)
+	})
+
+	t.Run("runtime env vars parsed", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.EnvRuntime, []string{"A=1", "B=2"})
+		got, err := updateExistingEnvironmentWithCmd(baseEnv(), in)
+		require.NoError(t, err)
+		require.Len(t, got.Spec.Runtime.Container.Env, 2)
+		assert.Equal(t, "A", got.Spec.Runtime.Container.Env[0].Name)
+	})
+
+	t.Run("cpu limit defaults to request when only min set", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.RuntimeMincpu, 100)
+		got, err := updateExistingEnvironmentWithCmd(baseEnv(), in)
+		require.NoError(t, err)
+		req := got.Spec.Resources.Requests[v1.ResourceCPU]
+		lim := got.Spec.Resources.Limits[v1.ResourceCPU]
+		assert.Equal(t, 0, req.Cmp(lim), "limit should default to request")
+	})
+
+	t.Run("mincpu greater than maxcpu errors", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.RuntimeMincpu, 200)
+		in.Set(flagkey.RuntimeMaxcpu, 100)
+		_, err := updateExistingEnvironmentWithCmd(baseEnv(), in)
+		require.Error(t, err)
+	})
+
+	t.Run("builder on a v1 environment errors", func(t *testing.T) {
+		t.Parallel()
+		env := baseEnv()
+		env.Spec.Version = 1
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.EnvBuilderImage, "builder:latest")
+		_, err := updateExistingEnvironmentWithCmd(env, in)
+		require.Error(t, err)
+	})
+}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -220,66 +220,20 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		}
 	}
 
-	var secrets []fv1.SecretReference
-	var cfgmaps []fv1.ConfigMapReference
-
-	if len(secretNames) > 0 {
-		// check the referenced secret is in the same ns as the function, if not give a warning.
-		if !toSpec { // TODO: workaround in order not to block users from creating function spec, remove it.
-			for _, secretName := range secretNames {
-				err := util.SecretExists(input.Context(), &metav1.ObjectMeta{Namespace: fnNamespace, Name: secretName}, opts.Client().KubernetesClient)
-				if err != nil {
-					if k8serrors.IsNotFound(err) {
-						console.Warn(fmt.Sprintf("Secret %s not found in Namespace: %s. Secret needs to be present in the same namespace as function", secretName, fnNamespace))
-					} else {
-						return fmt.Errorf("error checking secret %s: %w", secretName, err)
-					}
-				}
-				newSecret := fv1.SecretReference{
-					Name:      secretName,
-					Namespace: fnNamespace,
-				}
-				secrets = append(secrets, newSecret)
-			}
-		} else {
-			for _, secretName := range secretNames {
-				newSecret := fv1.SecretReference{
-					Name:      secretName,
-					Namespace: userProvidedNS,
-				}
-				secrets = append(secrets, newSecret)
-			}
-		}
-
+	// Secret/configmap references point at the function namespace when creating
+	// against the cluster (and are existence-checked there), or at the
+	// user-provided namespace when writing a spec (no cluster check).
+	refNamespace := fnNamespace
+	if toSpec {
+		refNamespace = userProvidedNS
 	}
-
-	if len(cfgMapNames) > 0 {
-		// check the referenced cfgmap is in the same ns as the function, if not give a warning.
-		if !toSpec {
-			for _, cfgMapName := range cfgMapNames {
-				err := util.ConfigMapExists(input.Context(), &metav1.ObjectMeta{Namespace: fnNamespace, Name: cfgMapName}, opts.Client().KubernetesClient)
-				if err != nil {
-					if k8serrors.IsNotFound(err) {
-						console.Warn(fmt.Sprintf("ConfigMap %s not found in Namespace: %s. ConfigMap needs to be present in the same namespace as function", cfgMapName, fnNamespace))
-					} else {
-						return fmt.Errorf("error checking configmap %s: %w", cfgMapName, err)
-					}
-				}
-				newCfgMap := fv1.ConfigMapReference{
-					Name:      cfgMapName,
-					Namespace: fnNamespace,
-				}
-				cfgmaps = append(cfgmaps, newCfgMap)
-			}
-		} else {
-			for _, cfgMapName := range cfgMapNames {
-				newCfgMap := fv1.ConfigMapReference{
-					Name:      cfgMapName,
-					Namespace: userProvidedNS,
-				}
-				cfgmaps = append(cfgmaps, newCfgMap)
-			}
-		}
+	secrets, err := util.ResolveSecretReferences(input.Context(), opts.Client().KubernetesClient, secretNames, refNamespace, !toSpec, true)
+	if err != nil {
+		return err
+	}
+	cfgmaps, err := util.ResolveConfigMapReferences(input.Context(), opts.Client().KubernetesClient, cfgMapNames, refNamespace, !toSpec, true)
+	if err != nil {
+		return err
 	}
 
 	opts.function = &fv1.Function{
@@ -347,18 +301,9 @@ func generatePackageName(fnName string, id string) string {
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	// if we're writing a spec, don't create the function
-	// save to spec file or display the spec to console
-	if input.Bool(flagkey.SpecDry) {
-		return spec.SpecDry(*opts.function)
-	}
-
-	if input.Bool(flagkey.SpecSave) {
-		err := spec.SpecSave(*opts.function, opts.specFile, false)
-		if err != nil {
-			return fmt.Errorf("error saving function spec: %w", err)
-		}
-		return nil
+	// if we're writing a spec, don't create the function; save/print and return.
+	if handled, err := spec.SaveOrDry(input, *opts.function, opts.specFile); handled {
+		return err
 	}
 
 	_, err := opts.Client().FissionClientSet.CoreV1().Functions(opts.function.ObjectMeta.Namespace).Create(input.Context(), opts.function, metav1.CreateOptions{})

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -7,7 +7,6 @@ package function
 import (
 	"fmt"
 
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -67,46 +66,21 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	secretNames := input.StringSlice(flagkey.FnSecret)
 	cfgMapNames := input.StringSlice(flagkey.FnCfgMap)
 
-	var secrets []fv1.SecretReference
-	var configMaps []fv1.ConfigMapReference
-
+	// Only overwrite secret/configmap refs when the flag was provided, so an
+	// update that doesn't mention them leaves the existing refs intact. Missing
+	// resources warn but don't abort (the update path is lenient).
 	if len(secretNames) > 0 {
-
-		// check that the referenced secret is in the same ns as the function, if not give a warning.
-		for _, secretName := range secretNames {
-			err := util.SecretExists(input.Context(), &metav1.ObjectMeta{Namespace: fnNamespace, Name: secretName}, opts.Client().KubernetesClient)
-			if k8serrors.IsNotFound(err) {
-				console.Warn(fmt.Sprintf("secret %s not found in Namespace: %s. Secret needs to be present in the same namespace as function", secretName, fnNamespace))
-			}
+		secrets, err := util.ResolveSecretReferences(input.Context(), opts.Client().KubernetesClient, secretNames, fnNamespace, true, false)
+		if err != nil {
+			return err
 		}
-
-		for _, secretName := range secretNames {
-			newSecret := fv1.SecretReference{
-				Name:      secretName,
-				Namespace: fnNamespace,
-			}
-			secrets = append(secrets, newSecret)
-		}
-
 		function.Spec.Secrets = secrets
 	}
 
 	if len(cfgMapNames) > 0 {
-
-		// check that the referenced cfgmap is in the same ns as the function, if not give a warning.
-		for _, cfgMapName := range cfgMapNames {
-			err := util.ConfigMapExists(input.Context(), &metav1.ObjectMeta{Namespace: fnNamespace, Name: cfgMapName}, opts.Client().KubernetesClient)
-			if k8serrors.IsNotFound(err) {
-				console.Warn(fmt.Sprintf("ConfigMap %s not found in Namespace: %s. ConfigMap needs to be present in the same namespace as the function", cfgMapName, fnNamespace))
-			}
-		}
-
-		for _, cfgMapName := range cfgMapNames {
-			newCfgMap := fv1.ConfigMapReference{
-				Name:      cfgMapName,
-				Namespace: fnNamespace,
-			}
-			configMaps = append(configMaps, newCfgMap)
+		configMaps, err := util.ResolveConfigMapReferences(input.Context(), opts.Client().KubernetesClient, cfgMapNames, fnNamespace, true, false)
+		if err != nil {
+			return err
 		}
 		function.Spec.ConfigMaps = configMaps
 	}

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -110,26 +110,8 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 
 	// For Specs, the spec validate checks for function reference
 	if input.Bool(flagkey.SpecSave) {
-		specDir := util.GetSpecDir(input)
-		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
-		if err != nil {
-			return fmt.Errorf("error reading spec in '%v': %w", specDir, err)
-		}
-		for _, fn := range functionList {
-			exists, err := fr.ExistsInSpecs(fv1.Function{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      fn,
-					Namespace: userProvidedNS,
-				},
-			})
-			if err != nil {
-				return err
-			}
-			if !exists {
-				console.Warn(fmt.Sprintf("HTTPTrigger '%v' references unknown Function '%v', please create it before applying spec",
-					triggerName, fn))
-			}
+		if err := spec.CheckFunctionReferencesInSpecs(input, "HTTPTrigger", triggerName, functionList, userProvidedNS); err != nil {
+			return err
 		}
 	} else {
 
@@ -177,19 +159,9 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	// if we're writing a spec, don't call the API
-	// save to spec file or display the spec to console
-	if input.Bool(flagkey.SpecDry) {
-		return spec.SpecDry(*opts.trigger)
-	}
-
-	if input.Bool(flagkey.SpecSave) {
-		specFile := fmt.Sprintf("route-%v.yaml", opts.trigger.Name)
-		err := spec.SpecSave(*opts.trigger, specFile, false)
-		if err != nil {
-			return fmt.Errorf("error saving HTTP trigger spec: %w", err)
-		}
-		return nil
+	// if we're writing a spec, don't call the API; save/print and return.
+	if handled, err := spec.SaveOrDry(input, *opts.trigger, fmt.Sprintf("route-%v.yaml", opts.trigger.Name)); handled {
+		return err
 	}
 
 	// Ensure we don't have a duplicate HTTP route defined (same URL and method)

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -15,7 +15,6 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
-	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils/uuid"
 )
 
@@ -52,25 +51,8 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	objType := input.String(flagkey.KwObjType)
 
 	if input.Bool(flagkey.SpecSave) {
-		specDir := util.GetSpecDir(input)
-		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
-		if err != nil {
-			return fmt.Errorf("error reading spec in '%v': %w", specDir, err)
-		}
-
-		exists, err := fr.ExistsInSpecs(fv1.Function{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fnName,
-				Namespace: namespace,
-			},
-		})
-		if err != nil {
+		if err := spec.CheckFunctionReferencesInSpecs(input, "KubernetesWatchTrigger", watchName, []string{fnName}, namespace); err != nil {
 			return err
-		}
-		if !exists {
-			console.Warn(fmt.Sprintf("KubernetesWatchTrigger '%v' references unknown Function '%v', please create it before applying spec",
-				watchName, fnName))
 		}
 	}
 
@@ -94,19 +76,9 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	// if we're writing a spec, don't call the API
-	// save to spec file or display the spec to console
-	if input.Bool(flagkey.SpecDry) {
-		return spec.SpecDry(*opts.watcher)
-	}
-
-	if input.Bool(flagkey.SpecSave) {
-		specFile := fmt.Sprintf("kubewatch-%v.yaml", opts.watcher.Name)
-		err := spec.SpecSave(*opts.watcher, specFile, false)
-		if err != nil {
-			return fmt.Errorf("error saving kubewatch spec: %w", err)
-		}
-		return nil
+	// if we're writing a spec, don't call the API; save/print and return.
+	if handled, err := spec.SaveOrDry(input, *opts.watcher, fmt.Sprintf("kubewatch-%v.yaml", opts.watcher.Name)); handled {
+		return err
 	}
 
 	_, err := opts.Client().FissionClientSet.CoreV1().KubernetesWatchTriggers(opts.watcher.ObjectMeta.Namespace).Create(input.Context(), opts.watcher, metav1.CreateOptions{})

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -38,7 +38,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	watchName := input.String(flagkey.KwName)
 	if len(watchName) == 0 {
-		console.Warn(fmt.Sprintf("--%v will be soon marked as required flag, see 'help' for details", flagkey.MqtName))
+		console.Warn(fmt.Sprintf("--%v will be soon marked as required flag, see 'help' for details", flagkey.KwName))
 		watchName = uuid.NewString()
 	}
 	fnName := input.String(flagkey.KwFnName)

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -115,25 +115,9 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	secret := input.String(flagkey.MqtSecret)
 
 	if input.Bool(flagkey.SpecSave) {
-		specDir := util.GetSpecDir(input)
-		specIgnore := util.GetSpecIgnore(input)
-		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
-		if err != nil {
-			return fmt.Errorf("error reading spec in '%v': %w", specDir, err)
-		}
-
-		exists, err := fr.ExistsInSpecs(fv1.Function{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fnName,
-				Namespace: userProvidedNS,
-			},
-		})
+		err = spec.CheckFunctionReferencesInSpecs(input, "MessageQueueTrigger", mqtName, []string{fnName}, userProvidedNS)
 		if err != nil {
 			return err
-		}
-		if !exists {
-			console.Warn(fmt.Sprintf("MessageQueueTrigger '%v' references unknown Function '%v', please create it before applying spec",
-				mqtName, fnName))
 		}
 	} else {
 		err = util.CheckFunctionExistence(input.Context(), opts.Client(), []string{fnName}, fnNamespace)
@@ -180,19 +164,9 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	// if we're writing a spec, don't call the API
-	// save to spec file or display the spec to console
-	if input.Bool(flagkey.SpecDry) {
-		return spec.SpecDry(*opts.trigger)
-	}
-
-	if input.Bool(flagkey.SpecSave) {
-		specFile := fmt.Sprintf("mqtrigger-%v.yaml", opts.trigger.Name)
-		err := spec.SpecSave(*opts.trigger, specFile, false)
-		if err != nil {
-			return fmt.Errorf("error saving message queue trigger spec: %w", err)
-		}
-		return nil
+	// if we're writing a spec, don't call the API; save/print and return.
+	if handled, err := spec.SaveOrDry(input, *opts.trigger, fmt.Sprintf("mqtrigger-%v.yaml", opts.trigger.Name)); handled {
+		return err
 	}
 
 	_, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.trigger.ObjectMeta.Namespace).Create(input.Context(), opts.trigger, metav1.CreateOptions{})

--- a/pkg/fission-cli/cmd/spec/saveordry_test.go
+++ b/pkg/fission-cli/cmd/spec/saveordry_test.go
@@ -23,6 +23,7 @@ func captureSpecStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
+	defer r.Close()
 	orig := os.Stdout
 	t.Cleanup(func() { os.Stdout = orig })
 	os.Stdout = w

--- a/pkg/fission-cli/cmd/spec/saveordry_test.go
+++ b/pkg/fission-cli/cmd/spec/saveordry_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spec
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+func captureSpecStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+	os.Stdout = w
+	runErr := fn()
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	require.NoError(t, runErr)
+	return buf.String()
+}
+
+func TestSaveOrDry(t *testing.T) {
+	fn := fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "ydry"}}
+
+	t.Run("no spec flag is not handled", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		handled, err := SaveOrDry(in, fn, "fn.yaml")
+		require.NoError(t, err)
+		assert.False(t, handled)
+	})
+
+	t.Run("spec-dry prints the resource YAML", func(t *testing.T) {
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.SpecDry, true)
+		var handled bool
+		out := captureSpecStdout(t, func() error {
+			var err error
+			handled, err = SaveOrDry(in, fn, "fn.yaml")
+			return err
+		})
+		assert.True(t, handled)
+		assert.Contains(t, out, "ydry")
+	})
+}

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/cmd/spec/types"
 	"github.com/fission/fission/pkg/fission-cli/console"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
@@ -200,6 +201,49 @@ func SpecDry(resource any) error {
 	}
 	fmt.Println(string(data))
 	return nil
+}
+
+// CheckFunctionReferencesInSpecs warns for every function name a trigger
+// references that is not present in the spec directory. It is the shared
+// --spec-save validation used by the trigger create commands (referrerKind is
+// e.g. "HTTPTrigger", referrerName the trigger name).
+func CheckFunctionReferencesInSpecs(input cli.Input, referrerKind, referrerName string, fnNames []string, namespace string) error {
+	specDir := util.GetSpecDir(input)
+	fr, err := ReadSpecs(specDir, util.GetSpecIgnore(input), false)
+	if err != nil {
+		return fmt.Errorf("error reading spec in '%v': %w", specDir, err)
+	}
+	for _, fn := range fnNames {
+		exists, err := fr.ExistsInSpecs(fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: fn, Namespace: namespace},
+		})
+		if err != nil {
+			return err
+		}
+		if !exists {
+			console.Warn(fmt.Sprintf("%s '%v' references unknown Function '%v', please create it before applying spec",
+				referrerKind, referrerName, fn))
+		}
+	}
+	return nil
+}
+
+// SaveOrDry handles the shared --spec-dry / --spec-save behaviour used by the
+// resource create commands. When --spec-dry is set it prints the resource YAML;
+// when --spec-save is set it writes it to specFile. It returns handled=true when
+// either flag was set, in which case the caller must return err immediately
+// instead of talking to the API server.
+func SaveOrDry(input cli.Input, resource any, specFile string) (handled bool, err error) {
+	if input.Bool(flagkey.SpecDry) {
+		return true, SpecDry(resource)
+	}
+	if input.Bool(flagkey.SpecSave) {
+		if err := SpecSave(resource, specFile, false); err != nil {
+			return true, fmt.Errorf("error saving spec to %s: %w", specFile, err)
+		}
+		return true, nil
+	}
+	return false, nil
 }
 
 func crdToYaml(resource any) (metav1.ObjectMeta, string, []byte, error) {

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -114,19 +114,9 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 }
 
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	// if we're writing a spec, don't call the API
-	// save to spec file or display the spec to console
-	if input.Bool(flagkey.SpecDry) {
-		return spec.SpecDry(*opts.trigger)
-	}
-
-	if input.Bool(flagkey.SpecSave) {
-		specFile := fmt.Sprintf("timetrigger-%v.yaml", opts.trigger.Name)
-		err := spec.SpecSave(*opts.trigger, specFile, false)
-		if err != nil {
-			return fmt.Errorf("error saving time trigger spec: %w", err)
-		}
-		return nil
+	// if we're writing a spec, don't call the API; save/print and return.
+	if handled, err := spec.SaveOrDry(input, *opts.trigger, fmt.Sprintf("timetrigger-%v.yaml", opts.trigger.Name)); handled {
+		return err
 	}
 
 	_, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(opts.trigger.Namespace).Create(input.Context(), opts.trigger, metav1.CreateOptions{})

--- a/pkg/fission-cli/cmd/token/create_test.go
+++ b/pkg/fission-cli/cmd/token/create_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package token
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+// captureStdout runs fn with os.Stdout redirected and returns what it wrote.
+func captureStdout(t *testing.T, fn func() error) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	orig := os.Stdout
+	t.Cleanup(func() { os.Stdout = orig })
+	os.Stdout = w
+	runErr := fn()
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	require.NoError(t, runErr)
+	return buf.String()
+}
+
+func TestTokenCreate(t *testing.T) {
+	t.Run("prints access token on 201", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/auth/login", r.URL.Path)
+			var body fv1.AuthLogin
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			assert.Equal(t, "alice", body.Username)
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(fv1.RouterAuthToken{AccessToken: "tok-123", TokenType: "Bearer"})
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("FISSION_ROUTER_URL", srv.URL)
+
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.TokUsername, "alice")
+		in.Set(flagkey.TokPassword, "secret")
+
+		out := captureStdout(t, func() error { return Create(in) })
+		assert.Contains(t, out, "tok-123")
+	})
+
+	t.Run("reports a 404 with guidance", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("FISSION_ROUTER_URL", srv.URL)
+
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.TokUsername, "bob")
+		in.Set(flagkey.TokPassword, "secret")
+
+		out := captureStdout(t, func() error { return Create(in) })
+		assert.True(t, strings.Contains(out, "authentication is enabled"),
+			"404 should print guidance, got: %q", out)
+	})
+
+	t.Run("honors the --authuri flag", func(t *testing.T) {
+		var gotPath string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(fv1.RouterAuthToken{AccessToken: "x"})
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("FISSION_ROUTER_URL", srv.URL)
+
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.TokUsername, "alice")
+		in.Set(flagkey.TokPassword, "secret")
+		in.Set(flagkey.TokAuthURI, "/custom/login")
+
+		_ = captureStdout(t, func() error { return Create(in) })
+		assert.Equal(t, "/custom/login", gotPath)
+	})
+}

--- a/pkg/fission-cli/cmd/token/create_test.go
+++ b/pkg/fission-cli/cmd/token/create_test.go
@@ -27,6 +27,7 @@ func captureStdout(t *testing.T, fn func() error) string {
 	t.Helper()
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
+	defer r.Close()
 	orig := os.Stdout
 	t.Cleanup(func() { os.Stdout = orig })
 	os.Stdout = w

--- a/pkg/fission-cli/util/function_refs.go
+++ b/pkg/fission-cli/util/function_refs.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+	"fmt"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/console"
+)
+
+// ResolveSecretReferences builds SecretReferences for the given secret names,
+// each pointing at namespace. When check is true it verifies every secret exists
+// in namespace, warning when one is missing; when strict is also true a
+// non-NotFound lookup error aborts with an error (the create path) instead of
+// being ignored (the update path). Returns nil for an empty name list.
+func ResolveSecretReferences(ctx context.Context, kc kubernetes.Interface, names []string, namespace string, check, strict bool) ([]fv1.SecretReference, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	if check {
+		for _, name := range names {
+			err := SecretExists(ctx, &metav1.ObjectMeta{Namespace: namespace, Name: name}, kc)
+			switch {
+			case err == nil:
+			case k8serrors.IsNotFound(err):
+				console.Warn(fmt.Sprintf("Secret %s not found in Namespace: %s. Secret needs to be present in the same namespace as function", name, namespace))
+			case strict:
+				return nil, fmt.Errorf("error checking secret %s: %w", name, err)
+			}
+		}
+	}
+	refs := make([]fv1.SecretReference, 0, len(names))
+	for _, name := range names {
+		refs = append(refs, fv1.SecretReference{Name: name, Namespace: namespace})
+	}
+	return refs, nil
+}
+
+// ResolveConfigMapReferences mirrors ResolveSecretReferences for config maps.
+func ResolveConfigMapReferences(ctx context.Context, kc kubernetes.Interface, names []string, namespace string, check, strict bool) ([]fv1.ConfigMapReference, error) {
+	if len(names) == 0 {
+		return nil, nil
+	}
+	if check {
+		for _, name := range names {
+			err := ConfigMapExists(ctx, &metav1.ObjectMeta{Namespace: namespace, Name: name}, kc)
+			switch {
+			case err == nil:
+			case k8serrors.IsNotFound(err):
+				console.Warn(fmt.Sprintf("ConfigMap %s not found in Namespace: %s. ConfigMap needs to be present in the same namespace as function", name, namespace))
+			case strict:
+				return nil, fmt.Errorf("error checking configmap %s: %w", name, err)
+			}
+		}
+	}
+	refs := make([]fv1.ConfigMapReference, 0, len(names))
+	for _, name := range names {
+		refs = append(refs, fv1.ConfigMapReference{Name: name, Namespace: namespace})
+	}
+	return refs, nil
+}

--- a/pkg/fission-cli/util/function_refs_test.go
+++ b/pkg/fission-cli/util/function_refs_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestResolveSecretReferences(t *testing.T) {
+	t.Parallel()
+	kc := k8sfake.NewClientset(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "ns"}})
+
+	t.Run("empty names returns nil", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ResolveSecretReferences(t.Context(), kc, nil, "ns", true, true)
+		require.NoError(t, err)
+		assert.Nil(t, refs)
+	})
+
+	t.Run("no check builds refs in the given namespace", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ResolveSecretReferences(t.Context(), kc, []string{"a", "b"}, "spec-ns", false, false)
+		require.NoError(t, err)
+		require.Len(t, refs, 2)
+		assert.Equal(t, "spec-ns", refs[0].Namespace)
+		assert.Equal(t, "a", refs[0].Name)
+	})
+
+	t.Run("existing secret passes the check", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ResolveSecretReferences(t.Context(), kc, []string{"s"}, "ns", true, true)
+		require.NoError(t, err)
+		require.Len(t, refs, 1)
+	})
+
+	t.Run("missing secret warns but still builds (strict)", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ResolveSecretReferences(t.Context(), kc, []string{"missing"}, "ns", true, true)
+		require.NoError(t, err)
+		require.Len(t, refs, 1)
+		assert.Equal(t, "missing", refs[0].Name)
+	})
+}
+
+func TestResolveConfigMapReferences(t *testing.T) {
+	t.Parallel()
+	kc := k8sfake.NewClientset(&v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "ns"}})
+
+	t.Run("empty names returns nil", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ResolveConfigMapReferences(t.Context(), kc, nil, "ns", true, false)
+		require.NoError(t, err)
+		assert.Nil(t, refs)
+	})
+
+	t.Run("builds refs and tolerates a missing configmap", func(t *testing.T) {
+		t.Parallel()
+		refs, err := ResolveConfigMapReferences(t.Context(), kc, []string{"c", "missing"}, "ns", true, false)
+		require.NoError(t, err)
+		require.Len(t, refs, 2)
+		assert.Equal(t, "ns", refs[1].Namespace)
+	})
+}

--- a/pkg/fission-cli/util/util_more_test.go
+++ b/pkg/fission-cli/util/util_more_test.go
@@ -1,0 +1,423 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	"github.com/fission/fission/pkg/info"
+)
+
+func TestGetResourceReqs(t *testing.T) {
+	t.Parallel()
+
+	mustQty := func(s string) resource.Quantity { return resource.MustParse(s) }
+
+	tests := []struct {
+		name      string
+		flags     map[string]any
+		existing  *v1.ResourceRequirements
+		wantErr   bool
+		wantReqs  map[v1.ResourceName]resource.Quantity
+		wantLimit map[v1.ResourceName]resource.Quantity
+	}{
+		{
+			name:      "no flags yields empty maps",
+			flags:     map[string]any{},
+			wantReqs:  map[v1.ResourceName]resource.Quantity{},
+			wantLimit: map[v1.ResourceName]resource.Quantity{},
+		},
+		{
+			name:      "mincpu only defaults limit to request",
+			flags:     map[string]any{flagkey.RuntimeMincpu: 100},
+			wantReqs:  map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: mustQty("100m")},
+			wantLimit: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: mustQty("100m")},
+		},
+		{
+			name:      "minmemory only defaults limit to request",
+			flags:     map[string]any{flagkey.RuntimeMinmemory: 64},
+			wantReqs:  map[v1.ResourceName]resource.Quantity{v1.ResourceMemory: mustQty("64Mi")},
+			wantLimit: map[v1.ResourceName]resource.Quantity{v1.ResourceMemory: mustQty("64Mi")},
+		},
+		{
+			name: "valid cpu and memory ranges",
+			flags: map[string]any{
+				flagkey.RuntimeMincpu:    100,
+				flagkey.RuntimeMaxcpu:    200,
+				flagkey.RuntimeMinmemory: 64,
+				flagkey.RuntimeMaxmemory: 128,
+			},
+			wantReqs:  map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: mustQty("100m"), v1.ResourceMemory: mustQty("64Mi")},
+			wantLimit: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: mustQty("200m"), v1.ResourceMemory: mustQty("128Mi")},
+		},
+		{
+			name:    "mincpu greater than maxcpu errors",
+			flags:   map[string]any{flagkey.RuntimeMincpu: 200, flagkey.RuntimeMaxcpu: 100},
+			wantErr: true,
+		},
+		{
+			name:    "minmemory greater than maxmemory errors",
+			flags:   map[string]any{flagkey.RuntimeMinmemory: 128, flagkey.RuntimeMaxmemory: 64},
+			wantErr: true,
+		},
+		{
+			name:      "existing requirements are preserved",
+			flags:     map[string]any{},
+			existing:  &v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: mustQty("50m")}, Limits: v1.ResourceList{v1.ResourceCPU: mustQty("50m")}},
+			wantReqs:  map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: mustQty("50m")},
+			wantLimit: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: mustQty("50m")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			in := dummy.TestFlagSet()
+			for k, v := range tt.flags {
+				in.Set(k, v)
+			}
+			got, err := GetResourceReqs(in, tt.existing)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			for name, want := range tt.wantReqs {
+				assert.Equal(t, 0, want.Cmp(got.Requests[name]), "request %s", name)
+			}
+			for name, want := range tt.wantLimit {
+				assert.Equal(t, 0, want.Cmp(got.Limits[name]), "limit %s", name)
+			}
+		})
+	}
+}
+
+func TestParseAnnotations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		in      []string
+		want    map[string]string
+		wantErr bool
+	}{
+		{"valid pairs", []string{"a=b", "c=d"}, map[string]string{"a": "b", "c": "d"}, false},
+		{"value with equals", []string{"a=b=c"}, map[string]string{"a": "b=c"}, false},
+		{"empty input", nil, map[string]string{}, false},
+		{"missing equals", []string{"a"}, nil, true},
+		{"leading equals", []string{"=b"}, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseAnnotations(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestApplyLabelsAndAnnotations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("applies labels and annotations", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Labels, "team=a,env=prod")
+		in.Set(flagkey.Annotation, []string{"owner=me"})
+		om := &metav1.ObjectMeta{}
+		require.NoError(t, ApplyLabelsAndAnnotations(in, om))
+		assert.Equal(t, map[string]string{"team": "a", "env": "prod"}, om.Labels)
+		assert.Equal(t, map[string]string{"owner": "me"}, om.Annotations)
+	})
+
+	t.Run("no flags leaves meta untouched", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		om := &metav1.ObjectMeta{}
+		require.NoError(t, ApplyLabelsAndAnnotations(in, om))
+		assert.Nil(t, om.Labels)
+		assert.Nil(t, om.Annotations)
+	})
+
+	t.Run("invalid label errors", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Labels, "not a label")
+		require.Error(t, ApplyLabelsAndAnnotations(in, &metav1.ObjectMeta{}))
+	})
+
+	t.Run("invalid annotation errors", func(t *testing.T) {
+		t.Parallel()
+		in := dummy.TestFlagSet()
+		in.Set(flagkey.Annotation, []string{"noequals"})
+		require.Error(t, ApplyLabelsAndAnnotations(in, &metav1.ObjectMeta{}))
+	})
+}
+
+func TestUrlForFunction(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "/fission-function/fn", UrlForFunction("fn", metav1.NamespaceDefault))
+	assert.Equal(t, "/fission-function/ns1/fn", UrlForFunction("fn", "ns1"))
+}
+
+func TestGetSpecDir(t *testing.T) {
+	t.Parallel()
+	in := dummy.TestFlagSet()
+	assert.Equal(t, "specs", GetSpecDir(in))
+	in.Set(flagkey.SpecDir, "custom")
+	assert.Equal(t, "custom", GetSpecDir(in))
+}
+
+func TestGetSpecIgnore(t *testing.T) {
+	t.Parallel()
+	in := dummy.TestFlagSet()
+	assert.Equal(t, SPEC_IGNORE_FILE, GetSpecIgnore(in))
+	in.Set(flagkey.SpecIgnore, ".myignore")
+	assert.Equal(t, ".myignore", GetSpecIgnore(in))
+}
+
+func TestGetValidationFlag(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		val  string
+		want bool
+	}{
+		{"", true},
+		{"false", false},
+		{"true", true},
+		{"anything", true},
+	}
+	for _, tt := range tests {
+		in := dummy.TestFlagSet()
+		if tt.val != "" {
+			in.Set(flagkey.SpecValidate, tt.val)
+		}
+		assert.Equal(t, tt.want, GetValidationFlag(in), "val=%q", tt.val)
+	}
+}
+
+func TestGetSpecIgnoreParser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default ignore missing returns empty parser", func(t *testing.T) {
+		t.Parallel()
+		p, err := GetSpecIgnoreParser(t.TempDir(), SPEC_IGNORE_FILE)
+		require.NoError(t, err)
+		require.NotNil(t, p)
+	})
+
+	t.Run("custom ignore missing errors", func(t *testing.T) {
+		t.Parallel()
+		_, err := GetSpecIgnoreParser(t.TempDir(), ".custom-ignore")
+		require.Error(t, err)
+	})
+
+	t.Run("existing ignore file is parsed", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, SPEC_IGNORE_FILE), []byte("*.log\n"), 0600))
+		p, err := GetSpecIgnoreParser(dir, SPEC_IGNORE_FILE)
+		require.NoError(t, err)
+		assert.True(t, p.MatchesPath("foo.log"))
+		assert.False(t, p.MatchesPath("foo.txt"))
+	})
+}
+
+func TestCheckFunctionExistence(t *testing.T) {
+	t.Parallel()
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "exists", Namespace: "default"}}
+	client := cmd.Client{FissionClientSet: fissionfake.NewClientset(fn)}
+
+	require.NoError(t, CheckFunctionExistence(t.Context(), client, []string{"exists"}, "default"))
+
+	err := CheckFunctionExistence(t.Context(), client, []string{"exists", "missing"}, "default")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestCheckHTTPTriggerDuplicates(t *testing.T) {
+	t.Parallel()
+	existing := &fv1.HTTPTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "t1", Namespace: "default"},
+		Spec:       fv1.HTTPTriggerSpec{RelativeURL: "/foo", Method: http.MethodGet},
+	}
+	client := cmd.Client{FissionClientSet: fissionfake.NewClientset(existing)}
+
+	t.Run("same host url method is a duplicate", func(t *testing.T) {
+		dup := &fv1.HTTPTrigger{
+			ObjectMeta: metav1.ObjectMeta{Name: "t2", Namespace: "default"},
+			Spec:       fv1.HTTPTriggerSpec{RelativeURL: "/foo", Method: http.MethodGet},
+		}
+		require.Error(t, CheckHTTPTriggerDuplicates(t.Context(), client, dup))
+	})
+
+	t.Run("different url is not a duplicate", func(t *testing.T) {
+		ok := &fv1.HTTPTrigger{
+			ObjectMeta: metav1.ObjectMeta{Name: "t3", Namespace: "default"},
+			Spec:       fv1.HTTPTriggerSpec{RelativeURL: "/bar", Method: http.MethodGet},
+		}
+		require.NoError(t, CheckHTTPTriggerDuplicates(t.Context(), client, ok))
+	})
+
+	t.Run("same resource is skipped", func(t *testing.T) {
+		require.NoError(t, CheckHTTPTriggerDuplicates(t.Context(), client, existing))
+	})
+}
+
+func TestSecretAndConfigMapExists(t *testing.T) {
+	t.Parallel()
+	secret := &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s", Namespace: "default"}}
+	cm := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: "default"}}
+	kc := k8sfake.NewClientset(secret, cm)
+
+	require.NoError(t, SecretExists(t.Context(), &metav1.ObjectMeta{Name: "s", Namespace: "default"}, kc))
+	require.Error(t, SecretExists(t.Context(), &metav1.ObjectMeta{Name: "nope", Namespace: "default"}, kc))
+
+	require.NoError(t, ConfigMapExists(t.Context(), &metav1.ObjectMeta{Name: "c", Namespace: "default"}, kc))
+	require.Error(t, ConfigMapExists(t.Context(), &metav1.ObjectMeta{Name: "nope", Namespace: "default"}, kc))
+}
+
+func TestGetSvcName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("single matching service", func(t *testing.T) {
+		t.Parallel()
+		svc := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "router", Namespace: "fission", Labels: map[string]string{"application": "fission-router"}}}
+		kc := k8sfake.NewClientset(svc)
+		name, err := GetSvcName(t.Context(), kc, "fission-router")
+		require.NoError(t, err)
+		assert.Equal(t, "router.fission", name)
+	})
+
+	t.Run("no matching service errors", func(t *testing.T) {
+		t.Parallel()
+		kc := k8sfake.NewClientset()
+		_, err := GetSvcName(t.Context(), kc, "fission-router")
+		require.Error(t, err)
+	})
+
+	t.Run("multiple matching services error", func(t *testing.T) {
+		t.Parallel()
+		s1 := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "fission", Labels: map[string]string{"application": "fission-router"}}}
+		s2 := &v1.Service{ObjectMeta: metav1.ObjectMeta{Name: "r2", Namespace: "fission", Labels: map[string]string{"application": "fission-router"}}}
+		kc := k8sfake.NewClientset(s1, s2)
+		_, err := GetSvcName(t.Context(), kc, "fission-router")
+		require.Error(t, err)
+	})
+}
+
+func TestGetRouterURL(t *testing.T) {
+	t.Setenv("FISSION_ROUTER_URL", "http://router.example:8080")
+	u, err := GetRouterURL(t.Context(), cmd.Client{})
+	require.NoError(t, err)
+	assert.Equal(t, "http://router.example:8080", u.String())
+}
+
+func TestGetApplicationUrl(t *testing.T) {
+	t.Setenv(ENV_FISSION_URL, "http://fission.example")
+	u, err := GetApplicationUrl(t.Context(), cmd.Client{}, "application=fission-router")
+	require.NoError(t, err)
+	assert.Equal(t, "http://fission.example", u)
+}
+
+func TestGetStorageURL(t *testing.T) {
+	t.Setenv("FISSION_STORAGESVC_URL", "http://storage.example:8000")
+	u, err := GetStorageURL(t.Context(), cmd.Client{})
+	require.NoError(t, err)
+	assert.Equal(t, "http://storage.example:8000", u.String())
+}
+
+func TestGetServerInfo(t *testing.T) {
+	t.Run("decodes server info on 200", func(t *testing.T) {
+		want := info.ServerInfo{Build: info.BuildMeta{Version: "9.9.9"}}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/_version", r.URL.Path)
+			_ = json.NewEncoder(w).Encode(want)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("FISSION_ROUTER_URL", srv.URL)
+
+		in := dummy.TestFlagSet()
+		got := GetServerInfo(in, cmd.Client{})
+		require.NotNil(t, got)
+		assert.Equal(t, "9.9.9", got.Build.Version)
+	})
+
+	t.Run("non-200 yields empty server info", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("FISSION_ROUTER_URL", srv.URL)
+
+		in := dummy.TestFlagSet()
+		got := GetServerInfo(in, cmd.Client{})
+		require.NotNil(t, got)
+		assert.Empty(t, got.Build.Version)
+	})
+}
+
+func TestGetVersion(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(info.ServerInfo{Build: info.BuildMeta{Version: "server-1"}})
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("FISSION_ROUTER_URL", srv.URL)
+
+	in := dummy.TestFlagSet()
+	versions := GetVersion(t.Context(), in, cmd.Client{})
+	assert.Contains(t, versions.Client, "fission/core")
+	assert.Equal(t, "server-1", versions.Server["fission/core"].Version)
+}
+
+func TestFunctionPodLogs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("function not found errors", func(t *testing.T) {
+		t.Parallel()
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewClientset(),
+			KubernetesClient: k8sfake.NewClientset(),
+		}
+		require.Error(t, FunctionPodLogs(t.Context(), "missing", "default", client))
+	})
+
+	t.Run("no pods for function errors", func(t *testing.T) {
+		t.Parallel()
+		fn := &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "default", UID: "uid-1"},
+			Spec:       fv1.FunctionSpec{Environment: fv1.EnvironmentReference{Name: "nodejs", Namespace: "default"}},
+		}
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewClientset(fn),
+			KubernetesClient: k8sfake.NewClientset(),
+		}
+		err := FunctionPodLogs(t.Context(), "fn", "default", client)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no active pods")
+	})
+}

--- a/test/integration/suites/common/cli_inspect_test.go
+++ b/test/integration/suites/common/cli_inspect_test.go
@@ -32,7 +32,7 @@ import (
 func TestCLICommands(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)
@@ -86,4 +86,47 @@ func TestCLICommands(t *testing.T) {
 
 	// Client + server version.
 	ns.CLI(t, ctx, "version")
+
+	// -----------------------------------------------------------------
+	// Mutating + lifecycle CLI paths (update / delete / create) that the
+	// Create* builders don't exercise. These fill the largest remaining
+	// gaps in pkg/fission-cli/cmd/* (the trigger update/delete run paths).
+	// ns.CLI t.Fatals on a non-zero exit, so running a command already
+	// asserts its code path executes cleanly.
+	// -----------------------------------------------------------------
+
+	// fn update: change the execution timeout and confirm it persisted.
+	ns.CLI(t, ctx, "fn", "update", "--name", fnName, "--fntimeout", "90")
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		fn, err := f.FissionClient().CoreV1().Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+		if assert.NoError(c, err) {
+			assert.Equal(c, 90, fn.Spec.FunctionTimeout, "fn timeout after `fn update`")
+		}
+	}, 30*time.Second, 1*time.Second)
+
+	// httptrigger get + update on the shared route.
+	ns.CLI(t, ctx, "httptrigger", "get", "--name", routeName)
+	ns.CLI(t, ctx, "httptrigger", "update", "--name", routeName, "--url", routePath+"-v2")
+
+	// timetrigger lifecycle: create (builder), update its cron, print a
+	// schedule preview, then delete.
+	ttName := "tt-cli-" + ns.ID
+	ns.CreateTimeTrigger(t, ctx, framework.TimeTriggerOptions{Name: ttName, Function: fnName, Cron: "@every 1h"})
+	ns.CLI(t, ctx, "timetrigger", "update", "--name", ttName, "--cron", "@every 2h")
+	ns.CLICaptureStdout(t, ctx, "timetrigger", "showschedule", "--cron", "@every 5m")
+	ns.CLI(t, ctx, "timetrigger", "delete", "--name", ttName)
+
+	// kubewatch lifecycle: create (builder) then delete via the CLI.
+	kwName := "kw-cli-" + ns.ID
+	ns.CreateKubernetesWatchTrigger(t, ctx, framework.KubernetesWatchTriggerOptions{
+		Name: kwName, Function: fnName, ObjType: "service", WatchNamespace: ns.Name,
+	})
+	ns.CLI(t, ctx, "watch", "delete", "--name", kwName)
+
+	// mqtrigger lifecycle: create + update + delete. The KEDA kind needs no
+	// running broker, so the CR round-trips purely through the API server.
+	mqtName := "mqt-cli-" + ns.ID
+	ns.CLI(t, ctx, "mqt", "create", "--name", mqtName, "--function", fnName, "--topic", "cli-topic", "--mqtype", "kafka")
+	ns.CLI(t, ctx, "mqt", "update", "--name", mqtName, "--maxretries", "3")
+	ns.CLI(t, ctx, "mqt", "delete", "--name", mqtName)
 }

--- a/test/integration/suites/common/cli_support_test.go
+++ b/test/integration/suites/common/cli_support_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestSupportDump exercises `fission support dump`, which collects cluster +
+// fission component specs and logs into a zip archive. It drives a large,
+// otherwise-uncovered slice of pkg/fission-cli/cmd/support (dump.go and the
+// resources/* dumpers) end to end against the real cluster. The dumpers are
+// best-effort, so a clean exit plus a produced archive is the assertion.
+func TestSupportDump(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	ns := f.NewTestNamespace(t)
+
+	outDir := filepath.Join(t.TempDir(), "dump")
+	out := ns.CLICaptureStdout(t, ctx, "support", "dump", "--output", outDir)
+
+	matches, err := filepath.Glob(filepath.Join(outDir, "fission-dump_*.zip"))
+	require.NoError(t, err)
+	require.NotEmpty(t, matches, "support dump should produce a zip archive; output:\n%s", out)
+}


### PR DESCRIPTION
## What

Coverage + cleanup work on `pkg/fission-cli`, integration-first.

## Fixes

- **canaryconfig update**: `updateNeeded` was declared but never set to `true`, so an updated CanaryConfig never reset its `Status` to `Pending`.
The flag is now set on each changed field (guarded by a unit test).

## Dedupe (behaviour-preserving)

- `spec.SaveOrDry`: collapse the duplicated `--spec-dry` / `--spec-save` block across the environment / function / httptrigger / kubewatch / mqtrigger / timetrigger create commands into one helper.
`package/create.go` is intentionally left as-is — it returns `ObjectMeta` and does spec-reuse dedup, so it is genuinely different.
- `util.ResolveSecretReferences` / `ResolveConfigMapReferences`: collapse the duplicated secret/configmap reference building in function create + update.
A `strict` flag preserves create's abort-on-error vs update's warn-only behaviour.
- `spec.CheckFunctionReferencesInSpecs`: collapse the duplicated `--spec-save` function-existence check across the three trigger create commands.

## Tests

- **Integration** (`test/integration/suites/common`): extend `TestCLICommands` with the previously-uncovered mutation/lifecycle CLI paths — `fn update`, `httptrigger get/update`, and full `timetrigger` / `kubewatch` / `mqtrigger` create → update → delete (the `mqtrigger update` path was 93 lines at 0%; the KEDA kind needs no broker).
Add `TestSupportDump` for `fission support dump`.
- **Unit**: util helpers (`GetResourceReqs`, `ParseAnnotations`, the new ref builders, env-var URL getters, fake-clientset checks), `token create` (httptest), the `environment` update builder, `canaryconfig` get/list/delete/update, and `spec.SaveOrDry`.

## Notes

- These changes lean on the integration suite's in-process CLI execution, which is what feeds `pkg/fission-cli` coverage to the `integration` codecov flag.
- Net `-236 / +139` lines in non-test source from the dedupe, plus the new helpers and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3455)
<!-- Reviewable:end -->
