### PR TITLE
refactor: simplify executor/CLI internals, harden error handling, fix 3 latent bugs

### DIFF
--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -16,7 +16,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -303,11 +302,7 @@ func (r *EnvironmentReconciler) createBuilderService(ctx context.Context, env *f
 	var ownerReferences []metav1.OwnerReference
 	if r.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(env, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Environment",
-			}),
+			*metav1.NewControllerRef(env, fv1.SchemeGroupVersion.WithKind("Environment")),
 		}
 	}
 	service := apiv1.Service{
@@ -482,11 +477,7 @@ func (r *EnvironmentReconciler) createBuilderDeployment(ctx context.Context, env
 	var ownerReferences []metav1.OwnerReference
 	if r.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(env, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Environment",
-			}),
+			*metav1.NewControllerRef(env, fv1.SchemeGroupVersion.WithKind("Environment")),
 		}
 	}
 

--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -13,7 +13,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -209,11 +208,7 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 	var ownerReferences []metav1.OwnerReference
 	if cn.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Function",
-			}),
+			*metav1.NewControllerRef(fn, fv1.SchemeGroupVersion.WithKind("Function")),
 		}
 	}
 	deployment := &appsv1.Deployment{

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -10,11 +10,11 @@ import (
 	"maps"
 
 	apiv1 "k8s.io/api/core/v1"
-	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/util"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -71,39 +71,14 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 		},
 	}
 
-	existingSvc, err := cn.kubernetesClient.CoreV1().Services(svcNamespace).Get(ctx, svcName, metav1.GetOptions{})
-	if err == nil {
-		// to adopt orphan service (the managed-by check upgrades Services
-		// created before RFC-0002 so their slices become router-visible)
-		if existingSvc.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != cn.instanceID ||
-			existingSvc.Labels[fv1.MANAGED_BY_LABEL] != fv1.MANAGED_BY_VALUE {
-			existingSvc.Annotations = service.Annotations
-			existingSvc.Labels = service.Labels
-			existingSvc.OwnerReferences = service.OwnerReferences
-			existingSvc.Spec.Ports = service.Spec.Ports
-			existingSvc.Spec.Selector = service.Spec.Selector
-			existingSvc.Spec.Type = service.Spec.Type
-			existingSvc, err = cn.kubernetesClient.CoreV1().Services(svcNamespace).Update(ctx, existingSvc, metav1.UpdateOptions{})
-			if err != nil {
-				logger.Error(err, "error adopting service", "service", svcName, "ns", svcNamespace)
-				return nil, err
-			}
-		}
-		return existingSvc, err
-	} else if k8s_err.IsNotFound(err) {
-		svc, err := cn.kubernetesClient.CoreV1().Services(svcNamespace).Create(ctx, service, metav1.CreateOptions{})
-		if err != nil {
-			if k8s_err.IsAlreadyExists(err) {
-				svc, err = cn.kubernetesClient.CoreV1().Services(svcNamespace).Get(ctx, svcName, metav1.GetOptions{})
-			}
-			if err != nil {
-				return nil, err
-			}
-		}
-		otelUtils.SpanTrackEvent(ctx, "svcCreated", otelUtils.GetAttributesForSvc(svc)...)
-		return svc, nil
+	svc, created, err := util.CreateOrAdoptService(ctx, cn.kubernetesClient, logger, cn.instanceID, svcNamespace, service)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	if created {
+		otelUtils.SpanTrackEvent(ctx, "svcCreated", otelUtils.GetAttributesForSvc(svc)...)
+	}
+	return svc, nil
 }
 
 func (cn *Container) deleteSvc(ctx context.Context, ns string, name string) error {

--- a/pkg/executor/executortype/container/svc.go
+++ b/pkg/executor/executortype/container/svc.go
@@ -12,7 +12,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -41,11 +40,7 @@ func (cn *Container) createOrGetSvc(ctx context.Context, fn *fv1.Function, deplo
 	var ownerReferences []metav1.OwnerReference
 	if cn.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Function",
-			}),
+			*metav1.NewControllerRef(fn, fv1.SchemeGroupVersion.WithKind("Function")),
 		}
 	}
 

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -16,7 +16,6 @@ import (
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -238,11 +237,7 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 	var ownerReferences []metav1.OwnerReference
 	if deploy.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Function",
-			}),
+			*metav1.NewControllerRef(fn, fv1.SchemeGroupVersion.WithKind("Function")),
 		}
 	}
 
@@ -396,11 +391,7 @@ func (deploy *NewDeploy) createOrGetSvc(ctx context.Context, fn *fv1.Function, d
 	var ownerReferences []metav1.OwnerReference
 	if deploy.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Function",
-			}),
+			*metav1.NewControllerRef(fn, fv1.SchemeGroupVersion.WithKind("Function")),
 		}
 	}
 

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -423,40 +423,14 @@ func (deploy *NewDeploy) createOrGetSvc(ctx context.Context, fn *fv1.Function, d
 		},
 	}
 
-	existingSvc, err := deploy.kubernetesClient.CoreV1().Services(svcNamespace).Get(ctx, svcName, metav1.GetOptions{})
-	if err == nil {
-		// to adopt orphan service (the managed-by check upgrades Services
-		// created before RFC-0002 so their slices become router-visible)
-		if existingSvc.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != deploy.instanceID ||
-			existingSvc.Labels[fv1.MANAGED_BY_LABEL] != fv1.MANAGED_BY_VALUE {
-			existingSvc.Annotations = service.Annotations
-			existingSvc.Labels = service.Labels
-			existingSvc.OwnerReferences = service.OwnerReferences
-			existingSvc.Spec.Ports = service.Spec.Ports
-			existingSvc.Spec.Selector = service.Spec.Selector
-			existingSvc.Spec.Type = service.Spec.Type
-			existingSvc, err = deploy.kubernetesClient.CoreV1().Services(svcNamespace).Update(ctx, existingSvc, metav1.UpdateOptions{})
-			if err != nil {
-				logger.Error(err, "error adopting service", "service", svcName, "ns", svcNamespace)
-				return nil, err
-			}
-		}
-		return existingSvc, err
-	} else if k8s_err.IsNotFound(err) {
-		svc, err := deploy.kubernetesClient.CoreV1().Services(svcNamespace).Create(ctx, service, metav1.CreateOptions{})
-		if err != nil {
-			if k8s_err.IsAlreadyExists(err) {
-				svc, err = deploy.kubernetesClient.CoreV1().Services(svcNamespace).Get(ctx, svcName, metav1.GetOptions{})
-			}
-			if err != nil {
-				return nil, err
-			}
-		}
-		otelUtils.SpanTrackEvent(ctx, "createdService", otelUtils.GetAttributesForSvc(svc)...)
-
-		return svc, nil
+	svc, created, err := util.CreateOrAdoptService(ctx, deploy.kubernetesClient, logger, deploy.instanceID, svcNamespace, service)
+	if err != nil {
+		return nil, err
 	}
-	return nil, err
+	if created {
+		otelUtils.SpanTrackEvent(ctx, "createdService", otelUtils.GetAttributesForSvc(svc)...)
+	}
+	return svc, nil
 }
 
 func (deploy *NewDeploy) deleteSvc(ctx context.Context, ns string, name string) error {

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -15,7 +15,6 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
@@ -55,11 +54,7 @@ func (gp *GenericPool) genDeploymentMeta(env *fv1.Environment) metav1.ObjectMeta
 	var ownerReferences []metav1.OwnerReference
 	if gp.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(env, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Environment",
-			}),
+			*metav1.NewControllerRef(env, fv1.SchemeGroupVersion.WithKind("Environment")),
 		}
 	}
 	return metav1.ObjectMeta{

--- a/pkg/executor/util/hpa/hpa.go
+++ b/pkg/executor/util/hpa/hpa.go
@@ -14,7 +14,6 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/go-logr/logr"
@@ -166,11 +165,7 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, fn *fv1.Functio
 	var ownerReferences []metav1.OwnerReference
 	if hpaops.enableOwnerReferences {
 		ownerReferences = []metav1.OwnerReference{
-			*metav1.NewControllerRef(fn, schema.GroupVersionKind{
-				Group:   "fission.io",
-				Version: "v1",
-				Kind:    "Function",
-			}),
+			*metav1.NewControllerRef(fn, fv1.SchemeGroupVersion.WithKind("Function")),
 		}
 	}
 

--- a/pkg/executor/util/service.go
+++ b/pkg/executor/util/service.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// CreateOrAdoptService ensures the desired Service exists in its namespace.
+//
+// If a Service with the same name already exists but is not managed by this
+// executor instance — its EXECUTOR_INSTANCEID annotation doesn't match, or it
+// lacks the RFC-0002 managed-by label (an orphan created before RFC-0002) — it
+// is adopted in place by overwriting the managed metadata and the relevant spec
+// fields so the EndpointSlice controller mirrors the managed-by label onto its
+// slices and the router's label-filtered informer sees them. Otherwise the
+// desired Service is created, tolerating a racing AlreadyExists by re-reading
+// the winner.
+//
+// created reports whether the not-found/create path was taken, so the caller
+// can emit its own create span event (the newdeploy and container managers use
+// different event names). desired must be fully populated by the caller.
+//
+// Shared by the newdeploy and container managers, whose per-function Service
+// adoption logic was otherwise byte-identical.
+func CreateOrAdoptService(ctx context.Context, kubeClient kubernetes.Interface, logger logr.Logger, instanceID, namespace string, desired *apiv1.Service) (*apiv1.Service, bool, error) {
+	svcName := desired.Name
+
+	existingSvc, err := kubeClient.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+	if err == nil {
+		// to adopt orphan service (the managed-by check upgrades Services
+		// created before RFC-0002 so their slices become router-visible)
+		if existingSvc.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL] != instanceID ||
+			existingSvc.Labels[fv1.MANAGED_BY_LABEL] != fv1.MANAGED_BY_VALUE {
+			existingSvc.Annotations = desired.Annotations
+			existingSvc.Labels = desired.Labels
+			existingSvc.OwnerReferences = desired.OwnerReferences
+			existingSvc.Spec.Ports = desired.Spec.Ports
+			existingSvc.Spec.Selector = desired.Spec.Selector
+			existingSvc.Spec.Type = desired.Spec.Type
+			existingSvc, err = kubeClient.CoreV1().Services(namespace).Update(ctx, existingSvc, metav1.UpdateOptions{})
+			if err != nil {
+				logger.Error(err, "error adopting service", "service", svcName, "ns", namespace)
+				return nil, false, err
+			}
+		}
+		return existingSvc, false, nil
+	} else if k8serrors.IsNotFound(err) {
+		svc, err := kubeClient.CoreV1().Services(namespace).Create(ctx, desired, metav1.CreateOptions{})
+		if err != nil {
+			if k8serrors.IsAlreadyExists(err) {
+				svc, err = kubeClient.CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+			}
+			if err != nil {
+				return nil, false, err
+			}
+		}
+		return svc, true, nil
+	}
+	return nil, false, err
+}

--- a/pkg/executor/util/service_test.go
+++ b/pkg/executor/util/service_test.go
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// desiredService builds the Service a caller would hand to CreateOrAdoptService:
+// managed-by label set, instanceID annotation set, a concrete selector/ports.
+func desiredService(name, instanceID string) *apiv1.Service {
+	return &apiv1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				fv1.MANAGED_BY_LABEL: fv1.MANAGED_BY_VALUE,
+				"app":                "desired",
+			},
+			Annotations: map[string]string{
+				fv1.EXECUTOR_INSTANCEID_LABEL: instanceID,
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Selector: map[string]string{"fn": name},
+			Type:     apiv1.ServiceTypeClusterIP,
+			Ports:    []apiv1.ServicePort{{Name: "http-env", Port: 80}},
+		},
+	}
+}
+
+func TestCreateOrAdoptService(t *testing.T) {
+	t.Parallel()
+	const ns, name, instanceID = "fission", "fn-svc", "inst-1"
+
+	t.Run("creates when absent", func(t *testing.T) {
+		t.Parallel()
+		client := fake.NewClientset()
+		got, created, err := CreateOrAdoptService(t.Context(), client, logr.Discard(), instanceID, ns, desiredService(name, instanceID))
+		require.NoError(t, err)
+		assert.True(t, created, "absent service should take the create path")
+		require.NotNil(t, got)
+		assert.Equal(t, name, got.Name)
+		assert.Equal(t, fv1.MANAGED_BY_VALUE, got.Labels[fv1.MANAGED_BY_LABEL])
+	})
+
+	t.Run("no drift returns existing untouched", func(t *testing.T) {
+		t.Parallel()
+		existing := desiredService(name, instanceID) // already managed by this instance
+		existing.Namespace = ns
+		existing.Labels["sentinel"] = "keep" // adoption would replace Labels wholesale
+		client := fake.NewClientset(existing)
+
+		got, created, err := CreateOrAdoptService(t.Context(), client, logr.Discard(), instanceID, ns, desiredService(name, instanceID))
+		require.NoError(t, err)
+		assert.False(t, created, "an in-sync service must not be (re)created")
+		require.NotNil(t, got)
+		assert.Equal(t, "keep", got.Labels["sentinel"], "no-drift path must not overwrite the live object")
+	})
+
+	t.Run("adopts orphan missing managed-by label", func(t *testing.T) {
+		t.Parallel()
+		orphan := &apiv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name, Namespace: ns,
+				Labels:      map[string]string{"app": "old"}, // no managed-by label -> orphan
+				Annotations: map[string]string{fv1.EXECUTOR_INSTANCEID_LABEL: instanceID},
+			},
+			Spec: apiv1.ServiceSpec{Selector: map[string]string{"fn": "stale"}, Type: apiv1.ServiceTypeClusterIP},
+		}
+		client := fake.NewClientset(orphan)
+
+		got, created, err := CreateOrAdoptService(t.Context(), client, logr.Discard(), instanceID, ns, desiredService(name, instanceID))
+		require.NoError(t, err)
+		assert.False(t, created, "adoption is an Update, not a Create")
+		require.NotNil(t, got)
+		assert.Equal(t, fv1.MANAGED_BY_VALUE, got.Labels[fv1.MANAGED_BY_LABEL], "orphan should gain the managed-by label")
+		assert.Equal(t, map[string]string{"fn": name}, got.Spec.Selector, "spec selector should be overwritten from desired")
+	})
+
+	t.Run("adopts service owned by a different instance", func(t *testing.T) {
+		t.Parallel()
+		orphan := desiredService(name, "other-instance") // managed-by set, but foreign instance id
+		orphan.Namespace = ns
+		orphan.Spec.Selector = map[string]string{"fn": "stale"}
+		client := fake.NewClientset(orphan)
+
+		got, created, err := CreateOrAdoptService(t.Context(), client, logr.Discard(), instanceID, ns, desiredService(name, instanceID))
+		require.NoError(t, err)
+		assert.False(t, created)
+		require.NotNil(t, got)
+		assert.Equal(t, map[string]string{"fn": name}, got.Spec.Selector, "foreign-instance service should be re-adopted to desired spec")
+	})
+}

--- a/pkg/featureconfig/config.go
+++ b/pkg/featureconfig/config.go
@@ -26,19 +26,19 @@ func GetFeatureConfig(logger logr.Logger) (*FeatureConfig, error) {
 	// read the file
 	b64EncodedContent, err := os.ReadFile(FeatureConfigFile)
 	if err != nil {
-		return nil, fmt.Errorf("error reading YAML file %s: %v", FeatureConfigFile, err)
+		return nil, fmt.Errorf("error reading YAML file %s: %w", FeatureConfigFile, err)
 	}
 
 	// b64 decode file
 	yamlContent, err := base64.StdEncoding.DecodeString(string(b64EncodedContent))
 	if err != nil {
-		return nil, fmt.Errorf("error b64 decoding the config : %v", err)
+		return nil, fmt.Errorf("error b64 decoding the config : %w", err)
 	}
 
 	// unmarshal into feature config
 	err = yaml.Unmarshal(yamlContent, featureConfig)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshalling YAML config %v", err)
+		return nil, fmt.Errorf("error unmarshalling YAML config %w", err)
 	}
 
 	if featureConfig.AuthConfig.AuthUriPath == "" {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -328,7 +328,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 	storePath, err := utils.RootJoin(fetcher.sharedVolumePath, req.Filename)
 	if err != nil {
 		logger.Error(err, "filename", req.Filename)
-		return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err, req)
+		return http.StatusBadRequest, fmt.Errorf("%w, request: %v", err, req)
 	}
 
 	// verify first if the file already exists.
@@ -343,7 +343,7 @@ func (fetcher *Fetcher) Fetch(ctx context.Context, pkg *fv1.Package, req Functio
 	tmpPath, err := utils.RootJoin(fetcher.sharedVolumePath, storePath+".tmp")
 	if err != nil {
 		logger.Error(err, "filename", req.Filename)
-		return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err, req)
+		return http.StatusBadRequest, fmt.Errorf("%w, request: %v", err, req)
 	}
 
 	if req.FetchType == fv1.FETCH_URL {
@@ -488,7 +488,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 			secretDir, err := utils.RootJoin(fetcher.sharedSecretPath, filepath.Join(secret.Namespace, secret.Name))
 			if err != nil {
 				logger.Error(err, "directory", secretDir, "secret_name", secret.Name, "secret_namespace", secret.Namespace)
-				return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err, secret)
+				return http.StatusBadRequest, fmt.Errorf("%w, request: %v", err, secret)
 			}
 
 			err = utils.RootMkdirAll(fetcher.sharedSecretPath, secretDir, 0750)
@@ -534,7 +534,7 @@ func (fetcher *Fetcher) FetchSecretsAndCfgMaps(ctx context.Context, secrets []fv
 			configDir, err := utils.RootJoin(fetcher.sharedConfigPath, filepath.Join(config.Namespace, config.Name))
 			if err != nil {
 				logger.Error(err, "directory", configDir, "config_map_name", config.Name, "config_map_namespace", config.Namespace)
-				return http.StatusBadRequest, fmt.Errorf("%s, request: %v", err,
+				return http.StatusBadRequest, fmt.Errorf("%w, request: %v", err,
 					config)
 			}
 

--- a/pkg/fission-cli/cmd/archive/geturl.go
+++ b/pkg/fission-cli/cmd/archive/geturl.go
@@ -46,7 +46,7 @@ func (opts *GetURLSubCommand) do(input cli.Input) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("error getting URL. Exited with Status:  %s", resp.Status)
+		return fmt.Errorf("error getting URL. Exited with Status: %s", resp.Status)
 	}
 
 	storageType := resp.Header.Get("X-FISSION-STORAGETYPE")

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
+	"github.com/fission/fission/pkg/utils"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
@@ -61,7 +62,7 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return fmt.Errorf("error getting router URL: %w", err)
 	}
-	fnURI := util.UrlForFunction(m.Name, m.Namespace)
+	fnURI := utils.UrlForFunction(m.Name, m.Namespace)
 	if input.IsSet(flagkey.FnSubPath) {
 		subPath := input.String(flagkey.FnSubPath)
 		if !strings.HasPrefix(subPath, "/") {

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -5,12 +5,10 @@
 package httptrigger
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
-
-	"errors"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,8 +70,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fallbackURL := ""
 
 	if triggerUrl == "" && prefix == "" {
-		console.Error("You need to supply either Prefix or URL/RelativeURL")
-		os.Exit(1)
+		return errors.New("you need to supply either Prefix or URL/RelativeURL")
 	}
 
 	if triggerUrl != "" && prefix != "" {

--- a/pkg/fission-cli/cmd/package/util/util.go
+++ b/pkg/fission-cli/cmd/package/util/util.go
@@ -273,7 +273,7 @@ func validArchiveURL(urlStr string) (bool, error) {
 	// Parse the URL string into a URL object
 	parsedURL, err := url.Parse(urlStr)
 	if err != nil {
-		return false, fmt.Errorf("failed to parse URL: %v", err)
+		return false, fmt.Errorf("failed to parse URL: %w", err)
 	}
 
 	// Check if the path starts with /v1/archive

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -78,7 +78,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var allenvs []fv1.Environment
 	allenvs, err = getAllEnvironments(input.Context(), opts.Client(), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting Environments from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting Environments from %s namespaces: %w", printNS, err)
 	}
 	specenvs := filterByDeployID[fv1.Environment](allenvs, deployID)
 	ShowEnvironments(specenvs)
@@ -86,7 +86,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var pkglists []fv1.Package
 	pkglists, err = getAllPackages(input.Context(), opts.Client(), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting Packages from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting Packages from %s namespaces: %w", printNS, err)
 	}
 	specPkgs := filterByDeployID[fv1.Package](pkglists, deployID)
 	ShowPackages(specPkgs)
@@ -94,7 +94,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var canaryCfgs []fv1.CanaryConfig
 	canaryCfgs, err = getAllCanaryConfigs(input.Context(), opts.Client(), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting Canary Config from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting Canary Config from %s namespaces: %w", printNS, err)
 	}
 	specCanaryCfgs := filterByDeployID[fv1.CanaryConfig](canaryCfgs, deployID)
 	ShowCanaryConfigs(specCanaryCfgs)
@@ -102,7 +102,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var hts []fv1.HTTPTrigger
 	hts, err = getAllHTTPTriggers(input.Context(), opts.Client(), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting HTTP Triggers from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting HTTP Triggers from %s namespaces: %w", printNS, err)
 	}
 	specHTTPTriggers := filterByDeployID[fv1.HTTPTrigger](hts, deployID)
 	ShowHTTPTriggers(specHTTPTriggers)
@@ -110,7 +110,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var mqts []fv1.MessageQueueTrigger
 	mqts, err = getAllMessageQueueTriggers(input.Context(), opts.Client(), input.String(flagkey.MqtMQType), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting MessageQueue Triggers from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting MessageQueue Triggers from %s namespaces: %w", printNS, err)
 	}
 	specMessageQueueTriggers := filterByDeployID[fv1.MessageQueueTrigger](mqts, deployID)
 	ShowMQTriggers(specMessageQueueTriggers)
@@ -118,7 +118,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var tts []fv1.TimeTrigger
 	tts, err = getAllTimeTriggers(input.Context(), opts.Client(), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting Time Triggers from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting Time Triggers from %s namespaces: %w", printNS, err)
 	}
 	specTimeTriggers := filterByDeployID[fv1.TimeTrigger](tts, deployID)
 	ShowTimeTriggers(specTimeTriggers)
@@ -126,7 +126,7 @@ func (opts *ListSubCommand) getResource(input cli.Input, namespace string, deplo
 	var kws []fv1.KubernetesWatchTrigger
 	kws, err = getAllKubeWatchTriggers(input.Context(), opts.Client(), namespace)
 	if err != nil {
-		return fmt.Errorf("error getting Kube Watchers from  %s namespaces: %w", printNS, err)
+		return fmt.Errorf("error getting Kube Watchers from %s namespaces: %w", printNS, err)
 	}
 	specKubeWatchers := filterByDeployID[fv1.KubernetesWatchTrigger](kws, deployID)
 	ShowAppliedKubeWatchers(specKubeWatchers)
@@ -329,7 +329,7 @@ func ShowAppliedKubeWatchers(ws []fv1.KubernetesWatchTrigger) {
 func getAllFunctions(ctx context.Context, client cmd.Client, namespace string) ([]fv1.Function, error) {
 	fns, err := client.FissionClientSet.CoreV1().Functions(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Functions %v", err.Error())
+		return nil, fmt.Errorf("unable to get Functions %w", err)
 	}
 	return fns.Items, nil
 }
@@ -338,7 +338,7 @@ func getAllFunctions(ctx context.Context, client cmd.Client, namespace string) (
 func getAllEnvironments(ctx context.Context, client cmd.Client, namespace string) ([]fv1.Environment, error) {
 	envs, err := client.FissionClientSet.CoreV1().Environments(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Environments %v", err.Error())
+		return nil, fmt.Errorf("unable to get Environments %w", err)
 	}
 	return envs.Items, nil
 }
@@ -347,7 +347,7 @@ func getAllEnvironments(ctx context.Context, client cmd.Client, namespace string
 func getAllPackages(ctx context.Context, client cmd.Client, namespace string) ([]fv1.Package, error) {
 	pkgList, err := client.FissionClientSet.CoreV1().Packages(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Packages %v", err.Error())
+		return nil, fmt.Errorf("unable to get Packages %w", err)
 	}
 	return pkgList.Items, nil
 }
@@ -356,7 +356,7 @@ func getAllPackages(ctx context.Context, client cmd.Client, namespace string) ([
 func getAllCanaryConfigs(ctx context.Context, client cmd.Client, namespace string) ([]fv1.CanaryConfig, error) {
 	canaryCfgs, err := client.FissionClientSet.CoreV1().CanaryConfigs(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Canary Configs %v", err.Error())
+		return nil, fmt.Errorf("unable to get Canary Configs %w", err)
 	}
 	return canaryCfgs.Items, nil
 }
@@ -365,7 +365,7 @@ func getAllCanaryConfigs(ctx context.Context, client cmd.Client, namespace strin
 func getAllHTTPTriggers(ctx context.Context, client cmd.Client, namespace string) ([]fv1.HTTPTrigger, error) {
 	hts, err := client.FissionClientSet.CoreV1().HTTPTriggers(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get HTTP Triggers %v", err.Error())
+		return nil, fmt.Errorf("unable to get HTTP Triggers %w", err)
 	}
 	return hts.Items, nil
 }
@@ -374,7 +374,7 @@ func getAllHTTPTriggers(ctx context.Context, client cmd.Client, namespace string
 func getAllMessageQueueTriggers(ctx context.Context, client cmd.Client, mqttype string, namespace string) ([]fv1.MessageQueueTrigger, error) {
 	mqts, err := client.FissionClientSet.CoreV1().MessageQueueTriggers(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get MessageQueue Triggers %v", err.Error())
+		return nil, fmt.Errorf("unable to get MessageQueue Triggers %w", err)
 	}
 	return mqts.Items, nil
 }
@@ -383,7 +383,7 @@ func getAllMessageQueueTriggers(ctx context.Context, client cmd.Client, mqttype 
 func getAllTimeTriggers(ctx context.Context, client cmd.Client, namespace string) ([]fv1.TimeTrigger, error) {
 	tts, err := client.FissionClientSet.CoreV1().TimeTriggers(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Time Triggers %v", err.Error())
+		return nil, fmt.Errorf("unable to get Time Triggers %w", err)
 	}
 	return tts.Items, nil
 }
@@ -392,7 +392,7 @@ func getAllTimeTriggers(ctx context.Context, client cmd.Client, namespace string
 func getAllKubeWatchTriggers(ctx context.Context, client cmd.Client, namespace string) ([]fv1.KubernetesWatchTrigger, error) {
 	ws, err := client.FissionClientSet.CoreV1().KubernetesWatchTriggers(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Kube Watchers %v", err.Error())
+		return nil, fmt.Errorf("unable to get Kube Watchers %w", err)
 	}
 	return ws.Items, nil
 }

--- a/pkg/fission-cli/cmd/spec/spec.go
+++ b/pkg/fission-cli/cmd/spec/spec.go
@@ -134,7 +134,7 @@ func save(data []byte, specDir string, specFile string, truncate bool) error {
 	newFile := false
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		if truncate {
-			return fmt.Errorf("spec file does not exists")
+			return fmt.Errorf("spec file does not exist")
 		}
 		newFile = true
 	}
@@ -521,7 +521,7 @@ func (fr *FissionResources) Validate(input cli.Input, client cmd.Client) ([]stri
 	// we do not error on unreferenced functions (you can call a function through workflows,
 	// `fission function test`, etc.)
 
-	// Index envs, warn on functions referencing an environment for which spes does not exist
+	// Index envs, warn on functions referencing an environment for which spec does not exist
 	environments := make(map[string]struct{})
 	for _, e := range fr.Environments {
 		environments[fmt.Sprintf("%s:%s", e.Name, e.Namespace)] = struct{}{}

--- a/pkg/fission-cli/cmd/spec/validate.go
+++ b/pkg/fission-cli/cmd/spec/validate.go
@@ -96,7 +96,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	fnList, err := getAllFunctions(ctx, c, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get Functions %v", err.Error())
+		return fmt.Errorf("unable to get Functions %w", err)
 	}
 	for _, sObj := range fr.Functions {
 		for _, cObj := range fnList {
@@ -109,7 +109,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	envList, err := getAllEnvironments(ctx, c, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get Environments %v", err.Error())
+		return fmt.Errorf("unable to get Environments %w", err)
 	}
 	for _, sObj := range fr.Environments {
 		for _, cObj := range envList {
@@ -122,7 +122,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	pkgList, err := getAllPackages(ctx, c, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get Packages %v", err.Error())
+		return fmt.Errorf("unable to get Packages %w", err)
 	}
 	for _, sObj := range fr.Packages {
 		for _, cObj := range pkgList {
@@ -135,7 +135,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	httptriggerList, err := getAllHTTPTriggers(ctx, c, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get HTTPTrigger %v", err.Error())
+		return fmt.Errorf("unable to get HTTPTrigger %w", err)
 	}
 	for _, sObj := range fr.HttpTriggers {
 		for _, cObj := range httptriggerList {
@@ -148,7 +148,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	mqtriggerList, err := getAllMessageQueueTriggers(ctx, c, "", namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get Message Queue Trigger %v", err.Error())
+		return fmt.Errorf("unable to get Message Queue Trigger %w", err)
 	}
 	for _, sObj := range fr.MessageQueueTriggers {
 		for _, cObj := range mqtriggerList {
@@ -161,7 +161,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	timetriggerList, err := getAllTimeTriggers(ctx, c, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get Time Trigger %v", err.Error())
+		return fmt.Errorf("unable to get Time Trigger %w", err)
 	}
 	for _, sObj := range fr.TimeTriggers {
 		for _, cObj := range timetriggerList {
@@ -174,7 +174,7 @@ func resourceConflictCheck(ctx context.Context, c cmd.Client, fr *FissionResourc
 
 	kubewatchtriggerList, err := getAllKubeWatchTriggers(ctx, c, namespace)
 	if err != nil {
-		return fmt.Errorf("unable to get Kubernetes Watch Trigger %v", err.Error())
+		return fmt.Errorf("unable to get Kubernetes Watch Trigger %w", err)
 	}
 	for _, sObj := range fr.KubernetesWatchTriggers {
 		for _, cObj := range kubewatchtriggerList {

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -44,15 +44,15 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		// support, but as files on disk these should not be world-readable.
 		err = os.Mkdir(outputDir, 0o700)
 		if err != nil {
-			panic(err)
+			return fmt.Errorf("error creating dump directory %q: %w", outputDir, err)
 		}
 	} else if err != nil {
-		panic(fmt.Errorf("error checking dump directory status: %w", err))
+		return fmt.Errorf("error checking dump directory status: %w", err)
 	}
 
 	outputDir, err = filepath.Abs(outputDir)
 	if err != nil {
-		panic(fmt.Errorf("error creating dump directory for dumping files: %w", err))
+		return fmt.Errorf("error resolving absolute dump directory path: %w", err)
 	}
 
 	k8sClient := opts.Client().KubernetesClient
@@ -116,7 +116,7 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		if _, err := os.Stat(dir); os.IsNotExist(err) {
 			err = os.MkdirAll(dir, 0o700)
 			if err != nil {
-				panic(err)
+				return fmt.Errorf("error creating dump subdirectory %q: %w", dir, err)
 			}
 		}
 		wg.Go(func() {

--- a/pkg/fission-cli/logdb/influxdb.go
+++ b/pkg/fission-cli/logdb/influxdb.go
@@ -191,8 +191,8 @@ func (influx InfluxDB) query(ctx context.Context, query influxdbClient.Query) (*
 	response := influxdbClient.Response{}
 	decoder := json.NewDecoder(resp.Body)
 	decoder.UseNumber()
-	if decoder.Decode(&response) != nil {
-		return nil, fmt.Errorf("failed to decode influxdb response: %v", err)
+	if err := decoder.Decode(&response); err != nil {
+		return nil, fmt.Errorf("failed to decode influxdb response: %w", err)
 	}
 	return &response, nil
 }

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -378,14 +378,6 @@ func GetEnvVarFromStringSlice(params []string) []v1.EnvVar {
 	return envVarList
 }
 
-func UrlForFunction(name, namespace string) string {
-	prefix := "/fission-function"
-	if namespace != metav1.NamespaceDefault {
-		prefix = fmt.Sprintf("/fission-function/%s", namespace)
-	}
-	return fmt.Sprintf("%v/%v", prefix, name)
-}
-
 func ParseAnnotations(annotations []string) (map[string]string, error) {
 	var invalidAnnotations string
 	annotationMap := make(map[string]string)

--- a/pkg/fission-cli/util/util_more_test.go
+++ b/pkg/fission-cli/util/util_more_test.go
@@ -178,12 +178,6 @@ func TestApplyLabelsAndAnnotations(t *testing.T) {
 	})
 }
 
-func TestUrlForFunction(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "/fission-function/fn", UrlForFunction("fn", metav1.NamespaceDefault))
-	assert.Equal(t, "/fission-function/ns1/fn", UrlForFunction("fn", "ns1"))
-}
-
 func TestGetSpecDir(t *testing.T) {
 	t.Parallel()
 	in := dummy.TestFlagSet()

--- a/pkg/mcp/authz.go
+++ b/pkg/mcp/authz.go
@@ -87,8 +87,11 @@ func (a *Authorizer) verifyToken(_ context.Context, token string, _ *http.Reques
 		}
 		return a.signingKey, nil
 	})
-	if err != nil || !parsed.Valid {
+	if err != nil {
 		return nil, fmt.Errorf("%w: %v", auth.ErrInvalidToken, err)
+	}
+	if !parsed.Valid {
+		return nil, fmt.Errorf("%w: token is invalid", auth.ErrInvalidToken)
 	}
 
 	scope, ok := parseScopeClaim(claims[claimAllowedNamespaces])

--- a/pkg/storagesvc/objectstore_local.go
+++ b/pkg/storagesvc/objectstore_local.go
@@ -92,6 +92,12 @@ func (s *localObjectStore) put(name string, r io.Reader, _ int64) (string, error
 	if _, err := io.Copy(f, r); err != nil {
 		return "", err
 	}
+	// io.Copy can succeed while the final Close (which flushes buffered writes)
+	// fails on a full or failing disk, storing a truncated archive but reporting
+	// success. Surface that error rather than leaving it to the deferred Close.
+	if err := f.Close(); err != nil {
+		return "", err
+	}
 	// id is the absolute path of the stored file.
 	return filepath.Join(s.containerPath, rel), nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -109,7 +109,7 @@ func FileSize(filePath string) (int64, error) {
 func GetFileChecksum(fileName string) (*fv1.Checksum, error) {
 	f, err := os.Open(fileName)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open file %v: %v", fileName, err)
+		return nil, fmt.Errorf("failed to open file %v: %w", fileName, err)
 	}
 	defer f.Close()
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -21,6 +21,26 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
+func TestUrlForFunction(t *testing.T) {
+	t.Parallel()
+	// "default" is metav1.NamespaceDefault: it is folded out of the path so the
+	// URL matches the form the router actually registers; other namespaces are
+	// kept. A hardcoded /fission-function/default/<name> would not resolve.
+	tests := []struct {
+		name, namespace, want string
+	}{
+		{"fn", "default", "/fission-function/fn"},
+		{"fn", "ns1", "/fission-function/ns1/fn"},
+		{"my-fn", "team-a", "/fission-function/team-a/my-fn"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.namespace, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, UrlForFunction(tc.name, tc.namespace))
+		})
+	}
+}
+
 func TestIsURL(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## What

A focused, low-risk pass over the codebase: converge on existing idioms, remove genuine duplication, improve error handling and CLI ergonomics, and fix three latent bugs found along the way.
Every commit is small, self-contained, and behavior-preserving (the three bug fixes excepted, by design).
The whole branch is green locally: `go build ./...`, `go vet ./...`, `make license-check`, and `go test -race` across the touched packages.

## Architecture / simplification

- **Owner references use the existing `fv1.SchemeGroupVersion.WithKind(...)` idiom** instead of verbose `schema.GroupVersionKind{Group:"fission.io",Version:"v1",Kind:...}` literals (8 sites across executor + buildermgr).
  Removes a copy-paste bug class (a typo'd group/version would silently break owner refs) and drops six now-unused imports.
- **Extracted `pkg/executor/util.CreateOrAdoptService`** from the byte-identical per-function Service create/adopt logic that was duplicated in the container and newdeploy managers (RFC-0002).
  CLAUDE.md flags that adoption path as subtle, so a single source of truth reduces drift risk; behavior is preserved (the helper takes the namespace explicitly and returns a `created` bool so each caller still emits its own span event).
- **Deduped `UrlForFunction`** — `pkg/fission-cli/util` carried a byte-for-byte copy of `pkg/utils.UrlForFunction`, the namespace-folding logic CLAUDE.md calls out as needing to stay consistent.
  The sole caller now uses the canonical version and the test moved onto it.

## Latent bug fixes

- **storagesvc**: `localObjectStore.put` relied on `defer f.Close()` after `io.Copy`, discarding the close error.
  A flush-on-close failure (full/failing disk) would store a truncated archive while reporting success; the success path now closes explicitly and checks the error.
- **MCP authz**: `verifyToken` collapsed the parse-error and `!token.Valid` cases into one branch that always formatted `err`, so a parseable-but-invalid JWT produced `"invalid token: <nil>"`.
- **CLI influxdb**: the response decode path discarded the decode error and formatted an always-nil outer `err`, producing `"failed to decode influxdb response: <nil>"`.

## Developer UX & error handling

- CLI error-message quality: wrap errors with `%w` (so `errors.Is/As` traverse) in spec/validate, featureconfig, fetcher, and utils; fix typos and double-spaces in user-facing messages.
- `fission support dump` returns errors instead of panicking with a Go stack trace; `fission httptrigger create` returns an error instead of calling `os.Exit(1)`.

## Tests

- Added fake-clientset branch coverage for the new `CreateOrAdoptService` helper and moved/expanded the `UrlForFunction` test onto the canonical implementation.

## Backward compatibility

No CRD/API/flag/CLI-surface changes.
The only behavior changes are the three bug fixes (each turns a wrong/`<nil>` result into a correct one) and error messages that now wrap their cause (rendered text unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
