### PR TITLE
chore(logging): fix three mislevelled/false-alarm control-plane logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 require (
 	github.com/docker/docker-credential-helpers v0.9.3 // indirect
 	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -41,8 +41,21 @@ var tapFlushErrors = prometheus.NewCounter(prometheus.CounterOpts{
 	Help: "Failed batched tap flushes from the router to the executor.",
 })
 
+// tapFlushNotFound counts tap flushes the executor answered 404 — every
+// tapped address had expired or was unknown. Occasional increments are
+// routine churn; a sustained rate means the router is tapping addresses the
+// executor genuinely should know (an index/registration drift), which the
+// idle reaper would otherwise silently let age out. Kept distinct from
+// tapFlushErrors so churn doesn't trip the failure alarm while a persistent
+// 404 rate stays observable.
+var tapFlushNotFound = prometheus.NewCounter(prometheus.CounterOpts{
+	Name: "fission_router_tap_flush_notfound_total",
+	Help: "Batched tap flushes the executor answered 404 (expired/unknown addresses).",
+})
+
 func init() {
 	metrics.Registry.MustRegister(tapFlushErrors)
+	metrics.Registry.MustRegister(tapFlushNotFound)
 }
 
 type (
@@ -277,6 +290,7 @@ func (c *client) flushTaps(urls map[string]TapServiceRequest) {
 	// genuine failures (unreachable executor, timeout, 5xx) escalate.
 	if ferror.IsNotFound(err) {
 		c.tapFailures.Store(0)
+		tapFlushNotFound.Inc()
 		c.logger.V(1).Info("tap flush skipped expired entries", "error", err.Error())
 		return
 	}

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -268,6 +268,18 @@ func (c *client) flushTaps(urls map[string]TapServiceRequest) {
 		c.tapFailures.Store(0)
 		return
 	}
+	// A 404 is routine churn, not a liveness failure: it means some tapped
+	// addresses already expired/were deleted on the executor side (the
+	// executor logs this at V(1) for the same reason). The executor can't be
+	// about to wrongly reap a pod it no longer tracks, so a NotFound must NOT
+	// count toward the "taps failing, serving pods at risk" escalation —
+	// otherwise normal function churn trips a misleading Error alarm. Only
+	// genuine failures (unreachable executor, timeout, 5xx) escalate.
+	if ferror.IsNotFound(err) {
+		c.tapFailures.Store(0)
+		c.logger.V(1).Info("tap flush skipped expired entries", "error", err.Error())
+		return
+	}
 	tapFlushErrors.Inc()
 	if failures := c.tapFailures.Add(1); failures >= tapFailureEscalation {
 		c.logger.Error(err, "tap flush failing persistently; idle reaper may reap serving pods",

--- a/pkg/executor/client/client_test.go
+++ b/pkg/executor/client/client_test.go
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// errorRecordingSink counts Error-level log calls so a test can assert that
+// routine churn does NOT escalate to Error.
+type errorRecordingSink struct {
+	mu        sync.Mutex
+	errCalls  int
+	lastErrMs string
+}
+
+func (s *errorRecordingSink) Init(logr.RuntimeInfo)          {}
+func (s *errorRecordingSink) Enabled(int) bool               { return true }
+func (s *errorRecordingSink) Info(int, string, ...any)       {}
+func (s *errorRecordingSink) WithValues(...any) logr.LogSink { return s }
+func (s *errorRecordingSink) WithName(string) logr.LogSink   { return s }
+func (s *errorRecordingSink) Error(_ error, msg string, _ ...any) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errCalls++
+	s.lastErrMs = msg
+}
+func (s *errorRecordingSink) errors() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.errCalls
+}
+
+// newTestClient builds a client pointed at url with retries disabled (so 5xx
+// responses don't add backoff delay to the test).
+func newTestClient(sink logr.LogSink, url string) *client {
+	hc := retryablehttp.NewClient()
+	hc.RetryMax = 0
+	hc.Logger = nil
+	return &client{
+		logger:      logr.New(sink),
+		executorURL: url,
+		tappedByURL: make(map[string]TapServiceRequest),
+		requestChan: make(chan TapServiceRequest, 100),
+		httpClient:  hc,
+	}
+}
+
+// TestFlushTapsNotFoundDoesNotEscalate locks the fix: a 404 from the executor
+// (some tapped addresses expired — routine churn) must reset the failure
+// counter and never reach the Error-level "serving pods at risk" escalation,
+// even when it happens many times in a row. Only genuine failures escalate.
+func TestFlushTapsNotFoundDoesNotEscalate(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	sink := &errorRecordingSink{}
+	c := newTestClient(sink, srv.URL)
+	batch := map[string]TapServiceRequest{"u": {ServiceURL: "http://10.0.0.1:8888"}}
+
+	for range tapFailureEscalation + 3 {
+		c.flushTaps(batch)
+	}
+	assert.Zero(t, sink.errors(), "routine 404 churn must not escalate to Error")
+	assert.Zero(t, c.tapFailures.Load(), "a 404 must reset the failure counter")
+}
+
+// TestFlushTapsGenuineFailureEscalates is the other half: a real failure
+// (5xx — executor errored) must escalate to Error once it persists past the
+// threshold, so a truly stuck tap path is still surfaced.
+func TestFlushTapsGenuineFailureEscalates(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	sink := &errorRecordingSink{}
+	c := newTestClient(sink, srv.URL)
+	batch := map[string]TapServiceRequest{"u": {ServiceURL: "http://10.0.0.1:8888"}}
+
+	for range tapFailureEscalation {
+		c.flushTaps(batch)
+	}
+	require.Positive(t, sink.errors(), "a persistent genuine failure must escalate to Error")
+	assert.Equal(t, "tap flush failing persistently; idle reaper may reap serving pods", sink.lastErrMs)
+}

--- a/pkg/executor/client/client_test.go
+++ b/pkg/executor/client/client_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -71,11 +72,18 @@ func TestFlushTapsNotFoundDoesNotEscalate(t *testing.T) {
 	c := newTestClient(sink, srv.URL)
 	batch := map[string]TapServiceRequest{"u": {ServiceURL: "http://10.0.0.1:8888"}}
 
-	for range tapFailureEscalation + 3 {
+	before := testutil.ToFloat64(tapFlushNotFound)
+	rounds := tapFailureEscalation + 3
+	for range rounds {
 		c.flushTaps(batch)
 	}
 	assert.Zero(t, sink.errors(), "routine 404 churn must not escalate to Error")
 	assert.Zero(t, c.tapFailures.Load(), "a 404 must reset the failure counter")
+	// The 404s stay observable via a distinct counter, so a SUSTAINED rate
+	// (an index/registration drift, not churn) is still visible without
+	// tripping the failure alarm.
+	assert.Equal(t, float64(rounds), testutil.ToFloat64(tapFlushNotFound)-before,
+		"each 404 flush must increment the NotFound counter")
 }
 
 // TestFlushTapsGenuineFailureEscalates is the other half: a real failure

--- a/pkg/executor/executortype/poolmgr/gp_pod.go
+++ b/pkg/executor/executortype/poolmgr/gp_pod.go
@@ -110,7 +110,11 @@ func (gp *GenericPool) choosePod(ctx context.Context, newLabels map[string]strin
 			continue
 		}
 		if !utils.IsReadyPod(pod) {
-			logger.Error(nil, "pod not ready, pod will be checked again", "key", key, "delay", expoDelay)
+			// Normal transient: the generic pod is still warming up. It is
+			// requeued with exponential backoff and re-checked, so this is an
+			// expected retry, not an error (it was logged at Error with a nil
+			// error, which flooded the executor log during pool warm-up).
+			logger.V(1).Info("pod not ready, pod will be checked again", "key", key, "delay", expoDelay)
 			gp.readyPodQueue.Done(key)
 			gp.readyPodQueue.AddAfter(key, expoDelay)
 			expoDelay *= 2

--- a/pkg/router/resolver_executor.go
+++ b/pkg/router/resolver_executor.go
@@ -6,6 +6,7 @@ package router
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -200,6 +201,15 @@ func (r *executorResolver) fromExecutor(ctx context.Context, fn *fv1.Function) (
 
 	service, err := r.executor.GetServiceForFunction(fContext, fn)
 	if err != nil {
+		// A canceled context is the caller giving up mid-cold-start (client
+		// disconnect / its deadline elsewhere), not an executor failure — log
+		// it quietly so client churn during specialization doesn't read as a
+		// server error. Genuine failures (executor down, 5xx, the cold-start
+		// deadline itself) still surface at Error.
+		if errors.Is(err, context.Canceled) {
+			logger.V(1).Info("GetServiceForFunction canceled by caller", "function", fn.Name, "namespace", fn.Namespace)
+			return nil, err
+		}
 		statusCode, errMsg := ferror.GetHTTPError(err)
 		logger.Error(err, "error from GetServiceForFunction", "error_message", errMsg,
 			"function", fn,

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -306,7 +306,14 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 
 		// if transport.RoundTrip returns a non-network dial error (e.g. "context canceled"), then relay it back to user
 		if !isNetDialErr {
-			logger.Error(err, "encountered non-network dial error")
+			// A canceled context is a client disconnect (the caller went away
+			// or its deadline fired), not a server-side error — log it quietly
+			// so client churn doesn't flood the router log at Error level.
+			if errors.Is(err, context.Canceled) {
+				logger.V(1).Info("request context canceled by client", "url", req.URL.Host)
+			} else {
+				logger.Error(err, "encountered non-network dial error")
+			}
 			return resp, err
 		}
 


### PR DESCRIPTION
## Summary

Three logging-correctness fixes found by analyzing the CI `kind-logs` from the gates-on (default) integration leg. Each is a log emitted at the wrong level — a routine condition surfaced as an Error, which both misleads operators and floods the control-plane logs. No behavior change beyond log level.

| Component | Was | Now | Why |
|---|---|---|---|
| router `client.go` (tap flush) | Error: "tap flush failing persistently; idle reaper may reap serving pods" on a 404 | V(1), counter reset; only genuine failures escalate | A 404 means some tapped addresses expired on the executor (it logs the same at V(1)) — routine churn, not a liveness failure. The executor can't wrongly reap a pod it no longer tracks. |
| router `transport.go` | Error: "encountered non-network dial error" for `context canceled` | V(1): "request context canceled by client" | A canceled context is a client disconnect, not a server-side error. |
| executor `gp_pod.go` | Error (nil err): "pod not ready, pod will be checked again" | V(1) | Normal pool warm-up transient; it requeues with exponential backoff and re-checks. |
| router `resolver_executor.go` | Error: "error from GetServiceForFunction" for `context canceled` | V(1) | Caller gave up mid-cold-start (client disconnect), not an executor failure. Genuine cold-start failures still surface at Error. |

## Impact

Observed counts in one v1.36.1 integration run: the tap-flush false alarm fired **6×**, `context canceled` **7×**, `pod not ready` **4×** — all at Error. The tap-flush one is the most important: it was added with the RFC-0002 warm path (now the v1.26 default), so it would fire under ordinary function churn in production and falsely warn about serving pods being reaped. The other two are pre-existing.

The genuine-failure escalation path (executor unreachable / timeout / 5xx) is preserved and now actually meaningful, since routine 404s no longer drown it.

Per the PR review, the 404 path keeps observability via a distinct `fission_router_tap_flush_notfound_total` counter: a *sustained* rate flags a genuine index/executor registration drift (the executor 404ing taps for pods it should know — newly possible with the warm path), while occasional churn stays benign and un-alarming.

**Verified against this PR's own CI kind-logs** (gates-on default leg): executor Error logs 4→0, router 24→12 — the remaining router Errors are real (a router funcTimeout and upstream EOFs) and correctly stay at Error.

## Verification

- New `pkg/executor/client/client_test.go`: a 404 (repeated past the threshold) resets the counter and never escalates to Error; a persistent 5xx still escalates.
- `make code-checks`, `make license-check` clean; router / client / poolmgr suites green under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

