### PR TITLE
chore(cli): remove deprecated per-resource namespace flags

### DIFF
--- a/pkg/fission-cli/cmd/canaryconfig/command.go
+++ b/pkg/fission-cli/cmd/canaryconfig/command.go
@@ -18,7 +18,7 @@ func Commands() *cobra.Command {
 		Short: "Create a canary config",
 	}, Create, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName, flag.CanaryTriggerName, flag.CanaryNewFunc, flag.CanaryOldFunc},
-		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceFunction},
+		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold},
 	})
 
 	getCmd := wrapper.SubCommand(&cobra.Command{
@@ -27,7 +27,7 @@ func Commands() *cobra.Command {
 		Short:   "View parameters in a canary config",
 	}, Get, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.Output},
+		Optional: []flag.Flag{flag.Output},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -36,7 +36,7 @@ func Commands() *cobra.Command {
 		Short:   "Update parameters of a canary config",
 	}, Update, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold, flag.NamespaceCanary},
+		Optional: []flag.Flag{flag.CanaryWeightIncrement, flag.CanaryIncrementInterval, flag.CanaryFailureThreshold},
 	})
 
 	deleteCmd := wrapper.SubCommand(&cobra.Command{
@@ -45,7 +45,7 @@ func Commands() *cobra.Command {
 		Short:   "Delete a canary config",
 	}, Delete, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName},
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.IgnoreNotFound},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -54,7 +54,7 @@ func Commands() *cobra.Command {
 		Short:   "List canary configs",
 		Long:    "List all canary configs in a namespace if specified, else, list canary configs across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{
@@ -68,7 +68,7 @@ func Commands() *cobra.Command {
 		Short: "Wait for a canary config to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.CanaryName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespaceCanary, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	command.AddCommand(createCmd, getCmd, updateCmd, deleteCmd, listCmd, waitCmd)

--- a/pkg/fission-cli/cmd/canaryconfig/create.go
+++ b/pkg/fission-cli/cmd/canaryconfig/create.go
@@ -43,7 +43,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 	newFunc := input.String(flagkey.CanaryNewFunc)
 	oldFunc := input.String(flagkey.CanaryOldFunc)
 
-	_, fnNs, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNs, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in creating canaryconfig: %w", err)
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/delete.go
+++ b/pkg/fission-cli/cmd/canaryconfig/delete.go
@@ -24,7 +24,7 @@ func Delete(input cli.Input) error {
 }
 
 func (opts *DeleteSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in deleting canaryConfig: %w", err)
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/get.go
+++ b/pkg/fission-cli/cmd/canaryconfig/get.go
@@ -25,7 +25,7 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
 
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error getting canary config: %w", err)
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/list.go
+++ b/pkg/fission-cli/cmd/canaryconfig/list.go
@@ -34,7 +34,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	opts.namespace, err = opts.ResolveNamespace(input, flagkey.NamespaceCanary)
+	opts.namespace, err = opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in listing canary config: %w", err)
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -35,7 +35,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	// get the current config
-	_, ns, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, ns, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error updating canary config: %w", err)
 	}

--- a/pkg/fission-cli/cmd/canaryconfig/wait.go
+++ b/pkg/fission-cli/cmd/canaryconfig/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceCanary)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/check/check.go
+++ b/pkg/fission-cli/cmd/check/check.go
@@ -25,7 +25,7 @@ func (opts *CheckSubCommand) do(input cli.Input) error {
 
 	checks := []healthcheck.CategoryID{}
 
-	userProvidedNS, _, err := opts.GetResourceNamespace(input, flagkey.Namespace)
+	userProvidedNS, _, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error retrieving user provided namespace: %w", err)
 	}

--- a/pkg/fission-cli/cmd/cmd.go
+++ b/pkg/fission-cli/cmd/cmd.go
@@ -59,28 +59,23 @@ func (c *CommandActioner) ClusterAvailable() bool {
 	return defaultClient.FissionClientSet != nil
 }
 
-func (c *CommandActioner) GetResourceNamespace(input cli.Input, deprecatedFlag string) (namespace, currentNS string, err error) {
-	namespace = input.String(deprecatedFlag)
-	currentNS = namespace
-
-	if input.String(flagkey.Namespace) != "" {
-		namespace = input.String(flagkey.Namespace)
-		currentNS = namespace
-		console.Verbose(2, "Namespace for resource %s ", currentNS)
-		return namespace, currentNS, err
+// GetResourceNamespace resolves the namespace a resource command operates in.
+// Precedence: --namespace (also the returned "user-provided" namespace) wins;
+// otherwise FISSION_DEFAULT_NAMESPACE; otherwise the kube-context namespace.
+// The first return value is non-empty only when the user explicitly set
+// --namespace, which cross-namespace checks rely on.
+func (c *CommandActioner) GetResourceNamespace(input cli.Input) (namespace, currentNS string, err error) {
+	if ns := input.String(flagkey.Namespace); ns != "" {
+		console.Verbose(2, "Namespace for resource %s ", ns)
+		return ns, ns, nil
 	}
 
-	if namespace == "" {
-		if os.Getenv("FISSION_DEFAULT_NAMESPACE") != "" {
-			currentNS = os.Getenv("FISSION_DEFAULT_NAMESPACE")
-		} else {
-			currentNS = c.Client().Namespace
-			return namespace, currentNS, err
-		}
+	if env := os.Getenv("FISSION_DEFAULT_NAMESPACE"); env != "" {
+		console.Verbose(2, "Namespace for resource %s ", env)
+		return "", env, nil
 	}
 
-	console.Verbose(2, "Namespace for resource %s ", currentNS)
-	return namespace, currentNS, nil
+	return "", c.Client().Namespace, nil
 }
 
 // ResolveNamespace returns the namespace a list command should operate in. It
@@ -88,8 +83,8 @@ func (c *CommandActioner) GetResourceNamespace(input cli.Input, deprecatedFlag s
 // metav1.NamespaceAll when --all-namespaces is set. This replaces the
 // GetResourceNamespace + AllNamespaces block that was duplicated across every
 // list command.
-func (c *CommandActioner) ResolveNamespace(input cli.Input, deprecatedFlag string) (string, error) {
-	_, namespace, err := c.GetResourceNamespace(input, deprecatedFlag)
+func (c *CommandActioner) ResolveNamespace(input cli.Input) (string, error) {
+	_, namespace, err := c.GetResourceNamespace(input)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/fission-cli/cmd/environment/command.go
+++ b/pkg/fission-cli/cmd/environment/command.go
@@ -21,7 +21,7 @@ func Commands() *cobra.Command {
 			flag.EnvPoolsize, flag.EnvBuilderImage, flag.EnvBuildCmd,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvVersion, flag.EnvImagePullSecret, flag.EnvKeepArchive,
-			flag.NamespaceEnvironment, flag.EnvExternalNetwork, flag.Labels, flag.Annotation,
+			flag.EnvExternalNetwork, flag.Labels, flag.Annotation,
 			flag.SpecSave, flag.SpecDry, flag.EnvBuilder, flag.EnvRuntime},
 	})
 
@@ -30,7 +30,7 @@ func Commands() *cobra.Command {
 		Short: "Get environment details",
 	}, Get, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment},
+		Optional: []flag.Flag{},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -42,7 +42,7 @@ func Commands() *cobra.Command {
 			flag.EnvBuilderImage, flag.EnvBuildCmd, flag.EnvImagePullSecret,
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory, flag.RunTimeMaxMemory,
 			flag.EnvTerminationGracePeriod, flag.EnvKeepArchive, flag.EnvRuntime,
-			flag.NamespaceEnvironment, flag.EnvExternalNetwork,
+			flag.EnvExternalNetwork,
 			flag.Labels, flag.Annotation},
 	})
 
@@ -51,7 +51,7 @@ func Commands() *cobra.Command {
 		Short: "Delete an environment",
 	}, Delete, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.IgnoreNotFound, flag.EnvForce},
+		Optional: []flag.Flag{flag.IgnoreNotFound, flag.EnvForce},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -59,7 +59,7 @@ func Commands() *cobra.Command {
 		Short: "List environments",
 		Long:  "List all environments in a namespace if specified, else, list environments across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.AllNamespaces, flag.Output},
 	})
 
 	listPodsCmd := wrapper.SubCommand(&cobra.Command{
@@ -69,7 +69,7 @@ func Commands() *cobra.Command {
 		Long:    "List pods currently maintained by an environment",
 	}, ListPods, flag.FlagSet{
 		Required: []flag.Flag{flag.EnvName},
-		Optional: []flag.Flag{flag.NamespaceEnvironment, flag.EnvExecutorType},
+		Optional: []flag.Flag{flag.EnvExecutorType},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/environment/create.go
+++ b/pkg/fission-cli/cmd/environment/create.go
@@ -51,7 +51,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) (err error) {
 
-	userDefinedNS, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	userDefinedNS, currentNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/environment/delete.go
+++ b/pkg/fission-cli/cmd/environment/delete.go
@@ -27,7 +27,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
-	_, currentContextNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentContextNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error deleting environment: %w", err)
 	}

--- a/pkg/fission-cli/cmd/environment/get.go
+++ b/pkg/fission-cli/cmd/environment/get.go
@@ -26,7 +26,7 @@ func Get(input cli.Input) error {
 
 func (opts *GetSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error getting environment: %w", err)
 	}

--- a/pkg/fission-cli/cmd/environment/list.go
+++ b/pkg/fission-cli/cmd/environment/list.go
@@ -25,7 +25,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
-	currentNS, err := opts.ResolveNamespace(input, flagkey.NamespaceEnvironment)
+	currentNS, err := opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error listing environments: %w", err)
 	}

--- a/pkg/fission-cli/cmd/environment/pods.go
+++ b/pkg/fission-cli/cmd/environment/pods.go
@@ -29,7 +29,7 @@ func ListPods(input cli.Input) error {
 
 func (opts *ListPodsSubCommand) do(input cli.Input) (err error) {
 
-	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error getting environment pods: %w", err)
 	}

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -41,7 +41,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 
-	_, currentContextNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentContextNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error updating environment: %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -40,7 +40,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMinCPU, flag.RunTimeMaxCPU, flag.RunTimeMinMemory,
 			flag.RunTimeMaxMemory, flag.ReplicasMin,
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
-			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
+			flag.SpecSave, flag.SpecDry},
 	})
 
 	getCmd := wrapper.SubCommand(&cobra.Command{
@@ -49,7 +49,7 @@ func Commands() *cobra.Command {
 		Short:   "Get function source code",
 	}, Get, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{},
 	})
 
 	getmetaCmd := wrapper.SubCommand(&cobra.Command{
@@ -58,7 +58,7 @@ func Commands() *cobra.Command {
 		Short:   "Get function metadata",
 	}, GetMeta, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Output},
+		Optional: []flag.Flag{flag.Output},
 	})
 
 	describeCmd := wrapper.SubCommand(&cobra.Command{
@@ -67,7 +67,7 @@ func Commands() *cobra.Command {
 		Short:   "Describe a function's health in one view (summary, conditions, build, pods)",
 	}, Describe, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -95,7 +95,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.NamespaceEnvironment, flag.SpecSave,
+			flag.SpecSave,
 		},
 	})
 
@@ -105,7 +105,7 @@ func Commands() *cobra.Command {
 		Short:   "Delete a function",
 	}, Delete, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.IgnoreNotFound},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -114,7 +114,7 @@ func Commands() *cobra.Command {
 		Short:   "List functions",
 		Long:    "List all functions in a namespace if specified, else, list functions across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.AllNamespaces, flag.Output},
 	})
 
 	logsCmd := wrapper.SubCommand(&cobra.Command{
@@ -125,7 +125,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{
 			flag.FnLogFollow, flag.FnLogReverseQuery, flag.FnLogCount,
-			flag.FnLogDetail, flag.FnLogPod, flag.NamespaceFunction, flag.FnLogDBType, flag.NamespacePod, flag.FnLogAllPods,
+			flag.FnLogDetail, flag.FnLogPod, flag.FnLogDBType, flag.NamespacePod, flag.FnLogAllPods,
 			flag.FnLogRequestID, flag.FnLogTraceID, flag.FnLogLevel},
 	})
 
@@ -136,9 +136,8 @@ func Commands() *cobra.Command {
 	}, Test, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{flag.HtMethod, flag.FnTestHeader, flag.FnTestBody,
-			flag.FnTestQuery, flag.FnTestTimeout, flag.NamespaceFunction,
-			// for getting log from log database if
-			// we failed to get logs from function pod.
+			flag.FnTestQuery, flag.FnTestTimeout,
+			// for getting log from log database if we failed to get logs from function pod.
 			flag.FnLogDBType,
 			flag.FnSubPath,
 		},
@@ -166,7 +165,6 @@ func Commands() *cobra.Command {
 			flag.FnRunKeep, flag.FnRunWatch, flag.FnRunEnvVar, flag.FnRunEnvFile,
 			flag.FnSecret, flag.FnCfgMap, flag.FnRunDebugPort,
 			flag.FnRunBuild, flag.FnRunBuilderImage, flag.FnBuildCmd,
-			flag.NamespaceFunction,
 		},
 	})
 
@@ -190,7 +188,7 @@ func Commands() *cobra.Command {
 			flag.ReplicasMax, flag.RunTimeTargetCPU,
 			flag.RunImagePullSecret,
 
-			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
+			flag.SpecSave, flag.SpecDry,
 		},
 	})
 
@@ -211,7 +209,7 @@ func Commands() *cobra.Command {
 			flag.RunTimeMaxMemory, flag.ReplicasMin, flag.ReplicasMax,
 			flag.RunTimeTargetCPU,
 
-			flag.NamespaceFunction, flag.SpecSave,
+			flag.SpecSave,
 		},
 	})
 
@@ -222,7 +220,7 @@ func Commands() *cobra.Command {
 		Long:    "List pods currently used by a function",
 	}, ListPods, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.NamespaceFunction},
+		Optional: []flag.Flag{},
 	})
 
 	waitCmd := wrapper.SubCommand(&cobra.Command{
@@ -230,14 +228,14 @@ func Commands() *cobra.Command {
 		Short: "Wait for a function to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	toolsCmd := wrapper.SubCommand(&cobra.Command{
 		Use:   "tools",
 		Short: "List functions exposed as MCP (Model Context Protocol) tools",
 	}, Tools, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceFunction, flag.Output},
+		Optional: []flag.Flag{flag.Output},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -100,7 +100,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 func (opts *CreateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error retrieving namespace information: %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -234,7 +234,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			_, err := opts.Client().FissionClientSet.CoreV1().Environments(fnNamespace).Get(input.Context(), envName, metav1.GetOptions{})
 			if err != nil {
 				if e, ok := err.(ferror.Error); ok && e.Code == ferror.ErrorNotFound {
-					console.Warn(fmt.Sprintf("Environment \"%s\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %s --envns %s --image <image>`\n", envName, envName, fnNamespace))
+					console.Warn(fmt.Sprintf("Environment \"%s\" does not exist. Please create the environment before executing the function. \nFor example: `fission env create --name %s --namespace %s --image <image>`\n", envName, envName, fnNamespace))
 				} else {
 					return fmt.Errorf("error retrieving environment information: %w", err)
 				}

--- a/pkg/fission-cli/cmd/function/delete.go
+++ b/pkg/fission-cli/cmd/function/delete.go
@@ -25,7 +25,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) error {
 
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in deleting function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/describe.go
+++ b/pkg/fission-cli/cmd/function/describe.go
@@ -39,7 +39,7 @@ func Describe(input cli.Input) error {
 }
 
 func (opts *DescribeSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error resolving namespace: %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/describe_test.go
+++ b/pkg/fission-cli/cmd/function/describe_test.go
@@ -79,7 +79,7 @@ func setDescribeClients(t *testing.T, fissionObjs []runtime.Object, pods ...runt
 func describeInput(name, ns string) dummy.Cli {
 	in := dummy.TestFlagSet()
 	in.Set(flagkey.FnName, name)
-	in.Set(flagkey.NamespaceFunction, ns)
+	in.Set(flagkey.Namespace, ns)
 	return in
 }
 

--- a/pkg/fission-cli/cmd/function/get.go
+++ b/pkg/fission-cli/cmd/function/get.go
@@ -24,7 +24,7 @@ func Get(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in get function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/getmeta.go
+++ b/pkg/fission-cli/cmd/function/getmeta.go
@@ -24,7 +24,7 @@ func GetMeta(input cli.Input) error {
 }
 
 func (opts *GetMetaSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in getting meta function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/list.go
+++ b/pkg/fission-cli/cmd/function/list.go
@@ -26,7 +26,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) error {
-	namespace, err := opts.ResolveNamespace(input, flagkey.NamespaceFunction)
+	namespace, err := opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in listing function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/log.go
+++ b/pkg/fission-cli/cmd/function/log.go
@@ -30,7 +30,7 @@ func Log(input cli.Input) error {
 }
 
 func (opts *LogSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in logs for function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/pods.go
+++ b/pkg/fission-cli/cmd/function/pods.go
@@ -30,7 +30,7 @@ func ListPods(input cli.Input) error {
 }
 
 func (opts *ListPodsSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in finding pod for function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/run.go
+++ b/pkg/fission-cli/cmd/function/run.go
@@ -122,7 +122,7 @@ func (opts *RunSubCommand) resolveRunConfig(input cli.Input) (runConfig, error) 
 	if fnName == "" {
 		fnName = defaultLocalFunctionName
 	}
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return runConfig{}, err
 	}

--- a/pkg/fission-cli/cmd/function/run_container.go
+++ b/pkg/fission-cli/cmd/function/run_container.go
@@ -44,7 +44,7 @@ func (opts *RunContainerSubCommand) do(input cli.Input) error {
 func (opts *RunContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	_, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in running container for function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -46,7 +46,7 @@ func Test(input cli.Input) error {
 
 func (opts *TestSubCommand) do(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in testing function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/tools.go
+++ b/pkg/fission-cli/cmd/function/tools.go
@@ -28,7 +28,7 @@ func Tools(input cli.Input) error {
 }
 
 func (opts *ToolsSubCommand) do(input cli.Input) error {
-	namespace, err := opts.ResolveNamespace(input, flagkey.NamespaceFunction)
+	namespace, err := opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error listing MCP tools: %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -39,7 +39,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
-	_, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in updating function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -40,7 +40,7 @@ func (opts *UpdateContainerSubCommand) do(input cli.Input) error {
 func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 	fnName := input.String(flagkey.FnName)
 
-	_, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in updating container for function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/wait.go
+++ b/pkg/fission-cli/cmd/function/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -21,7 +21,7 @@ func Commands() *cobra.Command {
 			flag.HtIngressRule, flag.HtIngressAnnotation, flag.HtIngressTLS,
 			flag.HtRouteProvider, flag.HtRouteHost, flag.HtRoutePath, flag.HtRouteAnnotation,
 			flag.HtRouteTLS, flag.HtGateway,
-			flag.HtFnWeight, flag.HtHost, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry,
+			flag.HtFnWeight, flag.HtHost, flag.SpecSave, flag.SpecDry,
 			flag.HtPrefix, flag.HtKeepPrefix},
 	})
 
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 		Short:   "Get HTTP trigger details",
 	}, Get, flag.FlagSet{
 		Required: []flag.Flag{flag.HtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.Output},
+		Optional: []flag.Flag{flag.Output},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -44,8 +44,7 @@ func Commands() *cobra.Command {
 			flag.HtMethod, flag.HtIngress, flag.HtIngressRule, flag.HtIngressAnnotation,
 			flag.HtIngressTLS, flag.HtRouteProvider, flag.HtRouteHost, flag.HtRoutePath,
 			flag.HtRouteAnnotation, flag.HtRouteTLS, flag.HtGateway,
-			flag.HtFnWeight, flag.HtHost, flag.NamespaceTrigger,
-			flag.HtPrefix, flag.HtKeepPrefix},
+			flag.HtFnWeight, flag.HtHost, flag.HtPrefix, flag.HtKeepPrefix},
 	})
 
 	deleteCmd := wrapper.SubCommand(&cobra.Command{
@@ -53,7 +52,7 @@ func Commands() *cobra.Command {
 		Aliases: []string{},
 		Short:   "Delete an HTTP trigger",
 	}, Delete, flag.FlagSet{
-		Optional: []flag.Flag{flag.HtName, flag.HtFnFilter, flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.HtName, flag.HtFnFilter, flag.IgnoreNotFound},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -62,7 +61,7 @@ func Commands() *cobra.Command {
 		Short:   "List HTTP triggers",
 		Long:    "List all HTTP triggers in a namespace if specified, else, list HTTP triggers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.HtFnFilter, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.HtFnFilter, flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{
@@ -76,7 +75,7 @@ func Commands() *cobra.Command {
 		Short: "Wait for an HTTP trigger to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.HtName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	command.AddCommand(createCmd, getCmd, updateCmd, deleteCmd, listCmd, waitCmd)

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -60,7 +60,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		triggerName = uuid.NewString()
 	}
 
-	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in creating HTTP trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/delete.go
+++ b/pkg/fission-cli/cmd/httptrigger/delete.go
@@ -44,7 +44,7 @@ func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 		return fmt.Errorf("need either of --%v or --%v and not both arguments", flagkey.HtName, flagkey.HtFnName)
 	}
 
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, opts.namespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in deleting HTTP trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/get.go
+++ b/pkg/fission-cli/cmd/httptrigger/get.go
@@ -30,7 +30,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 }
 
 func (opts *GetSubCommand) run(input cli.Input) (err error) {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in getting HTTP trigger: %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/list.go
+++ b/pkg/fission-cli/cmd/httptrigger/list.go
@@ -29,7 +29,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) run(input cli.Input) (err error) {
-	namespace, err := opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
+	namespace, err := opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in listing HTTP triggers: %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -42,7 +42,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	htName := input.String(flagkey.HtName)
 
-	_, triggerNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, triggerNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in updating HTTP trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/wait.go
+++ b/pkg/fission-cli/cmd/httptrigger/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/kubewatch/command.go
+++ b/pkg/fission-cli/cmd/kubewatch/command.go
@@ -17,7 +17,7 @@ func Commands() *cobra.Command {
 		Short: "Create a kube watcher",
 	}, Create, flag.FlagSet{
 		Required: []flag.Flag{flag.KwFnName},
-		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.NamespaceFunction, flag.SpecSave, flag.SpecDry},
+		Optional: []flag.Flag{flag.KwName, flag.KwObjType, flag.SpecSave, flag.SpecDry},
 		// TODO: add label selector flag
 		// flag.KwLabelsFlag
 	})
@@ -28,7 +28,7 @@ func Commands() *cobra.Command {
 		Short:   "Delete a kube watcher",
 	}, Delete, flag.FlagSet{
 		Required: []flag.Flag{flag.KwName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound, flag.KwFnName},
+		Optional: []flag.Flag{flag.IgnoreNotFound, flag.KwFnName},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -37,7 +37,7 @@ func Commands() *cobra.Command {
 		Short:   "List kube watchers",
 		Long:    "List all kube watchers in a namespace if specified, else, list kube watchers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{
@@ -51,7 +51,7 @@ func Commands() *cobra.Command {
 		Short: "Wait for a kube watcher to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.KwName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	command.AddCommand(createCmd, deleteCmd, listCmd, waitCmd)

--- a/pkg/fission-cli/cmd/kubewatch/create.go
+++ b/pkg/fission-cli/cmd/kubewatch/create.go
@@ -43,7 +43,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 	fnName := input.String(flagkey.KwFnName)
 
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.KwNamespace)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in listing function : %w", err)
 	}

--- a/pkg/fission-cli/cmd/kubewatch/delete.go
+++ b/pkg/fission-cli/cmd/kubewatch/delete.go
@@ -35,7 +35,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.KwName)
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, opts.namespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in deleting kubewatch: %w", err)
 	}

--- a/pkg/fission-cli/cmd/kubewatch/list.go
+++ b/pkg/fission-cli/cmd/kubewatch/list.go
@@ -34,7 +34,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	opts.namespace, err = opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
+	opts.namespace, err = opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error listing kubewatchers: %w", err)
 	}

--- a/pkg/fission-cli/cmd/kubewatch/wait.go
+++ b/pkg/fission-cli/cmd/kubewatch/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/command.go
+++ b/pkg/fission-cli/cmd/mqtrigger/command.go
@@ -19,7 +19,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.MqtFnName, flag.MqtTopic},
 		Optional: []flag.Flag{flag.MqtName, flag.MqtMQType, flag.MqtRespTopic,
 			flag.MqtErrorTopic, flag.MqtMaxRetries, flag.MqtMsgContentType,
-			flag.NamespaceFunction, flag.SpecSave, flag.SpecDry, flag.MqtPollingInterval,
+			flag.SpecSave, flag.SpecDry, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtSecret,
 			flag.MqtMetadata, flag.MqtKind},
 	})
@@ -31,7 +31,7 @@ func Commands() *cobra.Command {
 	}, Update, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName},
 		Optional: []flag.Flag{flag.MqtFnName, flag.MqtTopic, flag.MqtRespTopic, flag.MqtErrorTopic,
-			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.NamespaceTrigger, flag.MqtPollingInterval,
+			flag.MqtMaxRetries, flag.MqtMsgContentType, flag.MqtPollingInterval,
 			flag.MqtCooldownPeriod, flag.MqtMinReplicaCount, flag.MqtMaxReplicaCount, flag.MqtMetadata,
 			flag.MqtSecret, flag.MqtKind},
 	})
@@ -42,7 +42,7 @@ func Commands() *cobra.Command {
 		Short:   "Delete a message queue trigger",
 	}, Delete, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.IgnoreNotFound},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -51,7 +51,7 @@ func Commands() *cobra.Command {
 		Short:   "List message queue triggers",
 		Long:    "List all message queue triggers in a namespace if specified, else, list message queue triggers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.AllNamespaces, flag.Output},
 	})
 
 	command := &cobra.Command{
@@ -65,7 +65,7 @@ func Commands() *cobra.Command {
 		Short: "Wait for a message queue trigger to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.MqtName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	command.AddCommand(createCmd, updateCmd, deleteCmd, listCmd, waitCmd)

--- a/pkg/fission-cli/cmd/mqtrigger/create.go
+++ b/pkg/fission-cli/cmd/mqtrigger/create.go
@@ -47,7 +47,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 	}
 	fnName := input.String(flagkey.MqtFnName)
 
-	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in creating message queue trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/delete.go
+++ b/pkg/fission-cli/cmd/mqtrigger/delete.go
@@ -34,7 +34,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in deleting message queue trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/list.go
+++ b/pkg/fission-cli/cmd/mqtrigger/list.go
@@ -34,7 +34,7 @@ func (opts *ListSubCommand) do(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) complete(input cli.Input) (err error) {
-	opts.namespace, err = opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
+	opts.namespace, err = opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in listing message queue triggers: %w", err)
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -38,7 +38,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in updating message queue trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/wait.go
+++ b/pkg/fission-cli/cmd/mqtrigger/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -19,7 +19,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgOCI, flag.PkgBuildCmd,
-			flag.NamespacePackage, flag.SpecSave, flag.SpecDry},
+			flag.SpecSave, flag.SpecDry},
 	})
 
 	getSrcCmd := wrapper.SubCommand(&cobra.Command{
@@ -27,7 +27,7 @@ func Commands() *cobra.Command {
 		Short: "Get package details",
 	}, GetSrc, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.PkgOutput},
+		Optional: []flag.Flag{flag.PkgOutput},
 	})
 
 	getDeployCmd := wrapper.SubCommand(&cobra.Command{
@@ -35,7 +35,7 @@ func Commands() *cobra.Command {
 		Short: "Get package details",
 	}, GetDeploy, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.PkgOutput},
+		Optional: []flag.Flag{flag.PkgOutput},
 	})
 
 	updateCmd := wrapper.SubCommand(&cobra.Command{
@@ -44,15 +44,14 @@ func Commands() *cobra.Command {
 	}, Update, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
 		Optional: []flag.Flag{flag.PkgEnvironment, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
-			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgOCI, flag.PkgBuildCmd, flag.PkgForce,
-			flag.NamespacePackage, flag.NamespaceEnvironment},
+			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgOCI, flag.PkgBuildCmd, flag.PkgForce},
 	})
 
 	deleteCmd := wrapper.SubCommand(&cobra.Command{
 		Use:   "delete",
 		Short: "Delete a package",
 	}, Delete, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgName, flag.PkgForce, flag.PkgOrphan, flag.NamespacePackage, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.PkgName, flag.PkgForce, flag.PkgOrphan, flag.IgnoreNotFound},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -60,7 +59,7 @@ func Commands() *cobra.Command {
 		Short: "List packages",
 		Long:  "List all packages in a namespace if specified, else, list packages across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.NamespacePackage, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.PkgOrphan, flag.PkgStatus, flag.AllNamespaces, flag.Output},
 	})
 
 	infoCmd := wrapper.SubCommand(&cobra.Command{
@@ -68,7 +67,7 @@ func Commands() *cobra.Command {
 		Short: "Show package information",
 	}, Info, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.Output},
+		Optional: []flag.Flag{flag.Output},
 	})
 
 	rebuildCmd := wrapper.SubCommand(&cobra.Command{
@@ -76,7 +75,7 @@ func Commands() *cobra.Command {
 		Short: "Rebuild a failed package",
 	}, Rebuild, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{flag.NamespacePackage},
+		Optional: []flag.Flag{},
 	})
 
 	command := &cobra.Command{
@@ -90,7 +89,7 @@ func Commands() *cobra.Command {
 		Short: "Wait for a package to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespacePackage, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	command.AddCommand(createCmd, getSrcCmd, getDeployCmd, updateCmd, deleteCmd, listCmd, infoCmd, rebuildCmd, waitCmd)

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -51,7 +51,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 
 	envName := input.String(flagkey.PkgEnvironment)
 
-	userProvidedNS, pkgNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	userProvidedNS, pkgNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/delete.go
+++ b/pkg/fission-cli/cmd/package/delete.go
@@ -41,7 +41,7 @@ func (opts *DeleteSubCommand) do(input cli.Input) error {
 
 func (opts *DeleteSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/get.go
+++ b/pkg/fission-cli/cmd/package/get.go
@@ -50,7 +50,7 @@ func (opts *GetSubCommand) do(input cli.Input) error {
 
 func (opts *GetSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/info.go
+++ b/pkg/fission-cli/cmd/package/info.go
@@ -39,7 +39,7 @@ func (opts *InfoSubCommand) do(input cli.Input) error {
 func (opts *InfoSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
 
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/list.go
+++ b/pkg/fission-cli/cmd/package/list.go
@@ -41,7 +41,7 @@ func (opts *ListSubCommand) complete(input cli.Input) (err error) {
 	// option for the user to list all orphan packages (not referenced by any function)
 	opts.listOrphans = input.Bool(flagkey.PkgOrphan)
 	opts.status = input.String(flagkey.PkgStatus)
-	opts.pkgNamespace, err = opts.ResolveNamespace(input, flagkey.NamespacePackage)
+	opts.pkgNamespace, err = opts.ResolveNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -35,7 +35,7 @@ func (opts *RebuildSubCommand) do(input cli.Input) error {
 
 func (opts *RebuildSubCommand) complete(input cli.Input) (err error) {
 	opts.name = input.String(flagkey.PkgName)
-	_, opts.namespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.namespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -43,7 +43,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 
 func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 	opts.pkgName = input.String(flagkey.PkgName)
-	_, opts.pkgNamespace, err = opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, opts.pkgNamespace, err = opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Package", err)
 	}

--- a/pkg/fission-cli/cmd/package/wait.go
+++ b/pkg/fission-cli/cmd/package/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespacePackage)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -57,7 +57,7 @@ func (opts *ApplySubCommand) do(input cli.Input) error {
 // we make sure that all component of a resource should be present in the same Namespace. i.e.
 // Function's env and package should be present in same namespace
 func (opts *ApplySubCommand) insertNamespace(input cli.Input, fr *FissionResources) error {
-	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -116,7 +116,7 @@ func forceDeleteResources(ctx context.Context, fclient cmd.Client, fr *FissionRe
 // insertNSToResource provides a namespace to all resource which don't have a namespace specified
 // in resource
 func (opts *DestroySubCommand) insertNSToResource(input cli.Input, fr *FissionResources) error {
-	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/spec/list.go
+++ b/pkg/fission-cli/cmd/spec/list.go
@@ -48,7 +48,7 @@ func (opts *ListSubCommand) run(input cli.Input) error {
 		deployID = fr.DeploymentConfig.UID
 	}
 
-	_, currentNS, err := opts.GetResourceNamespace(input, flagkey.NamespaceEnvironment)
+	_, currentNS, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fv1.AggregateValidationErrors("Environment", err)
 	}

--- a/pkg/fission-cli/cmd/timetrigger/command.go
+++ b/pkg/fission-cli/cmd/timetrigger/command.go
@@ -17,8 +17,7 @@ func Commands() *cobra.Command {
 		Short: "Create a time trigger",
 	}, Create, flag.FlagSet{
 		Optional: []flag.Flag{flag.TtName, flag.TtFnName,
-			flag.TtCron, flag.NamespaceFunction,
-			flag.TtMethod, flag.FnSubPath,
+			flag.TtCron, flag.TtMethod, flag.FnSubPath,
 
 			flag.SpecSave, flag.SpecDry,
 		},
@@ -30,10 +29,7 @@ func Commands() *cobra.Command {
 		Short:   "Update a time trigger",
 	}, Update, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName},
-		Optional: []flag.Flag{flag.TtFnName, flag.TtCron, flag.NamespaceTrigger,
-
-			flag.TtMethod, flag.FnSubPath,
-		},
+		Optional: []flag.Flag{flag.TtFnName, flag.TtCron, flag.TtMethod, flag.FnSubPath},
 	})
 
 	deleteCmd := wrapper.SubCommand(&cobra.Command{
@@ -42,7 +38,7 @@ func Commands() *cobra.Command {
 		Short:   "Delete a time trigger",
 	}, Delete, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.IgnoreNotFound},
+		Optional: []flag.Flag{flag.IgnoreNotFound},
 	})
 
 	listCmd := wrapper.SubCommand(&cobra.Command{
@@ -51,7 +47,7 @@ func Commands() *cobra.Command {
 		Short:   "List time triggers",
 		Long:    "List all time triggers in a namespace if specified, else, list time triggers across all namespaces",
 	}, List, flag.FlagSet{
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.AllNamespaces, flag.Output},
+		Optional: []flag.Flag{flag.AllNamespaces, flag.Output},
 	})
 
 	showCmd := wrapper.SubCommand(&cobra.Command{
@@ -73,7 +69,7 @@ func Commands() *cobra.Command {
 		Short: "Wait for a time trigger to reach a status condition",
 	}, Wait, flag.FlagSet{
 		Required: []flag.Flag{flag.TtName, flag.WaitFor},
-		Optional: []flag.Flag{flag.NamespaceTrigger, flag.WaitTimeout},
+		Optional: []flag.Flag{flag.WaitTimeout},
 	})
 
 	command.AddCommand(createCmd, updateCmd, deleteCmd, listCmd, showCmd, waitCmd)

--- a/pkg/fission-cli/cmd/timetrigger/create.go
+++ b/pkg/fission-cli/cmd/timetrigger/create.go
@@ -52,7 +52,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) (err error) {
 		return errors.New("need a function name to create a trigger, use --function")
 	}
 
-	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceFunction)
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in creating time trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/timetrigger/delete.go
+++ b/pkg/fission-cli/cmd/timetrigger/delete.go
@@ -25,7 +25,7 @@ func Delete(input cli.Input) error {
 
 func (opts *DeleteSubCommand) do(input cli.Input) (err error) {
 
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in deleting time trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/timetrigger/list.go
+++ b/pkg/fission-cli/cmd/timetrigger/list.go
@@ -25,7 +25,7 @@ func List(input cli.Input) error {
 }
 
 func (opts *ListSubCommand) do(input cli.Input) (err error) {
-	ttNs, err := opts.ResolveNamespace(input, flagkey.NamespaceTrigger)
+	ttNs, err := opts.ResolveNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in listing time triggers: %w", err)
 	}

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -38,7 +38,7 @@ func (opts *UpdateSubCommand) do(input cli.Input) error {
 }
 
 func (opts *UpdateSubCommand) complete(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return fmt.Errorf("error in updating time trigger : %w", err)
 	}

--- a/pkg/fission-cli/cmd/timetrigger/wait.go
+++ b/pkg/fission-cli/cmd/timetrigger/wait.go
@@ -25,7 +25,7 @@ func Wait(input cli.Input) error {
 }
 
 func (opts *WaitSubCommand) do(input cli.Input) error {
-	_, namespace, err := opts.GetResourceNamespace(input, flagkey.NamespaceTrigger)
+	_, namespace, err := opts.GetResourceNamespace(input)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -70,23 +70,18 @@ var (
 
 	Namespace = Flag{Type: String, Name: flagkey.Namespace, Short: "n", Usage: "If present, the namespace scope for this CLI request"}
 
-	NamespaceFunction    = Flag{Type: String, Name: flagkey.NamespaceFunction, Aliases: []string{"fns"}, Usage: "Namespace for function object", Deprecated: true, Substitute: flagkey.Namespace}
-	NamespaceEnvironment = Flag{Type: String, Name: flagkey.NamespaceEnvironment, Aliases: []string{"envns"}, Usage: "Namespace for environment object", Deprecated: true, Substitute: flagkey.Namespace}
-	NamespacePackage     = Flag{Type: String, Name: flagkey.NamespacePackage, Aliases: []string{"pkgns"}, Usage: "Namespace for package object", Deprecated: true, Substitute: flagkey.Namespace}
-	NamespaceTrigger     = Flag{Type: String, Name: flagkey.NamespaceTrigger, Aliases: []string{"triggerns"}, Usage: "Namespace for trigger object", Deprecated: true, Substitute: flagkey.Namespace}
-	NamespaceCanary      = Flag{Type: String, Name: flagkey.NamespaceCanary, Aliases: []string{"canaryns"}, Usage: "Namespace for canary config object", Deprecated: true, Substitute: flagkey.Namespace}
-	ForceNamespace       = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"force"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace", DefaultValue: false}
-	ForceDelete          = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
-	AllNamespaces        = Flag{Type: Bool, Name: flagkey.AllNamespaces, Short: "A", Usage: "Fetch resources from all namespaces"}
-	Output               = Flag{Type: String, Name: flagkey.Output, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
-	WaitFor              = Flag{Type: String, Name: flagkey.WaitFor, Usage: "Condition to wait for, e.g. condition=Ready or condition=Ready=False"}
-	WaitTimeout          = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: util.DefaultWaitTimeout, Usage: "Maximum time to wait for the condition before giving up"}
-	RunTimeMinCPU        = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
-	RunTimeMaxCPU        = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
-	RunTimeTargetCPU     = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}
-	RunTimeMinMemory     = Flag{Type: Int, Name: flagkey.RuntimeMinmemory, Usage: "Minimum memory to be assigned to pod (In megabyte)"}
-	RunTimeMaxMemory     = Flag{Type: Int, Name: flagkey.RuntimeMaxmemory, Usage: "Maximum memory to be assigned to pod (In megabyte)"}
-	RunImagePullSecret   = Flag{Type: String, Name: flagkey.RunImagePullSecret, Usage: "Secret for Kubernetes to pull an image from a private registry"}
+	ForceNamespace     = Flag{Type: Bool, Name: flagkey.ForceNamespace, Aliases: []string{"force"}, Usage: "If true, resources will be created in namespace provided by (--namespace flag ) even if spec file contains some other namespace", DefaultValue: false}
+	ForceDelete        = Flag{Type: Bool, Name: flagkey.ForceDelete, Aliases: []string{"force"}, Usage: "Delete all resources across all namespaces present in spec"}
+	AllNamespaces      = Flag{Type: Bool, Name: flagkey.AllNamespaces, Short: "A", Usage: "Fetch resources from all namespaces"}
+	Output             = Flag{Type: String, Name: flagkey.Output, Short: "o", Usage: "Output format: wide, json or yaml (default: table)"}
+	WaitFor            = Flag{Type: String, Name: flagkey.WaitFor, Usage: "Condition to wait for, e.g. condition=Ready or condition=Ready=False"}
+	WaitTimeout        = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: util.DefaultWaitTimeout, Usage: "Maximum time to wait for the condition before giving up"}
+	RunTimeMinCPU      = Flag{Type: Int, Name: flagkey.RuntimeMincpu, Usage: "Minimum CPU to be assigned to pod (In millicore, minimum 1)"}
+	RunTimeMaxCPU      = Flag{Type: Int, Name: flagkey.RuntimeMaxcpu, Usage: "Maximum CPU to be assigned to pod (In millicore, minimum 1)"}
+	RunTimeTargetCPU   = Flag{Type: Int, Name: flagkey.RuntimeTargetcpu, Usage: "Target average CPU usage percentage across pods for scaling", DefaultValue: 80}
+	RunTimeMinMemory   = Flag{Type: Int, Name: flagkey.RuntimeMinmemory, Usage: "Minimum memory to be assigned to pod (In megabyte)"}
+	RunTimeMaxMemory   = Flag{Type: Int, Name: flagkey.RuntimeMaxmemory, Usage: "Maximum memory to be assigned to pod (In megabyte)"}
+	RunImagePullSecret = Flag{Type: String, Name: flagkey.RunImagePullSecret, Usage: "Secret for Kubernetes to pull an image from a private registry"}
 
 	ReplicasMin = Flag{Type: Int, Name: flagkey.ReplicasMinscale, Usage: "Minimum number of pods (Uses resource inputs to configure HPA)", DefaultValue: 1}
 	ReplicasMax = Flag{Type: Int, Name: flagkey.ReplicasMaxscale, Usage: "Maximum number of pods (Uses resource inputs to configure HPA)", DefaultValue: 1}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -21,16 +21,11 @@ const (
 
 	IgnoreNotFound = "ignorenotfound"
 
-	NamespaceFunction    = "fnNamespace"
-	NamespaceEnvironment = "envNamespace"
-	NamespacePackage     = "pkgNamespace"
-	NamespaceTrigger     = "triggerNamespace"
-	NamespaceCanary      = "canaryNamespace"
-	Namespace            = "namespace"
-	ForceNamespace       = "force-namespace"
-	AllNamespaces        = "all-namespaces"
-	NamespacePod         = "pod-namespace"
-	ForceDelete          = "force"
+	Namespace      = "namespace"
+	ForceNamespace = "force-namespace"
+	AllNamespaces  = "all-namespaces"
+	NamespacePod   = "pod-namespace"
+	ForceDelete    = "force"
 
 	RuntimeMincpu      = "mincpu"
 	RuntimeMaxcpu      = "maxcpu"

--- a/test/integration/suites/common/namespace_test.go
+++ b/test/integration/suites/common/namespace_test.go
@@ -87,45 +87,11 @@ func TestNamespaceCurrentContext(t *testing.T) {
 	assert.Equal(t, metav1.NamespaceDefault, tr.Namespace)
 }
 
-// TestNamespaceDeprecatedFlag is the Go port of test_namespace/test_ns_deprecated_flag.sh.
-// Verifies that the deprecated `--fnNamespace` flag is still honored on
-// `fission httptrigger create` (it's marked Deprecated in the CLI flag
-// definition with `Substitute: --namespace`, so the create call should
-// succeed and the trigger should land in the named namespace).
-func TestNamespaceDeprecatedFlag(t *testing.T) {
-	t.Parallel()
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
-	f := framework.Connect(t)
-	ns := f.NewTestNamespace(t)
-	customNS := "fission-it-ns-deprflag-" + ns.ID
-	createKubeNamespace(t, ctx, f, customNS)
-
-	trigger := "http-deprfl-" + ns.ID
-	url := "/url-deprfl-" + ns.ID
-	ns.CLI(t, ctx, "httptrigger", "create",
-		"--function", "nbuilderhello-"+ns.ID,
-		"--url", url, "--name", trigger,
-		"--fnNamespace", customNS)
-	t.Cleanup(func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		_ = f.FissionClient().CoreV1().HTTPTriggers(customNS).Delete(ctx, trigger, metav1.DeleteOptions{})
-	})
-
-	tr, err := f.FissionClient().CoreV1().HTTPTriggers(customNS).Get(ctx, trigger, metav1.GetOptions{})
-	require.NoErrorf(t, err, "get httptrigger %q in ns %q", trigger, customNS)
-	assert.Equal(t, customNS, tr.Namespace)
-}
-
 // TestNamespaceEnv is the Go port of test_namespace/test_ns_env.sh.
-// Verifies that FISSION_DEFAULT_NAMESPACE is honored when neither
-// `--namespace` nor the deprecated `--fnNamespace` is passed. The CLI's
-// resolution (pkg/fission-cli/cmd/cmd.go GetResourceNamespace) walks
-// flag → flag → env-var → ClientOptions.Namespace, so the env-var
-// branch wins over our default ClientOptions.Namespace="default".
+// Verifies that FISSION_DEFAULT_NAMESPACE is honored when `--namespace` is
+// not passed. The CLI's resolution (pkg/fission-cli/cmd/cmd.go
+// GetResourceNamespace) walks flag → env-var → ClientOptions.Namespace, so
+// the env-var branch wins over our default ClientOptions.Namespace="default".
 //
 // Uses the framework's CLIWithEnv helper which serializes the env-var
 // mutation against any other in-flight CLI calls via cliMu.


### PR DESCRIPTION
## What

Removes the five long-deprecated per-resource namespace flags from the `fission` CLI:

| Removed flag | Alias | Replacement |
|---|---|---|
| `--fnNamespace` | `--fns` | `--namespace` / `-n` |
| `--envNamespace` | `--envns` | `--namespace` / `-n` |
| `--pkgNamespace` | `--pkgns` | `--namespace` / `-n` |
| `--triggerNamespace` | `--triggerns` | `--namespace` / `-n` |
| `--canaryNamespace` | `--canaryns` | `--namespace` / `-n` |

## How to review

72 files look like a lot, but only **one** file carries logic — the rest is mechanical fan-out from collapsing a parameter that was always an alias.

- **Read this:** `pkg/fission-cli/cmd/cmd.go` — `GetResourceNamespace`/`ResolveNamespace` drop the now-unused `deprecatedFlag` parameter and the body is simplified to flat guard clauses. This is the only behavior-bearing change.
- **Skim — flag removal:** `pkg/fission-cli/flag/flag.go` + `pkg/fission-cli/flag/key/key.go` (delete 5 definitions + 5 key constants), and 8 `*/command.go` files (drop the 5 flags from command flag lists).
- **Skim — pure mechanical:** ~60 other `cmd/**` files, each a one-line change dropping the second argument (`GetResourceNamespace(input, flagkey.NamespaceX)` → `GetResourceNamespace(input)`); no behavior change.
- **Tests:** `describe_test.go` (set the surviving `--namespace` key) and `namespace_test.go` (delete the now-obsolete `--fnNamespace` test).

Commits are split along this seam: refactor → removal → test, each independently reviewable.

## Why

These flags were deprecated in October 2022 (~v1.15, #2556), marked `Deprecated: true` with `Substitute: --namespace`, and have printed a removal warning ever since.
1.27 has shipped, so the deprecation window is well past due — this is part of the post-1.27 deprecated-surface cleanup.

The unified `--namespace`/`-n` flag is a global persistent flag on the root command, so it is already available on every subcommand; the per-resource flags were pure aliases.

## Behavior change (breaking)

These flags were still *accepted* (with a deprecation warning) until now; this removes them, so passing any of them (or their aliases) now fails with `unknown flag`.
Use `--namespace`/`-n` instead.
`FISSION_DEFAULT_NAMESPACE` and kube-context namespace resolution are unchanged.

Worth a line in the 1.28 release notes at cut time (per this repo's release-note convention).

## Testing

- `go build ./...` clean
- `go test ./pkg/fission-cli/...` green
- `golangci-lint run ./pkg/fission-cli/...` — 0 issues
- `make license-check` clean
- `go vet -tags=integration ./test/integration/suites/common/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)