### PR TITLE
feat(httpmux): {var}/{var:regexp} path-template matching (Phase 2, stacked on #3510)

### DIFF
--- a/pkg/utils/httpmux/mux.go
+++ b/pkg/utils/httpmux/mux.go
@@ -10,12 +10,13 @@
 //
 // Routes are matched in REGISTRATION ORDER, first match wins; callers control
 // precedence by the order they register (the router feeds the precedence-
-// ordered routetable.Materialization). Template ({var}/{var:regex}) matching is
-// added in a later phase; this file handles static exact and prefix routes.
+// ordered routetable.Materialization). Patterns may be static paths, prefixes,
+// or {var}/{var:regexp} templates (see template.go).
 package httpmux
 
 import (
 	"net/http"
+	"regexp"
 	"strings"
 )
 
@@ -62,17 +63,6 @@ func (r *Route) matchesMethod(method string) bool {
 		}
 	}
 	return false
-}
-
-// matchesPath reports whether path matches this route and returns any extracted
-// path variables (none for static exact/prefix routes — templates come later).
-func (r *Route) matchesPath(path string) (bool, map[string]string) {
-	switch r.kind {
-	case Prefix:
-		return strings.HasPrefix(path, r.pattern), nil
-	default: // Exact
-		return path == r.pattern, nil
-	}
 }
 
 // Mux accumulates routes, middleware, and options, then compiles them into an
@@ -153,7 +143,12 @@ const (
 func (m *Mux) Handler() http.Handler {
 	compiled := make([]*compiledRoute, len(m.routes))
 	for i, r := range m.routes {
-		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler)}
+		// Templates compile to a regexp; a compile error (which the router
+		// prevents by pre-validating via CompilePattern) leaves re nil, so the
+		// route falls back to a never-matching static compare rather than
+		// panicking.
+		re, _ := compilePattern(r.pattern, r.kind)
+		compiled[i] = &compiledRoute{route: r, handler: instrument(m.recorder, r.pattern, r.handler), re: re}
 	}
 	var h http.Handler = &dispatcher{
 		routes:           compiled,
@@ -174,7 +169,33 @@ func methodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
 
 type compiledRoute struct {
 	route   *Route
-	handler http.Handler // instrumented
+	handler http.Handler   // instrumented
+	re      *regexp.Regexp // non-nil for {var}/{var:regexp} templates
+}
+
+// matchPath reports whether path matches the route and returns any extracted
+// path variables (nil for static routes).
+func (cr *compiledRoute) matchPath(path string) (bool, map[string]string) {
+	if cr.re != nil {
+		sub := cr.re.FindStringSubmatch(path)
+		if sub == nil {
+			return false, nil
+		}
+		var vars map[string]string
+		for i, name := range cr.re.SubexpNames() {
+			if name != "" {
+				if vars == nil {
+					vars = make(map[string]string, len(sub))
+				}
+				vars[name] = sub[i]
+			}
+		}
+		return true, vars
+	}
+	if cr.route.kind == Prefix {
+		return strings.HasPrefix(path, cr.route.pattern), nil
+	}
+	return path == cr.route.pattern, nil
 }
 
 // dispatcher is the built matcher: it scans routes in registration order and
@@ -198,7 +219,7 @@ func (d *dispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if rt.host != "" && rt.host != r.Host {
 			continue
 		}
-		ok, vars := rt.matchesPath(path)
+		ok, vars := cr.matchPath(path)
 		if !ok {
 			continue
 		}

--- a/pkg/utils/httpmux/template.go
+++ b/pkg/utils/httpmux/template.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// compilePattern turns a route pattern into a regexp matcher. A pattern with no
+// "{" is static and returns (nil, nil) — the dispatcher then string-compares.
+//
+// A template uses gorilla-compatible syntax: {name} matches a single path
+// segment ([^/]+); {name:regexp} matches the supplied regexp, which may span
+// "/" (e.g. /bank/{html:[a-zA-Z0-9./]+}). Each variable becomes a named capture
+// group, so they're extractable via Vars. Exact patterns are anchored at both
+// ends; prefix patterns only at the start. A malformed template (unbalanced
+// braces, empty name, or an uncompilable regexp) returns an error rather than
+// panicking — the caller (router) rejects the trigger instead.
+func compilePattern(pattern string, kind MatchKind) (*regexp.Regexp, error) {
+	if !strings.Contains(pattern, "{") {
+		return nil, nil // static path
+	}
+	var b strings.Builder
+	b.WriteByte('^')
+	rest := pattern
+	for {
+		i := strings.IndexByte(rest, '{')
+		if i < 0 {
+			b.WriteString(regexp.QuoteMeta(rest))
+			break
+		}
+		b.WriteString(regexp.QuoteMeta(rest[:i]))
+		rest = rest[i+1:]
+
+		// Find the matching '}', tracking nesting so a regexp quantifier like
+		// {3} inside {id:[0-9]{3}} doesn't terminate the variable early.
+		depth, j := 1, 0
+		for ; j < len(rest); j++ {
+			if rest[j] == '{' {
+				depth++
+			} else if rest[j] == '}' {
+				depth--
+				if depth == 0 {
+					break
+				}
+			}
+		}
+		if depth != 0 {
+			return nil, fmt.Errorf("httpmux: unbalanced '{' in pattern %q", pattern)
+		}
+		spec := rest[:j]
+		rest = rest[j+1:]
+
+		name, expr, hasExpr := strings.Cut(spec, ":")
+		if name == "" {
+			return nil, fmt.Errorf("httpmux: empty variable name in pattern %q", pattern)
+		}
+		if !hasExpr {
+			expr = "[^/]+" // bare {name}: one path segment, like gorilla
+		}
+		b.WriteString("(?P<")
+		b.WriteString(name)
+		b.WriteString(">")
+		b.WriteString(expr)
+		b.WriteString(")")
+	}
+	if kind == Exact {
+		b.WriteByte('$')
+	}
+	re, err := regexp.Compile(b.String())
+	if err != nil {
+		return nil, fmt.Errorf("httpmux: invalid template %q: %w", pattern, err)
+	}
+	return re, nil
+}
+
+// CompilePattern reports whether a route pattern is valid — a static path or a
+// well-formed {var}/{var:regexp} template. The router uses it to reject
+// malformed HTTPTrigger paths up front, replacing gorilla's panic-on-bad-
+// template behaviour with a returned error.
+func CompilePattern(pattern string, kind MatchKind) error {
+	_, err := compilePattern(pattern, kind)
+	return err
+}

--- a/pkg/utils/httpmux/template_test.go
+++ b/pkg/utils/httpmux/template_test.go
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpmux
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplateMatchingAndVars(t *testing.T) {
+	t.Parallel()
+	var gotVars map[string]string
+	m := New()
+	m.HandleFunc("/accounts/{id}", func(w http.ResponseWriter, r *http.Request) {
+		gotVars = Vars(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+	h := m.Handler()
+
+	rr := do(t, h, http.MethodGet, "/accounts/abc123")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, map[string]string{"id": "abc123"}, gotVars, "extracted path var feeds X-Fission-Params")
+
+	// A bare {id} is a single segment, so an embedded slash does not match.
+	assert.Equal(t, http.StatusNotFound, do(t, h, http.MethodGet, "/accounts/a/b").Code)
+}
+
+func TestTemplateRegexSpanningSlash(t *testing.T) {
+	t.Parallel()
+	// Real Fission trigger (routeshape_test.go): a regex var whose class
+	// includes '/' matches multiple path segments.
+	var gotVars map[string]string
+	m := New()
+	m.HandleFunc(`/bank/{html:[a-zA-Z0-9\./]+}`, func(w http.ResponseWriter, r *http.Request) {
+		gotVars = Vars(r)
+		w.WriteHeader(http.StatusOK)
+	}).Methods("GET")
+
+	rr := do(t, m.Handler(), http.MethodGet, "/bank/foo/bar/baz.html")
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "foo/bar/baz.html", gotVars["html"])
+}
+
+func TestTemplateCapturingGroupAccepted(t *testing.T) {
+	t.Parallel()
+	// gorilla PANICS on a capturing group like (asc|desc); httpmux uses named
+	// groups, so this previously-rejected pattern compiles and works.
+	require.NoError(t, CompilePattern("/sort/{by:(asc|desc)}", Exact))
+	m := New()
+	m.HandleFunc("/sort/{by:(asc|desc)}", ok("")).Methods("GET")
+	h := m.Handler()
+	assert.Equal(t, http.StatusOK, do(t, h, http.MethodGet, "/sort/asc").Code)
+	assert.Equal(t, http.StatusNotFound, do(t, h, http.MethodGet, "/sort/sideways").Code)
+}
+
+func TestTemplatePrefix(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.HandlePrefix("/files/{dir}/", ok("prefix")).Methods("GET")
+	// Prefix template is anchored at the start only.
+	assert.Equal(t, "prefix", do(t, m.Handler(), http.MethodGet, "/files/docs/readme").Body.String())
+}
+
+func TestCompilePatternValidation(t *testing.T) {
+	t.Parallel()
+	ok := []string{"/static/path", "/a/{id}", `/bank/{html:[a-zA-Z0-9\./]+}`, "/a/{id:[0-9]{3}}", "/sort/{by:(asc|desc)}"}
+	for _, p := range ok {
+		assert.NoErrorf(t, CompilePattern(p, Exact), "valid pattern %q", p)
+	}
+	bad := []string{"/a/{id", "/a/{}", "/a/{id:[}"} // unbalanced, empty name, uncompilable regexp
+	for _, p := range bad {
+		assert.Errorf(t, CompilePattern(p, Exact), "malformed pattern %q must error, not panic", p)
+	}
+}
+
+func TestTemplateFirstMatchOrderWithStatic(t *testing.T) {
+	t.Parallel()
+	// A static route registered before a template that would also match wins
+	// (registration order is precedence — the router relies on this).
+	m := New()
+	m.Handle("/accounts/me", ok("static")).Methods("GET")
+	m.Handle("/accounts/{id}", ok("template")).Methods("GET")
+	h := m.Handler()
+	assert.Equal(t, "static", do(t, h, http.MethodGet, "/accounts/me").Body.String())
+	assert.Equal(t, "template", do(t, h, http.MethodGet, "/accounts/42").Body.String())
+}


### PR DESCRIPTION
## Context

Phase 2 of the httpmux migration (**stacked on #3510** — review/merge that first; this PR's base is `feat/httpmux-phase1`, retarget to `main` once #3510 lands).

Adds `{var}`/`{var:regexp}` path-template matching to `pkg/utils/httpmux`, the last capability the router needs from gorilla before the Phase 3 cutover.

## What changed
- **`pkg/utils/httpmux/template.go`** — `compilePattern` turns a route pattern into an anchored regexp with named capture groups:
  - `{name}` → one path segment (`[^/]+`), like gorilla.
  - `{name:regexp}` → the supplied regexp, which **may span `/`** (e.g. the real Fission trigger `/bank/{html:[a-zA-Z0-9./]+}`).
  - Brace nesting is tracked, so a quantifier like `{3}` inside `{id:[0-9]{3}}` doesn't terminate the variable early.
  - Malformed templates (unbalanced braces, empty name, uncompilable regexp) return an **error, not a panic** — `CompilePattern` is exported so the router can reject bad HTTPTriggers up front (replacing gorilla's `validateRouteTemplate` + `recover()`).
- **`mux.go`** — the matcher uses the compiled regexp for template routes (extracting vars into the request context → `Vars(r)` → `X-Fission-Params`); static routes stay on the string-compare fast path.

## Parity note (an improvement)
gorilla **panics** on a capturing-group regex like `{by:(asc|desc)}` (group-numbering conflict), so the router's validation rejects it today. httpmux uses **named** groups, so that pattern now compiles and works — strictly more capable. (The router's `routeshape_test.go` case that expects rejection is updated in Phase 3.)

## Verification
`go test -race ./pkg/utils/httpmux/...` (var extraction, slash-spanning regex var, first-match vs static, prefix templates, malformed-pattern validation) → pass; `make code-checks` → 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9zVDf77ErVufYuMgnQXVb