### PR TITLE
chore(deps): keep direct and indirect requirements in separate go.mod blocks

### DIFF
--- a/.claude/resources/go-mod-conventions.md
+++ b/.claude/resources/go-mod-conventions.md
@@ -1,0 +1,39 @@
+# go.mod conventions
+
+Follow these when adding, upgrading, or removing Go dependencies in this repo.
+They keep `go.mod` readable — a glance at the first block tells you everything the project *directly* depends on, separate from the transitive graph.
+
+## The layout
+
+`go.mod` must hold its requirements in exactly two `require (...)` blocks:
+
+1. A **direct** block first — every dependency the module's own code (including `_test.go` files and tools) imports directly.
+   No `// indirect` comments appear here.
+2. An **indirect** block second — every transitively-pulled dependency, each carrying the `// indirect` comment `go mod tidy` adds.
+
+Additional rules:
+
+- **No single-line `require` directives** (`require foo v1.2.3`).
+  `go get` sometimes appends one; fold it into the matching block.
+- **One block of each kind.**
+  Don't split direct or indirect requirements across multiple blocks.
+- The `tool (...)`, `replace (...)`, `exclude (...)`, and `retract` directives are unaffected — this convention is only about the `require` blocks.
+
+## Why a guard is needed
+
+`go mod tidy` keeps the `// indirect` annotations correct, but it does **not** move entries between blocks.
+A dependency added by `go get` (or promoted from indirect to direct when you start importing it) stays in whatever block it landed in, so a direct dependency silently accumulates inside the indirect block over time.
+The guard catches that drift; `go mod tidy` alone will not.
+
+## Adding or changing a dependency
+
+1. `go get <module>@<version>` (or start importing it), then `go mod tidy`.
+2. If the new or newly-direct dependency landed in the indirect block, move its line into the direct block.
+3. `go mod edit -fmt` to re-sort each block, then `go mod tidy` again to confirm nothing else changed.
+4. `make verify-gomod` to check the layout.
+
+## Checking
+
+- `make verify-gomod` — fails if any `require` block mixes direct and indirect entries, if there is more than one block of either kind, or if a single-line `require` exists.
+- Runs in CI as part of the lint job's "Verify dependencies" step, and locally as a prerequisite of `make code-checks` (and therefore `make check`).
+- The check itself lives in [`hack/verify-gomod.sh`](../../hack/verify-gomod.sh).

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -63,6 +63,7 @@ jobs:
         run: |
           go mod verify
           go mod download
+          make verify-gomod
 
       - name: Check license headers
         run: make license-check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ Functions execute inside per-environment pods that the executor manages; the use
 Build / lint / test (run from repo root):
 - `make build-fission-cli` — build the `fission` CLI via goreleaser (snapshot, single target).
   `make install-fission-cli` copies it to `/usr/local/bin/fission`.
-- `make code-checks` — `golangci-lint run` (config in `.golangci.yaml`; goimports local prefix `github.com/fission/fission`).
+- `make code-checks` — `golangci-lint run` (config in `.golangci.yaml`; goimports local prefix `github.com/fission/fission`), plus `make verify-gomod`.
+- `make verify-gomod` — fails if `go.mod` does not keep direct and indirect requirements in separate blocks (`go mod tidy` does NOT enforce this); runs in CI's "Verify dependencies" step.
+  See "Dependency management".
 - `make license` — add the SPDX header (`SPDX-FileCopyrightText` + `SPDX-License-Identifier: Apache-2.0`) to any in-scope source file (`.go`/`.sh`/`.py`/`Dockerfile*`) missing one.
   `make license-check` is the CI gate (runs in `lint.yaml`); run it before pushing.
 - `make test-run` — runs `hack/runtests.sh`: pulls `setup-envtest` Kubebuilder assets for k8s 1.32.x, then `go test -race -coverprofile=coverage.txt ./...`.
@@ -41,7 +43,8 @@ kubectl port-forward svc/router-internal 8889:8889 -n fission &
 - The internal forward is required because `/fission-function/<ns>/<name>` moved off the public listener after GHSA-3g33-6vg6-27m8 (see Architecture).
   Tests that invoke functions go through the framework's `Router(t)` HTTP client which auto-routes those paths to 8889, or dial the URL from `f.RouterInternalBaseURL()` directly.
 - Export `FISSION_INTERNAL_AUTH_SECRET` (read from `kubectl get secret fission-internal-auth -n fission -o jsonpath='{.data.master}' | base64 -d`) so the framework's transport signs requests on the internal listener — leave unset to test the verifier's pass-through mode.
-- The MCP test (`TestMCPToolsListAndCall`) needs `svc/mcp` reachable: `kubectl port-forward svc/mcp 8890:8890 -n fission &` and `FISSION_MCP_BASE_URL=http://127.0.0.1:8890` (the framework defaults to that); it `t.Skip`s when the endpoint is unreachable. `mcp.enabled`/`mcp.allowInsecure` are on in the kind/kind-ci skaffold profiles.
+- The MCP test (`TestMCPToolsListAndCall`) needs `svc/mcp` reachable: `kubectl port-forward svc/mcp 8890:8890 -n fission &` and `FISSION_MCP_BASE_URL=http://127.0.0.1:8890` (the framework defaults to that); it `t.Skip`s when the endpoint is unreachable.
+  `mcp.enabled`/`mcp.allowInsecure` are on in the kind/kind-ci skaffold profiles.
 - Run the full suite: `go test -tags=integration -timeout=30m -parallel 6 -v ./test/integration/suites/common/...`.
   Set runtime/builder image env vars (`NODE_RUNTIME_IMAGE`, `PYTHON_RUNTIME_IMAGE`, etc.) — tests `t.Skip` when their required image is unset.
   `TEST_NOCLEANUP=1` leaves resources for debugging.
@@ -56,6 +59,12 @@ kubectl port-forward svc/router-internal 8889:8889 -n fission &
 
 When writing or modifying tests, follow `.claude/resources/test-writing-guidelines.md`.
 Key points: use `testify` (`require` for preconditions, `assert` for independent checks) over hand-written comparisons; use `t.Context()` instead of `context.Background()`; prefer fake clientsets over `envtest` for unit tests; table-driven subtests with `t.Parallel()`.
+
+## Dependency management
+
+When adding, upgrading, or removing Go dependencies, follow `.claude/resources/go-mod-conventions.md`.
+Key point: `go.mod` keeps **direct** requirements in the first `require (...)` block and **indirect** (`// indirect`) ones in a second block — `go mod tidy` does NOT move entries between blocks, so a `go get` that lands a direct dep in the indirect block must be moved by hand.
+`make verify-gomod` (CI-enforced in `lint.yaml`) guards the layout.
 
 ## Architecture
 
@@ -115,9 +124,14 @@ The CLI (`cmd/fission-cli` + `pkg/fission-cli/`) talks to Kubernetes directly th
 - New source files need an SPDX license header or the `lint` CI job fails (`make license-check`).
   Run `make license` to add it (template in `hack/license-header.tmpl`); the legacy 15-line Apache block is gone — do not reintroduce it.
   Generated code gets its header from `hack/boilerplate.go.txt`, so that file (not the output) is the source of truth for generated headers.
-- Any **new pod that calls the router internal listener** (port 8889) must be added to the `from` allowlist in `charts/fission-all/templates/router/networkpolicy.yaml` by its `svc:` label — `networkPolicy.enabled=true` in kind-ci, so a missing entry surfaces only in CI as `dial tcp <clusterIP>:8889: i/o timeout` (the request is silently dropped, not refused). This is how the MCP pod (`svc: mcp`) was wired.
-- When building a `/fission-function/<ns>/<name>` URL in Go, use `utils.UrlForFunction(name, namespace)` — it **folds the default namespace** to `/fission-function/<name>`, which is the form the router actually registers. A hardcoded `/fission-function/default/<name>` does not resolve.
+- Any **new pod that calls the router internal listener** (port 8889) must be added to the `from` allowlist in `charts/fission-all/templates/router/networkpolicy.yaml` by its `svc:` label — `networkPolicy.enabled=true` in kind-ci, so a missing entry surfaces only in CI as `dial tcp <clusterIP>:8889: i/o timeout` (the request is silently dropped, not refused).
+  This is how the MCP pod (`svc: mcp`) was wired.
+- When building a `/fission-function/<ns>/<name>` URL in Go, use `utils.UrlForFunction(name, namespace)` — it **folds the default namespace** to `/fission-function/<name>`, which is the form the router actually registers.
+  A hardcoded `/fission-function/default/<name>` does not resolve.
 - MCP test pod logs live in the `fission` namespace, which the integration-test diagnostics dump (scoped to `default`) does NOT capture — pull the CI `kind-logs-<run>-<ver>` artifact and read `.../containers/mcp-*.log` instead.
-- Poolmgr request accounting has **two disjoint modes that must never mix**: router-admitted requests (index `Admit`) decrement via the `ResolvedEntry.Release` closure, executor-resolved requests via the UnTap RPC into `PoolCache.activeRequests`. Calling Release for an executor-resolved entry (or skipping UnTap for one) corrupts the executor's concurrency accounting — when touching `pkg/router/transport.go` or the resolvers, check which mode owns the entry (`Release != nil` ⟺ router-admitted).
-- gorilla/mux's `Route.Methods()` **uppercases the slice it is handed in place** and keeps it as the route's matcher — passing a shared slice (an informer-owned object's field, or the route table's canonical spec) mutates the owner AND races the still-serving previous mux's matcher under churn. Always pass a clone (`registerRouteShape` does); the race only surfaces under `-race` with concurrent build+serve.
-- `EXECUTOR_SPECIALIZATION_CONCURRENCY` bounds **one semaphore shared by all executor types**: a small bound lets newdeploy's minutes-long `waitForDeployment` holds starve poolmgr's ~100ms specializations (head-of-line blocking; surfaced as mass cold-start timeouts in CI). Leave it 0 (unbounded) unless poolmgr-only pressure is the proven problem.
+- Poolmgr request accounting has **two disjoint modes that must never mix**: router-admitted requests (index `Admit`) decrement via the `ResolvedEntry.Release` closure, executor-resolved requests via the UnTap RPC into `PoolCache.activeRequests`.
+  Calling Release for an executor-resolved entry (or skipping UnTap for one) corrupts the executor's concurrency accounting — when touching `pkg/router/transport.go` or the resolvers, check which mode owns the entry (`Release != nil` ⟺ router-admitted).
+- gorilla/mux's `Route.Methods()` **uppercases the slice it is handed in place** and keeps it as the route's matcher — passing a shared slice (an informer-owned object's field, or the route table's canonical spec) mutates the owner AND races the still-serving previous mux's matcher under churn.
+  Always pass a clone (`registerRouteShape` does); the race only surfaces under `-race` with concurrent build+serve.
+- `EXECUTOR_SPECIALIZATION_CONCURRENCY` bounds **one semaphore shared by all executor types**: a small bound lets newdeploy's minutes-long `waitForDeployment` holds starve poolmgr's ~100ms specializations (head-of-line blocking; surfaced as mass cold-start timeouts in CI).
+  Leave it 0 (unbounded) unless poolmgr-only pressure is the proven problem.

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,15 @@ debug-vars: print-GOOS print-GOARCH print-GOAMD64 print-VERSION print-TIMESTAMP 
 ### Static checks
 check: test-run build-fission-cli clean
 
-code-checks:
+code-checks: verify-gomod
 	golangci-lint run
+
+# Fail if go.mod does not keep direct and indirect requirements in separate
+# blocks. `go mod tidy` does not enforce this layout, so this guard does.
+# Convention: .claude/resources/go-mod-conventions.md
+.PHONY: verify-gomod
+verify-gomod:
+	@hack/verify-gomod.sh
 
 ### License headers
 # Files that should carry an SPDX license header. Shared by the license

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/ory/dockertest/v3 v3.12.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.69.0
 	github.com/prometheus/otlptranslator v1.0.0
 	github.com/robfig/cron/v3 v3.0.1
@@ -44,12 +45,16 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.66.0
 	go.opentelemetry.io/otel/log v0.20.0
 	go.opentelemetry.io/otel/log/logtest v0.20.0
+	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.21.0
+	golang.org/x/term v0.44.0
 	google.golang.org/grpc v1.81.1
 	k8s.io/api v0.36.2
 	k8s.io/apiextensions-apiserver v0.36.2
@@ -173,7 +178,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/pjbgf/sha1cd v0.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20250401214520-65e299d6c5c9 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
@@ -200,9 +204,7 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	github.com/zeebo/xxh3 v1.1.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel/metric v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -210,9 +212,7 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.46.0 // indirect

--- a/hack/verify-gomod.sh
+++ b/hack/verify-gomod.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: The Fission Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Verifies go.mod keeps direct and indirect requirements in separate blocks:
+# exactly one direct `require (...)` block, one indirect (`// indirect`) block,
+# no block mixing the two, and no single-line `require` directives.
+# `go mod tidy` does NOT enforce this layout, so this guard does.
+# Convention: .claude/resources/go-mod-conventions.md
+
+set -euo pipefail
+
+GOMOD="${1:-go.mod}"
+
+awk '
+  # Single-line require (e.g. `require foo v1.2.3`) — must live in a block.
+  /^require[ \t]+[^(]/ {
+    printf "  line %d: single-line require — consolidate into a block: %s\n", NR, $0
+    bad = 1
+    next
+  }
+  /^require[ \t]*\(/ { inblk = 1; start = NR; direct = 0; indirect = 0; next }
+  inblk && /^\)/ {
+    inblk = 0
+    if (direct > 0 && indirect > 0) {
+      printf "  line %d: require block mixes %d direct + %d indirect entries\n", start, direct, indirect
+      bad = 1
+    } else if (direct > 0) {
+      directblocks++
+    } else if (indirect > 0) {
+      indirectblocks++
+    }
+    next
+  }
+  inblk && /\/\/ indirect/ { indirect++; next }
+  inblk && /[^ \t]/ && $0 !~ /^[ \t]*\/\// { direct++; next }
+  END {
+    if (directblocks > 1)   { printf "  found %d direct require blocks — collapse to one\n", directblocks; bad = 1 }
+    if (indirectblocks > 1) { printf "  found %d indirect require blocks — collapse to one\n", indirectblocks; bad = 1 }
+    if (bad) {
+      print "go.mod block layout is not canonical (see .claude/resources/go-mod-conventions.md):" > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$GOMOD" || {
+  echo "FAIL: $GOMOD violates the direct/indirect block convention." >&2
+  exit 1
+}
+
+echo "OK: $GOMOD keeps direct and indirect requirements in separate blocks."


### PR DESCRIPTION
## What & why

`go.mod` is meant to keep **direct** requirements in one `require (...)` block and **indirect** (`// indirect`) ones in another, but `go mod tidy` only maintains the `// indirect` annotations — it never moves entries between blocks. Over time, `go get` (and deps that became directly-imported) left several direct dependencies sitting inside the indirect block.

This PR fixes the current drift and adds a guard so it can't recur.

## Changes

- **`go.mod`:** move the 5 direct deps that had drifted into the indirect block — `github.com/prometheus/client_model`, `go.opentelemetry.io/otel/metric`, `go.uber.org/goleak`, `golang.org/x/sync`, `golang.org/x/term` — into the direct block. The move is **semantically neutral**: `go.sum` is unchanged, `go mod tidy` makes no further changes, and `go build ./...` is green.
- **`hack/verify-gomod.sh`:** a dependency-free checker that fails if a `require` block mixes direct + indirect entries, if there is more than one block of either kind, or if a single-line `require` exists.
- **Enforcement:** `make verify-gomod` (also a prerequisite of `make code-checks`, so it runs in `make check`) and a line in `lint.yaml`'s "Verify dependencies" CI step.
- **Convention captured** in `.claude/resources/go-mod-conventions.md`, referenced from a new "Dependency management" section in `CLAUDE.md` — mirroring how `test-writing-guidelines.md` is referenced.

## Verifying

```
make verify-gomod      # OK
git diff go.sum        # empty — no semantic change
go build ./...         # green
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
