### PR TITLE
perf(router): RFC-0014 — shared transport (fix never-working keep-alive), allocation diet, resolver-cache removal

### DIFF
--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -75,8 +75,14 @@ spec:
           value: {{ .Values.router.roundTrip.timeoutExponent | default 2 | quote }}
         - name: ROUTER_ROUND_TRIP_KEEP_ALIVE_TIME
           value: {{ .Values.router.roundTrip.keepAliveTime | default "30s" | quote }}
+        # NOTE: not `| default true`: sprig's default treats false as empty, so
+        # an explicit `disableKeepAlive: false` would silently coerce back to
+        # "true" and make keep-alive impossible to enable (the values.yaml
+        # default is false; nil also renders "false").
         - name: ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE
-          value: {{ .Values.router.roundTrip.disableKeepAlive | default true | quote }}
+          value: {{ if .Values.router.roundTrip.disableKeepAlive }}"true"{{ else }}"false"{{ end }}
+        - name: ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST
+          value: {{ .Values.router.roundTrip.maxIdleConnsPerHost | default 32 | quote }}
         - name: ROUTER_ROUND_TRIP_MAX_RETRIES
           value: {{ .Values.router.roundTrip.maxRetries | default 10 | quote }}
         - name: ROUTER_SVC_ADDRESS_MAX_RETRIES

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -426,8 +426,16 @@ router:
     ## so that kubernetes will be able to reap old function pod quickly.
     ##
     ## For details, see https://github.com/fission/fission/issues/723
+    ## Since RFC-0014 the router pools connections to function pods; this is
+    ## the escape hatch back to a fresh connection per request.
     ##
     disableKeepAlive: false
+
+    ## maxIdleConnsPerHost bounds the router's pooled idle connections per
+    ## function address (each poolmgr pod is its own address). 0 uses the
+    ## built-in default (32).
+    ##
+    maxIdleConnsPerHost: 32
 
     ## keepAliveTime is period for an active network connection to function pod.
     ##

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -432,8 +432,7 @@ router:
     disableKeepAlive: false
 
     ## maxIdleConnsPerHost bounds the router's pooled idle connections per
-    ## function address (each poolmgr pod is its own address). 0 uses the
-    ## built-in default (32).
+    ## function address (each poolmgr pod is its own address).
     ##
     maxIdleConnsPerHost: 32
 

--- a/docs/rfc/0013-incremental-router-routes.md
+++ b/docs/rfc/0013-incremental-router-routes.md
@@ -1,0 +1,190 @@
+# RFC-0013: Incremental Router Route Updates
+
+- Status: Proposed (published ahead of implementation — queued as the next router work after RFC-0014)
+- Tracking issue: TBD
+- Supersedes: —
+- Targets: Fission v1.27+ (phases 0–2); phase 3 conditional on benchmark evidence
+- Requires: no new dependencies (gorilla/mux is retained through phase 2); no Kubernetes floor change
+- Related: [RFC-0002](0002-endpointslice-native-data-plane.md) (addressResolver/tapper seams, shadow-promotion playbook), [RFC-0014](0014-router-hot-path-efficiency.md) (hot-path efficiency; handler-reuse interlock — shipped, including the uncached resolver this RFC's route table builds on)
+
+## Summary
+
+Every HTTPTrigger or Function change today rebuilds the router's entire public and internal muxes from full LISTs — at 10k triggers, a single canary weight tick re-allocates and re-registers every route.
+This RFC splits **route shape** (path/prefix/methods/host — changes rarely, human-driven) from **handler** (function map, canary weights — changes constantly): handlers live behind a stable atomic pointer, so the steady-churn class becomes a single pointer store with zero mux rebuild, while gorilla/mux is retained as a "materializer" rebuilt only on shape changes.
+A second, conditional phase replaces gorilla's per-request **linear regex scan** (O(triggers) per request) with a native incremental matcher behind a shadow-comparison gate — built only if benchmarks show the scan matters at target scale.
+
+## Motivation
+
+Verified anatomy of the current cost (all against main):
+
+- `buildMuxes` (`pkg/router/httpTriggers.go:232-442`) reconstructs two complete `mux.Router` instances from full LISTs of HTTPTriggers and Functions out of the Manager cache, on **every** trigger or function reconciliation, debounced 20ms (`httpTriggers.go:95`).
+  Per trigger it allocates a `functionHandler` (logger `WithName`, resolved function map, canary weight list, CORS wrap) and registers 1–2 routes; the internal mux gets 2 routes per Function.
+- The rebuild is cache-fed (zero network), so the cost is allocation + gorilla route compilation: gorilla/mux v1.8.1 **compiles a regexp per registered route**, even for literal paths.
+- **Canary weight updates change `FunctionWeights` — they bump the trigger generation but do not change the route's match shape.**
+  Today each weight tick is a full O(triggers + functions) rebuild; under steady canary traffic-shifting this is the dominant, recurring cost.
+- Second-order problem: gorilla's `Router.Match` is a **linear scan over all routes per request** — at 10k triggers the per-request match is O(10k) regex tests on the proxy hot path.
+- gorilla/mux has no route-removal API, which is why full rebuilds exist at all.
+
+What already works and must be preserved: trigger conditions PATCH only on transitions (`httpTriggers.go:506-542`); `UseEncodedPath` is applied inside `buildMuxes` (the CLAUDE.md gotcha — applying it only at startup gets dropped on the first swap); the GHSA-3g33-6vg6-27m8 public/internal split is pinned by `httpTriggers_test.go`; the atomic mux swap under load is pinned by `mutablemux_test.go`.
+
+## Goals
+
+- Canary weight ticks, function updates, and resolve refreshes update routing state in O(1) with zero mux rebuild.
+- Trigger create/delete (shape changes) stay correct and bounded; conditions are marked per-changed-trigger.
+- Defined, documented route-precedence and conflict semantics (today: accidental list order).
+- A conditional path to O(path-length) request matching at 10k+ triggers, gated on evidence.
+
+## Non-goals
+
+- Replacing gorilla/mux in phases 0–2.
+- Touching the ingress / Gateway API route providers (reconciled separately from the mux).
+- Changing the `addressResolver`/`tapper` seams (RFC-0002).
+- Admission-time **rejection** of conflicting routes (conditions only; a webhook is an open question).
+
+## Design
+
+### Route table (`pkg/router/routetable/`)
+
+```go
+type HandlerRef struct{ h atomic.Pointer[http.Handler] } // registered once; swapped freely
+func (r *HandlerRef) ServeHTTP(w, req)                   // one pointer load + delegate
+
+type RouteSpec struct {
+    // identity / change detection
+    TriggerUID types.UID
+    Namespace, Name, TriggerRV string
+    FnRVs map[string]string            // resolved fn name -> ResourceVersion
+    // match shape (equality drives "shape change")
+    ExactPath, PrefixPath, Host string
+    Methods []string                   // sorted
+    Created metav1.Time                // precedence tiebreak
+    // mutable side
+    Handler *HandlerRef
+}
+
+type Table struct {
+    mu       sync.Mutex
+    public   map[types.UID]*RouteSpec
+    internal map[types.NamespacedName]*internalSpec
+    fnIndex  map[types.NamespacedName]sets.Set[types.UID] // fn -> referencing triggers
+}
+
+func (t *Table) ApplyTrigger(spec *RouteSpec) ApplyResult // NoChange|HandlerSwapped|ShapeChanged|Conflict
+func (t *Table) DeleteTrigger(uid types.UID) ApplyResult  // always ShapeChanged
+func (t *Table) ApplyFunction(fn *fv1.Function) ApplyResult
+func (t *Table) Snapshot() []*RouteSpec                   // precedence-sorted, for materializers
+```
+
+The reconcilers (`pkg/router/reconciler.go:42-85,105-121`) become per-event diff sources, replacing the blanket `syncTriggers` signal:
+
+- **Trigger reconcile**: compute the `RouteSpec` for that trigger only — config validation, `resolver` resolution, `functionHandler` + CORS wrap built only when `(TriggerRV, FnRVs)` changed.
+  Shape equal → store the new handler into the existing `HandlerRef` (one atomic swap — **this is the canary-weight path**); shape changed → replace the spec and signal the materializer's debouncer.
+  Mark only this trigger's condition.
+- **Function reconcile**: internal route handler swap (keyed by fn ns/name, stable across updates) + `fnIndex` lookup → re-resolve and swap each referencing trigger's handler.
+  Match shapes never change from a function event, so **function churn never rebuilds either mux**.
+- **Resolve failure semantics (parity)**: function NotFound → remove the route + `Ready=False` (today's skip behavior); transient reader error → return the error from Reconcile (controller-runtime requeue) and keep the last-known-good route — parity with today, where a LIST error keeps the old mux.
+- **Drift guard**: a periodic full-resync (LIST → table diff) catches any missed event, with a `fission_router_route_resync_drift_total` metric whose CI acceptance bar is zero.
+
+`FnRVs` in the spec also supersedes the resolver cache's TTL-scan invalidation with precise per-trigger invalidation (interlocks with RFC-0014's refCache removal).
+
+### Handler indirection
+
+`HandlerRef` is registered into the mux once per shape; all volatile state (canary weights, function snapshots, resolved policy) lives in the swappable inner handler.
+A request entering the wrapper sees one consistent handler — one consistent canary distribution — for its lifetime; in-flight requests are untouched by swaps (same property the atomic mux swap gives today, pinned by `mutablemux_test.go`).
+
+### Gorilla materializer
+
+`buildMuxes` becomes `Materialize(snapshot)`: today's body minus resolution and handler allocation, iterating the precedence-sorted snapshot and registering each spec's `HandlerRef`.
+It runs (debounced) only when a diff reports `ShapeChanged`.
+**`UseEncodedPath` and the middleware chain (panic recovery → metrics → auth) are applied inside the materializer** — the CLAUDE.md gotcha carries over verbatim.
+Router-owned routes (`/router-healthz`, `/readyz`, `/_version`, the GKE `/` fallback) and the GHSA public/internal split live in the materializer, never in the table.
+
+### Precedence and conflict semantics (phase 2 — the only user-visible change)
+
+Today conflict outcomes are an accident of cache list order; two triggers can overlap silently.
+Specified precedence:
+
+1. Host-qualified routes before host-less routes (parity — Fission hosts are literal, gorilla already disambiguates).
+2. Exact path beats prefix path.
+3. Among prefixes, longest prefix wins.
+4. Method sets filter rather than rank (mismatch contributes to 405, matching gorilla's `ErrMethodMismatch`).
+5. Exact-duplicate tiebreak: oldest `creationTimestamp`, then lexicographic namespace/name; the loser stays registered (shadowed) and gets `RouteAdmitted=False, reason=RouteConflict` naming the winner — conflicts become observable for the first time.
+
+For non-overlapping route sets (the overwhelmingly common case) this is behavior-identical to today, since order only matters when two routes match the same request.
+
+### Native matcher (phase 3 — conditional, gated)
+
+`pkg/router/routematcher/`: host buckets → method-filtered exact map + longest-prefix radix, consuming the same table diffs incrementally with a COW root swap per applied batch.
+Gate: `ROUTER_MATCHER=gorilla|shadow|native`, default `gorilla`; shadow mode runs both matchers and emits `fission_router_matcher_shadow_mismatches_total` — promotion requires zero mismatches over a kind-ci burn-in plus a differential fuzz suite (random route sets × request corpus; gorilla and native must agree on matched trigger and status), the exact RFC-0002 playbook.
+**Build trigger stated up front: do not implement phase 3 unless the phase-0 10k-route benchmark shows p99 proxy match overhead > 1ms, or a user reports it.**
+
+### Consistency model
+
+Route-level atomicity suffices: the only cross-object invariant is the exact+prefix route *pair* a non-slash-prefix trigger registers, and both derive from one `RouteSpec` and swap together.
+Cross-trigger snapshot consistency was never client-observable, and the public/internal swap is already non-transactional today.
+
+### Observability
+
+`fission_router_routes_total{listener}`, `route_table_applies_total{result}`, `mux_rebuilds_total{listener,reason}`, `route_resync_drift_total`, and (phase 3) the shadow mismatch counter.
+
+## Configuration
+
+- `ROUTER_INCREMENTAL_ROUTES` (default `true` once phase 1 ships) — escape hatch reinstating the legacy full-rebuild loop for one release; the legacy loop is ~80 lines and stays compiled.
+- `ROUTER_MATCHER=gorilla|shadow|native` (phase 3 only), default `gorilla`.
+
+## Backward compatibility
+
+- Phase 1 is behavior-identical for non-overlapping route sets; in-flight requests keep the same swap guarantees.
+- Phase 2 changes overlap-winner outcomes deliberately (nondeterministic → specified) — release-noted, with `RouteConflict` conditions making every affected trigger visible, and the phase-1 escape hatch still active in that release.
+- The GHSA public/internal split, CORS deny-by-default, and rewrite semantics are pinned by the existing test suite, which must pass unchanged in every phase.
+
+## Rollout phases
+
+**Phase 0 — pin behavior + baselines.**
+Route-shape derivation golden tests (trigger spec → expected exact/prefix/methods/host registrations, including the non-slash-prefix dual registration, empty-Methods edge, CORS OPTIONS append, GKE `/` route).
+`BenchmarkBuildMuxes{100,1k,10k}` and `BenchmarkMuxMatch10k` baselines.
+`test/benchmark/tests/route-churn/generate.sh` (scale-index pattern: N triggers + N functions as API objects only — no pods needed; `churn M` rewrites M canary weights/sec).
+
+**Phase 1 — route table + handler indirection.**
+New `pkg/router/routetable/`; reconcilers become diff sources; gorilla materializer; per-trigger conditions; periodic resync; escape hatch env.
+Tests: `Table.Apply*` decision table, `HandlerRef` swap under concurrent ServeHTTP (`-race`), fnIndex maintenance; the full parity suite unchanged.
+
+**Phase 2 — precedence + conflict conditions.**
+Deterministic snapshot ordering per the spec; `RouteConflict` conditions; release note.
+
+**Phase 3 (conditional) — native matcher.**
+Differential fuzz; shadow burn-in; promotion per the gate.
+
+## Verification
+
+- Unit (`-race`): table decision tables; handler-swap concurrency; precedence-sort property tests; (phase 3) differential fuzz.
+- Parity (must pass unchanged): `httpTriggers_test.go` (GHSA pins, health/version routes, CORS), `rewrite_test.go`, canary tests, `mutablemux_test.go`.
+- No-route-flap test (extends `mutablemux_test.go`): sustained requests against one stable trigger plus one in-flight streaming request while 1k unrelated triggers and canary weights churn; zero non-200s, the stream survives handler swaps.
+- Benchmarks + acceptance bars at 10k triggers + 10k functions:
+  - canary weight update: **zero mux rebuilds** (metric-asserted), apply < 1ms, O(1) allocs;
+  - trigger create/delete: phase-1 rebuild ≤ today's baseline CPU; phase-3 apply ≤ 100µs;
+  - p99 proxy latency within ±5% of idle during 100 updates/s churn;
+  - router RSS flat over a 10-minute churn soak (no old-handler leak).
+- CI: one leg pins `ROUTER_INCREMENTAL_ROUTES=false` through the deprecation release; phase 3 adds a `ROUTER_MATCHER=shadow` burn-in leg with mismatch==0 as the machine-checked promotion step.
+
+## Alternatives considered
+
+- **Namespace-sharded muxes**: rejected — public `RelativeURL`/`Prefix` paths carry no namespace key, so shard dispatch requires a first-level path matcher, which is the native matcher in disguise.
+- **Straight to the native matcher**: owns matching semantics (encoded paths, trailing slashes, 405-vs-404, host matching, prefix boundaries) with no fallback; phase 1 captures nearly all of the rebuild win at a fraction of the risk.
+- **Handler cache without indirection** (reuse handlers, still re-register): still pays a regexp compile per route per rebuild on every canary tick.
+- **Per-trigger gorilla subrouters**: no removal API at any level; the linear scan remains.
+
+## Open questions
+
+- Bounded-staleness window for keep-last-good on transient resolve errors?
+- Should `RouteConflict` eventually become an admission-webhook rejection?
+- Does phase 3 subsume the internal mux or only the public one (the internal mux is namespace-structured and cheap)?
+
+## Risks (top 3, with mitigations)
+
+1. **Phase-3 matching-semantics regressions** (encoded paths / `UseEncodedPath`, the exact+`prefix/` dual-registration boundary that prevents `/foo` matching `/foobar`, 405-vs-404, host matching).
+   Mitigation: differential fuzz, shadow mode with a machine-checked zero-mismatch bar, default-gorilla gate — this risk is precisely why phase 3 is conditional.
+2. **Table/cache drift**: a missed or misordered event leaves a stale route serving or a live trigger 404ing, where today's full rebuild self-heals every event.
+   Mitigation: periodic full-resync diff with a drift metric (zero-in-CI acceptance), controller-runtime requeue semantics preserved.
+3. **Phase-2 overlap-winner flips** for users unknowingly relying on accidental registration order.
+   Mitigation: `RouteConflict` conditions surface every affected trigger before and after; release note; escape hatch active for that release.

--- a/docs/rfc/0014-router-hot-path-efficiency.md
+++ b/docs/rfc/0014-router-hot-path-efficiency.md
@@ -1,0 +1,175 @@
+# RFC-0014: Router Hot-Path Efficiency — Shared Transport, Per-Request Allocation Diet, Resolver-Cache Removal
+
+- Status: Implemented ([#3491](https://github.com/fission/fission/pull/3491), 2026-06-12) — all four phases plus review follow-ups in one PR of bisectable commits
+- Tracking issue: —
+- Supersedes: —
+- Targets: Fission v1.27
+- Requires: no new dependencies; no Kubernetes floor change; no user-facing API change
+- Related: RFC-0002 (perf harness, structural seams; the warm path this RFC now optimizes), RFC-0008 (streaming settle invariants that constrain the refactor), RFC-0013 (handler-reuse interlock; the deferred per-route ReverseProxy is designed jointly)
+
+## Summary
+
+The router constructs a **new `http.Transport` per proxied request** (`pkg/router/transport.go:137` via `getDefaultTransport()` at `transport.go:374-391`), which silently defeats HTTP keep-alive entirely: every request to a function pod pays a fresh TCP dial, the configured `MaxIdleConns: 100` is dead config, and the `otelhttp` wrapper is rebuilt per attempt too (`transport.go:276`).
+This RFC fixes that bug-class finding with one shared, properly sized transport; puts the per-request handler path on an allocation diet (pre-built loggers, per-route proxy policy); and removes the `functionReferenceResolver` refCache — a TTL'd cache of the Manager informer cache that sits off the hot path, costs two goroutines plus an O(n) copy-walk per Function reconcile, and whose staleness class is already mitigated elsewhere.
+
+## Motivation
+
+Verified against main:
+
+- **Transport**: `RoundTrip` calls `getDefaultTransport()` (value receiver — copies the whole ~15-field struct) per request; the comment says it exists "to prevent the value of http.DefaultTransport from being changed by goroutines" — a safety choice that created the bug.
+  Per-attempt code then mutates `transport.DialContext` with `Dialer{Timeout: executingTimeout, KeepAlive: keepAliveTime}` (`transport.go:248-251`).
+  Function pods are plain HTTP `:8888`, so the per-request cost is a TCP handshake + slow-start — pure waste under steady load, most visible at high RPS and larger responses.
+- **Per-request allocations** (`pkg/router/functionHandler.go:40-156`): a `RetryingRoundTripper` literal conflating immutable per-route config (resolver, tapper, trigger, params) with per-request state (serviceURL, tapURL, release, retryCounter — mutated at `transport.go:191-193,256`); `logger.WithName("roundtripper")` per request; `resolveProxyPolicy` per request (a pure function of fn + timeout); an `httputil.ReverseProxy` + closures per request; a metrics+tap goroutine (two spawn sites: `functionHandler.go:110-115` and the error handler).
+- **refCache** (`pkg/router/functionReferenceResolver.go`): keyed `(namespace, triggerName, triggerRV)` with a 1-minute TTL; each `pkg/cache` instance runs its own actor + expiry goroutines; `resolve` is called **only from `buildMuxes`** — results are closed into handlers at build time, so the cache is not on the request path at all.
+  Its known staleness class (trigger-RV keying misses function updates) is already mitigated by `resolver_executor.currentFunction` re-reading before any specialization.
+  `invalidateForFunction` does a full `Copy()` map walk on every Function reconcile (hook at `pkg/router/reconciler.go:117`).
+
+## Goals
+
+- Restore connection reuse on the proxy hot path with retry/quarantine semantics byte-identical to today.
+- Reduce per-request allocations without touching the delicate streaming-settle structure.
+- Delete the redundant resolver cache and its reconcile-time costs.
+
+## Non-goals
+
+- No retry-ladder semantic change — the transport/settle/streaming test matrices must pass **unchanged**.
+- No `pkg/cache` removal (`functionServiceMap` still uses it for the legacy/fallback address path; rationalization direction noted only).
+- No per-route `ReverseProxy` in this RFC (designed below, explicitly deferred; interlocks with RFC-0013's handler reuse).
+- No user-facing API or chart schema change (one new tuning env var only).
+
+## Design
+
+### Shared transport with a context-carried dial ladder
+
+One `*http.Transport` per router process (plus a once-wrapped `otelhttp.NewTransport` sibling for the non-websocket path), built where `tsRoundTripperParams` is constructed and stored on it.
+`disableKeepAlive` is process-wide config, so a single transport configured from it at startup suffices — no per-variant pool.
+
+The critical constraint: the per-attempt `Dialer.Timeout = executingTimeout` is not just a timeout, it is the **backoff-scaled fast-retry ladder for cold pods** — a not-yet-listening pod must fail the dial quickly so the loop re-resolves.
+It is preserved exactly via a context value read by a single shared `DialContext`:
+
+```go
+transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+    if d, ok := ctx.Value(dialTimeoutKey{}).(time.Duration); ok {
+        var cancel context.CancelFunc
+        ctx, cancel = context.WithTimeoutCause(ctx, d, errDialLadderTimeout)
+        defer cancel()
+    }
+    return sharedDialer.DialContext(ctx, network, addr) // Dialer{KeepAlive: params.keepAliveTime}
+}
+```
+
+`RoundTrip` stashes the attempt's `executingTimeout` into the per-attempt request context; a pooled-conn hit skips the dial entirely (correct — there is nothing to time out).
+Classification is unchanged: a ctx-deadline dial failure is `*net.OpError{Op: "dial"}` with `Timeout() == true` — identical through `network.Adapter` (`pkg/error/network/error.go`) to today's `Dialer.Timeout` path (which `net` implements as a ctx deadline internally), and `transport.RoundTrip` is called directly so there is no `*url.Error` wrapping.
+A pin test makes this an invariant (see Verification).
+
+Sizing (the current `MaxIdleConns: 100` never mattered because the transport never survived a request):
+
+- `MaxIdleConnsPerHost`: new env `ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST`, default 32 — each poolmgr pod is its own host (`ip:8888`), and the Go default of 2 would throttle per-pod reuse well below `requestsPerPod` ceilings.
+- `MaxIdleConns`: 1024 (explicit bound for fd hygiene).
+- `IdleConnTimeout`: 90s → **30s**, shorter than the poolmgr idle-reap window (120s), bounding how long a pooled conn can outlive its pod.
+
+**Pooled conns vs dead pods** is the one real behavioral shift: today a dead pod fails at dial (refused/timeout → quarantine/retry ladder); with pooling, a stale conn fails at write/read instead.
+Graceful reaps send FIN, which evicts the conn from the pool before reuse; the residual race is covered by Go's automatic retry of replayable requests on a reused-conn failure; a non-replayable POST surfaces the error to the caller (a 500 via the proxy error handler, logged with a distinct 'pooled connection failed mid-request' line; bare EOF is included in that class — Go deliberately does not retry possibly-executed requests) — documented and pinned by unit tests.
+The quarantine path is unaffected (it keys on dial errors, and a write-failure on a reused conn correctly is not one).
+`disableKeepAlive` — which today is nearly meaningless — becomes the documented escape hatch back to per-request connections.
+
+### Handler hoists (allocation diet)
+
+Computed once in `buildMuxes` and stored on the route's `functionHandler`:
+
+- The round-tripper logger (`logger.WithName("roundtripper")` moves out of the request path).
+- A per-(route, backend-UID) map of `proxyPolicy` + `funcTimeout` (`resolveProxyPolicy` is a pure function; the map covers the canary case, where `fh.function` is selected per request from the weight distribution).
+
+Kept deliberately per-request:
+
+- The `RetryingRoundTripper` itself — it *is* the per-request state (one small allocation; `sync.Pool` rejected: the streaming-deferred settle and `closeContextFunc` lifetimes make pooling error-prone for negligible gain).
+- The `ReverseProxy` + closures — a per-route proxy requires carrying per-request state through the request context so shared `ModifyResponse`/`ErrorHandler` can find it; the win is small next to the transport fix and the risk touches the streaming settle block, the most delicate code in the router.
+  The context-key design is recorded here; implementation is deferred and revisited alongside RFC-0013's handler reuse.
+- The metrics+tap goroutines (async is required — the tap send must never block response delivery; a worker pool adds queue/drop/shutdown semantics to save microseconds).
+
+An optional `roundTripperConfig` field-regrouping makes the immutable/mutable boundary explicit, as a refactor not a behavior change.
+
+### refCache removal
+
+`buildMuxes` resolves directly against the informer cache: `resolve()` stays as a thin uncached dispatch on `FunctionReference.Type` (smallest diff; `resolveResult` shape unchanged), and the following are deleted:
+
+- the `refCache` field and its `MakeCache` construction (−2 goroutines),
+- `invalidateForFunction` and its `Copy()` walk,
+- the reconciler hook at `reconciler.go:117` (the Function reconcile still triggers the rebuild — that is exactly what makes the cache redundant).
+
+Behavior delta: N informer `Get`s per rebuild instead of cache hits — in-memory map reads, negligible; canary weight lists are rebuilt per rebuild with identical results; the up-to-1-minute stale-snapshot window the cache could serve is gone outright (and was already moot for specialization via `currentFunction`).
+
+## Configuration
+
+| Knob | Default | Notes |
+|---|---|---|
+| `ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST` | 32 | new; tuning, not gating |
+| `ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE` | false | pre-existing; becomes the meaningful escape hatch |
+| `IdleConnTimeout` | 30s | internal constant, rationale documented |
+
+No new feature gate: the change is internal, and the keep-alive escape hatch already exists.
+
+## Backward compatibility
+
+- Failure-mode shift for non-replayable requests racing pod shutdown (documented above; integration-tested; GETs retry transparently).
+- `disableKeepAlive` semantics upgrade called out in chart docs.
+- Everything else is allocation/log-shape only; retry, settle, quarantine, and streaming semantics are frozen by the existing test matrices.
+
+## Rollout phases (one PR each, bisectable)
+
+**Phase 0 — baseline harness.**
+Alloc benchmarks (`BenchmarkHandlerClassic`, `BenchmarkRoundTripWarm` against a fake resolver + httptest backend, `b.ReportAllocs`) plus a dial-counting listener wrapper; capture the k6 warm-path baseline (as shipped: the before/after evidence is recorded on [#3491](https://github.com/fission/fission/pull/3491)).
+No production change — lands first so phases 1–2 have honest before/after deltas.
+
+**Phase 1 — shared transport (the bug fix, isolated).**
+Build transport + otel wrapper once; context-value dial ladder; delete `getDefaultTransport`; sizing knobs; classification pin test; chart-docs note for `disableKeepAlive`.
+
+**Phase 2 — handler hoists.**
+Per-route logger; per-(route, backend-UID) policy/timeout map; optional config/state field regrouping.
+Benchmarks show the allocs/op delta.
+
+**Phase 3 — refCache removal.**
+As designed; independent of phases 1–2 (sequenced last to keep perf-sensitive diffs first).
+
+**Deferred (recorded, not scheduled):** per-route `ReverseProxy` via context-carried per-request state — re-evaluate with RFC-0013.
+
+## Verification
+
+- **Connection reuse (headline)**: with the dial-counting listener, N serialized warm requests to one backend perform ≤ `MaxIdleConnsPerHost` dials after warmup (today: exactly N).
+- **Allocs**: `go test -bench -benchmem` — allocs/op strictly reduced after phases 1–2; numbers recorded on the implementing PR.
+- **k6 warm path** (RFC-0002 runbook): predicted p50 down by roughly one intra-cluster RTT plus slow-start effects, throughput up at fixed VUs; acceptance = p50 improvement observed, no p99 regression beyond noise.
+- **Semantics frozen**: `transport_test.go` retry matrix, settle dispatch matrix, streaming release tests, `functionHandler_test.go`, canary tests pass **unchanged** (the only deletion is `getDefaultTransport`'s own coverage).
+- **Classification pin**: unit test dialing a blackhole (TEST-NET `192.0.2.1`) with a 1ms ladder value asserts `IsDialError() && IsTimeoutError()`.
+- **Stale-conn behavior**: integration test kills the backend between requests; GET transparently retried by the transport; POST behavior documented and asserted.
+- **refCache removal**: resolver tests rewritten against direct resolution; router idle goroutine count drops by 2 (assertable via the CI pprof artifacts); CI pprof heap shows the `getDefaultTransport` allocation site gone.
+
+## Alternatives considered
+
+- Per-(keepalive-setting) transport variants — unnecessary; the setting is process-wide.
+- `sync.Pool` for the round tripper — lifetime hazards (streaming settle, closeContextFunc) for negligible gain.
+- A worker pool for the metrics/tap goroutines — queue/drop/shutdown complexity to save microseconds; revisit only if profiles show scheduler pressure.
+- Per-route `ReverseProxy` now — deferred (risk concentrated in the streaming settle block; small residual win).
+- Keeping refCache with function-RV keying — still a cache of an O(1) in-memory cache; deletion is simpler and removes the staleness class instead of re-keying it.
+
+## Open questions
+
+- Should `MaxIdleConnsPerHost` derive from poolmgr `requestsPerPod` ceilings instead of a flat default?
+- Is the 30s `IdleConnTimeout` right once RFC-0002's drain-aware reaping (unlabel → grace → delete) is considered — should it key off the drain grace floor (30s) explicitly?
+
+## Risks (top 3, with mitigations)
+
+1. **Pooled conns to dead pods change the error mode** (highest): write/read failures replace dial failures for stale conns.
+   Mitigations: FIN-driven pool eviction covers graceful reaps; 30s idle timeout; TCP keepalive; Go's replayable-request auto-retry; the integration test above; the `disableKeepAlive` escape hatch.
+2. **Dial-ladder semantic drift**: mitigated by the context-value design (ladder values unchanged), the classification pin test, and the frozen transport test matrices.
+3. **Pool sizing wrong by default**: too low throttles hot pods, too high holds fds across thousands of pods — mitigated by the env knob and k6 evidence before/after.
+
+## As shipped (2026-06-12, #3491)
+
+All four phases landed as specced, with these additions from the pre-merge review:
+
+- A distinct Info log class for stale-pooled-conn failures (`isStaleConnErr`: write/read OpErrors, bare EOF, and net/http's "server closed idle connection") — deliberately not quarantined.
+- A startup log of the effective transport settings (`router proxy transport configured`), the operator's verification point for the keep-alive escape hatch.
+- A defensive 30s dial cap when the ladder context value is absent.
+- A chart fix found during implementation: `ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE` used `| default true`, and sprig's `default` treats `false` as empty — every install rendered `"true"`, making keep-alive impossible to enable (masked until this RFC because the per-request transport made the setting moot).
+
+Measured: warm RoundTrip 253µs → 89µs (−65%), 267 → 165 allocs/op; e2e kind main-vs-branch k6: median −11.3%, p99 −10.8%, throughput +13.6%, max latency 185ms → 28.7ms (the dial tail eliminated); idle goroutines 87 → 86; CI pprof confirms the per-request transport allocation sites are gone.

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -2,7 +2,7 @@
 
 This directory holds the architecture RFCs behind shipped (or partially shipped) Fission features.
 RFCs describe non-trivial, cross-cutting changes — new CRDs, data-plane refactors, backward-compat strategies, release-skewing decisions — and are published here once their implementation lands on `main`, so the design rationale travels with the code.
-Proposals that have not been implemented yet are not published here.
+Proposals are normally published here once their implementation lands; a proposal slated for near-term implementation may be published early, marked Proposed.
 
 Each document carries a `Status` header naming the implementing PRs and, where applicable, the parts that remain.
 
@@ -18,6 +18,8 @@ Each document carries a `Status` header naming the implementing PRs and, where a
 | [0007](0007-gateway-api-route-provider.md) | Gateway API Route Provider | Implemented ([#3478](https://github.com/fission/fission/pull/3478)) |
 | [0008](0008-streaming-invocation-path.md) | Streaming Invocation Path (SSE / chunked / WebSocket) | Implemented ([#3482](https://github.com/fission/fission/pull/3482)) |
 | [0011](0011-functions-as-mcp-tools.md) | Functions as MCP Tools & AI Gateway | Part A implemented ([#3483](https://github.com/fission/fission/pull/3483)); Part B deferred |
+| [0013](0013-incremental-router-routes.md) | Incremental Router Route Updates | Proposed (queued for implementation) |
+| [0014](0014-router-hot-path-efficiency.md) | Router Hot-Path Efficiency | Implemented ([#3491](https://github.com/fission/fission/pull/3491)) |
 
 ## Companion material
 

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -171,9 +171,12 @@ func loadRouterConfig(logger logr.Logger) (routerConfig, error) {
 	// the built-in default — a sizing knob, not a correctness gate.
 	if raw := os.Getenv("ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST"); raw != "" {
 		perHost, err := strconv.Atoi(raw)
-		if err != nil || perHost < 0 {
+		switch {
+		case err != nil:
 			logger.Error(err, "failed to parse 'ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST' - using the default", "value", raw)
-		} else {
+		case perHost < 0:
+			logger.Error(nil, "'ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST' must not be negative - using the default", "value", raw)
+		default:
 			cfg.maxIdleConnsPerHost = perHost
 		}
 	}

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -56,6 +56,10 @@ type routerConfig struct {
 	svcAddrRetryCount    int
 	svcAddrUpdateTimeout time.Duration
 	unTapServiceTimeout  time.Duration
+	// maxIdleConnsPerHost bounds the shared proxy transport's idle-connection
+	// pool per function address (ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST;
+	// optional, 0 = the built-in default, soft-fail).
+	maxIdleConnsPerHost int
 }
 
 // loadRouterConfig parses the router's environment configuration. Behavior is
@@ -162,6 +166,17 @@ func loadRouterConfig(logger logr.Logger) (routerConfig, error) {
 		return cfg, fmt.Errorf("failed to parse USE_ENCODED_PATH: %w", err)
 	}
 	cfg.useEncodedPath = useEncodedPath
+
+	// Optional pooled-transport tuning (RFC-0014); unset or unparsable keeps
+	// the built-in default — a sizing knob, not a correctness gate.
+	if raw := os.Getenv("ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST"); raw != "" {
+		perHost, err := strconv.Atoi(raw)
+		if err != nil || perHost < 0 {
+			logger.Error(err, "failed to parse 'ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST' - using the default", "value", raw)
+		} else {
+			cfg.maxIdleConnsPerHost = perHost
+		}
+	}
 
 	// Optional; unset or unparsable means off — the flag is an optimization
 	// (per-endpoint dialing for newdeploy/container), not a correctness gate

--- a/pkg/router/config_test.go
+++ b/pkg/router/config_test.go
@@ -125,3 +125,28 @@ func TestLoadRouterConfigEndpointSliceMode(t *testing.T) {
 		})
 	}
 }
+
+// TestLoadRouterConfigMaxIdleConnsPerHost locks the RFC-0014 pool-sizing
+// knob's soft-fail contract: unset/garbage/negative keep the built-in default
+// (0 in cfg; resolved to defaultMaxIdleConnsPerHost at transport build).
+func TestLoadRouterConfigMaxIdleConnsPerHost(t *testing.T) {
+	cases := []struct {
+		value string
+		want  int
+	}{
+		{value: "", want: 0},
+		{value: "64", want: 64},
+		{value: "0", want: 0},
+		{value: "not-a-number", want: 0}, // soft-fail: logged, default kept
+		{value: "-5", want: 0},           // negative rejected, default kept
+	}
+	for _, tc := range cases {
+		t.Run("value="+tc.value, func(t *testing.T) {
+			setRequiredRouterEnv(t)
+			t.Setenv("ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST", tc.value)
+			cfg, err := loadRouterConfig(logr.Discard())
+			require.NoError(t, err, "the knob must never hard-fail startup")
+			assert.Equal(t, tc.want, cfg.maxIdleConnsPerHost)
+		})
+	}
+}

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -35,6 +35,30 @@ type functionHandler struct {
 	tsRoundTripperParams     *tsRoundTripperParams
 	isDebugEnv               bool
 	functionTimeoutMap       map[k8stypes.UID]int
+	// Hoisted per-route state (RFC-0014): computed once at mux build instead
+	// of per request. rtLogger is the round tripper's named logger;
+	// policyByUID holds the resolved proxy policy per backend function (the
+	// canary path selects the backend per request, hence per-UID).
+	rtLogger    logr.Logger
+	policyByUID map[k8stypes.UID]proxyPolicy
+}
+
+// proxyPolicyFor returns the hoisted policy for fn, computing it on the spot
+// only when the route was built without a precomputed map (test harnesses).
+func (fh *functionHandler) proxyPolicyFor(fn *fv1.Function, fnTimeout time.Duration) proxyPolicy {
+	if p, ok := fh.policyByUID[fn.GetUID()]; ok {
+		return p
+	}
+	return resolveProxyPolicy(fn, fnTimeout, fh.tsRoundTripperParams.streamIdleDefault)
+}
+
+// roundTripperLogger returns the hoisted per-route logger, falling back to
+// deriving it for handlers constructed without one (test harnesses).
+func (fh *functionHandler) roundTripperLogger() logr.Logger {
+	if fh.rtLogger.GetSink() != nil {
+		return fh.rtLogger
+	}
+	return fh.logger.WithName("roundtripper")
 }
 
 func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {
@@ -70,9 +94,7 @@ func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *h
 		fnTimeout = fv1.DEFAULT_FUNCTION_TIMEOUT
 	}
 
-	policy := resolveProxyPolicy(fh.function,
-		time.Duration(fnTimeout)*time.Second,
-		fh.tsRoundTripperParams.streamIdleDefault)
+	policy := fh.proxyPolicyFor(fh.function, time.Duration(fnTimeout)*time.Second)
 
 	// Streaming: scope the request to a max-duration ceiling and an idle
 	// Watchdog (see setupStreamContext). Classic path: the request context is
@@ -86,7 +108,7 @@ func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *h
 	}
 
 	rrt := &RetryingRoundTripper{
-		logger:      fh.logger.WithName("roundtripper"),
+		logger:      fh.roundTripperLogger(),
 		resolver:    fh.resolver,
 		tapper:      fh.tapper,
 		fn:          fh.function,

--- a/pkg/router/functionHandler_test.go
+++ b/pkg/router/functionHandler_test.go
@@ -138,10 +138,10 @@ func TestResolverFromExecutorFallsBackToSnapshot(t *testing.T) {
 func TestPrecomputedPolicyParity(t *testing.T) {
 	t.Parallel()
 	classic := fnWithPkg("rv1", "pkg1")
-	classic.ObjectMeta.UID = "uid-classic"
+	classic.UID = "uid-classic"
 	stream := fnWithPkg("rv2", "pkg2")
-	stream.ObjectMeta.UID = "uid-stream"
-	stream.ObjectMeta.Name = "fn-stream"
+	stream.UID = "uid-stream"
+	stream.Name = "fn-stream"
 	stream.Spec.Streaming = &fv1.StreamingConfig{IdleTimeoutSeconds: 7}
 
 	fns := map[string]*fv1.Function{classic.Name: classic, stream.Name: stream}

--- a/pkg/router/functionHandler_test.go
+++ b/pkg/router/functionHandler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -128,4 +129,47 @@ func TestResolverFromExecutorFallsBackToSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, exec.gotFn)
 	assert.Equal(t, "pkg-v1", exec.gotFn.Spec.Package.PackageRef.Name)
+}
+
+// TestPrecomputedPolicyParity pins the RFC-0014 hoist: the policy looked up
+// from the build-time map must equal what resolveProxyPolicy computes per
+// request — including the canary case where the backend (and so the policy)
+// is selected per request by UID.
+func TestPrecomputedPolicyParity(t *testing.T) {
+	t.Parallel()
+	classic := fnWithPkg("rv1", "pkg1")
+	classic.ObjectMeta.UID = "uid-classic"
+	stream := fnWithPkg("rv2", "pkg2")
+	stream.ObjectMeta.UID = "uid-stream"
+	stream.ObjectMeta.Name = "fn-stream"
+	stream.Spec.Streaming = &fv1.StreamingConfig{IdleTimeoutSeconds: 7}
+
+	fns := map[string]*fv1.Function{classic.Name: classic, stream.Name: stream}
+	timeouts := map[k8stypes.UID]int{classic.GetUID(): 42} // stream falls to default
+	const idleDefault = 33 * time.Second
+
+	policies := precomputePolicies(fns, timeouts, idleDefault)
+	require.Len(t, policies, 2)
+
+	for _, fn := range fns {
+		fnTimeout := timeouts[fn.GetUID()]
+		if fnTimeout == 0 {
+			fnTimeout = fv1.DEFAULT_FUNCTION_TIMEOUT
+		}
+		want := resolveProxyPolicy(fn, time.Duration(fnTimeout)*time.Second, idleDefault)
+		assert.Equal(t, want, policies[fn.GetUID()], "hoisted policy must match per-request computation for %s", fn.Name)
+	}
+
+	// The handler-side lookup helper returns the hoisted entry, and falls back
+	// to direct computation for handlers built without the map (test harnesses).
+	fh := &functionHandler{
+		tsRoundTripperParams: &tsRoundTripperParams{streamIdleDefault: idleDefault},
+		policyByUID:          policies,
+	}
+	assert.Equal(t, policies[stream.GetUID()], fh.proxyPolicyFor(stream, time.Duration(fv1.DEFAULT_FUNCTION_TIMEOUT)*time.Second))
+	bare := &functionHandler{tsRoundTripperParams: &tsRoundTripperParams{streamIdleDefault: idleDefault}}
+	assert.Equal(t,
+		resolveProxyPolicy(classic, 42*time.Second, idleDefault),
+		bare.proxyPolicyFor(classic, 42*time.Second),
+		"missing map must fall back to direct computation")
 }

--- a/pkg/router/functionReferenceResolver.go
+++ b/pkg/router/functionReferenceResolver.go
@@ -7,7 +7,6 @@ package router
 import (
 	"context"
 	"fmt"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -16,15 +15,17 @@ import (
 	"github.com/go-logr/logr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/cache"
 )
 
 type (
-	// functionReferenceResolver provides a resolver to turn a function
-	// reference into a resolveResult
+	// functionReferenceResolver turns a trigger's function reference into a
+	// resolveResult. Resolution reads straight from the Manager's informer
+	// cache (in-memory map reads): the trigger-RV-keyed result cache that used
+	// to sit in front of it was a cache of a cache — it cost two goroutines
+	// (pkg/cache actor + expiry), a full Copy() walk on every Function
+	// reconcile, and a stale-snapshot class (trigger-RV keying misses function
+	// updates) — and was removed in RFC-0014 phase 3.
 	functionReferenceResolver struct {
-		// FunctionReference -> function metadata
-		refCache *cache.Cache[namespacedTriggerReference, resolveResult]
 		// reader is the Manager's cache-backed client. Function lookups go
 		// through it (in-memory cache reads), replacing the per-namespace
 		// SharedIndexInformer stores the resolver used before the
@@ -43,14 +44,6 @@ type (
 		functionMap                map[string]*fv1.Function
 		functionWtDistributionList []functionWeightDistribution
 	}
-
-	// namespacedTriggerReference is just a trigger reference plus a
-	// namespace.
-	namespacedTriggerReference struct {
-		namespace              string
-		triggerName            string
-		triggerResourceVersion string
-	}
 )
 
 const (
@@ -59,52 +52,26 @@ const (
 )
 
 func makeFunctionReferenceResolver(logger logr.Logger, reader client.Reader) *functionReferenceResolver {
-	frr := &functionReferenceResolver{
-		refCache: cache.MakeCache[namespacedTriggerReference, resolveResult](time.Minute, 0),
-		reader:   reader,
-		logger:   logger.WithName("function_ref_resolver"),
+	return &functionReferenceResolver{
+		reader: reader,
+		logger: logger.WithName("function_ref_resolver"),
 	}
-	return frr
 }
 
-// resolve translates a trigger's function reference to a resolveResult.
+// resolve translates a trigger's function reference to a resolveResult,
+// reading current Function objects from the Manager cache. Uncached on
+// purpose: it runs only during mux rebuilds (never on the request path — the
+// result is closed into the route's handler at build time), and the informer
+// reads it fans out to are in-memory.
 func (frr *functionReferenceResolver) resolve(ctx context.Context, trigger fv1.HTTPTrigger) (*resolveResult, error) {
-	nfr := namespacedTriggerReference{
-		namespace:              trigger.Namespace,
-		triggerName:            trigger.Name,
-		triggerResourceVersion: trigger.ResourceVersion,
-	}
-
-	// check cache
-	result, err := frr.refCache.Get(nfr)
-	if err == nil {
-		return &result, nil
-	}
-
-	// resolve on cache miss
-	var rr *resolveResult
-
 	switch trigger.Spec.FunctionReference.Type {
 	case fv1.FunctionReferenceTypeFunctionName:
-		rr, err = frr.resolveByName(ctx, nfr.namespace, trigger.Spec.FunctionReference.Name)
-		if err != nil {
-			return nil, err
-		}
-
+		return frr.resolveByName(ctx, trigger.Namespace, trigger.Spec.FunctionReference.Name)
 	case fv1.FunctionReferenceTypeFunctionWeights:
-		rr, err = frr.resolveByFunctionWeights(ctx, nfr.namespace, &trigger.Spec.FunctionReference)
-		if err != nil {
-			return nil, err
-		}
-
+		return frr.resolveByFunctionWeights(ctx, trigger.Namespace, &trigger.Spec.FunctionReference)
 	default:
 		return nil, fmt.Errorf("unrecognized function reference type %v", trigger.Spec.FunctionReference.Type)
 	}
-
-	// cache resolve result
-	frr.refCache.Upsert(nfr, *rr)
-
-	return rr, nil
 }
 
 // getFunction reads a Function from the Manager's cache.
@@ -164,33 +131,4 @@ func (frr *functionReferenceResolver) resolveByFunctionWeights(ctx context.Conte
 	}
 
 	return &rr, nil
-}
-
-func (frr *functionReferenceResolver) delete(namespace string, triggerName, triggerRV string) {
-	nfr := namespacedTriggerReference{
-		namespace:              namespace,
-		triggerName:            triggerName,
-		triggerResourceVersion: triggerRV,
-	}
-	frr.refCache.Delete(nfr)
-}
-
-// invalidateForFunction drops any cached resolve result that references the
-// named function in the given namespace, so the next resolve re-reads the
-// function from the cache. Used by the function reconciler when a Function's
-// spec changes. Returns true if an entry was invalidated.
-func (frr *functionReferenceResolver) invalidateForFunction(namespace, name, resourceVersion string) bool {
-	invalidated := false
-	for key, rr := range frr.refCache.Copy() {
-		if key.namespace == namespace &&
-			rr.functionMap[name] != nil &&
-			rr.functionMap[name].ResourceVersion != resourceVersion {
-			frr.logger.V(1).Info("invalidating resolver cache", "function", name, "namespace", namespace, "trigger", key.triggerName)
-			frr.delete(key.namespace, key.triggerName, key.triggerResourceVersion)
-			invalidated = true
-			// Don't stop at the first match: the same function can back multiple
-			// triggers (and multiple cached trigger-RV entries), all now stale.
-		}
-	}
-	return invalidated
 }

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -229,6 +229,25 @@ func versionHandler(w http.ResponseWriter, r *http.Request) {
 // hmac.Verifier in the bundle process; the verifier is intentionally
 // not added here so this function stays unit-testable without HMAC env
 // state.
+// precomputePolicies resolves the proxy policy for every backend function of
+// a route at mux-build time (RFC-0014): resolveProxyPolicy is a pure function
+// of (fn, timeout, idle-default), and the canary path selects the backend per
+// request, so the map is keyed by function UID.
+func precomputePolicies(fns map[string]*fv1.Function, fnTimeoutMap map[types.UID]int, streamIdleDefault time.Duration) map[types.UID]proxyPolicy {
+	policies := make(map[types.UID]proxyPolicy, len(fns))
+	for _, fn := range fns {
+		if fn == nil {
+			continue
+		}
+		fnTimeout := fnTimeoutMap[fn.GetUID()]
+		if fnTimeout == 0 {
+			fnTimeout = fv1.DEFAULT_FUNCTION_TIMEOUT
+		}
+		policies[fn.GetUID()] = resolveProxyPolicy(fn, time.Duration(fnTimeout)*time.Second, streamIdleDefault)
+	}
+	return policies
+}
+
 func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types.UID]int) (public, internal *mux.Router, err error) {
 	featureConfig, err := config.GetFeatureConfig(ts.logger)
 	if err != nil {
@@ -291,8 +310,9 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 			continue
 		}
 
+		routeLogger := ts.logger.WithName(trigger.Name)
 		fh := &functionHandler{
-			logger:                   ts.logger.WithName(trigger.Name),
+			logger:                   routeLogger,
 			resolver:                 ts.addressResolver,
 			tapper:                   ts.tapper,
 			httpTrigger:              &trigger,
@@ -301,6 +321,11 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 			tsRoundTripperParams:     ts.tsRoundTripperParams,
 			isDebugEnv:               ts.isDebugEnv,
 			functionTimeoutMap:       fnTimeoutMap,
+			// Hoisted per-route state (RFC-0014): the round tripper logger and
+			// the per-backend proxy policies are pure functions of build-time
+			// inputs — computing them per request was pure allocator pressure.
+			rtLogger:    routeLogger.WithName("roundtripper"),
+			policyByUID: precomputePolicies(rr.functionMap, fnTimeoutMap, ts.tsRoundTripperParams.streamIdleDefault),
 		}
 
 		// The functionHandler for HTTP trigger with fn reference type "FunctionReferenceTypeFunctionName",
@@ -398,14 +423,18 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 	// exposing them on the public listener is GHSA-3g33-6vg6-27m8.
 	for i := range ts.functions {
 		fn := ts.functions[i]
+		routeLogger := ts.logger.WithName(fn.Name)
 		fh := &functionHandler{
-			logger:               ts.logger.WithName(fn.Name),
+			logger:               routeLogger,
 			resolver:             ts.addressResolver,
 			tapper:               ts.tapper,
 			function:             &fn,
 			tsRoundTripperParams: ts.tsRoundTripperParams,
 			isDebugEnv:           ts.isDebugEnv,
 			functionTimeoutMap:   fnTimeoutMap,
+			rtLogger:             routeLogger.WithName("roundtripper"),
+			policyByUID: precomputePolicies(map[string]*fv1.Function{fn.Name: &fn},
+				fnTimeoutMap, ts.tsRoundTripperParams.streamIdleDefault),
 		}
 
 		internalRoute := utils.UrlForFunction(fn.Name, fn.Namespace)

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -299,8 +299,9 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 		// resolve function reference
 		rr, err := ts.resolver.resolve(ctx, trigger)
 		if err != nil {
-			// Unresolvable function reference. Report the error via
-			// the trigger's status.
+			// Unresolvable function reference. NOTE: updateTriggerStatusFailed
+			// is still a stub (TODO below), so today this surfaces only in the
+			// router log, not on the trigger's status conditions.
 			go ts.updateTriggerStatusFailed(&trigger, err)
 
 			// Ignore this route and let it 404.

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -249,6 +249,12 @@ func precomputePolicies(fns map[string]*fv1.Function, fnTimeoutMap map[types.UID
 }
 
 func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types.UID]int) (public, internal *mux.Router, err error) {
+	// Hoisted-policy input (RFC-0014). Guarded: test trigger sets construct
+	// without round-trip params; production always wires them.
+	var streamIdleDefault time.Duration
+	if ts.tsRoundTripperParams != nil {
+		streamIdleDefault = ts.tsRoundTripperParams.streamIdleDefault
+	}
 	featureConfig, err := config.GetFeatureConfig(ts.logger)
 	if err != nil {
 		return nil, nil, err
@@ -325,7 +331,7 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 			// the per-backend proxy policies are pure functions of build-time
 			// inputs — computing them per request was pure allocator pressure.
 			rtLogger:    routeLogger.WithName("roundtripper"),
-			policyByUID: precomputePolicies(rr.functionMap, fnTimeoutMap, ts.tsRoundTripperParams.streamIdleDefault),
+			policyByUID: precomputePolicies(rr.functionMap, fnTimeoutMap, streamIdleDefault),
 		}
 
 		// The functionHandler for HTTP trigger with fn reference type "FunctionReferenceTypeFunctionName",
@@ -434,7 +440,7 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 			functionTimeoutMap:   fnTimeoutMap,
 			rtLogger:             routeLogger.WithName("roundtripper"),
 			policyByUID: precomputePolicies(map[string]*fv1.Function{fn.Name: &fn},
-				fnTimeoutMap, ts.tsRoundTripperParams.streamIdleDefault),
+				fnTimeoutMap, streamIdleDefault),
 		}
 
 		internalRoute := utils.UrlForFunction(fn.Name, fn.Namespace)

--- a/pkg/router/reconciler.go
+++ b/pkg/router/reconciler.go
@@ -113,9 +113,9 @@ func (r *functionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 		return ctrl.Result{}, err
 	}
-	if r.ts.resolver != nil {
-		r.ts.resolver.invalidateForFunction(fn.Namespace, fn.Name, fn.ResourceVersion)
-	}
+	// The rebuild triggered below re-resolves every trigger straight from the
+	// Manager cache (the resolver is uncached since RFC-0014 phase 3), so no
+	// explicit invalidation is needed — the rebuild IS the invalidation.
 	r.ts.syncTriggers()
 	return ctrl.Result{}, nil
 }

--- a/pkg/router/reconciler_test.go
+++ b/pkg/router/reconciler_test.go
@@ -143,26 +143,29 @@ func TestHTTPTriggerReconcilerNoIngressStillRebuilds(t *testing.T) {
 	requireRebuildSignal(t, ts)
 }
 
-func TestFunctionReconcilerInvalidatesAndRebuilds(t *testing.T) {
+func TestFunctionReconcilerRebuildsAndResolvesFresh(t *testing.T) {
 	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn1", Namespace: "default", ResourceVersion: "5"}}
 	ts, cl, _ := newReconcilerTS(t, fn)
 	r := &functionReconciler{logger: ts.logger, client: cl, ts: ts}
 
-	// Seed a resolver entry that references fn1 at an older ResourceVersion.
-	ts.resolver.refCache.Upsert(
-		namespacedTriggerReference{namespace: "default", triggerName: "trig", triggerResourceVersion: "1"},
-		resolveResult{
-			resolveResultType: resolveResultSingleFunction,
-			functionMap:       map[string]*fv1.Function{"fn1": {ObjectMeta: metav1.ObjectMeta{Name: "fn1", Namespace: "default", ResourceVersion: "4"}}},
-		},
-	)
-
 	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "fn1", Namespace: "default"}})
 	require.NoError(t, err)
-
-	_, gerr := ts.resolver.refCache.Get(namespacedTriggerReference{namespace: "default", triggerName: "trig", triggerResourceVersion: "1"})
-	assert.Error(t, gerr, "stale resolver entry must be invalidated when the function changes")
 	requireRebuildSignal(t, ts)
+
+	// The resolver is uncached (RFC-0014 phase 3): the rebuild the reconciler
+	// signalled re-resolves from the live Manager cache, so a resolve after a
+	// function update ALWAYS sees the current ResourceVersion — the staleness
+	// class the old trigger-RV-keyed cache could serve is structurally gone.
+	trigger := fv1.HTTPTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "trig", Namespace: "default", ResourceVersion: "1"},
+		Spec: fv1.HTTPTriggerSpec{
+			FunctionReference: fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "fn1"},
+		},
+	}
+	rr, err := ts.resolver.resolve(t.Context(), trigger)
+	require.NoError(t, err)
+	assert.Equal(t, "5", rr.functionMap["fn1"].ResourceVersion,
+		"resolution must read the function's current state from the Manager cache")
 }
 
 func TestFunctionReconcilerDeletedRebuilds(t *testing.T) {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -336,6 +336,18 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// manager cache sync and hang the router not-ready, so degrade to the
 	// legacy data plane loudly instead. Checked before manager construction
 	// because the cache options depend on the (possibly downgraded) mode.
+	// The pooled proxy transport's effective settings (RFC-0014): the one log
+	// line an operator can check to confirm keep-alive / pool sizing took
+	// effect (e.g. after using the disableKeepAlive escape hatch).
+	effPerHost := cfg.maxIdleConnsPerHost
+	if effPerHost <= 0 {
+		effPerHost = defaultMaxIdleConnsPerHost
+	}
+	logger.Info("router proxy transport configured",
+		"disableKeepAlive", cfg.disableKeepAlive,
+		"maxIdleConnsPerHost", effPerHost,
+		"idleConnTimeout", transportIdleConnTimeout)
+
 	requestedMode := cfg.endpointSliceCacheMode
 	if cfg.endpointSliceCacheMode != endpointSliceCacheOff {
 		if rerr := checkSliceWatchRBAC(ctx, kubeClient); rerr != nil {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -385,13 +385,14 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	}
 
 	triggers, err := makeHTTPTriggerSet(logger.WithName("triggerset"), fmap, fissionClient, kubeClient, crMgr.GetClient(), executor, &tsRoundTripperParams{
-		timeout:           cfg.roundTripTimeout,
-		timeoutExponent:   cfg.timeoutExponent,
-		disableKeepAlive:  cfg.disableKeepAlive,
-		keepAliveTime:     cfg.keepAliveTime,
-		maxRetries:        cfg.maxRetries,
-		svcAddrRetryCount: cfg.svcAddrRetryCount,
-		streamIdleDefault: cfg.streamIdleDefault,
+		timeout:             cfg.roundTripTimeout,
+		timeoutExponent:     cfg.timeoutExponent,
+		disableKeepAlive:    cfg.disableKeepAlive,
+		keepAliveTime:       cfg.keepAliveTime,
+		maxRetries:          cfg.maxRetries,
+		svcAddrRetryCount:   cfg.svcAddrRetryCount,
+		streamIdleDefault:   cfg.streamIdleDefault,
+		maxIdleConnsPerHost: cfg.maxIdleConnsPerHost,
 	}, cfg.isDebugEnv, cfg.useEncodedPath, cfg.unTapServiceTimeout, throttler.MakeThrottler(cfg.svcAddrUpdateTimeout))
 	if err != nil {
 		return fmt.Errorf("error making HTTP trigger set: %w", err)

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -33,6 +34,21 @@ type (
 		timeoutExponent  int
 		disableKeepAlive bool
 		keepAliveTime    time.Duration
+
+		// maxIdleConnsPerHost bounds the shared transport's idle pool per
+		// function address (each poolmgr pod is its own host). Go's default
+		// of 2 would throttle per-pod reuse below requestsPerPod ceilings.
+		// From ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST; 0 means the
+		// defaultMaxIdleConnsPerHost.
+		maxIdleConnsPerHost int
+
+		// The shared transport (RFC-0014): ONE pool for the router process,
+		// built lazily on first use. Before this, a fresh http.Transport was
+		// constructed per request, which silently defeated keep-alive
+		// entirely — every proxied request dialed TCP fresh.
+		transportOnce sync.Once
+		transport     *http.Transport
+		otelTransport http.RoundTripper
 
 		// streamIdleDefault is the idle timeout applied to streaming functions
 		// when StreamingConfig.IdleTimeoutSeconds is unset (from the router's
@@ -134,7 +150,7 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 
 	// set the timeout for transport context
 	addForwardedHostHeader(roundTripper.logger, req)
-	transport := roundTripper.getDefaultTransport()
+	transport, otelTransport := roundTripper.params.sharedTransport()
 
 	executingTimeout := roundTripper.params.timeout
 
@@ -244,16 +260,15 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 			rewriteFunctionURL(logger, req, roundTripper.trigger, fnMeta, roundTripper.serviceURL)
 		}
 
-		// over-riding default settings.
-		transport.DialContext = (&net.Dialer{
-			Timeout:   executingTimeout,
-			KeepAlive: roundTripper.params.keepAliveTime,
-		}).DialContext
-
 		// Do NOT assign returned request to "req"
 		// because the request used in the last round
 		// will be canceled when calling setContext.
 		newReq := roundTripper.setContext(req)
+		// Per-attempt dial deadline (the cold-pod fast-retry ladder) rides the
+		// context into the SHARED transport's DialContext; a pooled-conn hit
+		// skips the dial entirely, which is correct — there is nothing to
+		// time out.
+		newReq = newReq.WithContext(context.WithValue(newReq.Context(), dialTimeoutKey{}, executingTimeout))
 
 		if roundTripper.isDebugEnv {
 			debugDumpRequest(logger, newReq)
@@ -273,7 +288,7 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 		// breaks the hijack regardless of Spec.Streaming, so this also fixes classic
 		// WebSocket functions. The only cost is no otel span for the upgrade itself
 		// (a hijacked bidirectional connection isn't meaningfully traceable anyway).
-		var rt http.RoundTripper = otelhttp.NewTransport(transport)
+		var rt http.RoundTripper = otelTransport
 		if routerutil.IsWebsocketRequest(newReq) {
 			rt = transport
 		}
@@ -371,23 +386,69 @@ func jitter(d time.Duration) time.Duration {
 	return d + time.Duration(rand.Float64()*0.2*float64(d))
 }
 
-// getDefaultTransport returns a pointer to new copy of http.Transport object to prevent
-// the value of http.DefaultTransport from being changed by goroutines.
-func (roundTripper RetryingRoundTripper) getDefaultTransport() *http.Transport {
-	// The transport setup here follows the configurations of http.DefaultTransport
-	// but without Dialer since we will change it later.
-	return &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment,
-		MaxIdleConns:          100,
-		IdleConnTimeout:       90 * time.Second,
-		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 1 * time.Second,
-		// Default disables caching, Please refer to issue and specifically comment:
-		// https://github.com/fission/fission/issues/723#issuecomment-398781995
-		// You can change it by setting environment variable "ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE"
-		// of router or helm variable "disableKeepAlive" before installation to false.
-		DisableKeepAlives: roundTripper.params.disableKeepAlive,
-	}
+// dialTimeoutKey carries the per-attempt dial timeout through the request
+// context into the shared transport's DialContext. The backoff-scaled
+// executingTimeout ladder is NOT just a timeout — it is the fast-retry
+// mechanism for cold pods (a not-yet-listening pod must fail the dial
+// quickly so the loop re-resolves), so it must survive the move to a shared
+// transport whose Dialer cannot carry per-request state.
+type dialTimeoutKey struct{}
+
+const (
+	// defaultMaxIdleConnsPerHost: each poolmgr pod is its own host (ip:8888),
+	// so this is effectively the per-pod pooled-connection ceiling.
+	defaultMaxIdleConnsPerHost = 32
+	// transportIdleConnTimeout is deliberately shorter than the poolmgr idle
+	// reap window (120s) and aligned with the RFC-0002 drain grace floor
+	// (30s), bounding how long a pooled connection can outlive its pod.
+	transportIdleConnTimeout = 30 * time.Second
+)
+
+// sharedTransport returns the process-wide pooled transport (and its
+// otel-instrumented wrapper), building both once. Connection reuse across
+// requests is the point (RFC-0014); per-attempt dial deadlines arrive via
+// dialTimeoutKey on the request context — net.Dialer.DialContext honors ctx
+// deadlines, and a deadline-exceeded dial classifies exactly like the old
+// Dialer.Timeout (*net.OpError{Op: "dial"} with Timeout() == true), keeping
+// the retry-ladder semantics byte-identical (pinned by
+// TestDialLadderTimeoutClassification).
+func (p *tsRoundTripperParams) sharedTransport() (*http.Transport, http.RoundTripper) {
+	p.transportOnce.Do(func() {
+		perHost := p.maxIdleConnsPerHost
+		if perHost <= 0 {
+			perHost = defaultMaxIdleConnsPerHost
+		}
+		// No Dialer.Timeout: the per-attempt deadline comes from the context
+		// (cancelling the derived ctx after a successful dial does not affect
+		// the established connection, per net.Dialer docs).
+		dialer := &net.Dialer{KeepAlive: p.keepAliveTime}
+		p.transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				if d, ok := ctx.Value(dialTimeoutKey{}).(time.Duration); ok && d > 0 {
+					var cancel context.CancelFunc
+					ctx, cancel = context.WithTimeout(ctx, d)
+					defer cancel()
+				}
+				return dialer.DialContext(ctx, network, addr)
+			},
+			MaxIdleConns:          1024,
+			MaxIdleConnsPerHost:   perHost,
+			IdleConnTimeout:       transportIdleConnTimeout,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			// The escape hatch back to per-request connections
+			// (ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE / helm
+			// router.roundTrip.disableKeepAlive); see
+			// https://github.com/fission/fission/issues/723 for the original
+			// stale-connection concern, now mitigated by FIN-driven pool
+			// eviction, the short idle timeout, and the transport's automatic
+			// retry of replayable requests on a reused-conn failure.
+			DisableKeepAlives: p.disableKeepAlive,
+		}
+		p.otelTransport = otelhttp.NewTransport(p.transport)
+	})
+	return p.transport, p.otelTransport
 }
 
 // setContext returns a shallow copy of request with a new timeout context.

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -143,7 +144,7 @@ func (roundTripper *RetryingRoundTripper) settle(release func(), tapURL *url.URL
 //     for executor-cached ones) and retries with exponential back-off, up to
 //     maxRetries.
 //   - Any non-dial response or error is relayed to the caller as-is, without
-//     retrying; a resolver error surfaces as 502 via the reverse proxy's error
+//     retrying; a resolver error surfaces as 500 via the reverse proxy's error
 //     handler (429 from ensureCapacity passes through unchanged).
 func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
@@ -321,12 +322,23 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 
 		// if transport.RoundTrip returns a non-network dial error (e.g. "context canceled"), then relay it back to user
 		if !isNetDialErr {
-			// A canceled context is a client disconnect (the caller went away
-			// or its deadline fired), not a server-side error — log it quietly
-			// so client churn doesn't flood the router log at Error level.
-			if errors.Is(err, context.Canceled) {
+			switch {
+			case errors.Is(err, context.Canceled):
+				// A canceled context is a client disconnect (the caller went
+				// away or its deadline fired), not a server-side error — log it
+				// quietly so client churn doesn't flood the log at Error level.
 				logger.V(1).Info("request context canceled by client", "url", req.URL.Host)
-			} else {
+			case isStaleConnErr(err):
+				// A pooled connection failed mid-request (write/read on a conn
+				// whose pod was reaped between requests — possible since the
+				// shared transport reuses connections). Replayable requests
+				// were already retried inside the transport; only
+				// non-replayable ones surface here. Deliberately NOT
+				// quarantined: the failure indicts the connection, not the
+				// (possibly fine) pod, and the next attempt dials fresh.
+				logger.Info("pooled connection failed mid-request; pod may have been reaped",
+					"url", req.URL.Host, "error", err.Error())
+			default:
 				logger.Error(err, "encountered non-network dial error")
 			}
 			return resp, err
@@ -386,6 +398,27 @@ func jitter(d time.Duration) time.Duration {
 	return d + time.Duration(rand.Float64()*0.2*float64(d))
 }
 
+// isStaleConnErr reports whether err is the reused-pooled-connection failure
+// class: a write/read error on a conn whose backend died between requests, or
+// net/http's "server closed idle connection". Dial errors are excluded — they
+// have their own quarantine/ladder handling.
+func isStaleConnErr(err error) bool {
+	var opErr *net.OpError
+	if errors.As(err, &opErr) && (opErr.Op == "write" || opErr.Op == "read") {
+		return true
+	}
+	// A bare EOF on a proxied exchange means the peer closed mid-request —
+	// either a pooled conn racing a pod reap (Go's auto-retry covers the
+	// nothing-written case but deliberately not a possibly-executed request)
+	// or the pod dying mid-response. Same operator story either way.
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+	// net/http's errServerClosedIdle is an unexported errors.New; the string
+	// is its only stable surface.
+	return err != nil && strings.Contains(err.Error(), "server closed idle connection")
+}
+
 // dialTimeoutKey carries the per-attempt dial timeout through the request
 // context into the shared transport's DialContext. The backoff-scaled
 // executingTimeout ladder is NOT just a timeout — it is the fast-retry
@@ -402,6 +435,12 @@ const (
 	// reap window (120s) and aligned with the RFC-0002 drain grace floor
 	// (30s), bounding how long a pooled connection can outlive its pod.
 	transportIdleConnTimeout = 30 * time.Second
+	// defaultDialTimeout caps a dial whose request context carries no
+	// dialTimeoutKey. RoundTrip always sets the key; this is the defensive
+	// bound for any future caller that forgets — without it, a streaming
+	// request (whose per-attempt context has no deadline) could hang a dial
+	// against a blackholed address indefinitely.
+	defaultDialTimeout = 30 * time.Second
 )
 
 // sharedTransport returns the process-wide pooled transport (and its
@@ -425,11 +464,13 @@ func (p *tsRoundTripperParams) sharedTransport() (*http.Transport, http.RoundTri
 		p.transport = &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-				if d, ok := ctx.Value(dialTimeoutKey{}).(time.Duration); ok && d > 0 {
-					var cancel context.CancelFunc
-					ctx, cancel = context.WithTimeout(ctx, d)
-					defer cancel()
+				d, ok := ctx.Value(dialTimeoutKey{}).(time.Duration)
+				if !ok || d <= 0 {
+					d = defaultDialTimeout
 				}
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithTimeout(ctx, d)
+				defer cancel()
 				return dialer.DialContext(ctx, network, addr)
 			},
 			MaxIdleConns:          1024,

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -288,7 +288,7 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 		// breaks the hijack regardless of Spec.Streaming, so this also fixes classic
 		// WebSocket functions. The only cost is no otel span for the upgrade itself
 		// (a hijacked bidirectional connection isn't meaningfully traceable anyway).
-		var rt http.RoundTripper = otelTransport
+		rt := otelTransport
 		if routerutil.IsWebsocketRequest(newReq) {
 			rt = transport
 		}

--- a/pkg/router/transport_bench_test.go
+++ b/pkg/router/transport_bench_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// newTestParams builds one tsRoundTripperParams the way production wiring
+// does: shared across every request of a trigger set, so connection pooling
+// (RFC-0014) is observable across RetryingRoundTripper instances.
+func newTestParams(maxRetries, svcAddrRetryCount int) *tsRoundTripperParams {
+	return &tsRoundTripperParams{
+		timeout:           50 * time.Millisecond,
+		timeoutExponent:   2,
+		keepAliveTime:     30 * time.Second,
+		maxRetries:        maxRetries,
+		svcAddrRetryCount: svcAddrRetryCount,
+	}
+}
+
+// connCountingServer wraps an httptest server counting NEW TCP connections —
+// the direct observable for keep-alive pooling.
+func connCountingServer(t *testing.T, handler http.Handler) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var newConns atomic.Int64
+	srv := httptest.NewUnstartedServer(handler)
+	srv.Config.ConnState = func(_ net.Conn, s http.ConnState) {
+		if s == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	srv.Start()
+	t.Cleanup(srv.Close)
+	return srv, &newConns
+}
+
+func drain(t testing.TB, resp *http.Response) {
+	t.Helper()
+	_, err := io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+}
+
+// TestTransportReusesConnections is the RFC-0014 headline regression guard:
+// serialized warm requests through the SAME shared params (as production
+// shares them across all of a trigger set's requests) must reuse pooled
+// connections instead of dialing per request. Before the shared transport,
+// every request built a fresh http.Transport and dialed fresh — the count
+// here equaled the request count.
+func TestTransportReusesConnections(t *testing.T) {
+	t.Parallel()
+	srv, newConns := connCountingServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	params := newTestParams(3, 2)
+	const requests = 20
+	for range requests {
+		// Fresh per-request RetryingRoundTripper, exactly like the handler.
+		rrt := &RetryingRoundTripper{
+			logger:      loggerfactory.GetLogger(),
+			resolver:    &scriptedResolver{answers: []*url.URL{u}},
+			tapper:      &nopTapper{},
+			fn:          poolmgrFnForTransport(),
+			params:      params,
+			funcTimeout: 5 * time.Second,
+		}
+		req := httptest.NewRequest("GET", "http://router.example/fission-function/fn", nil)
+		resp, err := rrt.RoundTrip(req)
+		require.NoError(t, err)
+		drain(t, resp)
+	}
+
+	assert.LessOrEqual(t, newConns.Load(), int64(2),
+		"serialized warm requests must reuse pooled connections (got %d new conns for %d requests)",
+		newConns.Load(), requests)
+}
+
+// BenchmarkRoundTripWarm measures the per-request cost of the transport path
+// with a warm upstream: allocations and wall time per proxied request,
+// constructing a fresh RetryingRoundTripper per iteration exactly like the
+// handler does.
+func BenchmarkRoundTripWarm(b *testing.B) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	params := newTestParams(3, 2)
+	logger := loggerfactory.GetLogger()
+	fn := poolmgrFnForTransport()
+
+	b.ReportAllocs()
+	for b.Loop() {
+		rrt := &RetryingRoundTripper{
+			logger:      logger,
+			resolver:    &scriptedResolver{answers: []*url.URL{u}},
+			tapper:      &nopTapper{},
+			fn:          fn,
+			params:      params,
+			funcTimeout: 5 * time.Second,
+		}
+		req := httptest.NewRequest("GET", "http://router.example/fission-function/fn", nil)
+		resp, err := rrt.RoundTrip(req)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+			b.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+}

--- a/pkg/router/transport_bench_test.go
+++ b/pkg/router/transport_bench_test.go
@@ -17,6 +17,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	k8stypes "k8s.io/apimachinery/pkg/types"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -132,3 +135,53 @@ func BenchmarkRoundTripWarm(b *testing.B) {
 		resp.Body.Close()
 	}
 }
+
+// benchHandler builds a functionHandler against upstream; hoisted toggles the
+// RFC-0014 phase-2 precomputation (the fallback path is the pre-hoist
+// behavior, so the two benchmarks compare old vs new in one binary).
+func benchHandler(b *testing.B, upstream *url.URL, hoisted bool) functionHandler {
+	logger := loggerfactory.GetLogger()
+	fn := poolmgrFnForTransport()
+	params := newTestParams(3, 2)
+	fh := functionHandler{
+		logger:               logger,
+		resolver:             &scriptedResolver{answers: []*url.URL{upstream}, fromCache: false},
+		tapper:               &nopTapper{},
+		function:             fn,
+		tsRoundTripperParams: params,
+		functionTimeoutMap:   map[k8stypes.UID]int{},
+	}
+	if hoisted {
+		fh.rtLogger = logger.WithName("roundtripper")
+		fh.policyByUID = precomputePolicies(map[string]*fv1.Function{fn.Name: fn}, fh.functionTimeoutMap, params.streamIdleDefault)
+	}
+	return fh
+}
+
+func benchProxyHandler(b *testing.B, hoisted bool) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		b.Fatal(err)
+	}
+	fh := benchHandler(b, u, hoisted)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		req := httptest.NewRequest("GET", "http://router.example/fn", nil)
+		rec := httptest.NewRecorder()
+		fh.handler(rec, req)
+		if rec.Code != http.StatusOK {
+			b.Fatalf("unexpected status %d", rec.Code)
+		}
+	}
+}
+
+// BenchmarkProxyHandlerHoisted measures the full handler path with the
+// phase-2 precomputed logger/policy; BenchmarkProxyHandlerPreHoist exercises
+// the fallback (per-request computation) path for comparison.
+func BenchmarkProxyHandlerHoisted(b *testing.B)  { benchProxyHandler(b, true) }
+func BenchmarkProxyHandlerPreHoist(b *testing.B) { benchProxyHandler(b, false) }

--- a/pkg/router/transport_test.go
+++ b/pkg/router/transport_test.go
@@ -6,9 +6,13 @@ package router
 
 import (
 	"context"
+	"errors"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -366,7 +370,7 @@ func TestTransportRecoversFromStaleConnection(t *testing.T) {
 	require.NoError(t, err)
 
 	params := newTestParams(3, 2)
-	do := func() {
+	do := func() error {
 		rrt := &RetryingRoundTripper{
 			logger:      loggerfactory.GetLogger(),
 			resolver:    &scriptedResolver{answers: []*url.URL{u}},
@@ -377,18 +381,128 @@ func TestTransportRecoversFromStaleConnection(t *testing.T) {
 		}
 		req := httptest.NewRequest("GET", "http://router.example/fission-function/fn", nil)
 		resp, err := rrt.RoundTrip(req)
-		require.NoError(t, err)
+		if err != nil {
+			return err
+		}
 		drain(t, resp)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
+		return nil
 	}
 
-	do() // establishes a pooled conn
+	require.NoError(t, do()) // establishes a pooled conn
 	require.EqualValues(t, 1, newConns.Load())
 
 	// Kill every established connection server-side: the pooled conn is now
 	// stale and the next reuse attempt fails at write/read, not dial.
 	srv.CloseClientConnections()
 
-	do() // must transparently retry on a fresh connection
+	// Common case: Go's transport detects the dead reused conn and retries the
+	// replayable GET transparently. Rare race: the conn is taken before the
+	// FIN is processed and the failure shape is one Go deliberately does NOT
+	// auto-retry (the request may have executed) — then the documented
+	// stale-conn error surfaces, and the NEXT request dials fresh and works.
+	if err := do(); err != nil {
+		assert.True(t, isStaleConnErr(err),
+			"a surfaced raced error must be the stale-conn class, got: %v", err)
+		require.NoError(t, do(), "the request after the raced one must dial fresh and succeed")
+	}
 	assert.LessOrEqual(t, newConns.Load(), int64(3), "recovery must not storm new connections")
 }
+
+// TestStaleConnectionPOSTSurfacesErrorWithoutQuarantine pins the one place
+// users see the pooled-transport failure class (RFC-0014): a NON-replayable
+// request (POST with a body) riding a pooled conn whose backend died must
+// surface an error (not hang), must NOT quarantine the endpoint (the failure
+// indicts the connection, not the pod), and must still settle its slot.
+func TestStaleConnectionPOSTSurfacesErrorWithoutQuarantine(t *testing.T) {
+	t.Parallel()
+	srv, _ := connCountingServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	params := newTestParams(3, 2)
+	tapper := &nopTapper{}
+
+	// Warm the pool with a GET.
+	warm := &RetryingRoundTripper{
+		logger: loggerfactory.GetLogger(), resolver: &scriptedResolver{answers: []*url.URL{u}},
+		tapper: tapper, fn: poolmgrFnForTransport(), params: params, funcTimeout: 5 * time.Second,
+	}
+	resp, err := warm.RoundTrip(httptest.NewRequest("GET", "http://router.example/fn", nil))
+	require.NoError(t, err)
+	drain(t, resp)
+
+	// Kill the pooled conn server-side, then POST a non-replayable body.
+	srv.CloseClientConnections()
+	resolver := &releaseTrackingResolver{answers: []*url.URL{u}}
+	rrt := &RetryingRoundTripper{
+		logger: loggerfactory.GetLogger(), resolver: resolver,
+		tapper: tapper, fn: poolmgrFnForTransport(), params: params, funcTimeout: 5 * time.Second,
+	}
+	req := httptest.NewRequest("POST", "http://router.example/fn", strings.NewReader("payload"))
+	req.ContentLength = -1 // unknown length: GetBody unset -> NOT replayable
+	resp2, err := rrt.RoundTrip(req)
+	if err == nil {
+		// The race is real: if the transport happened to dial fresh (pool
+		// already evicted), the POST succeeds — also acceptable behavior.
+		drain(t, resp2)
+		t.Skip("pool was already evicted; non-replayable path not exercised this run")
+	}
+	assert.True(t, isStaleConnErr(err) || errors.Is(err, io.ErrUnexpectedEOF),
+		"the surfaced error must be the stale-conn class, got: %v", err)
+	assert.Zero(t, resolver.invalidated.Load(),
+		"a stale-conn write failure must NOT quarantine the endpoint")
+	// The settle defer still fired for the admitted slot.
+	resolver.mu.Lock()
+	defer resolver.mu.Unlock()
+	for i, c := range resolver.released {
+		assert.EqualValuesf(t, 1, c.Load(), "slot %d must be settled on the relay return", i)
+	}
+}
+
+// TestDialLadderGrowsPerAttempt pins that the backoff-scaled dial budget
+// actually GROWS across retry attempts now that it rides a context value:
+// hoisting the WithValue out of the retry loop (or breaking the multiply)
+// would silently flatten the cold-pod fast-retry ladder.
+func TestDialLadderGrowsPerAttempt(t *testing.T) {
+	// NOT parallel: rewires the shared transport's DialContext.
+	params := newTestParams(3, 99) // svcAddrRetryCount high: stay on one address
+	transport, _ := params.sharedTransport()
+
+	var mu sync.Mutex
+	var seen []time.Duration
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		d, _ := ctx.Value(dialTimeoutKey{}).(time.Duration)
+		mu.Lock()
+		seen = append(seen, d)
+		mu.Unlock()
+		return nil, &net.OpError{Op: "dial", Net: network, Err: &timeoutErr{}}
+	}
+
+	dead := mustParseURL(t, "http://192.0.2.1:8888")
+	rrt := &RetryingRoundTripper{
+		logger: loggerfactory.GetLogger(), resolver: &scriptedResolver{answers: []*url.URL{dead}, fromCache: true},
+		tapper: &nopTapper{}, fn: poolmgrFnForTransport(), params: params, funcTimeout: 5 * time.Second,
+	}
+	_, err := rrt.RoundTrip(httptest.NewRequest("GET", "http://router.example/fn", nil)) //nolint:bodyclose
+	require.Error(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.GreaterOrEqual(t, len(seen), 3, "the retry loop must attempt multiple dials")
+	for i := 1; i < len(seen); i++ {
+		assert.Greaterf(t, seen[i], seen[i-1],
+			"attempt %d's dial budget (%v) must exceed attempt %d's (%v) — the ladder must grow",
+			i, seen[i], i-1, seen[i-1])
+	}
+}
+
+// timeoutErr is a minimal net.Error with Timeout()==true for ladder tests.
+type timeoutErr struct{}
+
+func (*timeoutErr) Error() string   { return "synthetic dial timeout" }
+func (*timeoutErr) Timeout() bool   { return true }
+func (*timeoutErr) Temporary() bool { return true }

--- a/pkg/router/transport_test.go
+++ b/pkg/router/transport_test.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/error/network"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -328,4 +329,66 @@ func TestSettleDispatchMatrix(t *testing.T) {
 			assert.Equal(t, tc.wantRelease, released.Load() == 1)
 		})
 	}
+}
+
+// TestDialLadderTimeoutClassification pins the RFC-0014 invariant that moving
+// the per-attempt dial timeout from Dialer.Timeout to a context deadline does
+// NOT change error classification: a timed-out dial must still be a dial
+// error AND a timeout error, or the retry ladder (which counts timeouts
+// toward address invalidation) silently changes behavior.
+func TestDialLadderTimeoutClassification(t *testing.T) {
+	t.Parallel()
+	params := newTestParams(1, 1)
+	transport, _ := params.sharedTransport()
+
+	// TEST-NET-1 (RFC 5737): guaranteed unroutable; the 50ms ladder deadline
+	// fires first. (Same address the pre-existing timeout-ladder test uses.)
+	ctx := context.WithValue(t.Context(), dialTimeoutKey{}, 50*time.Millisecond)
+	_, err := transport.DialContext(ctx, "tcp", "192.0.2.1:8888")
+	require.Error(t, err)
+
+	netErr := network.Adapter(err)
+	require.NotNil(t, netErr, "a ladder-deadline dial failure must classify as a network error")
+	assert.True(t, netErr.IsDialError(), "must classify as a dial error (Op == dial)")
+	assert.True(t, netErr.IsTimeoutError(), "must classify as a timeout (counts toward the invalidation ladder)")
+}
+
+// TestTransportRecoversFromStaleConnection pins the pooled-connection failure
+// mode RFC-0014 introduces: a pooled conn whose backend died is detected on
+// reuse, and the transport transparently retries replayable requests (GET, no
+// body) on a fresh connection — the caller sees a 200, not an error.
+func TestTransportRecoversFromStaleConnection(t *testing.T) {
+	t.Parallel()
+	srv, newConns := connCountingServer(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	params := newTestParams(3, 2)
+	do := func() {
+		rrt := &RetryingRoundTripper{
+			logger:      loggerfactory.GetLogger(),
+			resolver:    &scriptedResolver{answers: []*url.URL{u}},
+			tapper:      &nopTapper{},
+			fn:          poolmgrFnForTransport(),
+			params:      params,
+			funcTimeout: 5 * time.Second,
+		}
+		req := httptest.NewRequest("GET", "http://router.example/fission-function/fn", nil)
+		resp, err := rrt.RoundTrip(req)
+		require.NoError(t, err)
+		drain(t, resp)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	do() // establishes a pooled conn
+	require.EqualValues(t, 1, newConns.Load())
+
+	// Kill every established connection server-side: the pooled conn is now
+	// stale and the next reuse attempt fails at write/read, not dial.
+	srv.CloseClientConnections()
+
+	do() // must transparently retry on a fresh connection
+	assert.LessOrEqual(t, newConns.Load(), int64(3), "recovery must not storm new connections")
 }

--- a/rfc/0014-router-hot-path-efficiency.md
+++ b/rfc/0014-router-hot-path-efficiency.md
@@ -1,0 +1,164 @@
+# RFC-0014: Router Hot-Path Efficiency — Shared Transport, Per-Request Allocation Diet, Resolver-Cache Removal
+
+- Status: Proposed
+- Tracking issue: TBD
+- Supersedes: —
+- Targets: Fission v1.27
+- Requires: no new dependencies; no Kubernetes floor change; no user-facing API change
+- Related: RFC-0002 (perf harness, structural seams; the warm path this RFC now optimizes), RFC-0008 (streaming settle invariants that constrain the refactor), RFC-0013 (handler-reuse interlock; the deferred per-route ReverseProxy is designed jointly)
+
+## Summary
+
+The router constructs a **new `http.Transport` per proxied request** (`pkg/router/transport.go:137` via `getDefaultTransport()` at `transport.go:374-391`), which silently defeats HTTP keep-alive entirely: every request to a function pod pays a fresh TCP dial, the configured `MaxIdleConns: 100` is dead config, and the `otelhttp` wrapper is rebuilt per attempt too (`transport.go:276`).
+This RFC fixes that bug-class finding with one shared, properly sized transport; puts the per-request handler path on an allocation diet (pre-built loggers, per-route proxy policy); and removes the `functionReferenceResolver` refCache — a TTL'd cache of the Manager informer cache that sits off the hot path, costs two goroutines plus an O(n) copy-walk per Function reconcile, and whose staleness class is already mitigated elsewhere.
+
+## Motivation
+
+Verified against main:
+
+- **Transport**: `RoundTrip` calls `getDefaultTransport()` (value receiver — copies the whole ~15-field struct) per request; the comment says it exists "to prevent the value of http.DefaultTransport from being changed by goroutines" — a safety choice that created the bug.
+  Per-attempt code then mutates `transport.DialContext` with `Dialer{Timeout: executingTimeout, KeepAlive: keepAliveTime}` (`transport.go:248-251`).
+  Function pods are plain HTTP `:8888`, so the per-request cost is a TCP handshake + slow-start — pure waste under steady load, most visible at high RPS and larger responses.
+- **Per-request allocations** (`pkg/router/functionHandler.go:40-156`): a `RetryingRoundTripper` literal conflating immutable per-route config (resolver, tapper, trigger, params) with per-request state (serviceURL, tapURL, release, retryCounter — mutated at `transport.go:191-193,256`); `logger.WithName("roundtripper")` per request; `resolveProxyPolicy` per request (a pure function of fn + timeout); an `httputil.ReverseProxy` + closures per request; a metrics+tap goroutine (two spawn sites: `functionHandler.go:110-115` and the error handler).
+- **refCache** (`pkg/router/functionReferenceResolver.go`): keyed `(namespace, triggerName, triggerRV)` with a 1-minute TTL; each `pkg/cache` instance runs its own actor + expiry goroutines; `resolve` is called **only from `buildMuxes`** — results are closed into handlers at build time, so the cache is not on the request path at all.
+  Its known staleness class (trigger-RV keying misses function updates) is already mitigated by `resolver_executor.currentFunction` re-reading before any specialization.
+  `invalidateForFunction` does a full `Copy()` map walk on every Function reconcile (hook at `pkg/router/reconciler.go:117`).
+
+## Goals
+
+- Restore connection reuse on the proxy hot path with retry/quarantine semantics byte-identical to today.
+- Reduce per-request allocations without touching the delicate streaming-settle structure.
+- Delete the redundant resolver cache and its reconcile-time costs.
+
+## Non-goals
+
+- No retry-ladder semantic change — the transport/settle/streaming test matrices must pass **unchanged**.
+- No `pkg/cache` removal (`functionServiceMap` still uses it for the legacy/fallback address path; rationalization direction noted only).
+- No per-route `ReverseProxy` in this RFC (designed below, explicitly deferred; interlocks with RFC-0013's handler reuse).
+- No user-facing API or chart schema change (one new tuning env var only).
+
+## Design
+
+### Shared transport with a context-carried dial ladder
+
+One `*http.Transport` per router process (plus a once-wrapped `otelhttp.NewTransport` sibling for the non-websocket path), built where `tsRoundTripperParams` is constructed and stored on it.
+`disableKeepAlive` is process-wide config, so a single transport configured from it at startup suffices — no per-variant pool.
+
+The critical constraint: the per-attempt `Dialer.Timeout = executingTimeout` is not just a timeout, it is the **backoff-scaled fast-retry ladder for cold pods** — a not-yet-listening pod must fail the dial quickly so the loop re-resolves.
+It is preserved exactly via a context value read by a single shared `DialContext`:
+
+```go
+transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+    if d, ok := ctx.Value(dialTimeoutKey{}).(time.Duration); ok {
+        var cancel context.CancelFunc
+        ctx, cancel = context.WithTimeoutCause(ctx, d, errDialLadderTimeout)
+        defer cancel()
+    }
+    return sharedDialer.DialContext(ctx, network, addr) // Dialer{KeepAlive: params.keepAliveTime}
+}
+```
+
+`RoundTrip` stashes the attempt's `executingTimeout` into the per-attempt request context; a pooled-conn hit skips the dial entirely (correct — there is nothing to time out).
+Classification is unchanged: a ctx-deadline dial failure is `*net.OpError{Op: "dial"}` with `Timeout() == true` — identical through `network.Adapter` (`pkg/error/network/error.go`) to today's `Dialer.Timeout` path (which `net` implements as a ctx deadline internally), and `transport.RoundTrip` is called directly so there is no `*url.Error` wrapping.
+A pin test makes this an invariant (see Verification).
+
+Sizing (the current `MaxIdleConns: 100` never mattered because the transport never survived a request):
+
+- `MaxIdleConnsPerHost`: new env `ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST`, default 32 — each poolmgr pod is its own host (`ip:8888`), and the Go default of 2 would throttle per-pod reuse well below `requestsPerPod` ceilings.
+- `MaxIdleConns`: 1024 (explicit bound for fd hygiene).
+- `IdleConnTimeout`: 90s → **30s**, shorter than the poolmgr idle-reap window (120s), bounding how long a pooled conn can outlive its pod.
+
+**Pooled conns vs dead pods** is the one real behavioral shift: today a dead pod fails at dial (refused/timeout → quarantine/retry ladder); with pooling, a stale conn fails at write/read instead.
+Graceful reaps send FIN, which evicts the conn from the pool before reuse; the residual race is covered by Go's automatic retry of replayable requests on a reused-conn failure; a non-replayable POST surfaces the error to the caller (a 500 via the proxy error handler, logged with a distinct 'pooled connection failed mid-request' line) — documented and pinned by a unit test.
+The quarantine path is unaffected (it keys on dial errors, and a write-failure on a reused conn correctly is not one).
+`disableKeepAlive` — which today is nearly meaningless — becomes the documented escape hatch back to per-request connections.
+
+### Handler hoists (allocation diet)
+
+Computed once in `buildMuxes` and stored on the route's `functionHandler`:
+
+- The round-tripper logger (`logger.WithName("roundtripper")` moves out of the request path).
+- A per-(route, backend-UID) map of `proxyPolicy` + `funcTimeout` (`resolveProxyPolicy` is a pure function; the map covers the canary case, where `fh.function` is selected per request from the weight distribution).
+
+Kept deliberately per-request:
+
+- The `RetryingRoundTripper` itself — it *is* the per-request state (one small allocation; `sync.Pool` rejected: the streaming-deferred settle and `closeContextFunc` lifetimes make pooling error-prone for negligible gain).
+- The `ReverseProxy` + closures — a per-route proxy requires carrying per-request state through the request context so shared `ModifyResponse`/`ErrorHandler` can find it; the win is small next to the transport fix and the risk touches the streaming settle block, the most delicate code in the router.
+  The context-key design is recorded here; implementation is deferred and revisited alongside RFC-0013's handler reuse.
+- The metrics+tap goroutines (async is required — the tap send must never block response delivery; a worker pool adds queue/drop/shutdown semantics to save microseconds).
+
+An optional `roundTripperConfig` field-regrouping makes the immutable/mutable boundary explicit, as a refactor not a behavior change.
+
+### refCache removal
+
+`buildMuxes` resolves directly against the informer cache: `resolve()` stays as a thin uncached dispatch on `FunctionReference.Type` (smallest diff; `resolveResult` shape unchanged), and the following are deleted:
+
+- the `refCache` field and its `MakeCache` construction (−2 goroutines),
+- `invalidateForFunction` and its `Copy()` walk,
+- the reconciler hook at `reconciler.go:117` (the Function reconcile still triggers the rebuild — that is exactly what makes the cache redundant).
+
+Behavior delta: N informer `Get`s per rebuild instead of cache hits — in-memory map reads, negligible; canary weight lists are rebuilt per rebuild with identical results; the up-to-1-minute stale-snapshot window the cache could serve is gone outright (and was already moot for specialization via `currentFunction`).
+
+## Configuration
+
+| Knob | Default | Notes |
+|---|---|---|
+| `ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST` | 32 | new; tuning, not gating |
+| `ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE` | false | pre-existing; becomes the meaningful escape hatch |
+| `IdleConnTimeout` | 30s | internal constant, rationale documented |
+
+No new feature gate: the change is internal, and the keep-alive escape hatch already exists.
+
+## Backward compatibility
+
+- Failure-mode shift for non-replayable requests racing pod shutdown (documented above; integration-tested; GETs retry transparently).
+- `disableKeepAlive` semantics upgrade called out in chart docs.
+- Everything else is allocation/log-shape only; retry, settle, quarantine, and streaming semantics are frozen by the existing test matrices.
+
+## Rollout phases (one PR each, bisectable)
+
+**Phase 0 — baseline harness.**
+Alloc benchmarks (`BenchmarkHandlerClassic`, `BenchmarkRoundTripWarm` against a fake resolver + httptest backend, `b.ReportAllocs`) plus a dial-counting listener wrapper; capture the k6 warm-path baseline into `rfc/perf-results`.
+No production change — lands first so phases 1–2 have honest before/after deltas.
+
+**Phase 1 — shared transport (the bug fix, isolated).**
+Build transport + otel wrapper once; context-value dial ladder; delete `getDefaultTransport`; sizing knobs; classification pin test; chart-docs note for `disableKeepAlive`.
+
+**Phase 2 — handler hoists.**
+Per-route logger; per-(route, backend-UID) policy/timeout map; optional config/state field regrouping.
+Benchmarks show the allocs/op delta.
+
+**Phase 3 — refCache removal.**
+As designed; independent of phases 1–2 (sequenced last to keep perf-sensitive diffs first).
+
+**Deferred (recorded, not scheduled):** per-route `ReverseProxy` via context-carried per-request state — re-evaluate with RFC-0013.
+
+## Verification
+
+- **Connection reuse (headline)**: with the dial-counting listener, N serialized warm requests to one backend perform ≤ `MaxIdleConnsPerHost` dials after warmup (today: exactly N).
+- **Allocs**: `go test -bench -benchmem` — allocs/op strictly reduced after phases 1–2; numbers recorded in `rfc/perf-results`.
+- **k6 warm path** (RFC-0002 runbook): predicted p50 down by roughly one intra-cluster RTT plus slow-start effects, throughput up at fixed VUs; acceptance = p50 improvement observed, no p99 regression beyond noise.
+- **Semantics frozen**: `transport_test.go` retry matrix, settle dispatch matrix, streaming release tests, `functionHandler_test.go`, canary tests pass **unchanged** (the only deletion is `getDefaultTransport`'s own coverage).
+- **Classification pin**: unit test dialing a blackhole (TEST-NET `192.0.2.1`) with a 1ms ladder value asserts `IsDialError() && IsTimeoutError()`.
+- **Stale-conn behavior**: integration test kills the backend between requests; GET transparently retried by the transport; POST behavior documented and asserted.
+- **refCache removal**: resolver tests rewritten against direct resolution; router idle goroutine count drops by 2 (assertable via the CI pprof artifacts); CI pprof heap shows the `getDefaultTransport` allocation site gone.
+
+## Alternatives considered
+
+- Per-(keepalive-setting) transport variants — unnecessary; the setting is process-wide.
+- `sync.Pool` for the round tripper — lifetime hazards (streaming settle, closeContextFunc) for negligible gain.
+- A worker pool for the metrics/tap goroutines — queue/drop/shutdown complexity to save microseconds; revisit only if profiles show scheduler pressure.
+- Per-route `ReverseProxy` now — deferred (risk concentrated in the streaming settle block; small residual win).
+- Keeping refCache with function-RV keying — still a cache of an O(1) in-memory cache; deletion is simpler and removes the staleness class instead of re-keying it.
+
+## Open questions
+
+- Should `MaxIdleConnsPerHost` derive from poolmgr `requestsPerPod` ceilings instead of a flat default?
+- Is the 30s `IdleConnTimeout` right once RFC-0002's drain-aware reaping (unlabel → grace → delete) is considered — should it key off the drain grace floor (30s) explicitly?
+
+## Risks (top 3, with mitigations)
+
+1. **Pooled conns to dead pods change the error mode** (highest): write/read failures replace dial failures for stale conns.
+   Mitigations: FIN-driven pool eviction covers graceful reaps; 30s idle timeout; TCP keepalive; Go's replayable-request auto-retry; the integration test above; the `disableKeepAlive` escape hatch.
+2. **Dial-ladder semantic drift**: mitigated by the context-value design (ladder values unchanged), the classification pin test, and the frozen transport test matrices.
+3. **Pool sizing wrong by default**: too low throttles hot pods, too high holds fds across thousands of pods — mitigated by the env knob and k6 evidence before/after.


### PR DESCRIPTION
## Summary

Implements RFC-0014 (router hot-path efficiency), headlined by a genuine bug: **the proxy built a fresh `http.Transport` per request, so HTTP keep-alive has never worked** — every proxied request paid a TCP dial to the function pod, and the configured `MaxIdleConns: 100` was dead config.
Four bisectable phases: baseline harness → shared transport → handler hoists → resolver-cache removal, plus review follow-ups.

## Measured impact (unit benchmarks, this branch)

| Metric | Before | After | Delta |
|---|---|---|---|
| Warm RoundTrip wall time | 253,358 ns/op | 89,007 ns/op | **−65%** |
| Allocations | 45,708 B/op / 267 allocs | 19,518 B/op / 165 allocs | **−57% / −38%** |
| TCP dials for 20 serialized requests | 20 | ≤2 | pooling restored |

(End-to-end k6 numbers from a kind before/after run are posted as a PR comment.)

## What changed

**Phase 1 — shared transport (the fix):** one `http.Transport` per router process, lazily built on the shared `tsRoundTripperParams` (`sync.Once`); the `otelhttp` wrapper built once instead of per attempt.
The per-attempt dial timeout — which is the backoff-scaled **fast-retry ladder for cold pods**, not just a timeout — moves into a context value read by the shared `DialContext`; a deadline-exceeded dial classifies identically (`*net.OpError{Op:dial}, Timeout()==true`), pinned by `TestDialLadderTimeoutClassification`, and the ladder's per-attempt **growth** is pinned by `TestDialLadderGrowsPerAttempt`.
Sizing: `MaxIdleConnsPerHost` 32 (each poolmgr pod is its own host; tunable via `ROUTER_ROUND_TRIP_MAX_IDLE_CONNS_PER_HOST`), `IdleConnTimeout` 30s (under the poolmgr reap window).

**Chart bug fixed along the way:** `ROUTER_ROUND_TRIP_DISABLE_KEEP_ALIVE` used `| default true`, and sprig's `default` treats `false` as empty — the env rendered `"true"` unconditionally, making keep-alive impossible to enable even explicitly.
Previously masked (the per-request transport made the setting moot); now it is the meaningful escape hatch back to per-request connections.

**Phase 2 — handler hoists:** the round-tripper logger and per-backend proxy policies are computed once in `buildMuxes` (per backend UID, covering canary) instead of per request.
Honest numbers: marginal (217→215 allocs/op on the full handler path) — phase 1 was the lever; this is hygiene with a parity test.

**Phase 3 — resolver cache removal:** the `functionReferenceResolver`'s trigger-RV-keyed result cache was a cache of the Manager informer cache, used only during mux rebuilds (never on the request path).
Removed: −2 goroutines per router, no more full-map `Copy()` walk on every Function reconcile, and the trigger-RV staleness class is structurally gone (resolution always reads current state — pinned by test).

**Review follow-ups** (two-agent review; code-reviewer verdict: clean): distinct Info log for the pooled-conn failure class ("pooled connection failed mid-request; pod may have been reaped" — deliberately not quarantined: the failure indicts the connection, not the pod); startup log of effective transport settings; defensive 30s dial cap when the ladder value is absent; config soft-fail tests.

## The one behavioral shift, documented

A stale pooled conn to a reaped pod fails at write/read instead of dial.
Graceful reaps FIN-evict the conn from the pool; Go auto-retries replayable requests; a non-replayable POST (and the rare raced GET that may have executed) surfaces the error with the distinct log line — pinned by `TestStaleConnectionPOSTSurfacesErrorWithoutQuarantine` and the race-tolerant recovery test.
The quarantine path is untouched (it keys on dial errors, correctly).
Escape hatch: `router.roundTrip.disableKeepAlive: true`.

**Release-notes material:** every install effectively had keep-alive disabled (the chart coercion); after upgrade, pooling is ON by default with the settings logged at router startup.

## Verification

- New tests: connection-reuse regression (20 req ≤2 conns), ladder classification + growth pins, stale-conn POST/GET behavior, policy-hoist parity, fresh-resolution-after-fn-update, config soft-fail table; benchmarks committed.
- The frozen matrices — transport retry, settle dispatch, streaming release, canary, GHSA route pins — pass **unchanged**.
- `make code-checks` 0 issues; `make license-check` clean; helm renders verified for default/`true`/explicit-`false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
