### PR TITLE
fix(security): confine fetcher file ops to shared volume via os.Root

### DIFF
--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -329,7 +329,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 		// fetch the file and save it to the tmp path. FETCH_URL targets
 		// are user-supplied — pick the unsigned client unless the URL
 		// happens to point at our own storagesvc.
-		err := utils.DownloadUrl(ctx, fetcher.httpClientForURL(req.URL), req.URL, tmpPath)
+		err := utils.DownloadUrlToRoot(ctx, fetcher.httpClientForURL(req.URL), req.URL, fetcher.sharedVolumePath, tmpPath)
 		if err != nil {
 			e := "failed to download url from fetch request"
 			logger.Error(err, e, "url", req.URL)
@@ -378,7 +378,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 			// archive.URL may resolve to storagesvc (/v1/archive?id=...)
 			// or an external storage backend (S3, GCS, etc.). Sign only
 			// when the URL targets storagesvc.
-			err := utils.DownloadUrl(ctx, fetcher.httpClientForURL(archive.URL), archive.URL, tmpPath)
+			err := utils.DownloadUrlToRoot(ctx, fetcher.httpClientForURL(archive.URL), archive.URL, fetcher.sharedVolumePath, tmpPath)
 			if err != nil {
 				e := "failed to download url from archive"
 				logger.Error(err, e, "url", req.URL)
@@ -387,7 +387,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 
 			// check file integrity only if checksum is not empty.
 			if len(archive.Checksum.Sum) > 0 {
-				checksum, err := utils.GetFileChecksum(tmpPath)
+				checksum, err := utils.RootFileChecksum(fetcher.sharedVolumePath, tmpPath)
 				if err != nil {
 					e := "failed to get checksum"
 					logger.Error(err, e)
@@ -404,10 +404,10 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 	}
 
 	// checking if file is a zip
-	if match, _ := utils.IsZip(ctx, tmpPath); match && !req.KeepArchive {
+	if match, _ := utils.IsZipInRoot(ctx, fetcher.sharedVolumePath, tmpPath); match && !req.KeepArchive {
 		// unarchive tmp file to a tmp unarchive path
 		tmpUnarchivePath := filepath.Join(fetcher.sharedVolumePath, uuid.NewString())
-		err := utils.Unarchive(ctx, tmpPath, tmpUnarchivePath)
+		err := utils.UnarchiveInRoot(ctx, fetcher.sharedVolumePath, tmpPath, tmpUnarchivePath)
 		if err != nil {
 			logger.Error(err, "error unarchive", "archive_location", tmpPath,
 				"target_location", tmpUnarchivePath)
@@ -590,7 +590,7 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if req.ArchivePackage {
-		err = utils.Archive(ctx, srcFilepath, dstFilepath)
+		err = utils.ArchiveInRoot(ctx, fetcher.sharedVolumePath, srcFilepath, dstFilepath)
 		if err != nil {
 			e := "error archiving zip file"
 			logger.Error(err, e, "source", srcFilepath, "destination", dstFilepath)
@@ -610,7 +610,26 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Info("starting upload...")
 	ssClient := storageSvcClient.MakeClient(req.StorageSvcUrl, storageSvcClient.HMACSecretFromEnv())
 
-	fileID, err := ssClient.Upload(ctx, dstFilepath, nil)
+	// Open the archive once through an os.Root rooted at the shared volume so
+	// the request-derived path cannot escape it (CWE-22), then hand the open
+	// file to the storage client.
+	uploadFile, err := utils.RootOpen(fetcher.sharedVolumePath, dstFilepath)
+	if err != nil {
+		e := "error opening zip file for upload"
+		logger.Error(err, e, "file", dstFilepath)
+		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
+		return
+	}
+	uploadInfo, err := uploadFile.Stat()
+	if err != nil {
+		uploadFile.Close()
+		e := "error stating zip file for upload"
+		logger.Error(err, e, "file", dstFilepath)
+		http.Error(w, fmt.Sprintf("%s: %v", e, err), http.StatusInternalServerError)
+		return
+	}
+	fileID, err := ssClient.UploadReader(ctx, dstFilepath, uploadFile, uploadInfo.Size(), nil)
+	uploadFile.Close()
 	if err != nil {
 		e := "error uploading zip file"
 		logger.Error(err, e, "file", dstFilepath)
@@ -618,7 +637,7 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sum, err := utils.GetFileChecksum(dstFilepath)
+	sum, err := utils.RootFileChecksum(fetcher.sharedVolumePath, dstFilepath)
 	if err != nil {
 		e := "error calculating checksum of zip file"
 		logger.Error(err, e, "file", dstFilepath)

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -43,6 +43,7 @@ const internalAuthEnv = "FISSION_INTERNAL_AUTH_SECRET"
 type (
 	ClientInterface interface {
 		Upload(ctx context.Context, filePath string, metadata *map[string]string) (string, error)
+		UploadReader(ctx context.Context, fileName string, r io.Reader, fileSize int64, metadata *map[string]string) (string, error)
 		GetUrl(id string) string
 		Info(ctx context.Context, id string) (*http.Response, error)
 		List(ctx context.Context) ([]string, error)
@@ -138,16 +139,23 @@ func (c *client) Upload(ctx context.Context, filePath string, metadata *map[stri
 	if err != nil {
 		return "", err
 	}
-	fileSize := fi.Size()
+	return c.UploadReader(ctx, filePath, f, fi.Size(), metadata)
+}
 
+// UploadReader sends the contents of r (of length fileSize, named fileName in
+// the multipart form) to the storage service and returns the file ID. It is the
+// reader-based form of Upload: a caller that has already opened the file — for
+// example through an os.Root on the server-side fetch path — passes the open
+// file directly so no second, path-based open is needed.
+func (c *client) UploadReader(ctx context.Context, fileName string, r io.Reader, fileSize int64, metadata *map[string]string) (string, error) {
 	buf := &bytes.Buffer{}
 	bodyWriter := multipart.NewWriter(buf)
-	fileWriter, err := bodyWriter.CreateFormFile("uploadfile", filePath)
+	fileWriter, err := bodyWriter.CreateFormFile("uploadfile", fileName)
 	if err != nil {
 		return "", err
 	}
 
-	_, err = io.Copy(fileWriter, f)
+	_, err = io.Copy(fileWriter, r)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/root.go
+++ b/pkg/utils/root.go
@@ -95,6 +95,55 @@ func RootMkdirAll(base, path string, perm os.FileMode) error {
 	return root.MkdirAll(rel, perm.Perm())
 }
 
+// RootOpen opens path for reading within base through an os.Root, so a
+// traversing or symlinked path cannot reach a file outside base. path may be
+// base-relative or absolute-under-base. The returned file stays valid after the
+// transient root is closed.
+func RootOpen(base, path string) (*os.File, error) {
+	rel, err := relUnderRoot(base, path)
+	if err != nil {
+		return nil, err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	return root.Open(rel)
+}
+
+// RootOpenFile opens path with the given flags and permission within base
+// through an os.Root. It is the os.Root equivalent of os.OpenFile and confines
+// the open to base even for an attacker-influenced path. The returned file
+// stays valid after the transient root is closed.
+func RootOpenFile(base, path string, flag int, perm os.FileMode) (*os.File, error) {
+	rel, err := relUnderRoot(base, path)
+	if err != nil {
+		return nil, err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return nil, err
+	}
+	defer root.Close()
+	return root.OpenFile(rel, flag, perm.Perm())
+}
+
+// RootRemove removes path within base through an os.Root, so a traversing path
+// cannot delete a file outside base.
+func RootRemove(base, path string) error {
+	rel, err := relUnderRoot(base, path)
+	if err != nil {
+		return err
+	}
+	root, err := os.OpenRoot(base)
+	if err != nil {
+		return err
+	}
+	defer root.Close()
+	return root.Remove(rel)
+}
+
 // RootRename renames oldPath to newPath through an os.Root. Both ends must be
 // under the same base.
 func RootRename(base, oldPath, newPath string) error {

--- a/pkg/utils/root_test.go
+++ b/pkg/utils/root_test.go
@@ -97,3 +97,59 @@ func TestRootHelpersConfineToBase(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+func TestRootOpenHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("open reads a file under base", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(base, "a.txt"), []byte("alpha"), 0o600))
+
+		f, err := RootOpen(base, "a.txt")
+		require.NoError(t, err)
+		defer f.Close()
+		got, err := os.ReadFile(filepath.Join(base, "a.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "alpha", string(got))
+		// the returned file stays usable after the transient root is closed
+		buf := make([]byte, 5)
+		n, err := f.Read(buf)
+		require.NoError(t, err)
+		assert.Equal(t, "alpha", string(buf[:n]))
+	})
+
+	t.Run("openfile creates a file under base", func(t *testing.T) {
+		t.Parallel()
+		base := t.TempDir()
+		f, err := RootOpenFile(base, "out.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+		require.NoError(t, err)
+		_, err = f.WriteString("beta")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		got, err := os.ReadFile(filepath.Join(base, "out.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, "beta", string(got))
+	})
+
+	t.Run("escapes are rejected and the target outside base is untouched", func(t *testing.T) {
+		t.Parallel()
+		root := t.TempDir()
+		base := filepath.Join(root, "base")
+		require.NoError(t, os.MkdirAll(base, 0o755))
+		sentinel := filepath.Join(root, "sentinel")
+		require.NoError(t, os.WriteFile(sentinel, []byte("intact"), 0o600))
+
+		_, err := RootOpen(base, "../sentinel")
+		assert.Error(t, err)
+		_, err = RootOpen(base, sentinel)
+		assert.Error(t, err)
+		_, err = RootOpenFile(base, "../evil", os.O_RDWR|os.O_CREATE, 0o600)
+		assert.Error(t, err)
+
+		got, err := os.ReadFile(sentinel)
+		require.NoError(t, err)
+		assert.Equal(t, "intact", string(got))
+		assert.NoFileExists(t, filepath.Join(root, "evil"))
+	})
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -121,6 +121,24 @@ func GetFileChecksum(fileName string) (*fv1.Checksum, error) {
 	return sum, nil
 }
 
+// RootFileChecksum is GetFileChecksum with fileName opened through an os.Root
+// rooted at base, so a request-derived path cannot read a file outside base
+// (CWE-22). Use this on the server-side fetch path.
+func RootFileChecksum(base, fileName string) (*fv1.Checksum, error) {
+	f, err := RootOpen(base, fileName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %v: %w", fileName, err)
+	}
+	defer f.Close()
+
+	sum, err := GetChecksum(f)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate checksum for %v", fileName)
+	}
+
+	return sum, nil
+}
+
 func GetChecksum(src io.Reader) (*fv1.Checksum, error) {
 	if src == nil {
 		return nil, errors.New("cannot read from nil reader")
@@ -197,6 +215,47 @@ func DownloadUrl(ctx context.Context, httpClient *http.Client, targetURL string,
 	}
 
 	return nil
+}
+
+// DownloadUrlToRoot is DownloadUrl with the destination opened through an
+// os.Root rooted at base, so a request-derived localPath cannot write outside
+// base (CWE-22). Use this on the server-side fetch path. As in DownloadUrl, the
+// destination file is created only after a 2xx response, so a failed download
+// leaves no partial file behind.
+func DownloadUrlToRoot(ctx context.Context, httpClient *http.Client, targetURL string, base string, localPath string) error {
+	if targetURL == "" {
+		return errors.New("empty URL")
+	}
+	parsed, err := url.Parse(targetURL)
+	if err != nil {
+		return fmt.Errorf("invalid URL: %s: %w", targetURL, err)
+	}
+	resp, err := ctxhttp.Get(ctx, httpClient, parsed.String())
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if !isHttp2xxSuccessful(resp.StatusCode) {
+		return errors.New(resp.Status)
+	}
+
+	w, err := RootOpenFile(base, localPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	// Force 0o600 even on the overwrite path, for the same reason as DownloadUrl.
+	if err = w.Chmod(0o600); err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(w, resp.Body); err != nil {
+		return err
+	}
+
+	return w.Sync()
 }
 
 func GetStringValueFromEnv(envVar string) (string, error) {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -15,6 +15,9 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
@@ -249,4 +252,59 @@ func TestDownloadUrl_OverwriteAllowed(t *testing.T) {
 	if mode := fi.Mode().Perm(); mode != 0o600 {
 		t.Fatalf("mode after overwrite: got %#o, want 0600", mode)
 	}
+}
+
+func TestDownloadUrlToRoot_ConfinesToBase(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("payload"))
+	}))
+	t.Cleanup(srv.Close)
+
+	base := t.TempDir()
+
+	// Happy path: writes under base with mode 0600.
+	dst := filepath.Join(base, "out.bin")
+	if err := DownloadUrlToRoot(context.Background(), srv.Client(), srv.URL, base, dst); err != nil {
+		t.Fatalf("DownloadUrlToRoot: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil || string(got) != "payload" {
+		t.Fatalf("expected payload, got %q (err=%v)", got, err)
+	}
+	fi, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if mode := fi.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("mode: got %#o, want 0600", mode)
+	}
+
+	// A path escaping base is rejected and nothing is written outside base.
+	sentinel := filepath.Join(filepath.Dir(base), "sentinel.bin")
+	if err := os.WriteFile(sentinel, []byte("intact"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := DownloadUrlToRoot(context.Background(), srv.Client(), srv.URL, base, "../sentinel.bin"); err == nil {
+		t.Fatal("expected error for path escaping base")
+	}
+	if got, err := os.ReadFile(sentinel); err != nil || string(got) != "intact" {
+		t.Fatalf("sentinel was modified: %q (err=%v)", got, err)
+	}
+}
+
+func TestRootFileChecksum_ConfinesToBase(t *testing.T) {
+	base := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(base, "data.bin"), []byte("checksum me"), 0o600))
+
+	sum, err := RootFileChecksum(base, "data.bin")
+	require.NoError(t, err)
+	require.NotNil(t, sum)
+
+	want, err := GetFileChecksum(filepath.Join(base, "data.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, want.Sum, sum.Sum)
+
+	// A path escaping base is rejected.
+	_, err = RootFileChecksum(base, "../../etc/hostname")
+	assert.Error(t, err)
 }

--- a/pkg/utils/zip.go
+++ b/pkg/utils/zip.go
@@ -15,28 +15,47 @@ import (
 	"github.com/mholt/archives"
 )
 
+// isZipStream sniffs whether the stream (named filename, used only for the
+// extension heuristic) is a zip archive. It performs no filesystem access.
+func isZipStream(ctx context.Context, filename string, r io.Reader) (bool, error) {
+	result, err := archives.Zip{}.Match(ctx, filename, r)
+	if err != nil {
+		return false, err
+	}
+	return result.ByName || result.ByStream, nil
+}
+
 func IsZip(ctx context.Context, filename string) (bool, error) {
 	f, err := os.Open(filename)
 	if err != nil {
 		return false, nil
 	}
-	result, err := archives.Zip{}.Match(ctx, filename, f)
-	if err != nil {
-		return false, err
-	}
-	if result.ByName || result.ByStream {
-		return true, nil
-	}
-	return false, nil
+	defer f.Close()
+	return isZipStream(ctx, filename, f)
 }
 
-func MakeZipArchiveWithGlobs(ctx context.Context, targetName string, globs ...string) (string, error) {
+// IsZipInRoot is IsZip confined to base: filename is opened through an os.Root
+// so an attacker-influenced path cannot escape base (CWE-22). Use this on the
+// server-side fetch path where the path derives from request input.
+func IsZipInRoot(ctx context.Context, base, filename string) (bool, error) {
+	f, err := RootOpen(base, filename)
+	if err != nil {
+		return false, nil
+	}
+	defer f.Close()
+	return isZipStream(ctx, filename, f)
+}
+
+// writeZipArchive compresses the files matched by globs into out. It only reads
+// the glob inputs and writes to the provided writer, so it performs no
+// destination-path filesystem access of its own.
+func writeZipArchive(ctx context.Context, out io.Writer, globs ...string) error {
 	globFiles, err := FindAllGlobs(globs...)
 	if err != nil {
-		return "", err
+		return err
 	}
 	if len(globFiles) == 0 {
-		return "", fmt.Errorf("no files found for globs: %v", globs)
+		return fmt.Errorf("no files found for globs: %v", globs)
 	}
 	files := make(map[string]string, len(globFiles))
 	for _, file := range globFiles {
@@ -45,18 +64,29 @@ func MakeZipArchiveWithGlobs(ctx context.Context, targetName string, globs ...st
 
 	archiveFiles, err := archives.FilesFromDisk(ctx, nil, files)
 	if err != nil {
-		return "", fmt.Errorf("failed to read files from disk: %w", err)
+		return fmt.Errorf("failed to read files from disk: %w", err)
 	}
+	zip := archives.CompressedArchive{
+		Archival: archives.Zip{},
+	}
+	if err := zip.Archive(ctx, out, archiveFiles); err != nil {
+		return fmt.Errorf("failed to create archive: %w", err)
+	}
+	return nil
+}
+
+func MakeZipArchiveWithGlobs(ctx context.Context, targetName string, globs ...string) (string, error) {
 	out, err := os.OpenFile(targetName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return "", fmt.Errorf("failed to create archive file: %w", err)
 	}
 	defer out.Close()
-	zip := archives.CompressedArchive{
-		Archival: archives.Zip{},
-	}
-	if err := zip.Archive(ctx, out, archiveFiles); err != nil {
-		return "", fmt.Errorf("failed to create archive: %w", err)
+	if err := writeZipArchive(ctx, out, globs...); err != nil {
+		// Don't leave a partial/empty archive behind on failure, matching the
+		// pre-refactor contract where the output was created only after the
+		// glob inputs resolved successfully.
+		os.Remove(targetName)
+		return "", err
 	}
 	return filepath.Abs(targetName)
 }
@@ -75,6 +105,33 @@ func Archive(ctx context.Context, src string, dst string) error {
 	return err
 }
 
+// ArchiveInRoot is Archive with src stat and dst creation confined to base
+// through an os.Root, so request-derived paths cannot stat or write outside
+// base (CWE-22). The glob expansion of src is unchanged from Archive.
+func ArchiveInRoot(ctx context.Context, base, src, dst string) error {
+	srcInfo, err := RootStat(base, src)
+	if err != nil {
+		return fmt.Errorf("failed to get source directory info: %w", err)
+	}
+	if srcInfo.IsDir() {
+		src = src + "/*"
+	}
+	out, err := RootOpenFile(base, dst, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("failed to create archive file: %w", err)
+	}
+	err = writeZipArchive(ctx, out, src)
+	out.Close()
+	if err != nil {
+		// Don't leave a partial/empty archive behind on failure, mirroring
+		// MakeZipArchiveWithGlobs. dst is request-derived, so remove it through
+		// the same os.Root rather than a bare os.Remove.
+		_ = RootRemove(base, dst)
+		return err
+	}
+	return nil
+}
+
 // Unarchive unzips the zip file at src into dst.
 //
 // Extraction is confined to dst through an os.Root: the archive entry name
@@ -83,12 +140,31 @@ func Archive(ctx context.Context, src string, dst string) error {
 // kernel; we also reject escaping names and symlink entries up front for a
 // clear error (zip-slip / CWE-22).
 func Unarchive(ctx context.Context, src string, dst string) error {
-	var format archives.Zip
 	file, err := os.Open(src)
 	if err != nil {
 		return fmt.Errorf("failed to open file: %w", err)
 	}
 	defer file.Close()
+	return unarchiveStream(ctx, file, dst)
+}
+
+// UnarchiveInRoot is Unarchive with the source archive opened through an
+// os.Root rooted at base, so a request-derived src path cannot read a file
+// outside base (CWE-22). Extraction into dst is confined exactly as in
+// Unarchive.
+func UnarchiveInRoot(ctx context.Context, base, src, dst string) error {
+	file, err := RootOpen(base, src)
+	if err != nil {
+		return fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+	return unarchiveStream(ctx, file, dst)
+}
+
+// unarchiveStream extracts the zip stream file into dst. Extraction is confined
+// to dst through an os.Root (see Unarchive's doc comment for the threat model).
+func unarchiveStream(ctx context.Context, file io.Reader, dst string) error {
+	var format archives.Zip
 
 	// The destination must exist before we can open a root on it. Mode 0o755 is
 	// required so that other containers in the same pod (running under

--- a/pkg/utils/zip_test.go
+++ b/pkg/utils/zip_test.go
@@ -425,3 +425,61 @@ func TestArchiveOverwrite(t *testing.T) {
 		}
 	}
 }
+
+// TestZipInRootConfinement exercises the os.Root-confined variants used on the
+// server-side fetch path: archive creation, zip sniffing and extraction all
+// stay within base, and request-derived paths that escape base are rejected.
+func TestZipInRootConfinement(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	base := t.TempDir()
+	srcDir := filepath.Join(base, "src")
+	require.NoError(t, os.MkdirAll(srcDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "hello.txt"), []byte("world"), 0o644))
+
+	// ArchiveInRoot writes the zip under base.
+	zipPath := filepath.Join(base, "out.zip")
+	require.NoError(t, ArchiveInRoot(ctx, base, srcDir, zipPath))
+
+	// IsZipInRoot recognises it through the root.
+	isZip, err := IsZipInRoot(ctx, base, zipPath)
+	require.NoError(t, err)
+	assert.True(t, isZip)
+
+	// UnarchiveInRoot extracts it; the source archive is opened through the root.
+	extractDir := filepath.Join(base, "extract")
+	require.NoError(t, UnarchiveInRoot(ctx, base, zipPath, extractDir))
+	got, err := os.ReadFile(filepath.Join(extractDir, "hello.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "world", string(got))
+
+	// Escaping paths are rejected before any filesystem access outside base.
+	outside := filepath.Join(filepath.Dir(base), "outside.zip")
+	require.NoError(t, os.WriteFile(outside, []byte("intact"), 0o600))
+	assert.Error(t, ArchiveInRoot(ctx, base, srcDir, "../outside.zip"))
+	assert.Error(t, UnarchiveInRoot(ctx, base, "../outside.zip", extractDir))
+	isZip, err = IsZipInRoot(ctx, base, "../outside.zip")
+	require.NoError(t, err) // open failure is swallowed, matching IsZip
+	assert.False(t, isZip)
+	data, err := os.ReadFile(outside)
+	require.NoError(t, err)
+	assert.Equal(t, "intact", string(data))
+}
+
+// TestArchiveInRootCleansUpOnFailure verifies ArchiveInRoot does not leave a
+// partial/empty archive behind when there is nothing to archive, matching the
+// MakeZipArchiveWithGlobs contract.
+func TestArchiveInRootCleansUpOnFailure(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	base := t.TempDir()
+	emptyDir := filepath.Join(base, "empty")
+	require.NoError(t, os.MkdirAll(emptyDir, 0o755))
+
+	dst := filepath.Join(base, "out.zip")
+	err := ArchiveInRoot(ctx, base, emptyDir, dst)
+	require.Error(t, err) // "no files found for globs"
+	assert.NoFileExists(t, dst)
+}


### PR DESCRIPTION
## What

Resolves the 7 open CodeQL `go/path-injection` alerts (#17, #310, #312, #315, #335, #336, #337) and dispositions the one `go/command-injection` alert (#334).

## Root cause

Every flagged path-injection sink — the bare `os.Open` / `os.OpenFile` / `os.Stat` in the zip, checksum, download and storagesvc-client helpers — is reached **only** from the fetcher's HTTP handlers (`pkg/fetcher/fetcher.go`).
On that path the file path is already validated by `utils.RootJoin(fetcher.sharedVolumePath, …)`, which rejects `..` traversal and absolute escapes.
CodeQL does not recognise the custom `RootJoin` helper as a sanitizer, so the taint flow from `r.Body` to the file open stays open.

## Fix

Route the fetcher's file operations through `os.Root` rooted at the **untainted** `sharedVolumePath` — the established `Root*` helper pattern already in `pkg/utils/root.go` — so confinement is enforced in-kernel at the sink, not just by an upstream string check CodeQL can't see.

- `root.go`: add `RootOpen`, `RootOpenFile`.
- `zip.go`: factor `isZipStream` / `writeZipArchive` / `unarchiveStream` cores and add `IsZipInRoot`, `ArchiveInRoot`, `UnarchiveInRoot`.
- `utils.go`: add `RootFileChecksum`, `DownloadUrlToRoot`.
- `storagesvc/client`: add `UploadReader` so the fetcher can hand over an already-root-opened file; `Upload` now delegates to it.
- `fetcher.go`: call the root-confined variants.

The path-based helpers (`IsZip`, `Archive`, `Unarchive`, `MakeZipArchiveWithGlobs`, `GetFileChecksum`, `DownloadUrl`, `Upload`) are left unchanged.
Their only other callers are the CLI and tests, which are **not** CodeQL taint sources, so their signatures and behaviour are preserved.

Two benign drive-bys surfaced during review: `IsZip` now closes the file it sniffs (previously leaked an fd), and `MakeZipArchiveWithGlobs` no longer leaves an empty archive behind when glob resolution fails.

## Alert #334 (`go/command-injection`, builder.go) — dismissed as won't-fix

This is by design: the builder sidecar's purpose is to execute the operator-configured build command (`spec.builder.command`) against the user's source package, so the executable is intentionally caller-supplied.
It is already mitigated against shell injection — `resolveBuildCommand` rejects shell metacharacters and `exec.Command` invokes no shell — and the endpoint is an internal in-pod sidecar reached only by buildermgr.
No code change clears it without removing the build feature, so it has been dismissed on the code-scanning dashboard with that justification.

## Testing

- New confinement tests for `RootOpen`/`RootOpenFile`, `IsZipInRoot`/`ArchiveInRoot`/`UnarchiveInRoot`, `RootFileChecksum`, and `DownloadUrlToRoot` (happy path + escape rejection + sentinel-untouched).
- `go build ./...`, `go vet`, `golangci-lint`, `make license-check`, and the `pkg/utils`, `pkg/storagesvc/client`, `pkg/fetcher`, `pkg/builder`, `pkg/buildermgr` test packages all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fission/fission/3479)
<!-- Reviewable:end -->
