### PR TITLE
refactor(executor): share one Function reconciler across executor types

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -40,6 +40,7 @@ import (
 	"github.com/fission/fission/pkg/executor/executortype/newdeploy"
 	"github.com/fission/fission/pkg/executor/executortype/poolmgr"
 	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/executor/funcreconciler"
 	"github.com/fission/fission/pkg/executor/reaper/idle"
 	"github.com/fission/fission/pkg/executor/util"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
@@ -543,6 +544,15 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 		if err := et.RegisterReconcilers(crMgr); err != nil {
 			return fmt.Errorf("error registering reconcilers for executor type %s: %w", et.GetTypeName(ctx), err)
 		}
+	}
+
+	// One Function reconciler, shared across executor types: it resolves each
+	// Function's executor type and dispatches create/update/delete to the owning
+	// type (poolmgr/newdeploy/container) via FuncReconciler, handling executor-type
+	// transitions in one place. Replaces the three per-type Function reconcilers
+	// with a single workqueue, predicate, and last-reconciled cache.
+	if err := funcreconciler.RegisterReconciler(crMgr, logger, executorTypes); err != nil {
+		return err
 	}
 
 	// One Environment reconciler, shared across executor types: it dispatches each

--- a/pkg/executor/executortype/container/reconciler.go
+++ b/pkg/executor/executortype/container/reconciler.go
@@ -6,20 +6,15 @@ package container
 
 import (
 	"context"
-	"sync"
 
-	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/executor/fscache"
 )
 
-// functionManager is the subset of *Container the reconciler drives. Defined as
-// an interface so the reconcile routing (create/update/delete based on the
+// functionManager is the subset of *Container the Function handlers drive.
+// Defined as an interface so the reconcile routing (create-vs-update on the
 // last-reconciled object) is unit-testable with a fake.
 type functionManager interface {
 	createFunction(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
@@ -27,90 +22,36 @@ type functionManager interface {
 	deleteFunction(context.Context, *fv1.Function) error
 }
 
-// functionReconciler manages container-backed function deployments. It replaces
-// the Function informer event handlers: controller-runtime's workqueue (with
-// bounded MaxConcurrentReconciles and per-key serialization) is the reconciler,
-// replacing the unbounded bare goroutines the old handlers spawned — addressing
-// the code's own "should use a workqueue" TODO.
-//
-// updateFunction is diff-based (it compares old vs new for HPA min/max/metrics,
-// secret/configmap changes, and executor-type transitions), but a reconciler
-// only has the current Function. So the reconciler keeps the last-reconciled
-// Function per key to supply the "old" object: Reconcile calls createFunction on
-// first sight, updateFunction(old, current) thereafter, and deleteFunction(old)
-// when the Function is gone. It is registered with GenerationChangedPredicate, so
-// the executor's own status writes (which leave Generation unchanged) don't churn
-// the loop — they were no-ops through updateFunction anyway.
-type functionReconciler struct {
-	logger logr.Logger
-	client client.Client
-	caaf   functionManager
-	// lastReconciled maps client.ObjectKey -> *fv1.Function (the object as last
-	// reconciled), supplying the "old" object updateFunction diffs against.
-	lastReconciled sync.Map
+// ReconcileFunction satisfies executortype.FuncReconciler for container-backed
+// functions (Deployment/Service/HPA). The shared Function reconciler owns the
+// last-reconciled cache and executor-type transitions, so this only sees same-type
+// create (old == nil → createFunction) and update (old != nil →
+// updateFunction(old, fn), which diffs HPA min/max/metrics and secret/configmap
+// changes).
+func (caaf *Container) ReconcileFunction(ctx context.Context, old, fn *fv1.Function) error {
+	return reconcileContainerFunc(ctx, caaf, old, fn)
 }
 
-func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	fn := &fv1.Function{}
-	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Deleted: clean up using the last-reconciled object (the live one is gone).
-			if old, ok := r.lastReconciled.LoadAndDelete(req.NamespacedName); ok {
-				if err := r.caaf.deleteFunction(ctx, old.(*fv1.Function)); err != nil {
-					return ctrl.Result{}, err
-				}
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
-	}
-
-	old, seen := r.lastReconciled.Load(req.NamespacedName)
-	if !seen {
-		// First sight. Only manage functions whose executor type is container
-		// (createFunction is a no-op for any other type, so caching them would just
-		// grow lastReconciled). A function that later switches *to* container
-		// generates a spec change and arrives here uncached, so it is created then.
-		if !isContainerType(fn) {
-			return ctrl.Result{}, nil
-		}
-		if _, err := r.caaf.createFunction(ctx, fn); err != nil {
-			return ctrl.Result{}, err
-		}
-		r.lastReconciled.Store(req.NamespacedName, fn.DeepCopy())
-		return ctrl.Result{}, nil
-	}
-
-	// Already managing it: updateFunction handles spec/HPA diffs and executor-type
-	// transitions (it deletes the resources if the function is no longer container).
-	if err := r.caaf.updateFunction(ctx, old.(*fv1.Function), fn); err != nil {
-		return ctrl.Result{}, err
-	}
-	if isContainerType(fn) {
-		r.lastReconciled.Store(req.NamespacedName, fn.DeepCopy())
-	} else {
-		// Transitioned away from container; updateFunction cleaned up the resources.
-		r.lastReconciled.Delete(req.NamespacedName)
-	}
-	return ctrl.Result{}, nil
+// DeleteFunction satisfies executortype.FuncReconciler: it tears down the
+// function's Deployment/Service/HPA.
+func (caaf *Container) DeleteFunction(ctx context.Context, fn *fv1.Function) error {
+	return caaf.deleteFunction(ctx, fn)
 }
 
-// isContainerType reports whether the executor should manage this function.
-// createFunction is a no-op unless the executor type is exactly container, so we
-// only cache/manage those — caching unset-type functions (which the old handler
-// passed but createFunction ignored) would grow lastReconciled without ever
-// creating resources.
-func isContainerType(fn *fv1.Function) bool {
-	return fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer
+// reconcileContainerFunc holds the create-vs-update routing, split out so it is
+// unit-testable with a fake functionManager.
+func reconcileContainerFunc(ctx context.Context, mgr functionManager, old, fn *fv1.Function) error {
+	if old == nil {
+		_, err := mgr.createFunction(ctx, fn)
+		return err
+	}
+	return mgr.updateFunction(ctx, old, fn)
 }
 
-// RegisterReconcilers registers the container Function reconciler on the executor
-// Manager.
-func (caaf *Container) RegisterReconcilers(mgr ctrl.Manager) error {
-	r := &functionReconciler{
-		logger: caaf.logger.WithName("function_reconciler"),
-		client: mgr.GetClient(),
-		caaf:   caaf,
-	}
-	return controller.Register(mgr, &fv1.Function{}, r, "container-function")
+// RegisterReconcilers has no type-specific watches to register: the container
+// type's Function reconciles are handled by the shared executor-level Function
+// reconciler (see funcreconciler.RegisterReconciler), which it plugs into via
+// FuncReconciler.
+func (caaf *Container) RegisterReconcilers(ctrl.Manager) error {
+	return nil
 }

--- a/pkg/executor/executortype/container/reconciler_test.go
+++ b/pkg/executor/executortype/container/reconciler_test.go
@@ -8,18 +8,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
-	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 )
 
 type fakeFuncMgr struct {
@@ -45,71 +39,27 @@ func fnOfType(name string, et fv1.ExecutorType) *fv1.Function {
 	return fn
 }
 
-func crClient(objs ...client.Object) client.Client {
-	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
-}
+func TestReconcileContainerFunc(t *testing.T) {
+	fn := fnOfType("fn", fv1.ExecutorTypeContainer)
 
-func TestContainerFunctionReconcilerRouting(t *testing.T) {
-	key := types.NamespacedName{Name: "fn", Namespace: "default"}
-	req := ctrl.Request{NamespacedName: key}
-
-	t.Run("first sight of container function creates and caches", func(t *testing.T) {
+	t.Run("create (old == nil) creates the function", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypeContainer)), caaf: mgr}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, nil, fn))
 		assert.Equal(t, []string{"fn"}, mgr.created)
 		assert.Empty(t, mgr.updated)
-		_, cached := r.lastReconciled.Load(key)
-		assert.True(t, cached, "managed function must be cached")
 	})
 
-	t.Run("cached function updates with the cached old object", func(t *testing.T) {
+	t.Run("update (old != nil) diffs against the old object", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypeContainer)), caaf: mgr}
-		r.lastReconciled.Store(key, fnOfType("fn", fv1.ExecutorTypeContainer))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.updated)
 		assert.Empty(t, mgr.created)
 	})
 
-	t.Run("deleted function cleans up via the cached old object", func(t *testing.T) {
+	t.Run("DeleteFunction tears down the function", func(t *testing.T) {
+		// DeleteFunction delegates straight to deleteFunction; exercise the wiring.
 		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(), caaf: mgr} // empty client -> NotFound
-		r.lastReconciled.Store(key, fnOfType("fn", fv1.ExecutorTypeContainer))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, mgr.deleteFunction(t.Context(), fn))
 		assert.Equal(t, []string{"fn"}, mgr.deleted)
-		_, cached := r.lastReconciled.Load(key)
-		assert.False(t, cached, "deleted function must be evicted from cache")
 	})
-
-	t.Run("non-container function on first sight is ignored", func(t *testing.T) {
-		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypeNewdeploy)), caaf: mgr}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Empty(t, mgr.created)
-		_, cached := r.lastReconciled.Load(key)
-		assert.False(t, cached)
-	})
-
-	t.Run("transition away from container updates and uncaches", func(t *testing.T) {
-		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypeNewdeploy)), caaf: mgr}
-		r.lastReconciled.Store(key, fnOfType("fn", fv1.ExecutorTypeContainer))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"fn"}, mgr.updated, "updateFunction handles the type-transition cleanup")
-		_, cached := r.lastReconciled.Load(key)
-		assert.False(t, cached, "transitioned-away function must be evicted")
-	})
-}
-
-func TestIsContainerType(t *testing.T) {
-	assert.True(t, isContainerType(fnOfType("a", fv1.ExecutorTypeContainer)))
-	assert.False(t, isContainerType(fnOfType("a", "")), "unset type is not managed (createFunction no-ops on it)")
-	assert.False(t, isContainerType(fnOfType("a", fv1.ExecutorTypeNewdeploy)))
-	assert.False(t, isContainerType(fnOfType("a", fv1.ExecutorTypePoolmgr)))
 }

--- a/pkg/executor/executortype/executortype.go
+++ b/pkg/executor/executortype/executortype.go
@@ -72,6 +72,27 @@ type ExecutorType interface {
 	CleanupOldExecutorObjects(context.Context)
 }
 
+// FuncReconciler is implemented by executor types to reconcile the Functions
+// they own. The shared executor-level Function reconciler
+// (pkg/executor/funcreconciler) resolves each Function's executor type, owns the
+// last-reconciled cache, and handles delete/recreate and executor-type
+// transitions (tearing the old type down via DeleteFunction and building the new
+// via ReconcileFunction) — so the three executor types share one Function
+// workqueue, predicate, and cache instead of one reconciler each.
+type FuncReconciler interface {
+	// ReconcileFunction brings this executor type's backing resources for fn to
+	// the desired state. old is the previously reconciled Function for this key
+	// (guaranteed same executor type and same UID), or nil on the first reconcile
+	// of fn under this type — implementations create on nil and update (diffing
+	// against old) otherwise.
+	ReconcileFunction(ctx context.Context, old, fn *fv1.Function) error
+
+	// DeleteFunction tears down this executor type's backing resources for fn. It
+	// is called with the last-reconciled object — which carries this executor
+	// type — both when fn is deleted and when fn transitions away to another type.
+	DeleteFunction(ctx context.Context, fn *fv1.Function) error
+}
+
 // EnvReconciler is implemented by executor types that react to Environment
 // changes. The shared executor-level Environment reconciler holds the last-seen
 // Environment per key and dispatches each event to every executor type that

--- a/pkg/executor/executortype/newdeploy/reconciler.go
+++ b/pkg/executor/executortype/newdeploy/reconciler.go
@@ -6,22 +6,17 @@ package newdeploy
 
 import (
 	"context"
-	"sync"
 	"time"
 
-	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/executor/fscache"
 )
 
-// funcManager is the subset of *NewDeploy the Function reconciler drives. Defined
-// as an interface so the reconcile routing (create/update/delete based on the
-// last-reconciled object) is unit-testable with a fake.
+// funcManager is the subset of *NewDeploy the Function handlers drive. Defined as
+// an interface so the reconcile routing (create-vs-update on the last-reconciled
+// object) is unit-testable with a fake.
 type funcManager interface {
 	createFunction(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 	updateFunction(context.Context, *fv1.Function, *fv1.Function) error
@@ -36,80 +31,37 @@ type envFunctionUpdater interface {
 	updateEnvFunctions(context.Context, *fv1.Environment) error
 }
 
-// functionReconciler manages newdeploy-backed function Deployments/Services/HPAs.
-// It replaces the Function informer event handlers: controller-runtime's
-// workqueue (bounded concurrency, per-key serialization) is the reconciler,
-// replacing the unbounded bare goroutines the old handlers spawned — addressing
-// the code's own "should use a workqueue" TODO.
+// ReconcileFunction satisfies executortype.FuncReconciler for newdeploy-backed
+// functions (Deployment/Service/HPA). The shared Function reconciler owns the
+// last-reconciled cache and executor-type transitions, so this only sees same-type
+// create/update:
 //
-// updateFunction is diff-based (it compares old vs new for HPA min/max/metrics,
-// secret/configmap/package changes, and executor-type transitions), but a
-// reconciler only has the current Function. So the reconciler keeps the
-// last-reconciled Function per key to supply the "old" object: Reconcile calls
-// createFunction on first sight, updateFunction(old, current) thereafter, and
-// deleteFunction(old) when the Function is gone. Registered with
-// GenerationChangedPredicate, so the executor's own status writes (Generation
-// unchanged) don't churn the loop — they were no-ops through updateFunction anyway.
-type functionReconciler struct {
-	logger logr.Logger
-	client client.Client
-	deploy funcManager
-	// lastReconciled maps client.ObjectKey -> *fv1.Function (the object as last
-	// reconciled), supplying the "old" object updateFunction diffs against.
-	lastReconciled sync.Map
+//   - create (old == nil): createFunction, then reconcileDeploymentSpec to bring a
+//     possibly-stale adopted deployment (e.g. the router specialized the function
+//     on-demand before `fn update` landed) to the current spec. A no-op when
+//     already current.
+//   - update (old != nil): updateFunction(old, fn), which diffs HPA min/max/metrics
+//     and secret/configmap/package changes.
+func (deploy *NewDeploy) ReconcileFunction(ctx context.Context, old, fn *fv1.Function) error {
+	return reconcileNewdeployFunc(ctx, deploy, old, fn)
 }
 
-func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	fn := &fv1.Function{}
-	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Deleted: clean up using the last-reconciled object (the live one is gone).
-			if old, ok := r.lastReconciled.LoadAndDelete(req.NamespacedName); ok {
-				if err := r.deploy.deleteFunction(ctx, old.(*fv1.Function)); err != nil {
-					return ctrl.Result{}, err
-				}
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
-	}
+// DeleteFunction satisfies executortype.FuncReconciler: it tears down the
+// function's Deployment/Service/HPA.
+func (deploy *NewDeploy) DeleteFunction(ctx context.Context, fn *fv1.Function) error {
+	return deploy.deleteFunction(ctx, fn)
+}
 
-	old, seen := r.lastReconciled.Load(req.NamespacedName)
-	if !seen {
-		// First sight. Only manage functions whose executor type is newdeploy
-		// (createFunction is a no-op for any other type, so caching them would just
-		// grow lastReconciled). A function that later switches *to* newdeploy
-		// generates a spec change and arrives here uncached, so it is created then.
-		if !isNewdeployType(fn) {
-			return ctrl.Result{}, nil
+// reconcileNewdeployFunc holds the create-vs-update routing, split out so it is
+// unit-testable with a fake funcManager.
+func reconcileNewdeployFunc(ctx context.Context, mgr funcManager, old, fn *fv1.Function) error {
+	if old == nil {
+		if _, err := mgr.createFunction(ctx, fn); err != nil {
+			return err
 		}
-		if _, err := r.deploy.createFunction(ctx, fn); err != nil {
-			return ctrl.Result{}, err
-		}
-		// createFunction only adopts/scales an existing deployment. If this first
-		// reconcile coalesced the create with a later spec update (e.g. the router
-		// specialized the function on-demand before `fn update` landed), the adopted
-		// deployment can be stale with no transition for updateFunction to diff —
-		// bring it to the current spec. A no-op when already current.
-		if err := r.deploy.reconcileDeploymentSpec(ctx, fn); err != nil {
-			return ctrl.Result{}, err
-		}
-		r.lastReconciled.Store(req.NamespacedName, fn.DeepCopy())
-		return ctrl.Result{}, nil
+		return mgr.reconcileDeploymentSpec(ctx, fn)
 	}
-
-	// Already managing it: updateFunction handles spec/HPA diffs and executor-type
-	// transitions (it deletes the resources if the function is no longer newdeploy).
-	if err := r.deploy.updateFunction(ctx, old.(*fv1.Function), fn); err != nil {
-		return ctrl.Result{}, err
-	}
-	if isNewdeployType(fn) {
-		r.lastReconciled.Store(req.NamespacedName, fn.DeepCopy())
-	} else {
-		// Transitioned away from newdeploy; updateFunction cleaned up the resources.
-		r.lastReconciled.Delete(req.NamespacedName)
-	}
-	return ctrl.Result{}, nil
+	return mgr.updateFunction(ctx, old, fn)
 }
 
 // ReconcileEnvironment satisfies executortype.EnvReconciler: it propagates an
@@ -144,24 +96,10 @@ func reconcileNewdeployEnv(ctx context.Context, up envFunctionUpdater, old, env 
 	return 0, nil
 }
 
-// isNewdeployType reports whether the executor should manage this function.
-// createFunction is a no-op unless the executor type is exactly newdeploy, so we
-// only cache/manage those — caching other-type functions (which the old handler
-// passed but createFunction ignored) would grow lastReconciled without ever
-// creating resources.
-func isNewdeployType(fn *fv1.Function) bool {
-	return fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeNewdeploy
-}
-
-// RegisterReconcilers registers the newdeploy Function reconciler on the executor
-// Manager, replacing its informer event handler. The Environment watch is shared
-// across executor types and registered once at the executor level (see
-// envreconciler.RegisterReconciler); newdeploy plugs into it via EnvReconciler.
-func (deploy *NewDeploy) RegisterReconcilers(mgr ctrl.Manager) error {
-	fr := &functionReconciler{
-		logger: deploy.logger.WithName("function_reconciler"),
-		client: mgr.GetClient(),
-		deploy: deploy,
-	}
-	return controller.Register(mgr, &fv1.Function{}, fr, "newdeploy-function")
+// RegisterReconcilers has no type-specific watches to register: newdeploy's
+// Function and Environment reconciles are handled by the shared executor-level
+// reconcilers (see funcreconciler/envreconciler RegisterReconciler), which
+// newdeploy plugs into via FuncReconciler and EnvReconciler.
+func (deploy *NewDeploy) RegisterReconcilers(ctrl.Manager) error {
+	return nil
 }

--- a/pkg/executor/executortype/newdeploy/reconciler_test.go
+++ b/pkg/executor/executortype/newdeploy/reconciler_test.go
@@ -8,18 +8,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
-	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 )
 
 type fakeFuncMgr struct {
@@ -64,66 +58,29 @@ func envWithImage(name, image string) *fv1.Environment {
 	return env
 }
 
-func crClient(objs ...client.Object) client.Client {
-	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
-}
+func TestReconcileNewdeployFunc(t *testing.T) {
+	fn := fnOfType("fn", fv1.ExecutorTypeNewdeploy)
 
-func TestNewdeployFunctionReconcilerRouting(t *testing.T) {
-	key := types.NamespacedName{Name: "fn", Namespace: "default"}
-	req := ctrl.Request{NamespacedName: key}
-
-	t.Run("first sight of newdeploy function creates and caches", func(t *testing.T) {
+	t.Run("create (old == nil) creates then reconciles the deployment spec", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypeNewdeploy)), deploy: mgr}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, nil, fn))
 		assert.Equal(t, []string{"fn"}, mgr.created)
 		assert.Equal(t, []string{"fn"}, mgr.reconciled, "first sight must reconcile a possibly-stale adopted deployment to current spec")
 		assert.Empty(t, mgr.updated)
-		_, cached := r.lastReconciled.Load(key)
-		assert.True(t, cached, "managed function must be cached")
 	})
 
-	t.Run("cached function updates with the cached old object", func(t *testing.T) {
+	t.Run("update (old != nil) diffs against the old object", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypeNewdeploy)), deploy: mgr}
-		r.lastReconciled.Store(key, fnOfType("fn", fv1.ExecutorTypeNewdeploy))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.updated)
 		assert.Empty(t, mgr.created)
 	})
 
-	t.Run("deleted function cleans up via the cached old object", func(t *testing.T) {
+	t.Run("DeleteFunction tears down the function", func(t *testing.T) {
+		// DeleteFunction delegates straight to deleteFunction; exercise the wiring.
 		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(), deploy: mgr} // empty client -> NotFound
-		r.lastReconciled.Store(key, fnOfType("fn", fv1.ExecutorTypeNewdeploy))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, mgr.deleteFunction(t.Context(), fn))
 		assert.Equal(t, []string{"fn"}, mgr.deleted)
-		_, cached := r.lastReconciled.Load(key)
-		assert.False(t, cached, "deleted function must be evicted from cache")
-	})
-
-	t.Run("non-newdeploy function on first sight is ignored", func(t *testing.T) {
-		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypePoolmgr)), deploy: mgr}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Empty(t, mgr.created)
-		_, cached := r.lastReconciled.Load(key)
-		assert.False(t, cached)
-	})
-
-	t.Run("transition away from newdeploy updates and uncaches", func(t *testing.T) {
-		mgr := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(fnOfType("fn", fv1.ExecutorTypePoolmgr)), deploy: mgr}
-		r.lastReconciled.Store(key, fnOfType("fn", fv1.ExecutorTypeNewdeploy))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Equal(t, []string{"fn"}, mgr.updated, "updateFunction handles the type-transition cleanup")
-		_, cached := r.lastReconciled.Load(key)
-		assert.False(t, cached, "transitioned-away function must be evicted")
 	})
 }
 
@@ -154,11 +111,4 @@ func TestNewdeployReconcileEnvironment(t *testing.T) {
 		// Compile-time + behavioural guard that delete needs no newdeploy-side action.
 		(&NewDeploy{}).CleanupEnvironment(t.Context(), envWithImage("env", "img:1"))
 	})
-}
-
-func TestIsNewdeployType(t *testing.T) {
-	assert.True(t, isNewdeployType(fnOfType("a", fv1.ExecutorTypeNewdeploy)))
-	assert.False(t, isNewdeployType(fnOfType("a", "")), "unset type is not managed (createFunction no-ops on it)")
-	assert.False(t, isNewdeployType(fnOfType("a", fv1.ExecutorTypeContainer)))
-	assert.False(t, isNewdeployType(fnOfType("a", fv1.ExecutorTypePoolmgr)))
 }

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -6,7 +6,6 @@ package poolmgr
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -27,7 +26,7 @@ import (
 // informer resync the env workqueue used to get.
 const envResyncPeriod = 30 * time.Minute
 
-// funcManager is the subset of *GenericPoolManager the Function reconciler drives.
+// funcManager is the subset of *GenericPoolManager the Function handlers drive.
 // An interface so the reconcile routing is unit-testable with a fake.
 type funcManager interface {
 	markFuncDeleted(crd.CacheKeyURG)
@@ -125,106 +124,46 @@ var poolmgrWarmPodPredicate = predicate.NewPredicateFuncs(func(obj client.Object
 	return l[fv1.EXECUTOR_TYPE] == string(fv1.ExecutorTypePoolmgr) && l["managed"] == "true"
 })
 
-// isPoolmgrType reports whether the pool manager should handle this function.
-// Poolmgr is the default executor, so an empty executor type counts as poolmgr —
-// matching the old istio/handler filter (`type != "" && type != poolmgr → skip`).
-func isPoolmgrType(fn *fv1.Function) bool {
-	t := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType
-	return t == "" || t == fv1.ExecutorTypePoolmgr
-}
-
-// functionReconciler manages the pool manager's per-Function concerns, replacing
-// poolpodcontroller's istio Function handler and #3432's delete-only reconciler:
+// ReconcileFunction satisfies executortype.FuncReconciler for the pool manager:
 //
-//   - create: create the per-function istio Service (when istio is enabled).
-//   - update: refresh (delete) the function's specialized pods so the next
-//     request re-specializes a warm pod with the new package/config. Poolmgr had
-//     no function-update path before, so a stale specialized pod (old package)
+//   - create (old == nil): create the per-function istio Service (when istio is
+//     enabled). Pool pods themselves are specialized lazily by GetFuncSvc.
+//   - update (old != nil): refresh (delete) the function's specialized pods so the
+//     next request re-specializes a warm pod with the new package/config. Poolmgr
+//     had no function-update path before, so a stale specialized pod (old package)
 //     could keep being routed to until the idle reaper recycled it.
-//   - delete: mark the fsCache entries deleted (so the reaper recycles pods) and
-//     remove the istio Service.
 //
-// updateFunction-style diffing is unnecessary: GenerationChangedPredicate means a
-// reconcile of a cached function is always a spec change, and the istio Service is
-// keyed on the (stable) function name/uid so it only needs create/delete. The
-// last-seen Function supplies the object for cleanup once the live one is gone.
-type functionReconciler struct {
-	logger      logr.Logger
-	client      client.Client
-	mgr         funcManager
-	enableIstio bool
-	lastSeen    sync.Map // client.ObjectKey -> *fv1.Function
+// No old/new diffing is needed: a reconcile of a cached function is always a spec
+// change (GenerationChangedPredicate), and the istio Service is keyed on the
+// stable function name/uid, so it only needs create/delete.
+func (gpm *GenericPoolManager) ReconcileFunction(ctx context.Context, old, fn *fv1.Function) error {
+	return reconcilePoolmgrFunc(ctx, gpm, gpm.enableIstio, old, fn)
 }
 
-func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	fn := &fv1.Function{}
-	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
-		if apierrors.IsNotFound(err) {
-			if old, ok := r.lastSeen.LoadAndDelete(req.NamespacedName); ok {
-				if err := r.cleanupFunction(ctx, old.(*fv1.Function)); err != nil {
-					return ctrl.Result{}, err
-				}
-			}
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, err
-	}
-
-	old, seen := r.lastSeen.Load(req.NamespacedName)
-	if !seen {
-		// First sight. Only manage poolmgr-type functions.
-		if !isPoolmgrType(fn) {
-			return ctrl.Result{}, nil
-		}
-		if r.enableIstio {
-			if err := r.mgr.createIstioServiceForFunction(ctx, fn); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
-		return ctrl.Result{}, nil
-	}
-
-	oldFn := old.(*fv1.Function)
-	// A delete+recreate of the same name, or a switch away from poolmgr, can
-	// coalesce into one reconcile (the workqueue carries only namespace/name).
-	// If the cached function is no longer the one we should manage, clean it up.
-	if oldFn.UID != fn.UID || !isPoolmgrType(fn) {
-		if err := r.cleanupFunction(ctx, oldFn); err != nil {
-			return ctrl.Result{}, err
-		}
-		if !isPoolmgrType(fn) {
-			r.lastSeen.Delete(req.NamespacedName)
-			return ctrl.Result{}, nil
-		}
-		// New incarnation is still poolmgr: treat as a fresh create.
-		if r.enableIstio {
-			if err := r.mgr.createIstioServiceForFunction(ctx, fn); err != nil {
-				return ctrl.Result{}, err
-			}
-		}
-		r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
-		return ctrl.Result{}, nil
-	}
-
-	// Genuine spec change of a managed function: re-specialize its pods so the new
-	// package/config is served. The istio Service is keyed on the stable function
-	// name/uid, so it needs no change here.
-	if err := r.mgr.refreshFuncPods(ctx, fn); err != nil {
-		return ctrl.Result{}, err
-	}
-	r.lastSeen.Store(req.NamespacedName, fn.DeepCopy())
-	return ctrl.Result{}, nil
+// DeleteFunction satisfies executortype.FuncReconciler: it marks the function's
+// fsCache entries deleted (so the reaper recycles its pods) and removes its istio
+// Service (when enabled).
+func (gpm *GenericPoolManager) DeleteFunction(ctx context.Context, fn *fv1.Function) error {
+	return cleanupPoolmgrFunc(ctx, gpm, gpm.enableIstio, fn)
 }
 
-// cleanupFunction marks the function's fsCache entries deleted and removes its
-// istio Service (when enabled).
-func (r *functionReconciler) cleanupFunction(ctx context.Context, fn *fv1.Function) error {
-	r.mgr.markFuncDeleted(crd.CacheKeyURGFromMeta(&fn.ObjectMeta))
-	if r.enableIstio {
-		if err := r.mgr.deleteIstioServiceForFunction(ctx, fn); err != nil {
-			return err
+// reconcilePoolmgrFunc holds the create-vs-update routing, split out so it is
+// unit-testable with a fake funcManager.
+func reconcilePoolmgrFunc(ctx context.Context, mgr funcManager, enableIstio bool, old, fn *fv1.Function) error {
+	if old == nil {
+		if enableIstio {
+			return mgr.createIstioServiceForFunction(ctx, fn)
 		}
+		return nil
+	}
+	return mgr.refreshFuncPods(ctx, fn)
+}
+
+// cleanupPoolmgrFunc holds the teardown routing, split out for unit testing.
+func cleanupPoolmgrFunc(ctx context.Context, mgr funcManager, enableIstio bool, fn *fv1.Function) error {
+	mgr.markFuncDeleted(crd.CacheKeyURGFromMeta(&fn.ObjectMeta))
+	if enableIstio {
+		return mgr.deleteIstioServiceForFunction(ctx, fn)
 	}
 	return nil
 }
@@ -255,31 +194,18 @@ func reconcilePoolmgrEnv(ctx context.Context, pm poolManager, env *fv1.Environme
 	return envResyncPeriod, nil
 }
 
-// RegisterReconcilers registers the pool manager's Function, ReplicaSet, and
-// readyPod reconcilers on the executor Manager, replacing poolpodcontroller's
-// informer handlers. The Environment watch is shared across executor types and
-// registered once at the executor level (see envreconciler.RegisterReconciler);
-// the pool manager plugs into it via EnvReconciler. poolpodcontroller now only
-// owns the specialized-pod cleanup queue (fed by the ReplicaSet reconciler and
-// CleanupEnvironment) and the pod lister.
+// RegisterReconcilers registers the pool manager's ReplicaSet and readyPod
+// reconcilers on the executor Manager, replacing poolpodcontroller's informer
+// handlers. The Function and Environment watches are shared across executor types
+// and registered once at the executor level (see funcreconciler/envreconciler
+// RegisterReconciler); the pool manager plugs into them via FuncReconciler and
+// EnvReconciler. poolpodcontroller now only owns the specialized-pod cleanup
+// queue (fed by the ReplicaSet reconciler and CleanupEnvironment) and the pod
+// lister.
 func (gpm *GenericPoolManager) RegisterReconcilers(mgr ctrl.Manager) error {
 	// getFunctionEnv (hot path) reads Environments from the Manager cache instead
 	// of poolpodcontroller's informer lister now.
 	gpm.crClient = mgr.GetClient()
-
-	fr := &functionReconciler{
-		logger:      gpm.logger.WithName("function_reconciler"),
-		client:      mgr.GetClient(),
-		mgr:         gpm,
-		enableIstio: gpm.enableIstio,
-	}
-	if err := controller.Register(mgr, &fv1.Function{}, fr, "poolmgr-function"); err != nil {
-		return err
-	}
-
-	// The Environment watch is registered once at the executor level
-	// (envreconciler.RegisterReconciler), dispatching to this type via
-	// EnvReconciler, so the executor types share one Environment workqueue.
 
 	rr := &replicaSetReconciler{
 		logger:  gpm.logger.WithName("replicaset_reconciler"),

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -22,7 +22,6 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/crd"
-	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 )
 
 type fakeFuncMgr struct {
@@ -66,110 +65,52 @@ func (f *fakePoolMgr) cleanupEnvPool(_ context.Context, env *fv1.Environment) {
 	f.cleaned = append(f.cleaned, env.Name)
 }
 
-func crClient(objs ...client.Object) client.Client {
-	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
-}
-
 func poolmgrFn(name string, et fv1.ExecutorType) *fv1.Function {
 	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: "u1", ResourceVersion: "9", Generation: 2}}
 	fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType = et
 	return fn
 }
 
-func TestPoolmgrFunctionReconciler(t *testing.T) {
-	key := types.NamespacedName{Name: "fn", Namespace: "default"}
-	req := ctrl.Request{NamespacedName: key}
+func TestReconcilePoolmgrFunc(t *testing.T) {
+	fn := poolmgrFn("fn", fv1.ExecutorTypePoolmgr)
 
-	t.Run("first sight of poolmgr function creates istio service and caches", func(t *testing.T) {
+	t.Run("create (old == nil) creates the istio service when istio is enabled", func(t *testing.T) {
 		m := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", fv1.ExecutorTypePoolmgr)), mgr: m, enableIstio: true}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcilePoolmgrFunc(t.Context(), m, true, nil, fn))
 		assert.Equal(t, []string{"fn"}, m.istioCreated)
-		assert.Empty(t, m.deleted)
-		_, cached := r.lastSeen.Load(key)
-		assert.True(t, cached)
+		assert.Empty(t, m.refreshed, "no pod refresh on first sight — pods specialize lazily")
 	})
 
-	t.Run("istio disabled: no istio service on create", func(t *testing.T) {
+	t.Run("create with istio disabled is a no-op", func(t *testing.T) {
 		m := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", "")), mgr: m, enableIstio: false}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcilePoolmgrFunc(t.Context(), m, false, nil, fn))
 		assert.Empty(t, m.istioCreated)
-		_, cached := r.lastSeen.Load(key)
-		assert.True(t, cached, "empty executor type defaults to poolmgr and is managed")
 	})
 
-	t.Run("non-poolmgr function on first sight is ignored", func(t *testing.T) {
+	t.Run("update (old != nil) refreshes pods, leaving the stable istio service", func(t *testing.T) {
 		m := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", fv1.ExecutorTypeNewdeploy)), mgr: m, enableIstio: true}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Empty(t, m.istioCreated)
-		_, cached := r.lastSeen.Load(key)
-		assert.False(t, cached)
-	})
-
-	t.Run("spec change of a managed function refreshes its pods", func(t *testing.T) {
-		m := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(poolmgrFn("fn", fv1.ExecutorTypePoolmgr)), mgr: m, enableIstio: true}
-		r.lastSeen.Store(key, poolmgrFn("fn", fv1.ExecutorTypePoolmgr))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, reconcilePoolmgrFunc(t.Context(), m, true, fn, fn))
 		assert.Equal(t, []string{"fn"}, m.refreshed, "package/config change must re-specialize pods")
 		assert.Empty(t, m.istioCreated, "istio service is stable across spec updates")
 	})
+}
 
-	t.Run("deleted function is marked deleted and its istio service removed", func(t *testing.T) {
+func TestCleanupPoolmgrFunc(t *testing.T) {
+	fn := poolmgrFn("fn", fv1.ExecutorTypePoolmgr)
+
+	t.Run("marks fsCache deleted and removes the istio service", func(t *testing.T) {
 		m := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(), mgr: m, enableIstio: true} // empty client -> NotFound
-		cached := poolmgrFn("fn", fv1.ExecutorTypePoolmgr)
-		r.lastSeen.Store(key, cached)
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, cleanupPoolmgrFunc(t.Context(), m, true, fn))
 		require.Len(t, m.deleted, 1)
-		assert.Equal(t, crd.CacheKeyURGFromMeta(&cached.ObjectMeta), m.deleted[0])
+		assert.Equal(t, crd.CacheKeyURGFromMeta(&fn.ObjectMeta), m.deleted[0])
 		assert.Equal(t, []string{"fn"}, m.istioDeleted)
-		_, ok := r.lastSeen.Load(key)
-		assert.False(t, ok)
 	})
 
-	t.Run("delete of an unseen function is a no-op", func(t *testing.T) {
+	t.Run("istio disabled: marks fsCache deleted only", func(t *testing.T) {
 		m := &fakeFuncMgr{}
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(), mgr: m, enableIstio: true}
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Empty(t, m.deleted)
-	})
-
-	t.Run("delete+recreate with a new UID cleans the old and creates the new", func(t *testing.T) {
-		m := &fakeFuncMgr{}
-		old := poolmgrFn("fn", fv1.ExecutorTypePoolmgr) // UID u1
-		recreated := poolmgrFn("fn", fv1.ExecutorTypePoolmgr)
-		recreated.UID = "u2"
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(recreated), mgr: m, enableIstio: true}
-		r.lastSeen.Store(key, old)
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
+		require.NoError(t, cleanupPoolmgrFunc(t.Context(), m, false, fn))
 		require.Len(t, m.deleted, 1)
-		assert.Equal(t, crd.CacheKeyURGFromMeta(&old.ObjectMeta), m.deleted[0])
-		assert.Equal(t, []string{"fn"}, m.istioCreated, "new incarnation gets a fresh istio service")
-		newCached, _ := r.lastSeen.Load(key)
-		assert.Equal(t, types.UID("u2"), newCached.(*fv1.Function).UID)
-	})
-
-	t.Run("transition away from poolmgr cleans up and uncaches", func(t *testing.T) {
-		m := &fakeFuncMgr{}
-		now := poolmgrFn("fn", fv1.ExecutorTypeNewdeploy)
-		r := &functionReconciler{logger: logr.Discard(), client: crClient(now), mgr: m, enableIstio: true}
-		r.lastSeen.Store(key, poolmgrFn("fn", fv1.ExecutorTypePoolmgr))
-		_, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		require.Len(t, m.deleted, 1, "old poolmgr incarnation must be cleaned up")
-		assert.Equal(t, []string{"fn"}, m.istioDeleted)
-		_, ok := r.lastSeen.Load(key)
-		assert.False(t, ok)
+		assert.Empty(t, m.istioDeleted)
 	})
 }
 

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package funcreconciler holds the executor's single Function reconciler. It
+// replaces the per-executor-type Function reconcilers (poolmgr, newdeploy,
+// container) with one reconciler that resolves each Function's executor type and
+// dispatches the create/update/delete to the owning type via
+// executortype.FuncReconciler. Sharing one reconciler means one Function
+// workqueue, one predicate evaluation per event, and one last-reconciled cache
+// instead of one set per executor type — and it makes executor-type transitions
+// atomic: the same reconcile tears the old type down and builds the new, where
+// previously two independent reconcilers had to converge.
+package funcreconciler
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/controller"
+	"github.com/fission/fission/pkg/executor/executortype"
+)
+
+// resolveExecutorType returns the executor type that owns fn. An unset type
+// defaults to poolmgr (the default executor), matching the old per-type filters
+// where an empty type counted as poolmgr.
+func resolveExecutorType(fn *fv1.Function) fv1.ExecutorType {
+	if t := fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType; t != "" {
+		return t
+	}
+	return fv1.ExecutorTypePoolmgr
+}
+
+// functionReconciler dispatches Function events to the executor type that owns
+// each Function. It owns the last-reconciled Function per key, which supplies the
+// "old" object backends diff against on update, the previous executor type on a
+// transition, and the object to tear down on delete.
+type functionReconciler struct {
+	logger         logr.Logger
+	client         client.Client
+	backends       map[fv1.ExecutorType]executortype.FuncReconciler
+	lastReconciled sync.Map // client.ObjectKey -> *fv1.Function
+}
+
+func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	fn := &fv1.Function{}
+	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Deleted: tear down using the last-reconciled object (the live one is
+			// gone), routed to the executor type that owned it.
+			if old, ok := r.lastReconciled.LoadAndDelete(req.NamespacedName); ok {
+				oldFn := old.(*fv1.Function)
+				if b, ok := r.backends[resolveExecutorType(oldFn)]; ok {
+					if err := b.DeleteFunction(ctx, oldFn); err != nil {
+						return ctrl.Result{}, err
+					}
+				}
+			}
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	newType := resolveExecutorType(fn)
+
+	var old *fv1.Function
+	if v, ok := r.lastReconciled.Load(req.NamespacedName); ok {
+		old = v.(*fv1.Function)
+	}
+
+	// A delete+recreate of the same name (UID change) or a switch of executor type
+	// can coalesce into one reconcile (the workqueue carries only namespace/name).
+	// Tear the old incarnation down under its old type, then treat the new one as a
+	// fresh create under its (possibly different) type.
+	if old != nil && (old.UID != fn.UID || resolveExecutorType(old) != newType) {
+		if ob, ok := r.backends[resolveExecutorType(old)]; ok {
+			if err := ob.DeleteFunction(ctx, old); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		old = nil
+	}
+
+	backend, ok := r.backends[newType]
+	if !ok {
+		// No executor type manages this type (shouldn't happen — CEL validation
+		// restricts ExecutorType to the known set). Any old incarnation was already
+		// torn down above; drop the cache entry so we don't retain a stale object.
+		r.lastReconciled.Delete(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	if err := backend.ReconcileFunction(ctx, old, fn); err != nil {
+		return ctrl.Result{}, err
+	}
+	r.lastReconciled.Store(req.NamespacedName, fn.DeepCopy())
+	return ctrl.Result{}, nil
+}
+
+// collectBackends returns the executor types that reconcile Functions, keyed by
+// executor type. (Every current type does; the filter future-proofs against a
+// type that opts out.)
+func collectBackends(executorTypes map[fv1.ExecutorType]executortype.ExecutorType) map[fv1.ExecutorType]executortype.FuncReconciler {
+	backends := make(map[fv1.ExecutorType]executortype.FuncReconciler, len(executorTypes))
+	for name, et := range executorTypes {
+		if b, ok := et.(executortype.FuncReconciler); ok {
+			backends[name] = b
+		}
+	}
+	return backends
+}
+
+// RegisterReconciler wires the single Function reconciler onto the executor
+// Manager, dispatching to the executor types that implement FuncReconciler. If no
+// executor type reconciles Functions, no reconciler is registered and nil is
+// returned.
+func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[fv1.ExecutorType]executortype.ExecutorType) error {
+	backends := collectBackends(executorTypes)
+	if len(backends) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(backends))
+	for name := range backends {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+	logger.V(1).Info("registering shared function reconciler", "executor_types", names)
+
+	r := &functionReconciler{
+		logger:   logger.WithName("function_reconciler"),
+		client:   mgr.GetClient(),
+		backends: backends,
+	}
+	return controller.Register(mgr, &fv1.Function{}, r, "executor-function")
+}

--- a/pkg/executor/funcreconciler/reconciler_test.go
+++ b/pkg/executor/funcreconciler/reconciler_test.go
@@ -1,0 +1,220 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package funcreconciler
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/executortype"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
+)
+
+// reconcileCall records one ReconcileFunction invocation: the function name and
+// whether it was a first-sight create (old == nil).
+type reconcileCall struct {
+	name       string
+	firstSight bool
+}
+
+// fakeBackend is a FuncReconciler that records the calls it receives.
+type fakeBackend struct {
+	reconciled []reconcileCall
+	deleted    []string
+	reconcErr  error
+	deleteErr  error
+}
+
+func (f *fakeBackend) ReconcileFunction(_ context.Context, old, fn *fv1.Function) error {
+	f.reconciled = append(f.reconciled, reconcileCall{name: fn.Name, firstSight: old == nil})
+	return f.reconcErr
+}
+
+func (f *fakeBackend) DeleteFunction(_ context.Context, fn *fv1.Function) error {
+	f.deleted = append(f.deleted, fn.Name)
+	return f.deleteErr
+}
+
+func crClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
+}
+
+func fn(name string, et fv1.ExecutorType, uid types.UID) *fv1.Function {
+	f := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", UID: uid}}
+	f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType = et
+	return f
+}
+
+func TestResolveExecutorType(t *testing.T) {
+	assert.Equal(t, fv1.ExecutorTypePoolmgr, resolveExecutorType(fn("a", "", "u1")), "unset type defaults to poolmgr")
+	assert.Equal(t, fv1.ExecutorTypePoolmgr, resolveExecutorType(fn("a", fv1.ExecutorTypePoolmgr, "u1")))
+	assert.Equal(t, fv1.ExecutorTypeNewdeploy, resolveExecutorType(fn("a", fv1.ExecutorTypeNewdeploy, "u1")))
+	assert.Equal(t, fv1.ExecutorTypeContainer, resolveExecutorType(fn("a", fv1.ExecutorTypeContainer, "u1")))
+}
+
+func TestFunctionReconcilerDispatch(t *testing.T) {
+	key := types.NamespacedName{Name: "fn", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+
+	newReconciler := func(c client.Client, pm, nd *fakeBackend) *functionReconciler {
+		return &functionReconciler{
+			logger: logr.Discard(),
+			client: c,
+			backends: map[fv1.ExecutorType]executortype.FuncReconciler{
+				fv1.ExecutorTypePoolmgr:   pm,
+				fv1.ExecutorTypeNewdeploy: nd,
+			},
+		}
+	}
+
+	t.Run("first sight routes to the owning backend with nil old and caches", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")), pm, nd)
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []reconcileCall{{name: "fn", firstSight: true}}, nd.reconciled)
+		assert.Empty(t, pm.reconciled)
+		_, cached := r.lastReconciled.Load(key)
+		assert.True(t, cached)
+	})
+
+	t.Run("unset executor type routes to poolmgr", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(fn("fn", "", "u1")), pm, nd)
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []reconcileCall{{name: "fn", firstSight: true}}, pm.reconciled)
+		assert.Empty(t, nd.reconciled)
+	})
+
+	t.Run("same-type update hands the backend the cached old object", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")), pm, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []reconcileCall{{name: "fn", firstSight: false}}, nd.reconciled, "update must not be treated as a create")
+	})
+
+	t.Run("delete tears down via the cached object's backend and uncaches", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(), pm, nd) // empty client -> NotFound
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fn"}, nd.deleted)
+		assert.Empty(t, pm.deleted)
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached)
+	})
+
+	t.Run("delete of an unseen function is a no-op", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(), pm, nd)
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Empty(t, pm.deleted)
+		assert.Empty(t, nd.deleted)
+	})
+
+	t.Run("executor-type transition tears down the old type and creates under the new", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")), pm, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypePoolmgr, "u1"))
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fn"}, pm.deleted, "old poolmgr incarnation torn down")
+		assert.Equal(t, []reconcileCall{{name: "fn", firstSight: true}}, nd.reconciled, "created afresh under newdeploy")
+		cached, _ := r.lastReconciled.Load(key)
+		assert.Equal(t, fv1.ExecutorTypeNewdeploy, resolveExecutorType(cached.(*fv1.Function)))
+	})
+
+	t.Run("delete+recreate with a new UID tears down the old and creates the new", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{}
+		r := newReconciler(crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u2")), pm, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fn"}, nd.deleted, "old UID torn down")
+		assert.Equal(t, []reconcileCall{{name: "fn", firstSight: true}}, nd.reconciled, "new UID created afresh")
+	})
+
+	t.Run("a ReconcileFunction error does not advance the cache", func(t *testing.T) {
+		pm, nd := &fakeBackend{}, &fakeBackend{reconcErr: assert.AnError}
+		r := newReconciler(crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")), pm, nd)
+		_, err := r.Reconcile(t.Context(), req)
+		require.Error(t, err)
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached)
+	})
+
+	t.Run("transition cleanup error stops before creating under the new type", func(t *testing.T) {
+		pm, nd := &fakeBackend{deleteErr: assert.AnError}, &fakeBackend{}
+		r := newReconciler(crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")), pm, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypePoolmgr, "u1"))
+		_, err := r.Reconcile(t.Context(), req)
+		require.Error(t, err)
+		assert.Empty(t, nd.reconciled, "must not create the new type if tearing down the old failed")
+	})
+}
+
+func TestFunctionReconcilerUnmanagedType(t *testing.T) {
+	key := types.NamespacedName{Name: "fn", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+	// Only poolmgr is registered; "newdeploy" is unmanaged in this reconciler.
+	backends := map[fv1.ExecutorType]executortype.FuncReconciler{fv1.ExecutorTypePoolmgr: &fakeBackend{}}
+
+	t.Run("unmanaged type on first sight is a no-op and not cached", func(t *testing.T) {
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")), backends: backends}
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached)
+	})
+
+	t.Run("transition to an unmanaged type still tears down the old and drops the cache", func(t *testing.T) {
+		pm := &fakeBackend{}
+		r := &functionReconciler{logger: logr.Discard(), client: crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1")),
+			backends: map[fv1.ExecutorType]executortype.FuncReconciler{fv1.ExecutorTypePoolmgr: pm}}
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypePoolmgr, "u1"))
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"fn"}, pm.deleted, "old poolmgr resources torn down")
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached, "no stale cache entry for the now-unmanaged function")
+	})
+}
+
+// fakeFuncExecutorType is an ExecutorType that also implements FuncReconciler.
+type fakeFuncExecutorType struct {
+	executortype.ExecutorType
+	fakeBackend
+}
+
+// nonFuncExecutorType implements ExecutorType but NOT FuncReconciler.
+type nonFuncExecutorType struct{ executortype.ExecutorType }
+
+func TestCollectBackends(t *testing.T) {
+	types := map[fv1.ExecutorType]executortype.ExecutorType{
+		fv1.ExecutorTypePoolmgr:   &fakeFuncExecutorType{},
+		fv1.ExecutorTypeNewdeploy: &fakeFuncExecutorType{},
+		fv1.ExecutorTypeContainer: nonFuncExecutorType{},
+	}
+	backends := collectBackends(types)
+	require.Len(t, backends, 2, "only types implementing FuncReconciler are collected")
+	assert.Contains(t, backends, fv1.ExecutorTypePoolmgr)
+	assert.Contains(t, backends, fv1.ExecutorTypeNewdeploy)
+	assert.NotContains(t, backends, fv1.ExecutorTypeContainer)
+}

--- a/test/integration/suites/common/poolmgr_nd_test.go
+++ b/test/integration/suites/common/poolmgr_nd_test.go
@@ -46,10 +46,10 @@ func TestPoolmgrNewdeployToggle(t *testing.T) {
 	f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("world"))
 	require.Equal(t, "poolmgr", string(ns.GetFunction(t, ctx, fnName).Spec.InvokeStrategy.ExecutionStrategy.ExecutorType))
 
-	// → newdeploy: the transition (poolmgr→newdeploy) drives newdeploy's
-	// updateFunction "type changed to newdeploy" branch → createFunction, which
-	// must materialize a per-function Deployment. Assert on the live object, not
-	// just that traffic flows.
+	// → newdeploy: the shared Function reconciler (pkg/executor/funcreconciler)
+	// sees the executor type change, tears the poolmgr incarnation down, and
+	// creates the function under newdeploy — which must materialize a per-function
+	// Deployment. Assert on the live object, not just that traffic flows.
 	ns.CLI(t, ctx, "fn", "update", "--name", fnName, "--code", codePath,
 		"--minscale", "1", "--maxscale", "4", "--executortype", "newdeploy")
 	f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("world"))


### PR DESCRIPTION
## What

Collapse the executor's three per-type **Function** reconcilers into a single shared dispatcher.

Each executor type registered its own `.For(fv1.Function)` controller (`poolmgr`/`newdeploy`/`container`), so every Function event was fanned into **three** workqueues, evaluated by three predicates, and tracked in three last-reconciled caches — two of the three short-circuiting on the wrong `ExecutorType`. Executor-type transitions were split across two reconcilers that had to independently converge.

This PR introduces `pkg/executor/funcreconciler`: one reconciler that resolves each Function's executor type (`unset → poolmgr`) and routes create/update/delete to the owning type via the new `executortype.FuncReconciler` capability interface (`ReconcileFunction` / `DeleteFunction`). It owns the single last-reconciled cache and handles **delete/recreate (UID change)** and **executor-type transitions** in one place — tearing the old type down via its `DeleteFunction` and building the new via `ReconcileFunction(nil, fn)`, making a transition **atomic within one reconcile**.

Result: **executor reconcilers 8 → 6** (one Function workqueue/predicate/cache instead of three). Net **−320 lines**.

## Behaviour preserved

- newdeploy/container's `updateFunction` transition-away branch was literally `return deleteFunction(oldFn)` — the dispatcher now calls that old type's `DeleteFunction(old)` directly; transition-*to* and first-sight both run the create path (`createFunction` [+ `reconcileDeploymentSpec` for newdeploy]).
- poolmgr: create → istio service (when enabled); update → `refreshFuncPods`; delete → `markFuncDeleted` + remove istio service.
- Per-key serialization (controller-runtime, MaxConcurrentReconciles=1) keeps the single `sync.Map` cache safe; on a reconcile error the cache isn't advanced (same as before).
- poolmgr keeps its ReplicaSet + readyPod watches; `newdeploy`/`container` `RegisterReconcilers` are now no-ops (their Function/Environment reconciles are the shared executor-level reconcilers).

Per-type private create/update/delete logic is unchanged; only the routing moved up, behind small testable helpers (`reconcilePoolmgrFunc`, `reconcileNewdeployFunc`, `reconcileContainerFunc`).

## Tests

- **Unit** — `funcreconciler`: type resolution, first-sight vs update, delete teardown, **executor-type transition** (tear old down + create new), delete+recreate (UID change), unmanaged type (no-op + transition-to-unmanaged still tears the old down), error-does-not-advance-cache, transition-cleanup-error-stops-before-create, and `collectBackends` filtering. Plus per-type routing-helper tests migrated from the deleted per-type reconciler tests.
- **Integration** — the existing `TestPoolmgrNewdeployToggle` already drives the poolmgr↔newdeploy transition end-to-end (live-object + traffic assertions); its stale mechanism comment is updated to the new dispatch path. (My version tears the old type down *more* promptly — in the same reconcile — than the previous two-reconciler convergence.)

## Context

Second step of RFC-0004 (reconciler consolidation; design tracked locally). Builds on #3457 (Environment reconciler merge). Follow-ups (separate PRs): fold ConfigMap/Secret recycling and Deployment/Service/HPA drift-correction into `.Watches()` on this reconciler, retire the standalone Deployment/Service informer factory, and add opt-in finalizers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3458)
<!-- Reviewable:end -->
