### PR TITLE
fix(storagesvc): honor scheme in S3 endpoint and enable TLS for https

### DIFF
--- a/pkg/storagesvc/objectstore_s3.go
+++ b/pkg/storagesvc/objectstore_s3.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -22,14 +24,35 @@ type s3ObjectStore struct {
 	bucket string
 }
 
+// parseS3Endpoint splits a configured endpoint into the bare host[:port] minio
+// expects and whether to use TLS. minio.New rejects endpoints carrying a scheme
+// or path, so an "https://host:port" value (which Helm users have always been
+// able to set) has to be normalized here. A scheme-less endpoint keeps the
+// historical plain-HTTP behaviour.
+func parseS3Endpoint(endpoint string) (host string, secure bool, err error) {
+	if !strings.Contains(endpoint, "://") {
+		return endpoint, false, nil
+	}
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", false, err
+	}
+	return u.Host, u.Scheme == "https", nil
+}
+
 // newS3ObjectStore connects to the S3-compatible endpoint and ensures the
 // bucket exists.
 func newS3ObjectStore(endpoint, accessKeyID, secretAccessKey, region, bucket string) (*s3ObjectStore, error) {
-	client, err := minio.New(endpoint, &minio.Options{
+	host, secure, err := parseS3Endpoint(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := minio.New(host, &minio.Options{
 		Creds: credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
-		// Plain HTTP to the endpoint (the storagesvc S3 backend has always
-		// connected without TLS).
-		Secure: false,
+		// TLS is used when the endpoint is given as an https:// URL; a
+		// scheme-less endpoint keeps connecting over plain HTTP as before.
+		Secure: secure,
 		Region: region,
 	})
 	if err != nil {

--- a/pkg/storagesvc/objectstore_s3_test.go
+++ b/pkg/storagesvc/objectstore_s3_test.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package storagesvc
+
+import "testing"
+
+func TestParseS3Endpoint(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		wantHost string
+		wantTLS  bool
+	}{
+		{"bare host stays plain http", "minio.fission:9000", "minio.fission:9000", false},
+		{"https url enables tls and drops scheme", "https://local.s3.endpoint.com:5443", "local.s3.endpoint.com:5443", true},
+		{"http url stays plain", "http://minio.fission:9000", "minio.fission:9000", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			host, secure, err := parseS3Endpoint(c.endpoint)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if host != c.wantHost {
+				t.Errorf("host: got %q, want %q", host, c.wantHost)
+			}
+			if secure != c.wantTLS {
+				t.Errorf("secure: got %t, want %t", secure, c.wantTLS)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

After the switch to minio-go, `newS3ObjectStore` passed the configured endpoint straight into `minio.New` and hardcoded `Secure: false`. minio rejects an endpoint that carries a scheme or path, so an `https://host:port` value (which Helm users have always been able to set) fails with `Endpoint url cannot have fully qualified paths.`, and dropping the scheme then connects over plain HTTP to a TLS-only endpoint.

This parses the endpoint, passes the bare `host[:port]` to minio, and enables TLS when the endpoint is given as an `https://` URL. A scheme-less endpoint keeps the previous plain-HTTP behaviour, so existing configs are unaffected.

## Which issue(s) this PR fixes:

Fixes #3498

## Testing

Added `TestParseS3Endpoint` covering bare host, `http://` and `https://` forms, and ran `go test ./pkg/storagesvc/` and `go vet ./pkg/storagesvc/` locally.

## Checklist:
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
