### PR TITLE
feat(cli): RFC-0016/0017 — streaming `logs --follow` + data-plane invocability in describe

### DIFF
--- a/docs/rfc/0016-otlp-native-logging-pipeline.md
+++ b/docs/rfc/0016-otlp-native-logging-pipeline.md
@@ -5,7 +5,8 @@
   The router per-invocation access record landed in [#3517](https://github.com/fission/fission/pull/3517).
   Collection is delegated to an **operator-run external collector** — Fission does not bundle a collector container in the chart; it emits the structured logs an external pipeline ingests.
   A reference OpenTelemetry Collector + Loki wiring exercises the full round-trip on one CI leg (`test/integration/otel/`, not the chart).
-  Control-plane OTLP log push, streaming `--follow`, and the InfluxDB deprecation cutover remain.
+  Streaming `--follow` is implemented (the kubernetes driver follows the pod stream, the loki driver opens the `/tail` WebSocket).
+  InfluxDB is deprecated (the driver warns and is disabled by default); only the control-plane OTLP log push and the env-image per-line helpers (separate `fission/environments` repo) remain.
   See "As implemented".
 - Tracking issue: —
 - Supersedes: the InfluxDB-v1.x + Fluent-Bit logging path (deprecated by this RFC)
@@ -233,6 +234,9 @@ Concrete surface:
 - `pkg/fission-cli/cmd/function/log.go` + `flag` — new `--request-id` / `--trace-id` / `--level` flags wire into the filter; a one-shot query now surfaces a backend error (bad query / auth / unreachable) instead of swallowing it; the CLI warns when a correlation filter is set against a backend that does not index it.
 - `pkg/router/metrics.go` (`functionHandler.logAccessRecord`) + `config.go` — the per-invocation access record (section 1a), emitted to router stdout, opt-in via the pre-existing `DISPLAY_ACCESS_LOG` flag (`router.displayAccessLog`, default false) which was an orphaned env var until now.
   Threaded through the router config like `ROUTER_STRUCTURED_ERRORS`.
+- **Streaming `--follow`** (phase 5) — an optional `LogStreamer` interface (`pkg/fission-cli/logdb`): `--follow` streams live to stdout when the driver supports it, otherwise falls back to the one-second poll.
+  The kubernetes driver follows the pod log stream (`PodLogOptions.Follow`, one goroutine per env container, line-buffered under a lock); the loki driver opens the `/tail` WebSocket (`coder/websocket`, already vendored) and renders frames through the shared `lokiEntry` mapper.
+  `writeLogEntry` now takes `io.Writer` so a live stream renders without buffering; a cancelled context is a clean stop.
 
 The Loki adapter queries against the schema in "Structured-log standard" below, which the operator's external collector produces from the function pod labels + the access record — so it is immediately useful for a cluster already running a collector + Loki with that schema.
 

--- a/docs/rfc/0017-function-developer-debugging-toolkit.md
+++ b/docs/rfc/0017-function-developer-debugging-toolkit.md
@@ -1,8 +1,9 @@
 # RFC-0017: Function Developer Debugging Toolkit (CLI)
 
-- Status: Partially implemented.
-  Phase 1 (`fission function describe`, with an invocability headline), phase 2 (`fission function test` enrichment), and the CLI side of phase 3 (`logs --request-id/--trace-id`, shipped with RFC-0016) are implemented.
-  The parts that need unbuilt **server** surfaces — the deep `/v2/diag/function` invocability endpoint (RFC-0015 phase 5), real streaming `--follow` (RFC-0016 phase 5), and the cold-start metrics panel (a CLI→Prometheus query path) — remain.
+- Status: Partially implemented ([#3519](https://github.com/fission/fission/pull/3519) + follow-up).
+  Phase 1 (`fission function describe`), phase 2 (`fission function test` enrichment), and phase 3 (`logs --request-id/--trace-id` + real streaming `--follow`) are implemented.
+  The `describe` invocability headline reads the **RFC-0002 EndpointSlice data-plane** state (the `fission.io/served` label) via the k8s API — chosen over a CLI-reachable executor `/v2/diag/function` endpoint, which would have meant bypassing the executor's HMAC auth or adding CLI-side signing for marginal extra detail.
+  Only the cold-start metrics panel (a CLI→Prometheus query path, needs a metric that does not yet exist) remains.
   See "As implemented".
 - Tracking issue: —
 - Supersedes: —

--- a/docs/rfc/README.md
+++ b/docs/rfc/README.md
@@ -22,8 +22,8 @@ Each document carries a `Status` header naming the implementing PRs and, where a
 | [0013](0013-incremental-router-routes.md) | Incremental Router Route Updates | Implemented (phases 0–2, [#3493](https://github.com/fission/fission/pull/3493); phase 3 gated, not built) |
 | [0014](0014-router-hot-path-efficiency.md) | Router Hot-Path Efficiency | Implemented ([#3491](https://github.com/fission/fission/pull/3491)) |
 | [0015](0015-invocation-correlation-and-failure-attribution.md) | Invocation Correlation & Failure Attribution | Implemented ([#3515](https://github.com/fission/fission/pull/3515)); phase 5 folded into RFC-0017 |
-| [0016](0016-otlp-native-logging-pipeline.md) | Cloud-Native, OTLP-Native Logging Pipeline | Partially implemented (read path [#3516](https://github.com/fission/fission/pull/3516), access record [#3517](https://github.com/fission/fission/pull/3517), CI round-trip [#3518](https://github.com/fission/fission/pull/3518); OTLP push / streaming / deprecation cutover remain) |
-| [0017](0017-function-developer-debugging-toolkit.md) | Function Developer Debugging Toolkit (CLI) | Partially implemented (`function describe` + invocability, `test` enrichment, `logs` correlation flags); server-dependent diag endpoint / streaming / cold-start metrics remain |
+| [0016](0016-otlp-native-logging-pipeline.md) | Cloud-Native, OTLP-Native Logging Pipeline | Partially implemented (read path [#3516](https://github.com/fission/fission/pull/3516), access record [#3517](https://github.com/fission/fission/pull/3517), CI round-trip [#3518](https://github.com/fission/fission/pull/3518), streaming `--follow`); control-plane OTLP push + env-image helpers (separate repo) remain |
+| [0017](0017-function-developer-debugging-toolkit.md) | Function Developer Debugging Toolkit (CLI) | Partially implemented ([#3519](https://github.com/fission/fission/pull/3519) + follow-up: `describe` + data-plane invocability, `test` enrichment, `logs` correlation + streaming `--follow`); cold-start metrics panel remains |
 
 ## Companion material
 

--- a/pkg/fission-cli/cmd/function/describe.go
+++ b/pkg/fission-cli/cmd/function/describe.go
@@ -154,18 +154,29 @@ func describePodsTo(out io.Writer, active []*corev1.Pod) {
 // pods — so it needs no executor diagnostics endpoint. A Ready function with no
 // warm pod is still invocable (it cold-starts), which is called out.
 func invocability(fn *fv1.Function, active []*corev1.Pod) string {
-	warm := 0
+	warm, serving := 0, 0
 	for _, pod := range active {
-		if ready, total := utils.PodContainerReadyStatus(pod); total > 0 && ready == total {
-			warm++
+		ready, total := utils.PodContainerReadyStatus(pod)
+		if total == 0 || ready != total {
+			continue
+		}
+		warm++
+		// fission.io/served=true means the pod is published to its function's
+		// EndpointSlice and actually serving traffic (RFC-0002 data plane).
+		if pod.Labels[fv1.SERVED_LABEL] == fv1.SERVED_VALUE {
+			serving++
 		}
 	}
 	switch util.ConditionStatus(fn.Status.Conditions, fv1.FunctionConditionReady) {
 	case string(metav1.ConditionTrue):
-		if warm > 0 {
+		switch {
+		case serving > 0:
+			return fmt.Sprintf("Yes (%d warm pod(s), %d serving)", warm, serving)
+		case warm > 0:
 			return fmt.Sprintf("Yes (%d warm pod(s))", warm)
+		default:
+			return "Yes (cold start on first call)"
 		}
-		return "Yes (cold start on first call)"
 	case string(metav1.ConditionFalse):
 		return "No - function not Ready (see CONDITIONS)"
 	default:

--- a/pkg/fission-cli/cmd/function/describe.go
+++ b/pkg/fission-cli/cmd/function/describe.go
@@ -171,7 +171,7 @@ func invocability(fn *fv1.Function, active []*corev1.Pod) string {
 	case string(metav1.ConditionTrue):
 		switch {
 		case serving > 0:
-			return fmt.Sprintf("Yes (%d warm pod(s), %d serving)", warm, serving)
+			return fmt.Sprintf("Yes (%d of %d warm pod(s) serving)", serving, warm)
 		case warm > 0:
 			return fmt.Sprintf("Yes (%d warm pod(s))", warm)
 		default:

--- a/pkg/fission-cli/cmd/function/describe_test.go
+++ b/pkg/fission-cli/cmd/function/describe_test.go
@@ -56,6 +56,7 @@ func describeFunctionPod() *corev1.Pod {
 				fv1.FUNCTION_NAMESPACE: "default",
 				fv1.EXECUTOR_TYPE:      "poolmgr",
 				fv1.MANAGED:            "false",
+				fv1.SERVED_LABEL:       fv1.SERVED_VALUE,
 			},
 		},
 		Status: corev1.PodStatus{
@@ -105,6 +106,8 @@ func TestFunctionDescribe(t *testing.T) {
 		assert.Contains(t, out, "1/2", "partially-ready pod count (ready/total order)")
 		assert.Contains(t, out, "Invocable", "invocability headline")
 		assert.Contains(t, out, "Yes", "ready function with a warm pod is invocable")
+		assert.Contains(t, out, "serving", "served pod surfaced in the invocability headline (RFC-0002 data plane)")
+		assert.Contains(t, out, "SERVED", "pods table has a SERVED column")
 	})
 
 	t.Run("a not-Ready function reports not invocable", func(t *testing.T) {

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -68,25 +68,29 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 		console.Warn(fmt.Sprintf("--request-id/--trace-id/--level filters are only applied by the loki dbtype and are ignored for %q", dbType))
 	}
 
+	// The filter is built once; the polling loop below overrides only the
+	// per-iteration fields (Since/Reverse/WarnUser/Details).
+	baseFilter := logdb.LogFilter{
+		Pod:            fnPod,
+		PodNamespace:   input.String(flagkey.NamespacePod),
+		Function:       f.Name,
+		FuncUid:        string(f.UID),
+		RecordLimit:    recordLimit,
+		FunctionObject: f,
+		Details:        input.Bool(flagkey.FnLogDetail),
+		AllPods:        allPods,
+		RequestID:      input.String(flagkey.FnLogRequestID),
+		TraceID:        input.String(flagkey.FnLogTraceID),
+		Level:          input.String(flagkey.FnLogLevel),
+	}
+
 	// Live streaming: when --follow is set and the driver can tail (kubernetes
 	// follows the pod stream, loki opens a /tail WebSocket), stream straight to
 	// stdout instead of the one-second poll loop below. Drivers that can't
 	// stream fall through to polling.
 	if input.Bool(flagkey.FnLogFollow) {
 		if streamer, ok := logDB.(logdb.LogStreamer); ok {
-			return streamer.StreamLogs(input.Context(), logdb.LogFilter{
-				Pod:            fnPod,
-				PodNamespace:   input.String(flagkey.NamespacePod),
-				Function:       f.Name,
-				FuncUid:        string(f.UID),
-				RecordLimit:    recordLimit,
-				FunctionObject: f,
-				Details:        input.Bool(flagkey.FnLogDetail),
-				AllPods:        allPods,
-				RequestID:      input.String(flagkey.FnLogRequestID),
-				TraceID:        input.String(flagkey.FnLogTraceID),
-				Level:          input.String(flagkey.FnLogLevel),
-			}, os.Stdout)
+			return streamer.StreamLogs(input.Context(), baseFilter, os.Stdout)
 		}
 	}
 
@@ -99,26 +103,15 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 
 	go func(ctx context.Context, requestChan chan struct{}, responseChan chan error) {
 		t := time.Unix(0, 0*int64(time.Millisecond))
-		detail := input.Bool(flagkey.FnLogDetail)
+		detail := baseFilter.Details
 		for {
 			select {
 			case <-requestChan:
-				logFilter := logdb.LogFilter{
-					Pod:            fnPod,
-					PodNamespace:   input.String(flagkey.NamespacePod),
-					Function:       f.Name,
-					FuncUid:        string(f.UID),
-					Since:          t,
-					Reverse:        logReverseQuery,
-					RecordLimit:    recordLimit,
-					FunctionObject: f,
-					Details:        detail,
-					WarnUser:       warn,
-					AllPods:        allPods,
-					RequestID:      input.String(flagkey.FnLogRequestID),
-					TraceID:        input.String(flagkey.FnLogTraceID),
-					Level:          input.String(flagkey.FnLogLevel),
-				}
+				logFilter := baseFilter
+				logFilter.Since = t
+				logFilter.Reverse = logReverseQuery
+				logFilter.Details = detail
+				logFilter.WarnUser = warn
 
 				buf := new(bytes.Buffer)
 				qerr := logDB.GetLogs(ctx, logFilter, buf)

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -68,6 +68,28 @@ func (opts *LogSubCommand) do(input cli.Input) error {
 		console.Warn(fmt.Sprintf("--request-id/--trace-id/--level filters are only applied by the loki dbtype and are ignored for %q", dbType))
 	}
 
+	// Live streaming: when --follow is set and the driver can tail (kubernetes
+	// follows the pod stream, loki opens a /tail WebSocket), stream straight to
+	// stdout instead of the one-second poll loop below. Drivers that can't
+	// stream fall through to polling.
+	if input.Bool(flagkey.FnLogFollow) {
+		if streamer, ok := logDB.(logdb.LogStreamer); ok {
+			return streamer.StreamLogs(input.Context(), logdb.LogFilter{
+				Pod:            fnPod,
+				PodNamespace:   input.String(flagkey.NamespacePod),
+				Function:       f.Name,
+				FuncUid:        string(f.UID),
+				RecordLimit:    recordLimit,
+				FunctionObject: f,
+				Details:        input.Bool(flagkey.FnLogDetail),
+				AllPods:        allPods,
+				RequestID:      input.String(flagkey.FnLogRequestID),
+				TraceID:        input.String(flagkey.FnLogTraceID),
+				Level:          input.String(flagkey.FnLogLevel),
+			}, os.Stdout)
+		}
+	}
+
 	requestChan := make(chan struct{})
 	// responseChan carries each iteration's result so the one-shot exit returns
 	// the backend error by type, with no err variable shared across goroutines.

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -64,12 +64,16 @@ func (opts *ListPodsSubCommand) do(input cli.Input) error {
 // two never drift; READY is ready/total.
 func printFunctionPodsTo(out io.Writer, pods []*corev1.Pod) {
 	w := util.NewTabWriter(out)
-	fmt.Fprintln(w, "NAME\tNAMESPACE\tREADY\tSTATUS\tIP\tEXECUTORTYPE\tMANAGED")
+	// SERVED reflects the RFC-0002 data-plane state: a pod carries
+	// fission.io/served=true only while it is published to its function's
+	// EndpointSlice and actually handling traffic (the idle reaper strips it).
+	fmt.Fprintln(w, "NAME\tNAMESPACE\tREADY\tSTATUS\tIP\tEXECUTORTYPE\tMANAGED\tSERVED")
 	for _, pod := range pods {
 		ready, total := utils.PodContainerReadyStatus(pod)
-		fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\t%s\t%s\t%s\n",
+		fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\t%s\t%s\t%s\t%s\n",
 			pod.Name, pod.Namespace, ready, total, pod.Status.Phase,
-			valueOr(pod.Status.PodIP), valueOr(pod.Labels[v1.EXECUTOR_TYPE]), valueOr(pod.Labels[v1.MANAGED]))
+			valueOr(pod.Status.PodIP), valueOr(pod.Labels[v1.EXECUTOR_TYPE]), valueOr(pod.Labels[v1.MANAGED]),
+			valueOr(pod.Labels[v1.SERVED_LABEL]))
 	}
 	w.Flush()
 }

--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -5,13 +5,17 @@
 package logdb
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strconv"
+	"sync"
 
+	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -21,6 +25,8 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
+
+const fetcherContainer = "fetcher"
 
 type LogDBOptions struct {
 	Client cmd.Client
@@ -32,6 +38,10 @@ func init() {
 		return NewKubernetesEndpoint(opts)
 	})
 }
+
+// kubernetesLogs implements both one-shot pod-log reads (LogDatabase) and live
+// tailing (LogStreamer).
+var _ LogStreamer = kubernetesLogs{}
 
 type kubernetesLogs struct {
 	client cmd.Client
@@ -49,14 +59,28 @@ func NewKubernetesEndpoint(logDBOptions LogDBOptions) (kubernetesLogs, error) {
 
 // FunctionPodLogs : Get logs for a function directly from pod
 func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFilter, podLogs *bytes.Buffer) (err error) {
+	pods, err := selectFunctionPods(ctx, client, logFilter)
+	if err != nil {
+		return err
+	}
+	for i := range pods {
+		if err = streamContainerLog(ctx, client.KubernetesClient, &pods[i], logFilter, podLogs); err != nil {
+			return fmt.Errorf("error getting container logs: %w", err)
+		}
+	}
+	return nil
+}
 
+// selectFunctionPods resolves the pods whose logs `function logs` should read:
+// all of them with --all-pods, otherwise just the most recently created one
+// (highest resourceVersion). Shared by the one-shot and the --follow paths.
+func selectFunctionPods(ctx context.Context, client cmd.Client, logFilter LogFilter) ([]v1.Pod, error) {
 	f := logFilter.FunctionObject
 
 	podNs := f.Namespace
 	if logFilter.PodNamespace != "" {
 		podNs = logFilter.PodNamespace
 	}
-	// Get function Pods first
 	var selector map[string]string
 	if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType != fv1.ExecutorTypeContainer {
 		selector = map[string]string{
@@ -75,38 +99,92 @@ func GetFunctionPodLogs(ctx context.Context, client cmd.Client, logFilter LogFil
 		LabelSelector: labels.Set(selector).AsSelector().String(),
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	if len(podList.Items) <= 0 {
-		return fmt.Errorf("no active pods found for function in namespace %s", podNs)
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no active pods found for function in namespace %s", podNs)
 	}
 
 	pods := podList.Items
 	if logFilter.AllPods {
-		for _, pod := range pods {
-			// get the pod with highest resource version
-			err = streamContainerLog(ctx, client.KubernetesClient, &pod, logFilter, podLogs)
-			if err != nil {
-				return fmt.Errorf("error getting container logs: %w", err)
-			}
-		}
-	} else {
-		// Get the logs for last Pod executed
-		sort.Slice(pods, func(i, j int) bool {
-			rv1, _ := strconv.ParseInt(pods[i].ResourceVersion, 10, 32)
-			rv2, _ := strconv.ParseInt(pods[j].ResourceVersion, 10, 32)
-			return rv1 > rv2
-		})
+		return pods, nil
+	}
+	sort.Slice(pods, func(i, j int) bool {
+		rv1, _ := strconv.ParseInt(pods[i].ResourceVersion, 10, 32)
+		rv2, _ := strconv.ParseInt(pods[j].ResourceVersion, 10, 32)
+		return rv1 > rv2
+	})
+	return pods[:1], nil
+}
 
-		// get the pod with highest resource version
-		err = streamContainerLog(ctx, client.KubernetesClient, &pods[0], logFilter, podLogs)
-		if err != nil {
-			return fmt.Errorf("error getting container logs: %w", err)
+// StreamLogs follows the function's pod logs live (PodLogOptions.Follow), one
+// goroutine per env container, until the context is cancelled. Writes are
+// serialized and (when following more than one pod) prefixed with the pod name.
+func (k kubernetesLogs) StreamLogs(ctx context.Context, filter LogFilter, out io.Writer) error {
+	pods, err := selectFunctionPods(ctx, k.client, filter)
+	if err != nil {
+		return err
+	}
+	lw := &lockedWriter{w: out}
+	multi := len(pods) > 1
+	g, gctx := errgroup.WithContext(ctx)
+	for i := range pods {
+		pod := pods[i]
+		for _, c := range pod.Spec.Containers {
+			if c.Name == fetcherContainer {
+				continue
+			}
+			ns, name, container := pod.Namespace, pod.Name, c.Name
+			prefix := ""
+			if multi {
+				prefix = name + " "
+			}
+			g.Go(func() error {
+				return followContainer(gctx, k.client.KubernetesClient, ns, name, container, prefix, filter, lw)
+			})
 		}
 	}
-
+	err = g.Wait()
+	// A cancelled context (the user stopped --follow) is a clean exit.
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return nil
+	}
 	return err
+}
+
+func followContainer(ctx context.Context, kc kubernetes.Interface, ns, podName, container, prefix string, filter LogFilter, out io.Writer) error {
+	opts := &v1.PodLogOptions{Container: container, Follow: true}
+	if filter.RecordLimit > 0 {
+		tail := int64(filter.RecordLimit)
+		opts.TailLines = &tail
+	}
+	stream, err := kc.CoreV1().Pods(ns).GetLogs(podName, opts).Stream(ctx)
+	if err != nil {
+		return fmt.Errorf("error streaming pod log: %w", err)
+	}
+	defer stream.Close()
+
+	sc := bufio.NewScanner(stream)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // tolerate long log lines
+	for sc.Scan() {
+		if _, err := fmt.Fprintf(out, "%s%s\n", prefix, sc.Text()); err != nil {
+			return err
+		}
+	}
+	return sc.Err()
+}
+
+// lockedWriter serializes concurrent writes from multiple pod-log streams onto
+// one writer, so whole lines from different pods don't interleave mid-line.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }
 
 func streamContainerLog(ctx context.Context, kubernetesClient kubernetes.Interface, pod *v1.Pod, logFilter LogFilter, output *bytes.Buffer) (err error) {

--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -164,14 +164,31 @@ func followContainer(ctx context.Context, kc kubernetes.Interface, ns, podName, 
 	}
 	defer stream.Close()
 
-	sc := bufio.NewScanner(stream)
-	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024) // tolerate long log lines
-	for sc.Scan() {
-		if _, err := fmt.Fprintf(out, "%s%s\n", prefix, sc.Text()); err != nil {
+	if filter.Details {
+		fn := filter.FunctionObject
+		if _, err := fmt.Fprintf(out, "\n=== Function=%s Namespace=%s Pod=%s Container=%s\n", fn.Name, ns, podName, container); err != nil {
 			return err
 		}
 	}
-	return sc.Err()
+
+	// bufio.Reader (not Scanner) so a log line larger than the scanner's token
+	// cap doesn't abort the whole follow session — matches the unbounded
+	// one-shot io.Copy.
+	r := bufio.NewReader(stream)
+	for {
+		line, rerr := r.ReadString('\n')
+		if len(line) > 0 {
+			if _, werr := fmt.Fprintf(out, "%s%s", prefix, line); werr != nil {
+				return werr
+			}
+		}
+		if rerr != nil {
+			if errors.Is(rerr, io.EOF) {
+				return nil
+			}
+			return rerr
+		}
+	}
 }
 
 // lockedWriter serializes concurrent writes from multiple pod-log streams onto
@@ -188,9 +205,8 @@ func (l *lockedWriter) Write(p []byte) (int, error) {
 }
 
 func streamContainerLog(ctx context.Context, kubernetesClient kubernetes.Interface, pod *v1.Pod, logFilter LogFilter, output *bytes.Buffer) (err error) {
-	FETCHER := "fetcher"
 	for _, container := range pod.Spec.Containers {
-		if container.Name == FETCHER {
+		if container.Name == fetcherContainer {
 			continue
 		}
 		tailLines := int64(logFilter.RecordLimit)

--- a/pkg/fission-cli/logdb/logdb.go
+++ b/pkg/fission-cli/logdb/logdb.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sort"
 	"strings"
 	"time"
@@ -23,6 +24,17 @@ const (
 
 type LogDatabase interface {
 	GetLogs(context.Context, LogFilter, *bytes.Buffer) error
+}
+
+// LogStreamer is an optional capability a driver implements when it can tail
+// logs live. `fission function logs --follow` uses StreamLogs when the selected
+// driver supports it (the kubernetes driver follows the pod log stream, the
+// loki driver opens a /tail WebSocket), and falls back to one-second GetLogs
+// polling otherwise. StreamLogs writes lines to out as they arrive in the
+// driver's native format and blocks until the context is cancelled or the
+// stream ends.
+type LogStreamer interface {
+	StreamLogs(ctx context.Context, filter LogFilter, out io.Writer) error
 }
 
 type LogFilter struct {
@@ -79,7 +91,7 @@ func ByTimestamp(entries []LogEntry, desc bool) ByTimestampSort {
 // writeLogEntry renders one entry into output — the detailed multi-line form
 // (with --detail) or the compact "[timestamp] message" form — shared by every
 // driver so the CLI output is identical regardless of backend.
-func writeLogEntry(output *bytes.Buffer, entry LogEntry, details bool) error {
+func writeLogEntry(output io.Writer, entry LogEntry, details bool) error {
 	var msg string
 	if details {
 		msg = fmt.Sprintf("Timestamp: %s\nNamespace: %s\nFunction Name: %s\nFunction ID: %s\nPod: %s\nContainer: %s\nStream: %s\nLog: %s\n---\n",
@@ -87,7 +99,7 @@ func writeLogEntry(output *bytes.Buffer, entry LogEntry, details bool) error {
 	} else {
 		msg = fmt.Sprintf("[%s] %s\n", entry.Timestamp, entry.Message)
 	}
-	if _, err := output.WriteString(msg); err != nil {
+	if _, err := io.WriteString(output, msg); err != nil {
 		return fmt.Errorf("error copying pod log: %w", err)
 	}
 	return nil

--- a/pkg/fission-cli/logdb/loki.go
+++ b/pkg/fission-cli/logdb/loki.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -18,10 +19,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/console"
 	"github.com/fission/fission/pkg/fission-cli/util"
 )
+
+// loki implements both one-shot queries (LogDatabase) and live tailing
+// (LogStreamer).
+var _ LogStreamer = loki{}
 
 // loki is the reference OTLP-backend query adapter (RFC-0016): it queries a
 // Loki instance over the HTTP query_range API using LogQL. It assumes function
@@ -30,6 +38,7 @@ import (
 // produces.
 const (
 	lokiQueryRangePath = "/loki/api/v1/query_range"
+	lokiTailPath       = "/loki/api/v1/tail"
 	lokiHTTPTimeout    = 30 * time.Second
 	// defaultLokiLookback floors the query_range start. The CLI's default
 	// Since is the epoch, which would make the range span decades; Loki
@@ -164,23 +173,14 @@ func (l loki) GetLogs(ctx context.Context, filter LogFilter, output *bytes.Buffe
 	var entries []LogEntry
 	for _, stream := range parsed.Data.Result {
 		for _, v := range stream.Values {
-			ns, err := strconv.ParseInt(v[0], 10, 64)
+			entry, err := lokiEntry(stream.Stream, v)
 			if err != nil {
 				// Best-effort: skip one malformed row rather than discard the
 				// whole batch of valid lines over a single bad timestamp.
-				console.Warn(fmt.Sprintf("skipping loki log entry with invalid timestamp %q: %v", v[0], err))
+				console.Warn(fmt.Sprintf("skipping loki log entry: %v", err))
 				continue
 			}
-			entries = append(entries, LogEntry{
-				Timestamp: time.Unix(0, ns).UTC(),
-				Message:   strings.TrimSuffix(v[1], "\n"),
-				Stream:    stream.Stream["stream"],
-				Container: stream.Stream["k8s_container_name"],
-				Namespace: stream.Stream["fission_function_namespace"],
-				FuncName:  stream.Stream["fission_function_name"],
-				FuncUid:   stream.Stream["fission_function_uid"],
-				Pod:       stream.Stream["k8s_pod_name"],
-			})
+			entries = append(entries, entry)
 		}
 	}
 	sort.Sort(ByTimestamp(entries, filter.Reverse))
@@ -191,4 +191,79 @@ func (l loki) GetLogs(ctx context.Context, filter LogFilter, output *bytes.Buffe
 		}
 	}
 	return nil
+}
+
+// lokiEntry builds a LogEntry from a stream's labels and a [unix_nanos, line]
+// value, mapping the RFC-0016 label schema onto the entry fields. Shared by the
+// query_range read path and the /tail stream.
+func lokiEntry(streamLabels map[string]string, value [2]string) (LogEntry, error) {
+	ns, err := strconv.ParseInt(value[0], 10, 64)
+	if err != nil {
+		return LogEntry{}, fmt.Errorf("invalid timestamp %q: %w", value[0], err)
+	}
+	return LogEntry{
+		Timestamp: time.Unix(0, ns).UTC(),
+		Message:   strings.TrimSuffix(value[1], "\n"),
+		Stream:    streamLabels["stream"],
+		Container: streamLabels["k8s_container_name"],
+		Namespace: streamLabels["fission_function_namespace"],
+		FuncName:  streamLabels["fission_function_name"],
+		FuncUid:   streamLabels["fission_function_uid"],
+		Pod:       streamLabels["k8s_pod_name"],
+	}, nil
+}
+
+// lokiTailResponse is the subset of a /tail WebSocket frame we read.
+type lokiTailResponse struct {
+	Streams []struct {
+		Stream map[string]string `json:"stream"`
+		Values [][2]string       `json:"values"` // [ unix_nanos_string, line ]
+	} `json:"streams"`
+}
+
+// StreamLogs tails Loki live over the /tail WebSocket, rendering each new line
+// in the shared CLI format until the context is cancelled.
+func (l loki) StreamLogs(ctx context.Context, filter LogFilter, out io.Writer) error {
+	query, err := buildLogQL(filter)
+	if err != nil {
+		return err
+	}
+	params := url.Values{}
+	params.Set("query", query)
+	if filter.RecordLimit > 0 {
+		params.Set("limit", strconv.Itoa(filter.RecordLimit))
+	}
+	// The tail endpoint is WebSocket: http(s):// -> ws(s)://.
+	wsURL := strings.Replace(l.endpoint, "http", "ws", 1) + lokiTailPath + "?" + params.Encode()
+
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return fmt.Errorf("error opening loki tail stream: %w", err)
+	}
+	defer conn.CloseNow()
+
+	for {
+		var frame lokiTailResponse
+		if err := wsjson.Read(ctx, conn, &frame); err != nil {
+			// A cancelled context (user stopped --follow) or a normal close is a
+			// clean exit, not an error.
+			if ctx.Err() != nil || errors.Is(err, io.EOF) ||
+				websocket.CloseStatus(err) == websocket.StatusNormalClosure {
+				return nil
+			}
+			return fmt.Errorf("error reading loki tail stream: %w", err)
+		}
+		for _, stream := range frame.Streams {
+			for _, v := range stream.Values {
+				entry, err := lokiEntry(stream.Stream, v)
+				if err != nil {
+					console.Warn(fmt.Sprintf("skipping loki tail entry: %v", err))
+					continue
+				}
+				if err := writeLogEntry(out, entry, filter.Details); err != nil {
+					return err
+				}
+			}
+		}
+	}
 }

--- a/pkg/fission-cli/logdb/loki.go
+++ b/pkg/fission-cli/logdb/loki.go
@@ -252,7 +252,7 @@ func (l loki) StreamLogs(ctx context.Context, filter LogFilter, out io.Writer) e
 	if err != nil {
 		return fmt.Errorf("error opening loki tail stream: %w", err)
 	}
-	defer conn.CloseNow()
+	defer func() { _ = conn.CloseNow() }()
 
 	for {
 		var frame lokiTailResponse

--- a/pkg/fission-cli/logdb/loki.go
+++ b/pkg/fission-cli/logdb/loki.go
@@ -120,13 +120,17 @@ func buildLogQL(filter LogFilter) (string, error) {
 	return query, nil
 }
 
+// lokiStream is one labeled stream of [unix_nanos, line] values, the element
+// shape shared by the query_range and /tail responses.
+type lokiStream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][2]string       `json:"values"` // [ unix_nanos_string, line ]
+}
+
 // lokiQueryRangeResponse is the subset of Loki's query_range response we read.
 type lokiQueryRangeResponse struct {
 	Data struct {
-		Result []struct {
-			Stream map[string]string `json:"stream"`
-			Values [][2]string       `json:"values"` // [ unix_nanos_string, line ]
-		} `json:"result"`
+		Result []lokiStream `json:"result"`
 	} `json:"data"`
 }
 
@@ -215,10 +219,7 @@ func lokiEntry(streamLabels map[string]string, value [2]string) (LogEntry, error
 
 // lokiTailResponse is the subset of a /tail WebSocket frame we read.
 type lokiTailResponse struct {
-	Streams []struct {
-		Stream map[string]string `json:"stream"`
-		Values [][2]string       `json:"values"` // [ unix_nanos_string, line ]
-	} `json:"streams"`
+	Streams []lokiStream `json:"streams"`
 }
 
 // StreamLogs tails Loki live over the /tail WebSocket, rendering each new line
@@ -233,10 +234,21 @@ func (l loki) StreamLogs(ctx context.Context, filter LogFilter, out io.Writer) e
 	if filter.RecordLimit > 0 {
 		params.Set("limit", strconv.Itoa(filter.RecordLimit))
 	}
-	// The tail endpoint is WebSocket: http(s):// -> ws(s)://.
-	wsURL := strings.Replace(l.endpoint, "http", "ws", 1) + lokiTailPath + "?" + params.Encode()
+	// The tail endpoint is WebSocket: parse the base URL and swap the scheme
+	// (http->ws, https->wss) so a host that happens to contain "http" is safe.
+	u, err := url.Parse(l.endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid loki endpoint %q: %w", l.endpoint, err)
+	}
+	if u.Scheme == "https" {
+		u.Scheme = "wss"
+	} else {
+		u.Scheme = "ws"
+	}
+	u.Path = lokiTailPath
+	u.RawQuery = params.Encode()
 
-	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	conn, _, err := websocket.Dial(ctx, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("error opening loki tail stream: %w", err)
 	}

--- a/pkg/fission-cli/logdb/loki_test.go
+++ b/pkg/fission-cli/logdb/loki_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coder/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -126,4 +127,50 @@ func TestLokiGetLogsFloorsEpochStart(t *testing.T) {
 		"epoch Since must be floored to the recent lookback window, not sent as 1970")
 	assert.Truef(t, start.After(time.Unix(0, 0).Add(time.Hour)),
 		"start must not be the epoch; got %s", start)
+}
+
+// TestLokiStreamLogs exercises the /tail WebSocket path: a test server upgrades
+// the connection, emits one tail frame, and closes; StreamLogs must render the
+// line in the shared CLI format and return cleanly on the normal close.
+func TestLokiStreamLogs(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("query")
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.CloseNow()
+		// One tail frame, then a normal close.
+		_ = c.Write(r.Context(), websocket.MessageText,
+			[]byte(`{"streams":[{"stream":{"k8s_pod_name":"pod-1","fission_function_uid":"u1"},"values":[["1700000000000000000","tail line one"]]}]}`))
+		_ = c.Close(websocket.StatusNormalClosure, "")
+	}))
+	defer srv.Close()
+
+	l := loki{endpoint: srv.URL, client: &http.Client{Timeout: lokiHTTPTimeout}}
+	var buf bytes.Buffer
+	err := l.StreamLogs(t.Context(), LogFilter{FuncUid: "u1", RecordLimit: 10}, &buf)
+	require.NoError(t, err)
+
+	assert.Equal(t, lokiTailPath, gotPath, "tail uses the /tail endpoint")
+	assert.Contains(t, gotQuery, `fission_function_uid="u1"`, "tail query is built from the filter")
+	assert.Contains(t, buf.String(), "tail line one", "the tailed line is rendered")
+}
+
+func TestLokiEntry(t *testing.T) {
+	t.Parallel()
+	entry, err := lokiEntry(
+		map[string]string{"fission_function_uid": "u1", "k8s_pod_name": "p1", "fission_function_name": "fn"},
+		[2]string{"1700000000000000000", "hello\n"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "hello", entry.Message, "trailing newline trimmed")
+	assert.Equal(t, "u1", entry.FuncUid)
+	assert.Equal(t, "p1", entry.Pod)
+	assert.Equal(t, "fn", entry.FuncName)
+
+	_, err = lokiEntry(map[string]string{}, [2]string{"not-a-number", "x"})
+	require.Error(t, err, "a non-numeric timestamp is an error")
 }

--- a/pkg/fission-cli/logdb/loki_test.go
+++ b/pkg/fission-cli/logdb/loki_test.go
@@ -141,7 +141,7 @@ func TestLokiStreamLogs(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer c.CloseNow()
+		defer func() { _ = c.CloseNow() }()
 		// One tail frame, then a normal close.
 		_ = c.Write(r.Context(), websocket.MessageText,
 			[]byte(`{"streams":[{"stream":{"k8s_pod_name":"pod-1","fission_function_uid":"u1"},"values":[["1700000000000000000","tail line one"]]}]}`))

--- a/test/integration/suites/common/function_logs_follow_test.go
+++ b/test/integration/suites/common/function_logs_follow_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestFunctionLogsFollow exercises the RFC-0016 streaming `fission function logs
+// --follow` against the default (kubernetes) driver: with --follow the driver
+// follows the pod log stream (PodLogOptions.Follow) instead of the one-second
+// poll. The function logs "log test" per invocation; after a few GETs we run
+// `logs --follow` under a bounded context — the follow stream backfills the
+// existing lines (TailLines) immediately, so the assertion does not depend on
+// real-time new output, then the context cancel ends the stream cleanly.
+func TestFunctionLogsFollow(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	ns := f.NewTestNamespace(t)
+	envName := "nodejs-follow-" + ns.ID
+	fnName := "followtest-" + ns.ID
+	routePath := "/" + fnName
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+	codePath := framework.WriteTestData(t, "nodejs/log/log.js")
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: fnName, Env: envName, Code: codePath})
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: routePath, Method: "GET"})
+
+	r := f.Router(t)
+	r.GetEventually(t, ctx, routePath, framework.BodyContains("log test"))
+	for i := 0; i < 3; i++ {
+		status, _, err := r.Get(ctx, routePath)
+		require.NoErrorf(t, err, "warm GET #%d", i)
+		require.Equalf(t, 200, status, "warm GET #%d should be 200", i)
+	}
+
+	// Poll until the follow stream reports the backfilled lines. A bounded
+	// sub-context ends the otherwise-blocking --follow; StreamLogs treats the
+	// cancel as a clean stop.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		followCtx, followCancel := context.WithTimeout(ctx, 15*time.Second)
+		defer followCancel()
+		out := ns.CLICaptureStdout(t, followCtx, "function", "logs", "--name", fnName, "--follow")
+		assert.GreaterOrEqualf(c, strings.Count(out, "log test"), 1,
+			"follow stream should surface the function's log lines; got:\n%s", out)
+	}, 90*time.Second, 5*time.Second)
+}


### PR DESCRIPTION
Advances RFC-0016 and RFC-0017 toward completion — the two CLI-feasible pieces that fit one cohesive PR.

## Real streaming `fission function logs --follow` (RFC-0016 phase 5)

Replaces the one-second poll loop with live tailing when the driver supports it, via a new optional `LogStreamer` interface (`StreamLogs(ctx, filter, io.Writer)`):

- **kubernetes driver** — follows the pod log stream (`PodLogOptions.Follow`), one goroutine per env container, line-buffered under a lock and pod-name-prefixed when following more than one pod. Pod discovery is factored into a shared `selectFunctionPods` (reused by the one-shot path). A `bufio.Reader` (not Scanner) means a >1MB line never aborts the session; `--detail` emits the per-container header.
- **loki driver** — opens the `/tail` WebSocket (`coder/websocket`, already vendored), rendering each frame through the shared `lokiEntry` mapper + `writeLogEntry`.
- A cancelled context (user stops `--follow`) is a clean exit; drivers that can't tail fall back to polling.

`writeLogEntry` now takes `io.Writer` so a live stream renders without buffering. No new dependencies.

## Data-plane invocability in `describe` (RFC-0017)

Upgrades describe's invocability from pod-readiness to the **real EndpointSlice data-plane signal**, read straight from the k8s API: a poolmgr pod carries `fission.io/served=true` only while published to its function's EndpointSlice and actually serving traffic (RFC-0002; the idle reaper strips it).

- `function pods` / `describe` pods table gain a **SERVED** column.
- describe's `Invocable` headline folds in the serving count — `Yes (1 of 2 warm pod(s) serving)` — distinguishing warm-but-not-serving from actually-serving capacity.

Chosen over a CLI-reachable executor `/v2/diag/function` endpoint, which would have meant **bypassing the executor's HMAC auth** or adding CLI-side signing for marginal extra (active-request/last-error) detail — a poor security/effort trade.

## Tests

- Unit: loki `/tail` round-trip (WebSocket test server), the shared `lokiEntry` mapper, the describe served-signal headline + SERVED column.
- Integration: `TestFunctionLogsFollow` runs `logs --follow` end to end against the kubernetes driver (relies on the follow backfill, so it's not timing-flaky).

## Reviews

Ran code-review (correctness/concurrency) and the thermo-nuclear audit on the diff — both found the concurrency and resource lifecycle correct and the structure sound; their refinements are applied (single filter literal, shared loki struct, URL-parsed scheme swap, deduped `fetcher` const, graceful long-line handling).

## Remaining (separate concerns)

Control-plane OTLP log push (go.mod bump, server otel layer) and env-image per-line helpers (separate `fission/environments` repo) for RFC-0016; the cold-start metrics panel (CLI→Prometheus, needs a metric that doesn't exist yet) for RFC-0017. RFC docs + index updated to reflect this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)