### PR TITLE
docs(tenancy): refresh multi-namespace status docs for the completed effort

### DIFF
--- a/docs/multiple-namespace/README.md
+++ b/docs/multiple-namespace/README.md
@@ -7,6 +7,9 @@ These are living planning + implementation-tracking docs; they stay here until t
 
 **Approach in one line:** declarative `FissionTenant` CRD + label, dynamic per-namespace watching (zero restart), and per-namespace derived HMAC keys (master never leaves the control plane) — least-privilege preserved throughout.
 
+**Status:** functionally complete.
+A single chart value, `tenancy.mode: static | dynamic | cluster`, selects the posture; the critical-path implementation, the full per-namespace key security story, and all three modes have shipped (see [Tenancy modes](#tenancy-modes) and [Phase status](#phase-status)).
+
 ---
 
 ## Documents
@@ -35,21 +38,45 @@ Add implementation notes, decision logs, and sub-task trackers to this folder as
 
 ---
 
+## Tenancy modes
+
+Set `tenancy.mode` in the Helm values (default `static`).
+It replaced the older `tenancy.dynamicNamespaces` + `tenantController.enabled` booleans (removed in #3502).
+
+| Mode | Where Fission runs | Onboarding | Control-plane reads | Use when |
+|---|---|---|---|---|
+| `static` (default) | the env-seeded set (`defaultNamespace` + `additionalFissionNamespaces`) | install-time only | per-namespace Roles, scoped caches | single namespace, or a fixed known set; behaves exactly like pre-tenancy Fission |
+| `dynamic` | any namespace onboarded at runtime | `fission tenant enable <ns>` **or** the `fission.io/enabled=true` label — **no control-plane restart** | per-namespace Roles + per-namespace derived HMAC keys; **tenant Secrets/ConfigMaps never in a cluster-wide cache** | untrusted multi-tenant clusters (the recommended isolating posture) |
+| `cluster` | **any** namespace, automatically | the controller auto-onboards every namespace (no CR/label needed) | executor/buildermgr read Secrets/ConfigMaps and manage workloads **cluster-wide** | single-tenant / trusted clusters that value simplicity over isolation |
+
+**Least-privilege holds in every mode:** function pods (fetcher/builder) always get a narrow per-namespace RoleBinding and per-namespace derived HMAC key — even in `cluster` mode the controller provisions those per namespace; only the control plane goes cluster-wide. ⚠️ **`cluster` mode trade-off:** a compromised executor/buildermgr can read any namespace's Secrets — use it only on trusted clusters.
+
+**Opting a namespace out of `cluster` mode:** label it `fission.io/enabled=false`.
+The controller skips it (and offboards it, tearing down its Fission RBAC/keys, if it was already auto-onboarded).
+Removing the label re-onboards it.
+The `fission.io/enabled` label is thus a symmetric override: `true` opts in (dynamic mode), `false` opts out (cluster mode), absent = the mode default.
+
+---
+
 ## Phase status
+
+All phases shipped as separate PRs off `main` (not the original `feat/multi-namespace-tenancy` branch).
 
 | Phase | Summary | Status |
 |---|---|---|
-| 0 | Thread-safe `NamespaceResolver` (setter + change feed) | Not started |
-| 1 | FissionTenant CRD + `--tenantController` + CLI | Not started |
-| 2 | Helm migration Job — **fixes #3298 (zero restart)** | Not started |
-| 3 | Tier-A cluster-wide cache + membership predicate | Not started |
-| 4 | Tier-B dynamic per-namespace cache + RBAC provisioning | Not started |
-| 5 | Per-namespace derived HMAC keys | Not started |
-| 6 | Opt-in `tenancy.mode: cluster` (watch-all) | Not started |
-| 7 | Archive ns-prefix (storagesvc content isolation) — follow-up | Not started |
+| 0 | Thread-safe `NamespaceResolver` (setter + change feed) | ✅ Shipped (#3497) |
+| 1 | FissionTenant CRD + `--tenantController` + CLI | ✅ Shipped (#3497) |
+| 2 | Helm migration Job — **fixes #3298 (zero restart)** | ✅ Shipped (#3497) |
+| 3 | Tier-A cluster-wide cache + membership predicate + cross-process resolver-sync | ✅ Shipped (#3497) |
+| 4 | Executor Tier-A cache + per-namespace fetcher/builder/workload RBAC provisioning | ✅ Shipped (#3497) |
+| 5 | Per-namespace derived HMAC keys (fetcher, storagesvc, builder) + master-drop | ✅ Shipped (#3497) |
+| 7 | Archive ns-prefix (storagesvc archive-content isolation) | ✅ Shipped (#3500) |
+| — | RBAC unification — single-source fetcher/builder rules across Go ↔ Helm + admission policy | ✅ Shipped (#3501) |
+| 6 | Opt-in `tenancy.mode: cluster` (watch-all) + config converged to the `tenancy.mode` enum | ✅ Shipped (#3502) |
+| 4b | Tier-B dynamic per-namespace Secret/ConfigMap caches (RFC-0004 recycle in runtime-onboarded namespaces, **dynamic mode only**) | ⏳ Remaining — see [implementation-status.md](./implementation-status.md) |
 
-Phases 0–2 close the filed issue with zero security regression.
-Phases 3–5 deliver true multi-tenant isolation.
+Phases 0–2 close the filed issue with zero security regression; phases 3–5 deliver true multi-tenant isolation; phases 6–7 add the trusted-cluster opt-in and archive-content isolation.
+Remaining items (the dynamic-mode Tier-B recycle refinement + optional hardening) are tracked in [implementation-status.md](./implementation-status.md); none block any mode from working.
 
 ---
 

--- a/docs/multiple-namespace/implementation-status.md
+++ b/docs/multiple-namespace/implementation-status.md
@@ -1,43 +1,51 @@
 # Implementation status
 
-This tracks the PRD (`prd.md`) against what has shipped on the `feat/multi-namespace-tenancy` branch.
-Everything is gated behind `tenancy.dynamicNamespaces` / `FISSION_DYNAMIC_NAMESPACES` (default off), so a default install is byte-identical to before.
+This tracks the PRD (`prd.md`) against what has shipped.
+Everything is gated behind `tenancy.mode` (default `static`), so a default install is byte-identical to before tenancy existed.
+
+The effort shipped as a sequence of separate PRs off `main` (not the original `feat/multi-namespace-tenancy` branch): the dynamic-tenancy critical path (#3497), archive-content isolation (#3500), the Go↔Helm RBAC unification (#3501), and the `tenancy.mode=cluster` opt-in + config convergence (#3502).
 
 ## Shipped
 
-The critical-path implementation and the full security story are complete.
-A namespace onboarded at runtime — via `fission tenant enable <ns>` or the `fission.io/enabled=true` label — is served end-to-end with **no control-plane restart**: the router routes it, the executor pools and specializes in it, the buildermgr builds in it, and it is isolated by per-namespace HMAC keys.
+The critical-path implementation and the full security story are complete, across all three modes (`static` / `dynamic` / `cluster` — see [README.md](./README.md#tenancy-modes)).
+A namespace onboarded at runtime in `dynamic` mode — via `fission tenant enable <ns>` or the `fission.io/enabled=true` label — is served end-to-end with **no control-plane restart**: the router routes it, the executor pools and specializes in it, the buildermgr builds in it, and it is isolated by per-namespace HMAC keys.
+In `cluster` mode the controller auto-onboards every namespace (opt out with `fission.io/enabled=false`), keeping fetcher/builder least-privilege per namespace while the control plane reads cluster-wide.
 
-| PRD phase | What shipped | Key commits |
+| PRD phase | What shipped | PR |
 |---|---|---|
-| 0 — thread-safe resolver | `NamespaceResolver` behind a `RWMutex` + change feed + `IsTenant` | `d620b2f7` |
-| 1 — onboarding surface | `FissionTenant` CRD (cluster-scoped) + `--tenantController` + `fission tenant` CLI | `09f231f3`, `d0f65632`, `99e0c259` |
-| 2 — #3298 fix | one-shot seed Job migrates `additionalFissionNamespaces` → CRs on upgrade, env unchanged | `c17c2100` |
-| 3 — dynamic discovery | membership predicate + gated cluster-wide CRD cache + tenant-scoped reconcilers + **cross-process resolver-sync** (router, buildermgr, the four trigger managers, executor) | `2dfd43d6`, `d418f24e`, `e5969e50`, `f3448249` |
-| 4 — least-privilege provisioning | tenant controller provisions per-namespace fetcher/builder RBAC, **executor Tier-A cluster-wide cache** (Secrets/ConfigMaps/ReplicaSets stay namespace-scoped), and **executor/buildermgr workload RBAC** in tenant namespaces | `176aee41`, `1c253897`, `333af025` |
-| 5 — per-namespace HMAC keys | namespace-scoped derivation, version-aware signing on executor + buildermgr, the controller-owned derived-key Secret, the **master-drop** (master never in a tenant namespace), and the builder `/build` channel | `22978d16`, `5b60c454`, `16d248ab`, `6b770dd2`, `dafe9f67`, `2e939d66` |
+| 0 — thread-safe resolver | `NamespaceResolver` behind a `RWMutex` + change feed + `IsTenant` | #3497 |
+| 1 — onboarding surface | `FissionTenant` CRD (cluster-scoped) + `--tenantController` + `fission tenant` CLI | #3497 |
+| 2 — #3298 fix | one-shot seed Job migrates `additionalFissionNamespaces` → CRs on upgrade, env unchanged | #3497 |
+| 3 — dynamic discovery | membership predicate + cluster-wide CRD cache + tenant-scoped reconcilers + cross-process resolver-sync (router, buildermgr, the four trigger managers, executor) | #3497 |
+| 4 — least-privilege provisioning | controller provisions per-namespace fetcher/builder RBAC; executor Tier-A cluster-wide cache (Secrets/ConfigMaps/ReplicaSets stay namespace-scoped); executor/buildermgr workload RBAC in tenant namespaces | #3497 |
+| 5 — per-namespace HMAC keys | namespace-scoped derivation, version-aware signing on executor + buildermgr, controller-owned derived-key Secret, the master-drop (master never in a tenant namespace), and the builder `/build` channel | #3497 |
+| 7 — archive ns-prefix | `_tenant_/<ns>/<uuid>` storagesvc archive IDs + verifier-reports-principal authz (path-traversal-guarded) for true archive-content isolation | #3500 |
+| — RBAC unification | fetcher/builder rules single-sourced across Go and Helm (`_tenant-workload-roles.tpl`); a `ValidatingAdmissionPolicy` pins which SAs the controller may bind | #3501 |
+| 6 — `tenancy.mode=cluster` | opt-in trusted-cluster watch-all (cluster-wide Tier-B cache + control-plane ClusterRoleBindings); the controller auto-onboards every namespace with a `fission.io/enabled=false` opt-out; config converged from the `dynamicNamespaces`/`tenantController.enabled` booleans to the single `tenancy.mode` enum | #3502 |
 
 All three namespace-scoped channels (fetcher, storagesvc, builder) derive and verify per-namespace keys; the master-derived control-plane channels (executor, router-internal) are unchanged.
-Three review rounds were completed, with every finding fixed.
 
 ## Test coverage
 
-The implementation is comprehensively unit-tested: the security-critical invariant that the executor's Secret/ConfigMap cache is **never** cluster-wide is test-locked (`TestExecutorCacheOptionsTierSplit`), as are the version-aware signing decisions, the resolver-sync, the per-namespace key provisioning, the workload RoleBindings, and the required-key gating.
+Comprehensively unit-tested: the security-critical invariant that the executor's Secret/ConfigMap cache is **never** cluster-wide in `dynamic` mode is test-locked (`TestExecutorCacheOptionsTierSplit`, which also pins the deliberate cluster-wide widening in `cluster` mode), as are the version-aware signing decisions, the resolver-sync, the per-namespace key provisioning, the workload RoleBindings, the `tenancy.mode` enum precedence, and the cluster-mode auto-onboard + opt-out reconciler.
 
-CI exercises the **dynamic-off** path on every commit (so no regression is possible to the default install) but does not yet deploy a dynamic-mode cluster.
+Integration CI exercises **one posture per k8s leg** so every mode stays covered: `v1.32.11` = `dynamic` (the serial `TestDynamicTenantLifecycle` onboards a fresh namespace at runtime and asserts no restart), `v1.36.1` = `cluster` (the serial `TestClusterTenantAutoOnboard` runs a function in a fresh auto-onboarded namespace and asserts the fetcher's grant stays a per-namespace RoleBinding, never a ClusterRoleBinding), `v1.34.8` = `static`.
 
-## Remaining (validation + optional refinements — not on the critical path)
+## Remaining (refinements + optional hardening — not on the critical path)
 
-These do not block the feature working; they are validation infrastructure and optional enhancements, each of which warrants its own focused change.
+None of these block any mode from working; each warrants its own focused change.
 
-- **Gated dynamic-mode integration leg.**
-  CI currently deploys only the default (dynamic-off) profile, so the runtime onboarding path is unit-tested but not integration-tested.
-  Proving it in CI needs a new job that deploys with `tenancy.dynamicNamespaces=true` + `tenantController.enabled=true` plus a serial test that records control-plane pod UIDs, onboards a namespace at runtime, and asserts no restart and an invocable function (PRD §10).
-  This is a deliberate decision because it roughly doubles the integration CI time.
-- **Phase 4b — Tier-B dynamic caches.**
-  The executor's Secret/ConfigMap watch is namespace-scoped to the env-seeded set; functions in a runtime-onboarded namespace work (the fetcher reads Secrets directly), but the RFC-0004 pod-recycle-on-config-change does not yet follow a config change in a runtime-onboarded namespace.
-  Closing this needs a dynamic per-namespace `cluster.Cluster` with reliable teardown — the PRD's highest-risk new code.
-- **Phase 6 — `tenancy.mode=cluster`.**
-  An explicit opt-in that collapses to a single cluster-wide cache + ClusterRoles for trusted single-tenant clusters.
-- **Phase 7 — archive namespace-prefix.**
-  Namespace-prefixed storagesvc archive IDs for true archive-content isolation (the interim barrier is UUID-unguessability + NetworkPolicy).
+- **Phase 4b — Tier-B dynamic caches (dynamic mode only).**
+  The executor's Secret/ConfigMap watch is namespace-scoped to the env-seeded set, so in `dynamic` mode a function in a runtime-onboarded namespace works (the fetcher reads Secrets directly) but RFC-0004 pod-recycle-on-config-change does not yet follow a config change in that namespace.
+  Closing it needs a dynamic per-namespace `cluster.Cluster` with reliable teardown — the PRD's highest-risk new code.
+  (`cluster` mode does not have this gap; its cache is cluster-wide.)
+- **Builder `/build` channel verification.**
+  The builder *container* has no master env wired by buildermgr, so `/build` is pass-through today (buildermgr ns-signs, the builder does not verify).
+  An additive hardening.
+- **Per-namespace key rotation.**
+  Derived keys are create-once; rotating a tenant's key currently means offboard → re-onboard.
+  A proper SSA-reconcile rotation path is a follow-up.
+- **`functionNamespace` / `builderNamespace` immutability.**
+  `fission tenant enable` can overwrite a tenant's function/builder namespace with no orphan cleanup of the old one — flagged in review, needs a codegen-backed immutability marker.
+- **Minor polish.**
+  Storagesvc spec-apply uploads stay unscoped (dedup-by-checksum follow-up); `ParseTenancyMode`/warn-on-invalid-mode (deferred — the chart already fails the render on a bad value); a reserved-namespace denylist beyond the system ones; a chart-render CI assertion for the mode-gated objects.


### PR DESCRIPTION
## Summary

Docs-only refresh of `docs/multiple-namespace/` now that the multi-namespace tenancy effort is functionally complete. The two status docs were stale — the README phase table still read "Not started" for every phase, and `implementation-status.md` still listed Phases 6/7 and the dynamic-mode CI leg as remaining, all of which have shipped (#3497 phases 0–5, #3500 phase 7, #3501 RBAC unification, #3502 phase 6 + the `tenancy.mode` config convergence).

## Changes

- **README.md**
  - Phase-status table corrected to ✅ Shipped with PR references.
  - New **Tenancy modes** section: a user-facing reference for `tenancy.mode: static | dynamic | cluster` (what each does, onboarding, control-plane read scope, when to use), the least-privilege-in-every-mode guarantee + the documented `cluster`-mode Secret-read trade-off, and the `fission.io/enabled=false` cluster opt-out label (a symmetric override: `true` opts in, `false` opts out).
- **implementation-status.md**
  - Shipped table rewritten against the real PRs and the `tenancy.mode` enum.
  - CI-coverage description updated (one tenancy posture per k8s leg: 1.32=dynamic, 1.34=static, 1.36=cluster).
  - Remaining trimmed to the actual follow-ups: Phase 4b (dynamic-mode Tier-B recycle), builder `/build` verification, key rotation, `functionNamespace` immutability, minor polish.

No code, no rendered-output changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)