### PR TITLE
fix(executor): close specialize-vs-delete race; tolerate finalizer write races

### DIFF
--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/executortype"
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/metrics"
@@ -340,6 +341,25 @@ func destroyOnCreateError(err error) bool {
 }
 
 func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	// Authoritative re-read: the Function object reaching this path originates
+	// from the router's request body and can be stale — its DeletionTimestamp
+	// may be absent even though the Function is being deleted. Without this
+	// check a create can race the delete teardown (funcreconciler) and
+	// re-create the Deployment/Service/HPA *after* teardown removed them,
+	// leaking objects whose owning Function CR is already gone.
+	live, err := caaf.fissionClient.CoreV1().Functions(fn.Namespace).Get(ctx, fn.Name, metav1.GetOptions{})
+	if err != nil {
+		if k8sErrs.IsNotFound(err) {
+			return nil, ferror.MakeError(ferror.ErrorNotFound,
+				fmt.Sprintf("function %s is gone, not creating service", k8sCache.MetaObjectToName(fn)))
+		}
+		return nil, err
+	}
+	if live.UID != fn.UID || !live.DeletionTimestamp.IsZero() {
+		return nil, ferror.MakeError(ferror.ErrorNotFound,
+			fmt.Sprintf("function %s is being deleted, not creating service", k8sCache.MetaObjectToName(fn)))
+	}
+
 	cleanupFunc := func(ns string, name string) {
 		err := caaf.cleanupContainer(ctx, ns, name)
 		if err != nil {

--- a/pkg/executor/executortype/container/deployment_test.go
+++ b/pkg/executor/executortype/container/deployment_test.go
@@ -5,7 +5,9 @@
 package container
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,8 +17,10 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/fscache"
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
@@ -142,6 +146,132 @@ func TestContainerFnDeleteCacheMiss(t *testing.T) {
 	// fsCache is intentionally left empty so GetByFunctionUID misses.
 	require.NoError(t, cn.fnDelete(t.Context(), fn),
 		"fnDelete must tolerate a cache miss and clean up by computed name")
+}
+
+// TestContainerFnCreateDeletionGuard verifies the authoritative re-read at the
+// top of fnCreate refuses to create backing objects for a Function that the
+// router presented but which is gone or being deleted in the cluster. Without
+// this guard an in-flight create can race the delete teardown and re-create the
+// Deployment/Service/HPA after teardown removed them, leaking objects whose
+// owning Function CR is already gone.
+func TestContainerFnCreateDeletionGuard(t *testing.T) {
+	t.Parallel()
+
+	const liveUID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+	tests := []struct {
+		name string
+		// stored is the Function in the authoritative store (fake
+		// fissionClient); nil means the function is absent.
+		stored *fv1.Function
+	}{
+		{
+			name:   "function absent from fissionClient",
+			stored: nil,
+		},
+		{
+			name: "function present but being deleted",
+			stored: func() *fv1.Function {
+				fn := newTestContainerFunction()
+				fn.UID = liveUID
+				fn.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				fn.Finalizers = []string{"fission.io/test"}
+				return fn
+			}(),
+		},
+		{
+			name: "function present but with a different UID",
+			stored: func() *fv1.Function {
+				fn := newTestContainerFunction()
+				fn.UID = "00000000-0000-0000-0000-000000000000"
+				return fn
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := loggerfactory.GetLogger()
+			kubeClient := fake.NewClientset()
+			fissionClient := fissionfake.NewSimpleClientset()
+			if tc.stored != nil {
+				fissionClient = fissionfake.NewSimpleClientset(tc.stored)
+			}
+			caaf := &Container{
+				logger:           logger,
+				kubernetesClient: kubeClient,
+				fissionClient:    fissionClient,
+				fsCache:          fscache.MakeFunctionServiceCache(logger),
+				nsResolver:       utils.DefaultNSResolver(),
+				hpaops:           hpautils.NewHpaOperations(logger, kubeClient, "test-instance"),
+			}
+
+			// The Function the router presents looks alive (no DeletionTimestamp).
+			fn := newTestContainerFunction()
+			fn.UID = liveUID
+
+			_, err := caaf.fnCreate(t.Context(), fn)
+			require.Error(t, err, "fnCreate must refuse a gone/deleting function")
+			assert.True(t, ferror.IsNotFound(err),
+				"guard must surface a ferror NotFound, got: %v", err)
+
+			deploys, listErr := kubeClient.AppsV1().Deployments(metav1.NamespaceAll).List(t.Context(), metav1.ListOptions{})
+			require.NoError(t, listErr)
+			assert.Empty(t, deploys.Items,
+				"no Deployment must be created when the function is gone/deleting")
+		})
+	}
+}
+
+// TestContainerFnCreateGuardPass verifies the guard lets a live, matching
+// Function proceed past the re-read. We do not stand up a full happy-path
+// (running pods); proving the guard passed is enough: fnCreate proceeds to
+// create the backing objects and then fails waiting for the deployment to
+// become available once the bounded context expires — a DeadlineExceeded
+// error, which is not a ferror NotFound.
+func TestContainerFnCreateGuardPass(t *testing.T) {
+	t.Parallel()
+
+	// A container function needs exactly one container port for the Service to
+	// be created, so the create path can proceed past the guard to the
+	// deployment wait.
+	withPort := func(fn *fv1.Function) *fv1.Function {
+		fn.Spec.PodSpec.Containers[0].Ports = []apiv1.ContainerPort{{ContainerPort: 8080}}
+		return fn
+	}
+
+	live := withPort(newTestContainerFunction())
+	live.UID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+	logger := loggerfactory.GetLogger()
+	kubeClient := fake.NewClientset()
+	caaf := &Container{
+		logger:           logger,
+		kubernetesClient: kubeClient,
+		fissionClient:    fissionfake.NewSimpleClientset(live),
+		fsCache:          fscache.MakeFunctionServiceCache(logger),
+		nsResolver:       utils.DefaultNSResolver(),
+		hpaops:           hpautils.NewHpaOperations(logger, kubeClient, "test-instance"),
+	}
+
+	fn := withPort(newTestContainerFunction())
+	fn.UID = live.UID
+
+	// Bound the context so the (never-ready, no real pods) deployment wait
+	// returns promptly instead of blocking the default specialization timeout.
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	_, err := caaf.fnCreate(ctx, fn)
+	require.Error(t, err, "expected fnCreate to fail past the guard waiting for the deployment")
+	assert.False(t, ferror.IsNotFound(err),
+		"guard must have passed; the error should come from the deployment wait, not the guard. got: %v", err)
+	// The non-NotFound error proves the guard passed: fnCreate proceeded past
+	// the re-read into createOrGetDeployment and only failed at the bounded
+	// deployment-readiness wait ("context deadline exceeded").
+	assert.ErrorIs(t, err, context.DeadlineExceeded,
+		"guard-pass should fail at the deployment wait, got: %v", err)
 }
 
 func TestContainerGetResources(t *testing.T) {

--- a/pkg/executor/executortype/newdeploy/newdeploy_test.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy_test.go
@@ -6,6 +6,7 @@ package newdeploy
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,10 +15,12 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/util"
 	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
 	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
@@ -100,6 +103,113 @@ func TestNewDeployFnDeleteCacheMiss(t *testing.T) {
 	// fsCache is intentionally left empty so GetByFunctionUID misses.
 	require.NoError(t, deploy.fnDelete(t.Context(), fn),
 		"fnDelete must tolerate a cache miss and clean up by computed name")
+}
+
+// TestNewDeployFnCreateDeletionGuard verifies the authoritative re-read at the
+// top of fnCreate refuses to create backing objects for a Function that the
+// router presented but which is gone or being deleted in the cluster. Without
+// this guard an in-flight create can race the delete teardown and re-create the
+// Deployment/Service/HPA after teardown removed them, leaking objects whose
+// owning Function CR is already gone.
+func TestNewDeployFnCreateDeletionGuard(t *testing.T) {
+	t.Parallel()
+
+	const liveUID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+	tests := []struct {
+		name string
+		// stored is the Function in the authoritative store (fake
+		// fissionClient); nil means the function is absent.
+		stored *fv1.Function
+	}{
+		{
+			name:   "function absent from fissionClient",
+			stored: nil,
+		},
+		{
+			name: "function present but being deleted",
+			stored: func() *fv1.Function {
+				fn := newTestNewDeployFunction()
+				fn.UID = liveUID
+				fn.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+				fn.Finalizers = []string{"fission.io/test"}
+				return fn
+			}(),
+		},
+		{
+			name: "function present but with a different UID",
+			stored: func() *fv1.Function {
+				fn := newTestNewDeployFunction()
+				fn.UID = "00000000-0000-0000-0000-000000000000"
+				return fn
+			}(),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			logger := loggerfactory.GetLogger()
+			kubeClient := fake.NewSimpleClientset()
+			fissionClient := fissionfake.NewSimpleClientset()
+			if tc.stored != nil {
+				fissionClient = fissionfake.NewSimpleClientset(tc.stored)
+			}
+			deploy := &NewDeploy{
+				logger:           logger,
+				kubernetesClient: kubeClient,
+				fissionClient:    fissionClient,
+				fsCache:          fscache.MakeFunctionServiceCache(logger),
+				nsResolver:       utils.DefaultNSResolver(),
+				hpaops:           hpautils.NewHpaOperations(logger, kubeClient, "test-instance"),
+			}
+
+			// The Function the router presents looks alive (no DeletionTimestamp).
+			fn := newTestNewDeployFunction()
+			fn.UID = liveUID
+
+			_, err := deploy.fnCreate(t.Context(), fn)
+			require.Error(t, err, "fnCreate must refuse a gone/deleting function")
+			assert.True(t, ferror.IsNotFound(err),
+				"guard must surface a ferror NotFound, got: %v", err)
+
+			deploys, listErr := kubeClient.AppsV1().Deployments(metav1.NamespaceAll).List(t.Context(), metav1.ListOptions{})
+			require.NoError(t, listErr)
+			assert.Empty(t, deploys.Items,
+				"no Deployment must be created when the function is gone/deleting")
+		})
+	}
+}
+
+// TestNewDeployFnCreateGuardPass verifies the guard lets a live, matching
+// Function proceed past the re-read. We do not stand up a full happy-path
+// (Environment, package, pods); proving the guard passed is enough: fnCreate
+// fails later on the missing Environment with a non-NotFound error (a k8s
+// NotFound from the apiserver lookup, which is not a ferror NotFound).
+func TestNewDeployFnCreateGuardPass(t *testing.T) {
+	t.Parallel()
+
+	live := newTestNewDeployFunction()
+	live.UID = "abcdef01-2345-6789-abcd-ef0123456789"
+
+	logger := loggerfactory.GetLogger()
+	kubeClient := fake.NewSimpleClientset()
+	deploy := &NewDeploy{
+		logger:           logger,
+		kubernetesClient: kubeClient,
+		fissionClient:    fissionfake.NewSimpleClientset(live),
+		fsCache:          fscache.MakeFunctionServiceCache(logger),
+		nsResolver:       utils.DefaultNSResolver(),
+		hpaops:           hpautils.NewHpaOperations(logger, kubeClient, "test-instance"),
+	}
+
+	fn := newTestNewDeployFunction()
+	fn.UID = live.UID
+
+	_, err := deploy.fnCreate(t.Context(), fn)
+	require.Error(t, err, "expected fnCreate to fail past the guard on the missing Environment")
+	assert.False(t, ferror.IsNotFound(err),
+		"guard must have passed; the error should come from the missing Environment lookup, not the guard. got: %v", err)
 }
 
 // TestNewDeployPodSpecDoesNotAutomountTokenInUserContainer asserts the

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -29,6 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/executor/executortype"
 	"github.com/fission/fission/pkg/executor/fscache"
 	"github.com/fission/fission/pkg/executor/metrics"
@@ -415,6 +416,26 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 		return nil, fmt.Errorf("cross-namespace environment reference is not allowed: fn.namespace=%s env.namespace=%s",
 			fn.Namespace, envNs)
 	}
+
+	// Authoritative re-read: the Function object reaching this path originates
+	// from the router's request body and can be stale — its DeletionTimestamp
+	// may be absent even though the Function is being deleted. Without this
+	// check a create can race the delete teardown (funcreconciler) and
+	// re-create the Deployment/Service/HPA *after* teardown removed them,
+	// leaking objects whose owning Function CR is already gone.
+	live, err := deploy.fissionClient.CoreV1().Functions(fn.Namespace).Get(ctx, fn.Name, metav1.GetOptions{})
+	if err != nil {
+		if k8sErrs.IsNotFound(err) {
+			return nil, ferror.MakeError(ferror.ErrorNotFound,
+				fmt.Sprintf("function %s is gone, not creating service", k8sCache.MetaObjectToName(fn)))
+		}
+		return nil, err
+	}
+	if live.UID != fn.UID || !live.DeletionTimestamp.IsZero() {
+		return nil, ferror.MakeError(ferror.ErrorNotFound,
+			fmt.Sprintf("function %s is being deleted, not creating service", k8sCache.MetaObjectToName(fn)))
+	}
+
 	cleanupFunc := func(ctx context.Context, ns string, name string) {
 		err := deploy.cleanupNewdeploy(ctx, ns, name)
 		if err != nil {

--- a/pkg/executor/funcreconciler/finalizer_test.go
+++ b/pkg/executor/funcreconciler/finalizer_test.go
@@ -125,7 +125,8 @@ func TestFunctionReconcilerFinalizer(t *testing.T) {
 }
 
 // clientWithUpdateErr builds a fake client seeded with objs whose Update calls
-// all fail with updateErr — exercising the finalizer Update race tolerance.
+// all fail with updateErr — exercising the finalizer Update race tolerance
+// (persistent failure: every attempt fails).
 func clientWithUpdateErr(updateErr error, objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
@@ -133,6 +134,26 @@ func clientWithUpdateErr(updateErr error, objs ...client.Object) client.Client {
 		WithInterceptorFuncs(interceptor.Funcs{
 			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
 				return updateErr
+			},
+		}).
+		Build()
+}
+
+// clientWithTransientUpdateErr builds a fake client whose first failN Update
+// calls fail with updateErr and then succeed — exercising RetryOnConflict's
+// re-read-and-retry loop converging on a real write.
+func clientWithTransientUpdateErr(updateErr error, failN int, objs ...client.Object) client.Client {
+	calls := 0
+	return fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+				calls++
+				if calls <= failN {
+					return updateErr
+				}
+				return c.Update(ctx, obj, opts...)
 			},
 		}).
 		Build()
@@ -166,15 +187,34 @@ func TestFunctionReconcilerFinalizerUpdateRace(t *testing.T) {
 		assert.False(t, cached, "cache entry dropped on the NotFound branch")
 	})
 
-	t.Run("delete path: finalizer-remove Update returns Conflict -> requeue, no error", func(t *testing.T) {
+	t.Run("delete path: finalizer-remove Update Conflicts twice then succeeds -> absorbed, finalizer released", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := clientWithTransientUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), 2, deletingFn())
+		require.NoError(t, c.Delete(t.Context(), deletingFn()))
+		r := newReconcilerWith(c, true, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, res, "conflicts absorbed by RetryOnConflict; no deprecated Requeue")
+		assert.Equal(t, []string{"fn"}, nd.deleted, "teardown ran before the finalizer release")
+
+		got := &fv1.Function{}
+		err = c.Get(t.Context(), key, got)
+		assert.True(t, apierrors.IsNotFound(err), "removing the last finalizer let the object be collected")
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached, "cache entry dropped after teardown")
+	})
+
+	t.Run("delete path: finalizer-remove Update persistently Conflicts -> retry exhausts, error surfaced", func(t *testing.T) {
 		nd := &fakeBackend{}
 		c := clientWithUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), deletingFn())
 		require.NoError(t, c.Delete(t.Context(), deletingFn()))
 		r := newReconcilerWith(c, true, nd)
 
-		res, err := r.Reconcile(t.Context(), req)
-		require.NoError(t, err)
-		assert.Equal(t, ctrl.Result{Requeue: true}, res)
+		_, err := r.Reconcile(t.Context(), req)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "bounded retry exhausts and surfaces the Conflict")
 	})
 
 	t.Run("add path: finalizer-add Update returns NotFound -> tolerated, no requeue", func(t *testing.T) {
@@ -187,14 +227,29 @@ func TestFunctionReconcilerFinalizerUpdateRace(t *testing.T) {
 		assert.Equal(t, ctrl.Result{}, res)
 	})
 
-	t.Run("add path: finalizer-add Update returns Conflict -> requeue, no error", func(t *testing.T) {
+	t.Run("add path: finalizer-add Update Conflicts twice then succeeds -> absorbed, finalizer added", func(t *testing.T) {
 		nd := &fakeBackend{}
-		c := clientWithUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		c := clientWithTransientUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), 2, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
 		r := newReconcilerWith(c, true, nd)
 
 		res, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
-		assert.Equal(t, ctrl.Result{Requeue: true}, res)
+		assert.Equal(t, ctrl.Result{}, res, "conflicts absorbed by RetryOnConflict; no deprecated Requeue")
+
+		got := &fv1.Function{}
+		require.NoError(t, c.Get(t.Context(), key, got))
+		assert.True(t, controllerutil.ContainsFinalizer(got, functionFinalizer), "finalizer added after the retry converged")
+		assert.Len(t, nd.reconciled, 1, "reconcile still runs after the finalizer add")
+	})
+
+	t.Run("add path: finalizer-add Update persistently Conflicts -> retry exhausts, error surfaced", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := clientWithUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		r := newReconcilerWith(c, true, nd)
+
+		_, err := r.Reconcile(t.Context(), req)
+		require.Error(t, err)
+		assert.True(t, apierrors.IsConflict(err), "bounded retry exhausts and surfaces the Conflict")
 	})
 }
 

--- a/pkg/executor/funcreconciler/finalizer_test.go
+++ b/pkg/executor/funcreconciler/finalizer_test.go
@@ -5,6 +5,7 @@
 package funcreconciler
 
 import (
+	"context"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -15,11 +16,14 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/executortype"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 )
 
 func newReconcilerWith(c client.Client, finalizer bool, nd *fakeBackend) *functionReconciler {
@@ -117,6 +121,80 @@ func TestFunctionReconcilerFinalizer(t *testing.T) {
 		assert.Empty(t, nd.deleted, "not our finalizer: teardown deferred to the NotFound path")
 		_, cached := r.lastReconciled.Load(key)
 		assert.True(t, cached, "cache retained for the NotFound path to tear down later")
+	})
+}
+
+// clientWithUpdateErr builds a fake client seeded with objs whose Update calls
+// all fail with updateErr — exercising the finalizer Update race tolerance.
+func clientWithUpdateErr(updateErr error, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(objs...).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Update: func(context.Context, client.WithWatch, client.Object, ...client.UpdateOption) error {
+				return updateErr
+			},
+		}).
+		Build()
+}
+
+func TestFunctionReconcilerFinalizerUpdateRace(t *testing.T) {
+	key := types.NamespacedName{Name: "fn", Namespace: "default"}
+	req := ctrl.Request{NamespacedName: key}
+	gr := fv1.SchemeGroupVersion.WithResource("functions").GroupResource()
+
+	deletingFn := func() *fv1.Function {
+		f := fn("fn", fv1.ExecutorTypeNewdeploy, "u1")
+		// The fake client rejects a DeletionTimestamp object without a finalizer,
+		// so seed one and Delete() it to set the timestamp.
+		f.Finalizers = []string{functionFinalizer}
+		return f
+	}
+
+	t.Run("delete path: finalizer-remove Update returns NotFound -> tolerated, no requeue", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := clientWithUpdateErr(apierrors.NewNotFound(gr, "fn"), deletingFn())
+		require.NoError(t, c.Delete(t.Context(), deletingFn()))
+		r := newReconcilerWith(c, true, nd)
+		r.lastReconciled.Store(key, fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, res)
+		assert.Equal(t, []string{"fn"}, nd.deleted, "teardown must have run before the Update")
+		_, cached := r.lastReconciled.Load(key)
+		assert.False(t, cached, "cache entry dropped on the NotFound branch")
+	})
+
+	t.Run("delete path: finalizer-remove Update returns Conflict -> requeue, no error", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := clientWithUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), deletingFn())
+		require.NoError(t, c.Delete(t.Context(), deletingFn()))
+		r := newReconcilerWith(c, true, nd)
+
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{Requeue: true}, res)
+	})
+
+	t.Run("add path: finalizer-add Update returns NotFound -> tolerated, no requeue", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := clientWithUpdateErr(apierrors.NewNotFound(gr, "fn"), fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		r := newReconcilerWith(c, true, nd)
+
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, res)
+	})
+
+	t.Run("add path: finalizer-add Update returns Conflict -> requeue, no error", func(t *testing.T) {
+		nd := &fakeBackend{}
+		c := clientWithUpdateErr(apierrors.NewConflict(gr, "fn", assert.AnError), fn("fn", fv1.ExecutorTypeNewdeploy, "u1"))
+		r := newReconcilerWith(c, true, nd)
+
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{Requeue: true}, res)
 	})
 }
 

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,6 +121,30 @@ type functionReconciler struct {
 	lastReconciled sync.Map // client.ObjectKey -> *fv1.Function
 }
 
+// updateFinalizerWithRetry re-reads the Function and re-applies mutate under
+// RetryOnConflict, absorbing benign write races (concurrent status writers,
+// other finalizer actors) without surfacing them as reconciler errors. It
+// reports gone=true when the Function disappeared, which callers treat as
+// already-deleted. mutate returns false when the desired state already holds
+// (no write needed). On a Conflict the fresh Get re-reads the latest object, so
+// each retry re-evaluates mutate against current state.
+func (r *functionReconciler) updateFinalizerWithRetry(ctx context.Context, key types.NamespacedName, mutate func(*fv1.Function) bool) (gone bool, err error) {
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		fn := &fv1.Function{}
+		if err := r.client.Get(ctx, key, fn); err != nil {
+			return err
+		}
+		if !mutate(fn) {
+			return nil
+		}
+		return r.client.Update(ctx, fn)
+	})
+	if apierrors.IsNotFound(err) {
+		return true, nil
+	}
+	return false, err
+}
+
 func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	fn := &fv1.Function{}
 	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
@@ -152,18 +177,14 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 				return ctrl.Result{}, err // keep the finalizer; retry teardown
 			}
 		}
-		controllerutil.RemoveFinalizer(fn, functionFinalizer)
-		if err := r.client.Update(ctx, fn); err != nil {
-			if apierrors.IsNotFound(err) {
-				// Already collected — another actor removed the last finalizer
-				// or the object was force-deleted. Teardown already ran above.
-				r.lastReconciled.Delete(req.NamespacedName)
-				return ctrl.Result{}, nil
-			}
-			if apierrors.IsConflict(err) {
-				// Stale object; requeue silently and retry on a fresh read.
-				return ctrl.Result{Requeue: true}, nil
-			}
+		// Release the finalizer under RetryOnConflict so a concurrent writer
+		// (status update, another finalizer actor) does not surface as a
+		// reconciler error. gone == true means another actor already removed the
+		// last finalizer or the object was force-deleted; teardown already ran
+		// above, so the success path applies either way.
+		if _, err := r.updateFinalizerWithRetry(ctx, req.NamespacedName, func(f *fv1.Function) bool {
+			return controllerutil.RemoveFinalizer(f, functionFinalizer)
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 		r.lastReconciled.Delete(req.NamespacedName)
@@ -174,32 +195,27 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// finalizer is a metadata write (Generation unchanged), so it does not
 	// re-trigger this reconciler through GenerationChangedPredicate.
 	if r.finalizer && !controllerutil.ContainsFinalizer(fn, functionFinalizer) {
-		controllerutil.AddFinalizer(fn, functionFinalizer)
-		if err := r.client.Update(ctx, fn); err != nil {
-			if apierrors.IsNotFound(err) {
-				// Deleted out from under us; the deletion path will handle
-				// teardown via the watch event.
-				return ctrl.Result{}, nil
-			}
-			if apierrors.IsConflict(err) {
-				// Stale object; requeue silently and retry on a fresh read.
-				return ctrl.Result{Requeue: true}, nil
-			}
+		gone, err := r.updateFinalizerWithRetry(ctx, req.NamespacedName, func(f *fv1.Function) bool {
+			return controllerutil.AddFinalizer(f, functionFinalizer)
+		})
+		if err != nil {
 			return ctrl.Result{}, err
 		}
+		if gone {
+			// Deleted out from under us; nothing was created yet, and the deletion
+			// path handles teardown via the watch event.
+			return ctrl.Result{}, nil
+		}
+		// The helper mutated a fresh re-read, so the local fn now lacks the
+		// finalizer and carries an older resourceVersion. Nothing below writes fn
+		// back — it is only read (resolveExecutorType, ReconcileFunction) and
+		// deep-copied into lastReconciled — so proceeding with it is safe; the
+		// finalizer is metadata-only and is re-read on the next reconcile.
 	} else if !r.finalizer && controllerutil.ContainsFinalizer(fn, functionFinalizer) {
 		// Toggled off: drain the finalizer so a later delete is never wedged on it.
-		controllerutil.RemoveFinalizer(fn, functionFinalizer)
-		if err := r.client.Update(ctx, fn); err != nil {
-			if apierrors.IsNotFound(err) {
-				// Deleted out from under us; the deletion path will handle
-				// teardown via the watch event.
-				return ctrl.Result{}, nil
-			}
-			if apierrors.IsConflict(err) {
-				// Stale object; requeue silently and retry on a fresh read.
-				return ctrl.Result{Requeue: true}, nil
-			}
+		if _, err := r.updateFinalizerWithRetry(ctx, req.NamespacedName, func(f *fv1.Function) bool {
+			return controllerutil.RemoveFinalizer(f, functionFinalizer)
+		}); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -154,6 +154,16 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		controllerutil.RemoveFinalizer(fn, functionFinalizer)
 		if err := r.client.Update(ctx, fn); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Already collected — another actor removed the last finalizer
+				// or the object was force-deleted. Teardown already ran above.
+				r.lastReconciled.Delete(req.NamespacedName)
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				// Stale object; requeue silently and retry on a fresh read.
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		r.lastReconciled.Delete(req.NamespacedName)
@@ -166,12 +176,30 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if r.finalizer && !controllerutil.ContainsFinalizer(fn, functionFinalizer) {
 		controllerutil.AddFinalizer(fn, functionFinalizer)
 		if err := r.client.Update(ctx, fn); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Deleted out from under us; the deletion path will handle
+				// teardown via the watch event.
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				// Stale object; requeue silently and retry on a fresh read.
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	} else if !r.finalizer && controllerutil.ContainsFinalizer(fn, functionFinalizer) {
 		// Toggled off: drain the finalizer so a later delete is never wedged on it.
 		controllerutil.RemoveFinalizer(fn, functionFinalizer)
 		if err := r.client.Update(ctx, fn); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Deleted out from under us; the deletion path will handle
+				// teardown via the watch event.
+				return ctrl.Result{}, nil
+			}
+			if apierrors.IsConflict(err) {
+				// Stale object; requeue silently and retry on a fresh read.
+				return ctrl.Result{Requeue: true}, nil
+			}
 			return ctrl.Result{}, err
 		}
 	}

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -182,6 +182,7 @@ func (p *WebhookPublisher) makeHTTPRequest(r *publishRequest) {
 	if err != nil {
 		logger = logger.WithValues("request", r)
 	} else {
+		defer resp.Body.Close()
 		var body []byte
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
## Follow-ups from the RFC-0006 log analysis (#3468/#3469/#3470 reviews)

### 1. Specialize-vs-delete race → leaked objects (real leak)

The Function object reaching `fnCreate` originates from the **router's request body** and can be stale — its `DeletionTimestamp` may be absent even though the Function is mid-deletion. A create racing the finalizer teardown could re-create the Deployment/Service/HPA *after* teardown removed them, leaking objects whose owning Function CR is gone.

Fix: `fnCreate` (newdeploy + container) now does an authoritative `Functions.Get` and refuses creation when the function is **gone**, **being deleted**, or the **UID differs** (delete+recreate-same-name). Returns `ferror.ErrorNotFound`, which the router maps to a 404. Poolmgr is unaffected by design (no per-function backing objects).

Verified safe for the adopt/restart path (functions come from a live List — guard passes) and update-triggered recreates (same UID, no deletion timestamp). The throttler caches nothing, so a refused create cannot poison subsequent requests.

### 2. Finalizer write races (the `Reconciler error … functions.fission.io not found` in CI)

The funcreconciler's finalizer add/remove `Update` calls raced actual deletion: NotFound (object already collected) surfaced as a reconciler error; Conflict caused error-level noise. All three sites now go through a `RetryOnConflict`-wrapped read-modify-write helper (`updateFinalizerWithRetry`): NotFound → benign already-deleted; transient Conflict → absorbed in place (no deprecated `Result.Requeue`, no spurious error logs); persistent Conflict/other errors still surface.

### 3. Publisher response-body leak

`makeHTTPRequest` read but never closed `resp.Body` — one leaked connection per published trigger event. Now `defer`-closed in the non-error branch.

## Tests

- `TestNewDeployFnCreateDeletionGuard` / `TestContainerFnCreateDeletionGuard` (absent / deleting / UID-mismatch → NotFound + zero Deployments) + guard-pass sanity cases.
- `TestFunctionReconcilerFinalizerUpdateRace`: NotFound, transient-Conflict (heals + state actually changed), persistent-Conflict (bounded retry then error) on both add and delete paths, via interceptor fakes.

## Review notes

Adversarial error-handling review traced all relaxations end-to-end (no swallowed real failures; the executor Get is a strongly-consistent apiserver read, so no false 404 on just-created functions). One **pre-existing** issue surfaced for follow-up: the router converts executor 4xx to an opaque 500 with no retry (`functionHandler.go RoundTrip`) — a delete-racing invoke would be cleaner as a 404.

## Verification

`go build ./pkg/... ./cmd/...` clean; `go test -race ./pkg/executor/... ./pkg/publisher/` 13 packages green; `make code-checks` 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3472)
<!-- Reviewable:end -->
