### PR TITLE
fix(test): retry Function status writes on conflict

### DIFF
--- a/test/integration/suites/common/conditions_test.go
+++ b/test/integration/suites/common/conditions_test.go
@@ -51,6 +51,25 @@ func minimalFunction(name, namespace string) *fv1.Function {
 // remain stable once controllers begin populating their own conditions.
 const smokeConditionType = "fission.io/integration-test-smoke"
 
+// updateFunctionStatusWithRetry applies mutate to a fresh read of the
+// Function and submits it via UpdateStatus under RetryOnConflict. A bare
+// Get → mutate → UpdateStatus races the controllers that write to a
+// freshly created Function (409 "the object has been modified" flakes in
+// CI), so every status write in these tests must go through this helper.
+func updateFunctionStatusWithRetry(ctx context.Context, t *testing.T, f *framework.Framework, namespace, name string, mutate func(*fv1.Function)) {
+	t.Helper()
+	fc := f.FissionClient().CoreV1()
+	require.NoError(t, retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fn, err := fc.Functions(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		mutate(fn)
+		_, err = fc.Functions(namespace).UpdateStatus(ctx, fn, metav1.UpdateOptions{})
+		return err
+	}), "status update must succeed (with conflict retries)")
+}
+
 // TestConditions_FunctionStatusSubresource creates a Function via the
 // typed client, writes a uniquely-typed condition via UpdateStatus, and
 // re-fetches to verify the apiserver persists it through the new status
@@ -73,18 +92,16 @@ func TestConditions_FunctionStatusSubresource(t *testing.T) {
 		_ = fc.Functions(ns.Name).Delete(context.Background(), name, metav1.DeleteOptions{})
 	})
 
-	fn, err := fc.Functions(ns.Name).Get(ctx, name, metav1.GetOptions{})
-	require.NoError(t, err)
-	fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
-		Type:               smokeConditionType,
-		Status:             metav1.ConditionUnknown,
-		Reason:             "ConditionsSmoke",
-		Message:            "set by TestConditions_FunctionStatusSubresource",
-		LastTransitionTime: metav1.Now(),
-		ObservedGeneration: fn.Generation,
+	updateFunctionStatusWithRetry(ctx, t, f, ns.Name, name, func(fn *fv1.Function) {
+		fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
+			Type:               smokeConditionType,
+			Status:             metav1.ConditionUnknown,
+			Reason:             "ConditionsSmoke",
+			Message:            "set by TestConditions_FunctionStatusSubresource",
+			LastTransitionTime: metav1.Now(),
+			ObservedGeneration: fn.Generation,
+		})
 	})
-	_, err = fc.Functions(ns.Name).UpdateStatus(ctx, fn, metav1.UpdateOptions{})
-	require.NoError(t, err, "UpdateStatus on the new /status subresource must succeed")
 
 	got := ns.GetFunctionConditions(t, ctx, name)
 	c := conditions.Find(got, smokeConditionType)
@@ -239,15 +256,15 @@ func TestConditions_StatusSubresourceIsolated(t *testing.T) {
 
 	// Mutate both spec and status; submit via UpdateStatus.
 	// The apiserver must drop the spec change (subresource semantics).
-	fn.Spec.Environment.Name = "conds-tampered"
-	fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
-		Type:               smokeConditionType,
-		Status:             metav1.ConditionTrue,
-		Reason:             "Tampering",
-		LastTransitionTime: metav1.Now(),
+	updateFunctionStatusWithRetry(ctx, t, f, ns.Name, name, func(fn *fv1.Function) {
+		fn.Spec.Environment.Name = "conds-tampered"
+		fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
+			Type:               smokeConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Tampering",
+			LastTransitionTime: metav1.Now(),
+		})
 	})
-	_, err = fc.Functions(ns.Name).UpdateStatus(ctx, fn, metav1.UpdateOptions{})
-	require.NoError(t, err)
 
 	after, err := fc.Functions(ns.Name).Get(ctx, name, metav1.GetOptions{})
 	require.NoError(t, err)

--- a/test/integration/suites/common/wait_test.go
+++ b/test/integration/suites/common/wait_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/test/integration/framework"
 )
 
@@ -43,17 +44,15 @@ func TestWait_FunctionCondition(t *testing.T) {
 	})
 
 	// Drive the smoke condition to True via the status subresource.
-	fn, err := fc.Functions(ns.Name).Get(ctx, name, metav1.GetOptions{})
-	require.NoError(t, err)
-	fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
-		Type:               smokeConditionType,
-		Status:             metav1.ConditionTrue,
-		Reason:             "WaitSmoke",
-		LastTransitionTime: metav1.Now(),
-		ObservedGeneration: fn.Generation,
+	updateFunctionStatusWithRetry(ctx, t, f, ns.Name, name, func(fn *fv1.Function) {
+		fn.Status.Conditions = append(fn.Status.Conditions, metav1.Condition{
+			Type:               smokeConditionType,
+			Status:             metav1.ConditionTrue,
+			Reason:             "WaitSmoke",
+			LastTransitionTime: metav1.Now(),
+			ObservedGeneration: fn.Generation,
+		})
 	})
-	_, err = fc.Functions(ns.Name).UpdateStatus(ctx, fn, metav1.UpdateOptions{})
-	require.NoError(t, err)
 
 	// Already True → wait returns success and prints the "condition met" line.
 	out := ns.CLICaptureStdout(t, ctx, "fn", "wait", "--name", name,


### PR DESCRIPTION
## Problem

`TestWait_FunctionCondition` failed with a 409 in two consecutive CI runs (PR #3470's v1.36.1 then v1.34.8 legs):

```
Operation cannot be fulfilled on functions.fission.io "wait-fn-...": the object has been modified; please apply your changes to the latest version and try again
```

`wait_test.go` (and two sibling tests in `conditions_test.go`) did a bare `Get → mutate → UpdateStatus`, racing whichever controller writes to a freshly created Function. The repo already uses `retry.RetryOnConflict` for exactly this in `kubectl_test.go` and the Package-status test — these three sites just missed it.

## Fix

A shared `updateFunctionStatusWithRetry` helper (fresh `Get` + mutate + `UpdateStatus` under `retry.RetryOnConflict`) used by all three Function-status writes in the suite. No behavior assertions changed.

## Verification

`go vet -tags=integration ./test/integration/suites/common/` clean; `make code-checks` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3471)
<!-- Reviewable:end -->
