### PR TITLE
fix(httptrigger): enforce path-safety at admission (GHSA-vchh)

### DIFF
--- a/crds/v1/fission.io_httptriggers.yaml
+++ b/crds/v1/fission.io_httptriggers.yaml
@@ -38,13 +38,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: |-
-              HTTPTriggerSpec is for router to expose user functions at the given URL path.
-
-              The path rules below close GHSA-vchh-r53j-8mpw: HTTPTrigger no longer has
-              an admission webhook, so the API server's CEL evaluation is the only place
-              these invariants can be enforced for kubectl- or REST-created triggers.
-              Keep these CEL rules in sync with validateTriggerPath in validation.go.
+            description: HTTPTriggerSpec is for router to expose user functions at
+              the given URL path.
             properties:
               corsConfig:
                 description: |-

--- a/crds/v1/fission.io_httptriggers.yaml
+++ b/crds/v1/fission.io_httptriggers.yaml
@@ -38,8 +38,13 @@ spec:
           metadata:
             type: object
           spec:
-            description: HTTPTriggerSpec is for router to expose user functions at
-              the given URL path.
+            description: |-
+              HTTPTriggerSpec is for router to expose user functions at the given URL path.
+
+              The path rules below close GHSA-vchh-r53j-8mpw: HTTPTrigger no longer has
+              an admission webhook, so the API server's CEL evaluation is the only place
+              these invariants can be enforced for kubectl- or REST-created triggers.
+              Keep these CEL rules in sync with validateTriggerPath in validation.go.
             properties:
               corsConfig:
                 description: |-
@@ -237,6 +242,26 @@ spec:
             required:
             - functionref
             type: object
+            x-kubernetes-validations:
+            - message: 'HTTPTriggerSpec: at least one of relativeurl or prefix must
+                be set'
+              rule: self.relativeurl != '' || (has(self.prefix) && self.prefix !=
+                '')
+            - message: HTTPTriggerSpec.relativeurl must start with '/', not be '/',
+                not contain '..' path segments, not collide with a router-owned path
+                (/router-healthz, /readyz, /_version, /auth/login), and not start
+                with /fission-function/
+              rule: self.relativeurl == '' || (self.relativeurl.startsWith('/') &&
+                self.relativeurl != '/' && !self.relativeurl.matches('(^|/)[.][.](/|$)')
+                && !(self.relativeurl in ['/router-healthz','/readyz','/_version','/auth/login'])
+                && !self.relativeurl.startsWith('/fission-function/'))
+            - message: HTTPTriggerSpec.prefix must start with '/', not be '/', not
+                contain '..' path segments, not collide with a router-owned path (/router-healthz,
+                /readyz, /_version, /auth/login), and not start with /fission-function/
+              rule: '!has(self.prefix) || self.prefix == '''' || (self.prefix.startsWith(''/'')
+                && self.prefix != ''/'' && !self.prefix.matches(''(^|/)[.][.](/|$)'')
+                && !(self.prefix in [''/router-healthz'',''/readyz'',''/_version'',''/auth/login''])
+                && !self.prefix.startsWith(''/fission-function/''))'
           status:
             description: HTTPTriggerStatus describes the observed state of an HTTPTrigger.
             properties:

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -708,6 +708,14 @@ type (
 	//
 
 	// HTTPTriggerSpec is for router to expose user functions at the given URL path.
+	//
+	// The path rules below close GHSA-vchh-r53j-8mpw: HTTPTrigger no longer has
+	// an admission webhook, so the API server's CEL evaluation is the only place
+	// these invariants can be enforced for kubectl- or REST-created triggers.
+	// Keep these CEL rules in sync with validateTriggerPath in validation.go.
+	// +kubebuilder:validation:XValidation:rule="self.relativeurl != '' || (has(self.prefix) && self.prefix != '')",message="HTTPTriggerSpec: at least one of relativeurl or prefix must be set"
+	// +kubebuilder:validation:XValidation:rule="self.relativeurl == '' || (self.relativeurl.startsWith('/') && self.relativeurl != '/' && !self.relativeurl.matches('(^|/)[.][.](/|$)') && !(self.relativeurl in ['/router-healthz','/readyz','/_version','/auth/login']) && !self.relativeurl.startsWith('/fission-function/'))",message="HTTPTriggerSpec.relativeurl must start with '/', not be '/', not contain '..' path segments, not collide with a router-owned path (/router-healthz, /readyz, /_version, /auth/login), and not start with /fission-function/"
+	// +kubebuilder:validation:XValidation:rule="!has(self.prefix) || self.prefix == '' || (self.prefix.startsWith('/') && self.prefix != '/' && !self.prefix.matches('(^|/)[.][.](/|$)') && !(self.prefix in ['/router-healthz','/readyz','/_version','/auth/login']) && !self.prefix.startsWith('/fission-function/'))",message="HTTPTriggerSpec.prefix must start with '/', not be '/', not contain '..' path segments, not collide with a router-owned path (/router-healthz, /readyz, /_version, /auth/login), and not start with /fission-function/"
 	HTTPTriggerSpec struct {
 		// TODO: remove this field since we have IngressConfig already
 		// Deprecated: the original idea of this field is not for setting Ingress.

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -708,11 +708,6 @@ type (
 	//
 
 	// HTTPTriggerSpec is for router to expose user functions at the given URL path.
-	//
-	// The path rules below close GHSA-vchh-r53j-8mpw: HTTPTrigger no longer has
-	// an admission webhook, so the API server's CEL evaluation is the only place
-	// these invariants can be enforced for kubectl- or REST-created triggers.
-	// Keep these CEL rules in sync with validateTriggerPath in validation.go.
 	// +kubebuilder:validation:XValidation:rule="self.relativeurl != '' || (has(self.prefix) && self.prefix != '')",message="HTTPTriggerSpec: at least one of relativeurl or prefix must be set"
 	// +kubebuilder:validation:XValidation:rule="self.relativeurl == '' || (self.relativeurl.startsWith('/') && self.relativeurl != '/' && !self.relativeurl.matches('(^|/)[.][.](/|$)') && !(self.relativeurl in ['/router-healthz','/readyz','/_version','/auth/login']) && !self.relativeurl.startsWith('/fission-function/'))",message="HTTPTriggerSpec.relativeurl must start with '/', not be '/', not contain '..' path segments, not collide with a router-owned path (/router-healthz, /readyz, /_version, /auth/login), and not start with /fission-function/"
 	// +kubebuilder:validation:XValidation:rule="!has(self.prefix) || self.prefix == '' || (self.prefix.startsWith('/') && self.prefix != '/' && !self.prefix.matches('(^|/)[.][.](/|$)') && !(self.prefix in ['/router-healthz','/readyz','/_version','/auth/login']) && !self.prefix.startsWith('/fission-function/'))",message="HTTPTriggerSpec.prefix must start with '/', not be '/', not contain '..' path segments, not collide with a router-owned path (/router-healthz, /readyz, /_version, /auth/login), and not start with /fission-function/"

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -459,7 +459,71 @@ func (spec HTTPTriggerSpec) Validate() error {
 	if spec.CorsConfig != nil {
 		errs = errors.Join(errs, spec.CorsConfig.Validate())
 	}
+
+	// Path validation. HTTPTrigger has no admission webhook on current main
+	// (the API server's CEL evaluation is the admission gate); these checks
+	// mirror the CEL rules on HTTPTriggerSpec so the CLI and the router
+	// reconciler's status-Condition path agree with what the API server
+	// admits. Closes GHSA-vchh-r53j-8mpw.
+	prefix := ""
+	if spec.Prefix != nil {
+		prefix = *spec.Prefix
+	}
+	if spec.RelativeURL == "" && prefix == "" {
+		errs = errors.Join(errs, MakeValidationErr(ErrorInvalidValue, "HTTPTriggerSpec", "",
+			"at least one of relativeurl or prefix must be set"))
+	}
+	if spec.RelativeURL != "" {
+		errs = errors.Join(errs, validateTriggerPath("HTTPTriggerSpec.RelativeURL", spec.RelativeURL))
+	}
+	if prefix != "" {
+		errs = errors.Join(errs, validateTriggerPath("HTTPTriggerSpec.Prefix", prefix))
+	}
 	return errs
+}
+
+// routerReservedExactPaths are URL paths the router serves itself: liveness
+// (/router-healthz), readiness (/readyz), version (/_version), and the
+// chart-default auth login (/auth/login). Installations that change the auth
+// path must still ensure their custom path does not collide with another
+// HTTPTrigger; this list covers the defaults the router ships with.
+var routerReservedExactPaths = map[string]struct{}{
+	"/router-healthz": {},
+	"/readyz":         {},
+	"/_version":       {},
+	"/auth/login":     {},
+}
+
+// routerInternalFunctionPrefix is the URL prefix the router serves on its
+// internal listener (post-GHSA-3g33-6vg6-27m8) for direct function invocation.
+// Triggers under this prefix would shadow internal routes if the public/
+// internal listener split is misconfigured.
+const routerInternalFunctionPrefix = "/fission-function/"
+
+// validateTriggerPath enforces the URL-path safety invariants for RelativeURL
+// and Prefix in HTTPTriggerSpec. Keep these checks aligned with the CEL rules
+// on HTTPTriggerSpec in types.go.
+func validateTriggerPath(field, path string) error {
+	if !strings.HasPrefix(path, "/") {
+		return MakeValidationErr(ErrorInvalidValue, field, path, "must start with '/'")
+	}
+	if path == "/" {
+		return MakeValidationErr(ErrorInvalidValue, field, path, "root-only path '/' is not allowed")
+	}
+	// Reject any ".." path segment. Splitting on '/' (rather than substring
+	// match) permits literal names like "..foo" or "foo..bar" while catching
+	// the traversal form ".." that the router would otherwise resolve away.
+	if slices.Contains(strings.Split(path, "/"), "..") {
+		return MakeValidationErr(ErrorInvalidValue, field, path, "must not contain '..' path segments")
+	}
+	if _, reserved := routerReservedExactPaths[path]; reserved {
+		return MakeValidationErr(ErrorInvalidValue, field, path, "collides with a router-owned path")
+	}
+	if strings.HasPrefix(path, routerInternalFunctionPrefix) {
+		return MakeValidationErr(ErrorInvalidValue, field, path,
+			"collides with the router-internal "+routerInternalFunctionPrefix+" prefix")
+	}
+	return nil
 }
 
 // Validate enforces the CORS spec invariants that browsers will reject

--- a/pkg/apis/core/v1/validation_validators_test.go
+++ b/pkg/apis/core/v1/validation_validators_test.go
@@ -137,15 +137,91 @@ func TestHTTPTriggerSpecValidate(t *testing.T) {
 	t.Parallel()
 	valid := HTTPTriggerSpec{
 		Methods:           []string{"GET", "POST"},
+		RelativeURL:       "/api/hello",
 		FunctionReference: FunctionReference{Type: FunctionReferenceTypeFunctionName, Name: "hello"},
 	}
 	require.NoError(t, valid.Validate())
 
 	bad := HTTPTriggerSpec{
 		Method:            "FETCH",
+		RelativeURL:       "/api/hello",
 		FunctionReference: FunctionReference{Type: FunctionReferenceTypeFunctionName, Name: "hello"},
 	}
 	require.Error(t, bad.Validate())
+}
+
+// TestHTTPTriggerSpecValidate_Path covers the URL-path safety rules added for
+// GHSA-vchh-r53j-8mpw. Keep these cases aligned with the CEL rules on
+// HTTPTriggerSpec in types.go so the API server's admission decision and the
+// Go-side Validate() decision (used by the CLI and the router reconciler's
+// status-Condition path) stay in lockstep.
+func TestHTTPTriggerSpecValidate_Path(t *testing.T) {
+	t.Parallel()
+	str := func(s string) *string { return &s }
+	fnRef := FunctionReference{Type: FunctionReferenceTypeFunctionName, Name: "hello"}
+
+	for _, tc := range []struct {
+		name        string
+		relativeURL string
+		prefix      *string
+		wantErr     bool
+		errSub      string
+	}{
+		// happy paths
+		{name: "valid relativeurl", relativeURL: "/api/hello"},
+		{name: "valid prefix", prefix: str("/api/")},
+		{name: "valid both set", relativeURL: "/api/hello", prefix: str("/api/")},
+		{name: "literal dot-dot inside segment is allowed", relativeURL: "/api/..foo"},
+		{name: "double-dot suffix in segment is allowed", relativeURL: "/api/foo..bar"},
+
+		// at-least-one-set
+		{name: "neither set", wantErr: true, errSub: "at least one"},
+		{name: "empty relativeurl and empty prefix", prefix: str(""), wantErr: true, errSub: "at least one"},
+
+		// leading slash
+		{name: "no leading slash relativeurl", relativeURL: "hello", wantErr: true, errSub: "must start with '/'"},
+		{name: "no leading slash prefix", prefix: str("hello"), wantErr: true, errSub: "must start with '/'"},
+
+		// root-only
+		{name: "root-only relativeurl", relativeURL: "/", wantErr: true, errSub: "root-only"},
+		{name: "root-only prefix", prefix: str("/"), wantErr: true, errSub: "root-only"},
+
+		// `..` traversal
+		{name: "traversal relativeurl", relativeURL: "/api/../admin", wantErr: true, errSub: "'..'"},
+		{name: "traversal prefix", prefix: str("/api/../admin"), wantErr: true, errSub: "'..'"},
+		{name: "leading traversal", relativeURL: "/..", wantErr: true, errSub: "'..'"},
+		{name: "trailing traversal", relativeURL: "/api/..", wantErr: true, errSub: "'..'"},
+
+		// router-owned exact paths
+		{name: "reserved /router-healthz", relativeURL: "/router-healthz", wantErr: true, errSub: "router-owned"},
+		{name: "reserved /readyz", relativeURL: "/readyz", wantErr: true, errSub: "router-owned"},
+		{name: "reserved /_version", relativeURL: "/_version", wantErr: true, errSub: "router-owned"},
+		{name: "reserved /auth/login", relativeURL: "/auth/login", wantErr: true, errSub: "router-owned"},
+		{name: "reserved path as prefix", prefix: str("/readyz"), wantErr: true, errSub: "router-owned"},
+
+		// router-internal /fission-function/ prefix
+		{name: "internal-prefix relativeurl", relativeURL: "/fission-function/ns/fn", wantErr: true, errSub: "/fission-function/"},
+		{name: "internal-prefix as Prefix field", prefix: str("/fission-function/"), wantErr: true, errSub: "/fission-function/"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			spec := HTTPTriggerSpec{
+				RelativeURL:       tc.relativeURL,
+				Prefix:            tc.prefix,
+				FunctionReference: fnRef,
+				Methods:           []string{"GET"},
+			}
+			err := spec.Validate()
+			if tc.wantErr {
+				require.Error(t, err, "expected error containing %q", tc.errSub)
+				if tc.errSub != "" {
+					require.Contains(t, err.Error(), tc.errSub)
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestIngressConfigValidate(t *testing.T) {
@@ -209,6 +285,7 @@ func TestCRDValidate(t *testing.T) {
 	t.Run("httptrigger", func(t *testing.T) {
 		h := &HTTPTrigger{ObjectMeta: meta}
 		h.Spec.FunctionReference = FunctionReference{Type: FunctionReferenceTypeFunctionName, Name: "hello"}
+		h.Spec.RelativeURL = "/api/hello"
 		require.NoError(t, h.Validate())
 	})
 }


### PR DESCRIPTION
## Summary

Closes **[GHSA-vchh-r53j-8mpw](https://github.com/fission/fission/security/advisories/GHSA-vchh-r53j-8mpw)** (4.3 Medium, CWE-20).

`HTTPTrigger` lost its admission webhook in the recent CRD/CEL/SSA modernization (see `pkg/webhook/service.go:65`), and `HTTPTriggerSpec.Validate()` never checked `RelativeURL` or `Prefix` in the first place. As a result, an HTTPTrigger created via `kubectl apply` or the Kubernetes REST API could:

- Specify an empty path (no `RelativeURL`, no `Prefix`).
- Contain `..` path traversal (e.g. `/api/../admin`).
- Be root-only (`/`).
- Collide with router-owned routes: `/router-healthz`, `/readyz`, `/_version`, `/auth/login`.
- Collide with the router-internal function prefix `/fission-function/<ns>/<name>`.

The `fission` CLI rejected these at `pkg/fission-cli/cmd/httptrigger/create.go`, but `kubectl` / direct REST writes bypassed those checks.

## Approach

Enforce the same path-safety invariants at **both** layers, so admission and the CLI/router-reconciler agree:

1. **CEL admission gate (primary)** — three `+kubebuilder:validation:XValidation` rules on `HTTPTriggerSpec` in `pkg/apis/core/v1/types.go`, regenerated into `crds/v1/fission.io_httptriggers.yaml`:
   - at least one of `relativeurl` / `prefix` is non-empty;
   - `relativeurl`, when set, starts with `/`, is not `/`, contains no `..` segment, is not in the reserved exact-path set, and does not start with `/fission-function/`;
   - `prefix`, when set, the same rules guarded by `has(self.prefix)`.

2. **Go-side `Validate()` (CLI + router status Conditions)** — a `validateTriggerPath` helper in `pkg/apis/core/v1/validation.go`, called from `HTTPTriggerSpec.Validate()` for `RelativeURL` and (when non-empty) `Prefix`. Comments cross-reference the CEL markers so the two layers stay aligned.

3. **Test coverage** — a new table test `TestHTTPTriggerSpecValidate_Path` in `pkg/apis/core/v1/validation_validators_test.go` exercising every PoC case from the advisory (missing-both, no-leading-slash, root-only, leading/middle/trailing `..`, each reserved path, the `/fission-function/` prefix) plus literal `..`-prefixed-segment positives that must remain allowed. The existing `TestCRDValidate/httptrigger` fixture is patched to supply a valid `RelativeURL`.

## Behavior change

An HTTPTrigger with `relativeurl: ""` and no `prefix` is now rejected at admission. The `fission` CLI has rejected this case since the path-validation block in `httptrigger/create.go:71-75` — this PR aligns the API server with that long-standing CLI behavior, which is exactly what the advisory mitigation specifies.

## Test plan

- [x] `go test -race -count=1 ./pkg/apis/core/v1/...` — green, includes the new table test.
- [x] `go test -race -count=1 ./pkg/router/... ./pkg/fission-cli/cmd/httptrigger/... ./pkg/webhook/...` — green; no downstream regression.
- [x] `make code-checks` — 0 issues.
- [x] `make generate-crds` — CRD YAML regenerated (CEL rules visible in `crds/v1/fission.io_httptriggers.yaml`).
- [x] CEL ↔ Go parity walked through for `//abc`, `/api//../foo`, `/..foo`, `/foo..bar`, `/../..`, trailing `/api/` — both layers admit/reject identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3464)
<!-- Reviewable:end -->
