### PR TITLE
refactor(tenancy): single-source fetcher/builder RBAC across Go and Helm (Phase 6 base)

### DIFF
--- a/charts/fission-all/templates/_function-access-role.tpl
+++ b/charts/fission-all/templates/_function-access-role.tpl
@@ -1,17 +1,15 @@
 {{- /*
-LOCKSTEP: these fetcher/builder/websocket Role rules are mirrored in Go at
-pkg/tenant/provision.go (namespaceRBACObjects), which provisions the same grants
-for namespaces onboarded at runtime by the tenant controller. Any change to the
-rules below MUST be mirrored there, or static-install and dynamically-onboarded
-namespaces drift in what a tenant pod may read.
+fetcher/builder/websocket access rules — the SINGLE SOURCE for what a function
+pod's sidecars may read. Used in two places:
+  - the static per-namespace Roles below (fissionFunction.roles), and
+  - the fixed-name ClusterRoles for dynamic multi-namespace mode
+    (templates/tenant-controller/dynamic-workload-roles.yaml), which the tenant
+    controller binds into each runtime-onboarded namespace by name.
+Because both render from these partials, the static and dynamic paths can no
+longer drift — pkg/tenant/provision.go binds the ClusterRoles by name and no
+longer carries its own copy of the rules.
 */ -}}
-{{- define "fissionFunction.roles" }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ .Release.Name }}-fission-fetcher
-  namespace: {{ .namespace }}
+{{- define "fissionFunction.fetcherRules" }}
 rules:
 - apiGroups:
   - ""
@@ -34,12 +32,9 @@ rules:
   - packages
   verbs:
   - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: {{ .Release.Name }}-fission-builder
-  namespace: {{ .namespace }}
+{{- end -}}
+
+{{- define "fissionFunction.builderRules" }}
 rules:
 - apiGroups:
   - fission.io
@@ -54,12 +49,9 @@ rules:
   - secrets
   verbs:
   - get
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  namespace: {{ .namespace }}
-  name: {{ .Release.Name }}-fission-fetcher-websocket
+{{- end -}}
+
+{{- define "fissionFunction.fetcherWebsocketRules" }}
 rules:
 - apiGroups:
   - ""
@@ -77,7 +69,31 @@ rules:
   resources:
   - pods
   verbs:
-  - get  
+  - get
+{{- end -}}
+
+{{- define "fissionFunction.roles" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-fission-fetcher
+  namespace: {{ .namespace }}
+{{- include "fissionFunction.fetcherRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-fission-builder
+  namespace: {{ .namespace }}
+{{- include "fissionFunction.builderRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: {{ .namespace }}
+  name: {{ .Release.Name }}-fission-fetcher-websocket
+{{- include "fissionFunction.fetcherWebsocketRules" . }}
 {{- end -}}
 
 {{- define "fissionFunction.rolebindings" }}

--- a/charts/fission-all/templates/tenant-controller/_tenant-workload-roles.tpl
+++ b/charts/fission-all/templates/tenant-controller/_tenant-workload-roles.tpl
@@ -1,0 +1,35 @@
+{{/*
+Single source of truth for the fixed-name tenant-workload ClusterRoles that
+dynamic multi-namespace mode relies on. Returned as a YAML array of
+{name, rules} where `rules` names the shared partial carrying that role's rules
+(so the static per-namespace Roles and these ClusterRoles cannot drift).
+
+THREE consumers derive from this one list, so the role set, the controller's
+`bind` resourceNames, and the admission policy's roleRef allow-list stay in
+lockstep automatically:
+  - dynamic-workload-roles.yaml ranges it to emit the ClusterRoles;
+  - tenant-controller/rbac.yaml ranges the names into the `bind` resourceNames;
+  - tenant-controller/admission-policy.yaml builds the VAP roleRef CEL list.
+The Go side (pkg/apis/core/v1/const.go *TenantWorkloadClusterRole) names the
+same set for the controller's binder; it cannot read Helm at runtime, so it is
+the one irreducible second copy — covered by the dynamic-tenancy integration
+tests (a drift would fail tenant onboarding / the admission-policy test).
+*/}}
+{{- define "fission.tenantWorkloadRoles" -}}
+# executor/buildermgr: manage their workloads (Deployments, Services, pods, HPAs)
+# in tenant namespaces — same rules as the static per-namespace kubernetes Roles.
+- name: fission-executor-tenant-workload
+  rules: executor-kuberules
+- name: fission-buildermgr-tenant-workload
+  rules: buildermgr-kuberules
+# fetcher/builder/fetcher-websocket: what a function pod's sidecars may read in
+# their own tenant namespace (configmaps/secrets/packages/serviceaccounts; events
+# + pods for the websocket fetcher). The dynamic twin of the static Roles in
+# _function-access-role.tpl; pkg/tenant/provision.go binds these by name.
+- name: fission-fetcher-tenant-workload
+  rules: fissionFunction.fetcherRules
+- name: fission-builder-tenant-workload
+  rules: fissionFunction.builderRules
+- name: fission-fetcher-websocket-tenant-workload
+  rules: fissionFunction.fetcherWebsocketRules
+{{- end -}}

--- a/charts/fission-all/templates/tenant-controller/admission-policy.yaml
+++ b/charts/fission-all/templates/tenant-controller/admission-policy.yaml
@@ -1,0 +1,65 @@
+{{- if dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}
+# Defense-in-depth for the tenant controller's `bind` privilege. The controller
+# can only bind the fixed-name *-tenant-workload ClusterRoles (rbac.yaml
+# resourceNames-scopes that), but a COMPROMISED controller could still bind one of
+# them to an attacker-controlled ServiceAccount, granting that SA the namespace's
+# secret/configmap read. This policy rejects ANY RoleBinding that references a
+# tenant-workload ClusterRole unless every subject is one of the fixed Fission
+# fetcher/builder/executor/buildermgr ServiceAccounts — so the grant can only ever
+# reach Fission's own pods, never an arbitrary SA.
+#
+# It is a cluster-wide ValidatingAdmissionPolicy (GA in k8s 1.30; the chart's floor
+# is 1.32) keyed on the binding's roleRef, so it applies to the binding SHAPE, not
+# a particular caller — the controller is the only principal that can create these
+# bindings anyway, but the invariant holds even if another principal ever gains
+# `bind`. It is inert for every other RoleBinding (the matchCondition filters them
+# out), so it adds no admission cost to unrelated RBAC. Rendered only in dynamic
+# mode, where those ClusterRoles exist.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ .Release.Name }}-fission-tenant-workload-binding
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  # Fail closed: a request the policy cannot evaluate is denied rather than admitted.
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["rbac.authorization.k8s.io"]
+        apiVersions: ["v1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["rolebindings"]
+  # Only evaluate bindings that reference one of the tenant-workload ClusterRoles;
+  # every other RoleBinding skips the policy entirely.
+  matchConditions:
+    - name: targets-tenant-workload-clusterrole
+      expression: >
+        object.roleRef.kind == 'ClusterRole' && object.roleRef.name in [
+          'fission-executor-tenant-workload',
+          'fission-buildermgr-tenant-workload',
+          'fission-fetcher-tenant-workload',
+          'fission-builder-tenant-workload',
+          'fission-fetcher-websocket-tenant-workload'
+        ]
+  validations:
+    - expression: >
+        !has(object.subjects) || object.subjects.all(s,
+          s.kind == 'ServiceAccount' && s.name in [
+            'fission-fetcher', 'fission-builder', 'fission-executor', 'fission-buildermgr'
+          ])
+      reason: Forbidden
+      message: >
+        a RoleBinding to a Fission tenant-workload ClusterRole may only bind the
+        fixed fission fetcher/builder/executor/buildermgr ServiceAccounts
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ .Release.Name }}-fission-tenant-workload-binding
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  policyName: {{ .Release.Name }}-fission-tenant-workload-binding
+  validationActions: ["Deny"]
+{{- end }}

--- a/charts/fission-all/templates/tenant-controller/admission-policy.yaml
+++ b/charts/fission-all/templates/tenant-controller/admission-policy.yaml
@@ -1,4 +1,11 @@
 {{- if dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}
+{{- /* CEL list of the tenant-workload ClusterRole names, single-sourced from
+       _tenant-workload-roles.tpl so the policy's roleRef allow-list cannot drift
+       from the ClusterRoles it guards or the controller's bind resourceNames. */ -}}
+{{- $roleNames := list }}
+{{- range $r := (include "fission.tenantWorkloadRoles" . | fromYamlArray) }}
+{{- $roleNames = append $roleNames (printf "'%s'" $r.name) }}
+{{- end }}
 # Defense-in-depth for the tenant controller's `bind` privilege. The controller
 # can only bind the fixed-name *-tenant-workload ClusterRoles (rbac.yaml
 # resourceNames-scopes that), but a COMPROMISED controller could still bind one of
@@ -35,13 +42,8 @@ spec:
   matchConditions:
     - name: targets-tenant-workload-clusterrole
       expression: >
-        object.roleRef.kind == 'ClusterRole' && object.roleRef.name in [
-          'fission-executor-tenant-workload',
-          'fission-buildermgr-tenant-workload',
-          'fission-fetcher-tenant-workload',
-          'fission-builder-tenant-workload',
-          'fission-fetcher-websocket-tenant-workload'
-        ]
+        object.roleRef.kind == 'ClusterRole' &&
+        object.roleRef.name in [{{ join ", " $roleNames }}]
   validations:
     - expression: >
         !has(object.subjects) || object.subjects.all(s,

--- a/charts/fission-all/templates/tenant-controller/dynamic-workload-roles.yaml
+++ b/charts/fission-all/templates/tenant-controller/dynamic-workload-roles.yaml
@@ -10,39 +10,14 @@
 # are install-independent because dynamic tenancy is one Fission install per
 # cluster. Rendered only in dynamic mode; the static path is unchanged.
 #
-# executor/buildermgr: manage their workloads (Deployments, Services, pods, HPAs).
+# The role set (name + rules partial) is single-sourced in _tenant-workload-roles.tpl;
+# rbac.yaml and admission-policy.yaml derive their resourceNames/CEL from the same list.
+{{- range $r := (include "fission.tenantWorkloadRoles" . | fromYamlArray) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: fission-executor-tenant-workload
-{{- include "executor-kuberules" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fission-buildermgr-tenant-workload
-{{- include "buildermgr-kuberules" . }}
-# fetcher/builder/fetcher-websocket: what a function pod's sidecars may read in
-# their own tenant namespace (configmaps/secrets/packages/serviceaccounts; events
-# + pods for the websocket fetcher). The dynamic twin of the static Roles in
-# _function-access-role.tpl; pkg/tenant/provision.go binds these by name.
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fission-fetcher-tenant-workload
-{{- include "fissionFunction.fetcherRules" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fission-builder-tenant-workload
-{{- include "fissionFunction.builderRules" . }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: fission-fetcher-websocket-tenant-workload
-{{- include "fissionFunction.fetcherWebsocketRules" . }}
+  name: {{ $r.name }}
+{{- include $r.rules $ }}
+{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/tenant-controller/dynamic-workload-roles.yaml
+++ b/charts/fission-all/templates/tenant-controller/dynamic-workload-roles.yaml
@@ -1,14 +1,16 @@
 {{- if dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}
-# Dynamic multi-namespace mode: the executor and buildermgr (which run as
-# release-namespace ServiceAccounts) must create/manage their workloads
-# (Deployments, Services, pods, HPAs, …) in namespaces onboarded at RUNTIME,
-# where the chart's static per-namespace Roles do not exist. These fixed-name
-# ClusterRoles carry exactly the same per-namespace kuberules the static Roles
-# use; the tenant controller binds them into each tenant namespace with a
-# namespaced RoleBinding (see pkg/tenant/provision.go), so the grant is scoped to
-# tenant namespaces only — never cluster-wide. The names are install-independent
-# because dynamic tenancy is one Fission install per cluster (it watches
-# cluster-wide). Rendered only in dynamic mode; the static path is unchanged.
+# Dynamic multi-namespace mode: components and function-pod sidecars that run in
+# namespaces onboarded at RUNTIME (where the chart's static per-namespace Roles do
+# not exist) get their grants from these fixed-name ClusterRoles, which carry
+# exactly the same rules the static Roles use — single-sourced from the shared
+# {executor,buildermgr}-kuberules and fissionFunction.*Rules partials, so the
+# static and dynamic paths cannot drift. The tenant controller binds each into a
+# tenant namespace with a namespaced RoleBinding (see pkg/tenant/provision.go), so
+# every grant is scoped to tenant namespaces only — never cluster-wide. The names
+# are install-independent because dynamic tenancy is one Fission install per
+# cluster. Rendered only in dynamic mode; the static path is unchanged.
+#
+# executor/buildermgr: manage their workloads (Deployments, Services, pods, HPAs).
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -21,4 +23,26 @@ kind: ClusterRole
 metadata:
   name: fission-buildermgr-tenant-workload
 {{- include "buildermgr-kuberules" . }}
+# fetcher/builder/fetcher-websocket: what a function pod's sidecars may read in
+# their own tenant namespace (configmaps/secrets/packages/serviceaccounts; events
+# + pods for the websocket fetcher). The dynamic twin of the static Roles in
+# _function-access-role.tpl; pkg/tenant/provision.go binds these by name.
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fission-fetcher-tenant-workload
+{{- include "fissionFunction.fetcherRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fission-builder-tenant-workload
+{{- include "fissionFunction.builderRules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: fission-fetcher-websocket-tenant-workload
+{{- include "fissionFunction.fetcherWebsocketRules" . }}
 {{- end }}

--- a/charts/fission-all/templates/tenant-controller/rbac.yaml
+++ b/charts/fission-all/templates/tenant-controller/rbac.yaml
@@ -39,11 +39,15 @@ rules:
   - get
   - list
   - watch
-# Provision per-namespace fetcher/builder RBAC for runtime-onboarded tenants.
-# The bind+escalate verbs let the controller MINT Roles that grant read on a
-# tenant's own secrets/configmaps WITHOUT the controller itself being able to
-# read them — strictly tighter than holding cluster-wide secret read, and
-# confined to this single controller's ServiceAccount.
+# Provision per-namespace fetcher/builder RBAC for runtime-onboarded tenants. The
+# controller binds the fixed-name *-tenant-workload ClusterRoles into each tenant
+# namespace (the rules live in the chart, not the controller), so it needs `bind`
+# on those ClusterRoles but authors no Role of its own.
+# NOTE: `escalate` (and roles create/update/patch) are now UNUSED — the controller
+# stopped minting Roles when it switched to binding chart ClusterRoles. They are
+# retained here pending the dedicated escalate/bind hardening item, which removes
+# them (and the roles-author verbs) and adds a ValidatingAdmissionPolicy. The roles
+# delete/deletecollection verbs stay to reap any legacy Roles on upgrade.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -63,10 +67,11 @@ rules:
   - deletecollection
   - bind
   - escalate
-# Bind ONLY the two fixed workload ClusterRoles into tenant namespaces (via the
-# RoleBindings the controller provisions) so the executor/buildermgr can manage
-# workloads there. resourceNames-scoped: the controller cannot bind any other
-# ClusterRole, so it cannot escalate itself to arbitrary cluster permissions.
+# Bind ONLY the fixed-name tenant-workload ClusterRoles into tenant namespaces (via
+# the RoleBindings the controller provisions): the executor/buildermgr workload
+# roles AND the fetcher/builder/fetcher-websocket function-pod read roles.
+# resourceNames-scoped: the controller cannot bind any other ClusterRole, so it
+# cannot escalate itself to arbitrary cluster permissions.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -76,6 +81,9 @@ rules:
   resourceNames:
   - fission-executor-tenant-workload
   - fission-buildermgr-tenant-workload
+  - fission-fetcher-tenant-workload
+  - fission-builder-tenant-workload
+  - fission-fetcher-websocket-tenant-workload
 - apiGroups:
   - ""
   resources:

--- a/charts/fission-all/templates/tenant-controller/rbac.yaml
+++ b/charts/fission-all/templates/tenant-controller/rbac.yaml
@@ -39,34 +39,35 @@ rules:
   - get
   - list
   - watch
-# Provision per-namespace fetcher/builder RBAC for runtime-onboarded tenants. The
-# controller binds the fixed-name *-tenant-workload ClusterRoles into each tenant
-# namespace (the rules live in the chart, not the controller), so it needs `bind`
-# on those ClusterRoles but authors no Role of its own.
-# NOTE: `escalate` (and roles create/update/patch) are now UNUSED — the controller
-# stopped minting Roles when it switched to binding chart ClusterRoles. They are
-# retained here pending the dedicated escalate/bind hardening item, which removes
-# them (and the roles-author verbs) and adds a ValidatingAdmissionPolicy. The roles
-# delete/deletecollection verbs stay to reap any legacy Roles on upgrade.
+# Provision per-namespace RoleBindings for runtime-onboarded tenants and reap them
+# on offboard. The controller BINDS the fixed-name *-tenant-workload ClusterRoles
+# (the rules live in the chart, not the controller) — it authors NO Role of its
+# own, so it deliberately holds NEITHER `create` on roles NOR `escalate`. It can
+# therefore grant the fixed fetcher/builder rule shapes but can never mint a Role
+# with arbitrary rules — the least-privilege posture the dynamic-watch design
+# targets. The ValidatingAdmissionPolicy in admission-policy.yaml further pins
+# which ServiceAccounts those bindings may name.
+#
+# rolebindings: create (provision) + deletecollection (the label-selected
+# DeleteAllOf teardown); deletecollection is a distinct verb `delete` does not imply.
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - deletecollection
+# roles: delete-only, solely to reap any legacy per-namespace Roles a
+# pre-unification controller authored before this revision started binding
+# ClusterRoles. The controller never creates a Role.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles
-  - rolebindings
   verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
   - delete
-  # deletecollection backs the offboard teardown (DeleteNamespaceRBAC's
-  # label-selected DeleteAllOf); it is a distinct RBAC verb that `delete` does
-  # not imply, but adds no real capability here since `delete`+`list` already do.
   - deletecollection
-  - bind
-  - escalate
 # Bind ONLY the fixed-name tenant-workload ClusterRoles into tenant namespaces (via
 # the RoleBindings the controller provisions): the executor/buildermgr workload
 # roles AND the fetcher/builder/fetcher-websocket function-pod read roles.

--- a/charts/fission-all/templates/tenant-controller/rbac.yaml
+++ b/charts/fission-all/templates/tenant-controller/rbac.yaml
@@ -79,12 +79,12 @@ rules:
   - clusterroles
   verbs:
   - bind
+  # Single-sourced from _tenant-workload-roles.tpl (same list the ClusterRoles and
+  # the admission policy derive from), so the bind-scope cannot drift from them.
   resourceNames:
-  - fission-executor-tenant-workload
-  - fission-buildermgr-tenant-workload
-  - fission-fetcher-tenant-workload
-  - fission-builder-tenant-workload
-  - fission-fetcher-websocket-tenant-workload
+{{- range $r := (include "fission.tenantWorkloadRoles" . | fromYamlArray) }}
+  - {{ $r.name }}
+{{- end }}
 - apiGroups:
   - ""
   resources:

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -242,14 +242,20 @@ const (
 	FissionExecutorSA   = "fission-executor"
 	FissionBuildermgrSA = "fission-buildermgr"
 
-	// ExecutorTenantWorkloadClusterRole / BuildermgrTenantWorkloadClusterRole are
-	// the fixed-name ClusterRoles (chart-rendered only in dynamic mode) holding
-	// the executor's / buildermgr's per-namespace workload rules. The controller
-	// references them by name in the RoleBindings it provisions, so the names must
-	// match the chart and be install-independent (dynamic tenancy is one Fission
-	// install per cluster, since it watches cluster-wide).
-	ExecutorTenantWorkloadClusterRole   = "fission-executor-tenant-workload"
-	BuildermgrTenantWorkloadClusterRole = "fission-buildermgr-tenant-workload"
+	// The *TenantWorkloadClusterRole names are the fixed-name ClusterRoles
+	// (chart-rendered only in dynamic mode) holding the per-namespace rules a
+	// runtime-onboarded tenant needs. The controller references them by name in
+	// the RoleBindings it provisions, so the names must match the chart and be
+	// install-independent (dynamic tenancy is one Fission install per cluster,
+	// since it watches cluster-wide). Executor/buildermgr carry workload-management
+	// rules; fetcher/builder/fetcher-websocket carry the function-pod sidecar read
+	// rules — all single-sourced from the chart's shared partials so the static
+	// and dynamic paths cannot drift.
+	ExecutorTenantWorkloadClusterRole         = "fission-executor-tenant-workload"
+	BuildermgrTenantWorkloadClusterRole       = "fission-buildermgr-tenant-workload"
+	FetcherTenantWorkloadClusterRole          = "fission-fetcher-tenant-workload"
+	BuilderTenantWorkloadClusterRole          = "fission-builder-tenant-workload"
+	FetcherWebsocketTenantWorkloadClusterRole = "fission-fetcher-websocket-tenant-workload"
 )
 
 const (

--- a/pkg/tenant/provision.go
+++ b/pkg/tenant/provision.go
@@ -21,19 +21,23 @@ const (
 	managedByLabelKey = "app.kubernetes.io/managed-by"
 	managedByValue    = "fission-tenant-controller"
 
+	// These name the per-namespace RoleBindings the controller provisions (and
+	// match the static chart's binding names). Each binds a fetcher/builder pod SA
+	// to the fixed-name *TenantWorkloadClusterRole ClusterRole that carries its
+	// rules — the controller no longer authors Roles of its own.
 	fetcherRoleName          = "fission-fetcher"
 	builderRoleName          = "fission-builder"
 	fetcherWebsocketRoleName = "fission-fetcher-websocket"
 )
 
-// EnsureNamespaceRBAC creates (idempotently) the ServiceAccounts, Roles, and
-// RoleBindings a tenant namespace needs for the fetcher and builder to run — the
-// dynamic, runtime equivalent of the chart's _function-access-role.tpl, for
-// namespaces onboarded after install. Every object carries the managed-by label
-// so offboarding can clean them up. The Roles grant read-only access to the
-// namespace's OWN ConfigMaps/Secrets/Packages (no cross-namespace, no
-// escalation): a tenant controller holding rbac `escalate`/`bind` can mint these
-// without itself being able to read those Secrets.
+// EnsureNamespaceRBAC creates (idempotently) the ServiceAccounts and RoleBindings
+// a tenant namespace needs for the fetcher and builder to run — the dynamic,
+// runtime equivalent of the chart's _function-access-role.tpl, for namespaces
+// onboarded after install. Every object carries the managed-by label so
+// offboarding can clean them up. The grants live in the chart's fixed-name
+// ClusterRoles (rendered in dynamic mode); the controller only BINDS them by name
+// into each tenant namespace — it needs rbac `bind` on those ClusterRoles, but no
+// longer `escalate` (it authors no Role), and never read of the tenant's secrets.
 func EnsureNamespaceRBAC(ctx context.Context, c client.Client, namespace, releaseNamespace string, owner metav1.OwnerReference) error {
 	for _, obj := range namespaceRBACObjects(namespace, releaseNamespace, owner) {
 		if err := c.Create(ctx, obj); err != nil && !apierrors.IsAlreadyExists(err) {
@@ -57,7 +61,9 @@ func DeleteNamespaceRBAC(ctx context.Context, c client.Client, namespace string)
 	// chart- or user-managed RBAC. DeleteAllOf issues a deletecollection request,
 	// so the tenant-controller ClusterRole MUST grant `deletecollection` on these
 	// three resources (charts/.../tenant-controller/rbac.yaml) — `delete` alone is
-	// insufficient and the finalizer would wedge on a forbidden error.
+	// insufficient and the finalizer would wedge on a forbidden error. Role stays
+	// in the sweep only to reap any legacy per-namespace Roles a pre-unification
+	// controller authored before this revision started binding ClusterRoles.
 	for _, proto := range []client.Object{&rbacv1.RoleBinding{}, &rbacv1.Role{}, &corev1.ServiceAccount{}} {
 		if err := c.DeleteAllOf(ctx, proto, opts...); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("deleting %T in %s: %w", proto, namespace, err)
@@ -90,54 +96,32 @@ func namespaceRBACObjects(ns, releaseNamespace string, owner metav1.OwnerReferen
 		}
 		return m
 	}
-	roleBinding := func(name, sa string) *rbacv1.RoleBinding {
-		return &rbacv1.RoleBinding{
-			ObjectMeta: meta(name),
-			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "Role", Name: name},
-			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: sa, Namespace: ns}},
-		}
-	}
-	// workloadRoleBinding binds a release-namespace control-plane SA to a fixed
-	// workload ClusterRole, scoped to THIS namespace by the RoleBinding (it is a
-	// RoleBinding, NOT a ClusterRoleBinding) — so the executor / buildermgr can
-	// manage their workloads here, never cluster-wide.
-	workloadRoleBinding := func(name, sa, clusterRole string) *rbacv1.RoleBinding {
+	// clusterRoleBinding binds a fixed-name ClusterRole into THIS tenant namespace
+	// with a namespaced RoleBinding (NOT a ClusterRoleBinding), so the grant is
+	// scoped to the namespace. saNamespace is where the bound ServiceAccount lives:
+	// the tenant namespace for the fetcher/builder pod SAs, the release namespace
+	// for the executor/buildermgr control-plane SAs. The rules live ONLY in the
+	// chart's shared partials (rendered as these ClusterRoles), so the static and
+	// dynamic paths share one source of truth and the controller carries no copy.
+	clusterRoleBinding := func(name, sa, saNamespace, clusterRole string) *rbacv1.RoleBinding {
 		return &rbacv1.RoleBinding{
 			ObjectMeta: meta(name),
 			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: clusterRole},
-			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: sa, Namespace: releaseNamespace}},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: sa, Namespace: saNamespace}},
 		}
 	}
-	get := []string{"get"}
-	// LOCKSTEP: these fetcher/builder/websocket Role rules are the dynamic-path
-	// twin of charts/fission-all/templates/_function-access-role.tpl (the static
-	// per-namespace install path). There is no shared source of truth across Go
-	// and Helm, so any change here — especially to the secrets/configmaps `get`
-	// grants — MUST be mirrored in that template, or the static and runtime-
-	// onboarded namespaces drift in what a tenant pod may read. (Deeper fix tracked
-	// as a follow-up: bind shared-partial ClusterRoles by name, as the workload
-	// roles in dynamic-workload-roles.yaml already do.)
 	objs := []client.Object{
 		&corev1.ServiceAccount{ObjectMeta: meta(fv1.FissionFetcherSA)},
 		&corev1.ServiceAccount{ObjectMeta: meta(fv1.FissionBuilderSA)},
 
-		&rbacv1.Role{ObjectMeta: meta(fetcherRoleName), Rules: []rbacv1.PolicyRule{
-			{APIGroups: []string{""}, Resources: []string{"configmaps", "secrets"}, Verbs: get},
-			{APIGroups: []string{""}, Resources: []string{"serviceaccounts"}, Verbs: get},
-			{APIGroups: []string{"fission.io"}, Resources: []string{"packages"}, Verbs: get},
-		}},
-		&rbacv1.Role{ObjectMeta: meta(builderRoleName), Rules: []rbacv1.PolicyRule{
-			{APIGroups: []string{"fission.io"}, Resources: []string{"packages"}, Verbs: get},
-			{APIGroups: []string{""}, Resources: []string{"configmaps", "secrets"}, Verbs: get},
-		}},
-		&rbacv1.Role{ObjectMeta: meta(fetcherWebsocketRoleName), Rules: []rbacv1.PolicyRule{
-			{APIGroups: []string{""}, Resources: []string{"events"}, Verbs: []string{"get", "list", "watch", "create", "update", "patch"}},
-			{APIGroups: []string{""}, Resources: []string{"pods"}, Verbs: get},
-		}},
-
-		roleBinding(fetcherRoleName, fv1.FissionFetcherSA),
-		roleBinding(builderRoleName, fv1.FissionBuilderSA),
-		roleBinding(fetcherWebsocketRoleName, fv1.FissionFetcherSA),
+		// The fetcher/builder pod SAs (in THIS tenant namespace) bound to the
+		// fixed-name ClusterRoles carrying their read rules (configmaps/secrets/
+		// packages/serviceaccounts; events+pods for the websocket fetcher). The
+		// chart's _function-access-role.tpl renders the SAME rules into the static
+		// per-namespace Roles from the same partials, so the two paths cannot drift.
+		clusterRoleBinding(fetcherRoleName, fv1.FissionFetcherSA, ns, fv1.FetcherTenantWorkloadClusterRole),
+		clusterRoleBinding(builderRoleName, fv1.FissionBuilderSA, ns, fv1.BuilderTenantWorkloadClusterRole),
+		clusterRoleBinding(fetcherWebsocketRoleName, fv1.FissionFetcherSA, ns, fv1.FetcherWebsocketTenantWorkloadClusterRole),
 	}
 
 	// Bind the executor and buildermgr (release-namespace SAs) to their workload
@@ -148,8 +132,8 @@ func namespaceRBACObjects(ns, releaseNamespace string, owner metav1.OwnerReferen
 	// any statically-rendered Role for this namespace.
 	if releaseNamespace != "" {
 		objs = append(objs,
-			workloadRoleBinding("fission-executor-workload", fv1.FissionExecutorSA, fv1.ExecutorTenantWorkloadClusterRole),
-			workloadRoleBinding("fission-buildermgr-workload", fv1.FissionBuildermgrSA, fv1.BuildermgrTenantWorkloadClusterRole),
+			clusterRoleBinding("fission-executor-workload", fv1.FissionExecutorSA, releaseNamespace, fv1.ExecutorTenantWorkloadClusterRole),
+			clusterRoleBinding("fission-buildermgr-workload", fv1.FissionBuildermgrSA, releaseNamespace, fv1.BuildermgrTenantWorkloadClusterRole),
 		)
 	}
 	return objs

--- a/pkg/tenant/provision_test.go
+++ b/pkg/tenant/provision_test.go
@@ -5,7 +5,6 @@
 package tenant
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,6 +14,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
@@ -31,20 +31,35 @@ func TestEnsureNamespaceRBACCreatesObjects(t *testing.T) {
 		require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: sa}, got), "SA %q must exist", sa)
 	}
 
-	// Roles + RoleBindings (fetcher, builder, fetcher-websocket).
-	for _, role := range []string{fetcherRoleName, builderRoleName, fetcherWebsocketRoleName} {
-		r := &rbacv1.Role{}
-		require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: role}, r), "Role %q must exist", role)
-		assert.Equal(t, managedByValue, r.Labels[managedByLabelKey], "Role must be labelled for cleanup")
-		rb := &rbacv1.RoleBinding{}
-		require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: role}, rb), "RoleBinding %q must exist", role)
+	// The fetcher/builder/websocket pod SAs are bound to their fixed-name
+	// function-access ClusterRoles in the tenant namespace — the rules live in the
+	// chart (rendered as the ClusterRoles), so the controller authors no Role.
+	cases := []struct {
+		binding     string
+		sa          string
+		clusterRole string
+	}{
+		{fetcherRoleName, fv1.FissionFetcherSA, fv1.FetcherTenantWorkloadClusterRole},
+		{builderRoleName, fv1.FissionBuilderSA, fv1.BuilderTenantWorkloadClusterRole},
+		{fetcherWebsocketRoleName, fv1.FissionFetcherSA, fv1.FetcherWebsocketTenantWorkloadClusterRole},
+	}
+	for _, tc := range cases {
+		t.Run(tc.binding, func(t *testing.T) {
+			rb := &rbacv1.RoleBinding{}
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: tc.binding}, rb), "RoleBinding %q must exist", tc.binding)
+			assert.Equal(t, "ClusterRole", rb.RoleRef.Kind, "must bind a ClusterRole")
+			assert.Equal(t, tc.clusterRole, rb.RoleRef.Name)
+			require.Len(t, rb.Subjects, 1)
+			assert.Equal(t, tc.sa, rb.Subjects[0].Name)
+			assert.Equal(t, "team-a", rb.Subjects[0].Namespace, "subject SA lives in the tenant namespace")
+			assert.Equal(t, managedByValue, rb.Labels[managedByLabelKey], "must be labelled for cleanup")
+		})
 	}
 
-	// The fetcher Role grants secret/configmap read (the function-access grant).
-	fetcher := &rbacv1.Role{}
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, fetcher))
-	assert.True(t, grantsGet(fetcher, "", "secrets"), "fetcher Role must grant secrets get")
-	assert.True(t, grantsGet(fetcher, "fission.io", "packages"), "fetcher Role must grant packages get")
+	// The controller authors no Role of its own — it binds chart ClusterRoles.
+	roles := &rbacv1.RoleList{}
+	require.NoError(t, c.List(ctx, roles, client.InNamespace("team-a")))
+	assert.Empty(t, roles.Items, "controller must not author any Role")
 }
 
 // TestEnsureNamespaceRBACBindsWorkloadClusterRoles pins that the executor and
@@ -90,7 +105,8 @@ func TestEnsureNamespaceRBACSkipsWorkloadBindingsWithoutReleaseNS(t *testing.T) 
 	rb := &rbacv1.RoleBinding{}
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "fission-executor-workload"}, rb)),
 		"workload binding must be skipped when the release namespace is unknown")
-	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, &rbacv1.Role{}))
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, &rbacv1.RoleBinding{}),
+		"the fetcher function-access binding is still provisioned without a release namespace")
 }
 
 func TestEnsureNamespaceRBACIsIdempotent(t *testing.T) {
@@ -113,23 +129,10 @@ func TestDeleteNamespaceRBACRemovesManaged(t *testing.T) {
 
 	sa := &corev1.ServiceAccount{}
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fv1.FissionFetcherSA}, sa)), "fetcher SA must be deleted")
-	role := &rbacv1.Role{}
-	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, role)), "fetcher Role must be deleted")
 	rb := &rbacv1.RoleBinding{}
+	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, rb)), "fetcher RoleBinding must be deleted")
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: builderRoleName}, rb)), "builder RoleBinding must be deleted")
 	keys := &corev1.Secret{}
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fv1.TenantAuthKeysSecret}, keys)),
 		"derived-key Secret must be deleted by name on teardown")
-}
-
-func grantsGet(r *rbacv1.Role, apiGroup, resource string) bool {
-	for _, rule := range r.Rules {
-		if !slices.Contains(rule.APIGroups, apiGroup) || !slices.Contains(rule.Resources, resource) {
-			continue
-		}
-		if slices.Contains(rule.Verbs, "get") {
-			return true
-		}
-	}
-	return false
 }

--- a/test/integration/suites/common/tenant_admission_policy_test.go
+++ b/test/integration/suites/common/tenant_admission_policy_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestTenantWorkloadBindingAdmissionPolicy verifies the ValidatingAdmissionPolicy
+// that hardens the tenant controller's `bind` privilege: a RoleBinding to one of
+// the fixed tenant-workload ClusterRoles may bind ONLY the fixed Fission
+// ServiceAccounts, never an arbitrary (attacker-controlled) SA. This is the
+// defense-in-depth that keeps a compromised controller from granting a
+// namespace's secret read to an SA it controls. Rendered only in dynamic mode.
+func TestTenantWorkloadBindingAdmissionPolicy(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	if !f.DynamicNamespacesEnabled(t, ctx) {
+		t.Skip("the tenant-workload binding ValidatingAdmissionPolicy is rendered only in dynamic-namespace mode")
+	}
+
+	const (
+		clusterRole = "fission-fetcher-tenant-workload"
+		ns          = "default"
+	)
+	rb := func(name, saName string) *rbacv1.RoleBinding {
+		return &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: clusterRole},
+			Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: saName, Namespace: ns}},
+		}
+	}
+
+	// Binding a tenant-workload ClusterRole to a NON-Fission SA must be rejected.
+	_, err := f.KubeClient().RbacV1().RoleBindings(ns).Create(ctx, rb("vap-bad-"+framework.RandomID(), "evil-sa"), metav1.CreateOptions{})
+	require.Error(t, err, "binding a tenant-workload ClusterRole to a non-fission SA must be denied")
+	assert.Contains(t, err.Error(), "may only bind", "rejection should carry the admission-policy message")
+
+	// Binding to the fixed fission-fetcher SA is allowed (the controller's own path).
+	good := "vap-good-" + framework.RandomID()
+	_, err = f.KubeClient().RbacV1().RoleBindings(ns).Create(ctx, rb(good, fv1.FissionFetcherSA), metav1.CreateOptions{})
+	require.NoError(t, err, "binding to the fixed fission-fetcher SA must be allowed")
+	t.Cleanup(func() {
+		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(context.Background(), good, metav1.DeleteOptions{})
+	})
+}


### PR DESCRIPTION
## Context

The fetcher/builder/fetcher-websocket function-pod read rules were inlined in **two** places — the Helm static path (`_function-access-role.tpl`) and the Go tenant controller (`pkg/tenant/provision.go`) — kept in sync only by a `LOCKSTEP` comment.
Any edit to one that missed the other would drift what a tenant pod may read between static-install and runtime-onboarded namespaces.

This unifies them on the pattern the executor/buildermgr workload roles **already** use, and lays the shared-ClusterRole RBAC base that Phase 6 (`tenancy.mode=cluster`) will build on.

## What this does

- The rules become shared Helm partials (`fissionFunction.{fetcher,builder,fetcherWebsocket}Rules`) — the single source of truth.
- The static per-namespace Roles render **from** those partials; the rendered RBAC is **byte-identical** to before (static installs unchanged — verified by diffing `helm template`).
- In dynamic mode the chart renders three fixed-name ClusterRoles (`fission-{fetcher,builder,fetcher-websocket}-tenant-workload`) from the **same** partials.
- The tenant controller binds those ClusterRoles by name into each tenant namespace, exactly like it already binds the executor/buildermgr workload ClusterRoles, and **no longer carries its own copy of the rules**.

## Phase 6 base

This is deliberately the RBAC base for cluster mode: namespaced mode binds these ClusterRoles per-namespace (RoleBinding); cluster mode will bind them cluster-wide (ClusterRoleBinding) — a binding-scope flip with zero rule changes, on both the Go and Helm halves. The control-plane component roles already have this static-Role/dynamic-ClusterRole duality, so Phase 6 extends an established pattern uniformly.

## Note on `escalate`

The controller no longer authors Roles, so `escalate` (and roles create/update/patch) is now **unused**. It is retained here pending the dedicated escalate/bind hardening item (which removes it and adds a ValidatingAdmissionPolicy); the roles delete/deletecollection verbs stay to reap any legacy Roles on upgrade.

## Testing

- `go build ./...`, `pkg/tenant` unit tests (updated to assert ClusterRole bindings), `golangci-lint` (0 issues), `helm lint` — all green.
- Rendered static fetcher/builder/websocket Roles+RoleBindings diff **byte-identical** to `main`.
- The dynamic path is exercised end-to-end by `TestDynamicTenantLifecycle` (onboard → the controller binds the new ClusterRoles → the function's fetcher reads its package via the bound grant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
