### PR TITLE
ci(integration): serialise pod DNS A/AAAA queries to stop CoreDNS i/o-timeout flakes

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -164,6 +164,25 @@ jobs:
           esac
           SKAFFOLD_PROFILE="$PROFILE" make skaffold-deploy
 
+      # The 6-way-parallel integration suite resolves short in-cluster names
+      # (executor.fission, storagesvc.fission, router-internal.fission, ...) on
+      # every cold-start RPC. Go's resolver fires the A and AAAA queries
+      # concurrently; on this single-node kind cluster the two UDP datagrams
+      # race through kube-proxy's DNAT and are intermittently dropped, surfacing
+      # as "lookup executor.fission: i/o timeout" cascades that fail dozens of
+      # otherwise-passing tests at once. single-request-reopen serialises the
+      # A/AAAA queries (Go's resolver honours the resolv.conf option), removing
+      # the race. CI-only hardening of the control-plane pods.
+      - name: Harden in-cluster DNS for the parallel test load
+        timeout-minutes: 6
+        run: |
+          set -euo pipefail
+          kubectl -n fission patch deploy --all --type merge -p \
+            '{"spec":{"template":{"spec":{"dnsConfig":{"options":[{"name":"single-request-reopen"}]}}}}}'
+          for d in $(kubectl -n fission get deploy -o name); do
+            kubectl -n fission rollout status "$d" --timeout=5m
+          done
+
       # Pin the v1.34 leg back to the legacy data plane (RFC-0002 gates off):
       # kind-ci deploys with the EndpointSlice path on everywhere, so without
       # this the executor-RPC warm path would lose all CI coverage. The

--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -177,8 +177,12 @@ jobs:
         timeout-minutes: 6
         run: |
           set -euo pipefail
-          kubectl -n fission patch deploy --all --type merge -p \
-            '{"spec":{"template":{"spec":{"dnsConfig":{"options":[{"name":"single-request-reopen"}]}}}}}'
+          # kubectl patch takes no --all, so patch each Deployment, then wait
+          # for every rollout (patch-all-first so the rollouts run in parallel).
+          for d in $(kubectl -n fission get deploy -o name); do
+            kubectl -n fission patch "$d" --type merge -p \
+              '{"spec":{"template":{"spec":{"dnsConfig":{"options":[{"name":"single-request-reopen"}]}}}}}'
+          done
           for d in $(kubectl -n fission get deploy -o name); do
             kubectl -n fission rollout status "$d" --timeout=5m
           done


### PR DESCRIPTION
## Problem

Integration legs intermittently fail *en masse* with the control plane unable to reach itself:

```
error from GetServiceForFunction ... Post "http://executor.fission/v2/getServiceForFunction":
dial tcp: lookup executor.fission: i/o timeout
```

Observed on a `v1.36.1` leg: **132** `lookup executor.fission: i/o timeout` log lines and **63 test failures** in one run — while the *same commit* passed on the `v1.32` and `v1.34` legs. No control-plane pod crashed or restarted; CoreDNS simply couldn't answer in time.

## Root cause

The suite runs **6-way parallel**, and every cold-start RPC resolves a short in-cluster name (`executor.fission`, `storagesvc.fission`, `router-internal.fission`, …). Go's resolver fires the **A and AAAA queries concurrently**. On the **single-node** kind cluster both UDP datagrams traverse kube-proxy's DNAT, where the well-known [conntrack insert race](https://github.com/kubernetes/kubernetes/issues/56903) intermittently drops one — a 5s resolver timeout. Because the router→executor RPC underpins *every* function invocation, one storm cascades into dozens of unrelated test failures (TestNodeHelloHTTP, TestJVM*, TestMCP*, TestKubernetesWatchTrigger, … all timing out at 120s).

## Fix

Patch the `fission` control-plane deployments with:

```yaml
dnsConfig:
  options:
  - name: single-request-reopen
```

This makes the resolver send A and AAAA on **separate, sequential** sockets instead of racing them — Go's resolver honours the `single-request-reopen` resolv.conf option — which removes the conntrack race. Applied as a workflow step right after the Fission deploy, on **all** legs.

## Why this approach

- **CI-only**: no production chart/manifest changes — the patch is a workflow `kubectl` step. (Scaling CoreDNS replicas was rejected: on a single-node cluster they share one conntrack table, so it doesn't address the race.)
- **Root-cause, not retry**: targets the actual packet race rather than masking it with re-runs.
- **Low blast radius**: a self-contained, easily-reverted step; if the patch ever failed it would fail only this step.

## Notes / scope

- Covers the **control-plane** pods (router, executor, buildermgr, storagesvc, …), which generate the dominant `executor.fission` / `storagesvc.fission` lookup volume. Function/fetcher pods (created by the executor, not Helm deployments) aren't covered here; if their lookups still flake, the heavier follow-up is **NodeLocal DNSCache** (a link-local cache with no DNAT), which eliminates the race cluster-wide.
- Verified: workflow YAML parses, patch JSON is valid, step runs on all legs (no `if:` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zVDf77ErVufYuMgnQXVb