### PR TITLE
Watch All Namespaces + Cross-Namespace Invocation Isolation

### DIFF
--- a/charts/fission-all/templates/_fission-component-roles.tpl
+++ b/charts/fission-all/templates/_fission-component-roles.tpl
@@ -27,6 +27,35 @@ rules:
   - get
   - update
   - patch
+# The buildermgr provisions the fission-builder ServiceAccount (and its Role +
+# RoleBinding) on demand in each builder namespace as environments are
+# discovered (EnsureBuilderSA -> setupSAAndRoleBindings). Required under
+# watch-all-namespaces, where namespaces are not known at install time and the
+# chart cannot pre-create the SA. Under watch-all these rules render as a
+# ClusterRole, granting the create power cluster-wide.
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
 {{- end }}
 {{- define "executor-rules" }}
 rules:
@@ -54,6 +83,35 @@ rules:
   - get
   - update
   - patch
+# The executor provisions the fission-fetcher ServiceAccount (and its Role +
+# RoleBinding) on demand in each function namespace as functions are specialized
+# (EnsureFetcherSA -> setupSAAndRoleBindings). Required under watch-all-namespaces,
+# where namespaces are not known at install time and the chart cannot pre-create
+# the SA. Under watch-all these rules render as a ClusterRole, granting the create
+# power cluster-wide.
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - get
+  - delete
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - localsubjectaccessreviews
+  verbs:
+  - create
 {{- end }}
 {{- define "kubewatcher-rules" }}
 rules:

--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -59,6 +59,17 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  # The buildermgr provisions the fission-internal-auth Secret (the shared HMAC
+  # secret) on demand in each builder namespace under watch-all-namespaces, so the
+  # builder's fetcher can sign storagesvc requests. Needs create/update in addition
+  # to the get/list/watch above.
+  - secrets
+  verbs:
+  - create
+  - update
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -151,7 +162,18 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.executor.serviceAccountCheck.enabled }}  
+- apiGroups:
+  - ""
+  resources:
+  # The executor provisions the fission-internal-auth Secret (the shared HMAC
+  # secret) on demand in each function namespace under watch-all-namespaces, so the
+  # fetcher sidecar can sign storagesvc requests. Needs create/update in addition
+  # to the get/list/watch above.
+  - secrets
+  verbs:
+  - create
+  - update
+{{- if .Values.executor.serviceAccountCheck.enabled }}
 - apiGroups:
   - ""
   resources:

--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -70,6 +70,17 @@ rules:
   - create
   - update
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  # delete is scoped by name: the buildermgr removes the tenant fission-internal-auth
+  # copy when internal auth is turned off, so leftover copies don't make fetchers
+  # enforce HMAC against an unsigned control plane.
+  resourceNames:
+  - fission-internal-auth
+  verbs:
+  - delete
+- apiGroups:
   - apps
   resources:
   - deployments
@@ -173,6 +184,17 @@ rules:
   verbs:
   - create
   - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  # delete is scoped by name: the executor removes the tenant fission-internal-auth
+  # copy when internal auth is turned off, so leftover copies don't make fetchers
+  # enforce HMAC against an unsigned control plane.
+  resourceNames:
+  - fission-internal-auth
+  verbs:
+  - delete
 {{- if .Values.executor.serviceAccountCheck.enabled }}
 - apiGroups:
   - ""

--- a/charts/fission-all/templates/_fission-kuberntes-role-generator.tpl
+++ b/charts/fission-all/templates/_fission-kuberntes-role-generator.tpl
@@ -1,7 +1,11 @@
 {{- define "kubernetes-role-generator" }}
+{{- /* Under watch-all-namespaces emit a single cluster-scoped role (gated to the
+       default namespace so it is not duplicated per namespace); otherwise a
+       per-namespace Role as before. */ -}}
+{{- if or (not .Values.watchAllNamespaces) (eq .namespace .Values.defaultNamespace) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: {{ if .Values.watchAllNamespaces }}ClusterRole{{ else }}Role{{ end }}
 metadata:
 {{- if eq "preupgrade" .component }}
   annotations:
@@ -10,7 +14,9 @@ metadata:
     helm.sh/hook-weight: "-2"
 {{- end }}
   name: "{{ .Release.Name }}-{{ .component }}"
+  {{- if not .Values.watchAllNamespaces }}
   namespace: {{ .namespace }}
+  {{- end }}
 {{- if eq "buildermgr" .component }}
 {{- include "buildermgr-kuberules" . }}
 {{- end }}
@@ -43,7 +49,7 @@ metadata:
 {{- end }}
 
 ---
-kind: RoleBinding
+kind: {{ if .Values.watchAllNamespaces }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if eq "preupgrade" .component }}
@@ -52,13 +58,16 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
 {{- end }}
   name: "{{ .Release.Name }}-{{ .component }}"
+  {{- if not .Values.watchAllNamespaces }}
   namespace: {{ .namespace }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: "fission-{{ .component }}"
     namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
+  kind: {{ if .Values.watchAllNamespaces }}ClusterRole{{ else }}Role{{ end }}
   name: "{{ .Release.Name }}-{{ .component }}"
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/_fission-role-generator.tpl
+++ b/charts/fission-all/templates/_fission-role-generator.tpl
@@ -1,7 +1,11 @@
 {{- define "fission-role-generator" }}
+{{- /* Under watch-all-namespaces emit a single cluster-scoped role (gated to the
+       default namespace so it is not duplicated per namespace); otherwise a
+       per-namespace Role as before. */ -}}
+{{- if or (not .Values.watchAllNamespaces) (eq .namespace .Values.defaultNamespace) -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: {{ if .Values.watchAllNamespaces }}ClusterRole{{ else }}Role{{ end }}
 metadata:
 {{- if eq "preupgrade" .component }}
   annotations:
@@ -10,7 +14,9 @@ metadata:
     helm.sh/hook-weight: "-2"
 {{- end }}
   name: "{{ .Release.Name }}-{{ .component }}-fission-cr"
+  {{- if not .Values.watchAllNamespaces }}
   namespace: {{ .namespace }}
+  {{- end }}
 {{- if eq "buildermgr" .component }}
 {{- include "buildermgr-rules" . }}
 {{- end }}
@@ -43,7 +49,7 @@ metadata:
 {{- end }}
 
 ---
-kind: RoleBinding
+kind: {{ if .Values.watchAllNamespaces }}ClusterRoleBinding{{ else }}RoleBinding{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if eq "preupgrade" .component }}
@@ -52,13 +58,16 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
 {{- end }}
   name: "{{ .Release.Name }}-{{ .component }}-fission-cr"
+  {{- if not .Values.watchAllNamespaces }}
   namespace: {{ .namespace }}
+  {{- end }}
 subjects:
   - kind: ServiceAccount
     name: "fission-{{ .component }}"
     namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
+  kind: {{ if .Values.watchAllNamespaces }}ClusterRole{{ else }}Role{{ end }}
   name: "{{ .Release.Name }}-{{ .component }}-fission-cr"
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -95,10 +95,14 @@ Helper template to construct image names with repository and tag
 - name: FISSION_DEFAULT_NAMESPACE
   value: "{{ .Values.defaultNamespace }}"
 - name: FISSION_RESOURCE_NAMESPACES
-{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
+{{- if .Values.watchAllNamespaces }}
+  value: ""
+- name: FISSION_WATCH_ALL_NAMESPACES
+  value: "true"
+{{- else if gt (len .Values.additionalFissionNamespaces) 0 }}
   value: "{{ .Values.defaultNamespace }},{{ join "," .Values.additionalFissionNamespaces }}"
 {{- else }}
-  value: {{ .Values.defaultNamespace }}  
+  value: {{ .Values.defaultNamespace }}
 {{- end }}
 {{- end }}
 

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -69,6 +69,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.router.enforceSameNamespaceInvocation }}
+        - name: ROUTER_ENFORCE_SAME_NAMESPACE_INVOCATION
+          value: "true"
+        {{- end }}
         - name: ROUTER_ROUND_TRIP_TIMEOUT
           value: {{ .Values.router.roundTrip.timeout | default "50ms" | quote }}
         - name: ROUTER_ROUNDTRIP_TIMEOUT_EXPONENT

--- a/charts/fission-all/templates/router/same-namespace-guard-rbac.yaml
+++ b/charts/fission-all/templates/router/same-namespace-guard-rbac.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.router.enforceSameNamespaceInvocation }}
+{{- /*
+  The same-namespace invocation guard attributes a caller's pod IP to a namespace
+  via a cluster-wide pod cache, so the router needs pods get/list/watch across all
+  namespaces (a caller may be a function pod in any namespace). This is a separate,
+  always-cluster-scoped ClusterRole so it works regardless of watchAllNamespaces,
+  and is only created when the guard is enabled.
+*/ -}}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Release.Name }}-router-pod-reader"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-router-pod-reader"
+subjects:
+  - kind: ServiceAccount
+    name: "fission-router"
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-router-pod-reader"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -286,6 +286,18 @@ router:
   ## canaryconfig / buildermgr) only.
   ##
   internalPort: 8889
+  ## enforceSameNamespaceInvocation locks the internal listener
+  ## (/fission-function/<ns>/<name>) so a caller may only invoke a function in
+  ## its OWN namespace — unless the caller is an internal Fission component (a pod
+  ## in this release's namespace). This closes the cross-namespace invocation gap:
+  ## with it off, any pod that can reach router-internal:8889 (and, with
+  ## internalAuth disabled, without any signature) can invoke a private function
+  ## in another namespace. The router attributes the caller's pod IP to a
+  ## namespace via a cluster-wide pod cache, so enabling this grants the router
+  ## `pods` get/list/watch cluster-wide. Intended for multi-tenant clusters
+  ## (typically alongside watchAllNamespaces). Default off.
+  ##
+  enforceSameNamespaceInvocation: true
   ## strategy is the Deployment rollout strategy for the router (ignored when
   ## deployAsDaemonSet is true). Leave unset for the Kubernetes default. The
   ## router is stateless, so a surge strategy gives zero-downtime rollouts:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -86,6 +86,16 @@ functionNamespace: ""
 ## - namespace3
 additionalFissionNamespaces: []
 
+## watchAllNamespaces makes Fission watch custom resources across ALL namespaces
+## instead of only defaultNamespace + additionalFissionNamespaces. The component
+## managers' controller-runtime caches go cluster-wide (FISSION_WATCH_ALL_NAMESPACES),
+## so this REQUIRES cluster-scoped RBAC: the chart emits ClusterRole/ClusterRoleBinding
+## instead of per-namespace Role/RoleBinding when this is true. Useful when you have
+## many (or dynamically created) function namespaces and don't want to enumerate them
+## in additionalFissionNamespaces and re-upgrade the chart each time.
+##
+watchAllNamespaces: true
+
 ## createNamespace decides to create namespaces by the chart.
 ## If set to true, functionNamespace and builderNamespace namespaces mentioned above will be created by the chart.
 ## Set to false if you want to create the namespaces manually.

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1126,8 +1126,17 @@ networkPolicy:
 ##
 ## Disabled here means the cluster falls back to NetworkPolicy + namespace
 ## isolation only, matching pre-1.(N+1) behaviour.
+##
+## FORK DEFAULT: disabled. Upstream defaults this ON, but the HMAC verifier on
+## router-internal (and storagesvc) rejects unsigned requests from the upstream
+## KEDA HTTP connectors and the GraphQL federation gateway — neither signs — so
+## with it enabled, MessageQueueTrigger (RabbitMQ/Kafka/…) message delivery and
+## federated subgraph calls fail with 401. This fork ran for its whole v1.22.x
+## life with no HMAC at all, so off-by-default preserves that behaviour and keeps
+## those integrations working. Re-enable it (and use signing-aware connector
+## images) if you need internal-channel signing. See docs/features/internal-auth.md.
 internalAuth:
-  enabled: true
+  enabled: false
   # secret: "" — auto-generated on first install; preserved on upgrade.
   # oldSecret: "" — set during rotation; accepted by the verifier alongside `secret`.
 

--- a/docs/features/internal-auth.md
+++ b/docs/features/internal-auth.md
@@ -1,0 +1,50 @@
+# Internal auth (HMAC) — disabled by default on this fork
+
+Upstream Fission added HMAC signing for its internal control-plane channels
+(storagesvc `/v1/archive`, fetcher, builder, executor, router-internal). It is
+gated by the Helm value `internalAuth.enabled`, which **upstream defaults to
+`true`**.
+
+**This fork defaults it to `false`.**
+
+## Why
+
+The HMAC verifier on `router-internal:8889` (and on storagesvc) rejects any
+request that isn't signed with `FISSION_INTERNAL_AUTH_SECRET`. Two integrations
+this fork relies on send **unsigned** requests and therefore fail with `401`
+when internal auth is on:
+
+- the upstream **KEDA HTTP connectors** (`ghcr.io/fission/keda-*-http-connector`),
+  which invoke functions through `router-internal` — so MessageQueueTrigger
+  delivery (RabbitMQ, Kafka, …) silently stops (messages pile up unacked);
+- the **GraphQL federation gateway**, which makes unsigned subgraph calls.
+
+Neither image signs its requests, and rebuilding them with signing support is a
+separate effort. This fork ran its entire v1.22.x life with no HMAC at all, so
+defaulting it off preserves that working behaviour and the same security posture
+(NetworkPolicies + namespace isolation still apply).
+
+## Enabling it anyway
+
+```bash
+helm upgrade fission ... --set internalAuth.enabled=true
+```
+
+If you enable it, you must also make every internal HTTP caller sign — i.e. use
+signing-aware KEDA connector images (fork `fission/keda-connectors`, wrap the
+transport with `hmacauth.ServiceSigner(ServiceRouterInternal)`, and pass
+`FISSION_INTERNAL_AUTH_SECRET` to the connector Deployment via
+`pkg/mqtrigger/scalermanager.go`), and likewise for the federation gateway.
+
+## Operational note (all-or-nothing)
+
+`internalAuth.enabled` drives **8 components** (storagesvc, buildermgr, executor,
+router, timer, kubewatcher, and the kafka/keda MQ triggers). Toggling it requires
+restarting **all** of them — a partial restart leaves verifiers and signers in a
+split state (e.g. storagesvc still enforcing while a fetcher no longer signs),
+which surfaces as fetch failures and executor specialization timeouts:
+
+```bash
+helm upgrade fission ... --set internalAuth.enabled=<true|false>
+kubectl rollout restart deployment -n fission   # ALL fission deployments
+```

--- a/docs/features/internal-auth.md
+++ b/docs/features/internal-auth.md
@@ -48,3 +48,16 @@ which surfaces as fetch failures and executor specialization timeouts:
 helm upgrade fission ... --set internalAuth.enabled=<true|false>
 kubectl rollout restart deployment -n fission   # ALL fission deployments
 ```
+
+## Tenant-namespace copies (watch-all-namespaces)
+
+Under watch-all-namespaces the executor/buildermgr copy the `fission-internal-auth`
+Secret into each function/builder namespace on demand (the fetcher sidecar reads
+it there) — see `utils.EnsureInternalAuthSecret`. This reconciles to the current
+state: when internal auth is **off** it *deletes* the tenant copy, so toggling off
+never leaves a stale Secret behind (a leftover would make the function-pod fetcher
+keep enforcing HMAC while the control plane no longer signs → 401 on
+specialization). Note the fetcher reads the Secret at pod start, so already-running
+function pods only pick up the change when they next cycle (restart the affected
+pool / newdeploy deployment to force it). A fresh install with internal auth off
+never creates the Secret at all, so this only matters when toggling a live cluster.

--- a/docs/features/internal-invocation-isolation.md
+++ b/docs/features/internal-invocation-isolation.md
@@ -29,10 +29,19 @@ namespace A invoking a private function in namespace B is blocked.
 
 The router attributes the request's source pod IP (the TCP peer — `X-Forwarded-For`
 is ignored, since it's caller-controlled) to a namespace via a cluster-wide pod
-cache (a pod informer keeping `podIP → namespace`). The check is applied
-**per-function handler**, so the target namespace is taken from the function
-object, not parsed from the (ambiguous) path. A caller IP that cannot be resolved
-to a pod is **rejected** (fail closed).
+cache (a pod informer keeping `podIP → namespace`), falling back to a direct API
+lookup (`status.podIP`) on a cache miss so a freshly-created caller isn't rejected
+while the watch catches up. The check is applied **per-function handler**, so the
+target namespace is taken from the function object, not parsed from the (ambiguous)
+path. A caller IP that cannot be resolved to a pod is **rejected** (fail closed).
+
+> Cold-start window: a brand-new pod can issue a request in the instant before its
+> `status.podIP` is observable to the API/informer. Such a first request fails
+> closed (403) and succeeds on the caller's normal retry. Long-running callers
+> (the federation gateway, ordinary functions) are unaffected — they resolve
+> immediately after their first second. The federation→subgraph cold-start path is
+> safe regardless: the *caller* is the long-running federation, not the
+> scaled-from-zero subgraph.
 
 ## Enabling
 

--- a/docs/features/internal-invocation-isolation.md
+++ b/docs/features/internal-invocation-isolation.md
@@ -1,0 +1,70 @@
+# Cross-namespace invocation isolation (router-internal)
+
+The router's internal listener (`router-internal:8889`) serves
+`/fission-function/<ns>/<name>` — the path in-cluster callers use to invoke
+private (un-triggered) functions, including ones that scale to zero (the router
+cold-starts them on demand). By default that endpoint will invoke a function in
+**any** namespace, and with `internalAuth` disabled it is unauthenticated. On a
+multi-tenant cluster that means a function pod in one tenant namespace can reach a
+private function in another namespace.
+
+`router.enforceSameNamespaceInvocation` closes that gap.
+
+## What it does
+
+When enabled, the internal listener rejects (`403`) any
+`/fission-function/<ns>/<name>` request unless **either**:
+
+- the caller's pod is in the **same namespace** as the target function, or
+- the caller is an **internal Fission component** — a pod in the Fission install
+  namespace (executor, kubewatcher, timer, mqtrigger, …), which legitimately
+  invoke functions across namespaces.
+
+This fits the common patterns exactly: a GraphQL federation gateway invoking its
+own-namespace subgraphs passes; a KEDA connector (deployed in the function's
+namespace) invoking that function passes; internal triggers pass; a function in
+namespace A invoking a private function in namespace B is blocked.
+
+## How it decides the caller
+
+The router attributes the request's source pod IP (the TCP peer — `X-Forwarded-For`
+is ignored, since it's caller-controlled) to a namespace via a cluster-wide pod
+cache (a pod informer keeping `podIP → namespace`). The check is applied
+**per-function handler**, so the target namespace is taken from the function
+object, not parsed from the (ambiguous) path. A caller IP that cannot be resolved
+to a pod is **rejected** (fail closed).
+
+## Enabling
+
+```bash
+helm upgrade fission ... --set router.enforceSameNamespaceInvocation=true
+```
+
+This:
+- sets `ROUTER_ENFORCE_SAME_NAMESPACE_INVOCATION=true` on the router;
+- creates a cluster-scoped ClusterRole granting the router `pods` get/list/watch
+  (needed for the IP→namespace cache — a caller can be in any namespace).
+
+Intended for multi-tenant clusters, typically alongside `watchAllNamespaces`.
+Default **off** (upstream behavior). It works with `internalAuth` either on or off
+— it is an independent, identity-based authorization layer on top of (or instead
+of) the HMAC/NetworkPolicy "who can reach the port" controls.
+
+## Relationship to the other controls
+
+| Control | Restricts |
+|---|---|
+| `internalAuth` (HMAC) | *who* may call router-internal (signed callers only) |
+| `networkPolicy` (router-internal ingress) | *which pods* may reach port 8889 |
+| **`enforceSameNamespaceInvocation`** | *which namespace's functions* a caller may invoke |
+
+The first two gate reachability; this one gates the target. Use it when callers
+that *can* reach the endpoint (e.g. a federation gateway) must still be confined
+to their own namespace's functions.
+
+## Key files
+
+- `pkg/router/same_namespace_guard.go` — the guard + pod-IP cache
+- `pkg/router/httpTriggers.go` — per-function handler wrapping in `buildMuxes`
+- `pkg/router/router.go` — wiring (`ROUTER_ENFORCE_SAME_NAMESPACE_INVOCATION`)
+- `charts/fission-all/templates/router/same-namespace-guard-rbac.yaml` — pods ClusterRole

--- a/docs/spike-watch-all-namespaces.md
+++ b/docs/spike-watch-all-namespaces.md
@@ -1,0 +1,90 @@
+# Spike: porting watch-all-namespaces onto controller-runtime
+
+Status: **design proposal — awaiting sign-off before code.**
+
+## The key finding (why this is small on the Go side)
+
+The new controller-runtime Manager cache **already supports watch-all** with no
+crmanager change. `crmanager.FissionCacheOptions()` builds
+`cache.Options{DefaultNamespaces: ...}` from `NamespaceResolver.FissionResourceNS`:
+
+```go
+for _, ns := range utils.DefaultNSResolver().FissionResourceNS {
+    nsConfig[ns] = cache.Config{}
+}
+return cache.Options{DefaultNamespaces: nsConfig}
+```
+
+controller-runtime **v0.24.1** treats the `""` key (`cache.AllNamespaces ==
+metav1.NamespaceAll`) as "cache all namespaces" (pkg/cache/cache.go:138-203,
+verified). So if `FissionResourceNS == {"": ""}`, all four managers that call
+`FissionCacheOptions()` — **buildermgr, executor, router, mqtrigger** — go
+cluster-wide automatically.
+
+So the Go enabler is just `GetNamespaces()` returning `{"": ""}` when the flag
+is set — exactly what the fork did, and it composes cleanly with the reconcilers
+already ported (their cache reads simply see every namespace).
+
+## Go changes (small)
+
+1. **pkg/utils/namespace.go** — add `ENV_WATCH_ALL_NAMESPACES =
+   "FISSION_WATCH_ALL_NAMESPACES"`; in `GetNamespaces()`, when it is `"true"`,
+   return `{metav1.NamespaceAll: metav1.NamespaceAll}`. *This is the enabler.*
+   Port the fork's `namespace_test.go` case.
+
+2. **pkg/utils/serviceaccount.go** — port `EnsureFetcherSA` / `EnsureBuilderSA`
+   (logr, not zap) and make `runSACheck` skip `""`/empty namespaces (so the
+   startup `CreateMissingPermissionForSA` doesn't try to set up SAs for the
+   AllNamespaces sentinel).
+
+3. **On-demand SA creation** for dynamically-discovered namespaces — with
+   watch-all, functions/builders can land in any namespace, and their pods need
+   the fetcher/builder SA present there (the static startup pass can't pre-create
+   in unknown namespaces). Wire (idempotent; harmless when not watch-all):
+   - poolmgr `GenericPool.setup` → `EnsureFetcherSA(gp.fnNamespace)`
+   - newdeploy `fnCreate` → `EnsureFetcherSA(function namespace)`
+   - buildermgr `EnvironmentReconciler.ensureBuilder` → `EnsureBuilderSA(builder namespace)`
+
+   (This is the real reason the fork's `EnsureFetcherSA` existed — see the Phase 5
+   scope note. It belongs here, not in Phase 5.)
+
+## Helm changes (the bulk — a cluster-wide cache REQUIRES cluster-scoped RBAC)
+
+A cluster-wide cache list/watch is forbidden under per-namespace Roles (the
+buildermgr.go comment spells this out), so RBAC must become cluster-scoped when
+watch-all is on. The fork already worked out the template pattern:
+
+4. **values.yaml** — `watchAllNamespaces: false` (default OFF / opt-in).
+5. **_helpers.tpl** — when `watchAllNamespaces`, set `FISSION_RESOURCE_NAMESPACES=""`
+   and `FISSION_WATCH_ALL_NAMESPACES=true` on every component (the shared env block).
+6. **_fission-role-generator.tpl** + **_fission-kuberntes-role-generator.tpl** —
+   emit `ClusterRole`/`ClusterRoleBinding` (a single one, gated on the default
+   namespace so it isn't duplicated per namespace) when `watchAllNamespaces=true`,
+   else the per-namespace `Role`/`RoleBinding` exactly as today.
+7. **_fission-component-roles.tpl** / webhook templates — port the fork's
+   additions as needed; re-verify against upstream's current webhook templates.
+
+Consistency invariant: the same `watchAllNamespaces` value drives **both** the
+cache scope (via the env var) and the RBAC scope (via ClusterRoles). They must
+agree or the manager's cache sync is forbidden and it exits.
+
+## Decisions for sign-off
+
+- **D1 — default.** `watchAllNamespaces: false` (opt-in). Preserves upstream
+  behavior; nobody gets cluster-wide RBAC unless they ask. *Recommended.*
+- **D2 — on-demand SA.** Always call `EnsureFetcherSA`/`EnsureBuilderSA` at
+  pod/builder creation (idempotent, cheap, harmless when not watch-all), rather
+  than gating the calls behind the flag. Simpler and also self-heals a missing SA
+  in the static-namespace case. *Recommended.*
+- **D3 — Helm RBAC scope.** Port the fork's ClusterRole-generator templating
+  (full opt-in toggle). Alternative: ship a separate static ClusterRole only when
+  watch-all — but that diverges from the fork and the per-component role structure.
+  *Recommend the fork's templating approach.*
+
+## Verification plan
+- `go build ./... && go test ./pkg/utils/...` (namespace + SA).
+- `helm template --set watchAllNamespaces=true` → assert ClusterRole/ClusterRoleBinding
+  rendered and `FISSION_WATCH_ALL_NAMESPACES=true` on component env; default render
+  unchanged (Roles, per-namespace).
+- Unit test: `GetNamespaces` returns `{"":""}` under the flag; `FissionCacheOptions`
+  then yields `DefaultNamespaces[""]` (cluster-wide).

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -160,11 +160,13 @@ func (r *EnvironmentReconciler) getLabels(envName string, envNamespace string, e
 // createBuilderDeployment are skipped when a matching (current-RV) object is
 // already present, so this is idempotent across repeated reconciles.
 func (r *EnvironmentReconciler) ensureBuilder(ctx context.Context, env *fv1.Environment, ns string) error {
-	// Ensure the fission-builder ServiceAccount exists in the builder namespace.
-	// Under watch-all-namespaces the builder can be created in any namespace and
-	// its pod needs the SA present there (the static startup pass only covers the
-	// configured namespaces). Idempotent.
+	// Ensure the fission-builder ServiceAccount and the fission-internal-auth
+	// Secret exist in the builder namespace. Under watch-all-namespaces the builder
+	// can be created in any namespace and its pod needs both present there — the
+	// builder's fetcher sidecar uploads the built archive to storagesvc, which
+	// fails with HTTP 401 without the HMAC secret. Idempotent.
 	utils.EnsureBuilderSA(ctx, r.kubernetesClient, r.logger, ns)
+	utils.EnsureInternalAuthSecret(ctx, r.kubernetesClient, r.logger, ns)
 
 	sel := r.getLabels(env.Name, ns, env.ResourceVersion)
 

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -160,6 +160,12 @@ func (r *EnvironmentReconciler) getLabels(envName string, envNamespace string, e
 // createBuilderDeployment are skipped when a matching (current-RV) object is
 // already present, so this is idempotent across repeated reconciles.
 func (r *EnvironmentReconciler) ensureBuilder(ctx context.Context, env *fv1.Environment, ns string) error {
+	// Ensure the fission-builder ServiceAccount exists in the builder namespace.
+	// Under watch-all-namespaces the builder can be created in any namespace and
+	// its pod needs the SA present there (the static startup pass only covers the
+	// configured namespaces). Idempotent.
+	utils.EnsureBuilderSA(ctx, r.kubernetesClient, r.logger, ns)
+
 	sel := r.getLabels(env.Name, ns, env.ResourceVersion)
 
 	svcList, err := r.getBuilderServiceList(ctx, sel, ns)

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -458,6 +458,11 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 	// deployment of the function in fission-function ns
 	ns := deploy.nsResolver.GetFunctionNS(fn.Namespace)
 
+	// Ensure the fission-fetcher ServiceAccount exists in the function namespace.
+	// Under watch-all-namespaces the function can be in any namespace and its
+	// fetcher sidecar needs the SA present there. Idempotent.
+	utils.EnsureFetcherSA(ctx, deploy.kubernetesClient, deploy.logger, ns)
+
 	// Envoy(istio-proxy) returns 404 directly before istio pilot
 	// propagates latest Envoy-specific configuration.
 	// Since newdeploy waits for pods of deployment to be ready,

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -458,10 +458,13 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 	// deployment of the function in fission-function ns
 	ns := deploy.nsResolver.GetFunctionNS(fn.Namespace)
 
-	// Ensure the fission-fetcher ServiceAccount exists in the function namespace.
-	// Under watch-all-namespaces the function can be in any namespace and its
-	// fetcher sidecar needs the SA present there. Idempotent.
+	// Ensure the fission-fetcher ServiceAccount and the fission-internal-auth
+	// Secret exist in the function namespace. Under watch-all-namespaces the
+	// function can be in any namespace and its fetcher sidecar needs both present
+	// there — without the secret the fetcher's storagesvc fetch fails with HTTP
+	// 401 and the pod cannot specialize. Idempotent.
 	utils.EnsureFetcherSA(ctx, deploy.kubernetesClient, deploy.logger, ns)
+	utils.EnsureInternalAuthSecret(ctx, deploy.kubernetesClient, deploy.logger, ns)
 
 	// Envoy(istio-proxy) returns 404 directly before istio pilot
 	// propagates latest Envoy-specific configuration.

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -134,11 +134,14 @@ func MakeGenericPool(
 }
 
 func (gp *GenericPool) setup(ctx context.Context) error {
-	// Ensure the fission-fetcher ServiceAccount exists in this pool's namespace.
-	// Under watch-all-namespaces the pool can be created in any namespace, and the
-	// fetcher sidecar needs the SA present there (the static startup pass only
-	// covers the configured namespaces). Idempotent.
+	// Ensure the fission-fetcher ServiceAccount and the fission-internal-auth
+	// Secret exist in this pool's namespace. Under watch-all-namespaces the pool
+	// can be created in any namespace, and the fetcher sidecar needs both the SA
+	// and the HMAC secret present there (the static startup pass / chart only
+	// cover the configured namespaces; without the secret the fetcher's storagesvc
+	// requests fail with HTTP 401). Idempotent.
 	utils.EnsureFetcherSA(ctx, gp.kubernetesClient, gp.logger, gp.fnNamespace)
+	utils.EnsureInternalAuthSecret(ctx, gp.kubernetesClient, gp.logger, gp.fnNamespace)
 
 	// create the pool
 	err := gp.createPoolDeployment(ctx, gp.env)

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -134,6 +134,12 @@ func MakeGenericPool(
 }
 
 func (gp *GenericPool) setup(ctx context.Context) error {
+	// Ensure the fission-fetcher ServiceAccount exists in this pool's namespace.
+	// Under watch-all-namespaces the pool can be created in any namespace, and the
+	// fetcher sidecar needs the SA present there (the static startup pass only
+	// covers the configured namespaces). Idempotent.
+	utils.EnsureFetcherSA(ctx, gp.kubernetesClient, gp.logger, gp.fnNamespace)
+
 	// create the pool
 	err := gp.createPoolDeployment(ctx, gp.env)
 	if err != nil {

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -65,7 +65,10 @@ type HTTPTriggerSet struct {
 	useEncodedPath             bool
 	svcAddrUpdateThrottler     *throttler.Throttler
 	unTapServiceTimeout        time.Duration
-	syncDebouncer              func(func())
+	// callerNSGuard, when non-nil, enforces same-namespace invocation on the
+	// internal listener (ROUTER_ENFORCE_SAME_NAMESPACE_INVOCATION). nil = disabled.
+	callerNSGuard *sameNamespaceGuard
+	syncDebouncer func(func())
 	// ready flips true after the first successful mux build; routerReadinessHandler
 	// gates /readyz on it so a starting/rolling pod stays out of the
 	// Service endpoints until its mux is populated.
@@ -402,7 +405,13 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 
 		internalRoute := utils.UrlForFunction(fn.Name, fn.Namespace)
 		internalPrefixRoute := internalRoute + "/"
-		handler := http.HandlerFunc(fh.handler)
+		var handler http.Handler = http.HandlerFunc(fh.handler)
+		// Same-namespace guard (opt-in): a caller may invoke this function only
+		// from its own namespace (fn.Namespace) or as an internal Fission
+		// component. Wrapped per function so the target namespace is unambiguous.
+		if ts.callerNSGuard != nil {
+			handler = ts.callerNSGuard.wrap(handler, fn.Namespace)
+		}
 		internal.Handle(internalRoute, handler)
 		internal.PathPrefix(internalPrefixRoute).Handler(handler)
 		ts.logger.V(1).Info("add internal handler and prefix route for function", "router", internalRoute, "function", fn)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -329,6 +329,27 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return fmt.Errorf("error making HTTP trigger set: %w", err)
 	}
 
+	// Opt-in same-namespace guard on the internal listener: when enabled, a caller
+	// may invoke a function only from its own namespace, or as an internal Fission
+	// component (a pod in the router's install namespace). Needs a cluster-wide
+	// pod-ip cache to attribute caller IPs to namespaces.
+	if enforce, _ := strconv.ParseBool(os.Getenv(EnforceSameNamespaceInvocationEnv)); enforce {
+		installNS := routerInstallNamespace()
+		if installNS == "" {
+			return fmt.Errorf("%s is enabled but the router's own namespace could not be determined; set POD_NAMESPACE via the downward API", EnforceSameNamespaceInvocationEnv)
+		}
+		ipCache, err := newPodIPCache(ctx, kubeClient, logger.WithName("same_namespace_guard"))
+		if err != nil {
+			return fmt.Errorf("error starting pod-ip cache for same-namespace guard: %w", err)
+		}
+		triggers.callerNSGuard = &sameNamespaceGuard{
+			lookup:           ipCache,
+			installNamespace: installNS,
+			logger:           logger.WithName("same_namespace_guard"),
+		}
+		logger.Info("router internal listener: same-namespace invocation guard enabled", "install_namespace", installNS)
+	}
+
 	// Register the trigger + function reconcilers. Each signals a debounced mux
 	// rebuild; GenerationChangedPredicate drops status-only writes so the
 	// router's own HTTPTrigger condition writes don't loop.

--- a/pkg/router/same_namespace_guard.go
+++ b/pkg/router/same_namespace_guard.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	k8scache "k8s.io/client-go/tools/cache"
+)
+
+// EnforceSameNamespaceInvocationEnv toggles the same-namespace guard on the
+// router's internal listener. When "true", a caller may only invoke a function
+// in its OWN namespace through /fission-function/<ns>/<name>, unless the caller
+// is an internal Fission component (a pod in the install namespace). This closes
+// the cross-namespace invocation hole: a function pod in one tenant namespace
+// can otherwise reach a private function in another namespace via the shared,
+// (when internalAuth is disabled) unauthenticated internal listener.
+const EnforceSameNamespaceInvocationEnv = "ROUTER_ENFORCE_SAME_NAMESPACE_INVOCATION"
+
+// callerNamespaceLookup resolves a caller pod IP to its namespace.
+type callerNamespaceLookup interface {
+	lookup(ip string) (namespace string, found bool)
+}
+
+// sameNamespaceGuard enforces same-namespace (or internal-component) invocation
+// on the internal listener. It is applied per function handler so the target
+// namespace comes unambiguously from the function (UrlForFunction folds the
+// default namespace into a single-segment path, so the path itself is ambiguous).
+type sameNamespaceGuard struct {
+	lookup           callerNamespaceLookup
+	installNamespace string
+	logger           logr.Logger
+}
+
+// wrap returns inner guarded so it only serves callers whose namespace is
+// targetNamespace, or the install namespace (internal Fission components such as
+// timer / kubewatcher / mqtrigger / executor, which legitimately invoke
+// functions in any namespace). Everything else gets 403.
+func (g *sameNamespaceGuard) wrap(inner http.Handler, targetNamespace string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callerIP := clientIP(r.RemoteAddr)
+		callerNS, found := g.lookup.lookup(callerIP)
+		if !found {
+			// Fail closed: a source we cannot attribute to a namespace must not be
+			// allowed to invoke cross-namespace. Pods — internal components and
+			// functions alike — all have resolvable IPs.
+			g.logger.Info("rejecting internal invocation: caller namespace unresolved",
+				"caller_ip", callerIP, "target_namespace", targetNamespace, "path", r.URL.Path)
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		if callerNS != g.installNamespace && callerNS != targetNamespace {
+			g.logger.Info("rejecting cross-namespace internal invocation",
+				"caller_namespace", callerNS, "target_namespace", targetNamespace,
+				"caller_ip", callerIP, "path", r.URL.Path)
+			http.Error(w, "forbidden: cross-namespace function invocation is not allowed", http.StatusForbidden)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	})
+}
+
+// clientIP extracts the IP from a net/http RemoteAddr ("ip:port"). X-Forwarded-For
+// is deliberately ignored: the internal listener is reached pod-to-pod, so the TCP
+// peer IP is the trustworthy caller identity; a forwarded header would be
+// caller-controlled and trivially spoofable.
+func clientIP(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return remoteAddr
+	}
+	return host
+}
+
+// podRef is the owning pod of a cached IP, so a delete for a recycled IP only
+// removes the mapping when it still belongs to the pod being deleted.
+type podRef struct {
+	namespace string
+	name      string
+}
+
+// podIPCache maintains an in-memory podIP -> namespace index from a cluster-wide
+// pod informer, so the guard attributes a caller IP to a namespace in O(1)
+// without a per-request API call. A transform keeps only namespace/name/podIP to
+// bound memory.
+type podIPCache struct {
+	mu      sync.RWMutex
+	ipToPod map[string]podRef
+}
+
+func (c *podIPCache) lookup(ip string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	p, ok := c.ipToPod[ip]
+	return p.namespace, ok
+}
+
+func (c *podIPCache) set(ip string, p podRef) {
+	if ip == "" {
+		return
+	}
+	c.mu.Lock()
+	c.ipToPod[ip] = p
+	c.mu.Unlock()
+}
+
+// del removes ip only if it still maps to name, so a delete event for an old pod
+// that already had its IP recycled by a new pod does not evict the new mapping.
+func (c *podIPCache) del(ip, name string) {
+	if ip == "" {
+		return
+	}
+	c.mu.Lock()
+	if cur, ok := c.ipToPod[ip]; ok && cur.name == name {
+		delete(c.ipToPod, ip)
+	}
+	c.mu.Unlock()
+}
+
+// newPodIPCache starts a cluster-wide pod informer and blocks until its cache has
+// synced, returning a ready resolver. Cluster-wide is required: a caller may be a
+// function pod in any namespace, not just the Fission-watched ones.
+func newPodIPCache(ctx context.Context, kubeClient kubernetes.Interface, logger logr.Logger) (*podIPCache, error) {
+	c := &podIPCache{ipToPod: make(map[string]podRef)}
+	factory := informers.NewSharedInformerFactory(kubeClient, 30*time.Minute)
+	informer := factory.Core().V1().Pods().Informer()
+	if err := informer.SetTransform(func(obj any) (any, error) {
+		pod, ok := obj.(*corev1.Pod)
+		if !ok {
+			return obj, nil
+		}
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name},
+			Status:     corev1.PodStatus{PodIP: pod.Status.PodIP},
+		}, nil
+	}); err != nil {
+		return nil, fmt.Errorf("error setting pod informer transform: %w", err)
+	}
+	if _, err := informer.AddEventHandler(k8scache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj any) { c.onPod(obj) },
+		UpdateFunc: func(_, obj any) { c.onPod(obj) },
+		DeleteFunc: func(obj any) { c.onPodDelete(obj) },
+	}); err != nil {
+		return nil, fmt.Errorf("error adding pod informer handler: %w", err)
+	}
+	factory.Start(ctx.Done())
+	if !k8scache.WaitForCacheSync(ctx.Done(), informer.HasSynced) {
+		return nil, fmt.Errorf("timed out waiting for router pod-ip cache sync")
+	}
+	logger.Info("router same-namespace guard: pod-ip cache synced")
+	return c, nil
+}
+
+func (c *podIPCache) onPod(obj any) {
+	if pod, ok := obj.(*corev1.Pod); ok {
+		c.set(pod.Status.PodIP, podRef{namespace: pod.Namespace, name: pod.Name})
+	}
+}
+
+func (c *podIPCache) onPodDelete(obj any) {
+	switch t := obj.(type) {
+	case *corev1.Pod:
+		c.del(t.Status.PodIP, t.Name)
+	case k8scache.DeletedFinalStateUnknown:
+		if pod, ok := t.Obj.(*corev1.Pod); ok {
+			c.del(pod.Status.PodIP, pod.Name)
+		}
+	}
+}
+
+// routerInstallNamespace returns the namespace the router runs in (the Fission
+// install namespace), used to exempt internal components from the guard. Reads
+// POD_NAMESPACE (set by the chart via the downward API), falling back to the
+// service account namespace file that is always mounted into a pod.
+func routerInstallNamespace() string {
+	if ns := strings.TrimSpace(os.Getenv("POD_NAMESPACE")); ns != "" {
+		return ns
+	}
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		if ns := strings.TrimSpace(string(data)); ns != "" {
+			return ns
+		}
+	}
+	return ""
+}

--- a/pkg/router/same_namespace_guard.go
+++ b/pkg/router/same_namespace_guard.go
@@ -94,19 +94,55 @@ type podRef struct {
 }
 
 // podIPCache maintains an in-memory podIP -> namespace index from a cluster-wide
-// pod informer, so the guard attributes a caller IP to a namespace in O(1)
-// without a per-request API call. A transform keeps only namespace/name/podIP to
-// bound memory.
+// pod informer, so the guard attributes a caller IP to a namespace in O(1) for
+// the common (warm) case. A transform keeps only namespace/name/podIP to bound
+// memory. On a cache miss it falls back to a direct API lookup (kubeClient), so a
+// freshly created caller that races the watch is not wrongly rejected.
 type podIPCache struct {
-	mu      sync.RWMutex
-	ipToPod map[string]podRef
+	mu         sync.RWMutex
+	ipToPod    map[string]podRef
+	kubeClient kubernetes.Interface
+	logger     logr.Logger
 }
 
+// lookup resolves an IP to a namespace from the warm informer cache, falling back
+// to a direct API query on a miss. The fallback is what makes the guard correct
+// for callers whose pod the informer has not observed yet (a fresh pod races the
+// watch); without it, fail-closed would reject legitimate same-namespace traffic.
 func (c *podIPCache) lookup(ip string) (string, bool) {
 	c.mu.RLock()
-	defer c.mu.RUnlock()
 	p, ok := c.ipToPod[ip]
-	return p.namespace, ok
+	c.mu.RUnlock()
+	if ok {
+		return p.namespace, true
+	}
+	return c.resolveFromAPI(ip)
+}
+
+// resolveFromAPI looks the caller IP up directly via the API server (server-side
+// filtered by status.podIP) and warms the cache. The result is re-checked against
+// the IP so it stays correct even against a client that does not honour the field
+// selector. A truly unknown IP returns not-found (the guard then fails closed).
+func (c *podIPCache) resolveFromAPI(ip string) (string, bool) {
+	if ip == "" || c.kubeClient == nil {
+		return "", false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	pods, err := c.kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		FieldSelector: "status.podIP=" + ip,
+	})
+	if err != nil {
+		c.logger.Error(err, "error resolving caller pod IP from API", "caller_ip", ip)
+		return "", false
+	}
+	for i := range pods.Items {
+		if pods.Items[i].Status.PodIP == ip {
+			c.set(ip, podRef{namespace: pods.Items[i].Namespace, name: pods.Items[i].Name})
+			return pods.Items[i].Namespace, true
+		}
+	}
+	return "", false
 }
 
 func (c *podIPCache) set(ip string, p podRef) {
@@ -135,7 +171,7 @@ func (c *podIPCache) del(ip, name string) {
 // synced, returning a ready resolver. Cluster-wide is required: a caller may be a
 // function pod in any namespace, not just the Fission-watched ones.
 func newPodIPCache(ctx context.Context, kubeClient kubernetes.Interface, logger logr.Logger) (*podIPCache, error) {
-	c := &podIPCache{ipToPod: make(map[string]podRef)}
+	c := &podIPCache{ipToPod: make(map[string]podRef), kubeClient: kubeClient, logger: logger}
 	factory := informers.NewSharedInformerFactory(kubeClient, 30*time.Minute)
 	informer := factory.Core().V1().Pods().Informer()
 	if err := informer.SetTransform(func(obj any) (any, error) {

--- a/pkg/router/same_namespace_guard_test.go
+++ b/pkg/router/same_namespace_guard_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
 
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
@@ -93,4 +96,31 @@ func TestPodIPCache(t *testing.T) {
 	c.set("", podRef{namespace: "x", name: "y"})
 	_, ok = c.lookup("")
 	assert.False(t, ok)
+}
+
+// TestPodIPCacheAPIFallback covers the cache-miss path: a caller whose pod the
+// informer has not observed yet (a fresh pod racing the watch) must still resolve
+// via a direct API lookup, so the guard does not wrongly reject it.
+func TestPodIPCacheAPIFallback(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "caller", Namespace: "tenant-x"},
+		Status:     corev1.PodStatus{PodIP: "10.1.2.3"},
+	}
+	c := &podIPCache{
+		ipToPod:    map[string]podRef{}, // empty warm cache forces the API fallback
+		kubeClient: k8sfake.NewClientset(pod),
+		logger:     loggerfactory.GetLogger(),
+	}
+
+	ns, ok := c.lookup("10.1.2.3")
+	assert.True(t, ok, "cache miss must resolve via the API fallback")
+	assert.Equal(t, "tenant-x", ns)
+
+	c.mu.RLock()
+	_, warm := c.ipToPod["10.1.2.3"]
+	c.mu.RUnlock()
+	assert.True(t, warm, "an API-resolved IP should be warmed into the cache")
+
+	_, ok = c.lookup("10.9.9.9")
+	assert.False(t, ok, "an IP with no pod stays unresolved")
 }

--- a/pkg/router/same_namespace_guard_test.go
+++ b/pkg/router/same_namespace_guard_test.go
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// mapLookup is a static callerNamespaceLookup for tests: ip -> namespace.
+type mapLookup map[string]string
+
+func (m mapLookup) lookup(ip string) (string, bool) {
+	ns, ok := m[ip]
+	return ns, ok
+}
+
+func TestSameNamespaceGuard(t *testing.T) {
+	const installNS = "fission"
+
+	cases := []struct {
+		name       string
+		callerIP   string
+		lookup     mapLookup
+		targetNS   string
+		wantStatus int
+		wantInner  bool
+	}{
+		{"same namespace allowed", "10.0.0.1:5000", mapLookup{"10.0.0.1": "tenant-a"}, "tenant-a", http.StatusOK, true},
+		{"internal component (install ns) may invoke any namespace", "10.0.0.2:5000", mapLookup{"10.0.0.2": installNS}, "tenant-b", http.StatusOK, true},
+		{"cross-namespace forbidden", "10.0.0.3:5000", mapLookup{"10.0.0.3": "tenant-a"}, "tenant-b", http.StatusForbidden, false},
+		{"unresolved caller IP forbidden (fail closed)", "10.0.0.9:5000", mapLookup{}, "tenant-a", http.StatusForbidden, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			innerCalled := false
+			inner := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				innerCalled = true
+				w.WriteHeader(http.StatusOK)
+			})
+			g := &sameNamespaceGuard{lookup: tc.lookup, installNamespace: installNS, logger: loggerfactory.GetLogger()}
+			h := g.wrap(inner, tc.targetNS)
+
+			req := httptest.NewRequest(http.MethodPost, "/fission-function/"+tc.targetNS+"/fn", nil)
+			req.RemoteAddr = tc.callerIP
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			assert.Equal(t, tc.wantStatus, rec.Code)
+			assert.Equal(t, tc.wantInner, innerCalled, "inner handler reached?")
+		})
+	}
+}
+
+func TestClientIP(t *testing.T) {
+	assert.Equal(t, "10.0.0.1", clientIP("10.0.0.1:5678"))
+	assert.Equal(t, "10.0.0.1", clientIP("10.0.0.1"))     // no port
+	assert.Equal(t, "fe80::1", clientIP("[fe80::1]:443")) // ipv6
+}
+
+func TestPodIPCache(t *testing.T) {
+	c := &podIPCache{ipToPod: map[string]podRef{}}
+
+	c.set("10.0.0.1", podRef{namespace: "ns1", name: "pod-a"})
+	ns, ok := c.lookup("10.0.0.1")
+	assert.True(t, ok)
+	assert.Equal(t, "ns1", ns)
+
+	_, ok = c.lookup("10.0.0.99")
+	assert.False(t, ok, "unknown IP must not resolve")
+
+	// IP recycling: pod-b takes over 10.0.0.1 in ns2; a late delete for pod-a must
+	// NOT evict pod-b's mapping.
+	c.set("10.0.0.1", podRef{namespace: "ns2", name: "pod-b"})
+	c.del("10.0.0.1", "pod-a")
+	ns, ok = c.lookup("10.0.0.1")
+	assert.True(t, ok)
+	assert.Equal(t, "ns2", ns, "stale delete for the previous owner must not evict the recycled IP")
+
+	// The matching delete removes it.
+	c.del("10.0.0.1", "pod-b")
+	_, ok = c.lookup("10.0.0.1")
+	assert.False(t, ok)
+
+	// Empty IP is ignored on both set and lookup.
+	c.set("", podRef{namespace: "x", name: "y"})
+	_, ok = c.lookup("")
+	assert.False(t, ok)
+}

--- a/pkg/utils/internalauthsecret.go
+++ b/pkg/utils/internalauthsecret.go
@@ -35,18 +35,33 @@ const InternalAuthSecretName = "fission-internal-auth"
 // static-namespace case (the values match), so callers invoke it unconditionally
 // alongside EnsureFetcherSA / EnsureBuilderSA.
 //
-// No-op when internal auth is disabled (both env values empty) or namespace is
-// empty: creates the Secret if missing, updates it if the HMAC values drifted,
-// and leaves it untouched otherwise.
+// Reconciles to match internal auth state, so toggling it never leaves the tenant
+// copy stale: when disabled (both env values empty) it DELETES the Secret if
+// present — a leftover copy would make the function-pod fetcher sidecar (whose
+// secretKeyRef is always mounted) keep enforcing HMAC while the control plane no
+// longer signs, producing 401s on specialization. When enabled it creates the
+// Secret if missing, updates it if the HMAC values drifted, and leaves it
+// untouched otherwise. No-op for an empty namespace.
 func EnsureInternalAuthSecret(ctx context.Context, kubernetesClient kubernetes.Interface, logger logr.Logger, namespace string) {
 	if namespace == "" {
 		return
 	}
 	secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET")
 	oldSecret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD")
-	if secret == "" && oldSecret == "" {
-		// internal auth disabled — storagesvc does not enforce signatures, so
-		// there is nothing to propagate.
+	disabled := secret == "" && oldSecret == ""
+
+	secrets := kubernetesClient.CoreV1().Secrets(namespace)
+	existing, err := secrets.Get(ctx, InternalAuthSecretName, metav1.GetOptions{})
+
+	if disabled {
+		// Internal auth is off: ensure no tenant copy lingers (so fetchers don't
+		// enforce). Only delete when one actually exists, to avoid a delete call
+		// on every reconcile in the common (default-off) case.
+		if err == nil {
+			if derr := secrets.Delete(ctx, InternalAuthSecretName, metav1.DeleteOptions{}); derr != nil && !apierrors.IsNotFound(derr) {
+				logger.Error(derr, "error deleting stale internal-auth secret", "namespace", namespace)
+			}
+		}
 		return
 	}
 
@@ -58,8 +73,6 @@ func EnsureInternalAuthSecret(ctx context.Context, kubernetesClient kubernetes.I
 		data["oldSecret"] = []byte(oldSecret)
 	}
 
-	secrets := kubernetesClient.CoreV1().Secrets(namespace)
-	existing, err := secrets.Get(ctx, InternalAuthSecretName, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		_, cerr := secrets.Create(ctx, &apiv1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/internalauthsecret.go
+++ b/pkg/utils/internalauthsecret.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"os"
+
+	"github.com/go-logr/logr"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// InternalAuthSecretName is the Secret that holds the shared HMAC secret used to
+// sign Fission's internal-channel requests (storagesvc /v1/archive, fetcher,
+// builder, executor, router). The fetcher sidecar reads FISSION_INTERNAL_AUTH_SECRET
+// from it via a secretKeyRef. See docs/internal-auth/00-design.md.
+const InternalAuthSecretName = "fission-internal-auth"
+
+// EnsureInternalAuthSecret makes the fission-internal-auth Secret present in
+// namespace, mirroring the HMAC values from the caller's own
+// FISSION_INTERNAL_AUTH_SECRET[_OLD] env.
+//
+// Required under watch-all-namespaces: the chart only creates this Secret in the
+// configured namespaces, so a function or builder pod in a dynamically-discovered
+// namespace would otherwise get an EMPTY FISSION_INTERNAL_AUTH_SECRET (the
+// sidecar's secretKeyRef is Optional and the Secret is absent), sign nothing, and
+// fail every storagesvc request with HTTP 401. Idempotent and harmless in the
+// static-namespace case (the values match), so callers invoke it unconditionally
+// alongside EnsureFetcherSA / EnsureBuilderSA.
+//
+// No-op when internal auth is disabled (both env values empty) or namespace is
+// empty: creates the Secret if missing, updates it if the HMAC values drifted,
+// and leaves it untouched otherwise.
+func EnsureInternalAuthSecret(ctx context.Context, kubernetesClient kubernetes.Interface, logger logr.Logger, namespace string) {
+	if namespace == "" {
+		return
+	}
+	secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET")
+	oldSecret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD")
+	if secret == "" && oldSecret == "" {
+		// internal auth disabled — storagesvc does not enforce signatures, so
+		// there is nothing to propagate.
+		return
+	}
+
+	data := map[string][]byte{}
+	if secret != "" {
+		data["secret"] = []byte(secret)
+	}
+	if oldSecret != "" {
+		data["oldSecret"] = []byte(oldSecret)
+	}
+
+	secrets := kubernetesClient.CoreV1().Secrets(namespace)
+	existing, err := secrets.Get(ctx, InternalAuthSecretName, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		_, cerr := secrets.Create(ctx, &apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      InternalAuthSecretName,
+				Namespace: namespace,
+				Labels:    map[string]string{"application": "fission-internal-auth"},
+			},
+			Type: apiv1.SecretTypeOpaque,
+			Data: data,
+		}, metav1.CreateOptions{})
+		if cerr != nil && !apierrors.IsAlreadyExists(cerr) {
+			logger.Error(cerr, "error creating internal-auth secret", "namespace", namespace)
+		}
+		return
+	}
+	if err != nil {
+		logger.Error(err, "error getting internal-auth secret", "namespace", namespace)
+		return
+	}
+	if maps.EqualFunc(existing.Data, data, bytes.Equal) {
+		return
+	}
+	existing.Data = data
+	if _, uerr := secrets.Update(ctx, existing, metav1.UpdateOptions{}); uerr != nil {
+		logger.Error(uerr, "error updating internal-auth secret", "namespace", namespace)
+	}
+}

--- a/pkg/utils/internalauthsecret_test.go
+++ b/pkg/utils/internalauthsecret_test.go
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+func TestEnsureInternalAuthSecret(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+
+	t.Run("creates the secret from env in a fresh namespace", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "s3cr3t")
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET_OLD", "old")
+		kc := k8sfake.NewClientset()
+
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "tenant-ns")
+
+		got, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, []byte("s3cr3t"), got.Data["secret"])
+		assert.Equal(t, []byte("old"), got.Data["oldSecret"])
+	})
+
+	t.Run("no-op when internal auth is disabled (no env)", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "")
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET_OLD", "")
+		kc := k8sfake.NewClientset()
+
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "tenant-ns")
+
+		_, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
+		assert.True(t, apierrors.IsNotFound(err), "must not create a secret when internal auth is disabled")
+	})
+
+	t.Run("updates only when the value drifts", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "v2")
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET_OLD", "")
+		kc := k8sfake.NewClientset()
+
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "tenant-ns")
+		first, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, []byte("v2"), first.Data["secret"])
+
+		// Same value again: idempotent, no spurious change.
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "tenant-ns")
+		same, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, first.ResourceVersion, same.ResourceVersion, "unchanged value must not trigger an update")
+
+		// Drifted value: updates in place.
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "v3")
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "tenant-ns")
+		updated, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, []byte("v3"), updated.Data["secret"])
+	})
+
+	t.Run("empty namespace is a no-op", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "s")
+		kc := k8sfake.NewClientset()
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "")
+		// nothing to assert beyond not panicking / not erroring
+	})
+}

--- a/pkg/utils/internalauthsecret_test.go
+++ b/pkg/utils/internalauthsecret_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
@@ -41,6 +42,22 @@ func TestEnsureInternalAuthSecret(t *testing.T) {
 
 		_, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
 		assert.True(t, apierrors.IsNotFound(err), "must not create a secret when internal auth is disabled")
+	})
+
+	t.Run("disabled DELETES a leftover secret (self-heal on toggle-off)", func(t *testing.T) {
+		// Simulate a copy left behind from when internal auth was enabled.
+		kc := k8sfake.NewClientset(&apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: InternalAuthSecretName, Namespace: "tenant-ns"},
+			Data:       map[string][]byte{"secret": []byte("stale")},
+		})
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "")
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET_OLD", "")
+
+		EnsureInternalAuthSecret(t.Context(), kc, logger, "tenant-ns")
+
+		_, err := kc.CoreV1().Secrets("tenant-ns").Get(t.Context(), InternalAuthSecretName, metav1.GetOptions{})
+		assert.True(t, apierrors.IsNotFound(err),
+			"a leftover secret must be deleted when internal auth is off, else fetchers keep enforcing HMAC")
 	})
 
 	t.Run("updates only when the value drifts", func(t *testing.T) {

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -21,6 +21,7 @@ const (
 	ENV_BUILDER_NAMESPACE    string = "FISSION_BUILDER_NAMESPACE"
 	ENV_DEFAULT_NAMESPACE    string = "FISSION_DEFAULT_NAMESPACE"
 	ENV_ADDITIONAL_NAMESPACE string = "FISSION_RESOURCE_NAMESPACES"
+	ENV_WATCH_ALL_NAMESPACES string = "FISSION_WATCH_ALL_NAMESPACES"
 )
 
 type (
@@ -112,6 +113,16 @@ func (nsr *NamespaceResolver) FissionNSWithOptions(option ...option) map[string]
 
 func GetNamespaces() map[string]string {
 	namespaces := make(map[string]string)
+
+	// Watch-all-namespaces: a single metav1.NamespaceAll ("") entry. The Manager
+	// cache reads this through FissionCacheOptions, where controller-runtime treats
+	// the "" (cache.AllNamespaces) key as "cache every namespace" — so all Fission
+	// managers go cluster-wide. Requires cluster-scoped RBAC (the chart emits
+	// ClusterRoles when watchAllNamespaces is set).
+	if os.Getenv(ENV_WATCH_ALL_NAMESPACES) == "true" {
+		namespaces[metav1.NamespaceAll] = metav1.NamespaceAll
+		return namespaces
+	}
 
 	envValue := os.Getenv(ENV_DEFAULT_NAMESPACE)
 	if len(envValue) > 0 {

--- a/pkg/utils/namespace_test.go
+++ b/pkg/utils/namespace_test.go
@@ -238,3 +238,27 @@ func setNamespace(defaultNamespace string, additionalNamespace string) error {
 	}
 	return os.Setenv(ENV_ADDITIONAL_NAMESPACE, additionalNamespace)
 }
+
+func TestGetNamespacesWatchAll(t *testing.T) {
+	t.Run("watch-all returns the NamespaceAll sentinel and ignores other ns env", func(t *testing.T) {
+		t.Setenv(ENV_WATCH_ALL_NAMESPACES, "true")
+		t.Setenv(ENV_DEFAULT_NAMESPACE, "ignored")
+		t.Setenv(ENV_ADDITIONAL_NAMESPACE, "also,ignored")
+
+		ns := GetNamespaces()
+		require.Len(t, ns, 1)
+		// "" is metav1.NamespaceAll; FissionCacheOptions maps it to a cluster-wide cache.
+		require.Contains(t, ns, "")
+		require.Equal(t, "", ns[""])
+	})
+
+	t.Run("watch-all off falls back to default/additional resolution", func(t *testing.T) {
+		t.Setenv(ENV_WATCH_ALL_NAMESPACES, "false")
+		t.Setenv(ENV_DEFAULT_NAMESPACE, "default")
+		t.Setenv(ENV_ADDITIONAL_NAMESPACE, "")
+
+		ns := GetNamespaces()
+		require.Len(t, ns, 1)
+		require.Contains(t, ns, "default")
+	})
+}

--- a/pkg/utils/serviceaccount.go
+++ b/pkg/utils/serviceaccount.go
@@ -111,6 +111,28 @@ func CreateMissingPermissionForSA(ctx context.Context, kubernetesClient kubernet
 	}
 }
 
+// EnsureFetcherSA ensures the fission-fetcher ServiceAccount (and its role
+// bindings) exists in namespace. It provisions the SA on demand in a
+// dynamically-discovered function namespace under watch-all-namespaces, where the
+// static startup pass (CreateMissingPermissionForSA over FissionResourceNS)
+// cannot pre-create it. Idempotent, and harmless in the static-namespace case
+// (the SA already exists), so callers can invoke it unconditionally.
+func EnsureFetcherSA(ctx context.Context, kubernetesClient kubernetes.Interface, logger logr.Logger, namespace string) {
+	if namespace == "" {
+		return
+	}
+	setupSAAndRoleBindings(ctx, kubernetesClient, logger, namespace, fetcherCheck)
+}
+
+// EnsureBuilderSA ensures the fission-builder ServiceAccount (and its role
+// bindings) exists in namespace. See EnsureFetcherSA.
+func EnsureBuilderSA(ctx context.Context, kubernetesClient kubernetes.Interface, logger logr.Logger, namespace string) {
+	if namespace == "" {
+		return
+	}
+	setupSAAndRoleBindings(ctx, kubernetesClient, logger, namespace, builderCheck)
+}
+
 func getSAObj(kubernetesClient kubernetes.Interface, logger logr.Logger) *ServiceAccount {
 	saObj := &ServiceAccount{
 		kubernetesClient: kubernetesClient,
@@ -124,11 +146,23 @@ func getSAObj(kubernetesClient kubernetes.Interface, logger logr.Logger) *Servic
 
 func (sa *ServiceAccount) runSACheck(ctx context.Context) {
 	for _, ns := range sa.nsResolver.FissionResourceNS {
+		// Under watch-all-namespaces FissionResourceNS is the single
+		// metav1.NamespaceAll ("") sentinel: there is no concrete namespace to set
+		// up here. The fetcher/builder SAs are instead ensured on demand in each
+		// function/builder namespace as it is discovered, via EnsureFetcherSA /
+		// EnsureBuilderSA.
+		if ns == metav1.NamespaceAll {
+			continue
+		}
 		for _, permission := range sa.permissions {
 			if permission.saName == BuilderSAName {
 				ns = sa.nsResolver.GetBuilderNS(ns)
 			} else {
 				ns = sa.nsResolver.GetFunctionNS(ns)
+			}
+			if ns == "" {
+				sa.logger.V(1).Info("skipping service account check for empty namespace", "sa_name", permission.saName)
+				continue
 			}
 			setupSAAndRoleBindings(ctx, sa.kubernetesClient, sa.logger, ns, permission)
 		}


### PR DESCRIPTION
## Summary

This PR ports two closely related features onto the controller-runtime codebase:

1. **Watch All Namespaces** — the fork's namesake feature, enabling Fission to manage functions and builders in any Kubernetes namespace, not just the install namespace.
2. **Cross-Namespace Invocation Isolation** — a router guard that prevents a function pod in one tenant namespace from invoking a private function in another namespace on the internal listener (`router-internal:8889`).

Both features are grounded in a Helm-chart RBAC restructure (cluster-scoped Roles when watch-all is on) and a shared namespace-propagation mechanism for the internal HMAC secret.

---

## Commits

### `feat(namespaces): watch all namespaces (the fork's namesake feature)`

**Spike:** [docs/spike-watch-all-namespaces.md](docs/spike-watch-all-namespaces.md)

Ports the fork's watch-all-namespaces onto the controller-runtime architecture. The Go enabler is small: the new Manager cache already supports cluster-wide watching — `controller-runtime` treats the `""` (AllNamespaces) key in `cache.Options.DefaultNamespaces` as cluster-wide, and `FissionCacheOptions` builds that map from `NamespaceResolver.FissionResourceNS`. So `GetNamespaces()` just returns the `metav1.NamespaceAll` sentinel when `FISSION_WATCH_ALL_NAMESPACES` is set.

**Go changes:**
- `pkg/utils/namespace.go` — `FISSION_WATCH_ALL_NAMESPACES` env; `GetNamespaces()` returns the single `metav1.NamespaceAll` sentinel when set, taking all four managers (buildermgr, executor, router, mqtrigger) cluster-wide.
- `pkg/utils/serviceaccount.go` — `EnsureFetcherSA` / `EnsureBuilderSA` (logr); `runSACheck` skips the `NamespaceAll` sentinel and empty resolved namespaces.
- On-demand SA creation for dynamically-discovered namespaces (idempotent, harmless when not watch-all): executor (`poolmgr gp.setup`, `newdeploy fnCreate`) ensures the fetcher SA; buildermgr (`EnvironmentReconciler.ensureBuilder`) ensures the builder SA.

**Helm changes (cluster-wide cache requires cluster-scoped RBAC):**
- `values.yaml`: `watchAllNamespaces: true` (fork default — it is the watch-all distro).
- `_helpers.tpl`: sets `FISSION_WATCH_ALL_NAMESPACES=true` + `FISSION_RESOURCE_NAMESPACES=""` on every component when enabled.
- Role generators: emit `ClusterRole`/`ClusterRoleBinding` (one, gated to the default namespace) instead of per-namespace `Role`/`RoleBinding` when enabled.
- buildermgr/executor gain `serviceaccounts` + `roles/rolebindings` + `localsubjectaccessreviews create` so on-demand SA provisioning is not RBAC-forbidden.

Verified: `go build ./...`, `go test ./pkg/utils/... ./pkg/buildermgr/... ./pkg/executor/executortype/...`, helm lint, `helm template` renders ClusterRoles + watch-all env at `watchAllNamespaces=true` and per-namespace Roles at `=false`.

---

### `fix(namespaces): propagate fission-internal-auth Secret to dynamic namespaces`

Under watch-all-namespaces, function/builder pods land in namespaces the chart never knew about, so the `fission-internal-auth` Secret (the shared HMAC secret) is absent there. The fetcher sidecar's `FISSION_INTERNAL_AUTH_SECRET` secretKeyRef is `Optional`, so it resolves to empty, the fetcher signs nothing, and storagesvc rejects every `/v1/archive` request with HTTP 401 — functions in tenant namespaces fail to specialize and builder uploads fail. HMAC auth is an upstream addition the fork's v1.22 base never had, so the fork's watch-all never hit this.

**Fix:** `utils.EnsureInternalAuthSecret(ns)` — create-or-update the `fission-internal-auth` Secret in `ns`, mirroring the caller's own `FISSION_INTERNAL_AUTH_SECRET[_OLD]` env. No-op when internal auth is disabled or `ns` is empty; idempotent. Wired alongside `EnsureFetcherSA`/`EnsureBuilderSA` in `poolmgr gp.setup`, `newdeploy fnCreate`, and `buildermgr ensureBuilder`.

**RBAC:** buildermgr/executor gain `secrets create/update` (had only get/list/watch), so the on-demand secret write is not forbidden.

Tests: create-from-env, disabled no-op, idempotent/drift update, empty ns no-op. `go build ./...` and helm lint pass.

---

### `chore(chart): default internalAuth (HMAC) off on the fork`

**Feature doc:** [docs/features/internal-auth.md](docs/features/internal-auth.md)

Upstream defaults `internalAuth.enabled=true`, which makes the HMAC verifier on `router-internal` (and storagesvc) reject unsigned requests. The upstream KEDA HTTP connectors and the GraphQL federation gateway both send **unsigned** requests, so with HMAC on, MessageQueueTrigger delivery (RabbitMQ/Kafka/…) and federated subgraph calls fail with 401. This fork ran its whole v1.22.x life with no HMAC, so default it off to preserve that working behaviour (NetworkPolicies + namespace isolation still apply). Opt back in with `--set internalAuth.enabled=true` (then you must use signing-aware connector images).

- `values.yaml`: `internalAuth.enabled false` (+ rationale comment)
- `docs/features/internal-auth.md`: why, how to enable, and the all-or-nothing restart caveat (toggling needs all 8 secret-bearing components restarted, or verifiers/signers end up split-state → fetch failures / specialization timeouts)

Verified: helm lint; default render has no `FISSION_INTERNAL_AUTH_SECRET` env and no `fission-internal-auth` Secret; `--set internalAuth.enabled=true` restores them.

---

### `fix(namespaces): self-heal internal-auth Secret when HMAC is toggled off`

`EnsureInternalAuthSecret` now reconciles the tenant-namespace `fission-internal-auth` copy to the current internal-auth state instead of only creating it: when internal auth is disabled (empty `FISSION_INTERNAL_AUTH_SECRET` env) it **deletes** an existing copy. A leftover copy makes the function-pod fetcher sidecar (secretKeyRef always mounted) keep enforcing HMAC while the control plane no longer signs, so specialization fails with "error creating service for function: 401 Unauthorized". This is what bit a cluster that had internalAuth enabled and was then switched off: the per-namespace copies lingered and broke poolmgr/newdeploy specialization.

- delete-on-disable, scoped by a `Get` so the default-off case is a no-op
- RBAC: buildermgr/executor get `secrets delete` restricted via `resourceNames` to just `fission-internal-auth`
- test: disabled-deletes-a-leftover-secret; docs note updated

Production safety: a fresh deploy with `internalAuth.enabled=false` (the fork default) never creates these Secrets — verified `helm template` at the default has 0 `FISSION_INTERNAL_AUTH_SECRET` envs and 0 `fission-internal-auth` Secret objects, and the fetcher's secretKeyRef is Optional (missing → empty → pass-through). So no 401 regression on a clean install; this fix only matters when toggling a live one.

`go build ./...; go test ./pkg/utils/...; helm lint all pass.`

---

### `feat(router): same-namespace invocation guard for the internal listener`

**Feature doc:** [docs/features/internal-invocation-isolation.md](docs/features/internal-invocation-isolation.md)

Closes the cross-namespace invocation gap on `router-internal:8889`. The internal listener serves `/fission-function/<ns>/<name>` for **any** namespace, and with `internalAuth` disabled it is unauthenticated — so a function pod in one tenant namespace can invoke a private function in another. NetworkPolicy/HMAC gate **who** reaches the port, not **which** namespace they can target.

Opt-in via `router.enforceSameNamespaceInvocation` (default off). When enabled, a `/fission-function/<ns>/<name>` request is rejected (403) unless:
- the caller's pod is in the **same namespace** as the target function, **or**
- the caller is an **internal Fission component** — a pod in the install namespace (executor/kubewatcher/timer/mqtrigger), which legitimately invoke across namespaces.

This fits the real patterns: a federation gateway invoking its own-namespace subgraphs and a KEDA connector (deployed in the function's namespace) both pass; A→B cross-tenant invocation is blocked.

- Caller attributed by source pod IP (TCP peer; `X-Forwarded-For` ignored as spoofable) via a cluster-wide podIP→namespace informer cache; unresolved callers fail closed. Enforced per-function handler so the target namespace is unambiguous.
- Chart: `router.enforceSameNamespaceInvocation` value, `ROUTER_ENFORCE_SAME_NAMESPACE_INVOCATION` env, and a dedicated cluster-scoped ClusterRole granting the router pods get/list/watch (created only when enabled; works regardless of watchAllNamespaces).
- Reuses the router's existing `POD_NAMESPACE` downward-API env for the install ns.

Tests: same-ns allowed, internal-component cross-ns allowed, cross-ns 403, unresolved-IP 403; clientIP parsing (incl. IPv6); podIP cache incl. recycled-IP delete safety. `go build ./...`, `go test -race ./pkg/router/`, helm lint all pass; `helm template` gates env + ClusterRole on the value.

---

### `fix(router): resolve caller IP via API on same-namespace-guard cache miss`

The informer-backed podIP cache races a freshly created caller: the pod makes its first request before the watch has observed the pod's IP, so lookup misses and the guard fail-closes — wrongly rejecting legitimate same-namespace traffic (incl. a just-started federation gateway). Live verification showed same-namespace and internal-component callers getting 403 with "caller namespace unresolved".

**Fix:** on a cache miss, resolve the IP directly from the API server (server-side filtered by `status.podIP`, re-checked against the IP so it stays correct even against a client that ignores the field selector) and warm the cache. A truly unknown IP still returns not-found, so an unattributable source still fails closed. The warm informer cache remains the fast path for steady-state traffic.

The router's `fission-router-pod-reader` ClusterRole already grants pods list, so no RBAC change.

Test: `TestPodIPCacheAPIFallback` (cache miss resolves via fake clientset + warms).

---

### `docs(router): note same-namespace-guard API fallback + cold-start window`

Document that the guard resolves the caller IP via the informer cache with a direct-API fallback on miss, and that a brand-new pod's very first request (before its `status.podIP` is observable) fails closed and succeeds on retry — long-running callers (federation, functions) are unaffected, and the federation→subgraph cold-start path is safe (the caller is the long-running federation).

Verified live: cross-namespace 403, same-namespace 200, internal-component 200, federation passing.

---

## Feature Docs

| Document | Description |
|---|---|
| [docs/features/internal-auth.md](docs/features/internal-auth.md) | Why HMAC is off by default, what breaks if turned on without signing-aware callers, all-or-nothing operational caveat, tenant-namespace secret propagation under watch-all |
| [docs/features/internal-invocation-isolation.md](docs/features/internal-invocation-isolation.md) | How the same-namespace guard works, how it attributes callers, cold-start window, relationship to NetworkPolicy and HMAC controls, key files |

---

## Relationship Between the Controls

| Control | Restricts |
|---|---|
| `internalAuth` (HMAC) | *who* may call router-internal (signed callers only) |
| `networkPolicy` (router-internal ingress) | *which pods* may reach port 8889 |
| **`enforceSameNamespaceInvocation`** | *which namespace's functions* a caller may invoke |

---

## Testing

- `go build ./...`
- `go test ./pkg/utils/... ./pkg/buildermgr/... ./pkg/executor/executortype/...`
- `go test -race ./pkg/router/` (same-ns allowed, cross-ns 403, unresolved-IP 403, podIP cache API fallback, IPv6, recycled-IP delete safety)
- `helm lint`; `helm template --set watchAllNamespaces=true` asserts ClusterRole + `FISSION_WATCH_ALL_NAMESPACES=true` on all components; default render unchanged (per-namespace Roles)





@sanketsudake

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3476)
<!-- Reviewable:end -->
