### PR TITLE
fix(executor,fetcher): use native sleep preStop hook instead of exec /bin/sleep

### DIFF
--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -18,6 +18,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
+	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -176,16 +177,8 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 		Name:                   fn.Name,
 		ImagePullPolicy:        cn.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
-		Lifecycle: &apiv1.Lifecycle{
-			PreStop: &apiv1.LifecycleHandler{
-				Exec: &apiv1.ExecAction{
-					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%d", gracePeriodSeconds),
-					},
-				},
-			},
-		},
+		// Connection-draining preStop hook; see utils.DrainLifecycle.
+		Lifecycle: utils.DrainLifecycle(gracePeriodSeconds),
 		Env: []apiv1.EnvVar{
 			{
 				Name:  fv1.ResourceVersionCount,

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -20,6 +20,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
+	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -172,16 +173,8 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		Image:                  env.Spec.Runtime.Image,
 		ImagePullPolicy:        deploy.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
-		Lifecycle: &apiv1.Lifecycle{
-			PreStop: &apiv1.LifecycleHandler{
-				Exec: &apiv1.ExecAction{
-					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%d", gracePeriodSeconds),
-					},
-				},
-			},
-		},
+		// Connection-draining preStop hook; see utils.DrainLifecycle.
+		Lifecycle: utils.DrainLifecycle(gracePeriodSeconds),
 		Env: []apiv1.EnvVar{
 			{
 				Name:  fv1.ResourceVersionCount,

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -18,6 +18,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
+	"github.com/fission/fission/pkg/utils"
 )
 
 // getPoolName returns a unique name of an environment
@@ -102,22 +103,8 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 		ImagePullPolicy:        gp.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
 		Resources:              env.Spec.Resources,
-		// Pod is removed from endpoints list for service when it's
-		// state became "Termination". We used preStop hook as the
-		// workaround for connection draining since pod maybe shutdown
-		// before grace period expires.
-		// https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-		// https://github.com/kubernetes/kubernetes/issues/47576#issuecomment-308900172
-		Lifecycle: &apiv1.Lifecycle{
-			PreStop: &apiv1.LifecycleHandler{
-				Exec: &apiv1.ExecAction{
-					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%d", gracePeriodSeconds),
-					},
-				},
-			},
-		},
+		// Connection-draining preStop hook; see utils.DrainLifecycle.
+		Lifecycle: utils.DrainLifecycle(gracePeriodSeconds),
 		// https://istio.io/docs/setup/kubernetes/additional-setup/requirements/
 		Ports: []apiv1.ContainerPort{
 			{

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -137,8 +137,8 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 			ServiceAccountName:           fv1.FissionFetcherSA,
 			AutomountServiceAccountToken: &automountSAToken,
 			// TerminationGracePeriodSeconds should be equal to the
-			// sleep time of preStop to make sure that SIGTERM is sent
-			// to pod after 6 mins.
+			// preStop sleep so SIGTERM is only sent once the drain
+			// window has elapsed.
 			TerminationGracePeriodSeconds: &gracePeriodSeconds,
 			Volumes: []apiv1.Volume{
 				util.FetcherSATokenProjectedVolume(),

--- a/pkg/executor/executortype/poolmgr/gp_deployment_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment_test.go
@@ -19,6 +19,62 @@ import (
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
+// TestGenDeploymentSpecPreStopLifecycle asserts that genDeploymentSpec sets a
+// kubelet-native Sleep preStop hook on the runtime container for a positive
+// TerminationGracePeriod, and sets nil Lifecycle when the grace period is 0
+// (no drain window needed, and Kubernetes rejects Sleep.Seconds < 1).
+func TestGenDeploymentSpecPreStopLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("positive grace period uses native sleep", func(t *testing.T) {
+		t.Parallel()
+		gp := newTestGenericPool(t)
+		env := newTestEnv()
+		env.Spec.TerminationGracePeriod = 360
+
+		deploymentSpec, err := gp.genDeploymentSpec(env)
+		require.NoError(t, err)
+
+		// Locate the runtime (user) container — it carries the preStop hook.
+		var runtimeContainer *apiv1.Container
+		for i := range deploymentSpec.Template.Spec.Containers {
+			if deploymentSpec.Template.Spec.Containers[i].Name == envContainerName {
+				runtimeContainer = &deploymentSpec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, runtimeContainer, "runtime container must be present in the deployment spec")
+		require.NotNil(t, runtimeContainer.Lifecycle, "runtime container must have a Lifecycle set")
+		require.NotNil(t, runtimeContainer.Lifecycle.PreStop, "runtime container Lifecycle.PreStop must be set")
+
+		preStop := runtimeContainer.Lifecycle.PreStop
+		assert.Nil(t, preStop.Exec, "PreStop.Exec must be nil — no /bin/sleep exec")
+		require.NotNil(t, preStop.Sleep, "PreStop.Sleep must be set for kubelet-native drain")
+		assert.Equal(t, int64(360), preStop.Sleep.Seconds, "PreStop.Sleep.Seconds must equal the environment TerminationGracePeriod")
+	})
+
+	t.Run("zero grace period produces nil lifecycle", func(t *testing.T) {
+		t.Parallel()
+		gp := newTestGenericPool(t)
+		env := newTestEnv()
+		env.Spec.TerminationGracePeriod = 0
+
+		deploymentSpec, err := gp.genDeploymentSpec(env)
+		require.NoError(t, err)
+
+		var runtimeContainer *apiv1.Container
+		for i := range deploymentSpec.Template.Spec.Containers {
+			if deploymentSpec.Template.Spec.Containers[i].Name == envContainerName {
+				runtimeContainer = &deploymentSpec.Template.Spec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, runtimeContainer, "runtime container must be present in the deployment spec")
+		assert.Nil(t, runtimeContainer.Lifecycle,
+			"runtime container Lifecycle must be nil when TerminationGracePeriod is 0 (no drain window, Sleep.Seconds>=1 is required by the API)")
+	})
+}
+
 const envContainerName = "test-env"
 
 func TestGetPoolName(t *testing.T) {

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -309,23 +309,11 @@ func (cfg *Config) addFetcherToPodSpecWithCommand(podSpec *apiv1.PodSpec, mainCo
 		Env: append(otel.OtelEnvForContainer(), internalAuthEnvVars()...),
 	}
 
-	// Pod is removed from endpoints list for service when it's
-	// state became "Termination". We used preStop hook as the
-	// workaround for connection draining since pod maybe shutdown
-	// before grace period expires.
-	// https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-	// https://github.com/kubernetes/kubernetes/issues/47576#issuecomment-308900172
+	// Connection-draining preStop hook; see utils.DrainLifecycle. Must be
+	// the kubelet-native sleep action — the fetcher image is distroless
+	// (chainguard/static) and has no /bin/sleep to exec.
 	if podSpec.TerminationGracePeriodSeconds != nil {
-		c.Lifecycle = &apiv1.Lifecycle{
-			PreStop: &apiv1.LifecycleHandler{
-				Exec: &apiv1.ExecAction{
-					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%v", *podSpec.TerminationGracePeriodSeconds),
-					},
-				},
-			},
-		}
+		c.Lifecycle = utils.DrainLifecycle(*podSpec.TerminationGracePeriodSeconds)
 	}
 
 	found := false

--- a/pkg/fetcher/config/config_test.go
+++ b/pkg/fetcher/config/config_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// TestAddFetcherToPodSpecPreStopLifecycle asserts that addFetcherToPodSpecWithCommand
+// (exercised through the exported AddFetcherToPodSpec entry point) sets a
+// kubelet-native Sleep preStop hook on the fetcher sidecar container when the
+// pod's TerminationGracePeriodSeconds is positive, and nil Lifecycle when it
+// is zero. The fetcher image is distroless (chainguard/static) and has no
+// /bin/sleep binary, so an exec-based hook would fail on every termination.
+func TestAddFetcherToPodSpecPreStopLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("positive grace period uses native sleep", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := MakeFetcherConfig("/userfunc")
+		require.NoError(t, err)
+
+		grace := int64(360)
+		podSpec := &apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{Name: "user"},
+			},
+			TerminationGracePeriodSeconds: &grace,
+		}
+
+		err = cfg.AddFetcherToPodSpec(podSpec, "user")
+		require.NoError(t, err)
+
+		// Locate the fetcher sidecar that was injected.
+		var fetcherContainer *apiv1.Container
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == "fetcher" {
+				fetcherContainer = &podSpec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, fetcherContainer, "fetcher container must be injected into the pod spec")
+		require.NotNil(t, fetcherContainer.Lifecycle, "fetcher Lifecycle must be set")
+		require.NotNil(t, fetcherContainer.Lifecycle.PreStop, "fetcher Lifecycle.PreStop must be set")
+
+		preStop := fetcherContainer.Lifecycle.PreStop
+		assert.Nil(t, preStop.Exec, "PreStop.Exec must be nil — fetcher image has no /bin/sleep")
+		require.NotNil(t, preStop.Sleep, "PreStop.Sleep must be set for kubelet-native drain")
+		assert.Equal(t, int64(360), preStop.Sleep.Seconds,
+			"PreStop.Sleep.Seconds must equal the pod's TerminationGracePeriodSeconds")
+	})
+
+	t.Run("zero grace period produces nil lifecycle", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := MakeFetcherConfig("/userfunc")
+		require.NoError(t, err)
+
+		grace := int64(0)
+		podSpec := &apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{Name: "user"},
+			},
+			TerminationGracePeriodSeconds: &grace,
+		}
+
+		err = cfg.AddFetcherToPodSpec(podSpec, "user")
+		require.NoError(t, err)
+
+		var fetcherContainer *apiv1.Container
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == "fetcher" {
+				fetcherContainer = &podSpec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, fetcherContainer, "fetcher container must be injected into the pod spec")
+		assert.Nil(t, fetcherContainer.Lifecycle,
+			"fetcher Lifecycle must be nil when grace=0 (no drain window; Sleep.Seconds>=1 required by the API)")
+	})
+
+	t.Run("nil grace period leaves lifecycle unset", func(t *testing.T) {
+		t.Parallel()
+		cfg, err := MakeFetcherConfig("/userfunc")
+		require.NoError(t, err)
+
+		podSpec := &apiv1.PodSpec{
+			Containers: []apiv1.Container{
+				{Name: "user"},
+			},
+			TerminationGracePeriodSeconds: nil,
+		}
+
+		err = cfg.AddFetcherToPodSpec(podSpec, "user")
+		require.NoError(t, err)
+
+		var fetcherContainer *apiv1.Container
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == "fetcher" {
+				fetcherContainer = &podSpec.Containers[i]
+				break
+			}
+		}
+		require.NotNil(t, fetcherContainer, "fetcher container must be injected into the pod spec")
+		assert.Nil(t, fetcherContainer.Lifecycle,
+			"fetcher Lifecycle must be nil when TerminationGracePeriodSeconds is nil")
+	})
+}

--- a/pkg/utils/lifecycle.go
+++ b/pkg/utils/lifecycle.go
@@ -18,9 +18,8 @@ import (
 // binary, and an exec'd sleep spanning the whole grace window is always
 // SIGKILLed at expiry, failing the hook on every termination.
 //
-// A non-positive grace returns nil: there is no drain window to hold open.
-// The API server's validation enforces Seconds >= 1 for sleep actions, so
-// zero is not a valid hook anyway.
+// A non-positive grace returns nil: there is no drain window to hold open,
+// so the hook is omitted entirely.
 func DrainLifecycle(gracePeriodSeconds int64) *apiv1.Lifecycle {
 	if gracePeriodSeconds <= 0 {
 		return nil

--- a/pkg/utils/lifecycle.go
+++ b/pkg/utils/lifecycle.go
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+)
+
+// DrainLifecycle returns a preStop lifecycle that keeps a terminating pod
+// alive for the full grace period so the router/endpoints controller can
+// drop it from rotation before the process is killed (connection draining,
+// see https://github.com/kubernetes/kubernetes/issues/47576#issuecomment-308900172).
+//
+// It uses the kubelet-native sleep action (GA since Kubernetes 1.30) instead
+// of `exec /bin/sleep`: distroless images (e.g. the fetcher) have no sleep
+// binary, and an exec'd sleep spanning the whole grace window is always
+// SIGKILLed at expiry, failing the hook on every termination.
+//
+// A non-positive grace returns nil: there is no drain window to hold open.
+// The API server's validation enforces Seconds >= 1 for sleep actions, so
+// zero is not a valid hook anyway.
+func DrainLifecycle(gracePeriodSeconds int64) *apiv1.Lifecycle {
+	if gracePeriodSeconds <= 0 {
+		return nil
+	}
+	return &apiv1.Lifecycle{
+		PreStop: &apiv1.LifecycleHandler{
+			Sleep: &apiv1.SleepAction{Seconds: gracePeriodSeconds},
+		},
+	}
+}

--- a/pkg/utils/lifecycle_test.go
+++ b/pkg/utils/lifecycle_test.go
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDrainLifecycle(t *testing.T) {
+	t.Parallel()
+
+	t.Run("positive grace returns native sleep preStop", func(t *testing.T) {
+		t.Parallel()
+		lc := DrainLifecycle(360)
+		require.NotNil(t, lc)
+		require.NotNil(t, lc.PreStop)
+		require.NotNil(t, lc.PreStop.Sleep)
+		assert.Nil(t, lc.PreStop.Exec)
+		assert.Equal(t, int64(360), lc.PreStop.Sleep.Seconds)
+	})
+
+	t.Run("zero grace returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, DrainLifecycle(0))
+	})
+
+	t.Run("negative grace returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, DrainLifecycle(-1))
+	})
+}


### PR DESCRIPTION
## Problem

Every function-pod termination currently fails its preStop hook. CI log analysis of one integration run (kind v1.36.1 leg) found **299 kubelet `FailedPreStopHook` errors + 276 `ExecSync` failures**, in three flavors:

| Flavor | Count | Cause |
|---|---|---|
| `exec: "/bin/sleep": no such file or directory` (fetcher container) | 273 | The fetcher image is `cgr.dev/chainguard/static` — distroless, no shell, no sleep binary |
| `command '/bin/sleep N' exited with 137` (runtime containers) | 23 | The hook sleeps the **full** grace period, so kubelet SIGKILLs it at grace expiry — it can never exit cleanly |
| `/bin/sleep 0` exec round-trips | 192 | grace=0 produces a no-op hook that still costs a CRI ExecSync |

## Fix

Replace the four `exec /bin/sleep <grace>` sites with the **kubelet-native sleep lifecycle handler** (`lifecycle.preStop.sleep`, GA since Kubernetes 1.30; our floor is 1.32), via a new shared helper:

- `pkg/utils.DrainLifecycle(gracePeriodSeconds)` — returns a `SleepAction` preStop, or nil when grace <= 0 (no drain window to hold open).
- Wired into: poolmgr (`gp_deployment.go`), newdeploy (`newdeploy.go`), container (`deployment.go`), and the fetcher sidecar (`fetcher/config/config.go` — the distroless one).

The native handler runs inside the kubelet (no exec, no binary needed) and is terminated cleanly at grace expiry, so the hook works on distroless images and never reports failure.

Connection-draining semantics are unchanged: the pod is held in Terminating for the same grace window (k8s [#47576](https://github.com/kubernetes/kubernetes/issues/47576)).

## Tests

- `pkg/utils/lifecycle_test.go` — helper unit tests (positive/zero/negative grace).
- `pkg/executor/executortype/poolmgr/gp_deployment_test.go` — generated deployment spec carries the Sleep hook (and no hook at grace=0).
- `pkg/fetcher/config/config_test.go` (new) — fetcher container lifecycle via `AddFetcherToPodSpec` for grace=360/0/nil.

## Verification

- `go build ./pkg/... ./cmd/...` clean; `make code-checks` 0 issues; `grep -rn '"/bin/sleep"' pkg/` empty.
- Post-merge check: `kubectl get events -A --field-selector reason=FailedPreStopHook` during a test run should be empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3468)
<!-- Reviewable:end -->
