### PR TITLE
feat(executor): self-heal newdeploy/container function workloads on drift

### DIFF
--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -261,6 +261,24 @@ func (caaf *Container) CleanupOldExecutorObjects(ctx context.Context) {
 	reaper.CleanupExecutorObjects(ctx, caaf.logger, caaf.kubernetesClient, caaf.instanceID, fv1.ExecutorTypeContainer)
 }
 
+// resourcesExist reports whether the function's backing Deployment and Service
+// are present in the Manager cache. A missing object means it drifted away
+// (deleted out-of-band) and the function should be recreated. Reads go through
+// the cache-backed crClient (same path as IsValid).
+func (caaf *Container) resourcesExist(ctx context.Context, fn *fv1.Function) (bool, error) {
+	ns := caaf.nsResolver.GetFunctionNS(fn.Namespace)
+	key := client.ObjectKey{Namespace: ns, Name: caaf.getObjName(fn)}
+	for _, obj := range []client.Object{&appsv1.Deployment{}, &apiv1.Service{}} {
+		if err := caaf.crClient.Get(ctx, key, obj); err != nil {
+			if k8sErrs.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+	return true, nil
+}
+
 func (caaf *Container) createFunction(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
 		return nil, nil

--- a/pkg/executor/executortype/container/reconciler.go
+++ b/pkg/executor/executortype/container/reconciler.go
@@ -20,6 +20,10 @@ type functionManager interface {
 	createFunction(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 	updateFunction(context.Context, *fv1.Function, *fv1.Function) error
 	deleteFunction(context.Context, *fv1.Function) error
+	// resourcesExist reports whether the function's backing Deployment and Service
+	// are present (read from the Manager cache). False means they drifted away
+	// (deleted out-of-band) and the function should be recreated.
+	resourcesExist(context.Context, *fv1.Function) (bool, error)
 }
 
 // ReconcileFunction satisfies executortype.FuncReconciler for container-backed
@@ -39,9 +43,20 @@ func (caaf *Container) DeleteFunction(ctx context.Context, fn *fv1.Function) err
 }
 
 // reconcileContainerFunc holds the create-vs-update routing, split out so it is
-// unit-testable with a fake functionManager.
+// unit-testable with a fake functionManager. It is level-triggered: a reconcile
+// of a managed function whose backing Deployment/Service drifted away (deleted
+// out-of-band, surfaced by the drift watch) recreates them via the idempotent
+// get-or-create path rather than diffing a no-longer-existent object.
 func reconcileContainerFunc(ctx context.Context, mgr functionManager, old, fn *fv1.Function) error {
 	if old == nil {
+		_, err := mgr.createFunction(ctx, fn)
+		return err
+	}
+	exist, err := mgr.resourcesExist(ctx, fn)
+	if err != nil {
+		return err
+	}
+	if !exist {
 		_, err := mgr.createFunction(ctx, fn)
 		return err
 	}

--- a/pkg/executor/executortype/container/reconciler_test.go
+++ b/pkg/executor/executortype/container/reconciler_test.go
@@ -18,6 +18,11 @@ import (
 
 type fakeFuncMgr struct {
 	created, updated, deleted []string
+	resourcesGone             bool // resourcesExist returns false (drift)
+}
+
+func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, error) {
+	return !f.resourcesGone, nil
 }
 
 func (f *fakeFuncMgr) createFunction(_ context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
@@ -54,6 +59,13 @@ func TestReconcileContainerFunc(t *testing.T) {
 		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.updated)
 		assert.Empty(t, mgr.created)
+	})
+
+	t.Run("drift: missing backing resources are recreated, not diffed", func(t *testing.T) {
+		mgr := &fakeFuncMgr{resourcesGone: true}
+		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
+		assert.Equal(t, []string{"fn"}, mgr.created, "drifted-away resources must be recreated via get-or-create")
+		assert.Empty(t, mgr.updated, "no diff against a non-existent object")
 	})
 
 	t.Run("DeleteFunction tears down the function", func(t *testing.T) {

--- a/pkg/executor/executortype/newdeploy/isvalid_test.go
+++ b/pkg/executor/executortype/newdeploy/isvalid_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +17,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/utils"
 )
 
 func svcObj(ns, name string) *apiv1.Service {
@@ -72,5 +75,42 @@ func TestNewdeployIsValid(t *testing.T) {
 	t.Run("invalid when there are no kubernetes objects", func(t *testing.T) {
 		d := newDeploy()
 		assert.False(t, d.IsValid(t.Context(), fsvcWith()))
+	})
+}
+
+// TestNewdeployResourcesExist covers the drift-detection read used by the
+// level-triggered reconcile: present when both backing objects exist, absent when
+// either has drifted away.
+func TestNewdeployResourcesExist(t *testing.T) {
+	fn := fnOfType("fn", fv1.ExecutorTypeNewdeploy)
+	fn.UID = "83c82da2-81e9-4ebd-867e-f383e65e603f"
+
+	build := func(objs ...client.Object) *NewDeploy {
+		c := fake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(objs...).Build()
+		return &NewDeploy{logger: logr.Discard(), crClient: c, nsResolver: &utils.NamespaceResolver{}}
+	}
+	// Object name/namespace match what createOrGet* use.
+	name := build().getObjName(fn)
+	ns := (&utils.NamespaceResolver{}).GetFunctionNS(fn.Namespace)
+
+	t.Run("present when both Deployment and Service exist", func(t *testing.T) {
+		d := build(deplObj(ns, name, 1), svcObj(ns, name))
+		exist, err := d.resourcesExist(t.Context(), fn)
+		require.NoError(t, err)
+		assert.True(t, exist)
+	})
+
+	t.Run("absent when the Deployment has drifted away", func(t *testing.T) {
+		d := build(svcObj(ns, name)) // no deployment
+		exist, err := d.resourcesExist(t.Context(), fn)
+		require.NoError(t, err)
+		assert.False(t, exist)
+	})
+
+	t.Run("absent when the Service has drifted away", func(t *testing.T) {
+		d := build(deplObj(ns, name, 1)) // no service
+		exist, err := d.resourcesExist(t.Context(), fn)
+		require.NoError(t, err)
+		assert.False(t, exist)
 	})
 }

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -324,6 +324,24 @@ func (deploy *NewDeploy) updateEnvFunctions(ctx context.Context, env *fv1.Enviro
 	return nil
 }
 
+// resourcesExist reports whether the function's backing Deployment and Service
+// are present in the Manager cache. A missing object means it drifted away
+// (deleted out-of-band) and the function should be recreated. Reads go through
+// the cache-backed crClient (same path as IsValid).
+func (deploy *NewDeploy) resourcesExist(ctx context.Context, fn *fv1.Function) (bool, error) {
+	ns := deploy.nsResolver.GetFunctionNS(fn.Namespace)
+	key := client.ObjectKey{Namespace: ns, Name: deploy.getObjName(fn)}
+	for _, obj := range []client.Object{&appsv1.Deployment{}, &apiv1.Service{}} {
+		if err := deploy.crClient.Get(ctx, key, obj); err != nil {
+			if k8sErrs.IsNotFound(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+	return true, nil
+}
+
 func (deploy *NewDeploy) createFunction(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	if fn.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeNewdeploy {
 		return nil, nil

--- a/pkg/executor/executortype/newdeploy/reconciler.go
+++ b/pkg/executor/executortype/newdeploy/reconciler.go
@@ -22,6 +22,10 @@ type funcManager interface {
 	updateFunction(context.Context, *fv1.Function, *fv1.Function) error
 	deleteFunction(context.Context, *fv1.Function) error
 	reconcileDeploymentSpec(context.Context, *fv1.Function) error
+	// resourcesExist reports whether the function's backing Deployment and Service
+	// are present (read from the Manager cache). False means they drifted away
+	// (deleted out-of-band) and must be recreated.
+	resourcesExist(context.Context, *fv1.Function) (bool, error)
 }
 
 // envFunctionUpdater is the subset of *NewDeploy the Environment handler drives —
@@ -53,13 +57,26 @@ func (deploy *NewDeploy) DeleteFunction(ctx context.Context, fn *fv1.Function) e
 }
 
 // reconcileNewdeployFunc holds the create-vs-update routing, split out so it is
-// unit-testable with a fake funcManager.
+// unit-testable with a fake funcManager. It is level-triggered: a reconcile of a
+// managed function whose backing Deployment/Service drifted away (deleted
+// out-of-band, surfaced by the drift watch) recreates them via the idempotent
+// get-or-create path rather than diffing a no-longer-existent object. (The
+// request path also recreates on the next invocation; this keeps MinScale>0
+// functions warm without waiting for one.)
 func reconcileNewdeployFunc(ctx context.Context, mgr funcManager, old, fn *fv1.Function) error {
 	if old == nil {
 		if _, err := mgr.createFunction(ctx, fn); err != nil {
 			return err
 		}
 		return mgr.reconcileDeploymentSpec(ctx, fn)
+	}
+	exist, err := mgr.resourcesExist(ctx, fn)
+	if err != nil {
+		return err
+	}
+	if !exist {
+		_, err := mgr.createFunction(ctx, fn)
+		return err
 	}
 	return mgr.updateFunction(ctx, old, fn)
 }

--- a/pkg/executor/executortype/newdeploy/reconciler_test.go
+++ b/pkg/executor/executortype/newdeploy/reconciler_test.go
@@ -18,6 +18,11 @@ import (
 
 type fakeFuncMgr struct {
 	created, updated, deleted, reconciled []string
+	resourcesGone                         bool // resourcesExist returns false (drift)
+}
+
+func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, error) {
+	return !f.resourcesGone, nil
 }
 
 func (f *fakeFuncMgr) createFunction(_ context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
@@ -74,6 +79,13 @@ func TestReconcileNewdeployFunc(t *testing.T) {
 		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.updated)
 		assert.Empty(t, mgr.created)
+	})
+
+	t.Run("drift: missing backing resources are recreated, not diffed", func(t *testing.T) {
+		mgr := &fakeFuncMgr{resourcesGone: true}
+		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
+		assert.Equal(t, []string{"fn"}, mgr.created, "drifted-away resources must be recreated via get-or-create")
+		assert.Empty(t, mgr.updated, "no diff against a non-existent object")
 	})
 
 	t.Run("DeleteFunction tears down the function", func(t *testing.T) {

--- a/pkg/executor/funcreconciler/drift_test.go
+++ b/pkg/executor/funcreconciler/drift_test.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package funcreconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+func TestOwnedObjectToFunction(t *testing.T) {
+	t.Run("maps a managed object back to its owning Function by label", func(t *testing.T) {
+		obj := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name:      "newdeploy-fn-default-abc", // workload name, not the function name
+			Namespace: "fission-function",         // workload namespace, not the function namespace
+			Labels: map[string]string{
+				fv1.FUNCTION_NAME:      "fn",
+				fv1.FUNCTION_NAMESPACE: "default",
+			},
+		}}
+		reqs := ownedObjectToFunction(t.Context(), obj)
+		assert.Equal(t, []reconcile.Request{{NamespacedName: types.NamespacedName{Name: "fn", Namespace: "default"}}}, reqs,
+			"must point at the Function CR (from labels), not the workload name/namespace")
+	})
+
+	t.Run("returns nil for an object without the function labels", func(t *testing.T) {
+		obj := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "y"}}
+		assert.Nil(t, ownedObjectToFunction(t.Context(), obj))
+	})
+}
+
+func TestDeleteOnlyPredicate(t *testing.T) {
+	assert.True(t, deleteOnlyPredicate.Delete(event.DeleteEvent{}),
+		"a deleted backing object must re-enqueue the owning Function")
+	assert.False(t, deleteOnlyPredicate.Create(event.CreateEvent{}),
+		"the executor creates these objects itself — no need to react")
+	assert.False(t, deleteOnlyPredicate.Update(event.UpdateEvent{}),
+		"must NOT react to updates — the idle reaper scales the Deployment and we'd fight it")
+	assert.False(t, deleteOnlyPredicate.Generic(event.GenericEvent{}))
+}

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -19,17 +19,48 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/controller"
 	"github.com/fission/fission/pkg/executor/executortype"
 )
+
+// deleteOnlyPredicate passes only Delete events. The drift watch uses it so a
+// Function is re-enqueued when one of its backing objects is removed out-of-band,
+// but NOT on Create (the executor creates them itself) or Update — crucially, the
+// newdeploy idle reaper *scales* the Deployment toward MinScale (it never deletes
+// it), so reacting to Updates would fight the reaper and churn the workqueue.
+var deleteOnlyPredicate = predicate.Funcs{
+	CreateFunc:  func(event.CreateEvent) bool { return false },
+	UpdateFunc:  func(event.UpdateEvent) bool { return false },
+	DeleteFunc:  func(event.DeleteEvent) bool { return true },
+	GenericFunc: func(event.GenericEvent) bool { return false },
+}
+
+// ownedObjectToFunction maps a managed Deployment/Service back to the Function
+// that owns it, via the function-identifying labels getDeployLabels stamps. The
+// labels carry the Function CR's own name/namespace (not the workload namespace),
+// so the request points straight at the Function. Returns nil for an object
+// without them (it is not ours).
+func ownedObjectToFunction(_ context.Context, obj client.Object) []reconcile.Request {
+	l := obj.GetLabels()
+	name, ns := l[fv1.FUNCTION_NAME], l[fv1.FUNCTION_NAMESPACE]
+	if name == "" || ns == "" {
+		return nil
+	}
+	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}}}
+}
 
 // functionFinalizer gates a Function's deletion on the executor tearing its
 // backing workloads down. It is the reliable mechanism for cross-namespace
@@ -209,6 +240,21 @@ func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[
 		backends:  backends,
 		finalizer: finalizerEnabled,
 	}
-	return controller.RegisterWithPredicates(mgr, &fv1.Function{}, r, "executor-function", 0,
-		predicate.Or(predicate.GenerationChangedPredicate{}, deletionTimestampPredicate))
+
+	// Built directly (not via controller.Register) because this reconciler needs
+	// .Watches() in addition to .For(): besides Function spec/delete events, it
+	// watches the Deployments and Services it manages so a backing object deleted
+	// out-of-band re-enqueues the owning Function, which recreates it (drift
+	// self-healing). The Manager cache already scopes those types to
+	// executor-managed objects (executorManagedSelector), so only newdeploy /
+	// container workloads reach the delete-only watch.
+	return builder.ControllerManagedBy(mgr).
+		Named("executor-function").
+		For(&fv1.Function{}, builder.WithPredicates(
+			predicate.Or(predicate.GenerationChangedPredicate{}, deletionTimestampPredicate))).
+		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(ownedObjectToFunction),
+			builder.WithPredicates(deleteOnlyPredicate)).
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(ownedObjectToFunction),
+			builder.WithPredicates(deleteOnlyPredicate)).
+		Complete(r)
 }

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -82,6 +83,20 @@ var deletionTimestampPredicate = predicate.Funcs{
 		return e.ObjectNew != nil && !e.ObjectNew.GetDeletionTimestamp().IsZero()
 	},
 }
+
+// funcReconcileConcurrency is the shared Function reconciler's worker count. A
+// reconcile can block for up to the specialization timeout: createFunction
+// (first sight, or recreating a drifted-away workload) waits in waitForDeploy for
+// the Deployment to become available. With a single worker that wait would
+// head-of-line-block every other function's reconcile — and merging the three
+// per-type reconcilers (each previously its own 1-worker controller, so a
+// blocking newdeploy create never stalled container/poolmgr) into one collapsed
+// that cross-type isolation. Several workers restore it; controller-runtime still
+// serializes reconciles per Function key, so per-function state stays safe.
+// Sized above the integration suite's parallelism (-parallel 6) so several
+// concurrent first-sight/drift creates can be in their waitForDeploy wait
+// without starving unrelated functions' updates.
+const funcReconcileConcurrency = 10
 
 // resolveExecutorType returns the executor type that owns fn. An unset type
 // defaults to poolmgr (the default executor), matching the old per-type filters
@@ -250,6 +265,7 @@ func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[
 	// container workloads reach the delete-only watch.
 	return builder.ControllerManagedBy(mgr).
 		Named("executor-function").
+		WithOptions(ctrlcontroller.Options{MaxConcurrentReconciles: funcReconcileConcurrency}).
 		For(&fv1.Function{}, builder.WithPredicates(
 			predicate.Or(predicate.GenerationChangedPredicate{}, deletionTimestampPredicate))).
 		Watches(&appsv1.Deployment{}, handler.EnqueueRequestsFromMapFunc(ownedObjectToFunction),

--- a/test/integration/suites/common/drift_selfheal_test.go
+++ b/test/integration/suites/common/drift_selfheal_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestDriftSelfHeal verifies the executor's drift watch: a newdeploy function's
+// backing Deployment deleted out-of-band is recreated proactively — without an
+// invocation — by the shared Function reconciler's .Watches() on Deployments.
+//
+// The test deliberately does NOT call the function after deleting the Deployment:
+// the request path (GetFuncSvc → IsValid → re-specialize) would also recreate it,
+// so to prove the *watch* healed it we wait on the Deployment reappearing with a
+// fresh UID without sending any traffic.
+func TestDriftSelfHeal(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequirePython(t)
+
+	ns := f.NewTestNamespace(t)
+	envName := "python-drift-" + ns.ID
+	fnName := "fn-drift-" + ns.ID
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	codePath := framework.WriteTestData(t, "python/hello/hello.py")
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{
+		Name: fnName, Env: envName, Code: codePath,
+		ExecutorType: "newdeploy", MinScale: 1, MaxScale: 2,
+		MinCPU: 20, MaxCPU: 100, MinMemory: 128, MaxMemory: 256,
+	})
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: "/" + fnName, Method: "GET"})
+	f.Router(t).GetEventually(t, ctx, "/"+fnName, framework.BodyContains("world"))
+
+	// Capture the live Deployment, then delete it out-of-band.
+	orig := ns.FunctionDeployment(t, ctx, fnName)
+	origUID := orig.UID
+	err := f.KubeClient().AppsV1().Deployments(orig.Namespace).Delete(ctx, orig.Name, metav1.DeleteOptions{})
+	require.NoErrorf(t, err, "deleting deployment %s/%s out-of-band", orig.Namespace, orig.Name)
+
+	// The drift watch must recreate it — a Deployment with a fresh UID — without
+	// any request driving the recreation.
+	ns.WaitForFunctionDeployment(t, ctx, fnName, func(d *appsv1.Deployment) bool {
+		return d.UID != origUID
+	}, "drift watch must recreate the deleted Deployment without an invocation", 90*time.Second)
+}


### PR DESCRIPTION
## What

The shared Function reconciler now `.Watches()` the Deployments and Services it manages, so a backing object **deleted out-of-band re-enqueues the owning Function and is recreated** — proactively, without waiting for the next request.

> The request path already heals on the next invocation (`GetFuncSvc → IsValid → re-specialize`); this keeps `MinScale>0` functions warm in the meantime. So drift-watch is a proactive optimization with the request path as backstop — which is why getting it slightly wrong is non-catastrophic.

## Two pieces

**1. Watch wiring (`funcreconciler`)** — the reconciler is now built directly with `builder.ControllerManagedBy` so it can add `.Watches()` alongside `.For(Function)`:
- `ownedObjectToFunction` maps a managed Deployment/Service back to its Function via the `FUNCTION_NAME`/`FUNCTION_NAMESPACE` labels `getDeployLabels` stamps (the labels carry the *Function CR's* name/namespace, so the request points straight at it).
- **delete-only predicate**: the newdeploy idle reaper *scales* the Deployment toward `MinScale` (never deletes it), so reacting to Updates would fight the reaper and churn the workqueue — only an actual **delete** re-enqueues.
- The Manager cache already scopes Deployment/Service to executor-managed objects (`executorManagedSelector`, from #3459), so poolmgr workloads never reach the watch.

**2. Level-triggered reconcile (newdeploy/container)** — `ReconcileFunction` now checks `resourcesExist` (cache reads of the backing Deployment+Service) on an update; if they drifted away it recreates via the idempotent `createOrGet*` path instead of diffing a non-existent object. Recreate targets `MinScale`, matching the reaper, so the two never fight. poolmgr is unaffected (no per-function Deployment). **HPA drift is out of scope** (HPA isn't in the Manager cache) — a possible follow-up.

## Tests

- **Unit**: `ownedObjectToFunction` (label mapping + nil when unlabelled); `deleteOnlyPredicate` (delete → yes; create/update/generic → no); recreate-on-drift routing (newdeploy + container); `resourcesExist` cache reads (present / missing Deployment / missing Service).
- **Integration** (`TestDriftSelfHeal`): deletes a newdeploy function's Deployment out-of-band and asserts a **fresh-UID** Deployment reappears **without an invocation** — proving the *watch* healed it, not the request path.

## Context

Final phase of RFC-0004's executor reconciler/cache consolidation. Builds on #3457 / #3458 / #3459 / #3460. With this, the executor went 9→6 reconcilers, dropped its second informer factory, gained reliable cross-namespace teardown (finalizers), and now self-heals workload drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3461)
<!-- Reviewable:end -->
