### PR TITLE
fix: tolerate deletion races and stop logging routine churn as errors

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -217,7 +217,7 @@ func (builder *Builder) Clean(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		e := "error deleting src package after build"
 		logger.Error(err, e)
-		builder.reply(r.Context(), w, srcPkgFilename, "", http.StatusInternalServerError)
+		builder.reply(r.Context(), w, srcPkgFilename, fmt.Sprintf("%s: %s", e, err.Error()), http.StatusInternalServerError)
 		return
 	}
 

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -68,7 +68,10 @@ func buildPackage(ctx context.Context, logger logr.Logger, fissionClient version
 		logger.Info("cleaning src pkg from builder storage", "source_package", srcPkgFilename)
 		if errC := cleanPackage(ctx, builderC, srcPkgFilename); errC != nil {
 			if ferror.IsNotFound(errC) {
-				return // already gone — fine
+				// Defensive: today's builder Clean never 404s (os.RemoveAll
+				// is idempotent), but a future handler that does shouldn't
+				// log "already gone" as an error.
+				return
 			}
 			logger.Error(errC, "error cleaning src pkg from builder storage",
 				"source_package", srcPkgFilename,

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -66,10 +66,13 @@ func buildPackage(ctx context.Context, logger logr.Logger, fissionClient version
 
 	defer func() {
 		logger.Info("cleaning src pkg from builder storage", "source_package", srcPkgFilename)
-		errC := cleanPackage(ctx, builderC, srcPkgFilename)
-		if errC != nil {
-			m := "error cleaning src pkg from builder storage"
-			logger.Error(errC, m)
+		if errC := cleanPackage(ctx, builderC, srcPkgFilename); errC != nil {
+			if ferror.IsNotFound(errC) {
+				return // already gone — fine
+			}
+			logger.Error(errC, "error cleaning src pkg from builder storage",
+				"source_package", srcPkgFilename,
+				"package", pkg.Name, "package_namespace", pkg.Namespace)
 		}
 	}()
 

--- a/pkg/buildermgr/package_reconciler.go
+++ b/pkg/buildermgr/package_reconciler.go
@@ -83,6 +83,11 @@ func (r *PackageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		// buildTriggerPredicate) when a build is actually needed; deploy-only
 		// packages settle on "none" and are not built.
 		if _, err := setInitialBuildStatus(ctx, r.fissionClient, pkg); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Package deleted between our Get and the status write —
+				// nothing to initialize.
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, fmt.Errorf("error setting initial package build status: %w", err)
 		}
 		return ctrl.Result{}, nil

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -183,7 +183,7 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var errs error
+	var errs, notFound error
 	for _, req := range tapSvcReqs {
 		svcHost := strings.TrimPrefix(req.ServiceURL, "http://")
 
@@ -195,10 +195,13 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
-		err = et.TapService(ctx, svcHost)
-		if err != nil {
-			errs = errors.Join(errs,
-				fmt.Errorf("error tapping function '%s/%s' with executor '%s' and service url '%s': %w", req.FnMetadata.Namespace, req.FnMetadata.Name, req.FnExecutorType, req.ServiceURL, err))
+		if err := et.TapService(ctx, svcHost); err != nil {
+			wrapped := fmt.Errorf("error tapping function '%s/%s' with executor '%s' and service url '%s': %w", req.FnMetadata.Namespace, req.FnMetadata.Name, req.FnExecutorType, req.ServiceURL, err)
+			if ferror.IsNotFound(err) {
+				notFound = errors.Join(notFound, wrapped)
+			} else {
+				errs = errors.Join(errs, wrapped)
+			}
 		}
 	}
 
@@ -207,7 +210,14 @@ func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}
-
+	if notFound != nil {
+		// Expired/deleted fsvcs are routine churn — the router's entry is
+		// stale, not broken. Still 404 so the caller knows, but not an
+		// error-level log.
+		logger.V(1).Info("tap skipped for expired function services", "detail", notFound.Error())
+		http.Error(w, "Not found", http.StatusNotFound)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/executor/api_tapservices_test.go
+++ b/pkg/executor/api_tapservices_test.go
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package executor
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
+	"github.com/fission/fission/pkg/executor/client"
+	"github.com/fission/fission/pkg/executor/executortype"
+)
+
+// tapStubExecutorType implements executortype.ExecutorType by embedding the
+// interface (nil) and overriding only TapService, which is all tapServices
+// touches.
+type tapStubExecutorType struct {
+	executortype.ExecutorType
+	err error
+}
+
+func (s *tapStubExecutorType) TapService(_ context.Context, _ string) error {
+	return s.err
+}
+
+// recordingSink captures whether Error() was ever invoked on the logger, so a
+// test can assert routine churn does NOT log at error level.
+type recordingSink struct {
+	mu       sync.Mutex
+	errCalls int
+}
+
+func (s *recordingSink) Init(logr.RuntimeInfo)          {}
+func (s *recordingSink) Enabled(int) bool               { return true }
+func (s *recordingSink) Info(int, string, ...any)       {}
+func (s *recordingSink) WithValues(...any) logr.LogSink { return s }
+func (s *recordingSink) WithName(string) logr.LogSink   { return s }
+func (s *recordingSink) Error(error, string, ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errCalls++
+}
+
+func (s *recordingSink) errors() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.errCalls
+}
+
+func tapBody(t *testing.T, reqs ...client.TapServiceRequest) *http.Request {
+	t.Helper()
+	b, err := json.Marshal(reqs)
+	require.NoError(t, err)
+	return httptest.NewRequest(http.MethodPost, "/v2/tapServices", bytes.NewReader(b))
+}
+
+func tapReq(et fv1.ExecutorType) client.TapServiceRequest {
+	return client.TapServiceRequest{
+		FnMetadata:     metav1.ObjectMeta{Name: "fn", Namespace: "default"},
+		FnExecutorType: et,
+		ServiceURL:     "http://10.0.0.1:8888",
+	}
+}
+
+func TestTapServices(t *testing.T) {
+	notFound := ferror.MakeError(ferror.ErrorNotFound, "no such entry")
+
+	tests := []struct {
+		name          string
+		stub          *tapStubExecutorType
+		req           client.TapServiceRequest
+		wantCode      int
+		wantErrLevels int
+	}{
+		{
+			name:          "success -> 200, no error log",
+			stub:          &tapStubExecutorType{err: nil},
+			req:           tapReq(fv1.ExecutorTypePoolmgr),
+			wantCode:      http.StatusOK,
+			wantErrLevels: 0,
+		},
+		{
+			name:          "expired fsvc (NotFound) -> 404, no error log",
+			stub:          &tapStubExecutorType{err: notFound},
+			req:           tapReq(fv1.ExecutorTypePoolmgr),
+			wantCode:      http.StatusNotFound,
+			wantErrLevels: 0,
+		},
+		{
+			name:          "wrapped NotFound -> 404, no error log",
+			stub:          &tapStubExecutorType{err: fmt.Errorf("touch failed: %w", notFound)},
+			req:           tapReq(fv1.ExecutorTypePoolmgr),
+			wantCode:      http.StatusNotFound,
+			wantErrLevels: 0,
+		},
+		{
+			name:          "real error -> 404, error logged",
+			stub:          &tapStubExecutorType{err: errors.New("kaboom")},
+			req:           tapReq(fv1.ExecutorTypePoolmgr),
+			wantCode:      http.StatusNotFound,
+			wantErrLevels: 1,
+		},
+		{
+			name:          "unknown executor type -> 404, error logged",
+			stub:          &tapStubExecutorType{err: nil},
+			req:           tapReq("does-not-exist"),
+			wantCode:      http.StatusNotFound,
+			wantErrLevels: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			sink := &recordingSink{}
+			e := &Executor{
+				logger: logr.New(sink),
+				executorTypes: map[fv1.ExecutorType]executortype.ExecutorType{
+					fv1.ExecutorTypePoolmgr: tc.stub,
+				},
+			}
+			rec := httptest.NewRecorder()
+			e.tapServices(rec, tapBody(t, tc.req))
+			assert.Equal(t, tc.wantCode, rec.Code)
+			assert.Equal(t, tc.wantErrLevels, sink.errors(),
+				"error-level log count mismatch")
+		})
+	}
+}

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -169,7 +169,9 @@ func (c *client) service() {
 				c.logger.V(1).Info("tapped services in batch", "service_count", len(urls))
 				err := c._tapService(context.Background(), svcReqs)
 				if err != nil {
-					c.logger.Error(err, "error tapping function service address")
+					// Best-effort atime refresh; a 404 here just means some
+					// entries expired on the executor side.
+					c.logger.V(1).Info("error tapping function service address", "error", err.Error())
 				}
 			}()
 		}

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -604,24 +604,27 @@ func (caaf *Container) fnDelete(ctx context.Context, fn *fv1.Function) error {
 	// is deleted and cause Container backend fails to delete the entry.
 	// Use GetByFunctionUID instead of GetByFunction here to find correct
 	// fsvc entry.
+	objName := caaf.getObjName(fn)
 	fsvc, err := caaf.fsCache.GetByFunctionUID(fn.UID)
 	if err != nil {
-		return fmt.Errorf("fsvc not found in cache %s: %w", k8sCache.MetaObjectToName(fn), err)
-	}
-
-	objName := fsvc.Name
-
-	_, err = caaf.fsCache.DeleteOld(fsvc, time.Second*0)
-	if err != nil {
-		multierr = errors.Join(multierr, fmt.Errorf("error deleting function from cache: %w", err))
+		// Not in cache (never specialized, evicted, or executor restarted).
+		// The backing object names are deterministic, so proceed with
+		// cleanup using the computed name instead of failing — bailing out
+		// here would leak the Deployment/Service/HPA.
+		caaf.logger.V(1).Info("fsvc not in cache, cleaning up by computed name",
+			"function", k8sCache.MetaObjectToName(fn), "obj_name", objName)
+	} else {
+		objName = fsvc.Name
+		if _, err := caaf.fsCache.DeleteOld(fsvc, time.Second*0); err != nil {
+			multierr = errors.Join(multierr, fmt.Errorf("error deleting function from cache: %w", err))
+		}
 	}
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns, so cleaning up resources there
 	ns := caaf.nsResolver.GetFunctionNS(fn.Namespace)
 
-	err = caaf.cleanupContainer(ctx, ns, objName)
-	multierr = errors.Join(multierr, err)
+	multierr = errors.Join(multierr, caaf.cleanupContainer(ctx, ns, objName))
 	return multierr
 }
 

--- a/pkg/executor/executortype/container/deployment_test.go
+++ b/pkg/executor/executortype/container/deployment_test.go
@@ -15,6 +15,9 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
+	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -116,6 +119,29 @@ func TestContainerGetDeploymentSpec(t *testing.T) {
 		assert.Equal(t, "Function", deployment.OwnerReferences[0].Kind)
 		assert.Equal(t, "ctr-fn", deployment.OwnerReferences[0].Name)
 	})
+}
+
+// TestContainerFnDeleteCacheMiss verifies that deleting a function whose fsvc
+// is absent from the in-memory cache (never specialized, evicted, or executor
+// restarted) does not error out — it must fall back to the deterministic
+// computed object name and clean up the backing objects instead of leaking
+// them.
+func TestContainerFnDeleteCacheMiss(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	cn := &Container{
+		logger:           logger,
+		kubernetesClient: fake.NewClientset(),
+		fsCache:          fscache.MakeFunctionServiceCache(logger),
+		nsResolver:       utils.DefaultNSResolver(),
+		hpaops:           hpautils.NewHpaOperations(logger, fake.NewClientset(), "test-instance"),
+	}
+
+	fn := newTestContainerFunction()
+	fn.UID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+	// fsCache is intentionally left empty so GetByFunctionUID misses.
+	require.NoError(t, cn.fnDelete(t.Context(), fn),
+		"fnDelete must tolerate a cache miss and clean up by computed name")
 }
 
 func TestContainerGetResources(t *testing.T) {

--- a/pkg/executor/executortype/newdeploy/newdeploy_test.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy_test.go
@@ -14,8 +14,11 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/util"
+	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
+	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -74,6 +77,29 @@ func newTestNewDeployFunction() *fv1.Function {
 			},
 		},
 	}
+}
+
+// TestNewDeployFnDeleteCacheMiss verifies that deleting a function whose fsvc
+// is absent from the in-memory cache (never specialized, evicted, or executor
+// restarted) does not error out — it must fall back to the deterministic
+// computed object name and clean up the backing objects instead of leaking
+// them.
+func TestNewDeployFnDeleteCacheMiss(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	deploy := &NewDeploy{
+		logger:           logger,
+		kubernetesClient: fake.NewSimpleClientset(),
+		fsCache:          fscache.MakeFunctionServiceCache(logger),
+		nsResolver:       utils.DefaultNSResolver(),
+		hpaops:           hpautils.NewHpaOperations(logger, fake.NewSimpleClientset(), "test-instance"),
+	}
+
+	fn := newTestNewDeployFunction()
+	fn.UID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+	// fsCache is intentionally left empty so GetByFunctionUID misses.
+	require.NoError(t, deploy.fnDelete(t.Context(), fn),
+		"fnDelete must tolerate a cache miss and clean up by computed name")
 }
 
 // TestNewDeployPodSpecDoesNotAutomountTokenInUserContainer asserts the

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -762,24 +762,27 @@ func (deploy *NewDeploy) fnDelete(ctx context.Context, fn *fv1.Function) error {
 	// is deleted and cause newdeploy backend fails to delete the entry.
 	// Use GetByFunctionUID instead of GetByFunction here to find correct
 	// fsvc entry.
+	objName := deploy.getObjName(fn)
 	fsvc, err := deploy.fsCache.GetByFunctionUID(fn.UID)
 	if err != nil {
-		return fmt.Errorf("fsvc not found in cache: %s: %w", k8sCache.MetaObjectToName(fn), err)
-	}
-
-	objName := fsvc.Name
-
-	_, err = deploy.fsCache.DeleteOld(fsvc, time.Second*0)
-	if err != nil {
-		errs = errors.Join(errs, fmt.Errorf("error deleting the function from cache"))
+		// Not in cache (never specialized, evicted, or executor restarted).
+		// The backing object names are deterministic, so proceed with
+		// cleanup using the computed name instead of failing — bailing out
+		// here would leak the Deployment/Service/HPA.
+		deploy.logger.V(1).Info("fsvc not in cache, cleaning up by computed name",
+			"function", k8sCache.MetaObjectToName(fn), "obj_name", objName)
+	} else {
+		objName = fsvc.Name
+		if _, err := deploy.fsCache.DeleteOld(fsvc, time.Second*0); err != nil {
+			errs = errors.Join(errs, fmt.Errorf("error deleting the function from cache"))
+		}
 	}
 
 	// to support backward compatibility, if the function was created in default ns, we fall back to creating the
 	// deployment of the function in fission-function ns, so cleaning up resources there
 	ns := deploy.nsResolver.GetFunctionNS(fn.Namespace)
 
-	err = deploy.cleanupNewdeploy(ctx, ns, objName)
-	errs = errors.Join(errs, err)
+	errs = errors.Join(errs, deploy.cleanupNewdeploy(ctx, ns, objName))
 
 	return errs
 }

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -698,6 +698,14 @@ func (gp *GenericPool) destroy(ctx context.Context) error {
 	err := gp.kubernetesClient.AppsV1().
 		Deployments(gp.fnNamespace).Delete(ctx, gp.deployment.Name, delOpt)
 	if err != nil {
+		if k8s_err.IsNotFound(err) {
+			// Already gone (e.g. namespace teardown raced us) — destroy is
+			// idempotent, nothing left to do.
+			gp.logger.V(1).Info("deployment already deleted",
+				"deployment_name", gp.deployment.Name,
+				"deployment_namespace", gp.fnNamespace)
+			return nil
+		}
 		gp.logger.Error(err, "error destroying deployment", "deployment_name", gp.deployment.Name,
 			"deployment_namespace", gp.fnNamespace)
 		return err

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -532,7 +532,7 @@ func (gpm *GenericPoolManager) service() {
 			key := crd.CacheKeyUIDFromMeta(&req.env.ObjectMeta)
 			pool, ok := gpm.pools[key]
 			if !ok {
-				gpm.logger.Error(nil, "Could not find pool", "environment", env.Name, "namespace", env.Namespace)
+				gpm.logger.Info("pool already removed", "environment", env.Name, "namespace", env.Namespace)
 				continue
 			}
 			delete(gpm.pools, key)


### PR DESCRIPTION
## Problem

CI log analysis of a single integration run found Fission components logging **errors for routine deletion churn**, training operators to ignore the error log:

| Component | Error (per-run count) |
|---|---|
| executor | `error destroying deployment ... not found` → `failed to destroy pool` (on already-deleted pools) |
| executor | `Reconciler error: error deleting kubernetes objects of function ...: fsvc not found in cache` (3×) |
| buildermgr | `Reconciler error: error setting initial package build status: packages "X" not found` (3×) |
| buildermgr | `error cleaning src pkg from builder storage: Internal error - {"artifactFilename":...,"buildLogs":""}` — raw JSON, real cause lost (2×) |
| executor + router | `error tapping function service (address)` for expired fsvcs (8×) |

## Fixes (one commit each)

1. **poolmgr**: pool destroy treats NotFound as success (idempotent delete); missing-pool on CLEANUP downgraded to Info.
2. **buildermgr**: package reconciler returns cleanly when the Package was deleted between Get and the initial status write.
3. **executor (newdeploy + container)**: `fnDelete` no longer aborts on an fsvc cache miss — it falls back to the deterministic computed object name and still cleans up. **This also fixes a real leak**: previously a cache miss (never specialized / evicted / executor restarted) left the backing Deployment/Service/HPA orphaned and wedged the finalizer. Covered by new cache-miss tests in both backends.
4. **builder + buildermgr**: the builder `Clean` 500-path now carries the underlying error instead of an empty reply struct; the buildermgr clean log gains `source_package`/`package` context. (Builder half ships with the next env-builder image rebuild.)
5. **executor**: `tapServices` splits expired-fsvc churn (V(1), still HTTP 404 — the 404 rate stays visible in HTTP metrics) from real errors (still Error level); router-side batch-tap log downgraded to V(1). Covered by a new table-driven handler test asserting log levels per case.

## Review notes

An adversarial error-handling review traced each relaxation end-to-end; all five are scoped to genuine NotFound/idempotent churn — real failures still log at Error level, and mass tap failure remains visible via `code="404"` HTTP metrics. One pre-existing (not introduced here) specialize-vs-delete race was identified; follow-up: short-circuit `fnCreate` when `fn.DeletionTimestamp != nil`.

## Verification

`go build ./pkg/... ./cmd/...` clean; `go test -race ./pkg/executor/... ./pkg/buildermgr/ ./pkg/builder/...` green; `make code-checks` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3469)
<!-- Reviewable:end -->
