### PR TITLE
chore(codegen): regenerate swagger docs for FissionTenant

### DIFF
--- a/pkg/apis/core/v1/zz_generated.swagger_doc_generated.go
+++ b/pkg/apis/core/v1/zz_generated.swagger_doc_generated.go
@@ -168,6 +168,43 @@ func (ExecutionStrategy) SwaggerDoc() map[string]string {
 	return map_ExecutionStrategy
 }
 
+var map_FissionTenant = map[string]string{
+	"": "FissionTenant onboards a Kubernetes namespace for Fission. It is the cluster-scoped source of truth the tenant-lifecycle controller reconciles into the live resource-namespace set (and, in later phases, per-namespace RBAC, service accounts, and auth keys). Setting the label fission.io/enabled=true on a Namespace is sugar the controller materializes into one of these. See docs/multiple-namespace/prd.md.",
+}
+
+func (FissionTenant) SwaggerDoc() map[string]string {
+	return map_FissionTenant
+}
+
+var map_FissionTenantList = map[string]string{
+	"": "FissionTenantList is a list of FissionTenants.",
+}
+
+func (FissionTenantList) SwaggerDoc() map[string]string {
+	return map_FissionTenantList
+}
+
+var map_FissionTenantSpec = map[string]string{
+	"":                  "FissionTenantSpec declares which namespace Fission manages and, optionally, where that tenant's function and builder workloads run.",
+	"namespace":         "Namespace is the Kubernetes namespace this tenant onboards. It is the immutable join key to the live Namespace.",
+	"functionNamespace": "FunctionNamespace, if set, is where this tenant's function pods and Services run; empty means they run in spec.namespace. Generalizes the deprecated cluster-global FISSION_FUNCTION_NAMESPACE to a per-tenant mapping.",
+	"builderNamespace":  "BuilderNamespace, if set, is where this tenant's builder pods run; empty means they run in spec.namespace.",
+}
+
+func (FissionTenantSpec) SwaggerDoc() map[string]string {
+	return map_FissionTenantSpec
+}
+
+var map_FissionTenantStatus = map[string]string{
+	"":                   "FissionTenantStatus reports the controller's progress onboarding the tenant.",
+	"observedGeneration": "ObservedGeneration is the spec generation the controller last reconciled.",
+	"conditions":         "Conditions are the latest observations of the tenant's state: RBACProvisioned, ServiceAccountsReady, AuthKeyProvisioned, WatchActive, and the Ready rollup.",
+}
+
+func (FissionTenantStatus) SwaggerDoc() map[string]string {
+	return map_FissionTenantStatus
+}
+
 var map_Function = map[string]string{
 	"": "Function is function runs within environment runtime with given package and secrets/configmaps.",
 }


### PR DESCRIPTION
## Summary

`pkg/apis/core/v1/zz_generated.swagger_doc_generated.go` was out of sync with the committed CRD types.
The `FissionTenant` types (`FissionTenant`, `FissionTenantList`, `FissionTenantSpec`, `FissionTenantStatus`) were added to `pkg/apis/core/v1/types.go` on `main`, but their `SwaggerDoc()` entries were never regenerated into the swagger doc file.

This PR commits the regenerated output so the generated file matches its source types again.

## Details

- Generated by `make generate-swagger-doc` (which runs `hack/update-swagger-docs.sh`).
- The change is byte-identical to the generator output — no hand edits to the generated file.
- Adds the four `map_FissionTenant*` blocks and their `SwaggerDoc()` methods; no source-type changes.

## Test plan

- `make generate-swagger-doc` produces no further diff against this branch (working tree clean after regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)