### PR TITLE
chore(executor): remove deprecated no-op /v2/tapService endpoint

### DIFF
--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -227,13 +227,6 @@ func (executor *Executor) ensureCapacityHandler(w http.ResponseWriter, r *http.R
 }
 
 // find funcSvc and update its atime
-// TODO: Deprecated tapService
-func (executor *Executor) tapService(w http.ResponseWriter, r *http.Request) {
-	// only for upgrade compatibility
-	w.WriteHeader(http.StatusOK)
-}
-
-// find funcSvc and update its atime
 func (executor *Executor) tapServices(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	logger := otelUtils.LoggerWithTraceID(ctx, executor.logger)
@@ -384,7 +377,6 @@ func (executor *Executor) GetHandler() http.Handler {
 	)
 	m.HandleFunc("/v2/getServiceForFunction", executor.getServiceForFunctionAPI).Methods("POST")
 	m.HandleFunc("/v2/ensureCapacity", executor.ensureCapacityHandler).Methods("POST")
-	m.HandleFunc("/v2/tapService", executor.tapService).Methods("POST") // for backward compatibility
 	m.HandleFunc("/v2/tapServices", executor.tapServices).Methods("POST")
 	m.HandleFunc("/v2/unTapService", executor.unTapService).Methods("POST")
 	m.HandleFunc("/v2/debugInfo", executor.dumpDebugInfo).Methods("GET")


### PR DESCRIPTION
## What

Removes the executor's singular `/v2/tapService` endpoint and its handler `tapService` — an 8-line deletion in `pkg/executor/api.go`. The plural `/v2/tapServices` endpoint is unchanged.

## Why

`tapService` was a no-op stub kept only for rolling-upgrade compatibility:

```go
// TODO: Deprecated tapService
func (executor *Executor) tapService(w http.ResponseWriter, r *http.Request) {
	// only for upgrade compatibility
	w.WriteHeader(http.StatusOK)
}
```

It returned `200 OK` and did nothing — it never actually updated a service's atime. The live executor client (`pkg/executor/client/client.go`) has POSTed to the plural `/v2/tapServices` since 2019, so the singular route and its empty handler are dead. This is post-1.27 deprecated-surface cleanup.

## Safety

- No in-repo caller of the singular `/v2/tapService` path (verified across Go, the executor client, router, tests, and Helm charts — all tap traffic goes to `/v2/tapServices`).
- The handler was already a no-op, so even a hypothetical old client got no functional effect; it now receives a clean `404` instead of a silent `200`.
- `api_tapservices_test.go` exercises the plural endpoint and still passes.

## Testing

- `go build ./...` clean
- `go test ./pkg/executor/ -run TapServices` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)