### PR TITLE
feat(httpmux): internal HTTP router (static + {var}/{var:regexp}) + pure-recorder metrics; migrate executor/storagesvc

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -15,7 +15,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"golang.org/x/sync/errgroup"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/fission/fission/pkg/executor/client"
 	"github.com/fission/fission/pkg/executor/executortype"
 	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/utils/httpmux"
 	"github.com/fission/fission/pkg/utils/httpsecurity"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/metrics"
@@ -358,38 +358,38 @@ func (executor *Executor) dumpDebugInfo(w http.ResponseWriter, r *http.Request) 
 
 // GetHandler returns an http.Handler.
 func (executor *Executor) GetHandler() http.Handler {
-	r := mux.NewRouter()
-	// Register the HMAC verifier middleware before the metrics
-	// middleware so 401 rejections are counted at the same layer as
-	// other auth failures and the metrics middleware sees the post-
-	// verification request. The master secret (when set via
-	// FISSION_INTERNAL_AUTH_SECRET on the executor pod) is derived
-	// per-service for ServiceExecutor so a leak of this executor's
-	// runtime memory cannot forge requests on other Fission internal
-	// channels (storagesvc, fetcher, builder, router-internal). An
-	// empty master means the underlying Verifier short-circuits to
-	// pass-through, preserving backwards compatibility for installs
-	// with internalAuth disabled. /healthz is bypassed so kubelet
-	// probes continue to pass without signing. See
+	// The HMAC verifier wraps the whole mux as the OUTERMOST middleware so 401
+	// rejections are handled at the auth layer and the per-route metrics see
+	// only post-verification requests. The master secret (when set via
+	// FISSION_INTERNAL_AUTH_SECRET on the executor pod) is derived per-service
+	// for ServiceExecutor so a leak of this executor's runtime memory cannot
+	// forge requests on other Fission internal channels (storagesvc, fetcher,
+	// builder, router-internal). An empty master means the underlying Verifier
+	// short-circuits to pass-through, preserving backwards compatibility for
+	// installs with internalAuth disabled. /healthz and /readyz are bypassed so
+	// kubelet probes continue to pass without signing. See
 	// docs/internal-auth/00-design.md.
 	master := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
 	masterOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
-	r.Use(hmacauth.ServiceVerifier(master, masterOld, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
+	verifier := hmacauth.ServiceVerifier(master, masterOld, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
 		SkewSec:      60,
 		Bypass:       []string{"/healthz", "/readyz"},
 		MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
 		Logger:       executor.logger.WithName("hmac"),
-	}))
-	r.Use(metrics.HTTPMetricMiddleware)
-	r.HandleFunc("/v2/getServiceForFunction", executor.getServiceForFunctionAPI).Methods("POST")
-	r.HandleFunc("/v2/ensureCapacity", executor.ensureCapacityHandler).Methods("POST")
-	r.HandleFunc("/v2/tapService", executor.tapService).Methods("POST") // for backward compatibility
-	r.HandleFunc("/v2/tapServices", executor.tapServices).Methods("POST")
-	r.HandleFunc("/healthz", executor.healthHandler).Methods("GET")
-	r.HandleFunc("/readyz", executor.readyzHandler).Methods("GET")
-	r.HandleFunc("/v2/unTapService", executor.unTapService).Methods("POST")
-	r.HandleFunc("/v2/debugInfo", executor.dumpDebugInfo).Methods("GET")
-	return r
+	})
+	m := httpmux.New(
+		httpmux.WithMiddleware(verifier),
+		httpmux.WithMetrics(metrics.HTTPRecorder{}),
+	)
+	m.HandleFunc("/v2/getServiceForFunction", executor.getServiceForFunctionAPI).Methods("POST")
+	m.HandleFunc("/v2/ensureCapacity", executor.ensureCapacityHandler).Methods("POST")
+	m.HandleFunc("/v2/tapService", executor.tapService).Methods("POST") // for backward compatibility
+	m.HandleFunc("/v2/tapServices", executor.tapServices).Methods("POST")
+	m.HandleFunc("/v2/unTapService", executor.unTapService).Methods("POST")
+	m.HandleFunc("/v2/debugInfo", executor.dumpDebugInfo).Methods("GET")
+	m.HandleFunc("/healthz", executor.healthHandler).Methods("GET")
+	m.HandleFunc("/readyz", executor.readyzHandler).Methods("GET")
+	return m.Handler()
 }
 
 // Serve starts an HTTP server.

--- a/pkg/executor/api_auth_test.go
+++ b/pkg/executor/api_auth_test.go
@@ -9,34 +9,34 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/httpmux"
 )
 
 // TestExecutorVerifierMiddlewareWiring guards the wiring contract in
-// (*Executor).GetHandler: the HMAC verifier is registered before the
-// metrics middleware, /healthz bypasses signing, and unsigned requests
-// to a non-bypass path are rejected with 401.
+// (*Executor).GetHandler: the HMAC verifier wraps the mux as the outermost
+// middleware, /healthz bypasses signing, and unsigned requests to a non-bypass
+// path are rejected with 401.
 //
-// This mirrors the precedent in pkg/storagesvc/storagesvc_auth_test.go
-// and runs without requiring a full Executor instance.
+// This mirrors the precedent in pkg/storagesvc/storagesvc_auth_test.go and runs
+// without requiring a full Executor instance.
 func TestExecutorVerifierMiddlewareWiring(t *testing.T) {
 	master := []byte("test-master-must-be-32-bytes-min!!")
 
-	r := mux.NewRouter()
-	r.Use(hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
+	m := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
 		SkewSec:      60,
 		Bypass:       []string{"/healthz"},
 		MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
-	}))
-	r.HandleFunc("/v2/getServiceForFunction", func(w http.ResponseWriter, _ *http.Request) {
+	})))
+	m.HandleFunc("/v2/getServiceForFunction", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodPost)
-	r.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+	m.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet)
+	r := m.Handler()
 
 	t.Run("rejects unsigned /v2/getServiceForFunction", func(t *testing.T) {
 		rr := httptest.NewRecorder()
@@ -55,19 +55,18 @@ func TestExecutorVerifierMiddlewareWiring(t *testing.T) {
 	})
 
 	t.Run("empty master short-circuits to pass-through", func(t *testing.T) {
-		r2 := mux.NewRouter()
-		r2.Use(hmacauth.ServiceVerifier(nil, nil, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
+		m2 := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifier(nil, nil, hmacauth.ServiceExecutor, hmacauth.VerifierOpts{
 			SkewSec:      60,
 			Bypass:       []string{"/healthz"},
 			MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
-		}))
-		r2.HandleFunc("/v2/getServiceForFunction", func(w http.ResponseWriter, _ *http.Request) {
+		})))
+		m2.HandleFunc("/v2/getServiceForFunction", func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}).Methods(http.MethodPost)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/v2/getServiceForFunction", nil)
-		r2.ServeHTTP(rr, req)
+		m2.Handler().ServeHTTP(rr, req)
 		assert.Equal(t, http.StatusOK, rr.Code,
 			"empty master must short-circuit the verifier and pass requests through")
 	})

--- a/pkg/router/auth_test.go
+++ b/pkg/router/auth_test.go
@@ -24,7 +24,6 @@ import (
 	config "github.com/fission/fission/pkg/featureconfig"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
-	"github.com/fission/fission/pkg/utils/metrics"
 )
 
 func GetRouterWithAuth() *mux.Router {
@@ -43,7 +42,7 @@ func GetRouterWithAuth() *mux.Router {
 
 	muxRouter := mux.NewRouter()
 	muxRouter.Use(authMiddleware(&featureConfig))
-	muxRouter.Use(metrics.HTTPMetricMiddleware)
+	muxRouter.Use(metricMiddleware)
 
 	muxRouter.HandleFunc("/auth/login", authLoginHandler(&featureConfig)).Methods("POST")
 	// We should be able to access health without login

--- a/pkg/router/metrics_middleware.go
+++ b/pkg/router/metrics_middleware.go
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/fission/fission/pkg/utils/httpmux"
+	"github.com/fission/fission/pkg/utils/metrics"
+)
+
+// metricMiddleware records HTTP request metrics for the (still gorilla-backed)
+// router, labelling each request by the matched route's path template. The
+// gorilla CurrentRoute lookup is isolated here — the only place the router uses
+// gorilla for metrics — and the recording (in-flight gauge, duration, status
+// code, websocket bypass) is delegated to httpmux.Instrument so that logic
+// lives in exactly one place. When the router migrates onto httpmux this is
+// replaced by httpmux's WithMetrics option and deleted.
+func metricMiddleware(next http.Handler) http.Handler {
+	return httpmux.Instrument(metrics.HTTPRecorder{}, routePathTemplate, next)
+}
+
+// routePathTemplate returns the matched gorilla route's registered template
+// (e.g. /fission-function/{name}), falling back to the raw request path when no
+// route matched or the template is unavailable. gorilla's Use middleware runs
+// after route matching, so CurrentRoute is populated by the time this runs.
+func routePathTemplate(r *http.Request) string {
+	if route := mux.CurrentRoute(r); route != nil {
+		if tmpl, err := route.GetPathTemplate(); err == nil {
+			return tmpl
+		}
+	}
+	return r.URL.Path
+}

--- a/pkg/router/mutablemux_test.go
+++ b/pkg/router/mutablemux_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
-	"github.com/fission/fission/pkg/utils/metrics"
 )
 
 func OldHandler(responseWriter http.ResponseWriter, request *http.Request) {
@@ -60,7 +59,7 @@ func TestMutableMux(t *testing.T) {
 	// make a simple mutable router
 	log.Print("Create mutable router")
 	muxRouter := mux.NewRouter()
-	muxRouter.Use(metrics.HTTPMetricMiddleware)
+	muxRouter.Use(metricMiddleware)
 	muxRouter.HandleFunc("/", OldHandler)
 	logger := loggerfactory.GetLogger()
 
@@ -91,7 +90,7 @@ func TestMutableMux(t *testing.T) {
 	// change the muxer
 	log.Print("Change mux router")
 	newMuxRouter := mux.NewRouter()
-	newMuxRouter.Use(metrics.HTTPMetricMiddleware)
+	newMuxRouter.Use(metricMiddleware)
 	newMuxRouter.HandleFunc("/", NewHandler)
 	mr.updateRouter(newMuxRouter)
 

--- a/pkg/router/routeshape.go
+++ b/pkg/router/routeshape.go
@@ -17,7 +17,6 @@ import (
 	config "github.com/fission/fission/pkg/featureconfig"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/httpsecurity"
-	"github.com/fission/fission/pkg/utils/metrics"
 )
 
 // This file holds the route-shape derivation and mux-registration helpers
@@ -237,7 +236,7 @@ func (ts *HTTPTriggerSet) newListenerMuxes(featureConfig *config.FeatureConfig) 
 	// The internal mux deliberately omits the metrics middleware, the auth
 	// middleware, and the router-owned routes: those concerns are
 	// public-listener only.
-	public.Use(metrics.HTTPMetricMiddleware)
+	public.Use(metricMiddleware)
 	if featureConfig.AuthConfig.IsEnabled {
 		public.Use(authMiddleware(featureConfig))
 	}

--- a/pkg/storagesvc/authz_test.go
+++ b/pkg/storagesvc/authz_test.go
@@ -15,11 +15,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/httpmux"
 )
 
 func TestArchiveNamespace(t *testing.T) {
@@ -116,12 +116,12 @@ func TestArchiveAuthzHandlers(t *testing.T) {
 	require.NoError(t, err)
 	ss := MakeStorageService(logr.Discard(), sc, 0, master, nil)
 
-	r := mux.NewRouter()
-	r.Use(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
-		hmacauth.VerifierOpts{SkewSec: 60, Now: func() time.Time { return now }}))
-	r.HandleFunc("/v1/archive", ss.downloadHandler).Queries("id", "{id}").Methods(http.MethodGet)
-	r.HandleFunc("/v1/archive", ss.deleteHandler).Methods(http.MethodDelete)
-	r.HandleFunc("/v1/archive", ss.infoHandler).Methods(http.MethodHead)
+	m := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
+		hmacauth.VerifierOpts{SkewSec: 60, Now: func() time.Time { return now }})))
+	m.HandleFunc("/v1/archive", ss.getOrListHandler).Methods(http.MethodGet) // ?id= → download
+	m.HandleFunc("/v1/archive", ss.deleteHandler).Methods(http.MethodDelete)
+	m.HandleFunc("/v1/archive", ss.infoHandler).Methods(http.MethodHead)
+	r := m.Handler()
 
 	// Seed archives directly through the backend (the upload path is covered by
 	// TestGetUploadFileNameScoping); returns the stored id.

--- a/pkg/storagesvc/client/makeclientns_test.go
+++ b/pkg/storagesvc/client/makeclientns_test.go
@@ -9,11 +9,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/httpmux"
 )
 
 // TestMakeClientNS proves the namespace-scoped client signs with the per-namespace
@@ -26,16 +26,15 @@ func TestMakeClientNS(t *testing.T) {
 
 	var principal string
 	var sawRequest bool
-	r := mux.NewRouter()
-	r.Use(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
-		hmacauth.VerifierOpts{SkewSec: 60}))
-	r.HandleFunc("/v1/archive", func(w http.ResponseWriter, req *http.Request) {
+	m := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
+		hmacauth.VerifierOpts{SkewSec: 60})))
+	m.HandleFunc("/v1/archive", func(w http.ResponseWriter, req *http.Request) {
 		principal, _ = hmacauth.AuthenticatedNamespace(req.Context())
 		sawRequest = true
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodHead)
 
-	srv := httptest.NewServer(r)
+	srv := httptest.NewServer(m.Handler())
 	defer srv.Close()
 
 	t.Run("namespace-scoped client is attributed to its namespace", func(t *testing.T) {

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -16,11 +16,11 @@ import (
 	"errors"
 
 	"github.com/go-logr/logr"
-	"github.com/gorilla/mux"
 	"golang.org/x/sync/errgroup"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/crd"
+	"github.com/fission/fission/pkg/utils/httpmux"
 	"github.com/fission/fission/pkg/utils/httpsecurity"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/metrics"
@@ -182,6 +182,18 @@ func (ss *StorageService) uploadHandler(w http.ResponseWriter, r *http.Request) 
 	totalArchives.WithLabelValues().Inc()
 }
 
+// getOrListHandler dispatches GET /v1/archive: a request carrying an `id` query
+// param downloads that archive, otherwise it lists archives. stdlib-style
+// routing cannot match on query params (gorilla used .Queries("id", "{id}") to
+// split these), so the two GET routes merge here.
+func (ss *StorageService) getOrListHandler(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Query().Has("id") {
+		ss.downloadHandler(w, r)
+		return
+	}
+	ss.listItems(w, r)
+}
+
 func (ss *StorageService) getIdFromRequest(r *http.Request) (string, error) {
 	values := r.URL.Query()
 	ids, ok := values["id"]
@@ -300,11 +312,14 @@ func MakeStorageService(logger logr.Logger, storageClient *StorageClient, port i
 }
 
 func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port int) {
-	r := mux.NewRouter()
+	// Per-route metrics always; the HMAC verifier wraps the whole mux as the
+	// OUTERMOST middleware (so 401s are handled at the auth layer and metrics
+	// see only post-verification requests) only when a master is configured.
+	opts := []httpmux.Option{httpmux.WithMetrics(metrics.HTTPRecorder{})}
 	if len(ss.authSecret) > 0 {
 		// HMAC enforcement is opt-in via the FISSION_INTERNAL_AUTH_SECRET env
-		// var; an empty master means the verifier middleware is not registered
-		// at all (backwards-compatible with pre-1.(N+1) installs).
+		// var; an empty master means the verifier is not registered at all
+		// (backwards-compatible with pre-1.(N+1) installs).
 		//
 		// The verifier derives the per-service key for ServiceStoragesvc rather
 		// than using the master directly, so a leak of this server's memory
@@ -318,7 +333,7 @@ func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port i
 		// master-derived key for callers that send no namespace header (existing
 		// fetchers, the CLI, the pruner), so this is safe to adopt unconditionally
 		// — multi-namespace tenancy doesn't have to be enabled for it to be inert.
-		r.Use(hmacauth.ServiceVerifierNamespaceFromHeader(ss.authSecret, ss.authSecretOld, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
+		opts = append(opts, httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(ss.authSecret, ss.authSecretOld, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
 			SkewSec: 60,
 			Bypass:  []string{"/healthz"},
 			// 256 MiB caps the verifier's in-memory body buffer; this is
@@ -326,15 +341,17 @@ func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port i
 			// of an unsigned/malicious upload to /v1/archive.
 			MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
 			Logger:       ss.logger.WithName("hmac"),
-		}))
+		})))
 	}
-	r.Use(metrics.HTTPMetricMiddleware)
-	r.HandleFunc("/v1/archive", ss.uploadHandler).Methods("POST")
-	r.HandleFunc("/v1/archive", ss.downloadHandler).Queries("id", "{id}").Methods("GET")
-	r.HandleFunc("/v1/archive", ss.listItems).Methods("GET")
-	r.HandleFunc("/v1/archive", ss.deleteHandler).Methods("DELETE")
-	r.HandleFunc("/v1/archive", ss.infoHandler).Methods("HEAD")
-	r.HandleFunc("/healthz", ss.healthHandler).Methods("GET")
+	m := httpmux.New(opts...)
+	m.HandleFunc("/v1/archive", ss.uploadHandler).Methods("POST")
+	// stdlib-style matching can't key on the ?id= query param (gorilla used
+	// .Queries to split these), so the download (GET with id) and list (GET
+	// without) handlers merge into getOrListHandler.
+	m.HandleFunc("/v1/archive", ss.getOrListHandler).Methods("GET")
+	m.HandleFunc("/v1/archive", ss.deleteHandler).Methods("DELETE")
+	m.HandleFunc("/v1/archive", ss.infoHandler).Methods("HEAD")
+	m.HandleFunc("/healthz", ss.healthHandler).Methods("GET")
 
 	// Storagesvc is router/builder/function-pod internal per
 	// charts/fission-all/templates/storagesvc/networkpolicy.yaml.
@@ -343,7 +360,7 @@ func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port i
 	// browser-readable archive store.
 	handler := httpsecurity.SecurityHeaders(
 		httpsecurity.DenyAllCORS(
-			otelUtils.GetHandlerWithOTEL(r, "fission-storagesvc", otelUtils.UrlsToIgnore("/healthz")),
+			otelUtils.GetHandlerWithOTEL(m.Handler(), "fission-storagesvc", otelUtils.UrlsToIgnore("/healthz")),
 		),
 	)
 	httpserver.StartServer(ctx, ss.logger, mgr, "storagesvc", fmt.Sprintf("%d", port), handler)

--- a/pkg/storagesvc/storagesvc_auth_test.go
+++ b/pkg/storagesvc/storagesvc_auth_test.go
@@ -9,10 +9,10 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/httpmux"
 )
 
 // TestVerifierMiddlewareWiring exercises the middleware chain that
@@ -24,17 +24,17 @@ import (
 func TestVerifierMiddlewareWiring(t *testing.T) {
 	master := []byte("test-master-must-be-32-bytes-min")
 
-	r := mux.NewRouter()
-	r.Use(hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
+	m := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
 		SkewSec: 60,
 		Bypass:  []string{"/healthz"},
-	}))
-	r.HandleFunc("/v1/archive", func(w http.ResponseWriter, _ *http.Request) {
+	})))
+	m.HandleFunc("/v1/archive", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet)
-	r.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+	m.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}).Methods(http.MethodGet)
+	r := m.Handler()
 
 	t.Run("rejects unsigned /v1/archive", func(t *testing.T) {
 		rr := httptest.NewRecorder()

--- a/pkg/utils/httpmux/bench_test.go
+++ b/pkg/utils/httpmux/bench_test.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Benchmarks for the matcher hot path. The executor/storagesvc muxes are small
+// (a handful of exact routes); the router (Phase 3) scans templates in
+// precedence order. These guard that neither path regresses and give a baseline
+// to compare the Phase 3 router cutover against gorilla/mux.
+
+func benchServe(b *testing.B, h http.Handler, method, path string) {
+	b.Helper()
+	req := httptest.NewRequest(method, path, nil)
+	rr := httptest.NewRecorder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.ServeHTTP(rr, req)
+	}
+}
+
+// BenchmarkExactMatch: the executor/storagesvc shape — a few exact, method-gated
+// routes, hitting the last one so the scan runs the full length.
+func BenchmarkExactMatch(b *testing.B) {
+	m := New()
+	m.Handle("/v2/getServiceForFunction", ok("")).Methods("POST")
+	m.Handle("/v2/tapServices", ok("")).Methods("POST")
+	m.Handle("/healthz", ok("")).Methods("GET")
+	m.Handle("/readyz", ok("")).Methods("GET")
+	benchServe(b, m.Handler(), http.MethodGet, "/readyz")
+}
+
+// BenchmarkTemplateMatch: the router shape — a bare {var} segment, the common
+// /fission-function/{name} / /accounts/{id} case.
+func BenchmarkTemplateMatch(b *testing.B) {
+	m := New()
+	m.Handle("/accounts/{id}", ok("")).Methods("GET")
+	benchServe(b, m.Handler(), http.MethodGet, "/accounts/abc123")
+}
+
+// BenchmarkTemplateMatchRegex: a {var:regex} that spans path segments — the
+// heaviest matcher case (real Fission trigger from routeshape_test.go).
+func BenchmarkTemplateMatchRegex(b *testing.B) {
+	m := New()
+	m.Handle(`/bank/{html:[a-zA-Z0-9\./]+}`, ok("")).Methods("GET")
+	benchServe(b, m.Handler(), http.MethodGet, "/bank/foo/bar/baz.html")
+}
+
+// BenchmarkNoMatch404: the scan-everything-then-404 path (probes / scanners),
+// confirming an unmatched request stays cheap and bounded.
+func BenchmarkNoMatch404(b *testing.B) {
+	m := New()
+	m.Handle("/accounts/{id}", ok("")).Methods("GET")
+	m.Handle("/healthz", ok("")).Methods("GET")
+	benchServe(b, m.Handler(), http.MethodGet, "/nonexistent/path")
+}

--- a/pkg/utils/httpmux/context.go
+++ b/pkg/utils/httpmux/context.go
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"context"
+	"net/http"
+)
+
+type ctxKey int
+
+const (
+	varsKey ctxKey = iota
+	patternKey
+)
+
+// withMatch returns a shallow copy of r carrying the matched route's pattern
+// and (optionally) its extracted path variables, so downstream handlers can
+// read them via Pattern / Vars.
+func withMatch(r *http.Request, pattern string, vars map[string]string) *http.Request {
+	ctx := context.WithValue(r.Context(), patternKey, pattern)
+	if len(vars) > 0 {
+		ctx = context.WithValue(ctx, varsKey, vars)
+	}
+	return r.WithContext(ctx)
+}
+
+// Vars returns the path variables extracted from the matched route template
+// (e.g. {id} → "id"), or nil if the route had none. Replaces gorilla's
+// mux.Vars.
+func Vars(r *http.Request) map[string]string {
+	if v, ok := r.Context().Value(varsKey).(map[string]string); ok {
+		return v
+	}
+	return nil
+}
+
+// Pattern returns the registered pattern of the route that matched the request
+// (e.g. "/fission-function/{name}"), or "" if no route matched. It is the
+// low-cardinality label for metrics/logging — replaces gorilla's
+// mux.CurrentRoute(r).GetPathTemplate().
+func Pattern(r *http.Request) string {
+	if p, ok := r.Context().Value(patternKey).(string); ok {
+		return p
+	}
+	return ""
+}

--- a/pkg/utils/httpmux/httpmux_test.go
+++ b/pkg/utils/httpmux/httpmux_test.go
@@ -198,6 +198,22 @@ func TestMetricsRecorded(t *testing.T) {
 	assert.Equal(t, 1, rec.maxFlt, "in-flight incremented during the request")
 }
 
+func TestMetricsRecordsUnmatchedUnderFixedLabel(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRecorder{}
+	m := New(WithMetrics(rec))
+	m.Handle("/only-post", ok("")).Methods("POST")
+	h := m.Handler()
+
+	do(t, h, http.MethodGet, "/only-post") // 405: path matches, method doesn't
+	do(t, h, http.MethodGet, "/nope")      // 404: nothing matches
+
+	assert.Equal(t, []string{
+		"<method not allowed> GET 405",
+		"<not found> GET 404",
+	}, rec.observed, "unmatched requests are recorded under fixed, low-cardinality labels (not the raw path)")
+}
+
 func TestWebsocketBypassesMetrics(t *testing.T) {
 	t.Parallel()
 	rec := &fakeRecorder{}

--- a/pkg/utils/httpmux/httpmux_test.go
+++ b/pkg/utils/httpmux/httpmux_test.go
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ok is a handler that writes a marker so tests can assert which route served.
+func ok(marker string) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(marker))
+	}
+}
+
+func do(t *testing.T, h http.Handler, method, target string) *httptest.ResponseRecorder {
+	t.Helper()
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(method, target, nil))
+	return rr
+}
+
+func TestExactAndMethod(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/v2/getServiceForFunction", ok("svc")).Methods("POST")
+	m.Handle("/healthz", ok("health")).Methods("GET")
+	h := m.Handler()
+
+	t.Run("exact POST", func(t *testing.T) {
+		rr := do(t, h, http.MethodPost, "/v2/getServiceForFunction")
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "svc", rr.Body.String())
+	})
+	t.Run("wrong method 405", func(t *testing.T) {
+		rr := do(t, h, http.MethodGet, "/v2/getServiceForFunction")
+		assert.Equal(t, http.StatusMethodNotAllowed, rr.Code)
+	})
+	t.Run("unknown path 404", func(t *testing.T) {
+		rr := do(t, h, http.MethodGet, "/nope")
+		assert.Equal(t, http.StatusNotFound, rr.Code)
+	})
+	t.Run("exact / is not a catch-all", func(t *testing.T) {
+		m2 := New()
+		m2.Handle("/", ok("root")).Methods("GET")
+		rr := do(t, m2.Handler(), http.MethodGet, "/other")
+		assert.Equal(t, http.StatusNotFound, rr.Code, "Handle(\"/\") is exact, unlike stdlib's catch-all")
+	})
+}
+
+func TestMultipleMethodsAndQueryDispatch(t *testing.T) {
+	t.Parallel()
+	// Mirrors storagesvc: GET and HEAD on the same path go to different handlers.
+	m := New()
+	m.Handle("/v1/archive", ok("get")).Methods("GET")
+	m.Handle("/v1/archive", ok("head")).Methods("HEAD")
+	m.Handle("/v1/archive", ok("post")).Methods("POST")
+	h := m.Handler()
+
+	assert.Equal(t, "get", do(t, h, http.MethodGet, "/v1/archive?id=x").Body.String())
+	assert.Equal(t, "post", do(t, h, http.MethodPost, "/v1/archive").Body.String())
+	// HEAD has its own route — GET must not swallow it (unlike stdlib's GET→HEAD).
+	headRR := do(t, h, http.MethodHead, "/v1/archive")
+	assert.Equal(t, http.StatusOK, headRR.Code)
+}
+
+func TestPrefix(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.HandlePrefix("/api/", ok("api")).Methods("GET")
+	m.Handle("/api", ok("exact")).Methods("GET")
+	h := m.Handler()
+
+	assert.Equal(t, "exact", do(t, h, http.MethodGet, "/api").Body.String())
+	assert.Equal(t, "api", do(t, h, http.MethodGet, "/api/things").Body.String())
+}
+
+func TestHostMatching(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/x", ok("hosted")).Methods("GET").Host("api.example.com")
+	m.Handle("/x", ok("hostless")).Methods("GET")
+	h := m.Handler()
+
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Host = "api.example.com"
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	assert.Equal(t, "hosted", rr.Body.String(), "host-specific route wins when host matches")
+
+	assert.Equal(t, "hostless", do(t, h, http.MethodGet, "/x").Body.String(),
+		"falls through to the host-less route otherwise")
+}
+
+func TestFirstMatchWins(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/dup", ok("first")).Methods("GET")
+	m.Handle("/dup", ok("second")).Methods("GET")
+	assert.Equal(t, "first", do(t, m.Handler(), http.MethodGet, "/dup").Body.String(),
+		"registration order is precedence")
+}
+
+func TestPatternInContext(t *testing.T) {
+	t.Parallel()
+	var got string
+	m := New()
+	m.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		got = Pattern(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	do(t, m.Handler(), http.MethodGet, "/healthz")
+	assert.Equal(t, "/healthz", got)
+}
+
+func TestMiddlewareOrder(t *testing.T) {
+	t.Parallel()
+	var order []string
+	mw := func(name string) func(http.Handler) http.Handler {
+		return func(next http.Handler) http.Handler {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				order = append(order, name)
+				next.ServeHTTP(w, r)
+			})
+		}
+	}
+	m := New(WithMiddleware(mw("outer"), mw("inner")))
+	m.HandleFunc("/x", func(w http.ResponseWriter, _ *http.Request) {
+		order = append(order, "handler")
+	}).Methods("GET")
+	do(t, m.Handler(), http.MethodGet, "/x")
+	assert.Equal(t, []string{"outer", "inner", "handler"}, order,
+		"first-added middleware runs first (outermost)")
+}
+
+func TestEncodedPath(t *testing.T) {
+	t.Parallel()
+	m := New(WithEncodedPath())
+	m.Handle("/a%2Fb", ok("raw")).Methods("GET")
+	// httptest request keeps the raw path; EscapedPath returns "/a%2Fb".
+	req := httptest.NewRequest(http.MethodGet, "/a%2Fb", nil)
+	rr := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "raw", rr.Body.String())
+}
+
+// fakeRecorder records the metrics calls so tests can assert instrumentation.
+type fakeRecorder struct {
+	mu       sync.Mutex
+	inflight int
+	maxFlt   int
+	observed []string // "pattern method code"
+}
+
+func (f *fakeRecorder) InFlightInc(_, _ string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inflight++
+	if f.inflight > f.maxFlt {
+		f.maxFlt = f.inflight
+	}
+}
+func (f *fakeRecorder) InFlightDec(_, _ string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.inflight--
+}
+func (f *fakeRecorder) Observe(pattern, method string, code int, _ time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.observed = append(f.observed, fmt.Sprintf("%s %s %d", pattern, method, code))
+}
+
+func TestMetricsRecorded(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRecorder{}
+	m := New(WithMetrics(rec))
+	m.HandleFunc("/v1/archive", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}).Methods("POST")
+	do(t, m.Handler(), http.MethodPost, "/v1/archive")
+
+	assert.Equal(t, []string{"/v1/archive POST 201"}, rec.observed,
+		"records the route pattern (not the raw URL), method, and status")
+	assert.Equal(t, 0, rec.inflight, "in-flight gauge balanced")
+	assert.Equal(t, 1, rec.maxFlt, "in-flight incremented during the request")
+}
+
+func TestWebsocketBypassesMetrics(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRecorder{}
+	m := New(WithMetrics(rec))
+	m.Handle("/ws", ok("")).Methods("GET")
+	req := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "keep-alive, Upgrade")
+	m.Handler().ServeHTTP(httptest.NewRecorder(), req)
+	assert.Empty(t, rec.observed, "websocket upgrades are not instrumented")
+}
+
+func TestFlushPassthrough(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRecorder{}
+	m := New(WithMetrics(rec))
+	flushed := make(chan struct{}, 1)
+	m.HandleFunc("/stream", func(w http.ResponseWriter, _ *http.Request) {
+		f, ok := w.(http.Flusher)
+		require.True(t, ok, "instrumented ResponseWriter must still be a Flusher")
+		_, _ = w.Write([]byte("chunk"))
+		f.Flush()
+		flushed <- struct{}{}
+	}).Methods("GET")
+	do(t, m.Handler(), http.MethodGet, "/stream")
+	select {
+	case <-flushed:
+	default:
+		t.Fatal("handler did not flush")
+	}
+}

--- a/pkg/utils/httpmux/matcher_edge_test.go
+++ b/pkg/utils/httpmux/matcher_edge_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMethodMismatchFallsThroughToLaterMatch pins the most refactor-fragile line
+// in the dispatcher: a method-mismatching route earlier in the scan must NOT
+// short-circuit to 405 — a later route that fully matches still wins. An early
+// `return 405` would pass every other test but break real multi-method paths.
+func TestMethodMismatchFallsThroughToLaterMatch(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/p", ok("get")).Methods("GET")
+	m.Handle("/p", ok("post")).Methods("POST")
+	h := m.Handler()
+	assert.Equal(t, "post", do(t, h, http.MethodPost, "/p").Body.String(),
+		"POST must reach the second route, not 405 on the first")
+	assert.Equal(t, "get", do(t, h, http.MethodGet, "/p").Body.String())
+}
+
+// TestMethodNotAllowedAcrossRoutes: the path matches several routes but no
+// method matches → 405 (not 404), proving the flag survives the whole scan.
+func TestMethodNotAllowedAcrossRoutes(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/p", ok("")).Methods("GET")
+	m.Handle("/p", ok("")).Methods("HEAD")
+	assert.Equal(t, http.StatusMethodNotAllowed, do(t, m.Handler(), http.MethodPost, "/p").Code)
+}
+
+// TestHostMismatchIs404Not405: a host-restricted route whose host doesn't match
+// must be skipped BEFORE the method check, so it can't poison the 405 flag — a
+// request for a different host that matches nothing is 404, not 405.
+func TestHostMismatchIs404Not405(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/x", ok("")).Methods("GET").Host("a.com")
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	req.Host = "b.com"
+	rr := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// TestMetricsDefaultStatus200: a handler that writes a body but never calls
+// WriteHeader is recorded as 200 (the responseRecorder's default status).
+func TestMetricsDefaultStatus200(t *testing.T) {
+	t.Parallel()
+	rec := &fakeRecorder{}
+	m := New(WithMetrics(rec))
+	m.HandleFunc("/x", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("hi")) // implicit 200, no WriteHeader call
+	}).Methods("GET")
+	do(t, m.Handler(), http.MethodGet, "/x")
+	assert.Equal(t, []string{"/x GET 200"}, rec.observed)
+}
+
+// TestHandlerPanicsOnInvalidTemplate: a malformed template registered without
+// prior CompilePattern validation is a programming error — Handler() must fail
+// loud, not silently create a dead (never-matching) route.
+func TestHandlerPanicsOnInvalidTemplate(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.Handle("/a/{id", ok("")).Methods("GET") // unbalanced brace
+	assert.Panics(t, func() { _ = m.Handler() })
+}
+
+// TestTemplateMultipleVars: a template with several variables extracts them all
+// (guards the SubexpNames index mapping that a single-var test can't catch).
+func TestTemplateMultipleVars(t *testing.T) {
+	t.Parallel()
+	var gotVars map[string]string
+	m := New()
+	m.HandleFunc("/{a}/{b}", func(w http.ResponseWriter, r *http.Request) {
+		gotVars = Vars(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	do(t, m.Handler(), http.MethodGet, "/x/y")
+	assert.Equal(t, map[string]string{"a": "x", "b": "y"}, gotVars)
+}
+
+// TestTemplateWithEncodedPath: under WithEncodedPath a template matches the raw
+// (escaped) path and the captured var keeps the raw encoding — the shape the
+// router's /fission-function/{name} hot path runs under USE_ENCODED_PATH.
+func TestTemplateWithEncodedPath(t *testing.T) {
+	t.Parallel()
+	var gotVars map[string]string
+	m := New(WithEncodedPath())
+	m.HandleFunc("/fn/{name}", func(w http.ResponseWriter, r *http.Request) {
+		gotVars = Vars(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	req := httptest.NewRequest(http.MethodGet, "/fn/a%20b", nil)
+	rr := httptest.NewRecorder()
+	m.Handler().ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "a%20b", gotVars["name"], "matches EscapedPath; var keeps the raw encoding")
+}

--- a/pkg/utils/httpmux/mux.go
+++ b/pkg/utils/httpmux/mux.go
@@ -12,9 +12,19 @@
 // precedence by the order they register (the router feeds the precedence-
 // ordered routetable.Materialization). Patterns may be static paths, prefixes,
 // or {var}/{var:regexp} templates (see template.go).
+//
+// Paths are matched LITERALLY against r.URL.Path (or r.URL.EscapedPath under
+// WithEncodedPath): httpmux does NOT clean or redirect non-canonical paths
+// (".", "..", "//") the way gorilla/mux does by default. This is safe for exact,
+// method-gated routes behind an outermost auth verifier (a non-canonical path
+// simply 404s). A future consumer that routes security-sensitive paths — the
+// router's HMAC-signed internal listener, which signs the raw request-URI — must
+// decide its normalization policy explicitly and test "..", "//", and
+// encoded-slash inputs at that boundary.
 package httpmux
 
 import (
+	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
@@ -143,11 +153,14 @@ const (
 func (m *Mux) Handler() http.Handler {
 	compiled := make([]*compiledRoute, len(m.routes))
 	for i, r := range m.routes {
-		// Templates compile to a regexp; a compile error (which the router
-		// prevents by pre-validating via CompilePattern) leaves re nil, so the
-		// route falls back to a never-matching static compare rather than
-		// panicking.
-		re, _ := compilePattern(r.pattern, r.kind)
+		// Templates compile to a regexp. A compile error here is a registration
+		// bug: callers handling user-supplied patterns (the router) must reject
+		// them up front via CompilePattern. Failing loud at build time surfaces
+		// it, rather than silently leaving a dead, never-matching route.
+		re, err := compilePattern(r.pattern, r.kind)
+		if err != nil {
+			panic(fmt.Errorf("httpmux: route %q has an invalid template (validate with CompilePattern before registering): %w", r.pattern, err))
+		}
 		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler), re: re}
 	}
 	var h http.Handler = &dispatcher{

--- a/pkg/utils/httpmux/mux.go
+++ b/pkg/utils/httpmux/mux.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package httpmux is Fission's internal HTTP router: a small, SOLID layer over
+// net/http that replaces gorilla/mux. It owns route matching and dispatch
+// (method/host/exact/prefix matching, path-variable extraction, the matched
+// pattern), wires a middleware chain, and drives optional per-route metrics —
+// keeping those concerns out of the metrics/auth packages.
+//
+// Routes are matched in REGISTRATION ORDER, first match wins; callers control
+// precedence by the order they register (the router feeds the precedence-
+// ordered routetable.Materialization). Template ({var}/{var:regex}) matching is
+// added in a later phase; this file handles static exact and prefix routes.
+package httpmux
+
+import (
+	"net/http"
+	"strings"
+)
+
+// MatchKind selects how a route's pattern is matched against the request path.
+type MatchKind uint8
+
+const (
+	// Exact matches the request path equal to the pattern.
+	Exact MatchKind = iota
+	// Prefix matches when the request path starts with the pattern.
+	Prefix
+)
+
+// Route is one registration. Handle/HandlePrefix return it so callers can
+// fluently restrict the method set and host (gorilla-style, keeping method and
+// path separate for readability).
+type Route struct {
+	pattern string
+	kind    MatchKind
+	methods []string // nil/empty = any method
+	host    string   // "" = any host
+	handler http.Handler
+}
+
+// Methods restricts the route to the given HTTP methods (case-insensitive).
+func (r *Route) Methods(methods ...string) *Route {
+	r.methods = methods
+	return r
+}
+
+// Host restricts the route to requests for the given (exact) host.
+func (r *Route) Host(host string) *Route {
+	r.host = host
+	return r
+}
+
+func (r *Route) matchesMethod(method string) bool {
+	if len(r.methods) == 0 {
+		return true
+	}
+	for _, m := range r.methods {
+		if strings.EqualFold(m, method) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesPath reports whether path matches this route and returns any extracted
+// path variables (none for static exact/prefix routes — templates come later).
+func (r *Route) matchesPath(path string) (bool, map[string]string) {
+	switch r.kind {
+	case Prefix:
+		return strings.HasPrefix(path, r.pattern), nil
+	default: // Exact
+		return path == r.pattern, nil
+	}
+}
+
+// Mux accumulates routes, middleware, and options, then compiles them into an
+// http.Handler via Handler(). It is configured up front and not mutated after
+// Handler() is called; the router builds a fresh Mux per route-table change and
+// swaps it atomically.
+type Mux struct {
+	routes      []*Route
+	middleware  []func(http.Handler) http.Handler
+	recorder    Recorder
+	encodedPath bool
+}
+
+// Option configures a Mux at construction.
+type Option func(*Mux)
+
+// WithMiddleware adds middleware wrapped OUTERMOST in registration order (the
+// first added runs first), around the matched handler — e.g. an HMAC verifier.
+func WithMiddleware(mw ...func(http.Handler) http.Handler) Option {
+	return func(m *Mux) { m.middleware = append(m.middleware, mw...) }
+}
+
+// WithMetrics enables per-route metrics: each matched route is instrumented
+// with rec, labelled by the route's pattern. A nil Recorder disables it.
+func WithMetrics(rec Recorder) Option {
+	return func(m *Mux) { m.recorder = rec }
+}
+
+// WithEncodedPath matches against the raw (percent-encoded) request path
+// (r.URL.EscapedPath) instead of the decoded one — replaces gorilla's
+// UseEncodedPath.
+func WithEncodedPath() Option {
+	return func(m *Mux) { m.encodedPath = true }
+}
+
+// New returns a Mux configured by opts.
+func New(opts ...Option) *Mux {
+	m := &Mux{}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
+}
+
+// Handle registers an exact-path route and returns it for fluent configuration.
+func (m *Mux) Handle(pattern string, h http.Handler) *Route {
+	return m.add(pattern, Exact, h)
+}
+
+// HandleFunc is Handle for an http.HandlerFunc.
+func (m *Mux) HandleFunc(pattern string, h http.HandlerFunc) *Route {
+	return m.add(pattern, Exact, h)
+}
+
+// HandlePrefix registers a prefix (subtree) route and returns it for fluent
+// configuration.
+func (m *Mux) HandlePrefix(pattern string, h http.Handler) *Route {
+	return m.add(pattern, Prefix, h)
+}
+
+func (m *Mux) add(pattern string, kind MatchKind, h http.Handler) *Route {
+	r := &Route{pattern: pattern, kind: kind, handler: h}
+	m.routes = append(m.routes, r)
+	return r
+}
+
+// Handler compiles the registered routes into an http.Handler: each route's
+// handler is instrumented (if metrics are enabled), then the dispatcher is
+// wrapped with the middleware chain. Safe to call once configuration is done.
+func (m *Mux) Handler() http.Handler {
+	compiled := make([]*compiledRoute, len(m.routes))
+	for i, r := range m.routes {
+		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler)}
+	}
+	var h http.Handler = &dispatcher{routes: compiled, encodedPath: m.encodedPath}
+	// Apply middleware so the first-added wraps outermost (runs first).
+	for i := len(m.middleware) - 1; i >= 0; i-- {
+		h = m.middleware[i](h)
+	}
+	return h
+}
+
+type compiledRoute struct {
+	route   *Route
+	handler http.Handler // instrumented
+}
+
+// dispatcher is the built matcher: it scans routes in registration order and
+// dispatches the first full match.
+type dispatcher struct {
+	routes      []*compiledRoute
+	encodedPath bool
+}
+
+func (d *dispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	if d.encodedPath {
+		path = r.URL.EscapedPath()
+	}
+	methodNotAllowed := false
+	for _, cr := range d.routes {
+		rt := cr.route
+		if rt.host != "" && rt.host != r.Host {
+			continue
+		}
+		ok, vars := rt.matchesPath(path)
+		if !ok {
+			continue
+		}
+		if !rt.matchesMethod(r.Method) {
+			// Path matched but method didn't: remember for 405, but keep
+			// scanning — a later route may match this request fully.
+			methodNotAllowed = true
+			continue
+		}
+		cr.handler.ServeHTTP(w, withMatch(r, rt.pattern, vars))
+		return
+	}
+	if methodNotAllowed {
+		http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	http.NotFound(w, r)
+}

--- a/pkg/utils/httpmux/mux.go
+++ b/pkg/utils/httpmux/mux.go
@@ -139,6 +139,14 @@ func (m *Mux) add(pattern string, kind MatchKind, h http.Handler) *Route {
 	return r
 }
 
+// Constant patterns under which unmatched requests are recorded, so 404/405
+// stay visible in metrics WITHOUT the unbounded label cardinality that
+// recording the raw request path would cause (e.g. path-scanning probes).
+const (
+	patternNotFound         = "<not found>"
+	patternMethodNotAllowed = "<method not allowed>"
+)
+
 // Handler compiles the registered routes into an http.Handler: each route's
 // handler is instrumented (if metrics are enabled), then the dispatcher is
 // wrapped with the middleware chain. Safe to call once configuration is done.
@@ -147,12 +155,21 @@ func (m *Mux) Handler() http.Handler {
 	for i, r := range m.routes {
 		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler)}
 	}
-	var h http.Handler = &dispatcher{routes: compiled, encodedPath: m.encodedPath}
+	var h http.Handler = &dispatcher{
+		routes:           compiled,
+		encodedPath:      m.encodedPath,
+		notFound:         instrument(m.recorder, patternNotFound, http.HandlerFunc(http.NotFound)),
+		methodNotAllowed: instrument(m.recorder, patternMethodNotAllowed, http.HandlerFunc(methodNotAllowedHandler)),
+	}
 	// Apply middleware so the first-added wraps outermost (runs first).
 	for i := len(m.middleware) - 1; i >= 0; i-- {
 		h = m.middleware[i](h)
 	}
 	return h
+}
+
+func methodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
 }
 
 type compiledRoute struct {
@@ -161,10 +178,13 @@ type compiledRoute struct {
 }
 
 // dispatcher is the built matcher: it scans routes in registration order and
-// dispatches the first full match.
+// dispatches the first full match, falling back to instrumented 405/404
+// handlers.
 type dispatcher struct {
-	routes      []*compiledRoute
-	encodedPath bool
+	routes           []*compiledRoute
+	encodedPath      bool
+	notFound         http.Handler
+	methodNotAllowed http.Handler
 }
 
 func (d *dispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -192,8 +212,8 @@ func (d *dispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if methodNotAllowed {
-		http.Error(w, "405 method not allowed", http.StatusMethodNotAllowed)
+		d.methodNotAllowed.ServeHTTP(w, r)
 		return
 	}
-	http.NotFound(w, r)
+	d.notFound.ServeHTTP(w, r)
 }

--- a/pkg/utils/httpmux/mux.go
+++ b/pkg/utils/httpmux/mux.go
@@ -10,12 +10,13 @@
 //
 // Routes are matched in REGISTRATION ORDER, first match wins; callers control
 // precedence by the order they register (the router feeds the precedence-
-// ordered routetable.Materialization). Template ({var}/{var:regex}) matching is
-// added in a later phase; this file handles static exact and prefix routes.
+// ordered routetable.Materialization). Patterns may be static paths, prefixes,
+// or {var}/{var:regexp} templates (see template.go).
 package httpmux
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 )
 
@@ -62,17 +63,6 @@ func (r *Route) matchesMethod(method string) bool {
 		}
 	}
 	return false
-}
-
-// matchesPath reports whether path matches this route and returns any extracted
-// path variables (none for static exact/prefix routes — templates come later).
-func (r *Route) matchesPath(path string) (bool, map[string]string) {
-	switch r.kind {
-	case Prefix:
-		return strings.HasPrefix(path, r.pattern), nil
-	default: // Exact
-		return path == r.pattern, nil
-	}
 }
 
 // Mux accumulates routes, middleware, and options, then compiles them into an
@@ -153,7 +143,12 @@ const (
 func (m *Mux) Handler() http.Handler {
 	compiled := make([]*compiledRoute, len(m.routes))
 	for i, r := range m.routes {
-		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler)}
+		// Templates compile to a regexp; a compile error (which the router
+		// prevents by pre-validating via CompilePattern) leaves re nil, so the
+		// route falls back to a never-matching static compare rather than
+		// panicking.
+		re, _ := compilePattern(r.pattern, r.kind)
+		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler), re: re}
 	}
 	var h http.Handler = &dispatcher{
 		routes:           compiled,
@@ -174,7 +169,33 @@ func methodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
 
 type compiledRoute struct {
 	route   *Route
-	handler http.Handler // instrumented
+	handler http.Handler   // instrumented
+	re      *regexp.Regexp // non-nil for {var}/{var:regexp} templates
+}
+
+// matchPath reports whether path matches the route and returns any extracted
+// path variables (nil for static routes).
+func (cr *compiledRoute) matchPath(path string) (bool, map[string]string) {
+	if cr.re != nil {
+		sub := cr.re.FindStringSubmatch(path)
+		if sub == nil {
+			return false, nil
+		}
+		var vars map[string]string
+		for i, name := range cr.re.SubexpNames() {
+			if name != "" {
+				if vars == nil {
+					vars = make(map[string]string, len(sub))
+				}
+				vars[name] = sub[i]
+			}
+		}
+		return true, vars
+	}
+	if cr.route.kind == Prefix {
+		return strings.HasPrefix(path, cr.route.pattern), nil
+	}
+	return path == cr.route.pattern, nil
 }
 
 // dispatcher is the built matcher: it scans routes in registration order and
@@ -198,7 +219,7 @@ func (d *dispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if rt.host != "" && rt.host != r.Host {
 			continue
 		}
-		ok, vars := rt.matchesPath(path)
+		ok, vars := cr.matchPath(path)
 		if !ok {
 			continue
 		}

--- a/pkg/utils/httpmux/recorder.go
+++ b/pkg/utils/httpmux/recorder.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Recorder records per-request HTTP metrics. The mux invokes it for each
+// matched route with the route's registered pattern as the (low-cardinality)
+// label. The interface is declared here — where it is consumed — so httpmux
+// stays metrics-agnostic; an implementation lives in pkg/utils/metrics and
+// satisfies it structurally (no import back into httpmux).
+type Recorder interface {
+	InFlightInc(pattern, method string)
+	InFlightDec(pattern, method string)
+	Observe(pattern, method string, statusCode int, duration time.Duration)
+}
+
+// responseRecorder captures the status code (and forwards Flush for streaming
+// responses) so the metrics Observe can label by code. It deliberately does
+// NOT implement http.Hijacker: websocket upgrades bypass instrumentation (see
+// instrument) and reach the unwrapped ResponseWriter, which keeps Hijack.
+type responseRecorder struct {
+	http.ResponseWriter
+	status      int
+	wroteHeader bool
+}
+
+func (w *responseRecorder) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.status = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *responseRecorder) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Instrument wraps next to record metrics via rec, labelling each request by
+// patternOf(r) — evaluated BEFORE serving so the in-flight gauge inc/dec and
+// the observation share one label series. A nil rec returns next unchanged.
+// Websocket upgrades bypass instrumentation: the hijacked connection never
+// returns until the socket closes, so an in-flight gauge / duration timer
+// around it would be meaningless.
+//
+// The mux uses this internally with a constant per-route pattern (see
+// instrument). It is exported for callers that still route with another library
+// during migration (e.g. the gorilla-backed router) and must compute the label
+// from that library at request time.
+func Instrument(rec Recorder, patternOf func(*http.Request) string, next http.Handler) http.Handler {
+	if rec == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if isWebSocketUpgrade(r) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		pattern := patternOf(r)
+		start := time.Now()
+		rec.InFlightInc(pattern, r.Method)
+		rw := &responseRecorder{ResponseWriter: w, status: http.StatusOK}
+		defer func() {
+			rec.InFlightDec(pattern, r.Method)
+			rec.Observe(pattern, r.Method, rw.status, time.Since(start))
+		}()
+		next.ServeHTTP(rw, r)
+	})
+}
+
+// instrument is Instrument bound to a constant pattern (the matched route's).
+func instrument(rec Recorder, pattern string, h http.Handler) http.Handler {
+	if rec == nil {
+		return h
+	}
+	return Instrument(rec, func(*http.Request) string { return pattern }, h)
+}
+
+// isWebSocketUpgrade reports whether r is a websocket upgrade handshake
+// (Upgrade: websocket + Connection: Upgrade, per RFC 6455).
+func isWebSocketUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
+		headerTokenContains(r.Header.Get("Connection"), "upgrade")
+}
+
+// headerTokenContains reports whether the comma-separated header value contains
+// token (case-insensitive), e.g. Connection: keep-alive, Upgrade.
+func headerTokenContains(header, token string) bool {
+	for v := range strings.SplitSeq(header, ",") {
+		if strings.EqualFold(strings.TrimSpace(v), token) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/utils/httpmux/recorder.go
+++ b/pkg/utils/httpmux/recorder.go
@@ -6,8 +6,9 @@ package httpmux
 
 import (
 	"net/http"
-	"strings"
 	"time"
+
+	"golang.org/x/net/http/httpguts"
 )
 
 // Recorder records per-request HTTP metrics. The mux invokes it for each
@@ -86,19 +87,10 @@ func instrument(rec Recorder, pattern string, h http.Handler) http.Handler {
 }
 
 // isWebSocketUpgrade reports whether r is a websocket upgrade handshake
-// (Upgrade: websocket + Connection: Upgrade, per RFC 6455).
+// (Upgrade: websocket + Connection: Upgrade, per RFC 6455). Connection is a
+// comma-separated token list, so it is parsed with the canonical
+// httpguts tokenizer rather than a string compare.
 func isWebSocketUpgrade(r *http.Request) bool {
-	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket") &&
-		headerTokenContains(r.Header.Get("Connection"), "upgrade")
-}
-
-// headerTokenContains reports whether the comma-separated header value contains
-// token (case-insensitive), e.g. Connection: keep-alive, Upgrade.
-func headerTokenContains(header, token string) bool {
-	for v := range strings.SplitSeq(header, ",") {
-		if strings.EqualFold(strings.TrimSpace(v), token) {
-			return true
-		}
-	}
-	return false
+	return httpguts.HeaderValuesContainsToken(r.Header["Upgrade"], "websocket") &&
+		httpguts.HeaderValuesContainsToken(r.Header["Connection"], "upgrade")
 }

--- a/pkg/utils/httpmux/template.go
+++ b/pkg/utils/httpmux/template.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// compilePattern turns a route pattern into a regexp matcher. A pattern with no
+// "{" is static and returns (nil, nil) — the dispatcher then string-compares.
+//
+// A template uses gorilla-compatible syntax: {name} matches a single path
+// segment ([^/]+); {name:regexp} matches the supplied regexp, which may span
+// "/" (e.g. /bank/{html:[a-zA-Z0-9./]+}). Each variable becomes a named capture
+// group, so they're extractable via Vars. Exact patterns are anchored at both
+// ends; prefix patterns only at the start. A malformed template (unbalanced
+// braces, empty name, or an uncompilable regexp) returns an error rather than
+// panicking — the caller (router) rejects the trigger instead.
+func compilePattern(pattern string, kind MatchKind) (*regexp.Regexp, error) {
+	if !strings.Contains(pattern, "{") {
+		return nil, nil // static path
+	}
+	var b strings.Builder
+	b.WriteByte('^')
+	rest := pattern
+	for {
+		i := strings.IndexByte(rest, '{')
+		if i < 0 {
+			b.WriteString(regexp.QuoteMeta(rest))
+			break
+		}
+		b.WriteString(regexp.QuoteMeta(rest[:i]))
+		rest = rest[i+1:]
+
+		// Find the matching '}', tracking nesting so a regexp quantifier like
+		// {3} inside {id:[0-9]{3}} doesn't terminate the variable early.
+		depth, j := 1, 0
+		for ; j < len(rest); j++ {
+			if rest[j] == '{' {
+				depth++
+			} else if rest[j] == '}' {
+				depth--
+				if depth == 0 {
+					break
+				}
+			}
+		}
+		if depth != 0 {
+			return nil, fmt.Errorf("httpmux: unbalanced '{' in pattern %q", pattern)
+		}
+		spec := rest[:j]
+		rest = rest[j+1:]
+
+		name, expr, hasExpr := strings.Cut(spec, ":")
+		if name == "" {
+			return nil, fmt.Errorf("httpmux: empty variable name in pattern %q", pattern)
+		}
+		if !hasExpr {
+			expr = "[^/]+" // bare {name}: one path segment, like gorilla
+		}
+		b.WriteString("(?P<")
+		b.WriteString(name)
+		b.WriteString(">")
+		b.WriteString(expr)
+		b.WriteString(")")
+	}
+	if kind == Exact {
+		b.WriteByte('$')
+	}
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil, fmt.Errorf("httpmux: invalid template %q: %w", pattern, err)
+	}
+	return re, nil
+}
+
+// CompilePattern reports whether a route pattern is valid — a static path or a
+// well-formed {var}/{var:regexp} template. The router uses it to reject
+// malformed HTTPTrigger paths up front, replacing gorilla's panic-on-bad-
+// template behaviour with a returned error.
+func CompilePattern(pattern string, kind MatchKind) error {
+	_, err := compilePattern(pattern, kind)
+	return err
+}

--- a/pkg/utils/httpmux/template_test.go
+++ b/pkg/utils/httpmux/template_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateMatchingAndVars(t *testing.T) {
+	t.Parallel()
+	var gotVars map[string]string
+	m := New()
+	m.HandleFunc("/accounts/{id}", func(w http.ResponseWriter, r *http.Request) {
+		gotVars = Vars(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	h := m.Handler()
+
+	rr := do(t, h, http.MethodGet, "/accounts/abc123")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, map[string]string{"id": "abc123"}, gotVars, "extracted path var feeds X-Fission-Params")
+
+	// A bare {id} is a single segment, so an embedded slash does not match.
+	assert.Equal(t, http.StatusNotFound, do(t, h, http.MethodGet, "/accounts/a/b").Code)
+}
+
+func TestTemplateRegexSpanningSlash(t *testing.T) {
+	t.Parallel()
+	// Real Fission trigger (routeshape_test.go): a regex var whose class
+	// includes '/' matches multiple path segments.
+	var gotVars map[string]string
+	m := New()
+	m.HandleFunc(`/bank/{html:[a-zA-Z0-9\./]+}`, func(w http.ResponseWriter, r *http.Request) {
+		gotVars = Vars(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+
+	rr := do(t, m.Handler(), http.MethodGet, "/bank/foo/bar/baz.html")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "foo/bar/baz.html", gotVars["html"])
+}
+
+func TestTemplateCapturingGroupAccepted(t *testing.T) {
+	t.Parallel()
+	// gorilla PANICS on a capturing group like (asc|desc); httpmux uses named
+	// groups, so this previously-rejected pattern compiles and works.
+	require.NoError(t, CompilePattern("/sort/{by:(asc|desc)}", Exact))
+	m := New()
+	m.HandleFunc("/sort/{by:(asc|desc)}", ok("")).Methods("GET")
+	h := m.Handler()
+	assert.Equal(t, http.StatusOK, do(t, h, http.MethodGet, "/sort/asc").Code)
+	assert.Equal(t, http.StatusNotFound, do(t, h, http.MethodGet, "/sort/sideways").Code)
+}
+
+func TestTemplatePrefix(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.HandlePrefix("/files/{dir}/", ok("prefix")).Methods("GET")
+	// Prefix template is anchored at the start only.
+	assert.Equal(t, "prefix", do(t, m.Handler(), http.MethodGet, "/files/docs/readme").Body.String())
+}
+
+func TestCompilePatternValidation(t *testing.T) {
+	t.Parallel()
+	ok := []string{"/static/path", "/a/{id}", `/bank/{html:[a-zA-Z0-9\./]+}`, "/a/{id:[0-9]{3}}", "/sort/{by:(asc|desc)}"}
+	for _, p := range ok {
+		assert.NoErrorf(t, CompilePattern(p, Exact), "valid pattern %q", p)
+	}
+	bad := []string{"/a/{id", "/a/{}", "/a/{id:[}"} // unbalanced, empty name, uncompilable regexp
+	for _, p := range bad {
+		assert.Errorf(t, CompilePattern(p, Exact), "malformed pattern %q must error, not panic", p)
+	}
+}
+
+func TestTemplateFirstMatchOrderWithStatic(t *testing.T) {
+	t.Parallel()
+	// A static route registered before a template that would also match wins
+	// (registration order is precedence — the router relies on this).
+	m := New()
+	m.Handle("/accounts/me", ok("static")).Methods("GET")
+	m.Handle("/accounts/{id}", ok("template")).Methods("GET")
+	h := m.Handler()
+	assert.Equal(t, "static", do(t, h, http.MethodGet, "/accounts/me").Body.String())
+	assert.Equal(t, "template", do(t, h, http.MethodGet, "/accounts/42").Body.String())
+}

--- a/pkg/utils/httpserver/server_test.go
+++ b/pkg/utils/httpserver/server_test.go
@@ -14,11 +14,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/fission/fission/pkg/utils/httpmux"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
 
@@ -28,7 +28,10 @@ func TestStartServer(t *testing.T) {
 
 	ctx := t.Context()
 	logger := loggerfactory.GetLogger()
-	m := mux.NewRouter()
+	// A free port (not a hardcoded one) avoids a bind conflict with anything
+	// else on the runner. httpmux's Handle("/") is exact, so /notfound still 404s.
+	addr := freePort(t)
+	m := httpmux.New()
 	m.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("test handler"))
@@ -38,9 +41,19 @@ func TestStartServer(t *testing.T) {
 	}))
 
 	mgr.Go(func() error {
-		StartServer(ctx, logger, mgr, "test", "8999", m)
+		StartServer(ctx, logger, mgr, "test", addr, m.Handler())
 		return nil
 	})
+
+	// Wait for the server to start accepting connections before requesting.
+	require.Eventually(t, func() bool {
+		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = c.Close()
+		return true
+	}, 3*time.Second, 20*time.Millisecond)
 
 	tests := []struct {
 		Name       string
@@ -50,13 +63,13 @@ func TestStartServer(t *testing.T) {
 	}{
 		{
 			Name:       "test handler",
-			URL:        "http://localhost:8999",
+			URL:        "http://" + addr,
 			StatusCode: http.StatusOK,
 			Body:       "test handler",
 		},
 		{
 			Name:       "not found",
-			URL:        "http://localhost:8999/notfound",
+			URL:        "http://" + addr + "/notfound",
 			StatusCode: http.StatusNotFound,
 			Body:       "404 page not found\n",
 		},

--- a/pkg/utils/metrics/http_metrics.go
+++ b/pkg/utils/metrics/http_metrics.go
@@ -5,19 +5,11 @@
 package metrics
 
 import (
-	"fmt"
-	"net/http"
+	"strconv"
+	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus"
-
-	"github.com/fission/fission/pkg/router/util"
 )
-
-type ResponseWriterWrapper struct {
-	http.ResponseWriter
-	statusCode int
-}
 
 var (
 	httpRequestsTotal = prometheus.NewCounterVec(
@@ -53,40 +45,25 @@ func init() {
 	Registry.MustRegister(httpRequestInFlight)
 }
 
-func (rw *ResponseWriterWrapper) WriteHeader(statuscode int) {
-	rw.statusCode = statuscode
-	rw.ResponseWriter.WriteHeader(statuscode)
+// HTTPRecorder records HTTP request metrics into this package's vecs, labelled
+// by a low-cardinality path (the matched route pattern). It exists so routing
+// packages can drive HTTP metrics without this package knowing anything about
+// routing — it satisfies pkg/utils/httpmux.Recorder structurally, so httpmux
+// invokes it per matched route without importing back into metrics. The zero
+// value is ready to use.
+type HTTPRecorder struct{}
+
+func (HTTPRecorder) InFlightInc(path, method string) {
+	httpRequestInFlight.With(prometheus.Labels{"path": path, "method": method}).Inc()
 }
 
-func (rw *ResponseWriterWrapper) Flush() {
-	if f, ok := rw.ResponseWriter.(http.Flusher); ok {
-		f.Flush()
-	}
+func (HTTPRecorder) InFlightDec(path, method string) {
+	httpRequestInFlight.With(prometheus.Labels{"path": path, "method": method}).Dec()
 }
 
-func HTTPMetricMiddleware(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if util.IsWebsocketRequest(r) {
-			next.ServeHTTP(w, r)
-			return
-		}
-		labels := make(prometheus.Labels, 0)
-		labels["path"] = r.URL.Path
-		if route := mux.CurrentRoute(r); route != nil {
-			if routePath, err := route.GetPathTemplate(); err == nil {
-				labels["path"] = routePath
-			}
-		}
-		labels["method"] = r.Method
-		rw := ResponseWriterWrapper{w, http.StatusOK}
-		httpRequestInFlight.With(labels).Inc()
-		httpRequestDuration := prometheus.NewTimer(httpRequestDuration.With(labels))
-		defer func() {
-			httpRequestDuration.ObserveDuration()
-			httpRequestInFlight.With(labels).Dec()
-			labels["code"] = fmt.Sprintf("%d", rw.statusCode)
-			httpRequestsTotal.With(labels).Inc()
-		}()
-		next.ServeHTTP(&rw, r)
-	})
+func (HTTPRecorder) Observe(path, method string, statusCode int, duration time.Duration) {
+	labels := prometheus.Labels{"path": path, "method": method}
+	httpRequestDuration.With(labels).Observe(duration.Seconds())
+	labels["code"] = strconv.Itoa(statusCode)
+	httpRequestsTotal.With(labels).Inc()
 }

--- a/pkg/utils/metrics/http_metrics_test.go
+++ b/pkg/utils/metrics/http_metrics_test.go
@@ -5,95 +5,33 @@
 package metrics
 
 import (
-	"bufio"
-	"context"
-	"fmt"
-	"io"
-	"log"
-	"net/http"
-	"net/http/httptest"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/require"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
-var dataRow = []byte("I'm the data Row\n")
+// TestHTTPRecorder verifies the recorder drives the package's HTTP metric vecs:
+// the in-flight gauge balances across inc/dec and the counter increments under
+// the {path, method, code} label set. (The request-level wiring — websocket
+// bypass, status capture, per-route labelling — is exercised in
+// pkg/utils/httpmux, which owns it.)
+func TestHTTPRecorder(t *testing.T) {
+	const path, method, code = "/metrics-recorder-test", "POST", "201"
+	rec := HTTPRecorder{}
 
-func chunkedHandler(w http.ResponseWriter, r *http.Request) {
-	ctx, cancel := context.WithCancel(r.Context())
-	ticker := time.NewTicker(time.Second) // We may set it to 10 secs
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		for {
-			select {
-			case <-ticker.C:
-				_, _ = w.Write(dataRow)
-				if f, ok := w.(http.Flusher); ok {
-					f.Flush()
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	})
+	before := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(path, method, code))
 
-	// Emulate some work
-	time.Sleep(5 * time.Second)
+	rec.InFlightInc(path, method)
+	assert.Equal(t, float64(1), testutil.ToFloat64(httpRequestInFlight.WithLabelValues(path, method)),
+		"in-flight gauge incremented")
 
-	// Telling the loop that keeps the connection alive to end
-	cancel()
+	rec.Observe(path, method, 201, 5*time.Millisecond)
+	rec.InFlightDec(path, method)
 
-	// Waiting until the loop ends
-	wg.Wait()
-}
-
-func TestChunked(t *testing.T) {
-	mr := mux.NewRouter()
-	mr.Use(HTTPMetricMiddleware)
-	mr.Handle("/", http.HandlerFunc(chunkedHandler))
-	s := httptest.NewServer(mr)
-	defer s.Close()
-
-	resp, err := http.Get(s.URL)
-	require.NoError(t, err)
-	require.Contains(t, resp.TransferEncoding, "chunked")
-	defer resp.Body.Close()
-
-	r := bufio.NewReader(resp.Body)
-	for {
-		line, err := readChunkedResponseLine(r)
-		if err != nil {
-			if err == io.EOF {
-				return
-			}
-			log.Fatal(err.Error())
-		}
-		if len(line) == 0 {
-			log.Println("Alive!")
-			continue
-		}
-
-		fmt.Println(string(line)) // we got the final response
-		require.Equal(t, dataRow, append(line, '\n'))
-	}
-}
-
-func readChunkedResponseLine(r *bufio.Reader) ([]byte, error) {
-	line, isPrefix, err := r.ReadLine()
-	if err != nil {
-		return nil, err
-	}
-
-	if isPrefix {
-		rest, err := readChunkedResponseLine(r)
-		if err != nil {
-			return nil, err
-		}
-		line = append(line, rest...)
-	}
-
-	return line, nil
+	assert.Zero(t, testutil.ToFloat64(httpRequestInFlight.WithLabelValues(path, method)),
+		"in-flight gauge balanced after dec")
+	assert.Equal(t, before+1, testutil.ToFloat64(httpRequestsTotal.WithLabelValues(path, method, code)),
+		"request counter incremented under {path, method, code}")
 }


### PR DESCRIPTION
## Context

Brainstormed redesign (supersedes #3508). The dependency cleanup confined `gorilla/mux` to `pkg/router` by moving executor/storagesvc onto the stdlib `ServeMux`, but it left two warts: routing/registration concerns leaked into `pkg/utils/metrics` (`RegisterHandler`/`InstrumentHandler*`), and gorilla still backs the router. The agreed end-state is **one internal routing package with full gorilla removal**, done in phases. This is **Phase 1**.

## What changed

**New `pkg/utils/httpmux`** — a small SOLID layer over `net/http`:
- Fluent, method-separate API: `m.Handle("/x", h).Methods("POST").Host(...)`, `HandlePrefix`, `New(WithMiddleware(...), WithMetrics(...), WithEncodedPath())`, `Handler()`.
- Matcher: first-match in **registration order** (caller controls precedence), `405` vs `404` parity, host/method/exact/prefix. `Handle("/")` is **exact** (not a stdlib catch-all).
- `Vars(r)` / `Pattern(r)` context accessors (replace `mux.Vars` / `CurrentRoute().GetPathTemplate()`).
- `Instrument(rec, patternOf, next)` — per-route metrics with a websocket bypass; exported so the still-gorilla router can reuse it during migration.

**`pkg/utils/metrics` reverted to a pure recorder:**
- `HTTPMetricMiddleware` + `ResponseWriterWrapper` deleted; the package now exposes only **`HTTPRecorder`** (over the existing metric vecs), which `httpmux` drives. `metrics` no longer imports `gorilla/mux` or `pkg/router/util`. (It also fixes a latent bug: the old websocket-bypass missed `Connection: keep-alive, Upgrade`; httpmux's check is RFC-correct.)

**Consumers:**
- `pkg/executor`, `pkg/storagesvc` build via `httpmux.New(WithMiddleware(verifier), WithMetrics(...))`; verifier stays outermost (401 before metrics). storagesvc's two `GET /v1/archive` routes merge into `getOrListHandler` (can't match on `?id=`).
- `pkg/router/metrics_middleware.go`: interim bridge recording via `httpmux.Instrument` + a gorilla `CurrentRoute` label fn — **deleted in the router-migration phase**.

**Tests** migrated to httpmux; `server_test` switches the hardcoded `:8999` to `freePort` (kills the flake); `HTTPRecorder` gets a focused metrics test; new `httpmux` package has thorough unit tests (matching, 405/404, host, prefix, first-match, encoded path, metrics, websocket bypass, flush passthrough).

## Outcome
`grep -rl gorilla/mux pkg` → only `pkg/router`. Phases 2 (`{var}`/`{var:regex}` template matcher + parity tests) and 3 (router cutover, drop `gorilla/mux` from `go.mod`) follow.

## Verification
- `go test -race ./pkg/utils/httpmux/... ./pkg/utils/metrics/... ./pkg/utils/httpserver/... ./pkg/executor/... ./pkg/storagesvc/... ./pkg/router/...` → pass
- `make code-checks` → 0 issues; `make license-check` → clean; integration build compiles.

> Supersedes #3508 — that PR can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zVDf77ErVufYuMgnQXVb