### PR TITLE
feat: namespace-scoped archive content isolation in storagesvc (RFC tenancy Phase 7)

### DIFF
--- a/pkg/auth/hmac/keys.go
+++ b/pkg/auth/hmac/keys.go
@@ -209,20 +209,27 @@ func DecodeKeyFromEnv(s string) []byte {
 // caller can only produce a valid signature with the namespace key it actually
 // holds, so claiming a different namespace just makes the verifier derive a key
 // the caller cannot sign with → rejection.
+//
+// Candidates are labeled with the principal they authenticate so a handler can
+// authorize on the namespace whose key actually matched (AuthenticatedNamespace),
+// not the raw header: an ns-key match reports the header namespace, a master-key
+// match reports "" (unrestricted) regardless of any header the caller set — so a
+// master holder is never mis-scoped to a namespace it merely claimed.
 func ServiceVerifierNamespaceFromHeader(masterSecret, masterOldSecret []byte, service Service, opts VerifierOpts) func(http.Handler) http.Handler {
-	opts.KeysFromRequest = func(r *http.Request) [][]byte {
-		keys := make([][]byte, 0, 4)
+	opts.KeysFromRequestLabeled = func(r *http.Request) []LabeledKey {
+		keys := make([]LabeledKey, 0, 4)
 		if ns := r.Header.Get(HeaderNamespace); ns != "" {
 			keys = append(keys,
-				DeriveServiceKeyNS(masterSecret, service, ns),
-				DeriveServiceKeyNS(masterOldSecret, service, ns),
+				LabeledKey{Namespace: ns, Key: DeriveServiceKeyNS(masterSecret, service, ns)},
+				LabeledKey{Namespace: ns, Key: DeriveServiceKeyNS(masterOldSecret, service, ns)},
 			)
 		}
 		// Dual-accept the master-derived key for pre-migration clients that sign
-		// master-derived and send no namespace header.
+		// master-derived and send no namespace header. Labeled "" (unrestricted):
+		// only the control plane holds the master.
 		keys = append(keys,
-			DeriveServiceKey(masterSecret, service),
-			DeriveServiceKey(masterOldSecret, service),
+			LabeledKey{Namespace: "", Key: DeriveServiceKey(masterSecret, service)},
+			LabeledKey{Namespace: "", Key: DeriveServiceKey(masterOldSecret, service)},
 		)
 		return keys
 	}

--- a/pkg/auth/hmac/keys_ns_test.go
+++ b/pkg/auth/hmac/keys_ns_test.go
@@ -154,6 +154,69 @@ func TestServiceVerifierNamespaceFromHeader(t *testing.T) {
 	assert.Equal(t, 200, serve(signed(DeriveServiceKey(master, ServiceStoragesvc), "")))
 }
 
+// TestVerifierReportsPrincipal locks the property storagesvc authorization
+// relies on: the namespace exposed via AuthenticatedNamespace is the one whose
+// key actually verified, NOT a caller-controlled header. This is the case a
+// "trust the post-verifier header" approach gets wrong — a master holder can set
+// any header — and is exactly why the verifier labels candidates.
+func TestVerifierReportsPrincipal(t *testing.T) {
+	master := []byte(testMaster)
+	now := func() time.Time { return time.Unix(1715000123, 0) }
+
+	var gotNS string
+	var gotOK bool
+	handler := ServiceVerifierNamespaceFromHeader(master, nil, ServiceStoragesvc, VerifierOpts{SkewSec: 60, Now: now})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotNS, gotOK = AuthenticatedNamespace(r.Context())
+			w.WriteHeader(200)
+		}))
+
+	signed := func(key []byte, nsHeader string) *http.Request {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/v1/archive?id=x", nil)
+		_, err := NewSigner(key, &recordingTransport{rr: rr}, now).RoundTrip(req)
+		require.NoError(t, err)
+		req2 := signedRequestFromRecorder(t, rr)
+		if nsHeader != "" {
+			req2.Header.Set(HeaderNamespace, nsHeader)
+		}
+		return req2
+	}
+	serve := func(req *http.Request) int {
+		gotNS, gotOK = "", false
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	t.Run("ns-key holder → principal is its own namespace", func(t *testing.T) {
+		require.Equal(t, 200, serve(signed(DeriveServiceKeyNS(master, ServiceStoragesvc, "team-a"), "team-a")))
+		assert.True(t, gotOK)
+		assert.Equal(t, "team-a", gotNS)
+	})
+
+	t.Run("master holder, no header → unrestricted principal", func(t *testing.T) {
+		require.Equal(t, 200, serve(signed(DeriveServiceKey(master, ServiceStoragesvc), "")))
+		assert.True(t, gotOK)
+		assert.Empty(t, gotNS, "master principal is unrestricted")
+	})
+
+	t.Run("master holder spoofing a header is NOT mis-scoped to it", func(t *testing.T) {
+		// Master signs master-derived but sets header=team-b. The verifier accepts
+		// (the master key matches) but must report "" — the matched key's label —
+		// never the spoofed header.
+		require.Equal(t, 200, serve(signed(DeriveServiceKey(master, ServiceStoragesvc), "team-b")))
+		assert.True(t, gotOK)
+		assert.Empty(t, gotNS, "must reflect the matched master key, not the spoofed header")
+	})
+
+	t.Run("rejected request never reaches the handler", func(t *testing.T) {
+		// Tenant team-a spoofing header=team-b → 401; the principal is never set.
+		require.Equal(t, 401, serve(signed(DeriveServiceKeyNS(master, ServiceStoragesvc, "team-a"), "team-b")))
+		assert.False(t, gotOK, "handler must not run on rejection")
+	})
+}
+
 func TestVerifierFromKeyRoundTrip(t *testing.T) {
 	// A pod that holds ONLY a derived ns key (never the master) verifies with it.
 	now := func() time.Time { return time.Unix(1715000123, 0) }

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -79,38 +79,24 @@ type VerifierOpts struct {
 	// care about audit logs don't crash. Rejection log lines deliberately
 	// omit the signature and timestamp values to avoid log poisoning.
 	Logger logr.Logger
-	// KeysFromRequest, when set, supplies the ordered candidate keys to try for
-	// each request — used by namespace-scoped verifiers that derive the key from
-	// a request header (e.g. ServiceVerifierNamespaceFromHeader). It REPLACES
-	// Secret/OldSecret for the verification step; Secret is then ignored for
-	// key selection but a non-nil KeysFromRequest still enables enforcement.
-	// Empty/nil candidate keys are skipped. Keep it cheap — it runs per request.
-	// Candidates from this hook are unlabeled (unrestricted principal); use
-	// KeysFromRequestLabeled to also report the authenticated namespace.
-	KeysFromRequest func(*http.Request) [][]byte
-	// KeysFromRequestLabeled is KeysFromRequest plus a principal label per
-	// candidate: the namespace recorded (via AuthenticatedNamespace) when that
-	// candidate verifies. Takes precedence over KeysFromRequest and
-	// Secret/OldSecret. Lets a multi-tenant verifier authorize on the namespace
-	// whose key actually matched, not a caller-controlled header.
+	// KeysFromRequestLabeled, when set, supplies the ordered candidate keys to try
+	// for each request, each tagged with the principal namespace recorded (via
+	// AuthenticatedNamespace) when that candidate verifies — used by namespace-
+	// scoped verifiers that derive the key from a request header (e.g.
+	// ServiceVerifierNamespaceFromHeader). It REPLACES Secret/OldSecret for key
+	// selection, and a non-nil hook enables enforcement. Empty/nil candidate keys
+	// are skipped; an empty namespace label is an unrestricted principal. Lets a
+	// multi-tenant verifier authorize on the namespace whose key actually matched,
+	// not a caller-controlled header. Keep it cheap — it runs per request.
 	KeysFromRequestLabeled func(*http.Request) []LabeledKey
 }
 
 // labeledCandidates returns the ordered candidate keys to try for a request,
-// each tagged with the principal namespace to record on a match. Precedence:
-// the labeled hook, then the unlabeled hook (all unrestricted), then the static
-// active+rotation pair (unrestricted).
+// each tagged with the principal namespace to record on a match: the per-request
+// labeled hook when set, else the static active+rotation pair (unrestricted).
 func (o VerifierOpts) labeledCandidates(r *http.Request) []LabeledKey {
 	if o.KeysFromRequestLabeled != nil {
 		return o.KeysFromRequestLabeled(r)
-	}
-	if o.KeysFromRequest != nil {
-		raw := o.KeysFromRequest(r)
-		out := make([]LabeledKey, len(raw))
-		for i, k := range raw {
-			out[i] = LabeledKey{Key: k}
-		}
-		return out
 	}
 	return []LabeledKey{{Key: o.Secret}, {Key: o.OldSecret}}
 }
@@ -146,7 +132,7 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 			// (backwards-compat short-circuit). In pass-through mode we
 			// deliberately do NOT bound the body — the downstream handler's
 			// existing limits apply unchanged.
-			if len(opts.Secret) == 0 && opts.KeysFromRequest == nil && opts.KeysFromRequestLabeled == nil {
+			if len(opts.Secret) == 0 && opts.KeysFromRequestLabeled == nil {
 				next.ServeHTTP(w, r)
 				return
 			}

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -6,6 +6,7 @@ package hmac
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -15,6 +16,34 @@ import (
 
 	"github.com/go-logr/logr"
 )
+
+// LabeledKey is a candidate verification key tagged with the principal it
+// authenticates. When a request verifies against a LabeledKey, that Namespace is
+// the request's authenticated principal — recoverable downstream via
+// AuthenticatedNamespace. An empty Namespace means an unrestricted principal
+// (e.g. a master-derived key held only by the control plane), so a holder of it
+// is never scoped to a namespace it merely claimed in a header.
+type LabeledKey struct {
+	Namespace string
+	Key       []byte
+}
+
+// authNamespaceCtxKey is the context key under which the verifier stores the
+// authenticated principal namespace on a successful match. Unexported so only
+// this package can set it; readers use AuthenticatedNamespace.
+type authNamespaceCtxKeyType struct{}
+
+var authNamespaceCtxKey authNamespaceCtxKeyType
+
+// AuthenticatedNamespace returns the namespace whose key verified the request,
+// as recorded by the verifier middleware on success. ok is false when no
+// verifier ran or enforcement was off; ns == "" with ok == true is an
+// unrestricted (master) principal. Handlers treat both the unset case and ""
+// as unrestricted.
+func AuthenticatedNamespace(ctx context.Context) (ns string, ok bool) {
+	ns, ok = ctx.Value(authNamespaceCtxKey).(string)
+	return ns, ok
+}
 
 // DefaultMaxBodyBytes caps the size of a request body the verifier will buffer
 // in memory. 256 MiB comfortably exceeds any realistic Fission archive while
@@ -56,16 +85,34 @@ type VerifierOpts struct {
 	// Secret/OldSecret for the verification step; Secret is then ignored for
 	// key selection but a non-nil KeysFromRequest still enables enforcement.
 	// Empty/nil candidate keys are skipped. Keep it cheap — it runs per request.
+	// Candidates from this hook are unlabeled (unrestricted principal); use
+	// KeysFromRequestLabeled to also report the authenticated namespace.
 	KeysFromRequest func(*http.Request) [][]byte
+	// KeysFromRequestLabeled is KeysFromRequest plus a principal label per
+	// candidate: the namespace recorded (via AuthenticatedNamespace) when that
+	// candidate verifies. Takes precedence over KeysFromRequest and
+	// Secret/OldSecret. Lets a multi-tenant verifier authorize on the namespace
+	// whose key actually matched, not a caller-controlled header.
+	KeysFromRequestLabeled func(*http.Request) []LabeledKey
 }
 
-// candidateKeys returns the ordered keys to try for a request: the per-request
-// hook when set, else the static active+rotation pair.
-func (o VerifierOpts) candidateKeys(r *http.Request) [][]byte {
-	if o.KeysFromRequest != nil {
-		return o.KeysFromRequest(r)
+// labeledCandidates returns the ordered candidate keys to try for a request,
+// each tagged with the principal namespace to record on a match. Precedence:
+// the labeled hook, then the unlabeled hook (all unrestricted), then the static
+// active+rotation pair (unrestricted).
+func (o VerifierOpts) labeledCandidates(r *http.Request) []LabeledKey {
+	if o.KeysFromRequestLabeled != nil {
+		return o.KeysFromRequestLabeled(r)
 	}
-	return [][]byte{o.Secret, o.OldSecret}
+	if o.KeysFromRequest != nil {
+		raw := o.KeysFromRequest(r)
+		out := make([]LabeledKey, len(raw))
+		for i, k := range raw {
+			out[i] = LabeledKey{Key: k}
+		}
+		return out
+	}
+	return []LabeledKey{{Key: o.Secret}, {Key: o.OldSecret}}
 }
 
 // Replay note: a signature presented twice within the SkewSec window will pass
@@ -99,7 +146,7 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 			// (backwards-compat short-circuit). In pass-through mode we
 			// deliberately do NOT bound the body — the downstream handler's
 			// existing limits apply unchanged.
-			if len(opts.Secret) == 0 && opts.KeysFromRequest == nil {
+			if len(opts.Secret) == 0 && opts.KeysFromRequest == nil && opts.KeysFromRequestLabeled == nil {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -175,9 +222,13 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 			// order (active, then rotation, or the per-request namespace keys);
 			// constant-time compare happens inside Verify per candidate.
 			ru := r.URL.RequestURI()
-			for _, key := range opts.candidateKeys(r) {
-				if len(key) > 0 && Verify(key, r.Method, ru, body, tsNum, sig) {
-					next.ServeHTTP(w, r)
+			for _, c := range opts.labeledCandidates(r) {
+				if len(c.Key) > 0 && Verify(c.Key, r.Method, ru, body, tsNum, sig) {
+					// Record the principal whose key matched so downstream
+					// handlers authorize on the authenticated namespace rather
+					// than a caller-controlled header.
+					ctx := context.WithValue(r.Context(), authNamespaceCtxKey, c.Namespace)
+					next.ServeHTTP(w, r.WithContext(ctx))
 					return
 				}
 			}

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -201,7 +201,7 @@ func CreatePackage(input cli.Input, client cmd.Client, pkgName string, pkgNamesp
 		if len(specFile) > 0 { // we should do this in all cases, i think
 			pkgStatus = fv1.BuildStatusNone
 		}
-		deployment, err := CreateArchive(client, input, deployArchiveFiles, noZip, insecure, deployChecksum, specDir, specFile)
+		deployment, err := CreateArchive(client, input, deployArchiveFiles, noZip, insecure, deployChecksum, specDir, specFile, pkgNamespace)
 		if err != nil {
 			return nil, fmt.Errorf("error creating deploy archive: %w", err)
 		}
@@ -211,7 +211,7 @@ func CreatePackage(input cli.Input, client cmd.Client, pkgName string, pkgNamesp
 		}
 	}
 	if len(srcArchiveFiles) > 0 {
-		source, err := CreateArchive(client, input, srcArchiveFiles, false, insecure, srcChecksum, specDir, specFile)
+		source, err := CreateArchive(client, input, srcArchiveFiles, false, insecure, srcChecksum, specDir, specFile, pkgNamespace)
 		if err != nil {
 			return nil, fmt.Errorf("error creating source archive: %w", err)
 		}

--- a/pkg/fission-cli/cmd/package/package.go
+++ b/pkg/fission-cli/cmd/package/package.go
@@ -34,7 +34,11 @@ import (
 // create an archive upload spec in the specs directory; otherwise
 // upload the archive using client.  noZip avoids zipping the
 // includeFiles, but is ignored if there's more than one includeFile.
-func CreateArchive(client cmd.Client, input cli.Input, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string) (*fv1.Archive, error) {
+// CreateArchive builds (and, for non-spec mode, uploads) the archive for the
+// given files. namespace scopes a real upload to its owning tenant (see
+// UploadArchiveFile); spec mode returns a spec-reference URL and never uploads,
+// so namespace is unused there.
+func CreateArchive(client cmd.Client, input cli.Input, includeFiles []string, noZip bool, insecure bool, checksum string, specDir string, specFile string, namespace string) (*fv1.Archive, error) {
 	// get root dir
 	var rootDir string
 	var err error
@@ -178,7 +182,7 @@ func CreateArchive(client cmd.Client, input cli.Input, includeFiles []string, no
 		return nil, err
 	}
 
-	return pkgutil.UploadArchiveFile(input.Context(), client, archivePath)
+	return pkgutil.UploadArchiveFile(input.Context(), client, archivePath, namespace)
 }
 
 // makeArchiveFile creates a zip file from the given list of input files,

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -131,7 +131,7 @@ func UpdatePackage(input cli.Input, client cmd.Client, specFile string, pkg *fv1
 	}
 
 	if input.IsSet(flagkey.PkgSrcArchive) {
-		srcArchive, err := CreateArchive(client, input, srcArchiveFiles, noZip, insecure, srcChecksum, "", "")
+		srcArchive, err := CreateArchive(client, input, srcArchiveFiles, noZip, insecure, srcChecksum, "", "", pkg.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("error creating source archive: %w", err)
 		}
@@ -147,7 +147,7 @@ func UpdatePackage(input cli.Input, client cmd.Client, specFile string, pkg *fv1
 	}
 
 	if input.IsSet(flagkey.PkgDeployArchive) || input.IsSet(flagkey.PkgCode) {
-		deployArchive, err := CreateArchive(client, input, deployArchiveFiles, noZip, insecure, deployChecksum, "", "")
+		deployArchive, err := CreateArchive(client, input, deployArchiveFiles, noZip, insecure, deployChecksum, "", "", pkg.Namespace)
 		if err != nil {
 			return nil, fmt.Errorf("error creating deploy archive: %w", err)
 		}

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -22,7 +22,12 @@ import (
 	"github.com/fission/fission/pkg/utils/uuid"
 )
 
-func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string) (*fv1.Archive, error) {
+// UploadArchiveFile uploads fileName to storagesvc and returns the resulting
+// Archive. When namespace is non-empty the upload is scoped to that tenant, so
+// the archive id carries the namespace and storagesvc isolates it from other
+// tenants; an empty namespace uploads master-derived/unscoped (the legacy form,
+// for callers without an unambiguous owning namespace such as spec apply).
+func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName, namespace string) (*fv1.Archive, error) {
 	var archive fv1.Archive
 
 	size, err := utils.FileSize(fileName)
@@ -47,7 +52,10 @@ func UploadArchiveFile(ctx context.Context, client cmd.Client, fileName string) 
 			return nil, fmt.Errorf("error reading internal-auth secret: %w", err)
 		}
 
-		storageClient := storageSvcClient.MakeClient(storagesvcURL.String(), hmacSecret)
+		// Scope the upload to the owning namespace when known, so the archive id
+		// is namespace-tagged and storagesvc isolates it; falls back to
+		// master-derived/unscoped for an empty namespace.
+		storageClient := storageSvcClient.MakeClientNS(storagesvcURL.String(), hmacSecret, namespace)
 		// TODO add a progress bar
 		id, err := storageClient.Upload(ctx, fileName, nil)
 		if err != nil {

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -401,8 +401,13 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 		} else {
 			// doesn't exist, upload
 			fmt.Printf("uploading archive %v\n", name)
-			// ar.URL is actually a local filename at this stage
-			uploadedAr, err := pkgutil.UploadArchiveFile(input.Context(), fclient, ar.URL)
+			// ar.URL is actually a local filename at this stage.
+			// Unscoped ("" namespace): spec archives are de-duplicated by checksum
+			// and may be shared by packages across namespaces, so they cannot be
+			// pinned to a single tenant. They upload as legacy (unscoped) ids,
+			// readable by any tenant (grandfathered) — scoping the spec path is a
+			// tracked follow-up that needs per-package-namespace upload handling.
+			uploadedAr, err := pkgutil.UploadArchiveFile(input.Context(), fclient, ar.URL, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/storagesvc/authz.go
+++ b/pkg/storagesvc/authz.go
@@ -6,7 +6,9 @@ package storagesvc
 
 import (
 	"net/http"
+	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -28,8 +30,16 @@ const archiveTenantMarker = "_tenant_"
 // (container path for local, subDir for S3), so it needs no backend state and is
 // robust to a subDir change between releases. "" maps a legacy id to the
 // grandfathered path in authorizedFor.
+//
+// The id is path.Clean'd first so the namespace we authorize against is the one
+// the storage backend will actually resolve to. Without this, a crafted id like
+// "_tenant_/<ownNS>/../<victimNS>/<uuid>" would parse as ownNS (authorized) yet
+// the local backend (relName → filepath.Clean) collapses the ".." and resolves
+// the victim's file — a cross-tenant read/delete. idHasParentTraversal is the
+// belt-and-suspenders reject; cleaning here keeps parse and resolve in agreement
+// regardless.
 func archiveNamespace(id string) string {
-	segs := strings.Split(filepath.ToSlash(id), "/")
+	segs := strings.Split(path.Clean(filepath.ToSlash(id)), "/")
 	for i, s := range segs {
 		if s != archiveTenantMarker {
 			continue
@@ -43,6 +53,14 @@ func archiveNamespace(id string) string {
 		return ""
 	}
 	return ""
+}
+
+// idHasParentTraversal reports whether the id contains a ".." path segment. Such
+// an id is never legitimate (real ids are clean uuids / _tenant_/ns/uuid /
+// absolute container paths) and is rejected outright before authorization, so a
+// parse-vs-resolve disagreement can never be reached.
+func idHasParentTraversal(id string) bool {
+	return slices.Contains(strings.Split(filepath.ToSlash(id), "/"), "..")
 }
 
 // validNamespaceLabel reports whether ns is a syntactically valid RFC-1123
@@ -64,6 +82,11 @@ func (ss *StorageService) authorizedFor(r *http.Request, id string) bool {
 	authNS, _ := hmacauth.AuthenticatedNamespace(r.Context())
 	if authNS == "" {
 		return true
+	}
+	// Reject traversal before authorizing: a ".." could otherwise steer a request
+	// authorized as the caller's namespace to another tenant's archive.
+	if idHasParentTraversal(id) {
+		return false
 	}
 	arcNS := archiveNamespace(id)
 	if arcNS == "" {

--- a/pkg/storagesvc/authz.go
+++ b/pkg/storagesvc/authz.go
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package storagesvc
+
+import (
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// archiveTenantMarker is the fixed path segment that precedes the owning
+// namespace in a namespace-scoped archive id (".../_tenant_/<namespace>/<uuid>").
+// It contains an underscore, which an RFC-1123 namespace label cannot, so it can
+// never collide with a real namespace or a UUID. It is RESERVED: it must not be
+// used as a storage sub-directory (SUBDIR / STORAGE_S3_SUB_DIR).
+const archiveTenantMarker = "_tenant_"
+
+// archiveNamespace returns the namespace that owns the archive id, or "" for a
+// legacy/unscoped id (one with no marker). It locates the marker segment and
+// returns the following segment when it is a valid namespace label and is itself
+// followed by a (uuid) segment — independent of the backend's storage prefix
+// (container path for local, subDir for S3), so it needs no backend state and is
+// robust to a subDir change between releases. "" maps a legacy id to the
+// grandfathered path in authorizedFor.
+func archiveNamespace(id string) string {
+	segs := strings.Split(filepath.ToSlash(id), "/")
+	for i, s := range segs {
+		if s != archiveTenantMarker {
+			continue
+		}
+		// Require <namespace> at i+1 and a trailing <uuid> segment at i+2 so a
+		// directory that happens to be named like the marker (e.g. a misconfigured
+		// subDir) with a single trailing segment is not mistaken for a namespace.
+		if i+2 < len(segs) && validNamespaceLabel(segs[i+1]) {
+			return segs[i+1]
+		}
+		return ""
+	}
+	return ""
+}
+
+// validNamespaceLabel reports whether ns is a syntactically valid RFC-1123
+// namespace label. Used both to parse a namespace out of an id and to reject a
+// malformed authenticated namespace before it is joined into a storage path —
+// load-bearing for S3, which has no os.Root path confinement.
+func validNamespaceLabel(ns string) bool {
+	return len(validation.IsDNS1123Label(ns)) == 0
+}
+
+// authorizedFor reports whether the request's authenticated principal may access
+// the archive id. The principal is the namespace whose HMAC key verified the
+// request (hmacauth.AuthenticatedNamespace) — never a caller-controlled header:
+//   - "" (master / control-plane / pre-tenancy caller): unrestricted, unchanged.
+//   - a tenant namespace N: may access archives owned by N, plus legacy/unscoped
+//     archives (grandfathered — UUID-unguessability, as before this change), but
+//     not another tenant's namespace-scoped archive.
+func (ss *StorageService) authorizedFor(r *http.Request, id string) bool {
+	authNS, _ := hmacauth.AuthenticatedNamespace(r.Context())
+	if authNS == "" {
+		return true
+	}
+	arcNS := archiveNamespace(id)
+	if arcNS == "" {
+		legacyArchiveAccess.WithLabelValues().Inc()
+		return true
+	}
+	return arcNS == authNS
+}

--- a/pkg/storagesvc/authz_test.go
+++ b/pkg/storagesvc/authz_test.go
@@ -38,12 +38,26 @@ func TestArchiveNamespace(t *testing.T) {
 		{"marker without trailing uuid is not a namespace", archiveTenantMarker + "/team-a", ""},
 		{"segment after marker is not a valid label", archiveTenantMarker + "/Not_A_Label/" + uuid, ""},
 		{"marker as a coincidental subdir with single trailing segment", archiveTenantMarker + "/" + uuid, ""},
+		// Traversal: the parsed namespace must reflect what the backend resolves
+		// (the cleaned path), not the literal prefix — else a sibling-escape id
+		// would authorize as one tenant but read another's file.
+		{"traversal resolves to the real owner, not the literal prefix", archiveTenantMarker + "/team-a/../team-b/" + uuid, "team-b"},
+		{"traversal escaping the marker is unowned", archiveTenantMarker + "/team-a/../../etc/passwd", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.want, archiveNamespace(tc.id))
 		})
 	}
+}
+
+func TestIdHasParentTraversal(t *testing.T) {
+	assert.True(t, idHasParentTraversal("_tenant_/a/../b/uuid"))
+	assert.True(t, idHasParentTraversal("/container/_tenant_/a/../b/uuid"))
+	assert.True(t, idHasParentTraversal("../../etc/passwd"))
+	assert.False(t, idHasParentTraversal("_tenant_/team-a/uuid"))
+	assert.False(t, idHasParentTraversal("550e8400-e29b-41d4-a716-446655440000"))
+	assert.False(t, idHasParentTraversal("/container/_tenant_/team-a/uuid"))
 }
 
 func TestValidNamespaceLabel(t *testing.T) {
@@ -157,6 +171,21 @@ func TestArchiveAuthzHandlers(t *testing.T) {
 		assert.Equal(t, http.StatusOK, do(http.MethodGet, idB, keyMaster, ""))
 		assert.Equal(t, http.StatusOK, do(http.MethodGet, idLegacy, keyMaster, ""))
 	})
+	// Regression: a path-traversal id that CLEANS to tenant B's archive but is
+	// prefixed with the attacker's own namespace must NOT grant access. Without the
+	// fix archiveNamespace parsed the literal prefix ("team-a") and authorized,
+	// while the local backend collapsed the ".." and resolved team-b's file.
+	t.Run("path traversal cannot reach another tenant's archive", func(t *testing.T) {
+		crafted := strings.Replace(idB, "/"+archiveTenantMarker+"/team-b/", "/"+archiveTenantMarker+"/team-a/../team-b/", 1)
+		require.NotEqual(t, idB, crafted, "craft must differ from the real id")
+		require.Equal(t, "team-b", archiveNamespace(crafted), "cleaned id resolves to the real owner")
+		assert.Equal(t, http.StatusNotFound, do(http.MethodGet, crafted, keyA, "team-a"))
+		assert.Equal(t, http.StatusNotFound, do(http.MethodDelete, crafted, keyA, "team-a"))
+		assert.Equal(t, http.StatusNotFound, do(http.MethodHead, crafted, keyA, "team-a"))
+		// And team-b's archive is intact (master can still read it).
+		assert.Equal(t, http.StatusOK, do(http.MethodGet, idB, keyMaster, ""))
+	})
+
 	// Guard the local nested-dir put: a scoped id round-trips on disk.
 	t.Run("scoped archive is retrievable by exact id", func(t *testing.T) {
 		require.Equal(t, "team-a", archiveNamespace(idA))

--- a/pkg/storagesvc/authz_test.go
+++ b/pkg/storagesvc/authz_test.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package storagesvc
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+func TestArchiveNamespace(t *testing.T) {
+	const uuid = "550e8400-e29b-41d4-a716-446655440000"
+	cases := []struct {
+		name string
+		id   string
+		want string
+	}{
+		{"legacy bare uuid", uuid, ""},
+		{"legacy s3 subdir/uuid", "sub/" + uuid, ""},
+		{"legacy local absolute", "/data/fission-functions/" + uuid, ""},
+		{"scoped local", "/data/fission-functions/" + archiveTenantMarker + "/team-a/" + uuid, "team-a"},
+		{"scoped s3 no subdir", archiveTenantMarker + "/team-a/" + uuid, "team-a"},
+		{"scoped s3 with subdir", "sub/dir/" + archiveTenantMarker + "/team-b/" + uuid, "team-b"},
+		{"marker without trailing uuid is not a namespace", archiveTenantMarker + "/team-a", ""},
+		{"segment after marker is not a valid label", archiveTenantMarker + "/Not_A_Label/" + uuid, ""},
+		{"marker as a coincidental subdir with single trailing segment", archiveTenantMarker + "/" + uuid, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, archiveNamespace(tc.id))
+		})
+	}
+}
+
+func TestValidNamespaceLabel(t *testing.T) {
+	assert.True(t, validNamespaceLabel("team-a"))
+	assert.True(t, validNamespaceLabel("default"))
+	assert.False(t, validNamespaceLabel(""))
+	assert.False(t, validNamespaceLabel("../escape"))
+	assert.False(t, validNamespaceLabel("a/b"))
+	assert.False(t, validNamespaceLabel("UpperCase"))
+	assert.False(t, validNamespaceLabel(strings.Repeat("a", 64)))
+}
+
+// TestGetUploadFileNameScoping locks the round-trip: a namespace-scoped upload
+// name parses back to its namespace via archiveNamespace, for both backends and
+// regardless of the S3 subDir, while an empty namespace yields a legacy id.
+func TestGetUploadFileNameScoping(t *testing.T) {
+	t.Run("local", func(t *testing.T) {
+		s := NewLocalStorage(t.TempDir())
+		scoped, err := s.getUploadFileName("team-a")
+		require.NoError(t, err)
+		assert.Equal(t, "team-a", archiveNamespace(scoped))
+		legacy, err := s.getUploadFileName("")
+		require.NoError(t, err)
+		assert.Empty(t, archiveNamespace(legacy))
+	})
+	t.Run("s3 empty subdir", func(t *testing.T) {
+		t.Setenv("STORAGE_S3_SUB_DIR", "")
+		s := NewS3Storage()
+		scoped, err := s.getUploadFileName("team-a")
+		require.NoError(t, err)
+		assert.Equal(t, "team-a", archiveNamespace(scoped))
+		legacy, err := s.getUploadFileName("")
+		require.NoError(t, err)
+		assert.Empty(t, archiveNamespace(legacy))
+	})
+	t.Run("s3 with subdir", func(t *testing.T) {
+		t.Setenv("STORAGE_S3_SUB_DIR", "some/prefix")
+		s := NewS3Storage()
+		scoped, err := s.getUploadFileName("team-b")
+		require.NoError(t, err)
+		assert.True(t, strings.HasPrefix(scoped, "some/prefix/"), "keeps the configured subDir")
+		assert.Equal(t, "team-b", archiveNamespace(scoped))
+	})
+}
+
+// TestArchiveAuthzHandlers exercises the full authorization wiring: the real
+// namespace-scoped verifier sets the principal, and the handlers enforce it. A
+// tenant reaches its own and legacy archives but a 404 (not 403) hides another
+// tenant's; the master principal is unrestricted.
+func TestArchiveAuthzHandlers(t *testing.T) {
+	master := []byte("storagesvc-test-master-key-long-enough")
+	now := time.Unix(1715000123, 0)
+
+	storage := NewLocalStorage(t.TempDir())
+	sc, err := MakeStorageClient(logr.Discard(), storage)
+	require.NoError(t, err)
+	ss := MakeStorageService(logr.Discard(), sc, 0, master, nil)
+
+	r := mux.NewRouter()
+	r.Use(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
+		hmacauth.VerifierOpts{SkewSec: 60, Now: func() time.Time { return now }}))
+	r.HandleFunc("/v1/archive", ss.downloadHandler).Queries("id", "{id}").Methods(http.MethodGet)
+	r.HandleFunc("/v1/archive", ss.deleteHandler).Methods(http.MethodDelete)
+	r.HandleFunc("/v1/archive", ss.infoHandler).Methods(http.MethodHead)
+
+	// Seed archives directly through the backend (the upload path is covered by
+	// TestGetUploadFileNameScoping); returns the stored id.
+	seed := func(ns, content string) string {
+		name, err := storage.getUploadFileName(ns)
+		require.NoError(t, err)
+		id, err := sc.backend.put(name, strings.NewReader(content), int64(len(content)))
+		require.NoError(t, err)
+		return id
+	}
+	idA := seed("team-a", "a-archive")
+	idB := seed("team-b", "b-archive")
+	idLegacy := seed("", "legacy-archive")
+
+	do := func(method, id string, signKey []byte, nsHeader string) int {
+		target := "/v1/archive?id=" + url.QueryEscape(id)
+		req := httptest.NewRequest(method, target, nil)
+		ts := now.Unix()
+		sig := hmacauth.Sign(signKey, method, req.URL.RequestURI(), nil, ts)
+		req.Header.Set(hmacauth.HeaderTimestamp, strconv.FormatInt(ts, 10))
+		req.Header.Set(hmacauth.HeaderSignature, sig)
+		if nsHeader != "" {
+			req.Header.Set(hmacauth.HeaderNamespace, nsHeader)
+		}
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	keyA := hmacauth.DeriveServiceKeyNS(master, hmacauth.ServiceStoragesvc, "team-a")
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+
+	t.Run("tenant reads its own archive", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, do(http.MethodGet, idA, keyA, "team-a"))
+		assert.Equal(t, http.StatusOK, do(http.MethodHead, idA, keyA, "team-a"))
+	})
+	t.Run("tenant is 404 on another tenant's archive (no existence oracle)", func(t *testing.T) {
+		assert.Equal(t, http.StatusNotFound, do(http.MethodGet, idB, keyA, "team-a"))
+		assert.Equal(t, http.StatusNotFound, do(http.MethodHead, idB, keyA, "team-a"))
+		assert.Equal(t, http.StatusNotFound, do(http.MethodDelete, idB, keyA, "team-a"))
+	})
+	t.Run("tenant reads a legacy unscoped archive (grandfathered)", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, do(http.MethodGet, idLegacy, keyA, "team-a"))
+	})
+	t.Run("master principal is unrestricted", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, do(http.MethodGet, idA, keyMaster, ""))
+		assert.Equal(t, http.StatusOK, do(http.MethodGet, idB, keyMaster, ""))
+		assert.Equal(t, http.StatusOK, do(http.MethodGet, idLegacy, keyMaster, ""))
+	})
+	// Guard the local nested-dir put: a scoped id round-trips on disk.
+	t.Run("scoped archive is retrievable by exact id", func(t *testing.T) {
+		require.Equal(t, "team-a", archiveNamespace(idA))
+		_, statErr := sc.backend.size(idA)
+		require.NoError(t, statErr)
+		require.True(t, strings.Contains(filepath.ToSlash(idA), "/"+archiveTenantMarker+"/team-a/"))
+	})
+}

--- a/pkg/storagesvc/client.go
+++ b/pkg/storagesvc/client.go
@@ -70,9 +70,11 @@ func MakeStorageClient(logger logr.Logger, storage Storage) (*StorageClient, err
 	}, nil
 }
 
-// putFile writes the file on the storage
-func (client *StorageClient) putFile(file multipart.File, fileSize int64) (string, error) {
-	uploadName, err := client.config.storage.getUploadFileName()
+// putFile writes the file on the storage. namespace, when non-empty, scopes the
+// generated id to that tenant (see getUploadFileName / authz.go); empty yields a
+// legacy unscoped id.
+func (client *StorageClient) putFile(file multipart.File, fileSize int64, namespace string) (string, error) {
+	uploadName, err := client.config.storage.getUploadFileName(namespace)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -92,6 +92,37 @@ func MakeClientWithTransport(url string, rt http.RoundTripper) ClientInterface {
 	}
 }
 
+// namespaceHeaderRoundTripper sets the X-Fission-Auth-Namespace header (the
+// tenant the request is scoped to) before delegating to the signing transport.
+// The header is not part of the HMAC canonical, so setting it here does not
+// affect the signature; it tells storagesvc which namespace's key to verify with.
+type namespaceHeaderRoundTripper struct {
+	namespace string
+	next      http.RoundTripper
+}
+
+func (n *namespaceHeaderRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r = r.Clone(r.Context())
+	r.Header.Set(hmacauth.HeaderNamespace, n.namespace)
+	return n.next.RoundTrip(r)
+}
+
+// MakeClientNS is MakeClient for a namespace-scoped caller: it signs with the
+// per-namespace derived ServiceStoragesvc key (so an archive it uploads is scoped
+// to `namespace`, and storagesvc reports `namespace` as the authenticated
+// principal) and sets the namespace header. masterSecret is the chart-installed
+// master, from which the namespace key is derived in-process. With an empty
+// masterSecret (internalAuth disabled) or an empty namespace it is exactly
+// MakeClient — unsigned or master-derived/unscoped — so it is always a safe drop-in.
+func MakeClientNS(url string, masterSecret []byte, namespace string) ClientInterface {
+	if len(masterSecret) == 0 || namespace == "" {
+		return MakeClient(url, masterSecret)
+	}
+	rt := hmacauth.ServiceSignerNS(masterSecret, hmacauth.ServiceStoragesvc, namespace,
+		otelhttp.NewTransport(http.DefaultTransport), time.Now)
+	return MakeClientWithTransport(url, &namespaceHeaderRoundTripper{namespace: namespace, next: rt})
+}
+
 // HMACSecretFromEnv returns the HMAC secret from
 // FISSION_INTERNAL_AUTH_SECRET. Returns nil when unset, which leaves
 // the storagesvc client unsigned — the correct backwards-compatible

--- a/pkg/storagesvc/client/makeclientns_test.go
+++ b/pkg/storagesvc/client/makeclientns_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// TestMakeClientNS proves the namespace-scoped client signs with the per-namespace
+// derived storagesvc key and sets the namespace header, so the real verifier both
+// accepts the request and attributes it to that namespace — the property the
+// storagesvc archive authorization relies on. An empty namespace falls back to a
+// master-derived, unscoped client (principal "").
+func TestMakeClientNS(t *testing.T) {
+	master := []byte("storagesvc-test-master-key-long-enough")
+
+	var principal string
+	var sawRequest bool
+	r := mux.NewRouter()
+	r.Use(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
+		hmacauth.VerifierOpts{SkewSec: 60}))
+	r.HandleFunc("/v1/archive", func(w http.ResponseWriter, req *http.Request) {
+		principal, _ = hmacauth.AuthenticatedNamespace(req.Context())
+		sawRequest = true
+		w.WriteHeader(http.StatusOK)
+	}).Methods(http.MethodHead)
+
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	t.Run("namespace-scoped client is attributed to its namespace", func(t *testing.T) {
+		principal, sawRequest = "", false
+		c := MakeClientNS(srv.URL, master, "team-a")
+		resp, err := c.Info(t.Context(), "some-archive-id")
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.True(t, sawRequest)
+		assert.Equal(t, "team-a", principal, "verifier must attribute the request to team-a")
+	})
+
+	t.Run("empty namespace falls back to unrestricted (master) principal", func(t *testing.T) {
+		principal, sawRequest = "x", false
+		c := MakeClientNS(srv.URL, master, "")
+		resp, err := c.Info(t.Context(), "some-archive-id")
+		require.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		require.True(t, sawRequest)
+		assert.Empty(t, principal, "master principal is unrestricted")
+	})
+}

--- a/pkg/storagesvc/localstorage.go
+++ b/pkg/storagesvc/localstorage.go
@@ -6,6 +6,7 @@ package storagesvc
 
 import (
 	"os"
+	"path"
 
 	"github.com/fission/fission/pkg/utils/uuid"
 )
@@ -34,10 +35,16 @@ func (ls localStorage) getStorageType() StorageType {
 	return ls.storageType
 }
 
-func (ls localStorage) getUploadFileName() (string, error) {
+func (ls localStorage) getUploadFileName(namespace string) (string, error) {
 	// This is not the item ID (that's returned by Put)
 	// should we just use handler.Filename? what are the constraints here?
-	return uuid.NewString(), nil
+	id := uuid.NewString()
+	if namespace != "" {
+		// Namespace-scoped: _tenant_/<ns>/<uuid> under the container, so storagesvc
+		// can authorize a caller against the owning namespace (see authz.go).
+		return path.Join(archiveTenantMarker, namespace, id), nil
+	}
+	return id, nil
 }
 
 func (ls localStorage) getSubDir() string {

--- a/pkg/storagesvc/metrics.go
+++ b/pkg/storagesvc/metrics.go
@@ -26,10 +26,22 @@ var (
 		},
 		functionLabels,
 	)
+	// legacyArchiveAccess counts accesses by a namespace-scoped caller to a
+	// legacy (unscoped) archive, which are grandfathered for backward
+	// compatibility. A nonzero-and-not-shrinking value tells operators how much
+	// traffic still touches un-migrated archives before tightening the policy.
+	legacyArchiveAccess = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "fission_storagesvc_legacy_archive_access_total",
+			Help: "Accesses by a namespace-scoped caller to a legacy (unscoped) archive, grandfathered for backward compatibility",
+		},
+		functionLabels,
+	)
 )
 
 func init() {
 	registry := metrics.Registry
 	registry.MustRegister(totalArchives)
 	registry.MustRegister(totalMemoryUsage)
+	registry.MustRegister(legacyArchiveAccess)
 }

--- a/pkg/storagesvc/objectstore_local.go
+++ b/pkg/storagesvc/objectstore_local.go
@@ -72,7 +72,18 @@ func (s *localObjectStore) put(name string, r io.Reader, _ int64) (string, error
 	}
 	defer root.Close()
 
-	f, err := root.Create(filepath.FromSlash(name))
+	rel := filepath.FromSlash(name)
+	// A namespace-scoped name (e.g. _tenant_/<ns>/<uuid>) nests under directories
+	// that must exist before Create. MkdirAll runs through the os.Root, so it is
+	// confined to the container — even a crafted name cannot create directories
+	// outside it.
+	if dir := filepath.Dir(rel); dir != "." {
+		if err := root.MkdirAll(dir, 0o755); err != nil {
+			return "", err
+		}
+	}
+
+	f, err := root.Create(rel)
 	if err != nil {
 		return "", err
 	}
@@ -82,7 +93,7 @@ func (s *localObjectStore) put(name string, r io.Reader, _ int64) (string, error
 		return "", err
 	}
 	// id is the absolute path of the stored file.
-	return filepath.Join(s.containerPath, filepath.FromSlash(name)), nil
+	return filepath.Join(s.containerPath, rel), nil
 }
 
 func (s *localObjectStore) open(id string) (io.ReadCloser, error) {

--- a/pkg/storagesvc/s3storage.go
+++ b/pkg/storagesvc/s3storage.go
@@ -55,8 +55,13 @@ func (ss s3Storage) getSubDir() string {
 	return ss.subDir
 }
 
-func (ss s3Storage) getUploadFileName() (string, error) {
+func (ss s3Storage) getUploadFileName(namespace string) (string, error) {
 	id := uuid.NewString()
+	if namespace != "" {
+		// Namespace-scoped: <subDir>/_tenant_/<ns>/<uuid>, so storagesvc can
+		// authorize a caller against the owning namespace (see authz.go).
+		return path.Join(ss.subDir, archiveTenantMarker, namespace, id), nil
+	}
 	return path.Join(ss.subDir, id), nil
 }
 

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -34,7 +34,10 @@ type (
 		dial() (objectStore, error)
 		getSubDir() string
 		getContainerName() string
-		getUploadFileName() (string, error)
+		// getUploadFileName returns the storage name for a new upload. When
+		// namespace is non-empty the id is namespace-scoped (carries the tenant
+		// marker + namespace); an empty namespace yields the legacy unscoped id.
+		getUploadFileName(namespace string) (string, error)
 	}
 
 	// StorageService is a struct to hold all things for storage service
@@ -67,6 +70,17 @@ func (ss *StorageService) listItems(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		logger.Error(err, "error getting items from storage")
 		return
+	}
+	// A namespace-scoped caller sees only its own archives; an unrestricted
+	// (master) caller — the pruner, the CLI — sees everything, unchanged.
+	if authNS, _ := hmacauth.AuthenticatedNamespace(r.Context()); authNS != "" {
+		scoped := make([]string, 0, len(archivesInStorage))
+		for _, id := range archivesInStorage {
+			if archiveNamespace(id) == authNS {
+				scoped = append(scoped, id)
+			}
+		}
+		archivesInStorage = scoped
 	}
 	logger.V(1).Info("archives in storage", "archives", archivesInStorage)
 
@@ -124,7 +138,17 @@ func (ss *StorageService) uploadHandler(w http.ResponseWriter, r *http.Request) 
 	logger.V(1).Info("handling upload",
 		"filename", handler.Filename)
 
-	id, err := ss.storageClient.putFile(file, int64(fileSize))
+	// authNS is the namespace whose key verified the request (empty = master /
+	// unrestricted), set by the verifier — never a raw header. A non-empty value
+	// scopes the new archive's id to that tenant. Validate it before it is joined
+	// into a storage path (load-bearing for S3, which has no os.Root confinement).
+	authNS, _ := hmacauth.AuthenticatedNamespace(r.Context())
+	if authNS != "" && !validNamespaceLabel(authNS) {
+		http.Error(w, "invalid namespace", http.StatusBadRequest)
+		return
+	}
+
+	id, err := ss.storageClient.putFile(file, int64(fileSize), authNS)
 	if err != nil {
 		logger.Error(err, "error saving uploaded file", "filename", handler.Filename)
 		http.Error(w, "Error saving uploaded file", http.StatusInternalServerError)
@@ -170,6 +194,13 @@ func (ss *StorageService) deleteHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// A namespace-scoped caller may only delete its own (or legacy) archives.
+	// 404, not 403, so it cannot probe whether another tenant's archive exists.
+	if !ss.authorizedFor(r, fileId) {
+		http.Error(w, "Error deleting item: not found", http.StatusNotFound)
+		return
+	}
+
 	filesize, err := ss.storageClient.getFileSize(fileId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -197,6 +228,13 @@ func (ss *StorageService) downloadHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// A namespace-scoped caller may only download its own (or legacy) archives.
+	// 404, not 403, so it cannot probe whether another tenant's archive exists.
+	if !ss.authorizedFor(r, fileId) {
+		http.Error(w, "Error retrieving item: not found", http.StatusNotFound)
+		return
+	}
+
 	// Get the file, open it, and stream it to the response.
 	err = ss.storageClient.copyFileToStream(fileId, w)
 	if err != nil {
@@ -218,6 +256,13 @@ func (ss *StorageService) infoHandler(w http.ResponseWriter, r *http.Request) {
 	fileID, err := ss.getIdFromRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// A namespace-scoped caller may only probe its own (or legacy) archives;
+	// deny as 404 (identical to a real miss) so it is not an existence oracle.
+	if !ss.authorizedFor(r, fileID) {
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -73,6 +73,10 @@ func (ss *StorageService) listItems(w http.ResponseWriter, r *http.Request) {
 	}
 	// A namespace-scoped caller sees only its own archives; an unrestricted
 	// (master) caller — the pruner, the CLI — sees everything, unchanged.
+	// Deliberately stricter than authorizedFor: list does NOT surface legacy/
+	// unscoped archives to a tenant (it shows only what the tenant owns), whereas
+	// get/delete/info grandfather legacy ids. The asymmetry leaks nothing — list
+	// is the more restrictive direction.
 	if authNS, _ := hmacauth.AuthenticatedNamespace(r.Context()); authNS != "" {
 		scoped := make([]string, 0, len(archivesInStorage))
 		for _, id := range archivesInStorage {
@@ -105,6 +109,7 @@ func (ss *StorageService) uploadHandler(w http.ResponseWriter, r *http.Request) 
 	err := r.ParseMultipartForm(0)
 	if err != nil {
 		http.Error(w, "failed to parse request", http.StatusBadRequest)
+		return
 	}
 	file, handler, err := r.FormFile("uploadfile")
 	if err != nil {
@@ -204,6 +209,7 @@ func (ss *StorageService) deleteHandler(w http.ResponseWriter, r *http.Request) 
 	filesize, err := ss.storageClient.getFileSize(fileId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
 	}
 
 	err = ss.storageClient.removeFileByID(fileId)

--- a/test/integration/suites/common/archive_isolation_test.go
+++ b/test/integration/suites/common/archive_isolation_test.go
@@ -108,6 +108,12 @@ func TestArchiveNamespaceIsolation(t *testing.T) {
 	require.Error(t, clientA.Delete(ctx, idB), "tenant A must not delete tenant B's archive")
 	assert.Equal(t, http.StatusOK, info(masterClient, idB), "B's archive must survive A's denied delete")
 
+	// Path traversal cannot reach another tenant's archive: the crafted id cleans
+	// to B's path but is prefixed with A's namespace (and A signs it with its own key).
+	crafted := strings.Replace(idB, "_tenant_/"+nsB+"/", "_tenant_/"+nsA+"/../"+nsB+"/", 1)
+	require.NotEqual(t, idB, crafted, "craft must differ from the real id")
+	assert.Equal(t, http.StatusNotFound, info(clientA, crafted), "traversal must not reach B's archive")
+
 	// A tenant can download its own archive end-to-end.
 	dst := filepath.Join(t.TempDir(), "dl.bin")
 	require.NoError(t, clientA.Download(ctx, idA, dst))

--- a/test/integration/suites/common/archive_isolation_test.go
+++ b/test/integration/suites/common/archive_isolation_test.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	cliutil "github.com/fission/fission/pkg/fission-cli/util"
+	ssclient "github.com/fission/fission/pkg/storagesvc/client"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestArchiveNamespaceIsolation exercises the storagesvc archive content
+// isolation (Phase 7) end-to-end against the deployed storagesvc: an archive
+// uploaded by a namespace-scoped caller carries its owning namespace in the id,
+// and a different tenant cannot read or delete it (404, never an existence
+// oracle), while legacy/unscoped archives stay readable by anyone (grandfathered)
+// and the master principal is unrestricted. It also satisfies the cross-namespace
+// isolation negative-test backlog item.
+//
+// It drives storagesvc directly with derived per-namespace keys (the same keys
+// the tenant fetcher and `package create` use), so it needs no dynamic tenancy —
+// only HMAC enforcement. It skips when the master is unset (verifier pass-through).
+func TestArchiveNamespaceIsolation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	master := f.InternalAuthSecret()
+	if len(master) == 0 {
+		t.Skip("FISSION_INTERNAL_AUTH_SECRET is unset; archive namespace isolation requires HMAC enforcement")
+	}
+
+	// Reach the deployed storagesvc the way the CLI does — a port-forward to
+	// application=fission-storage in the release namespace.
+	cmdClient, err := cmd.NewClient(cmd.ClientOptions{RestConfig: f.RestConfig(), Namespace: f.FissionNamespace()})
+	require.NoError(t, err, "build cmd client")
+	storageURL, err := cliutil.GetStorageURL(ctx, *cmdClient)
+	require.NoError(t, err, "resolve storagesvc URL")
+	urlStr := storageURL.String()
+
+	nsA := "iso-a-" + framework.RandomID()
+	nsB := "iso-b-" + framework.RandomID()
+	clientA := ssclient.MakeClientNS(urlStr, master, nsA)
+	clientB := ssclient.MakeClientNS(urlStr, master, nsB)
+	masterClient := ssclient.MakeClient(urlStr, master)
+
+	upload := func(c ssclient.ClientInterface, content string) string {
+		t.Helper()
+		fp := filepath.Join(t.TempDir(), "archive.bin")
+		require.NoError(t, os.WriteFile(fp, []byte(content), 0o600))
+		id, err := c.Upload(ctx, fp, nil)
+		require.NoError(t, err)
+		return id
+	}
+	info := func(c ssclient.ClientInterface, id string) int {
+		t.Helper()
+		resp, err := c.Info(ctx, id)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	idA := upload(clientA, "archive-a")
+	idB := upload(clientB, "archive-b")
+	idLegacy := upload(masterClient, "archive-legacy")
+	t.Cleanup(func() {
+		cctx, c := context.WithTimeout(context.Background(), 30*time.Second)
+		defer c()
+		for _, id := range []string{idA, idB, idLegacy} {
+			_ = masterClient.Delete(cctx, id) // best-effort; master is unrestricted
+		}
+	})
+
+	// Scoped uploads carry the tenant marker; the legacy upload does not.
+	assert.Contains(t, idA, "/_tenant_/"+nsA+"/", "tenant A upload must be namespace-scoped")
+	assert.Contains(t, idB, "/_tenant_/"+nsB+"/", "tenant B upload must be namespace-scoped")
+	assert.NotContains(t, idLegacy, "_tenant_", "master upload stays legacy/unscoped")
+
+	// Each tenant reads its own archive; neither can see the other's (404).
+	assert.Equal(t, http.StatusOK, info(clientA, idA))
+	assert.Equal(t, http.StatusOK, info(clientB, idB))
+	assert.Equal(t, http.StatusNotFound, info(clientA, idB), "tenant A must not see tenant B's archive")
+	assert.Equal(t, http.StatusNotFound, info(clientB, idA), "tenant B must not see tenant A's archive")
+
+	// Legacy archives are grandfathered; the master principal is unrestricted.
+	assert.Equal(t, http.StatusOK, info(clientA, idLegacy), "legacy archive is grandfathered")
+	assert.Equal(t, http.StatusOK, info(masterClient, idA))
+	assert.Equal(t, http.StatusOK, info(masterClient, idB))
+
+	// Cross-tenant DELETE is denied, and the archive survives (master still reads it).
+	require.Error(t, clientA.Delete(ctx, idB), "tenant A must not delete tenant B's archive")
+	assert.Equal(t, http.StatusOK, info(masterClient, idB), "B's archive must survive A's denied delete")
+
+	// A tenant can download its own archive end-to-end.
+	dst := filepath.Join(t.TempDir(), "dl.bin")
+	require.NoError(t, clientA.Download(ctx, idA, dst))
+	got, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "archive-a", strings.TrimSpace(string(got)))
+}


### PR DESCRIPTION
## Context

Multi-namespace tenancy (#3497) gives each tenant its own derived HMAC keys, but archive *content* was not yet isolated.
storagesvc archive ids were bare UUIDs, and the verifier authenticated the caller's namespace yet never authorized which archive was touched — so a tenant who learned another tenant's archive UUID could download or delete it (only UUID-unguessability + NetworkPolicy stood in the way).

This is the documented residual gap from the tenancy PRD (Phase 7), plus the cross-namespace isolation negative test.

## What this does

New archives carry their owning namespace in the id, and storagesvc authorizes every access against the namespace whose HMAC key actually verified the request — never a caller-controlled header.

- **hmac: verifier reports the matched principal.**
Labeled candidate keys; on a successful match the verifier records the principal namespace in request context (`AuthenticatedNamespace`).
ns-key match → that namespace; master-key match → `""` (unrestricted, regardless of any header).
Additive and inert for every other channel (fetcher/builder/executor/router-internal).
- **storagesvc: namespace-scoped ids + authorization.**
`getUploadFileName(ns)` tags new archives `.../_tenant_/<ns>/<uuid>` (the marker has an underscore, which an RFC-1123 label cannot, so it never collides with a real namespace or UUID).
download/delete/info deny a cross-namespace access with **404** (not 403 — no existence oracle); list filters to the caller's namespace; the master principal stays unrestricted.
Legacy/unscoped ids parse to `""` and are grandfathered.
- **CLI scoping.**
`MakeClientNS` signs with the per-namespace key and sets the namespace header; `package create`/`package update` scope uploads to the package's namespace.

## Backward compatibility

- Existing bare-UUID archives keep resolving — **no migration, no flag day**.
- Static single-namespace installs, the pruner, and unscoped CLI ops are unchanged (master principal = unrestricted).
- spec-apply uploads stay unscoped on purpose (their archives are de-duplicated by checksum and may be shared across namespaces, so they cannot be pinned to one tenant) — tracked as a follow-up.

## Testing

- Unit: verifier-principal (incl. a master-holder spoofing a header → principal `""`), the handler authz matrix (tenant 404 on another tenant's archive, grandfather, master-unrestricted), `archiveNamespace` parsing across both backends + subDir variations, RFC-1123 validation, `MakeClientNS` end-to-end through the real verifier.
- Integration: drives the deployed storagesvc with derived per-namespace keys — A reads/deletes only its own archive, B gets 404, legacy is grandfathered, master is unrestricted, own-download round-trips (closes the cross-namespace negative-test item).
- `go build ./...`, `golangci-lint` (0 issues), `go vet -tags=integration`, `make license-check` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
