### PR TITLE
feat(tenancy): opt-in tenancy.mode=cluster (watch-all) + tenancy config/code cleanup

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -145,17 +145,22 @@ jobs:
           # and leave it empty.
           docker exec kind-control-plane sh -c \
             'mkdir -p /fission-coverage && chown 10001:10001 /fission-coverage && chmod 0700 /fission-coverage'
-          # Multi-namespace tenancy (dynamic, restart-free onboarding) is
-          # exercised on the two non-legacy legs by composing the dynamic-tenancy
-          # skaffold profile onto kind-ci. The whole suite then runs against a
-          # dynamic-mode control plane (default is auto-seeded as a tenant), and
-          # the serial TestDynamicTenantLifecycle onboards a fresh namespace at
-          # runtime. v1.34.8 stays on the static model — it is the all-legacy leg
-          # (RFC-0002/0013/0012 pinned off below), so static namespacing keeps
-          # that path covered too.
+          # Multi-namespace tenancy: each leg exercises one of the three postures
+          # by composing a skaffold profile onto kind-ci, so every mode stays
+          # covered.
+          #   v1.32.11 → dynamic  (restart-free FissionTenant onboarding; the
+          #              serial TestDynamicTenantLifecycle onboards a fresh ns).
+          #   v1.36.1  → cluster  (trusted-cluster watch-all; the controller
+          #              auto-onboards every namespace; the serial
+          #              TestClusterTenantAutoOnboard runs a function in a fresh,
+          #              never-declared namespace and asserts fetcher RBAC stays
+          #              per-namespace).
+          #   v1.34.8  → static   (the all-legacy leg; RFC-0002/0013/0012 pinned
+          #              off below, so the static namespacing path is covered too).
           PROFILE=kind-ci
           case "${{ matrix.kindversion }}" in
-            v1.32.11|v1.36.1) PROFILE=kind-ci,dynamic-tenancy ;;
+            v1.32.11) PROFILE=kind-ci,dynamic-tenancy ;;
+            v1.36.1)  PROFILE=kind-ci,cluster-tenancy ;;
           esac
           SKAFFOLD_PROFILE="$PROFILE" make skaffold-deploy
 

--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -466,3 +466,30 @@ rules:
 rules:
 {{- include "leases-kuberules" . }}
 {{- end }}
+
+{{/*
+router-dataplane-kuberules: the RFC-0002 EndpointSlice data-plane read grant
+(Fission-managed function Services' EndpointSlices + the Services themselves).
+Single-sourced so the per-namespace Role (router/role-dataplane.yaml) and the
+cluster-wide ClusterRole (tenant-controller/cluster-mode-bindings.yaml) cannot
+drift.
+*/}}
+{{- define "router-dataplane-kuberules" }}
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -100,9 +100,26 @@ Helper template to construct image names with repository and tag
 {{- else }}
   value: {{ .Values.defaultNamespace }}
 {{- end }}
-- name: FISSION_DYNAMIC_NAMESPACES
-  value: "{{ dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}"
+- name: FISSION_TENANCY_MODE
+  value: "{{ include "fission.tenancyMode" . }}"
 {{- end }}
+
+{{/*
+fission.tenancyMode — the configured multi-namespace tenancy posture, normalised
+to one of static|dynamic|cluster. Single source of truth for every gate.
+*/}}
+{{- define "fission.tenancyMode" -}}
+{{- dig "mode" "static" (.Values.tenancy | default dict) -}}
+{{- end -}}
+
+{{/*
+fission.tenancyControllerEnabled — true (non-empty) when the tenant controller and
+the dynamic-cluster machinery should be rendered, i.e. tenancy.mode is dynamic OR
+cluster. Empty string (falsey) for static. Use: {{- if include "fission.tenancyControllerEnabled" . }}
+*/}}
+{{- define "fission.tenancyControllerEnabled" -}}
+{{- if ne (include "fission.tenancyMode" .) "static" -}}true{{- end -}}
+{{- end -}}
 
 {{- define "kube_client.envs" }}
 - name: KUBE_CLIENT_QPS

--- a/charts/fission-all/templates/internal-auth-secret.yaml
+++ b/charts/fission-all/templates/internal-auth-secret.yaml
@@ -10,7 +10,7 @@ Cross-namespace secretKeyRef isn't supported by kubelet, so per-namespace
 copies are the simplest way to make the env vars resolve in dynamically
 created builder and function pods.
 
-Under multi-namespace tenancy (.Values.tenancy.dynamicNamespaces) the master is
+Under multi-namespace tenancy (tenancy.mode dynamic OR cluster) the master is
 replicated ONLY into the install namespace — the control plane. Tenant
 namespaces instead receive a controller-owned derived-key Secret
 (fission-internal-auth-keys, see pkg/tenant) holding only their own per-namespace
@@ -43,9 +43,9 @@ rotation window) and re-run helm upgrade.
 {{- end -}}
 
 {{- $namespaces := list .Release.Namespace -}}
-{{- /* Under dynamic tenancy the master stays in the control-plane namespace only;
-       tenant namespaces get the controller's derived-key Secret instead. */ -}}
-{{- if not .Values.tenancy.dynamicNamespaces -}}
+{{- /* Under dynamic/cluster tenancy the master stays in the control-plane namespace
+       only; tenant namespaces get the controller's derived-key Secret instead. */ -}}
+{{- if eq (include "fission.tenancyMode" .) "static" -}}
 {{-   if and .Values.defaultNamespace (ne .Values.defaultNamespace .Release.Namespace) -}}
 {{-     $namespaces = append $namespaces .Values.defaultNamespace -}}
 {{-   end -}}

--- a/charts/fission-all/templates/router/role-dataplane.yaml
+++ b/charts/fission-all/templates/router/role-dataplane.yaml
@@ -28,23 +28,7 @@ kind: Role
 metadata:
   name: "{{ $.Release.Name }}-router-dataplane"
   namespace: {{ $ns }}
-rules:
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
+{{- include "router-dataplane-kuberules" $ }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/fission-all/templates/tenant-controller/admission-policy.yaml
+++ b/charts/fission-all/templates/tenant-controller/admission-policy.yaml
@@ -20,8 +20,9 @@
 # a particular caller — the controller is the only principal that can create these
 # bindings anyway, but the invariant holds even if another principal ever gains
 # `bind`. It is inert for every other RoleBinding (the matchCondition filters them
-# out), so it adds no admission cost to unrelated RBAC. Rendered only in dynamic
-# mode, where those ClusterRoles exist.
+# out), so it adds no admission cost to unrelated RBAC. Rendered in dynamic AND
+# cluster mode (whenever the controller provisions per-namespace RoleBindings to
+# those ClusterRoles); never in static.
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicy
 metadata:

--- a/charts/fission-all/templates/tenant-controller/admission-policy.yaml
+++ b/charts/fission-all/templates/tenant-controller/admission-policy.yaml
@@ -1,4 +1,4 @@
-{{- if dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}
+{{- if include "fission.tenancyControllerEnabled" . }}
 {{- /* CEL list of the tenant-workload ClusterRole names, single-sourced from
        _tenant-workload-roles.tpl so the policy's roleRef allow-list cannot drift
        from the ClusterRoles it guards or the controller's bind resourceNames. */ -}}

--- a/charts/fission-all/templates/tenant-controller/cluster-mode-bindings.yaml
+++ b/charts/fission-all/templates/tenant-controller/cluster-mode-bindings.yaml
@@ -43,23 +43,7 @@ metadata:
   name: "{{ .Release.Name }}-router-dataplane-cluster"
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-rules:
-- apiGroups:
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - services
-  verbs:
-  - get
-  - list
-  - watch
+{{- include "router-dataplane-kuberules" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/fission-all/templates/tenant-controller/cluster-mode-bindings.yaml
+++ b/charts/fission-all/templates/tenant-controller/cluster-mode-bindings.yaml
@@ -1,0 +1,108 @@
+{{- if eq (include "fission.tenancyMode" .) "cluster" }}
+# Cluster (trusted-cluster) tenancy mode only. The control plane manages workloads
+# and reads Secrets/ConfigMaps CLUSTER-WIDE so functions run in any namespace with
+# no per-namespace provisioning — the operational simplification this opt-in mode
+# trades isolation for (PRD §4.5).
+#
+# SECURITY TRADE-OFF: the executor/buildermgr ServiceAccounts hold cluster-wide
+# read of Secrets/ConfigMaps here. A compromise of either reaches every namespace's
+# Secrets. This is the documented cost of cluster mode; use ONLY on single-tenant /
+# trusted clusters. Function pods (fetcher/builder) are NOT bound here — they keep
+# their narrow per-namespace RBAC, provisioned by the tenant controller.
+#
+# These bind the SAME fixed-name *-tenant-workload ClusterRoles the controller
+# binds per-namespace in dynamic mode (single-sourced in _tenant-workload-roles.tpl);
+# the only difference is the binding scope — a ClusterRoleBinding instead of a
+# per-namespace RoleBinding.
+{{- range $b := list (dict "sa" "fission-executor" "role" "fission-executor-tenant-workload") (dict "sa" "fission-buildermgr" "role" "fission-buildermgr-tenant-workload") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ $.Release.Name }}-{{ $b.sa }}-cluster-workload"
+  labels:
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ $b.sa }}
+    namespace: {{ $.Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $b.role }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- if ne (.Values.router.endpointSliceCache.mode | default "off") "off" }}
+---
+# Router EndpointSlice data plane (RFC-0002), cluster-wide: in cluster mode the
+# function Services live in any namespace, so the router reads their EndpointSlices
+# + Services cluster-wide (the per-namespace router-dataplane Role covers the
+# static/dynamic paths). Read-only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Release.Name }}-router-dataplane-cluster"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+rules:
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-router-dataplane-cluster"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+subjects:
+  - kind: ServiceAccount
+    name: fission-router
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-router-dataplane-cluster"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- if .Values.influxdb.enabled }}
+---
+# Fluentbit log collector (DaemonSet, deployed when influxdb.enabled), cluster-wide:
+# in cluster mode function pods
+# run in any namespace, so the collector reads Pods cluster-wide (the per-namespace
+# fluentbit Role covers static/dynamic). Read-only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: "{{ .Release.Name }}-fluentbit-cluster"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+{{- include "fluentbit-kuberules" . }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: "{{ .Release.Name }}-fluentbit-cluster"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+subjects:
+  - kind: ServiceAccount
+    name: fission-fluentbit
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: "{{ .Release.Name }}-fluentbit-cluster"
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+{{- end }}

--- a/charts/fission-all/templates/tenant-controller/deployment.yaml
+++ b/charts/fission-all/templates/tenant-controller/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tenantController.enabled }}
+{{- if include "fission.tenancyControllerEnabled" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/fission-all/templates/tenant-controller/dynamic-cluster-roles.yaml
+++ b/charts/fission-all/templates/tenant-controller/dynamic-cluster-roles.yaml
@@ -1,12 +1,13 @@
-{{- if dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}
-# Dynamic multi-namespace mode (FISSION_DYNAMIC_NAMESPACES): the data-plane
-# components that watch Fission CRDs do so cluster-wide and filter to the live
-# tenant set (controller.MembershipPredicate), so they need cluster-wide read of
-# Fission's own CRD types. For most components that is fission.io types only.
-# The executor additionally reads its label-bounded workloads (pods, services,
-# deployments) cluster-wide — Tier A per PRD §4.1, read-only; its Secrets,
-# ConfigMaps and ReplicaSets stay namespace-scoped (per-namespace Roles + the
-# scoped cache). The per-namespace Roles remain for the default (off) path.
+{{- if include "fission.tenancyControllerEnabled" . }}
+# Dynamic + cluster tenancy (tenancy.mode != static, FISSION_TENANCY_MODE): the
+# data-plane components that watch Fission CRDs do so cluster-wide, so they need
+# cluster-wide read of Fission's own CRD types. For most components that is
+# fission.io types only. The executor additionally reads its label-bounded
+# workloads (pods, services, deployments) cluster-wide — Tier A per PRD §4.1,
+# read-only. In dynamic mode its Secrets/ConfigMaps/ReplicaSets stay
+# namespace-scoped (per-namespace Roles + scoped cache); cluster mode grants those
+# cluster-wide via the separate cluster-mode-bindings.yaml. The per-namespace Roles
+# remain for the static path.
 {{- range $component := list "buildermgr" "kubewatcher" "mcp" "kafka" "keda" "router" "timer" "canaryconfig" "executor" }}
 {{- include "fission-cluster-role-generator" (merge (dict "component" $component) $) }}
 {{- end }}

--- a/charts/fission-all/templates/tenant-controller/dynamic-workload-roles.yaml
+++ b/charts/fission-all/templates/tenant-controller/dynamic-workload-roles.yaml
@@ -1,4 +1,4 @@
-{{- if dig "dynamicNamespaces" false (.Values.tenancy | default dict) }}
+{{- if include "fission.tenancyControllerEnabled" . }}
 # Dynamic multi-namespace mode: components and function-pod sidecars that run in
 # namespaces onboarded at RUNTIME (where the chart's static per-namespace Roles do
 # not exist) get their grants from these fixed-name ClusterRoles, which carry

--- a/charts/fission-all/templates/tenant-controller/migration-job.yaml
+++ b/charts/fission-all/templates/tenant-controller/migration-job.yaml
@@ -1,11 +1,12 @@
-{{- if and .Values.tenantController.enabled (dig "seedExistingNamespaces" true (.Values.tenantController | default dict)) }}
+{{- if and (eq (include "fission.tenancyMode" .) "dynamic") (dig "seedExistingNamespaces" true (.Values.tenantController | default dict)) }}
 # Post-install/post-upgrade migration: seed a FissionTenant for each namespace
 # in the env-driven config (defaultNamespace + additionalFissionNamespaces) so
 # existing installs adopt the CR model. Idempotent (create-if-absent), never
 # touches user/label/CLI-created tenants, and mutates no Deployment — so running
 # it on upgrade restarts nothing (the fix for #3298's mass-restart). Reuses the
 # tenant-controller ServiceAccount, which already has create permission on
-# fissiontenants.
+# fissiontenants. Dynamic mode only: cluster mode auto-onboards every namespace,
+# so there is nothing to seed.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/fission-all/templates/tenant-controller/rbac.yaml
+++ b/charts/fission-all/templates/tenant-controller/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tenantController.enabled }}
+{{- if include "fission.tenancyControllerEnabled" . }}
 # The tenant controller's only cluster-wide grant: read/write Fission's own
 # FissionTenant CRD and read Namespaces. Both are cluster-scoped types; this
 # touches no core/workload type (no pods/secrets/configmaps), so it is the

--- a/charts/fission-all/templates/tenant-controller/rbac.yaml
+++ b/charts/fission-all/templates/tenant-controller/rbac.yaml
@@ -50,22 +50,14 @@ rules:
 #
 # rolebindings: create (provision) + deletecollection (the label-selected
 # DeleteAllOf teardown); deletecollection is a distinct verb `delete` does not imply.
+# The controller authors NO Role of its own (it binds the fixed-name
+# *-tenant-workload ClusterRoles), so it holds no grant on `roles` at all.
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings
   verbs:
   - create
-  - delete
-  - deletecollection
-# roles: delete-only, solely to reap any legacy per-namespace Roles a
-# pre-unification controller authored before this revision started binding
-# ClusterRoles. The controller never creates a Role.
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - roles
-  verbs:
   - delete
   - deletecollection
 # Bind ONLY the fixed-name tenant-workload ClusterRoles into tenant namespaces (via

--- a/charts/fission-all/templates/tenant-controller/serviceaccount.yaml
+++ b/charts/fission-all/templates/tenant-controller/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tenantController.enabled }}
+{{- if include "fission.tenancyControllerEnabled" . }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/fission-all/templates/tenant-controller/validate.yaml
+++ b/charts/fission-all/templates/tenant-controller/validate.yaml
@@ -1,19 +1,11 @@
 {{- /*
-Multi-namespace tenancy render-time invariant: the dynamic data plane and the
-tenant controller must be enabled together.
-
-- tenancy.dynamicNamespaces (data plane) makes the fetcher key REQUIRED and the
-  executor version-aware ns-sign each /specialize, expecting the controller to
-  have provisioned every tenant namespace's derived-key Secret. Without the
-  controller, fetcher pods wedge waiting for a key nobody writes.
-- tenantController.enabled without dynamicNamespaces provisions per-namespace
-  keys the data plane never consumes (it still master-signs), which would 401
-  every specialization in those namespaces.
-
-Either way a half-wired install is broken, so fail the render rather than ship
-one. This mirrors the chart's other fail-closed guards (e.g. the MQT cert
-checks).
+Multi-namespace tenancy render-time invariant: tenancy.mode must be one of the
+three known postures. An unknown value would silently fall back to static in the
+data plane (utils.TenancyMode) while the chart might still render controller RBAC
+from a mistyped gate, i.e. a half-wired install. Fail the render instead. This
+mirrors the chart's other fail-closed guards (e.g. the MQT cert checks).
 */ -}}
-{{- if ne (.Values.tenancy.dynamicNamespaces | toString) (.Values.tenantController.enabled | toString) }}
-{{- fail "multi-namespace tenancy misconfigured: tenancy.dynamicNamespaces and tenantController.enabled must be set together (both true or both false). The dynamic data plane requires the tenant controller to provision per-namespace auth keys, and the controller is pointless (and 401s the data plane) without it." }}
+{{- $mode := include "fission.tenancyMode" . }}
+{{- if not (has $mode (list "static" "dynamic" "cluster")) }}
+{{- fail (printf "multi-namespace tenancy misconfigured: tenancy.mode must be one of static|dynamic|cluster, got %q. static = env-seeded namespaces only; dynamic = runtime per-namespace onboarding (least-privilege, recommended for untrusted multi-tenant); cluster = opt-in trusted-cluster watch-all (control plane reads Secrets cluster-wide)." $mode) }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -715,12 +715,14 @@ tenancy:
   ##           Secrets/ConfigMaps/workloads are NEVER in a cluster-wide cache. The
   ##           recommended posture for untrusted multi-tenant clusters.
   ##   cluster — opt-in trusted-cluster mode. The controller auto-onboards every
-  ##           function-bearing namespace (no FissionTenant CR needed), so
-  ##           fetcher/builder pods keep their narrow per-namespace RBAC + keys,
-  ##           but the control plane (executor/buildermgr) reads Secrets/ConfigMaps
-  ##           and manages workloads CLUSTER-WIDE for operational simplicity.
-  ##           SECURITY TRADE-OFF: a compromised executor/buildermgr can read any
-  ##           namespace's Secrets. Use ONLY on single-tenant/trusted clusters.
+  ##           namespace (no FissionTenant CR needed), so fetcher/builder pods keep
+  ##           their narrow per-namespace RBAC + keys, but the control plane
+  ##           (executor/buildermgr) reads Secrets/ConfigMaps and manages workloads
+  ##           CLUSTER-WIDE for operational simplicity. Label a namespace
+  ##           `fission.io/enabled=false` to opt it OUT of auto-onboarding (and to
+  ##           offboard one already onboarded). SECURITY TRADE-OFF: a compromised
+  ##           executor/buildermgr can read any namespace's Secrets. Use ONLY on
+  ##           single-tenant/trusted clusters.
   ## dynamic and cluster set FISSION_TENANCY_MODE on the data-plane components and
   ## render the tenant controller; static renders neither.
   mode: static

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -701,23 +701,35 @@ mcp:
 ## Multi-namespace tenancy (docs/multiple-namespace).
 ##
 tenancy:
-  ## dynamicNamespaces turns on the cluster-wide Fission-CRD watch + live
-  ## tenant-membership filtering, so namespaces can be onboarded/offboarded at
-  ## runtime without restarting the control plane. Requires tenantController.enabled.
-  ## It adds exactly one cluster-wide grant per data-plane component, on
-  ## fission.io CRD types ONLY (no core/workload type), and sets
-  ## FISSION_DYNAMIC_NAMESPACES on those components. Off by default — the
-  ## per-namespace caches and RBAC behave exactly as before.
-  dynamicNamespaces: false
+  ## mode selects the multi-namespace tenancy posture (docs/multiple-namespace).
+  ## One of:
+  ##   static  (default) — Fission resources only in the env-seeded namespace set
+  ##           (defaultNamespace + additionalFissionNamespaces); per-namespace
+  ##           Roles rendered by Helm; no tenant controller. Behaves exactly as
+  ##           pre-tenancy Fission.
+  ##   dynamic — namespaces onboarded/offboarded at runtime via FissionTenant CRs
+  ##           or the fission.io/enabled label, with NO control-plane restart. The
+  ##           tenant controller provisions narrow per-namespace fetcher/builder
+  ##           RBAC + per-namespace derived HMAC keys; data-plane managers watch
+  ##           Fission CRDs cluster-wide and filter to the onboarded set; tenant
+  ##           Secrets/ConfigMaps/workloads are NEVER in a cluster-wide cache. The
+  ##           recommended posture for untrusted multi-tenant clusters.
+  ##   cluster — opt-in trusted-cluster mode. The controller auto-onboards every
+  ##           function-bearing namespace (no FissionTenant CR needed), so
+  ##           fetcher/builder pods keep their narrow per-namespace RBAC + keys,
+  ##           but the control plane (executor/buildermgr) reads Secrets/ConfigMaps
+  ##           and manages workloads CLUSTER-WIDE for operational simplicity.
+  ##           SECURITY TRADE-OFF: a compromised executor/buildermgr can read any
+  ##           namespace's Secrets. Use ONLY on single-tenant/trusted clusters.
+  ## dynamic and cluster set FISSION_TENANCY_MODE on the data-plane components and
+  ## render the tenant controller; static renders neither.
+  mode: static
 
 ## The tenant controller is the multi-namespace tenancy lifecycle controller
-## (docs/multiple-namespace). It reconciles FissionTenant CRs and namespaces
-## labelled fission.io/enabled=true into the live resource-namespace set and
-## reports readiness. Off by default; enabling it is additive (the existing
-## env-driven namespace set keeps working).
+## (docs/multiple-namespace). It is rendered automatically when tenancy.mode is
+## dynamic or cluster (and never when static); the settings below tune it.
 ##
 tenantController:
-  enabled: false
   replicas: 1
   ## Run active-passive with leader election when replicas > 1.
   leaderElection:

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -30,18 +30,11 @@ import (
 const mqtReconcileConcurrency = 4
 
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, _ *errgroup.Group, routerUrl string) error {
+	// fissionClient is needed below for the subscription manager; NewTriggerManager
+	// resolves its own to wait for the Function CRDs (a cheap cached call).
 	fissionClient, err := clientGen.GetFissionClient()
 	if err != nil {
 		return fmt.Errorf("failed to get fission client: %w", err)
-	}
-	restConfig, err := clientGen.GetRestConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get rest config: %w", err)
-	}
-
-	err = crd.WaitForFunctionCRDs(ctx, logger, fissionClient)
-	if err != nil {
-		return fmt.Errorf("error waiting for CRDs: %w", err)
 	}
 
 	mqType := (fv1.MessageQueueType)(os.Getenv("MESSAGE_QUEUE_TYPE"))
@@ -76,8 +69,8 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// elected leader consumes the message queue and manages triggers, so two
 	// replicas don't double-consume. No-op when LEADER_ELECTION_ENABLED is unset
 	// (single-replica default). The reconciler watches MessageQueueTriggers
-	// through the Manager's namespace-scoped cache and runs only on the leader.
-	crMgr, err := crmanager.NewLeaderElected(restConfig, "fission-mqtrigger", logger)
+	// through the Manager's cache and runs only on the leader.
+	crMgr, err := crmanager.NewTriggerManager(ctx, clientGen, "fission-mqtrigger", logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/buildermgr/builderauth_test.go
+++ b/pkg/buildermgr/builderauth_test.go
@@ -5,7 +5,6 @@
 package buildermgr
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,7 +37,7 @@ func TestBuilderAuthEnvVars(t *testing.T) {
 
 	// Sourcing: the active builder key comes from the tenant keys Secret.
 	t.Run("builder key sourced from the tenant keys Secret", func(t *testing.T) {
-		t.Setenv("FISSION_DYNAMIC_NAMESPACES", "false")
+		t.Setenv("FISSION_TENANCY_MODE", "static")
 		bk := byName(builderAuthEnvVars(tenantNS))["FISSION_BUILDER_KEY"]
 		require.NotNil(t, bk.ValueFrom.SecretKeyRef)
 		assert.Equal(t, fv1.TenantAuthKeysSecret, bk.ValueFrom.SecretKeyRef.Name)
@@ -59,7 +58,7 @@ func TestBuilderAuthEnvVars(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("FISSION_DYNAMIC_NAMESPACES", strconv.FormatBool(tt.dynamic))
+			t.Setenv("FISSION_TENANCY_MODE", tenancyModeEnv(tt.dynamic))
 			t.Setenv("FISSION_INTERNAL_AUTH_SECRET", tt.master)
 			bk := byName(builderAuthEnvVars(tt.namespace))["FISSION_BUILDER_KEY"]
 			require.NotNil(t, bk.ValueFrom.SecretKeyRef.Optional)

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -34,12 +34,12 @@ import (
 // fetcher/builder sidecar calls with that namespace's per-namespace derived key.
 // Version-aware, the sibling of the executor's poolmgr.fetcherSigningNamespace:
 // only a builder pod stamped with the namespace key-scheme annotation (created by
-// createBuilderDeployment while dynamic tenancy was on for its namespace) holds
-// the per-namespace keys and verifies with them, so we sign with the builder
-// namespace key. Pre-upgrade pods carrying no annotation, and every pod when
-// tenancy is off, verify with the master-derived key and stay master-signed.
+// createBuilderDeployment while per-namespace keys were in use for its namespace)
+// holds the per-namespace keys and verifies with them, so we sign with the builder
+// namespace key. Pre-upgrade pods carrying no annotation, and every pod under
+// static tenancy, verify with the master-derived key and stay master-signed.
 func builderSigningNamespace(pod *apiv1.Pod, builderNs string) (string, bool) {
-	if pod != nil && utils.DynamicNamespacesEnabled() && fv1.HasNamespaceKeyScheme(pod.Annotations) {
+	if pod != nil && utils.PerNamespaceKeysEnabled() && fv1.HasNamespaceKeyScheme(pod.Annotations) {
 		return builderNs, true
 	}
 	return "", false

--- a/pkg/buildermgr/common_internalauth_test.go
+++ b/pkg/buildermgr/common_internalauth_test.go
@@ -5,7 +5,6 @@
 package buildermgr
 
 import (
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -14,6 +13,14 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
+
+// tenancyModeEnv maps a test's "dynamic?" flag to a FISSION_TENANCY_MODE value.
+func tenancyModeEnv(dynamic bool) string {
+	if dynamic {
+		return "dynamic"
+	}
+	return "static"
+}
 
 // TestBuilderSigningNamespace pins buildermgr's version-aware signing decision —
 // the sibling of the executor's. buildermgr must sign each builder pod's
@@ -42,7 +49,7 @@ func TestBuilderSigningNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("FISSION_DYNAMIC_NAMESPACES", strconv.FormatBool(tt.dynamic))
+			t.Setenv("FISSION_TENANCY_MODE", tenancyModeEnv(tt.dynamic))
 			ns, scoped := builderSigningNamespace(tt.pod, builderNs)
 			assert.Equal(t, tt.wantScoped, scoped, "nsScoped decision")
 			assert.Equal(t, tt.wantNS, ns, "signing namespace")

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -400,10 +400,10 @@ func (r *EnvironmentReconciler) createBuilderDeployment(ctx context.Context, env
 
 	// Stamp the HMAC key-scheme so buildermgr signs this builder pod's sidecar
 	// calls with the key its fetcher will verify with (version-aware signing,
-	// builderSigningNamespace). Present for tenant namespaces under dynamic
-	// tenancy, absent otherwise — stable, so at most one rollout when tenancy is
-	// first enabled, never ongoing churn.
-	if utils.DynamicNamespacesEnabled() && r.nsResolver.IsTenant(ns) {
+	// builderSigningNamespace). Present for tenant namespaces when per-namespace
+	// keys are in use (dynamic or cluster mode), absent otherwise — stable, so at
+	// most one rollout when tenancy is first enabled, never ongoing churn.
+	if utils.PerNamespaceKeysEnabled() && r.nsResolver.IsTenant(ns) {
 		podAnnotations[fv1.AuthKeySchemeAnnotation] = fv1.AuthKeySchemeNamespace
 	}
 

--- a/pkg/controller/membership.go
+++ b/pkg/controller/membership.go
@@ -43,11 +43,11 @@ func MembershipPredicate(nsr *utils.NamespaceResolver) predicate.Predicate {
 }
 
 // RegisterTenantScoped is Register for a namespaced Fission CRD reconciler under
-// the multi-namespace model. When dynamic namespaces are enabled (the Fission-CRD
-// cache is then cluster-wide), it composes MembershipPredicate so CRs in
-// non-tenant namespaces are dropped before the workqueue; otherwise it is exactly
-// Register. Use it ONLY for namespaced Fission CRDs — never cluster-scoped types,
-// whose empty namespace would always be dropped.
+// the multi-namespace model. When the Fission-CRD cache is cluster-wide (dynamic
+// OR cluster mode), it composes MembershipPredicate so CRs in non-tenant
+// namespaces are dropped before the workqueue; otherwise it is exactly Register.
+// Use it ONLY for namespaced Fission CRDs — never cluster-scoped types, whose
+// empty namespace would always be dropped.
 func RegisterTenantScoped(mgr ctrl.Manager, obj client.Object, reconciler reconcile.Reconciler, name string) error {
 	return RegisterTenantScopedWithPredicates(mgr, obj, reconciler, name, 0, predicate.GenerationChangedPredicate{})
 }
@@ -65,7 +65,7 @@ func RegisterTenantScopedWithConcurrency(mgr ctrl.Manager, obj client.Object, re
 // TenantReenqueueHandler). The supplied predicates REPLACE the default
 // GenerationChangedPredicate (pass it explicitly if wanted).
 func RegisterTenantScopedWithPredicates(mgr ctrl.Manager, obj client.Object, reconciler reconcile.Reconciler, name string, maxConcurrent int, predicates ...predicate.Predicate) error {
-	if !utils.DynamicNamespacesEnabled() {
+	if !utils.CrdWatchClusterWide() {
 		return RegisterWithPredicates(mgr, obj, reconciler, name, maxConcurrent, predicates...)
 	}
 	b := builder.ControllerManagedBy(mgr).
@@ -80,11 +80,11 @@ func RegisterTenantScopedWithPredicates(mgr ctrl.Manager, obj client.Object, rec
 	return b.Complete(reconciler)
 }
 
-// tenantScopedPredicates appends MembershipPredicate when dynamic namespaces are
-// enabled, copying rather than mutating the caller's slice. Extracted so the
-// composition is unit-testable without a Manager.
+// tenantScopedPredicates appends MembershipPredicate when the Fission-CRD cache is
+// cluster-wide (dynamic OR cluster mode), copying rather than mutating the caller's
+// slice. Extracted so the composition is unit-testable without a Manager.
 func tenantScopedPredicates(predicates []predicate.Predicate) []predicate.Predicate {
-	if !utils.DynamicNamespacesEnabled() {
+	if !utils.CrdWatchClusterWide() {
 		return predicates
 	}
 	out := make([]predicate.Predicate, 0, len(predicates)+1)

--- a/pkg/controller/membership_test.go
+++ b/pkg/controller/membership_test.go
@@ -86,6 +86,12 @@ func TestTenantScopedPredicates(t *testing.T) {
 
 	t.Setenv("FISSION_TENANCY_MODE", "dynamic")
 	got := tenantScopedPredicates(base)
-	assert.Len(t, got, 2, "on: membership predicate appended")
+	assert.Len(t, got, 2, "dynamic: membership predicate appended")
 	assert.Len(t, base, 1, "the caller's slice must not be mutated")
+
+	// Cluster mode also runs a cluster-wide cache, so it MUST get the membership
+	// predicate too — otherwise the cluster-wide cache reconciles every namespace
+	// before the resolver knows it is a tenant, breaking ordering + key stamping.
+	t.Setenv("FISSION_TENANCY_MODE", "cluster")
+	assert.Len(t, tenantScopedPredicates(base), 2, "cluster: membership predicate appended")
 }

--- a/pkg/controller/membership_test.go
+++ b/pkg/controller/membership_test.go
@@ -81,10 +81,10 @@ func TestTenantReenqueueMapFunc(t *testing.T) {
 func TestTenantScopedPredicates(t *testing.T) {
 	base := []predicate.Predicate{predicate.GenerationChangedPredicate{}}
 
-	t.Setenv("FISSION_DYNAMIC_NAMESPACES", "false")
+	t.Setenv("FISSION_TENANCY_MODE", "static")
 	assert.Len(t, tenantScopedPredicates(base), 1, "off: no membership predicate added")
 
-	t.Setenv("FISSION_DYNAMIC_NAMESPACES", "true")
+	t.Setenv("FISSION_TENANCY_MODE", "dynamic")
 	got := tenantScopedPredicates(base)
 	assert.Len(t, got, 2, "on: membership predicate appended")
 	assert.Len(t, base, 1, "the caller's slice must not be mutated")

--- a/pkg/executor/cache_test.go
+++ b/pkg/executor/cache_test.go
@@ -62,6 +62,25 @@ func TestExecutorCacheOptionsTierSplit(t *testing.T) {
 		assert.NotEmpty(t, cm.Namespaces, "ConfigMap cache must be namespace-scoped, NEVER cluster-wide")
 		assert.NotEmpty(t, rs.Namespaces, "ReplicaSet cache must be namespace-scoped to avoid mirroring the whole cluster")
 	})
+
+	t.Run("cluster mode caches Secrets/ConfigMaps/ReplicaSets cluster-wide", func(t *testing.T) {
+		t.Setenv("FISSION_TENANCY_MODE", "cluster")
+		opts := executorCacheOptions()
+		assert.Empty(t, opts.DefaultNamespaces, "everything cluster-wide in cluster mode")
+		secret, cm, rs := perTypeOverrides(opts)
+		// No per-type Namespaces override → these default to the cluster-wide cache.
+		// The Pod/Deployment/Service label bounds remain (memory bounds), but the
+		// Tier-B types are deliberately cluster-wide — the trusted-cluster trade.
+		if secret != nil {
+			assert.Empty(t, secret.Namespaces, "Secret cache is cluster-wide in cluster mode")
+		}
+		if cm != nil {
+			assert.Empty(t, cm.Namespaces, "ConfigMap cache is cluster-wide in cluster mode")
+		}
+		if rs != nil {
+			assert.Empty(t, rs.Namespaces, "ReplicaSet cache is cluster-wide in cluster mode")
+		}
+	})
 }
 
 // TestExecutorManagedSelector guards the Manager cache's Deployment/Service

--- a/pkg/executor/cache_test.go
+++ b/pkg/executor/cache_test.go
@@ -41,7 +41,7 @@ func TestExecutorCacheOptionsTierSplit(t *testing.T) {
 	}
 
 	t.Run("non-dynamic scopes every type to the env namespaces", func(t *testing.T) {
-		t.Setenv("FISSION_DYNAMIC_NAMESPACES", "false")
+		t.Setenv("FISSION_TENANCY_MODE", "static")
 		opts := executorCacheOptions()
 		assert.NotEmpty(t, opts.DefaultNamespaces, "per-namespace cache by default")
 		secret, cm, rs := perTypeOverrides(opts)
@@ -51,7 +51,7 @@ func TestExecutorCacheOptionsTierSplit(t *testing.T) {
 	})
 
 	t.Run("dynamic keeps Secrets and ConfigMaps namespace-scoped", func(t *testing.T) {
-		t.Setenv("FISSION_DYNAMIC_NAMESPACES", "true")
+		t.Setenv("FISSION_TENANCY_MODE", "dynamic")
 		opts := executorCacheOptions()
 		assert.Empty(t, opts.DefaultNamespaces, "Function/Environment cluster-wide in dynamic mode")
 		secret, cm, rs := perTypeOverrides(opts)

--- a/pkg/executor/executortype/poolmgr/gp_specialize.go
+++ b/pkg/executor/executortype/poolmgr/gp_specialize.go
@@ -52,29 +52,29 @@ func (gp *GenericPool) getFetcherURL(podIP string) string {
 }
 
 // shouldStampNamespaceKeyScheme reports whether a pool pod created in fnNamespace
-// should carry the namespace key-scheme annotation. Only when dynamic tenancy is
-// on and the namespace is a live tenant: the tenant controller provisions a
-// namespace's derived-key Secret before admitting it to the live set, so a live
-// tenant is guaranteed to have one — the pod will mount its per-namespace key and
-// the executor (fetcherSigningNamespace) will ns-sign it. Stamping a namespace
-// without that Secret would promise a key the pod never receives and 401 every
-// specialization, so the IsTenant gate is load-bearing, not cosmetic.
+// should carry the namespace key-scheme annotation. Only when per-namespace keys
+// are in use (dynamic or cluster mode) and the namespace is a live tenant: the
+// tenant controller provisions a namespace's derived-key Secret before admitting
+// it to the live set, so a live tenant is guaranteed to have one — the pod will
+// mount its per-namespace key and the executor (fetcherSigningNamespace) will
+// ns-sign it. Stamping a namespace without that Secret would promise a key the pod
+// never receives and 401 every specialization, so the IsTenant gate is
+// load-bearing, not cosmetic.
 func shouldStampNamespaceKeyScheme(fnNamespace string, resolver *utils.NamespaceResolver) bool {
-	return utils.DynamicNamespacesEnabled() && resolver != nil && resolver.IsTenant(fnNamespace)
+	return utils.PerNamespaceKeysEnabled() && resolver != nil && resolver.IsTenant(fnNamespace)
 }
 
 // fetcherSigningNamespace decides how the executor signs the /specialize call to
 // a pod's fetcher. A pod the executor stamped with the namespace key-scheme
-// annotation (genDeploymentSpec, only while dynamic tenancy is on for the pod's
-// namespace) holds only its per-namespace derived key and verifies with it, so
-// we sign with ServiceSignerNS for the pod's namespace and nsScoped is true.
+// annotation (genDeploymentSpec, only while per-namespace keys are in use for the
+// pod's namespace) holds only its per-namespace derived key and verifies with it,
+// so we sign with ServiceSignerNS for the pod's namespace and nsScoped is true.
 // Every other pod — pre-upgrade pods carrying no annotation across a rolling
-// upgrade, or any pod when dynamic tenancy is off — verifies with the
-// master-derived key, so nsScoped is false and the caller master-signs. The
-// dynamic-tenancy gate makes a stale annotation harmless if the feature is
-// turned back off.
+// upgrade, or any pod under static tenancy — verifies with the master-derived
+// key, so nsScoped is false and the caller master-signs. The per-namespace-keys
+// gate makes a stale annotation harmless if the feature is turned back off.
 func fetcherSigningNamespace(pod *apiv1.Pod) (namespace string, nsScoped bool) {
-	if utils.DynamicNamespacesEnabled() && fv1.HasNamespaceKeyScheme(pod.Annotations) {
+	if utils.PerNamespaceKeysEnabled() && fv1.HasNamespaceKeyScheme(pod.Annotations) {
 		return pod.Namespace, true
 	}
 	return "", false

--- a/pkg/executor/executortype/poolmgr/gp_specialize_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_specialize_test.go
@@ -45,7 +45,7 @@ func TestFetcherSigningNamespace(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("FISSION_DYNAMIC_NAMESPACES", boolEnv(tt.dynamic))
+			t.Setenv("FISSION_TENANCY_MODE", tenancyModeEnv(tt.dynamic))
 			ns, scoped := fetcherSigningNamespace(tt.pod)
 			assert.Equal(t, tt.wantScoped, scoped, "nsScoped decision")
 			assert.Equal(t, tt.wantNS, ns, "signing namespace")
@@ -77,15 +77,16 @@ func TestShouldStampNamespaceKeyScheme(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("FISSION_DYNAMIC_NAMESPACES", boolEnv(tt.dynamic))
+			t.Setenv("FISSION_TENANCY_MODE", tenancyModeEnv(tt.dynamic))
 			assert.Equal(t, tt.want, shouldStampNamespaceKeyScheme(tt.namespace, tt.resolver))
 		})
 	}
 }
 
-func boolEnv(b bool) string {
-	if b {
-		return "true"
+// tenancyModeEnv maps the test's "dynamic?" flag to a FISSION_TENANCY_MODE value.
+func tenancyModeEnv(dynamic bool) string {
+	if dynamic {
+		return "dynamic"
 	}
-	return "false"
+	return "static"
 }

--- a/pkg/executor/funcreconciler/reconciler.go
+++ b/pkg/executor/funcreconciler/reconciler.go
@@ -63,11 +63,12 @@ func ownedObjectToFunction(_ context.Context, obj client.Object) []reconcile.Req
 	if name == "" || ns == "" {
 		return nil
 	}
-	// Under dynamic tenancy the drift watch sees workloads cluster-wide; a leftover
-	// managed object in a namespace that has since left the tenant set must not
-	// re-enqueue its Function (the membership predicate gates .For but not this
-	// mapper). Drop it so an offboarded namespace stops reconciling immediately.
-	if utils.DynamicNamespacesEnabled() && !utils.DefaultNSResolver().IsTenant(ns) {
+	// With a cluster-wide cache (dynamic OR cluster mode) the drift watch sees
+	// workloads cluster-wide; a leftover managed object in a namespace not in the
+	// tenant set must not re-enqueue its Function (the membership predicate gates
+	// .For but not this mapper). Drop it so a non-tenant namespace stops
+	// reconciling immediately.
+	if utils.CrdWatchClusterWide() && !utils.DefaultNSResolver().IsTenant(ns) {
 		return nil
 	}
 	return []reconcile.Request{{NamespacedName: types.NamespacedName{Name: name, Namespace: ns}}}
@@ -316,11 +317,12 @@ func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[
 	// self-healing). The Manager cache already scopes those types to
 	// executor-managed objects (executorManagedSelector), so only newdeploy /
 	// container workloads reach the delete-only watch.
-	// Spec/delete events drive the reconciler; under dynamic tenancy AND the
-	// membership predicate so the cluster-wide cache only reconciles Functions in
-	// live tenant namespaces (no-op when dynamic tenancy is off).
+	// Spec/delete events drive the reconciler; when the cache is cluster-wide
+	// (dynamic OR cluster mode) the membership predicate is ANDed on so the
+	// cluster-wide cache only reconciles Functions in live tenant namespaces (no-op
+	// in static mode, where the cache is already namespace-scoped).
 	funcPredicate := predicate.Or(predicate.GenerationChangedPredicate{}, deletionTimestampPredicate)
-	if utils.DynamicNamespacesEnabled() {
+	if utils.CrdWatchClusterWide() {
 		funcPredicate = predicate.And(funcPredicate, controller.MembershipPredicate(utils.DefaultNSResolver()))
 	}
 	b := builder.ControllerManagedBy(mgr).
@@ -331,7 +333,7 @@ func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[
 			builder.WithPredicates(deleteOnlyPredicate)).
 		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(ownedObjectToFunction),
 			builder.WithPredicates(deleteOnlyPredicate))
-	if utils.DynamicNamespacesEnabled() {
+	if utils.CrdWatchClusterWide() {
 		// Re-converge a namespace's Functions when it is onboarded at runtime: the
 		// membership predicate above otherwise permanently drops a Function whose
 		// event predated the tenant. Mirrors controller.RegisterTenantScoped (this

--- a/pkg/executor/start.go
+++ b/pkg/executor/start.go
@@ -95,6 +95,19 @@ func executorCacheOptions() crcache.Options {
 		&corev1.Service{}:    {Label: executorManagedSelector},
 	}
 
+	if utils.ClusterTenancyEnabled() {
+		// Cluster (trusted-cluster) mode: Tier A AND Tier B go cluster-wide. The
+		// executor reads Secrets/ConfigMaps/ReplicaSets across all namespaces — the
+		// operational simplification this opt-in mode trades isolation for (PRD
+		// §4.5; the executor holds the matching cluster-wide read via
+		// cluster-mode-bindings.yaml). The label-bounded Pod/Deployment/Service
+		// watches above are kept (memory bounds, valid in any mode); Secret/
+		// ConfigMap/ReplicaSet get NO per-namespace override, so they default to the
+		// cluster-wide cache. Function pods still hold only narrow per-namespace
+		// fetcher RBAC — this widening is the control plane's, not the workload's.
+		return crcache.Options{ByObject: byObject}
+	}
+
 	if utils.DynamicNamespacesEnabled() {
 		// Tier A (Function/Environment) goes cluster-wide so a namespace onboarded
 		// at runtime is visible without a restart; the func/env reconcilers filter

--- a/pkg/executor/start.go
+++ b/pkg/executor/start.go
@@ -119,14 +119,14 @@ func executorCacheOptions() crcache.Options {
 		// Tier B (Secret/ConfigMap) MUST stay namespace-scoped: a cluster-wide
 		// Secret cache would mirror every Secret in the cluster into the executor's
 		// memory, the one read the design forbids. Override the per-type namespaces
-		// to the env-seeded set (the dynamic per-namespace cache is a later phase),
-		// leaving the cluster-wide default to the Tier-A CRDs only.
+		// to the env-seeded set, leaving the cluster-wide default to the Tier-A CRDs
+		// only. (Operators needing Tier-B reads in arbitrary runtime-onboarded
+		// namespaces use cluster mode, which goes cluster-wide above.)
 		byObject[&corev1.Secret{}] = crcache.ByObject{Namespaces: nsConfig}
 		byObject[&corev1.ConfigMap{}] = crcache.ByObject{Namespaces: nsConfig}
 		// ReplicaSets (poolmgr's specialized-pod cleanup watch) are not label-bounded
 		// here, so a cluster-wide cache would mirror every ReplicaSet in the cluster.
-		// Keep them namespace-scoped too — and out of the cluster-wide RBAC; runtime
-		// onboarding's specialized-pod cleanup follows with the provisioning phase.
+		// Keep them namespace-scoped too — and out of the cluster-wide RBAC.
 		byObject[&appsv1.ReplicaSet{}] = crcache.ByObject{Namespaces: nsConfig}
 		return crcache.Options{ByObject: byObject}
 	}

--- a/pkg/fetcher/config/internalauth_test.go
+++ b/pkg/fetcher/config/internalauth_test.go
@@ -31,7 +31,7 @@ func envByName(t *testing.T, vars []apiv1.EnvVar) map[string]apiv1.EnvVar {
 // controller-owned TenantAuthKeysSecret (a distinct name so it never collides
 // with the chart copy). All are optional in the default single-namespace mode.
 func TestInternalAuthEnvVarsSources(t *testing.T) {
-	t.Setenv("FISSION_DYNAMIC_NAMESPACES", "false")
+	t.Setenv("FISSION_TENANCY_MODE", "static")
 	vars := envByName(t, internalAuthEnvVars("team-a"))
 
 	cases := []struct {
@@ -90,7 +90,7 @@ func TestInternalAuthEnvVarsFetcherKeyRequiredInDynamicMode(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("FISSION_DYNAMIC_NAMESPACES", boolStr(tt.dynamic))
+			t.Setenv("FISSION_TENANCY_MODE", tenancyModeEnv(tt.dynamic))
 			t.Setenv("FISSION_INTERNAL_AUTH_SECRET", tt.master)
 
 			vars := envByName(t, internalAuthEnvVars(tt.namespace))
@@ -108,9 +108,10 @@ func TestInternalAuthEnvVarsFetcherKeyRequiredInDynamicMode(t *testing.T) {
 	}
 }
 
-func boolStr(b bool) string {
-	if b {
-		return "true"
+// tenancyModeEnv maps the test's "dynamic?" flag to a FISSION_TENANCY_MODE value.
+func tenancyModeEnv(dynamic bool) string {
+	if dynamic {
+		return "dynamic"
 	}
-	return "false"
+	return "static"
 }

--- a/pkg/kubewatcher/main.go
+++ b/pkg/kubewatcher/main.go
@@ -19,22 +19,9 @@ import (
 )
 
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, _ *errgroup.Group, routerUrl string) error {
-	fissionClient, err := clientGen.GetFissionClient()
-	if err != nil {
-		return fmt.Errorf("failed to get fission client: %w", err)
-	}
 	kubeClient, err := clientGen.GetKubernetesClient()
 	if err != nil {
 		return fmt.Errorf("failed to get kubernetes client: %w", err)
-	}
-	restConfig, err := clientGen.GetRestConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get rest config: %w", err)
-	}
-
-	err = crd.WaitForFunctionCRDs(ctx, logger, fissionClient)
-	if err != nil {
-		return fmt.Errorf("error waiting for CRDs: %w", err)
 	}
 
 	poster := publisher.MakeWebhookPublisher(logger, routerUrl)
@@ -43,9 +30,9 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// Active-passive HA via native controller-runtime leader election: only the
 	// elected leader registers watches, so two replicas don't double-register /
 	// double-fire functions. No-op when LEADER_ELECTION_ENABLED is unset
-	// (single-replica default). The reconciler watches through the Manager's
-	// namespace-scoped cache and runs only on the elected leader.
-	crMgr, err := crmanager.NewLeaderElected(restConfig, "fission-kubewatcher", logger)
+	// (single-replica default). The reconciler watches through the Manager's cache
+	// and runs only on the elected leader.
+	crMgr, err := crmanager.NewTriggerManager(ctx, clientGen, "fission-kubewatcher", logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -246,11 +246,18 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 // pods); isValidFunctionPodOnNode still filters in the reconciler.
 func loggerCacheOptions() crcache.Options {
 	resolver := utils.DefaultNSResolver()
-	nsConfig := map[string]crcache.Config{}
-	for _, ns := range resolver.FissionNSWithOptions(utils.WithBuilderNs(), utils.WithFunctionNs(), utils.WithDefaultNs()) {
-		nsConfig[ns] = crcache.Config{}
+	opts := crcache.Options{}
+	// Cluster mode: function pods run in any namespace, so the log collector
+	// watches Pods cluster-wide (it holds the matching cluster-wide read via the
+	// fluentbit ClusterRole rendered only in cluster mode). Other modes scope the
+	// Pod cache to the Fission namespaces, matching fluentbit's per-namespace Roles.
+	if !utils.ClusterTenancyEnabled() {
+		nsConfig := map[string]crcache.Config{}
+		for _, ns := range resolver.FissionNSWithOptions(utils.WithBuilderNs(), utils.WithFunctionNs(), utils.WithDefaultNs()) {
+			nsConfig[ns] = crcache.Config{}
+		}
+		opts.DefaultNamespaces = nsConfig
 	}
-	opts := crcache.Options{DefaultNamespaces: nsConfig}
 	if nodeName != "" {
 		opts.ByObject = map[client.Object]crcache.ByObject{
 			&corev1.Pod{}: {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -98,15 +98,21 @@ func routerCacheOptions(mode endpointSliceCacheMode) crcache.Options {
 	if mode == endpointSliceCacheOff {
 		return opts
 	}
-	sliceNS := map[string]crcache.Config{}
-	for _, ns := range sliceWatchNamespaces() {
-		sliceNS[ns] = crcache.Config{}
+	sliceByObject := crcache.ByObject{
+		Label: labels.SelectorFromSet(labels.Set{fv1.MANAGED_BY_LABEL: fv1.MANAGED_BY_VALUE}),
+	}
+	// Cluster mode: functions (and their Services) live in any namespace, so the
+	// label-bounded slice watch goes cluster-wide (no per-namespace scoping). Other
+	// modes scope it to the function namespaces where the Services live.
+	if !utils.ClusterTenancyEnabled() {
+		sliceNS := map[string]crcache.Config{}
+		for _, ns := range sliceWatchNamespaces() {
+			sliceNS[ns] = crcache.Config{}
+		}
+		sliceByObject.Namespaces = sliceNS
 	}
 	opts.ByObject = map[client.Object]crcache.ByObject{
-		&discoveryv1.EndpointSlice{}: {
-			Label:      labels.SelectorFromSet(labels.Set{fv1.MANAGED_BY_LABEL: fv1.MANAGED_BY_VALUE}),
-			Namespaces: sliceNS,
-		},
+		&discoveryv1.EndpointSlice{}: sliceByObject,
 	}
 	return opts
 }
@@ -124,7 +130,14 @@ func routerCacheOptions(mode endpointSliceCacheMode) crcache.Options {
 // data plane over a missing optimization grant (e.g. a GitOps prune dropping
 // the Role) would turn it into an outage.
 func checkSliceWatchRBAC(ctx context.Context, kubeClient kubernetes.Interface) error {
-	for _, ns := range sliceWatchNamespaces() {
+	// Cluster mode watches EndpointSlices cluster-wide, so a single cluster-scoped
+	// review (empty Namespace) is the right preflight; other modes check each
+	// function namespace the informer scopes to.
+	watchNamespaces := sliceWatchNamespaces()
+	if utils.ClusterTenancyEnabled() {
+		watchNamespaces = []string{""}
+	}
+	for _, ns := range watchNamespaces {
 		for _, verb := range []string{"list", "watch"} {
 			sar := &authorizationv1.SelfSubjectAccessReview{
 				Spec: authorizationv1.SelfSubjectAccessReviewSpec{

--- a/pkg/tenant/provision.go
+++ b/pkg/tenant/provision.go
@@ -56,15 +56,15 @@ func DeleteNamespaceRBAC(ctx context.Context, c client.Client, namespace string)
 		client.InNamespace(namespace),
 		client.MatchingLabels{managedByLabelKey: managedByValue},
 	}
-	// RoleBindings before Roles before ServiceAccounts (reverse of creation). The
-	// label selector means only controller-managed objects are removed — never
-	// chart- or user-managed RBAC. DeleteAllOf issues a deletecollection request,
-	// so the tenant-controller ClusterRole MUST grant `deletecollection` on these
-	// three resources (charts/.../tenant-controller/rbac.yaml) — `delete` alone is
-	// insufficient and the finalizer would wedge on a forbidden error. Role stays
-	// in the sweep only to reap any legacy per-namespace Roles a pre-unification
-	// controller authored before this revision started binding ClusterRoles.
-	for _, proto := range []client.Object{&rbacv1.RoleBinding{}, &rbacv1.Role{}, &corev1.ServiceAccount{}} {
+	// RoleBindings before ServiceAccounts (reverse of creation). The label selector
+	// means only controller-managed objects are removed — never chart- or
+	// user-managed RBAC. DeleteAllOf issues a deletecollection request, so the
+	// tenant-controller ClusterRole MUST grant `deletecollection` on these resources
+	// (charts/.../tenant-controller/rbac.yaml) — `delete` alone is insufficient and
+	// the finalizer would wedge on a forbidden error. The controller authors no
+	// Role of its own (it binds the fixed-name *-tenant-workload ClusterRoles), so
+	// Roles are not in the sweep.
+	for _, proto := range []client.Object{&rbacv1.RoleBinding{}, &corev1.ServiceAccount{}} {
 		if err := c.DeleteAllOf(ctx, proto, opts...); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("deleting %T in %s: %w", proto, namespace, err)
 		}

--- a/pkg/tenant/reconciler.go
+++ b/pkg/tenant/reconciler.go
@@ -221,13 +221,21 @@ func (r *TenantReconciler) namespaceToRequests(ctx context.Context, obj client.O
 	return reqs
 }
 
-// NamespaceReconciler materializes a Namespace labelled fission.io/enabled=true
-// into a FissionTenant CR. It is the "label is sugar" ignition path: it only ever
-// creates, never deletes — removing the label leaves the CR in place (operators
-// disable a tenant explicitly via `fission tenant disable`).
+// NamespaceReconciler materializes a Namespace into a FissionTenant CR. In the
+// default (dynamic) mode it is the "label is sugar" ignition path: it materializes
+// only Namespaces labelled fission.io/enabled=true. In cluster (trusted-cluster)
+// mode autoOnboardAll is set and it materializes EVERY non-system namespace — the
+// auto-onboarding that lets functions run in any namespace with no FissionTenant
+// CR ceremony. Either way it only ever creates, never deletes.
 type NamespaceReconciler struct {
 	logger logr.Logger
 	client client.Client
+	// autoOnboardAll (cluster mode) materializes every non-system namespace,
+	// ignoring the fission.io/enabled label.
+	autoOnboardAll bool
+	// releaseNamespace is the control-plane install namespace, excluded from
+	// auto-onboarding (it runs no functions). Empty when not in cluster mode.
+	releaseNamespace string
 }
 
 func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -235,7 +243,13 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.client.Get(ctx, req.NamespacedName, target); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	if target.Labels[EnabledLabel] != "true" {
+	if r.autoOnboardAll {
+		// Cluster mode: onboard every namespace except Kubernetes system namespaces
+		// and the control-plane namespace, which never run function/builder pods.
+		if isExcludedFromAutoOnboard(target.Name, r.releaseNamespace) {
+			return ctrl.Result{}, nil
+		}
+	} else if target.Labels[EnabledLabel] != "true" {
 		return ctrl.Result{}, nil
 	}
 
@@ -267,6 +281,19 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err := r.client.Create(ctx, ft); err != nil && !apierrors.IsAlreadyExists(err) {
 		return ctrl.Result{}, err
 	}
-	r.logger.Info("materialized FissionTenant from namespace label", "namespace", target.Name)
+	r.logger.Info("materialized FissionTenant for namespace", "namespace", target.Name, "autoOnboard", r.autoOnboardAll)
 	return ctrl.Result{}, nil
+}
+
+// isExcludedFromAutoOnboard reports whether a namespace must NOT be auto-onboarded
+// in cluster mode: the Kubernetes system namespaces (which never run Fission
+// workloads) and the control-plane install namespace. Everything else is fair game
+// — cluster mode's premise is that every other namespace may run functions.
+func isExcludedFromAutoOnboard(namespace, releaseNamespace string) bool {
+	// kube-system, kube-public, and kube-node-lease run no Fission workloads.
+	switch namespace {
+	case metav1.NamespaceSystem, metav1.NamespacePublic, "kube-node-lease":
+		return true
+	}
+	return releaseNamespace != "" && namespace == releaseNamespace
 }

--- a/pkg/tenant/reconciler.go
+++ b/pkg/tenant/reconciler.go
@@ -5,10 +5,10 @@
 // Package tenant implements the fission-bundle --tenantController subsystem: the
 // lifecycle controller for multi-namespace tenancy (docs/multiple-namespace).
 // It reconciles FissionTenant CRs (and Namespaces labelled fission.io/enabled)
-// into the live resource-namespace set, provisions per-namespace RBAC and
-// service accounts for the fetcher/builder (tearing them down on offboard via a
-// finalizer), and reports readiness. Per-namespace HMAC auth-key provisioning is
-// layered on in a later phase.
+// into the live resource-namespace set, provisions per-namespace RBAC, service
+// accounts, and the derived HMAC auth-key Secret for the fetcher/builder (tearing
+// them down on offboard via a finalizer), and reports readiness. In cluster mode
+// it auto-onboards every namespace instead of requiring an explicit FissionTenant.
 package tenant
 
 import (
@@ -60,7 +60,7 @@ const (
 // reports a Ready condition. It runs on the leader-elected --tenantController
 // Manager (it writes status). The resolver drive is additive over the
 // env-seeded set (utils.GetNamespaces) so an empty tenant list never wipes the
-// env default; the env→CR source flip is a later phase.
+// env default.
 type TenantReconciler struct {
 	logger   logr.Logger
 	client   client.Client

--- a/pkg/tenant/reconciler.go
+++ b/pkg/tenant/reconciler.go
@@ -14,6 +14,7 @@ package tenant
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -254,15 +255,24 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	// Already onboarded by some FissionTenant (label-born or user-authored under
-	// any name)? Then there is nothing to materialize.
+	// any name)? Then there is nothing to materialize — UNLESS the matching CR is a
+	// controller-managed one owned by a DIFFERENT (deleted) instance of this
+	// namespace: the delete-recreate race, where a same-named namespace is recreated
+	// before owner-reference GC has reaped the old CR. That stale CR is about to be
+	// GC'd, leaving the new namespace stranded with no FissionTenant and no event to
+	// retry, so requeue to re-materialize once it clears.
 	list := &fv1.FissionTenantList{}
 	if err := r.client.List(ctx, list); err != nil {
 		return ctrl.Result{}, err
 	}
 	for i := range list.Items {
-		if list.Items[i].Spec.Namespace == target.Name {
-			return ctrl.Result{}, nil
+		if list.Items[i].Spec.Namespace != target.Name {
+			continue
 		}
+		if isStaleManagedTenant(&list.Items[i], target.UID) {
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		return ctrl.Result{}, nil
 	}
 
 	ft := &fv1.FissionTenant{
@@ -278,11 +288,34 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		},
 		Spec: fv1.FissionTenantSpec{Namespace: target.Name},
 	}
-	if err := r.client.Create(ctx, ft); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := r.client.Create(ctx, ft); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// A same-named CR exists but didn't match the list above (informer lag);
+			// requeue so the stale-vs-live check runs against the fresh object.
+			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
+		}
+		r.logger.Error(err, "failed to materialize FissionTenant", "namespace", target.Name)
 		return ctrl.Result{}, err
 	}
 	r.logger.Info("materialized FissionTenant for namespace", "namespace", target.Name, "autoOnboard", r.autoOnboardAll)
 	return ctrl.Result{}, nil
+}
+
+// isStaleManagedTenant reports whether ft is a controller-managed FissionTenant
+// left behind by a deleted instance of namespace nsUID — i.e. it is managed by us
+// and carries a Namespace owner reference whose UID differs from the current
+// namespace's. A user-authored CR (no managed annotation) or one owned by the
+// current namespace is NOT stale.
+func isStaleManagedTenant(ft *fv1.FissionTenant, nsUID types.UID) bool {
+	if ft.Annotations[managedByAnnotation] != managedByLabel {
+		return false
+	}
+	for _, o := range ft.OwnerReferences {
+		if o.Kind == "Namespace" {
+			return o.UID != nsUID
+		}
+	}
+	return false
 }
 
 // isExcludedFromAutoOnboard reports whether a namespace must NOT be auto-onboarded

--- a/pkg/tenant/reconciler.go
+++ b/pkg/tenant/reconciler.go
@@ -32,10 +32,16 @@ import (
 )
 
 const (
-	// EnabledLabel on a Namespace opts it in as a Fission tenant; the controller
-	// materializes a labelled Namespace into a FissionTenant CR (one-way
-	// ignition — removing the label never deletes the CR; see prd.md §6.2).
+	// EnabledLabel on a Namespace is an explicit Fission-tenancy membership
+	// override. In dynamic mode "true" opts a namespace IN (the controller
+	// materializes it into a FissionTenant; one-way ignition — removing the label
+	// never deletes the CR, see prd.md §6.2). In cluster mode, where every
+	// namespace is auto-onboarded by default, "false" opts a namespace OUT: the
+	// controller skips it and, if it was already auto-onboarded, offboards it.
 	EnabledLabel = "fission.io/enabled"
+	// EnabledLabelOptOut is the EnabledLabel value that excludes a namespace from
+	// cluster-mode auto-onboarding.
+	EnabledLabelOptOut = "false"
 
 	// managedByAnnotation records how a FissionTenant came to exist: "label"
 	// (materialized from EnabledLabel) vs a user/helm-authored CR. Only
@@ -250,6 +256,12 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if isExcludedFromAutoOnboard(target.Name, r.releaseNamespace) {
 			return ctrl.Result{}, nil
 		}
+		// Explicit operator opt-out: skip onboarding, and offboard the namespace if
+		// the controller had already auto-onboarded it (so labelling a live
+		// namespace fission.io/enabled=false tears its Fission RBAC/keys down).
+		if target.Labels[EnabledLabel] == EnabledLabelOptOut {
+			return r.offboardManaged(ctx, target.Name)
+		}
 	} else if target.Labels[EnabledLabel] != "true" {
 		return ctrl.Result{}, nil
 	}
@@ -266,10 +278,15 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 	for i := range list.Items {
-		if list.Items[i].Spec.Namespace != target.Name {
+		ft := &list.Items[i]
+		if ft.Spec.Namespace != target.Name {
 			continue
 		}
-		if isStaleManagedTenant(&list.Items[i], target.UID) {
+		// A managed CR from a deleted namespace instance (stale owner UID), or one
+		// currently being deleted (e.g. just offboarded via the opt-out label and
+		// now re-enabled), is transient — requeue so we re-materialize for the
+		// current, enabled namespace once it clears.
+		if isStaleManagedTenant(ft, target.UID) || !ft.DeletionTimestamp.IsZero() {
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		return ctrl.Result{}, nil
@@ -299,6 +316,39 @@ func (r *NamespaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	r.logger.Info("materialized FissionTenant for namespace", "namespace", target.Name, "autoOnboard", r.autoOnboardAll)
 	return ctrl.Result{}, nil
+}
+
+// offboardManaged deletes the controller-managed FissionTenant for namespace (if
+// any), used when a cluster-mode namespace is explicitly opted out with
+// fission.io/enabled=false. Deleting the CR runs the TenantReconciler's offboard
+// finalizer (tears down the per-namespace RBAC + key Secret and drops the
+// namespace from the resolver). A user/helm-authored FissionTenant is left
+// untouched — the opt-out label only governs auto-onboarded namespaces; an
+// operator who authored a CR manages it explicitly via `fission tenant disable`.
+func (r *NamespaceReconciler) offboardManaged(ctx context.Context, namespace string) (ctrl.Result, error) {
+	list := &fv1.FissionTenantList{}
+	if err := r.client.List(ctx, list); err != nil {
+		return ctrl.Result{}, err
+	}
+	for i := range list.Items {
+		ft := &list.Items[i]
+		if ft.Spec.Namespace != namespace {
+			continue
+		}
+		if ft.Annotations[managedByAnnotation] != managedByLabel {
+			return ctrl.Result{}, nil // user-authored: respect it, don't auto-offboard
+		}
+		if !ft.DeletionTimestamp.IsZero() {
+			return ctrl.Result{}, nil // already offboarding
+		}
+		if err := r.client.Delete(ctx, ft); err != nil && !apierrors.IsNotFound(err) {
+			r.logger.Error(err, "failed to offboard opted-out namespace", "namespace", namespace)
+			return ctrl.Result{}, err
+		}
+		r.logger.Info("offboarded namespace via fission.io/enabled=false opt-out", "namespace", namespace)
+		return ctrl.Result{}, nil
+	}
+	return ctrl.Result{}, nil // not onboarded; nothing to offboard
 }
 
 // isStaleManagedTenant reports whether ft is a controller-managed FissionTenant

--- a/pkg/tenant/reconciler_test.go
+++ b/pkg/tenant/reconciler_test.go
@@ -222,3 +222,34 @@ func TestNamespaceReconcilerUnlabeledNoCR(t *testing.T) {
 	require.NoError(t, c.List(t.Context(), list))
 	assert.Empty(t, list.Items, "an unlabeled namespace must not be materialized")
 }
+
+// TestNamespaceReconcilerAutoOnboardAll covers cluster mode: every non-system
+// namespace is materialized into a FissionTenant regardless of the label, while
+// the Kubernetes system namespaces and the control-plane namespace are excluded.
+func TestNamespaceReconcilerAutoOnboardAll(t *testing.T) {
+	reconcile := func(t *testing.T, c client.Client, name string) {
+		t.Helper()
+		r := &NamespaceReconciler{logger: logr.Discard(), client: c, autoOnboardAll: true, releaseNamespace: "fission"}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		require.NoError(t, err)
+	}
+
+	t.Run("unlabeled namespace is auto-onboarded", func(t *testing.T) {
+		c := newFakeClient(t, ns("team-x", nil))
+		reconcile(t, c, "team-x")
+		got := &fv1.FissionTenant{}
+		require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "team-x"}, got),
+			"cluster mode must materialize a FissionTenant for an unlabeled namespace")
+		assert.Equal(t, "team-x", got.Spec.Namespace)
+	})
+
+	for _, sys := range []string{"kube-system", "kube-public", "kube-node-lease", "fission"} {
+		t.Run("excludes "+sys, func(t *testing.T) {
+			c := newFakeClient(t, ns(sys, nil))
+			reconcile(t, c, sys)
+			list := &fv1.FissionTenantList{}
+			require.NoError(t, c.List(t.Context(), list))
+			assert.Empty(t, list.Items, "system / control-plane namespace %q must not be auto-onboarded", sys)
+		})
+	}
+}

--- a/pkg/tenant/reconciler_test.go
+++ b/pkg/tenant/reconciler_test.go
@@ -252,4 +252,40 @@ func TestNamespaceReconcilerAutoOnboardAll(t *testing.T) {
 			assert.Empty(t, list.Items, "system / control-plane namespace %q must not be auto-onboarded", sys)
 		})
 	}
+
+	// Delete-recreate race: a managed FissionTenant left by a deleted same-named
+	// namespace (stale owner UID) must not be treated as "already onboarded" — the
+	// reconciler requeues so it re-materializes for the current namespace once GC
+	// reaps the stale CR.
+	t.Run("requeues on a stale managed tenant from a recreated namespace", func(t *testing.T) {
+		staleFT := &fv1.FissionTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "team-x",
+				Annotations:     map[string]string{managedByAnnotation: managedByLabel},
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Namespace", Name: "team-x", UID: "team-x-OLD-uid"}},
+			},
+			Spec: fv1.FissionTenantSpec{Namespace: "team-x"},
+		}
+		c := newFakeClient(t, ns("team-x", nil), staleFT) // ns("team-x") has UID "team-x-uid" != stale
+		r := &NamespaceReconciler{logger: logr.Discard(), client: c, autoOnboardAll: true, releaseNamespace: "fission"}
+		res, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "team-x"}})
+		require.NoError(t, err)
+		assert.Positive(t, res.RequeueAfter, "stale managed tenant must trigger a requeue, not an early return")
+		list := &fv1.FissionTenantList{}
+		require.NoError(t, c.List(t.Context(), list))
+		assert.Len(t, list.Items, 1, "must not create a duplicate while the stale CR is still being GC'd")
+	})
+
+	// A user-authored CR (no managed annotation) for the namespace is respected:
+	// no requeue, no duplicate.
+	t.Run("respects a user-authored tenant under a different name", func(t *testing.T) {
+		c := newFakeClient(t, ns("team-y", nil), tenant("custom", "team-y"))
+		r := &NamespaceReconciler{logger: logr.Discard(), client: c, autoOnboardAll: true, releaseNamespace: "fission"}
+		res, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: "team-y"}})
+		require.NoError(t, err)
+		assert.Zero(t, res.RequeueAfter, "a user-authored tenant is not stale; no requeue")
+		list := &fv1.FissionTenantList{}
+		require.NoError(t, c.List(t.Context(), list))
+		assert.Len(t, list.Items, 1, "must not duplicate a user-authored tenant")
+	})
 }

--- a/pkg/tenant/reconciler_test.go
+++ b/pkg/tenant/reconciler_test.go
@@ -289,3 +289,47 @@ func TestNamespaceReconcilerAutoOnboardAll(t *testing.T) {
 		assert.Len(t, list.Items, 1, "must not duplicate a user-authored tenant")
 	})
 }
+
+// TestNamespaceReconcilerClusterOptOut covers the cluster-mode opt-out label
+// (fission.io/enabled=false): a labelled namespace is not onboarded, and labelling
+// an already-onboarded namespace offboards its controller-managed FissionTenant
+// while leaving a user-authored CR alone.
+func TestNamespaceReconcilerClusterOptOut(t *testing.T) {
+	reconcile := func(t *testing.T, c client.Client, name string) {
+		t.Helper()
+		r := &NamespaceReconciler{logger: logr.Discard(), client: c, autoOnboardAll: true, releaseNamespace: "fission"}
+		_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}})
+		require.NoError(t, err)
+	}
+	optedOut := map[string]string{EnabledLabel: EnabledLabelOptOut}
+
+	t.Run("opted-out namespace is not onboarded", func(t *testing.T) {
+		c := newFakeClient(t, ns("team-z", optedOut))
+		reconcile(t, c, "team-z")
+		list := &fv1.FissionTenantList{}
+		require.NoError(t, c.List(t.Context(), list))
+		assert.Empty(t, list.Items, "fission.io/enabled=false must keep a namespace un-onboarded")
+	})
+
+	t.Run("opting out a live namespace offboards its managed tenant", func(t *testing.T) {
+		managedFT := &fv1.FissionTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "team-w",
+				Annotations:     map[string]string{managedByAnnotation: managedByLabel},
+				OwnerReferences: []metav1.OwnerReference{{Kind: "Namespace", Name: "team-w", UID: "team-w-uid"}},
+			},
+			Spec: fv1.FissionTenantSpec{Namespace: "team-w"},
+		}
+		c := newFakeClient(t, ns("team-w", optedOut), managedFT)
+		reconcile(t, c, "team-w")
+		err := c.Get(t.Context(), types.NamespacedName{Name: "team-w"}, &fv1.FissionTenant{})
+		assert.True(t, apierrors.IsNotFound(err), "opting out must delete the controller-managed FissionTenant")
+	})
+
+	t.Run("opt-out leaves a user-authored tenant alone", func(t *testing.T) {
+		c := newFakeClient(t, ns("team-u", optedOut), tenant("user-owned", "team-u"))
+		reconcile(t, c, "team-u")
+		require.NoError(t, c.Get(t.Context(), types.NamespacedName{Name: "user-owned"}, &fv1.FissionTenant{}),
+			"a user-authored FissionTenant must survive the opt-out label")
+	})
+}

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -59,13 +59,16 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 }
 
 // AddResolverSync registers the resolver-sync reconciler on mgr, watching
-// FissionTenant. It is a no-op unless dynamic tenancy is on, so every data-plane
-// Start can call it unconditionally. The manager's cache is cluster-wide in that
-// mode, so the cluster-scoped FissionTenant watch needs no extra cache wiring;
-// the component's ClusterRole must grant fissiontenants get/list/watch
-// (charts/.../tenant-controller/dynamic-cluster-roles.yaml).
+// FissionTenant. It is a no-op unless the Fission-CRD cache is cluster-wide
+// (dynamic OR cluster mode), so every data-plane Start can call it
+// unconditionally. Both modes need it: it is what keeps each process's resolver —
+// and therefore IsTenant, which gates the membership predicate AND per-namespace
+// HMAC key stamping — in step with the live FissionTenant set. The manager's cache
+// is cluster-wide in these modes, so the cluster-scoped FissionTenant watch needs
+// no extra cache wiring; the component's ClusterRole must grant fissiontenants
+// get/list/watch (charts/.../tenant-controller/dynamic-cluster-roles.yaml).
 func AddResolverSync(mgr ctrl.Manager) error {
-	if !utils.DynamicNamespacesEnabled() {
+	if !utils.CrdWatchClusterWide() {
 		return nil
 	}
 	r := &ResolverSyncReconciler{client: mgr.GetClient(), resolver: utils.DefaultNSResolver()}

--- a/pkg/tenant/start.go
+++ b/pkg/tenant/start.go
@@ -137,16 +137,21 @@ func enabledLabelPredicate() predicate.Predicate {
 	})
 }
 
-// autoOnboardPredicate (cluster mode) admits Namespace create events only: every
-// existing namespace surfaces as an add on the informer's initial sync, and any
-// later namespace as a create, so the reconciler materializes a FissionTenant for
-// each exactly once. Label/spec updates change nothing (materialize is idempotent
-// and keyed on existence), and namespace deletes are handled by owner-reference GC
-// of the materialized FissionTenant — so neither needs to wake the reconciler.
+// autoOnboardPredicate (cluster mode) admits Namespace create events (every
+// existing namespace surfaces as an add on the informer's initial sync, any later
+// namespace as a create, so the reconciler materializes a FissionTenant for each
+// exactly once) AND updates that flip the fission.io/enabled opt-out label, so an
+// operator labelling a live namespace fission.io/enabled=false (or removing the
+// label to re-enable) wakes the reconciler to offboard / re-onboard it. Other
+// label/spec updates change nothing (materialize is idempotent, keyed on
+// existence), and namespace deletes are handled by owner-reference GC of the
+// materialized FissionTenant.
 func autoOnboardPredicate() predicate.Predicate {
 	return predicate.Funcs{
-		CreateFunc:  func(event.CreateEvent) bool { return true },
-		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		CreateFunc: func(event.CreateEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectOld.GetLabels()[EnabledLabel] != e.ObjectNew.GetLabels()[EnabledLabel]
+		},
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		GenericFunc: func(event.GenericEvent) bool { return false },
 	}

--- a/pkg/tenant/start.go
+++ b/pkg/tenant/start.go
@@ -87,7 +87,16 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// executor/buildermgr SAs live — the subject namespace for the per-tenant
 	// workload RoleBindings the controller provisions.
 	releaseNamespace := os.Getenv("POD_NAMESPACE")
-	tenantR := &TenantReconciler{logger: logger.WithName("tenant"), client: crMgr.GetClient(), resolver: resolver, master: master, releaseNamespace: releaseNamespace}
+	// In cluster mode the executor/buildermgr are bound cluster-wide via static
+	// ClusterRoleBindings (cluster-mode-bindings.yaml), so the controller must NOT
+	// also mint per-namespace workload RoleBindings for them — only the narrow
+	// fetcher/builder per-namespace RBAC. Passing an empty releaseNamespace to the
+	// reconciler makes namespaceRBACObjects skip the executor/buildermgr bindings.
+	tenantReleaseNamespace := releaseNamespace
+	if utils.ClusterTenancyEnabled() {
+		tenantReleaseNamespace = ""
+	}
+	tenantR := &TenantReconciler{logger: logger.WithName("tenant"), client: crMgr.GetClient(), resolver: resolver, master: master, releaseNamespace: tenantReleaseNamespace}
 	// Watch FissionTenant spec changes AND Namespace create/delete: the Ready
 	// condition and the resolver entry depend on whether the target namespace
 	// exists, which the FissionTenant watch alone cannot observe.
@@ -99,11 +108,19 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		Complete(tenantR); err != nil {
 		return fmt.Errorf("error registering fission-tenant reconciler: %w", err)
 	}
-	// The namespace reconciler triggers on the fission.io/enabled label rather
-	// than a generation change, so it overrides the default predicate.
+	// The namespace reconciler materializes Namespaces into FissionTenant CRs. In
+	// dynamic mode it triggers on the fission.io/enabled label; in cluster mode it
+	// auto-onboards every namespace (admit all; the reconciler excludes system /
+	// control-plane namespaces). Either way it overrides the default predicate.
+	nsReconciler := &NamespaceReconciler{logger: logger.WithName("namespace"), client: crMgr.GetClient()}
+	nsPredicate := enabledLabelPredicate()
+	if utils.ClusterTenancyEnabled() {
+		nsReconciler.autoOnboardAll = true
+		nsReconciler.releaseNamespace = releaseNamespace
+		nsPredicate = autoOnboardPredicate()
+	}
 	if err := controller.RegisterWithPredicates(crMgr, &corev1.Namespace{},
-		&NamespaceReconciler{logger: logger.WithName("namespace"), client: crMgr.GetClient()},
-		"fission-tenant-namespace", 0, enabledLabelPredicate()); err != nil {
+		nsReconciler, "fission-tenant-namespace", 0, nsPredicate); err != nil {
 		return fmt.Errorf("error registering tenant namespace reconciler: %w", err)
 	}
 
@@ -118,6 +135,21 @@ func enabledLabelPredicate() predicate.Predicate {
 	return predicate.NewPredicateFuncs(func(o client.Object) bool {
 		return o.GetLabels()[EnabledLabel] == "true"
 	})
+}
+
+// autoOnboardPredicate (cluster mode) admits Namespace create events only: every
+// existing namespace surfaces as an add on the informer's initial sync, and any
+// later namespace as a create, so the reconciler materializes a FissionTenant for
+// each exactly once. Label/spec updates change nothing (materialize is idempotent
+// and keyed on existence), and namespace deletes are handled by owner-reference GC
+// of the materialized FissionTenant — so neither needs to wake the reconciler.
+func autoOnboardPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return true },
+		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
 }
 
 // namespaceExistencePredicate admits only Namespace create and delete events —

--- a/pkg/timer/main.go
+++ b/pkg/timer/main.go
@@ -18,26 +18,12 @@ import (
 )
 
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, _ *errgroup.Group, routerUrl string) error {
-	fissionClient, err := clientGen.GetFissionClient()
-	if err != nil {
-		return fmt.Errorf("failed to get fission client: %w", err)
-	}
-	restConfig, err := clientGen.GetRestConfig()
-	if err != nil {
-		return fmt.Errorf("failed to get rest config: %w", err)
-	}
-
-	err = crd.WaitForFunctionCRDs(ctx, logger, fissionClient)
-	if err != nil {
-		return fmt.Errorf("error waiting for CRDs: %w", err)
-	}
-
 	// Active-passive HA via native controller-runtime leader election: only the
 	// elected leader schedules cron triggers, so two replicas don't double-fire
 	// timers. No-op when LEADER_ELECTION_ENABLED is unset (single-replica
-	// default). The TimeTrigger reconciler watches through the Manager's
-	// namespace-scoped cache and runs only on the elected leader.
-	crMgr, err := crmanager.NewLeaderElected(restConfig, "fission-timer", logger)
+	// default). The TimeTrigger reconciler watches through the Manager's cache and
+	// runs only on the elected leader.
+	crMgr, err := crmanager.NewTriggerManager(ctx, clientGen, "fission-timer", logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/crmanager/crmanager.go
+++ b/pkg/utils/crmanager/crmanager.go
@@ -71,13 +71,14 @@ func NewLeaderElected(restConfig *rest.Config, lockName string, logger logr.Logg
 // unchanged. The cache is inert until a controller registers an informer, so
 // this is harmless for Managers that only run non-reconciler runnables.
 func FissionCacheOptions() cache.Options {
-	if utils.DynamicNamespacesEnabled() {
-		// Cluster-wide cache: Fission-CRD informers see every namespace's CRs so
-		// a namespace can be onboarded/offboarded at runtime without rebuilding
-		// the Manager. Reconcilers drop non-tenant objects via
-		// controller.MembershipPredicate. This is the one cluster-wide read the
-		// dynamic-watch design adds, and only over Fission's own CRD types —
-		// these CRD-only Managers cache no core/workload type.
+	if utils.CrdWatchClusterWide() {
+		// Cluster-wide cache (dynamic OR cluster mode): Fission-CRD informers see
+		// every namespace's CRs so a namespace can be onboarded at runtime without
+		// rebuilding the Manager. In dynamic mode reconcilers drop non-tenant
+		// objects via controller.MembershipPredicate; in cluster mode every
+		// namespace is a tenant. This is the one cluster-wide read the watch design
+		// adds, and only over Fission's own CRD types — these CRD-only Managers
+		// cache no core/workload type.
 		return cache.Options{}
 	}
 	nsConfig := map[string]cache.Config{}

--- a/pkg/utils/crmanager/crmanager.go
+++ b/pkg/utils/crmanager/crmanager.go
@@ -12,6 +12,7 @@ package crmanager
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strconv"
 
@@ -21,10 +22,32 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
+	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/tenant"
 	"github.com/fission/fission/pkg/utils"
 )
+
+// NewTriggerManager is the shared bring-up for the trigger subsystems
+// (timer/kubewatcher/mqtrigger): resolve the Fission + REST clients, wait for the
+// Function CRDs to be served, and build the leader-elected Manager. lockName is the
+// per-subsystem Lease name passed to NewLeaderElected. Subsystems do their own
+// extra setup (e.g. kubewatcher's Kubernetes client, mqtrigger's queue) and then
+// register their reconciler on the returned Manager.
+func NewTriggerManager(ctx context.Context, clientGen crd.ClientGeneratorInterface, lockName string, logger logr.Logger) (ctrl.Manager, error) {
+	fissionClient, err := clientGen.GetFissionClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get fission client: %w", err)
+	}
+	restConfig, err := clientGen.GetRestConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get rest config: %w", err)
+	}
+	if err := crd.WaitForFunctionCRDs(ctx, logger, fissionClient); err != nil {
+		return nil, fmt.Errorf("error waiting for CRDs: %w", err)
+	}
+	return NewLeaderElected(restConfig, lockName, logger)
+}
 
 // NewLeaderElected builds a Manager whose only job is native leader election.
 // Its metrics and health-probe servers are disabled (the subsystem serves its

--- a/pkg/utils/crmanager/crmanager_test.go
+++ b/pkg/utils/crmanager/crmanager_test.go
@@ -45,11 +45,11 @@ func TestFissionCacheOptionsDynamic(t *testing.T) {
 	t.Cleanup(func() { r.SetTenants(orig) })
 	r.SetTenants(map[string]string{"ns-a": "ns-a"})
 
-	t.Setenv("FISSION_DYNAMIC_NAMESPACES", "true")
+	t.Setenv("FISSION_TENANCY_MODE", "dynamic")
 	assert.True(t, utils.DynamicNamespacesEnabled())
 	assert.Empty(t, FissionCacheOptions().DefaultNamespaces, "dynamic mode must use a cluster-wide cache")
 
-	t.Setenv("FISSION_DYNAMIC_NAMESPACES", "false")
+	t.Setenv("FISSION_TENANCY_MODE", "static")
 	assert.False(t, utils.DynamicNamespacesEnabled())
 	assert.Len(t, FissionCacheOptions().DefaultNamespaces, 1, "default mode stays per-namespace")
 }

--- a/pkg/utils/informer.go
+++ b/pkg/utils/informer.go
@@ -20,8 +20,15 @@ import (
 
 func GetInformerEventChecker(ctx context.Context, client kubernetes.Interface, reason string) map[string]cache.SharedInformer {
 	informers := make(map[string]cache.SharedInformer)
-	namespaces := DefaultNSResolver()
-	for _, ns := range namespaces.FissionNSWithOptions(WithBuilderNs(), WithFunctionNs(), WithDefaultNs()) {
+	// Cluster mode: function pods (and their websocket-connection events) live in
+	// any namespace, so watch Events cluster-wide via a single informer keyed ""
+	// (the executor holds the matching cluster-wide events read in cluster mode).
+	// Other modes build one per-namespace informer over the Fission namespaces.
+	watchNamespaces := listNamespaces(DefaultNSResolver().FissionNSWithOptions(WithBuilderNs(), WithFunctionNs(), WithDefaultNs()))
+	if ClusterTenancyEnabled() {
+		watchNamespaces = []string{metav1.NamespaceAll}
+	}
+	for _, ns := range watchNamespaces {
 		informers[ns] = cache.NewSharedInformer(
 			&cache.ListWatch{
 				ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -7,7 +7,6 @@ package utils
 import (
 	"maps"
 	"os"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -23,6 +22,31 @@ const (
 	ENV_BUILDER_NAMESPACE    string = "FISSION_BUILDER_NAMESPACE"
 	ENV_DEFAULT_NAMESPACE    string = "FISSION_DEFAULT_NAMESPACE"
 	ENV_ADDITIONAL_NAMESPACE string = "FISSION_RESOURCE_NAMESPACES"
+	// ENV_TENANCY_MODE selects the multi-namespace tenancy posture (see
+	// TenancyMode). The chart sets it from tenancy.mode.
+	ENV_TENANCY_MODE string = "FISSION_TENANCY_MODE"
+)
+
+// TenancyModeValue is the multi-namespace tenancy posture (chart value
+// tenancy.mode → env FISSION_TENANCY_MODE). See docs/multiple-namespace/prd.md §4.
+type TenancyModeValue string
+
+const (
+	// TenancyStatic (default): Fission resources only in the env-seeded namespace
+	// set; per-namespace Roles rendered by Helm; no tenant controller.
+	TenancyStatic TenancyModeValue = "static"
+	// TenancyDynamic: namespaces onboarded at runtime via FissionTenant CRs; the
+	// tenant controller provisions per-namespace fetcher/builder RBAC + derived
+	// HMAC keys; Fission-CRD caches go cluster-wide and reconcilers filter to the
+	// live tenant set; Tier-B (Secrets/ConfigMaps/workloads) stays per-namespace.
+	TenancyDynamic TenancyModeValue = "dynamic"
+	// TenancyCluster: opt-in trusted-cluster mode. The tenant controller
+	// auto-onboards every function-bearing namespace (no FissionTenant CR), so
+	// fetcher/builder pods keep their narrow per-namespace RBAC + per-namespace
+	// keys; the control plane (executor/buildermgr) reads Secrets/ConfigMaps and
+	// manages workloads cluster-wide for operational simplicity. Trades
+	// control-plane isolation for zero-ceremony coverage.
+	TenancyCluster TenancyModeValue = "cluster"
 )
 
 type (
@@ -250,14 +274,50 @@ func DefaultNSResolver() *NamespaceResolver {
 	return nsResolver
 }
 
-// DynamicNamespacesEnabled reports whether the dynamic multi-namespace watch
-// model is on (FISSION_DYNAMIC_NAMESPACES=true). When on, Fission-CRD caches are
-// cluster-wide and reconcilers filter to the live tenant set, so namespaces can
-// be onboarded/offboarded without a control-plane restart. Default off: the
-// per-namespace caches and behaviour are unchanged.
+// TenancyMode reports the configured multi-namespace tenancy posture from
+// FISSION_TENANCY_MODE. Unset or unrecognised → TenancyStatic (the safe default).
+func TenancyMode() TenancyModeValue {
+	switch TenancyModeValue(strings.ToLower(os.Getenv(ENV_TENANCY_MODE))) {
+	case TenancyDynamic:
+		return TenancyDynamic
+	case TenancyCluster:
+		return TenancyCluster
+	default:
+		return TenancyStatic
+	}
+}
+
+// DynamicNamespacesEnabled reports whether the dynamic per-namespace onboarding
+// model is on (tenancy.mode=dynamic). When on, Fission-CRD caches are cluster-wide
+// and reconcilers filter to the live tenant set, so namespaces can be
+// onboarded/offboarded without a control-plane restart. The shared cluster-wide
+// Fission-CRD watch is used by both dynamic and cluster mode (see
+// CrdWatchClusterWide); only the per-namespace Tier-B + tenant-membership
+// filtering is dynamic-specific.
 func DynamicNamespacesEnabled() bool {
-	v, _ := strconv.ParseBool(os.Getenv("FISSION_DYNAMIC_NAMESPACES"))
-	return v
+	return TenancyMode() == TenancyDynamic
+}
+
+// ClusterTenancyEnabled reports whether the opt-in trusted-cluster mode is on
+// (tenancy.mode=cluster). See TenancyCluster.
+func ClusterTenancyEnabled() bool {
+	return TenancyMode() == TenancyCluster
+}
+
+// CrdWatchClusterWide reports whether Fission-CRD informer caches should watch
+// all namespaces (Tier A). True in both dynamic and cluster mode; in dynamic mode
+// a tenant-membership predicate still filters reconciles to the onboarded set.
+func CrdWatchClusterWide() bool {
+	return TenancyMode() != TenancyStatic
+}
+
+// PerNamespaceKeysEnabled reports whether fetcher/builder pods use per-namespace
+// derived HMAC keys (rather than the master-derived service key). True in both
+// dynamic and cluster mode: the tenant controller provisions a per-namespace
+// derived-key Secret for every onboarded namespace in both, so fetcher/builder
+// stay least-privilege on the HMAC axis regardless of the control-plane posture.
+func PerNamespaceKeysEnabled() bool {
+	return TenancyMode() != TenancyStatic
 }
 
 // PerNamespaceKeyRequired reports whether a fetcher/builder pod scheduled into
@@ -267,8 +327,12 @@ func DynamicNamespacesEnabled() bool {
 // race-free. True only under dynamic tenancy, with internal auth enabled, for a
 // live tenant namespace: a non-tenant namespace never gets keys, so requiring one
 // there would wedge the pod in CreateContainerConfigError forever.
+//
+// True under dynamic OR cluster mode (both provision per-namespace derived keys —
+// cluster mode keeps fetcher/builder least-privilege on the HMAC axis too), with
+// internal auth enabled, for a live tenant namespace.
 func PerNamespaceKeyRequired(namespace string) bool {
-	return DynamicNamespacesEnabled() &&
+	return PerNamespaceKeysEnabled() &&
 		os.Getenv("FISSION_INTERNAL_AUTH_SECRET") != "" &&
 		DefaultNSResolver().IsTenant(namespace)
 }

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -324,13 +324,11 @@ func PerNamespaceKeysEnabled() bool {
 // `namespace` must mount its per-namespace derived HMAC key as a REQUIRED secret
 // ref — so the kubelet blocks pod start until the tenant controller has
 // provisioned it, making the executor/buildermgr's version-aware signing
-// race-free. True only under dynamic tenancy, with internal auth enabled, for a
-// live tenant namespace: a non-tenant namespace never gets keys, so requiring one
-// there would wedge the pod in CreateContainerConfigError forever.
-//
-// True under dynamic OR cluster mode (both provision per-namespace derived keys —
-// cluster mode keeps fetcher/builder least-privilege on the HMAC axis too), with
-// internal auth enabled, for a live tenant namespace.
+// race-free. True under dynamic OR cluster mode (both provision per-namespace
+// derived keys — cluster mode keeps fetcher/builder least-privilege on the HMAC
+// axis too), with internal auth enabled, for a live tenant namespace: a non-tenant
+// namespace never gets keys, so requiring one there would wedge the pod in
+// CreateContainerConfigError forever.
 func PerNamespaceKeyRequired(namespace string) bool {
 	return PerNamespaceKeysEnabled() &&
 		os.Getenv("FISSION_INTERNAL_AUTH_SECRET") != "" &&

--- a/pkg/utils/namespace.go
+++ b/pkg/utils/namespace.go
@@ -77,6 +77,11 @@ type (
 var nsResolver *NamespaceResolver
 
 func init() {
+	// Build the global resolver from the env at package load. Deliberately does NO
+	// logging here: init() runs before main() configures the logger (zap setup), so
+	// an init-time log would land on the default logger and couples state setup to
+	// logging. Subsystems that want the namespace set at startup log it themselves
+	// from their own (configured) logger via DefaultNSResolver().
 	nsResolver = &NamespaceResolver{
 		FunctionNamespace: os.Getenv(ENV_FUNCTION_NAMESPACE),
 		BuilderNamespace:  os.Getenv(ENV_BUILDER_NAMESPACE),
@@ -84,11 +89,6 @@ func init() {
 		fissionResourceNS: GetNamespaces(),
 		Logger:            loggerfactory.GetLogger(),
 	}
-
-	nsResolver.Logger.V(1).Info("namespaces", "function_namespace", nsResolver.FunctionNamespace,
-		"builder_namespace", nsResolver.BuilderNamespace,
-		"default_namespace", nsResolver.DefaultNamespace,
-		"fission_resource_namespace", listNamespaces(nsResolver.FissionResourceNamespaces()))
 }
 
 // listNamespaces => convert namespaces from map to slice

--- a/pkg/utils/namespace_test.go
+++ b/pkg/utils/namespace_test.go
@@ -325,3 +325,40 @@ func TestNamespaceResolverConcurrentAccess(t *testing.T) {
 
 	require.Contains(t, r.FissionResourceNamespaces(), "seed", "seed namespace must survive the churn")
 }
+
+func TestTenancyMode(t *testing.T) {
+	tests := []struct {
+		env          string // FISSION_TENANCY_MODE value; "" = unset
+		wantMode     TenancyModeValue
+		wantDynamic  bool
+		wantCluster  bool
+		wantCrdWide  bool
+		wantPerNSKey bool
+	}{
+		{"", TenancyStatic, false, false, false, false},
+		{"static", TenancyStatic, false, false, false, false},
+		{"dynamic", TenancyDynamic, true, false, true, true},
+		{"cluster", TenancyCluster, false, true, true, true},
+		// Case-insensitive + unknown falls back to static (the safe default).
+		{"Dynamic", TenancyDynamic, true, false, true, true},
+		{"CLUSTER", TenancyCluster, false, true, true, true},
+		{"bogus", TenancyStatic, false, false, false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.env, func(t *testing.T) {
+			if tt.env == "" {
+				t.Setenv(ENV_TENANCY_MODE, "")
+				_ = os.Unsetenv(ENV_TENANCY_MODE)
+			} else {
+				t.Setenv(ENV_TENANCY_MODE, tt.env)
+			}
+			assert.Equal(t, tt.wantMode, TenancyMode(), "TenancyMode")
+			assert.Equal(t, tt.wantDynamic, DynamicNamespacesEnabled(), "DynamicNamespacesEnabled")
+			assert.Equal(t, tt.wantCluster, ClusterTenancyEnabled(), "ClusterTenancyEnabled")
+			assert.Equal(t, tt.wantCrdWide, CrdWatchClusterWide(), "CrdWatchClusterWide")
+			assert.Equal(t, tt.wantPerNSKey, PerNamespaceKeysEnabled(), "PerNamespaceKeysEnabled")
+			// dynamic and cluster are mutually exclusive — never both true.
+			assert.False(t, DynamicNamespacesEnabled() && ClusterTenancyEnabled(), "modes must be mutually exclusive")
+		})
+	}
+}

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -69,13 +69,10 @@ manifests:
           serviceMonitor.namespace: monitoring
           storagesvc.archivePruner.enabled: "true"
           storagesvc.archivePruner.interval: "60"
-          # Multi-namespace tenancy is off by default; the dynamic-tenancy
-          # profile flips both flags on for the CI legs that exercise it. They
-          # must move together (the chart's validate.yaml fails the render
-          # otherwise): the dynamic data plane requires the controller to
-          # provision per-namespace auth keys.
-          tenancy.dynamicNamespaces: "false"
-          tenantController.enabled: "false"
+          # Multi-namespace tenancy is static by default; the dynamic-tenancy and
+          # cluster-tenancy profiles flip tenancy.mode for the CI legs that
+          # exercise each posture.
+          tenancy.mode: "static"
           terminationMessagePath: /var/log/termination-log
           terminationMessagePolicy: FallbackToLogsOnError
         setValueTemplates:
@@ -180,16 +177,21 @@ profiles:
   # onboarding model). Composed onto kind-ci as `-p kind-ci,dynamic-tenancy` on
   # the non-legacy CI legs, so the whole suite runs against a dynamic-mode
   # control plane (default is auto-seeded as a tenant by the migration job) and
-  # TestDynamicTenantLifecycle exercises runtime namespace onboarding. Both flags
-  # flip together — the chart's validate.yaml fails the render if they diverge.
+  # TestDynamicTenantLifecycle exercises runtime namespace onboarding.
   - name: dynamic-tenancy
     patches:
       - op: replace
-        path: /manifests/helm/releases/0/setValues/tenancy.dynamicNamespaces
-        value: true
+        path: /manifests/helm/releases/0/setValues/tenancy.mode
+        value: dynamic
+  # cluster-tenancy turns on the opt-in trusted-cluster watch-all model. Composed
+  # onto kind-ci as `-p kind-ci,cluster-tenancy` on one CI leg, so the suite runs
+  # against a cluster-mode control plane (every namespace auto-onboarded, control
+  # plane reads cluster-wide). Mirrors dynamic-tenancy / the RFC-0002 legacy-pin.
+  - name: cluster-tenancy
+    patches:
       - op: replace
-        path: /manifests/helm/releases/0/setValues/tenantController.enabled
-        value: true
+        path: /manifests/helm/releases/0/setValues/tenancy.mode
+        value: cluster
   - name: kind-ci-old
     patches:
       - op: replace

--- a/test/integration/framework/tenant.go
+++ b/test/integration/framework/tenant.go
@@ -8,7 +8,7 @@ package framework
 
 import (
 	"context"
-	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,20 +27,35 @@ import (
 // DynamicNamespacesEnabled lets a test skip itself otherwise, mirroring the
 // RFC-0002/0013 gate-detection helpers (RouterEndpointSliceMode etc.).
 
-// DynamicNamespacesEnabled reports whether the cluster runs the dynamic
-// multi-namespace tenancy model, read from FISSION_DYNAMIC_NAMESPACES on the
-// executor Deployment (the chart sets it on every control-plane Deployment via
-// the fission-resource-namespace.envs helper). The tenancy lifecycle test skips
-// itself when it is off, so the static-namespace CI leg stays a no-op for it.
-func (f *Framework) DynamicNamespacesEnabled(t *testing.T, ctx context.Context) bool {
+// TenancyMode reports the cluster's configured tenancy posture
+// (static|dynamic|cluster), read from FISSION_TENANCY_MODE on the executor
+// Deployment (the chart sets it on every control-plane Deployment via the
+// fission-resource-namespace.envs helper). Unset → "static" (production default).
+func (f *Framework) TenancyMode(t *testing.T, ctx context.Context) string {
 	t.Helper()
 	dep, err := f.kubeClient.AppsV1().Deployments(f.FissionNamespace()).Get(ctx, executorDeploymentName, metav1.GetOptions{})
-	require.NoErrorf(t, err, "DynamicNamespacesEnabled: get executor Deployment")
-	v, _ := executorEnvValue(dep, "FISSION_DYNAMIC_NAMESPACES")
-	// Parse like production (utils.DynamicNamespacesEnabled) so "1"/"True"/etc.
-	// agree with the cluster's own interpretation, not just the chart's "true".
-	on, _ := strconv.ParseBool(v)
-	return on
+	require.NoErrorf(t, err, "TenancyMode: get executor Deployment")
+	v, _ := executorEnvValue(dep, "FISSION_TENANCY_MODE")
+	if v == "" {
+		return "static"
+	}
+	return strings.ToLower(v)
+}
+
+// DynamicNamespacesEnabled reports whether the cluster runs the dynamic
+// multi-namespace tenancy model (tenancy.mode=dynamic). The tenancy lifecycle
+// test skips itself when it is off, so the static/cluster CI legs stay a no-op
+// for it.
+func (f *Framework) DynamicNamespacesEnabled(t *testing.T, ctx context.Context) bool {
+	t.Helper()
+	return f.TenancyMode(t, ctx) == "dynamic"
+}
+
+// ClusterTenancyEnabled reports whether the cluster runs the opt-in
+// trusted-cluster mode (tenancy.mode=cluster).
+func (f *Framework) ClusterTenancyEnabled(t *testing.T, ctx context.Context) bool {
+	t.Helper()
+	return f.TenancyMode(t, ctx) == "cluster"
 }
 
 // NewTestNamespaceIn creates a real Kubernetes namespace and returns a

--- a/test/integration/suites/serial/cluster_tenant_test.go
+++ b/test/integration/suites/serial/cluster_tenant_test.go
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package serial_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestClusterTenantAutoOnboard exercises the opt-in trusted-cluster mode: a
+// function runs in a brand-new, never-declared namespace with NO FissionTenant
+// ceremony (the controller auto-onboards it), and the fetcher's grant in that
+// namespace stays least-privilege — a per-namespace RoleBinding, never a
+// cluster-wide ClusterRoleBinding. That least-privilege guarantee is the whole
+// reason cluster mode runs the controller instead of binding fetcher cluster-wide.
+//
+// Serial because it mutates the cluster-wide watched set (auto-onboard) and
+// asserts no control-plane pod restarted. Skips itself unless tenancy.mode=cluster.
+func TestClusterTenantAutoOnboard(t *testing.T) {
+	// Not t.Parallel(): see the doc comment. 15m covers the control-plane-stable
+	// wait + a cold-start invoke (poolmgr spin-up + first specialization) in a
+	// freshly auto-onboarded namespace, after the other serial tests.
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Minute)
+	t.Cleanup(cancel)
+
+	f := framework.Connect(t)
+	if !f.ClusterTenancyEnabled(t, ctx) {
+		t.Skip("tenancy.mode is not cluster; this leg runs a different tenancy model")
+	}
+	pyImage := f.Images().RequirePython(t)
+
+	// Settle any rollout from a prior serial test, then snapshot the control plane:
+	// auto-onboarding a new namespace must restart nothing.
+	f.WaitForControlPlaneStable(t, ctx, 3*time.Minute)
+	before := f.ControlPlanePodUIDs(t, ctx)
+
+	// A namespace that did not exist at install time and is NEVER explicitly
+	// enabled — the auto-onboard path's reason to exist.
+	tenantNS := "fission-cluster-e2e-" + framework.RandomID()
+	ns := f.NewTestNamespaceIn(t, ctx, tenantNS)
+
+	// 1. Creating the namespace is the only trigger: the controller auto-materializes
+	//    a FissionTenant and provisions the namespace's fetcher/builder RBAC + key.
+	//    We assert readiness WITHOUT calling EnableTenant — that is the difference
+	//    from dynamic mode.
+	f.WaitForTenantReady(t, ctx, tenantNS)
+
+	// 2. The fetcher's grant must be a per-namespace RoleBinding to the
+	//    fetcher-tenant-workload ClusterRole — least privilege. It must NOT be a
+	//    ClusterRoleBinding (which would let the fetcher read Secrets cluster-wide).
+	rb, err := f.KubeClient().RbacV1().RoleBindings(tenantNS).Get(ctx, fv1.FissionFetcherSA, metav1.GetOptions{})
+	require.NoError(t, err, "the controller must provision a per-namespace fetcher RoleBinding")
+	assert.Equal(t, "ClusterRole", rb.RoleRef.Kind, "fetcher RoleBinding references a ClusterRole by name")
+	assert.Equal(t, fv1.FetcherTenantWorkloadClusterRole, rb.RoleRef.Name, "fetcher binds the narrow fetcher-tenant-workload rules")
+
+	crbs, err := f.KubeClient().RbacV1().ClusterRoleBindings().List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "list ClusterRoleBindings")
+	for i := range crbs.Items {
+		for _, s := range crbs.Items[i].Subjects {
+			if s.Kind == "ServiceAccount" && s.Name == fv1.FissionFetcherSA && s.Namespace == tenantNS {
+				t.Fatalf("fetcher SA in %q is bound cluster-wide by ClusterRoleBinding %q — cluster mode must keep fetcher per-namespace",
+					tenantNS, crbs.Items[i].Name)
+			}
+		}
+	}
+
+	// 3. Run a function in the auto-onboarded namespace, end to end.
+	envName := "python-" + ns.ID
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: pyImage, Poolsize: 1})
+
+	fnName := "hello-" + ns.ID
+	codePath := framework.WriteTestData(t, "python/hello/hello.py")
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: fnName, Env: envName, Code: codePath})
+
+	routeURL := "/" + fnName
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: routeURL, Method: "GET"})
+
+	// The namespace-explicit internal route proves the executor specialized a pod in
+	// the auto-onboarded namespace (whose fetcher used the namespace's own derived
+	// HMAC key), and the public HTTPTrigger proves the router admitted the trigger.
+	r := f.Router(t)
+	body := r.GetEventually(t, ctx, "/fission-function/"+tenantNS+"/"+fnName, framework.BodyContains("hello"))
+	require.Contains(t, strings.ToLower(body), "hello")
+	r.GetEventually(t, ctx, routeURL, framework.BodyContains("hello"))
+
+	// 4. Auto-onboarding + serving a fresh namespace must not have rolled any
+	//    control-plane pod.
+	f.AssertNoControlPlaneRestart(t, ctx, before)
+
+	// 5. Cleanup: the namespace (and its owner-referenced FissionTenant + RBAC) is
+	//    removed by the NewTestNamespaceIn cleanup hook.
+}

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -28,7 +28,7 @@ import (
 // It lives in the serial suite because it onboards a tenant (mutating the
 // cluster-wide watched set) and asserts that no control-plane pod restarted,
 // which the parallel suite's churn would invalidate. It skips itself on the
-// static-namespace CI leg (FISSION_DYNAMIC_NAMESPACES off), matching how the
+// static/cluster CI legs (tenancy.mode != dynamic), matching how the
 // RFC-0002/0013 gate-dependent tests detect their mode.
 func TestDynamicTenantLifecycle(t *testing.T) {
 	// Deliberately NOT t.Parallel(): see the doc comment. 15m (matching the adopt
@@ -40,7 +40,7 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 
 	f := framework.Connect(t)
 	if !f.DynamicNamespacesEnabled(t, ctx) {
-		t.Skip("FISSION_DYNAMIC_NAMESPACES is off; this leg runs the static namespace model")
+		t.Skip("tenancy.mode is not dynamic; this leg runs a different tenancy model")
 	}
 	pyImage := f.Images().RequirePython(t)
 


### PR DESCRIPTION
## Summary

Final multi-namespace tenancy phase (Phase 6): the opt-in **`tenancy.mode: cluster`** trusted-cluster posture, plus the tenancy config/code cleanup folded in. Replaces the two-bool config (`tenancy.dynamicNamespaces` + `tenantController.enabled`) with a single enum **`tenancy.mode: static | dynamic | cluster`** (default `static`).

| | static (default) | dynamic | **cluster (new)** |
|---|---|---|---|
| Onboarding | env-seeded set | explicit FissionTenant CR | **auto: every non-system namespace** |
| **Fetcher/builder RBAC** | per-ns Roles | per-ns RoleBindings | **per-ns RoleBindings (least-privilege kept)** |
| Per-ns derived HMAC keys | no (master) | yes | **yes (least-privilege kept)** |
| Control-plane Tier-B cache + RBAC | per-ns | per-ns | **cluster-wide** |

## Design: least-privilege cluster mode

Per maintainer steer, cluster mode does **not** give function pods cluster-wide secret read (the literal PRD §4.5 "PR #3476 model"). Instead the tenant controller **auto-onboards** every namespace (no FissionTenant ceremony), provisioning the **same narrow per-namespace** fetcher/builder SA + RoleBinding + derived key the dynamic path does. Only the **control plane** (executor/buildermgr) goes cluster-wide — the operational simplification cluster mode trades isolation for. The privileged `bind` verb stays isolated in the dedicated controller (PRD §4.3).

## ⚠️ Security trade-off (cluster mode only, opt-in)

In `cluster` mode the executor/buildermgr ServiceAccounts hold **cluster-wide read of Secrets/ConfigMaps** (`cluster-mode-bindings.yaml`). A compromise of either reaches every namespace's Secrets. This is the documented cost of the trusted-cluster posture — **use only on single-tenant/trusted clusters**. `static` (default) and `dynamic` are unchanged and remain the recommendation for untrusted multi-tenant clusters. Function pods (fetcher/builder) stay least-privilege in **every** mode.

## What's in here

1. **Config enum** — `tenancy.mode`; env `FISSION_DYNAMIC_NAMESPACES`→`FISSION_TENANCY_MODE`; `validate.yaml` fails closed on an unknown mode. Render verified **byte-identical (modulo the env rename)** for static-vs-old-default and dynamic-vs-old-`dynamicNamespaces=true`.
2. **Cluster-wide caches** — executor Tier-B (Secret/ConfigMap/ReplicaSet), router EndpointSlice, logger pods, poolmgr event-checker. All gated on `ClusterTenancyEnabled()`; inert otherwise.
3. **Controller auto-onboarding** — materializes a FissionTenant per non-system namespace; provisions with `releaseNamespace=""` so per-ns executor/buildermgr bindings are skipped (they're cluster-wide instead).
4. **Cluster RBAC** — `cluster-mode-bindings.yaml` (executor/buildermgr/router/fluentbit cluster-wide), rendered only in cluster mode.
5. **CI** — the v1.36.1 leg now runs `tenancy.mode=cluster` (1.32=dynamic, 1.34=static, 1.36=cluster — one posture each); new serial `TestClusterTenantAutoOnboard` runs a function in a fresh, never-declared namespace and asserts the fetcher grant is a **per-namespace RoleBinding, not a ClusterRoleBinding**.
6. **Cleanup** — `crmanager.NewTriggerManager` dedupes timer/kubewatcher/mqtrigger bring-up; removed the dead legacy Role reaper + grant; decoupled init-time logging; removed obsolete "later phase" comments.

## Testing

- Full `golangci-lint` (0 issues), `make license-check`, all affected unit tests, `helm lint` × 3 modes — green locally.
- New unit tests: `TestTenancyMode` (enum precedence), `executorCacheOptions` cluster branch, `NamespaceReconciler` auto-onboard (+ system-namespace exclusion).
- New integration test on the cluster CI leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)