### PR TITLE
test(rfc-0016): CI OTel Collector + Loki round-trip for the logging read path

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -312,6 +312,25 @@ jobs:
           EOF
           kubectl rollout status deploy/test-registry -n default --timeout=3m
 
+      # CI-ONLY OpenTelemetry Collector + Loki for the RFC-0016 OTLP logging
+      # read-path test (TestFunctionLogsLokiCorrelation). Fission bundles no log
+      # backend — collection is operator-run (see
+      # docs/rfc/0016-otlp-native-logging-pipeline.md) — so this stands up the
+      # operator's side in CI: the collector tails the router's per-invocation
+      # access record (router.displayAccessLog on via kind-ci) and pushes it to
+      # Loki's OTLP endpoint, where the `loki` logdb driver queries it by
+      # request id. One leg covers the pipeline; other legs leave
+      # FISSION_TEST_LOKI unset so the test skips (like the Gateway/registry
+      # gates). Manifests live in test/integration/otel/, not the chart.
+      - name: Deploy OTel Collector + Loki (RFC-0016 logging)
+        if: ${{ matrix.kindversion == 'v1.34.8' }}
+        timeout-minutes: 5
+        run: |
+          kubectl apply -f test/integration/otel/loki.yaml
+          kubectl apply -f test/integration/otel/otel-collector.yaml
+          kubectl rollout status deploy/loki -n fission-logging --timeout=3m
+          kubectl rollout status daemonset/otel-collector -n fission-logging --timeout=3m
+
       # Port-forward is started inside the Go test step rather than as a
       # standalone step, because background processes started with `&` may
       # not survive across GitHub Actions steps on every runner image.
@@ -452,7 +471,18 @@ jobs:
             export FISSION_TEST_REGISTRY_NODE=localhost:30500
             export FISSION_TEST_OCI_PRODUCER=1
           fi
-          trap "kill $PF_PID $PF_PID_INT $PF_PID_MCP $PF_PID_REG 2>/dev/null || true" EXIT
+          # OTel Collector + Loki (RFC-0016), deployed on the 1.34 leg. Forward
+          # Loki so the in-process `loki` logdb driver reaches it via LOKI_URL;
+          # FISSION_TEST_LOKI gates TestFunctionLogsLokiCorrelation (unset
+          # elsewhere => the test skips).
+          PF_PID_LOKI=""
+          if [ "${{ matrix.kindversion }}" = "v1.34.8" ]; then
+            ( while true; do kubectl port-forward svc/loki 3100:3100 -n fission-logging || true; sleep 1; done ) >/tmp/pf-loki.log 2>&1 &
+            PF_PID_LOKI=$!
+            export LOKI_URL=http://127.0.0.1:3100
+            export FISSION_TEST_LOKI=1
+          fi
+          trap "kill $PF_PID $PF_PID_INT $PF_PID_MCP $PF_PID_REG $PF_PID_LOKI 2>/dev/null || true" EXIT
 
           # Export the master HMAC secret so the framework's RouterClient
           # signs /fission-function/... requests against the internal

--- a/docs/rfc/0012-oci-default-package-delivery.md
+++ b/docs/rfc/0012-oci-default-package-delivery.md
@@ -1,6 +1,6 @@
 # RFC-0012: OCI-Native Package Delivery as the Default Cold-Start Path
 
-- Status: Implemented (phases 1–4; phase 5 docs/UX tracked post-merge)
+- Status: Implemented (phases 1–4, [#3494](https://github.com/fission/fission/pull/3494); phase 5 docs/UX tracked post-merge)
 - Tracking issue: —
 - Supersedes: — (builds directly on RFC-0001, shipped in #3484)
 - Targets: Fission v1.27+ (phases independently shippable; the default flip and the producer can land in different minors)

--- a/docs/rfc/0013-incremental-router-routes.md
+++ b/docs/rfc/0013-incremental-router-routes.md
@@ -1,6 +1,6 @@
 # RFC-0013: Incremental Router Route Updates
 
-- Status: Implemented (phases 0–2; phase 3 not built — its benchmark gate was not crossed, see "As shipped")
+- Status: Implemented (phases 0–2, [#3493](https://github.com/fission/fission/pull/3493); phase 3 not built — its benchmark gate was not crossed, see "As shipped")
 - Tracking issue: —
 - Supersedes: —
 - Targets: Fission v1.27+ (phases 0–2); phase 3 conditional on benchmark evidence

--- a/docs/rfc/0015-invocation-correlation-and-failure-attribution.md
+++ b/docs/rfc/0015-invocation-correlation-and-failure-attribution.md
@@ -1,6 +1,6 @@
 # RFC-0015: Invocation Correlation & Failure Attribution
 
-- Status: Proposed — phases 1–4 implemented; phase 5 (diagnostics surface) folded into RFC-0017 (planned) (see "As implemented").
+- Status: Implemented (phases 1–4, [#3515](https://github.com/fission/fission/pull/3515)); phase 5 (diagnostics surface) folded into RFC-0017 (planned) (see "As implemented").
 - Tracking issue: [#693](https://github.com/fission/fission/issues/693) (return a traceable ID to the caller)
 - Supersedes: —
 - Targets: Fission v1.N+ (phased; each phase independently shippable)

--- a/docs/rfc/0016-otlp-native-logging-pipeline.md
+++ b/docs/rfc/0016-otlp-native-logging-pipeline.md
@@ -239,8 +239,8 @@ The Loki adapter queries against the schema in "Structured-log standard" below, 
    Pure CLI change, unit-testable against an `httptest` Loki stub; immediately useful where Loki + a collector already run.
 2. **Router access record** (implemented) — emit the per-invocation correlation record in `collectFunctionMetric`, opt-in via `DISPLAY_ACCESS_LOG`.
    Consumes RFC-0015's request-ID.
-3. **External-collector wiring docs** — operator guidance for pointing an OTel Collector / Promtail / Vector at the function-namespace pod logs + the router access record, exporting to Loki with the `fission.function.*` label mapping.
-   No Fission chart container.
+3. **External-collector wiring** (CI integration implemented) — a reference OpenTelemetry Collector + Loki wiring proves the pipeline end to end on one CI leg (`test/integration/otel/` + `TestFunctionLogsLokiCorrelation`): the Collector tails the router access record, hoists `fission.function.*` to resource attributes, and pushes to Loki's OTLP endpoint, which indexes them as the labels the read path queries.
+   The manifests are CI-only — no Fission chart container — and double as operator guidance for pointing an OTel Collector / Promtail / Vector at the access record + function-namespace pod logs.
 4. **(Optional) Control-plane OTLP log push** — add an OTLP log exporter/provider to `pkg/utils/otel/provider.go` (`go.mod` bump) so control-plane components can *push* logs to the operator's `OTEL_EXPORTER_OTLP_ENDPOINT` instead of relying on stdout scraping.
    Additive transport; the stdout access record already works without it.
 5. **Streaming follow** — add `StreamingLogDatabase`; implement Loki `/tail` and the `kubernetes` follow stream; rewrite the CLI loop.
@@ -270,7 +270,8 @@ The Loki adapter queries against the schema in "Structured-log standard" below, 
   Registry register/lookup table tests; `loki.go` LogQL construction and response parsing against an `httptest.Server` (no real Loki), mirroring the `influxdb.go` style; access-record field assertions via a test `logr` sink in `functionHandler_test.go`; log-exporter init covered like `provider_test.go`.
 - **Integration.**
   The access record is exercised in the standard suite by enabling `DISPLAY_ACCESS_LOG` in kind-ci and asserting the structured `function access` record appears in the router logs after an invocation (the kind-logs artifact).
-  A full Loki-backed `fission function logs --db-type loki --request-id` test needs an operator collector + Loki stood up in CI — a follow-up, since Fission no longer bundles either.
+  A full Loki-backed round-trip — `TestFunctionLogsLokiCorrelation` — runs on one CI leg: a CI-only OpenTelemetry Collector + Loki (manifests in `test/integration/otel/`, **not** the chart) stand in for the operator's pipeline, the test invokes a function with a known `X-Fission-Request-ID`, and asserts `fission function logs --dbtype loki --request-id <id>` returns the access record for exactly that invocation.
+  It is gated on `FISSION_TEST_LOKI` so it skips on legs (and locally) without the stack, mirroring the Gateway-API / OCI-registry gates.
   The `kubernetes` driver path needs no backend and stays the default smoke test.
 - **Backward compat.**
   Assert the `influxdb` driver still registers and warns; assert the default `--db-type` remains `kubernetes`.

--- a/docs/rfc/0016-otlp-native-logging-pipeline.md
+++ b/docs/rfc/0016-otlp-native-logging-pipeline.md
@@ -1,8 +1,11 @@
 # RFC-0016: Cloud-Native, OTLP-Native Logging Pipeline
 
-- Status: Proposed — the read path (driver registry + Loki reference adapter + request-ID/trace-ID/level filtering) and the router per-invocation access record are implemented.
+- Status: Partially implemented.
+  The read path — driver registry + Loki reference adapter + request-ID/trace-ID/level filtering — landed in [#3516](https://github.com/fission/fission/pull/3516).
+  The router per-invocation access record landed in [#3517](https://github.com/fission/fission/pull/3517).
   Collection is delegated to an **operator-run external collector** — Fission does not bundle a collector container in the chart; it emits the structured logs an external pipeline ingests.
-  Control-plane OTLP log push is an optional follow-up.
+  A reference OpenTelemetry Collector + Loki wiring exercises the full round-trip on one CI leg (`test/integration/otel/`, not the chart).
+  Control-plane OTLP log push, streaming `--follow`, and the InfluxDB deprecation cutover remain.
   See "As implemented".
 - Tracking issue: —
 - Supersedes: the InfluxDB-v1.x + Fluent-Bit logging path (deprecated by this RFC)

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -18,11 +18,11 @@ Each document carries a `Status` header naming the implementing PRs and, where a
 | [0007](0007-gateway-api-route-provider.md) | Gateway API Route Provider | Implemented ([#3478](https://github.com/fission/fission/pull/3478)) |
 | [0008](0008-streaming-invocation-path.md) | Streaming Invocation Path (SSE / chunked / WebSocket) | Implemented ([#3482](https://github.com/fission/fission/pull/3482)) |
 | [0011](0011-functions-as-mcp-tools.md) | Functions as MCP Tools & AI Gateway | Part A implemented ([#3483](https://github.com/fission/fission/pull/3483)); Part B deferred |
-| [0012](0012-oci-default-package-delivery.md) | OCI-Native Package Delivery as the Default Cold-Start Path | Implemented (phases 1–4) |
-| [0013](0013-incremental-router-routes.md) | Incremental Router Route Updates | Implemented (phases 0–2; phase 3 gated, not built) |
+| [0012](0012-oci-default-package-delivery.md) | OCI-Native Package Delivery as the Default Cold-Start Path | Implemented (phases 1–4, [#3494](https://github.com/fission/fission/pull/3494)) |
+| [0013](0013-incremental-router-routes.md) | Incremental Router Route Updates | Implemented (phases 0–2, [#3493](https://github.com/fission/fission/pull/3493); phase 3 gated, not built) |
 | [0014](0014-router-hot-path-efficiency.md) | Router Hot-Path Efficiency | Implemented ([#3491](https://github.com/fission/fission/pull/3491)) |
 | [0015](0015-invocation-correlation-and-failure-attribution.md) | Invocation Correlation & Failure Attribution | Implemented ([#3515](https://github.com/fission/fission/pull/3515)); phase 5 folded into RFC-0017 |
-| [0016](0016-otlp-native-logging-pipeline.md) | Cloud-Native, OTLP-Native Logging Pipeline | Proposed (read path + router access record implemented; operator-run collection proven by a CI OTel Collector + Loki leg) |
+| [0016](0016-otlp-native-logging-pipeline.md) | Cloud-Native, OTLP-Native Logging Pipeline | Partially implemented (read path [#3516](https://github.com/fission/fission/pull/3516), access record [#3517](https://github.com/fission/fission/pull/3517); operator-run collection proven by a CI OTel Collector + Loki leg; OTLP push / streaming / deprecation cutover remain) |
 
 ## Companion material
 

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -22,7 +22,7 @@ Each document carries a `Status` header naming the implementing PRs and, where a
 | [0013](0013-incremental-router-routes.md) | Incremental Router Route Updates | Implemented (phases 0–2; phase 3 gated, not built) |
 | [0014](0014-router-hot-path-efficiency.md) | Router Hot-Path Efficiency | Implemented ([#3491](https://github.com/fission/fission/pull/3491)) |
 | [0015](0015-invocation-correlation-and-failure-attribution.md) | Invocation Correlation & Failure Attribution | Implemented ([#3515](https://github.com/fission/fission/pull/3515)); phase 5 folded into RFC-0017 |
-| [0016](0016-otlp-native-logging-pipeline.md) | Cloud-Native, OTLP-Native Logging Pipeline | Proposed (read path + router access record implemented; collection is operator-run) |
+| [0016](0016-otlp-native-logging-pipeline.md) | Cloud-Native, OTLP-Native Logging Pipeline | Proposed (read path + router access record implemented; operator-run collection proven by a CI OTel Collector + Loki leg) |
 
 ## Companion material
 

--- a/pkg/fission-cli/logdb/loki.go
+++ b/pkg/fission-cli/logdb/loki.go
@@ -31,6 +31,13 @@ import (
 const (
 	lokiQueryRangePath = "/loki/api/v1/query_range"
 	lokiHTTPTimeout    = 30 * time.Second
+	// defaultLokiLookback floors the query_range start. The CLI's default
+	// Since is the epoch, which would make the range span decades; Loki
+	// rejects any range over max_query_length (default 30d) with a 400. Floor
+	// the window to a recent span that stays well under that default so a
+	// no-bound `fission function logs --dbtype loki` works against a stock
+	// Loki. A caller asking for a tighter (more recent) Since is honored.
+	defaultLokiLookback = 7 * 24 * time.Hour
 )
 
 type loki struct {
@@ -127,9 +134,13 @@ func (l loki) GetLogs(ctx context.Context, filter LogFilter, output *bytes.Buffe
 	params.Set("query", query)
 	params.Set("limit", strconv.Itoa(filter.RecordLimit))
 	params.Set("direction", direction)
-	if !filter.Since.IsZero() {
-		params.Set("start", strconv.FormatInt(filter.Since.UnixNano(), 10))
+	// Floor the start to a recent window: the caller's Since may be the epoch
+	// (the CLI default), which Loki rejects as exceeding max_query_length.
+	start := filter.Since
+	if floor := time.Now().Add(-defaultLokiLookback); start.Before(floor) {
+		start = floor
 	}
+	params.Set("start", strconv.FormatInt(start.UnixNano(), 10))
 	params.Set("end", strconv.FormatInt(time.Now().UnixNano(), 10))
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, l.endpoint+lokiQueryRangePath+"?"+params.Encode(), nil)

--- a/pkg/fission-cli/logdb/loki_test.go
+++ b/pkg/fission-cli/logdb/loki_test.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -96,4 +98,32 @@ func TestLokiGetLogs(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "line one")
 	assert.Contains(t, out, "line two")
+}
+
+// TestLokiGetLogsFloorsEpochStart guards the regression where the CLI's default
+// Since (the epoch) made the query_range span decades, which Loki rejects with
+// "the query time range exceeds the limit". The adapter must floor the start to
+// the recent lookback window.
+func TestLokiGetLogsFloorsEpochStart(t *testing.T) {
+	var gotStart string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotStart = r.URL.Query().Get("start")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"streams","result":[]}}`))
+	}))
+	defer srv.Close()
+
+	t.Setenv("LOKI_URL", srv.URL)
+	l, err := NewLoki(t.Context(), LogDBOptions{})
+	require.NoError(t, err)
+
+	err = l.GetLogs(t.Context(), LogFilter{FuncUid: "u1", Since: time.Unix(0, 0), RecordLimit: 10}, new(bytes.Buffer))
+	require.NoError(t, err)
+
+	startNanos, perr := strconv.ParseInt(gotStart, 10, 64)
+	require.NoErrorf(t, perr, "start must be a unix-nano integer, got %q", gotStart)
+	start := time.Unix(0, startNanos)
+	assert.WithinDuration(t, time.Now().Add(-defaultLokiLookback), start, time.Hour,
+		"epoch Since must be floored to the recent lookback window, not sent as 1970")
+	assert.Truef(t, start.After(time.Unix(0, 0).Add(time.Hour)),
+		"start must not be the epoch; got %s", start)
 }

--- a/test/integration/framework/router.go
+++ b/test/integration/framework/router.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/correlation"
 )
 
 // RouterClient wraps an HTTP client pointed at the Fission router (typically
@@ -84,16 +85,26 @@ func (r *RouterClient) BaseURL() string { return r.baseURL }
 // Get performs a single GET against `path` (joined to BaseURL) and returns the
 // body. Non-2xx is returned as an error.
 func (r *RouterClient) Get(ctx context.Context, path string) (status int, body string, err error) {
-	return r.do(ctx, http.MethodGet, path, "", nil)
+	return r.do(ctx, http.MethodGet, path, "", nil, nil)
+}
+
+// GetWithRequestID performs a GET carrying a caller-supplied
+// X-Fission-Request-ID header. RFC-0015's correlation middleware honors an
+// inbound id, so the router's access record (RFC-0016) reports exactly this
+// value — letting a test assert an end-to-end, deterministic correlation id
+// without parsing the minted response header.
+func (r *RouterClient) GetWithRequestID(ctx context.Context, path, requestID string) (status int, body string, err error) {
+	return r.do(ctx, http.MethodGet, path, "", nil,
+		http.Header{correlation.HeaderRequestID: []string{requestID}})
 }
 
 // Post performs a single POST against `path` with the given content type and
 // body. Returns status, response body, and any transport-level error.
 func (r *RouterClient) Post(ctx context.Context, path, contentType string, body []byte) (status int, respBody string, err error) {
-	return r.do(ctx, http.MethodPost, path, contentType, body)
+	return r.do(ctx, http.MethodPost, path, contentType, body, nil)
 }
 
-func (r *RouterClient) do(ctx context.Context, method, path, contentType string, body []byte) (int, string, error) {
+func (r *RouterClient) do(ctx context.Context, method, path, contentType string, body []byte, header http.Header) (int, string, error) {
 	// /fission-function/... lives only on the internal listener after
 	// GHSA-3g33-6vg6-27m8; route to the internal base URL.
 	// `r.internal` is always non-empty after framework setup
@@ -112,6 +123,11 @@ func (r *RouterClient) do(ctx context.Context, method, path, contentType string,
 	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
 	if err != nil {
 		return 0, "", err
+	}
+	for k, vs := range header {
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)

--- a/test/integration/otel/README.md
+++ b/test/integration/otel/README.md
@@ -1,0 +1,68 @@
+<!--
+SPDX-FileCopyrightText: The Fission Authors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CI-only OTLP logging stack (RFC-0016)
+
+These manifests stand up an **OpenTelemetry Collector + Loki** for the
+RFC-0016 logging read-path integration test
+(`TestFunctionLogsLokiCorrelation`).
+
+They are **not** part of the Fission Helm chart.
+Fission bundles no log collector or backend — collection is delegated to an
+operator-run external pipeline (see
+[`docs/rfc/0016-otlp-native-logging-pipeline.md`](../../../docs/rfc/0016-otlp-native-logging-pipeline.md),
+"Collection — operators run an external collector").
+This stack plays the operator's side so CI can exercise the `loki` logdb driver
+end to end; it is applied only on one CI leg (see `.github/workflows/push_pr.yaml`).
+
+## What it proves
+
+The router emits one structured access record per invocation
+(`msg="function access"`, opt-in via `router.displayAccessLog`, on in kind-ci),
+carrying the request id, trace id, and function identity.
+The test asserts that record is queryable from Loki by request id, which
+validates the whole correlation pipeline:
+
+```
+router stdout (access record, zap JSON)
+  → otel-collector (filelog tail → keep access records → hoist
+                    fission.function.{uid,namespace,name} to resource attrs)
+  → Loki OTLP endpoint (/otlp/v1/logs), which indexes those resource attrs
+    as the stream labels fission_function_uid / fission_function_namespace
+  → fission function logs --dbtype loki --request-id <id>
+    → LogQL: {fission_function_uid="<uid>"} | json | fission_request_id="<id>"
+```
+
+## Files
+
+- `loki.yaml` — single-binary Loki (filesystem storage) in namespace
+  `fission-logging`, with `otlp_config` promoting `fission.function.*` resource
+  attributes to index labels.
+- `otel-collector.yaml` — a Collector DaemonSet that tails the router pod's
+  container log, keeps only the access record, hoists the function identity to
+  resource attributes (`groupbyattrs`), and pushes to Loki's OTLP endpoint.
+  No Kubernetes RBAC is needed: the function identity comes from the router log
+  body, not pod labels, so the Collector reads only the node's pod-log files.
+
+## Running the test locally
+
+```sh
+kubectl apply -f test/integration/otel/loki.yaml
+kubectl apply -f test/integration/otel/otel-collector.yaml
+kubectl rollout status deploy/loki -n fission-logging --timeout=3m
+kubectl rollout status daemonset/otel-collector -n fission-logging --timeout=3m
+
+kubectl port-forward svc/loki 3100:3100 -n fission-logging &
+export LOKI_URL=http://127.0.0.1:3100
+export FISSION_TEST_LOKI=1
+# plus the usual router port-forwards / image env vars (see the repo CLAUDE.md)
+
+go test -tags=integration -run TestFunctionLogsLokiCorrelation -v \
+  ./test/integration/suites/common/...
+```
+
+The cluster must run the router with `router.displayAccessLog=true` (kind-ci
+sets this) so the access record is emitted.

--- a/test/integration/otel/loki.yaml
+++ b/test/integration/otel/loki.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: The Fission Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# CI-ONLY Loki backend for the RFC-0016 OTLP logging integration test
+# (TestFunctionLogsLokiCorrelation). This is NOT part of the Fission Helm chart
+# — Fission bundles no log backend (see docs/rfc/0016-otlp-native-logging-pipeline.md,
+# "Collection — operators run an external collector"). It plays the operator's
+# backend so CI can exercise the read path (the `loki` logdb driver) end to end.
+#
+# Single-binary Loki with filesystem storage and OTLP ingestion. The OTLP
+# resource attributes the collector sets — fission.function.uid /
+# fission.function.namespace — are promoted to Loki stream labels
+# (fission_function_uid / fission_function_namespace, dots folded to
+# underscores) so the LogQL the `loki` driver builds
+# ({fission_function_uid="<uid>"} | json | fission_request_id="<id>") selects
+# the router access record.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fission-logging
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: loki-config
+  namespace: fission-logging
+data:
+  loki.yaml: |
+    auth_enabled: false
+    server:
+      http_listen_port: 3100
+      grpc_listen_port: 9096
+      log_level: warn
+    common:
+      instance_addr: 127.0.0.1
+      path_prefix: /loki
+      storage:
+        filesystem:
+          chunks_directory: /loki/chunks
+          rules_directory: /loki/rules
+      replication_factor: 1
+      ring:
+        kvstore:
+          store: inmemory
+    schema_config:
+      configs:
+        - from: 2024-01-01
+          store: tsdb
+          object_store: filesystem
+          schema: v13
+          index:
+            prefix: index_
+            period: 24h
+    limits_config:
+      allow_structured_metadata: true
+      # Promote the collector's fission.function.* resource attributes to index
+      # labels so the read-path stream selector resolves. Loki folds dots to
+      # underscores in label names.
+      otlp_config:
+        resource_attributes:
+          attributes_config:
+            - action: index_label
+              attributes:
+                - fission.function.uid
+                - fission.function.namespace
+                - fission.function.name
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: loki
+  namespace: fission-logging
+  labels: {app: loki}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: loki}
+  template:
+    metadata:
+      labels: {app: loki}
+    spec:
+      containers:
+        - name: loki
+          image: grafana/loki:3.4.1
+          args: ["-config.file=/etc/loki/loki.yaml"]
+          ports:
+            - {name: http, containerPort: 3100}
+          readinessProbe:
+            httpGet: {path: /ready, port: 3100}
+            initialDelaySeconds: 15
+            periodSeconds: 5
+          volumeMounts:
+            - {name: config, mountPath: /etc/loki}
+            - {name: storage, mountPath: /loki}
+      volumes:
+        - name: config
+          configMap: {name: loki-config}
+        - name: storage
+          emptyDir: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: loki
+  namespace: fission-logging
+  labels: {app: loki, svc: loki}
+spec:
+  selector: {app: loki}
+  ports:
+    - {name: http, port: 3100, targetPort: 3100}

--- a/test/integration/otel/otel-collector.yaml
+++ b/test/integration/otel/otel-collector.yaml
@@ -79,7 +79,11 @@ spec:
         runAsUser: 0
       containers:
         - name: otel-collector
-          image: otel/opentelemetry-collector-contrib:0.116.0
+          # Pin a statically-linked release: the distroless image ships no glibc
+          # loader, and 0.116.0's binary was anomalously built glibc-dynamic, so
+          # it fails with `exec /otelcol-contrib: no such file or directory`.
+          # 0.119.0+ reverted to a static binary.
+          image: otel/opentelemetry-collector-contrib:0.127.0
           args: ["--config=/etc/otel/config.yaml"]
           volumeMounts:
             - {name: config, mountPath: /etc/otel}

--- a/test/integration/otel/otel-collector.yaml
+++ b/test/integration/otel/otel-collector.yaml
@@ -27,7 +27,14 @@ data:
         start_at: beginning
         operators:
           # Strip the CRI/containerd wrapper, leaving the zap JSON as the body.
+          # add_metadata_from_filepath is disabled: it parses k8s identity from
+          # the log file path and needs log.file.path (off by default in the
+          # receiver), which otherwise makes every emit fail with
+          # "type '<nil>' cannot be parsed as log path field". We don't use the
+          # path metadata — the function identity comes from the access-record
+          # body below.
           - type: container
+            add_metadata_from_filepath: false
           # Parse the zap JSON into attributes; the body stays the JSON string
           # so Loki's `| json` pipeline can re-extract fission_request_id.
           # Non-JSON lines are dropped rather than failing the pipeline.

--- a/test/integration/otel/otel-collector.yaml
+++ b/test/integration/otel/otel-collector.yaml
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: The Fission Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# CI-ONLY OpenTelemetry Collector for the RFC-0016 OTLP logging integration
+# test. NOT part of the Fission Helm chart — Fission emits structured logs and
+# delegates collection to an operator-run external collector
+# (docs/rfc/0016-otlp-native-logging-pipeline.md). This DaemonSet plays that
+# operator role in CI: it tails the router pod's stdout, keeps the per-invocation
+# access record (msg="function access", opt-in via router.displayAccessLog),
+# hoists the function identity the record carries to OTLP resource attributes,
+# and pushes to Loki's native OTLP endpoint. Loki then indexes
+# fission.function.uid/namespace as labels so the `loki` logdb driver can query
+# the record by request id.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  namespace: fission-logging
+data:
+  config.yaml: |
+    receivers:
+      filelog:
+        # The router pod's container log on the node. The access record rides
+        # the router's normal stdout (zap JSON).
+        include: [/var/log/pods/fission_router-*/*/*.log]
+        start_at: beginning
+        operators:
+          # Strip the CRI/containerd wrapper, leaving the zap JSON as the body.
+          - type: container
+          # Parse the zap JSON into attributes; the body stays the JSON string
+          # so Loki's `| json` pipeline can re-extract fission_request_id.
+          # Non-JSON lines are dropped rather than failing the pipeline.
+          - type: json_parser
+            parse_from: body
+            parse_to: attributes
+            on_error: drop_quiet
+          # Keep only the per-invocation access record. Every other router log
+          # line is noise for this correlation index.
+          - type: filter
+            expr: 'attributes.msg != "function access"'
+    processors:
+      # Hoist the function identity from the log record up to resource
+      # attributes so the Loki OTLP endpoint promotes them to stream labels.
+      groupbyattrs:
+        keys: [fission.function.uid, fission.function.namespace, fission.function.name]
+      batch:
+        timeout: 1s
+    exporters:
+      otlphttp/loki:
+        logs_endpoint: http://loki.fission-logging.svc:3100/otlp/v1/logs
+        tls:
+          insecure: true
+    service:
+      telemetry:
+        logs:
+          level: warn
+      pipelines:
+        logs:
+          receivers: [filelog]
+          processors: [groupbyattrs, batch]
+          exporters: [otlphttp/loki]
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: otel-collector
+  namespace: fission-logging
+  labels: {app: otel-collector}
+spec:
+  selector:
+    matchLabels: {app: otel-collector}
+  template:
+    metadata:
+      labels: {app: otel-collector}
+    spec:
+      # Pod logs under /var/log/pods are root-owned on the node.
+      securityContext:
+        runAsUser: 0
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.116.0
+          args: ["--config=/etc/otel/config.yaml"]
+          volumeMounts:
+            - {name: config, mountPath: /etc/otel}
+            - {name: varlogpods, mountPath: /var/log/pods, readOnly: true}
+          # Watching one pod's logs and forwarding a handful of records is
+          # cheap; keep the footprint small so it never crowds the test workload.
+          resources:
+            requests: {cpu: 20m, memory: 64Mi}
+            limits: {memory: 192Mi}
+      volumes:
+        - name: config
+          configMap: {name: otel-collector-config}
+        - name: varlogpods
+          hostPath: {path: /var/log/pods}

--- a/test/integration/suites/common/function_logs_loki_test.go
+++ b/test/integration/suites/common/function_logs_loki_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestFunctionLogsLokiCorrelation exercises the RFC-0016 OTLP logging read path
+// end to end against a real Loki fed by an OpenTelemetry Collector (the CI-only
+// stack in test/integration/otel/, which Fission does NOT bundle in its chart).
+//
+// It invokes a function with a known X-Fission-Request-ID, then asserts
+// `fission function logs --dbtype loki --request-id <id>` returns the router
+// access record for exactly that invocation. That proves the whole correlation
+// pipeline: the router emits the structured access record (RFC-0016 section 1a,
+// router.displayAccessLog on in kind-ci) → the collector tails the router's
+// stdout, keeps the record, and pushes it to Loki with the function identity as
+// resource attributes → Loki indexes fission_function_uid/namespace as labels →
+// the loki logdb driver's LogQL ({fission_function_uid="<uid>"} | json |
+// fission_request_id="<id>") selects the line.
+//
+// Gated on FISSION_TEST_LOKI: the stack is stood up only on the CI leg that
+// installs it (see .github/workflows/push_pr.yaml) with LOKI_URL pointing at the
+// port-forwarded Loki. The test skips everywhere else, mirroring how the other
+// infra-gated tests (Gateway API, OCI registry) skip when their dependency is
+// absent.
+func TestFunctionLogsLokiCorrelation(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("FISSION_TEST_LOKI") == "" {
+		t.Skip("FISSION_TEST_LOKI unset; skipping Loki log-correlation test (needs the OTel Collector + Loki stack from test/integration/otel/, router.displayAccessLog=true, and LOKI_URL)")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	ns := f.NewTestNamespace(t)
+	envName := "node-loki-" + ns.ID
+	fnName := "lokifn-" + ns.ID
+	routePath := "/" + fnName
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+	codePath := framework.WriteTestData(t, "nodejs/hello/hello.js")
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: fnName, Env: envName, Code: codePath})
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: routePath, Method: "GET"})
+
+	// Make sure the route is live before the correlated invocation.
+	r := f.Router(t)
+	r.GetEventually(t, ctx, routePath, framework.BodyContains("hello"))
+
+	// Invoke with a request id we control: RFC-0015's correlation middleware
+	// honors an inbound X-Fission-Request-ID, so the access record — and thus
+	// the Loki query — keys on this exact value.
+	reqID := "itest-loki-" + ns.ID
+	status, _, err := r.GetWithRequestID(ctx, routePath, reqID)
+	require.NoError(t, err, "invoke with request id")
+	require.Equal(t, 200, status, "correlated invocation should succeed")
+
+	// Poll the loki driver until the collector has shipped the access record
+	// and Loki has indexed it. An empty result is not an error (no record yet),
+	// so the best-effort capture lets us retry; a real backend failure surfaces.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		out, qerr := ns.CLICaptureStdoutBestEffort(t, ctx,
+			"function", "logs",
+			"--name", fnName,
+			"--dbtype", "loki",
+			"--request-id", reqID)
+		if !assert.NoErrorf(c, qerr, "loki query failed:\n%s", out) {
+			return
+		}
+		assert.Containsf(c, out, reqID,
+			"loki logs --request-id should return the access record carrying %q; got:\n%s", reqID, out)
+		assert.Containsf(c, out, fnName,
+			"the access record should name function %q; got:\n%s", fnName, out)
+	}, 90*time.Second, 3*time.Second)
+}


### PR DESCRIPTION
## What

Proves the RFC-0016 OTLP logging pipeline end to end in CI, and updates the `docs/rfc` index/status headers to reflect everything merged so far.

This is the CI realization of RFC-0016 **phase 3** (external-collector wiring), building on the merged read path ([#3516](https://github.com/fission/fission/pull/3516)) and router access record ([#3517](https://github.com/fission/fission/pull/3517)).

## The test

`TestFunctionLogsLokiCorrelation` (gated on `FISSION_TEST_LOKI`) invokes a function with a known `X-Fission-Request-ID`, then asserts `fission function logs --dbtype loki --request-id <id>` returns the router access record for exactly that invocation.

That exercises the whole correlation pipeline:

```
router stdout (access record, zap JSON, router.displayAccessLog on in kind-ci)
  → otel-collector (filelog tail → keep access records → hoist
                    fission.function.{uid,namespace,name} to resource attrs)
  → Loki OTLP endpoint, which indexes those as stream labels
    fission_function_uid / fission_function_namespace
  → loki logdb driver: {fission_function_uid="<uid>"} | json | fission_request_id="<id>"
```

## No new chart surface

The OpenTelemetry Collector + Loki are **CI-only** (`test/integration/otel/`), not part of the Helm chart.
Fission bundles no log collector or backend — collection is operator-run per the RFC.
This stack plays the operator's side on one CI leg (v1.34.8), exactly like the Envoy Gateway and OCI test-registry are stood up; other legs leave `FISSION_TEST_LOKI` unset so the test skips.

## Changes

- `test/integration/otel/` — single-binary Loki (OTLP label promotion) + a Collector DaemonSet (filelog → filter access records → `groupbyattrs` → `otlphttp` to Loki), plus a README. No Kubernetes RBAC: the function identity comes from the router log body, not pod labels.
- `test/integration/suites/common/function_logs_loki_test.go` — the gated round-trip test.
- `test/integration/framework/router.go` — `RouterClient.GetWithRequestID`, so the test keys on an id it controls (RFC-0015 honors an inbound id) instead of parsing the minted response header.
- `.github/workflows/push_pr.yaml` — install step + Loki port-forward + `LOKI_URL` / `FISSION_TEST_LOKI` gating on the v1.34.8 leg.
- `docs/rfc/` — name the merged PRs in the index and status headers: 0015 → Implemented (#3515); 0016 → Partially implemented (#3516 / #3517); link the already-merged 0012 (#3494) and 0013 (#3493).

## Validation

Local: license-check, gofmt, golangci-lint, tagged build, and YAML (including the embedded collector/Loki configs) all clean.
The access record's exact JSON shape — `msg="function access"` with `fission.function.{uid,namespace,name}` and `fission.request.id` — was confirmed against #3517's CI artifact (1020 records on the v1.34.8 leg), which is what the collector filter and Loki label mapping key on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)