### PR TITLE
feat(executor): opt-in cleanup finalizer for reliable cross-namespace teardown

### DIFF
--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -51,6 +51,8 @@ spec:
           value: "{{ .Values.pullPolicy }}"
         - name: ADOPT_EXISTING_RESOURCES
           value: {{ .Values.executor.adoptExistingResources | default false | quote }}
+        - name: FINALIZER_ENABLED
+          value: {{ .Values.finalizerEnabled | quote }}
         - name: POD_READY_TIMEOUT
           value: {{ .Values.executor.podReadyTimeout | default false | quote }}
         - name: ENABLE_ISTIO

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -102,6 +102,21 @@ createNamespace: true
 ##
 disableOwnerReference: false
 
+## finalizerEnabled is a chart-wide toggle for finalizer-based cleanup of the
+## Kubernetes resources Fission controllers create. When enabled (default), a
+## controller adds a cleanup finalizer to the CRs it owns and tears their backing
+## resources down on delete before releasing it — the reliable mechanism for
+## cross-namespace cleanup, which owner-reference GC cannot do (see
+## builderNamespace / functionNamespace). Currently honoured by the executor
+## (Function); other Fission controllers will adopt the same flag over time.
+##
+## Disable (set false) only if you need deletes to never block on a controller
+## being available; cleanup then falls back to best-effort reaping. A finalizer
+## left behind because its controller is down can be cleared manually with:
+##   kubectl patch <resource> <name> -n <ns> --type=merge -p '{"metadata":{"finalizers":[]}}'
+##
+finalizerEnabled: true
+
 ## enableIstio indicates whether to enable istio integration.
 ##
 enableIstio: false

--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -565,7 +565,14 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	// type (poolmgr/newdeploy/container) via FuncReconciler, handling executor-type
 	// transitions in one place. Replaces the three per-type Function reconcilers
 	// with a single workqueue, predicate, and last-reconciled cache.
-	if err := funcreconciler.RegisterReconciler(crMgr, logger, executorTypes); err != nil {
+	//
+	// FINALIZER_ENABLED toggles the cleanup finalizer for reliable cross-namespace
+	// teardown. The Helm chart sets it from the chart-wide finalizerEnabled value
+	// (default true); when off, any existing finalizer is drained. A bare binary
+	// with the env unset defaults to off (conservative). See
+	// funcreconciler.functionFinalizer.
+	finalizerEnabled, _ := strconv.ParseBool(os.Getenv("FINALIZER_ENABLED"))
+	if err := funcreconciler.RegisterReconciler(crMgr, logger, executorTypes, finalizerEnabled); err != nil {
 		return err
 	}
 

--- a/pkg/executor/funcreconciler/finalizer_test.go
+++ b/pkg/executor/funcreconciler/finalizer_test.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package funcreconciler
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/executortype"
+)
+
+func newReconcilerWith(c client.Client, finalizer bool, nd *fakeBackend) *functionReconciler {
+	return &functionReconciler{
+		logger:    logr.Discard(),
+		client:    c,
+		finalizer: finalizer,
+		backends:  map[fv1.ExecutorType]executortype.FuncReconciler{fv1.ExecutorTypeNewdeploy: nd},
+	}
+}
+
+func TestFunctionReconcilerFinalizer(t *testing.T) {
+	key := types.NamespacedName{Name: "fn", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+
+	t.Run("enabled: a live function gets the finalizer added and is still reconciled", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := crClient(fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		r := newReconcilerWith(c, true, nd)
+
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+
+		got := &fv1.Function{}
+		require.NoError(t, c.Get(t.Context(), key, got))
+		assert.True(t, controllerutil.ContainsFinalizer(got, functionFinalizer), "finalizer must be added")
+		assert.Len(t, nd.reconciled, 1, "reconcile must still run after adding the finalizer")
+	})
+
+	t.Run("disabled: an existing finalizer is drained and the function is still reconciled", func(t *testing.T) {
+		nd := &fakeBackend{}
+		f := fn("fn", fv1.ExecutorTypeNewdeploy, "u1")
+		f.Finalizers = []string{functionFinalizer}
+		c := crClient(f)
+		r := newReconcilerWith(c, false, nd)
+
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+
+		got := &fv1.Function{}
+		require.NoError(t, c.Get(t.Context(), key, got))
+		assert.False(t, controllerutil.ContainsFinalizer(got, functionFinalizer), "finalizer must be drained when disabled")
+		assert.Len(t, nd.reconciled, 1)
+	})
+
+	t.Run("deletion with our finalizer tears the workloads down then releases the finalizer", func(t *testing.T) {
+		nd := &fakeBackend{}
+		f := fn("fn", fv1.ExecutorTypeNewdeploy, "u1")
+		f.Finalizers = []string{functionFinalizer}
+		c := crClient(f)
+		// Delete sets DeletionTimestamp (the finalizer keeps the object around).
+		require.NoError(t, c.Delete(t.Context(), f))
+		r := newReconcilerWith(c, true, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"fn"}, nd.deleted, "workloads must be torn down on delete")
+		got := &fv1.Function{}
+		err = c.Get(t.Context(), key, got)
+		assert.True(t, apierrors.IsNotFound(err), "removing the last finalizer lets the object be collected")
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached, "cache entry dropped after teardown")
+	})
+
+	t.Run("deletion teardown error keeps the finalizer for a retry", func(t *testing.T) {
+		nd := &fakeBackend{deleteErr: assert.AnError}
+		f := fn("fn", fv1.ExecutorTypeNewdeploy, "u1")
+		f.Finalizers = []string{functionFinalizer}
+		c := crClient(f)
+		require.NoError(t, c.Delete(t.Context(), f))
+		r := newReconcilerWith(c, true, nd)
+
+		_, err := r.Reconcile(t.Context(), req)
+		require.Error(t, err)
+
+		got := &fv1.Function{}
+		require.NoError(t, c.Get(t.Context(), key, got))
+		assert.True(t, controllerutil.ContainsFinalizer(got, functionFinalizer), "finalizer kept so teardown is retried")
+	})
+
+	t.Run("deletion without our finalizer is a no-op and leaves the cache for the NotFound path", func(t *testing.T) {
+		nd := &fakeBackend{}
+		f := fn("fn", fv1.ExecutorTypeNewdeploy, "u1")
+		f.Finalizers = []string{"someone-else/keep"}
+		c := crClient(f)
+		require.NoError(t, c.Delete(t.Context(), f))
+		r := newReconcilerWith(c, true, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+
+		_, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+
+		assert.Empty(t, nd.deleted, "not our finalizer: teardown deferred to the NotFound path")
+		_, cached := r.lastReconciled.Load(key)
+		assert.True(t, cached, "cache retained for the NotFound path to tear down later")
+	})
+}
+
+func TestDeletionTimestampPredicate(t *testing.T) {
+	now := metav1.Now()
+	live := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn"}}
+	deleting := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", DeletionTimestamp: &now}}
+
+	assert.True(t, deletionTimestampPredicate.Update(event.UpdateEvent{ObjectNew: deleting}),
+		"must pass updates where the object is being deleted (Generation unchanged, so GenerationChangedPredicate drops them)")
+	assert.False(t, deletionTimestampPredicate.Update(event.UpdateEvent{ObjectNew: live}),
+		"must not pass a normal update on its own — GenerationChangedPredicate handles those")
+}

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -22,11 +22,35 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/executor/executortype"
 )
+
+// functionFinalizer gates a Function's deletion on the executor tearing its
+// backing workloads down. It is the reliable mechanism for cross-namespace
+// cleanup: owner-reference GC cannot reach a Deployment/Service/HPA in a
+// different namespace than the Function CR (see GetFunctionNS), so the executor
+// must observe the delete and tear them down before the object is collected.
+// Toggled by the chart-wide finalizerEnabled value (default on); when off, the
+// finalizer is drained from any object that carries it so deletes never wedge.
+const functionFinalizer = "fission.io/function-cleanup"
+
+// deletionTimestampPredicate passes Update events where the object is being
+// deleted (DeletionTimestamp set). The shared GenerationChangedPredicate drops
+// these — setting DeletionTimestamp leaves Generation unchanged — which would
+// leave a finalizer-held Function unreconciled and wedge its delete. OR'd with
+// GenerationChangedPredicate so spec changes still trigger and status-only writes
+// are still filtered.
+var deletionTimestampPredicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return e.ObjectNew != nil && !e.ObjectNew.GetDeletionTimestamp().IsZero()
+	},
+}
 
 // resolveExecutorType returns the executor type that owns fn. An unset type
 // defaults to poolmgr (the default executor), matching the old per-type filters
@@ -46,6 +70,7 @@ type functionReconciler struct {
 	logger         logr.Logger
 	client         client.Client
 	backends       map[fv1.ExecutorType]executortype.FuncReconciler
+	finalizer      bool     // add+honour the cleanup finalizer (opt-in)
 	lastReconciled sync.Map // client.ObjectKey -> *fv1.Function
 }
 
@@ -53,8 +78,8 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	fn := &fv1.Function{}
 	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
 		if apierrors.IsNotFound(err) {
-			// Deleted: tear down using the last-reconciled object (the live one is
-			// gone), routed to the executor type that owned it.
+			// Gone (no finalizer of ours held it): tear down using the last-reconciled
+			// object, routed to the executor type that owned it.
 			if old, ok := r.lastReconciled.LoadAndDelete(req.NamespacedName); ok {
 				oldFn := old.(*fv1.Function)
 				if b, ok := r.backends[resolveExecutorType(oldFn)]; ok {
@@ -66,6 +91,43 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Deletion in progress. Only observable here while a finalizer holds the
+	// object; if it is ours, tear the workloads down and release it. If it is not
+	// ours, leave the cache intact so the NotFound path tears down once the object
+	// is actually removed.
+	if !fn.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(fn, functionFinalizer) {
+			return ctrl.Result{}, nil
+		}
+		if b, ok := r.backends[resolveExecutorType(fn)]; ok {
+			if err := b.DeleteFunction(ctx, fn); err != nil {
+				return ctrl.Result{}, err // keep the finalizer; retry teardown
+			}
+		}
+		controllerutil.RemoveFinalizer(fn, functionFinalizer)
+		if err := r.client.Update(ctx, fn); err != nil {
+			return ctrl.Result{}, err
+		}
+		r.lastReconciled.Delete(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	// Keep the cleanup finalizer in sync with the opt-in flag. Adding/removing a
+	// finalizer is a metadata write (Generation unchanged), so it does not
+	// re-trigger this reconciler through GenerationChangedPredicate.
+	if r.finalizer && !controllerutil.ContainsFinalizer(fn, functionFinalizer) {
+		controllerutil.AddFinalizer(fn, functionFinalizer)
+		if err := r.client.Update(ctx, fn); err != nil {
+			return ctrl.Result{}, err
+		}
+	} else if !r.finalizer && controllerutil.ContainsFinalizer(fn, functionFinalizer) {
+		// Toggled off: drain the finalizer so a later delete is never wedged on it.
+		controllerutil.RemoveFinalizer(fn, functionFinalizer)
+		if err := r.client.Update(ctx, fn); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	newType := resolveExecutorType(fn)
@@ -120,8 +182,15 @@ func collectBackends(executorTypes map[fv1.ExecutorType]executortype.ExecutorTyp
 // RegisterReconciler wires the single Function reconciler onto the executor
 // Manager, dispatching to the executor types that implement FuncReconciler. If no
 // executor type reconciles Functions, no reconciler is registered and nil is
-// returned.
-func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[fv1.ExecutorType]executortype.ExecutorType) error {
+// returned. finalizerEnabled opts the reconciler into the cleanup finalizer
+// (reliable cross-namespace teardown); when false, any existing cleanup finalizer
+// is drained instead.
+//
+// It uses Or(GenerationChangedPredicate, deletionTimestampPredicate) rather than
+// the bare GenerationChangedPredicate Register applies: status-only writes are
+// still filtered, but a delete (DeletionTimestamp set, Generation unchanged) must
+// reach the reconciler so a finalizer-held Function is torn down and released.
+func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[fv1.ExecutorType]executortype.ExecutorType, finalizerEnabled bool) error {
 	backends := collectBackends(executorTypes)
 	if len(backends) == 0 {
 		return nil
@@ -132,12 +201,14 @@ func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[
 		names = append(names, string(name))
 	}
 	sort.Strings(names)
-	logger.V(1).Info("registering shared function reconciler", "executor_types", names)
+	logger.V(1).Info("registering shared function reconciler", "executor_types", names, "finalizer", finalizerEnabled)
 
 	r := &functionReconciler{
-		logger:   logger.WithName("function_reconciler"),
-		client:   mgr.GetClient(),
-		backends: backends,
+		logger:    logger.WithName("function_reconciler"),
+		client:    mgr.GetClient(),
+		backends:  backends,
+		finalizer: finalizerEnabled,
 	}
-	return controller.Register(mgr, &fv1.Function{}, r, "executor-function")
+	return controller.RegisterWithPredicates(mgr, &fv1.Function{}, r, "executor-function", 0,
+		predicate.Or(predicate.GenerationChangedPredicate{}, deletionTimestampPredicate))
 }


### PR DESCRIPTION
## What

Add a cleanup finalizer (`fission.io/function-cleanup`) on the shared Function reconciler, for reliable teardown of a function's **cross-namespace** workloads, gated by a **chart-wide** toggle.

A function's Deployment/Service/HPA can live in a different namespace than the Function CR (`GetFunctionNS`). Kubernetes owner-reference GC **cannot cross namespaces**, so cleanup previously rode the NotFound path + last-reconciled cache + periodic reaper — best-effort, and it leaks if the executor misses the delete event.

With the finalizer:
- added on the live reconcile;
- on delete, the reconcile tears the workloads down via the owning type's `DeleteFunction` and **only then** releases the finalizer — so the object isn't collected until its cross-namespace workloads are gone;
- a teardown error keeps the finalizer for a retry.

## Global, default-on toggle

Wired from a **chart-wide** `finalizerEnabled` value (top-level, **default `true`**), mirroring `disableOwnerReference` — a global flag the other Fission controllers will adopt as they grow finalizers, not an executor-only knob. The executor reads it via `FINALIZER_ENABLED`.

- `--set finalizerEnabled=false` disables it (verified rendering: the template references the value directly — no `| default`, which would mis-handle a boolean `false`).
- When off, any existing finalizer is **drained**, and the deletion teardown path is **flag-independent**, so toggling off never strands an object.
- Escape hatch for a finalizer left by a down controller:
  ```
  kubectl patch function <name> -n <ns> --type=merge -p '{"metadata":{"finalizers":[]}}'
  ```

## Correctness — the GenerationChangedPredicate footgun

Setting `DeletionTimestamp` leaves `Generation` unchanged, so the reconciler's `GenerationChangedPredicate` would **drop the delete event** and wedge a finalizer-held Function. Switched to `Or(GenerationChangedPredicate, deletionTimestampPredicate)`: deletes reach the reconciler, spec changes still trigger, status-only writes still filtered. Finalizer add/remove are metadata writes (no Generation bump) → no self-trigger loop. The finalizer is added **before** the workloads are created, so a crash never leaves workloads unguarded.

## Tests

Unit (branch-complete): add, drain (disabled), teardown+release on delete, teardown-error-keeps-finalizer (retry), not-our-finalizer defers to the NotFound path, and the deletionTimestamp predicate. Existing dispatcher tests unaffected.

Integration: because the chart now defaults the flag **on**, the kind-ci suite exercises the finalizer path on **every function delete** end-to-end — no separate test needed, and a regression would surface as deletes wedging across the suite.

## Context

RFC-0004 (final phase besides drift self-healing, queued next). Builds on #3457 / #3458 / #3459. Scoped to **Function**; other controllers can adopt the same `finalizerEnabled` flag later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3460)
<!-- Reviewable:end -->
