### PR TITLE
fix(router): expire endpoint quarantines after a TTL

### DIFF
--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -23,6 +24,16 @@ import (
 )
 
 const shardCount = 64
+
+// DefaultQuarantineTTL bounds how long a dial-failed endpoint stays
+// unadmissible when NO slice event arrives to clear it. Slice events stay the
+// primary (fast) lift; the TTL is the backstop for a steady cluster — without
+// it, one transient dial error against a function's only endpoint while the
+// executor is down (no slice events, no pod churn) pins the function to the
+// executor fallback until the executor returns, which is exactly the outage
+// mode the warm path exists to survive. After expiry the endpoint is re-tried;
+// a genuinely dead pod just gets re-quarantined by the next dial failure.
+const DefaultQuarantineTTL = 30 * time.Second
 
 type (
 	// FnKey identifies a function by its CR coordinates (the labels mirrored
@@ -57,6 +68,8 @@ type (
 		shards [shardCount]indexShard
 		// size tracks the number of functions with at least one slice.
 		size atomic.Int64
+		// quarantineTTL is DefaultQuarantineTTL unless narrowed in tests.
+		quarantineTTL time.Duration
 	}
 
 	indexShard struct {
@@ -74,12 +87,14 @@ type (
 		// counters holds the per-pod in-flight counters, keyed by pod UID so
 		// they survive slice-event rebuilds; pruned with the endpoints.
 		counters map[types.UID]*atomic.Int64
-		// quarantined holds addresses the transport reported dial failures
-		// for; skipped by Admit until the next slice event for this function
-		// clears them (the slice controller removes dead pods promptly,
-		// independent of executor health). Copy-on-write (like eps) so Admit
-		// reads it lock-free; writes happen under mu.
-		quarantined atomic.Pointer[map[string]struct{}]
+		// quarantined maps addresses the transport reported dial failures for
+		// to their quarantine expiry; skipped by Admit until the next slice
+		// event for this function clears them (the slice controller removes
+		// dead pods promptly, independent of executor health) or the TTL
+		// expires (the backstop when no slice event will come — see
+		// DefaultQuarantineTTL). Copy-on-write (like eps) so Admit reads it
+		// lock-free; writes happen under mu.
+		quarantined atomic.Pointer[map[string]time.Time]
 		// eps is the merged endpoint list, swapped copy-on-write. Hot-path
 		// readers load it without taking mu.
 		eps atomic.Pointer[[]Endpoint]
@@ -88,7 +103,7 @@ type (
 
 // NewIndex returns an empty endpoint index.
 func NewIndex() *Index {
-	ix := &Index{}
+	ix := &Index{quarantineTTL: DefaultQuarantineTTL}
 	for i := range ix.shards {
 		ix.shards[i].m = make(map[FnKey]*fnEntry)
 	}
@@ -345,6 +360,10 @@ func (ix *Index) Admit(namespace, name string, requestsPerPod int) (Endpoint, fu
 	}
 
 	quarantined := e.quarantined.Load()
+	var now time.Time
+	if quarantined != nil {
+		now = time.Now()
+	}
 
 	// Least-outstanding selection with a bounded CAS retry: the snapshot is
 	// immutable, only the counters move.
@@ -360,7 +379,7 @@ func (ix *Index) Admit(namespace, name string, requestsPerPod int) (Endpoint, fu
 			}
 			counted++
 			if quarantined != nil {
-				if _, bad := (*quarantined)[ep.Address]; bad {
+				if expiry, bad := (*quarantined)[ep.Address]; bad && now.Before(expiry) {
 					quarantinedN++
 					continue
 				}
@@ -397,10 +416,11 @@ func (ix *Index) Admit(namespace, name string, requestsPerPod int) (Endpoint, fu
 }
 
 // Quarantine marks an address unadmissible until the next slice event for the
-// function. The transport calls it on the FIRST dial failure of an
-// index-admitted endpoint (re-resolving would just re-admit the same dead
-// pod); only the legacy executor-resolved path climbs a retry ladder before
-// invalidating. Each new quarantine is counted in
+// function or the quarantine TTL expires, whichever comes first. The transport
+// calls it on the FIRST dial failure of an index-admitted endpoint
+// (re-resolving would just re-admit the same dead pod); only the legacy
+// executor-resolved path climbs a retry ladder before invalidating. Each new
+// (or expired-and-renewed) quarantine is counted in
 // fission_router_endpointcache_quarantines_total.
 func (ix *Index) Quarantine(namespace, name, address string) {
 	key := FnKey{Namespace: namespace, Name: name}
@@ -411,23 +431,28 @@ func (ix *Index) Quarantine(namespace, name, address string) {
 	if !ok {
 		return
 	}
+	now := time.Now()
 	e.mu.Lock()
 	cur := e.quarantined.Load()
 	if cur != nil {
-		if _, already := (*cur)[address]; already {
+		if expiry, already := (*cur)[address]; already && now.Before(expiry) {
 			// Idempotent: a dead-pod storm quarantines the same address from
 			// many in-flight requests — only the first copy-and-store matters.
 			e.mu.Unlock()
 			return
 		}
 	}
-	next := make(map[string]struct{})
+	next := make(map[string]time.Time)
 	if cur != nil {
-		for a := range *cur {
-			next[a] = struct{}{}
+		// Copy only live entries: expired quarantines fall away here instead
+		// of accumulating across the entry's lifetime.
+		for a, expiry := range *cur {
+			if now.Before(expiry) {
+				next[a] = expiry
+			}
 		}
 	}
-	next[address] = struct{}{}
+	next[address] = now.Add(ix.quarantineTTL)
 	e.quarantined.Store(&next)
 	e.mu.Unlock()
 	RecordQuarantine()

--- a/pkg/router/endpointcache/index_test.go
+++ b/pkg/router/endpointcache/index_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,6 +260,32 @@ func TestAdmit(t *testing.T) {
 		_, release, result = ix.Admit("default", "fn-a", 1)
 		assert.Equal(t, Admitted, result)
 		release()
+	})
+
+	t.Run("quarantine expires after the TTL without a slice event", func(t *testing.T) {
+		t.Parallel()
+		ix := NewIndex()
+		ix.quarantineTTL = 50 * time.Millisecond
+		ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1"))
+
+		// The CI-observed outage mode: the function's ONLY endpoint gets
+		// quarantined while the executor is down, so no slice event will ever
+		// arrive to lift it. The TTL is the self-heal.
+		ix.Quarantine("default", "fn-a", "10.0.0.1:8888")
+		_, _, result := ix.Admit("default", "fn-a", 1)
+		require.Equal(t, AllQuarantined, result)
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			_, release, result := ix.Admit("default", "fn-a", 1)
+			if assert.Equal(c, Admitted, result, "quarantine must expire after the TTL") {
+				release()
+			}
+		}, 2*time.Second, 10*time.Millisecond)
+
+		// A dead pod is simply re-quarantined by the next dial failure.
+		ix.Quarantine("default", "fn-a", "10.0.0.1:8888")
+		_, _, result = ix.Admit("default", "fn-a", 1)
+		assert.Equal(t, AllQuarantined, result)
 	})
 
 	t.Run("not-ready endpoints are never admitted", func(t *testing.T) {

--- a/pkg/router/endpointcache/metrics.go
+++ b/pkg/router/endpointcache/metrics.go
@@ -59,7 +59,7 @@ var (
 	// this counter makes partial quarantine (one bad pod among many) visible.
 	quarantines = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "fission_router_endpointcache_quarantines_total",
-		Help: "Endpoints quarantined from the index after a dial failure (lifted on the next slice event).",
+		Help: "Endpoints quarantined from the index after a dial failure (lifted by the next slice event or the quarantine TTL).",
 	})
 	// fallbacks counts warm-path requests routed to the executor for a
 	// specific reason (strict-mode annotation, no endpoints, all endpoints

--- a/pkg/router/resolver_fallback.go
+++ b/pkg/router/resolver_fallback.go
@@ -135,7 +135,8 @@ func (f *fallbackResolver) resolveDeployBacked(ctx context.Context, fn *fv1.Func
 	return ResolvedEntry{SvcURL: svcURL}, nil
 }
 
-// Invalidate quarantines the failing endpoint (until the next slice event) and
+// Invalidate quarantines the failing endpoint (until the next slice event or
+// the quarantine TTL, whichever comes first) and
 // drops the executor resolver's cached address. Logged at Info: dial failures
 // are rare, and a partial quarantine (one bad pod among many) is otherwise
 // invisible — the aggregate fallback metric only fires when every endpoint of


### PR DESCRIPTION
## Summary

Endpoint quarantines in the router's EndpointSlice index now expire after a TTL (`DefaultQuarantineTTL`, 30s) instead of persisting until the next slice event for the function.

## Why

A quarantine could previously only be lifted by a slice event — and in a steady cluster that event may never come.
CI demonstrated the outage mode on run [27336657710](https://github.com/fission/fission/actions/runs/27336657710) (`TestWarmInvokeWithExecutorDown`, v1.36.1 leg): a transient dial error quarantined a warm function's **only** endpoint while the executor was scaled to zero, no slice event could arrive (no pod churn, executor down), and every request fell back to the dead executor until the test deadline.
That defeats the warm path's core promise — serving through executor downtime — and intermittently fails the serial suite.

The diagnosis came straight from the observability counters added in #3485's review pass: `fission_router_endpointcache_quarantines_total` ticked 14→15 at 09:37:30 (inside the executor-down window) and `fallbacks_total{reason="all_quarantined"}` climbed 4→6 across the failure.

## How

- Quarantine entries carry an expiry; `Admit` treats an expired entry as admissible (one `time.Now()` per admission, only when a quarantine map exists).
- Slice events remain the primary, fast lift (`ApplySlice`/`DeleteSlice` still clear wholesale); the TTL is the backstop for the no-slice-event case.
- After expiry the endpoint is simply retried: a genuinely dead pod is re-quarantined by its next dial failure, costing one retry-ladder bump rather than an outage.
- Expired entries are pruned on the next quarantine write, so the copy-on-write map doesn't accumulate.

This was flagged as a deferred cleanup in the #3485 review ("quarantine TTL or success-clears"); the CI evidence promoted it from phase-4 cleanup to a standalone fix.

## Verification

- New unit test reproduces the CI failure mode (single endpoint, quarantined, no slice events) and asserts TTL self-heal plus re-quarantine of a still-dead pod, with a narrowed TTL.
- Existing quarantine/admission tests unchanged and green; `go test -race ./pkg/router/...`, `make code-checks`, `make license-check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
