### PR TITLE
fix(storagesvc): make /v1/archive upload body cap operator-tunable

### DIFF
--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -52,6 +52,10 @@ spec:
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED
           value: {{ .Values.pprof.enabled | quote }}
+        {{- if .Values.storagesvc.maxArchiveSizeMib }}
+        - name: STORAGE_MAX_ARCHIVE_SIZE_MIB
+          value: {{ .Values.storagesvc.maxArchiveSizeMib | quote }}
+        {{- end }}
         {{- if and (.Values.persistence.enabled) (eq (.Values.persistence.storageType | default "local") "s3") }}
         - name: STORAGE_S3_ENDPOINT
           value: {{ .Values.persistence.s3.endPoint }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -772,6 +772,24 @@ storagesvc:
     ## Run prune routine at interval (in minutes)
     interval: 60
 
+  ## maxArchiveSizeMib caps the size (in MiB) of a single package archive
+  ## uploaded to /v1/archive. With internalAuth enabled, the HMAC verifier
+  ## buffers the upload body in memory to check its signature and rejects
+  ## anything larger with 413 Request Entity Too Large. (With internalAuth
+  ## disabled there is no verifier, so this cap has no effect.)
+  ## Use a plain integer number of MiB — no unit suffix (512, not 512Mi).
+  ## 0 or unset means the 256 MiB default; there is no "unlimited" setting.
+  ## Raise it for large packages instead of disabling internalAuth, and size
+  ## the storagesvc memory request/limit to match, since the body is held in
+  ## memory during verification. The cap applies to the multipart-wrapped
+  ## request body, which is marginally larger than the raw archive.
+  ##
+  ## For very large packages, prefer publishing them as OCI images
+  ## (packageRegistry.enabled + repositoryPrefix) over raising this cap: the
+  ## code is then pulled and mounted from a registry instead of buffered
+  ## through storagesvc, which scales and manages better.
+  maxArchiveSizeMib: 256
+
   ## Security Context
   ## It holds pod-level and container level security configuration.
   ## This is an experimental section, please verify before enabling in production.

--- a/docs/internal-auth/00-design.md
+++ b/docs/internal-auth/00-design.md
@@ -285,6 +285,9 @@ The verifier reads the entire request body into memory before computing the sign
 That cost is bounded by `VerifierOpts.MaxBodyBytes` (default 256 MiB, set on each registration).
 Bodies that exceed the cap are rejected with `413 Request Entity Too Large` *before* signature verification — i.e. an unauthenticated attacker cannot use a giant unsigned body to DoS a signed service.
 Operators that legitimately need to upload archives larger than 256 MiB should bump the cap rather than disable enforcement; the cap is the largest archive size we expect to see in practice.
+For the one bulk-data endpoint, `storagesvc /v1/archive`, the cap is operator-tunable: set the Helm value `storagesvc.maxArchiveSizeMib` (env var `STORAGE_MAX_ARCHIVE_SIZE_MIB`), and size the storagesvc memory request/limit to match, since the body is held in memory during verification.
+The other registrations (fetcher, builder, executor, router-internal) carry small control-plane payloads and keep the 256 MiB default.
+For very large packages, OCI-native delivery (`packageRegistry`) is the better-managed alternative to raising the cap — the code is pulled and mounted from a registry rather than buffered through storagesvc.
 
 **Replay within the skew window.**
 A captured signed request can be replayed any number of times within the `SkewSec` window (default 60s) and will pass verification each time.

--- a/pkg/storagesvc/authz_test.go
+++ b/pkg/storagesvc/authz_test.go
@@ -114,7 +114,7 @@ func TestArchiveAuthzHandlers(t *testing.T) {
 	storage := NewLocalStorage(t.TempDir())
 	sc, err := MakeStorageClient(logr.Discard(), storage)
 	require.NoError(t, err)
-	ss := MakeStorageService(logr.Discard(), sc, 0, master, nil)
+	ss := MakeStorageService(logr.Discard(), sc, 0, master, nil, 0)
 
 	m := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
 		hmacauth.VerifierOpts{SkewSec: 60, Now: func() time.Time { return now }})))

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -8,9 +8,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"errors"
@@ -49,6 +51,10 @@ type (
 		authSecret []byte
 		// authSecretOld is accepted alongside authSecret during rotation.
 		authSecretOld []byte
+		// maxUploadBytes is passed to VerifierOpts.MaxBodyBytes for /v1/archive;
+		// 0 (the default, and the only non-positive value maxUploadBytesFromEnv
+		// produces) means hmacauth.DefaultMaxBodyBytes (256 MiB).
+		maxUploadBytes int64
 	}
 
 	UploadResponse struct {
@@ -301,17 +307,25 @@ func (ss *StorageService) healthHandler(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusOK)
 }
 
-func MakeStorageService(logger logr.Logger, storageClient *StorageClient, port int, authSecret, authSecretOld []byte) *StorageService {
+func MakeStorageService(logger logr.Logger, storageClient *StorageClient, port int, authSecret, authSecretOld []byte, maxUploadBytes int64) *StorageService {
 	return &StorageService{
-		logger:        logger.WithName("storage_service"),
-		storageClient: storageClient,
-		port:          port,
-		authSecret:    authSecret,
-		authSecretOld: authSecretOld,
+		logger:         logger.WithName("storage_service"),
+		storageClient:  storageClient,
+		port:           port,
+		authSecret:     authSecret,
+		authSecretOld:  authSecretOld,
+		maxUploadBytes: maxUploadBytes,
 	}
 }
 
 func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port int) {
+	httpserver.StartServer(ctx, ss.logger, mgr, "storagesvc", fmt.Sprintf("%d", port), ss.makeHandler())
+}
+
+// makeHandler builds the storagesvc HTTP handler chain (auth + routes +
+// security headers + OTEL). Split out from Start so the wiring — in particular
+// the configurable upload body cap — is exercisable without binding a listener.
+func (ss *StorageService) makeHandler() http.Handler {
 	// Per-route metrics always; the HMAC verifier wraps the whole mux as the
 	// OUTERMOST middleware (so 401s are handled at the auth layer and metrics
 	// see only post-verification requests) only when a master is configured.
@@ -336,10 +350,10 @@ func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port i
 		opts = append(opts, httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(ss.authSecret, ss.authSecretOld, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
 			SkewSec: 60,
 			Bypass:  []string{"/healthz"},
-			// 256 MiB caps the verifier's in-memory body buffer; this is
-			// larger than any realistic Fission archive but bounds the cost
-			// of an unsigned/malicious upload to /v1/archive.
-			MaxBodyBytes: hmacauth.DefaultMaxBodyBytes,
+			// Caps the body the verifier buffers to check its signature; the
+			// verifier resolves 0 to 256 MiB. Operator-tunable via
+			// STORAGE_MAX_ARCHIVE_SIZE_MIB — see the maxUploadBytes field and values.yaml.
+			MaxBodyBytes: ss.maxUploadBytes,
 			Logger:       ss.logger.WithName("hmac"),
 		})))
 	}
@@ -358,12 +372,45 @@ func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port i
 	// SecurityHeaders + DenyAllCORS as defense-in-depth: a future
 	// regression exposing this port via Ingress must not become a
 	// browser-readable archive store.
-	handler := httpsecurity.SecurityHeaders(
+	return httpsecurity.SecurityHeaders(
 		httpsecurity.DenyAllCORS(
 			otelUtils.GetHandlerWithOTEL(m.Handler(), "fission-storagesvc", otelUtils.UrlsToIgnore("/healthz")),
 		),
 	)
-	httpserver.StartServer(ctx, ss.logger, mgr, "storagesvc", fmt.Sprintf("%d", port), handler)
+}
+
+// maxArchiveSizeMiBCeil is the largest STORAGE_MAX_ARCHIVE_SIZE_MIB we accept
+// before the `<< 20` MiB→bytes conversion would overflow int64; larger values
+// are treated as misconfiguration and fall back to the default cap.
+const maxArchiveSizeMiBCeil = math.MaxInt64 >> 20
+
+// maxUploadBytesFromEnv reads STORAGE_MAX_ARCHIVE_SIZE_MIB — a plain integer
+// number of MiB, no unit suffix — and returns the corresponding /v1/archive
+// upload body cap in bytes. Unset, zero, or invalid values return 0, which the
+// verifier resolves to hmacauth.DefaultMaxBodyBytes (256 MiB). The cap bounds
+// the multipart-wrapped request body, marginally larger than the raw archive.
+func maxUploadBytesFromEnv(logger logr.Logger) int64 {
+	v := strings.TrimSpace(os.Getenv("STORAGE_MAX_ARCHIVE_SIZE_MIB"))
+	if v == "" {
+		return 0
+	}
+	defaultMiB := hmacauth.DefaultMaxBodyBytes >> 20
+	mib, err := strconv.ParseInt(v, 10, 64)
+	switch {
+	case err != nil:
+		logger.Error(err, "STORAGE_MAX_ARCHIVE_SIZE_MIB is not a plain integer number of MiB; using the default upload cap",
+			"value", v, "defaultMiB", defaultMiB)
+		return 0
+	case mib < 0:
+		logger.Info("ignoring negative STORAGE_MAX_ARCHIVE_SIZE_MIB; using the default upload cap",
+			"value", v, "defaultMiB", defaultMiB)
+		return 0
+	case mib > maxArchiveSizeMiBCeil:
+		logger.Info("STORAGE_MAX_ARCHIVE_SIZE_MIB is too large; using the default upload cap",
+			"value", v, "maxMiB", maxArchiveSizeMiBCeil, "defaultMiB", defaultMiB)
+		return 0
+	}
+	return mib << 20
 }
 
 // Start runs storage service
@@ -385,7 +432,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	authSecretOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
 
 	// create http handlers
-	storageService := MakeStorageService(logger, storageClient, port, authSecret, authSecretOld)
+	storageService := MakeStorageService(logger, storageClient, port, authSecret, authSecretOld, maxUploadBytesFromEnv(logger))
 	mgr.Go(func() error {
 		metrics.ServeMetrics(ctx, "storagesvc", logger, mgr)
 		return nil

--- a/pkg/storagesvc/upload_bodysize_test.go
+++ b/pkg/storagesvc/upload_bodysize_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package storagesvc
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// signedArchiveUpload builds a multipart POST /v1/archive request carrying
+// payload, shaped like the storagesvc client (form field "uploadfile" + the
+// X-File-Size header), and signs it with the storagesvc-derived key so the HMAC
+// verifier admits it. The body the verifier buffers is the multipart wrapper
+// around payload, so it is marginally larger than len(payload).
+func signedArchiveUpload(t *testing.T, key, payload []byte) *http.Request {
+	t.Helper()
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	fw, err := mw.CreateFormFile("uploadfile", "deploy.zip")
+	require.NoError(t, err)
+	_, err = fw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+
+	body := buf.Bytes()
+	req := httptest.NewRequest(http.MethodPost, "/v1/archive", bytes.NewReader(body))
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	req.Header.Set("X-File-Size", strconv.Itoa(len(payload)))
+
+	ts := time.Now().Unix()
+	sig := hmacauth.Sign(key, http.MethodPost, req.URL.RequestURI(), body, ts)
+	req.Header.Set(hmacauth.HeaderTimestamp, strconv.FormatInt(ts, 10))
+	req.Header.Set(hmacauth.HeaderSignature, sig)
+	return req
+}
+
+// requireArchiveStored asserts the upload response carries a non-empty archive
+// id — i.e. the request reached uploadHandler and putFile actually stored the
+// archive, not merely that the verifier returned 200.
+func requireArchiveStored(t *testing.T, rr *httptest.ResponseRecorder) {
+	t.Helper()
+	var ur UploadResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &ur))
+	require.NotEmpty(t, ur.ID, "expected the archive to be stored and an id returned")
+}
+
+// TestUploadBodySizeCapConfigurable locks in the fix for #3538: the /v1/archive
+// upload body cap is operator-tunable. A correctly signed upload larger than the
+// configured cap is rejected with 413 (the regression); a cap above the body —
+// or the resolved default — admits and stores it.
+func TestUploadBodySizeCapConfigurable(t *testing.T) {
+	master := []byte("storagesvc-test-master-key-long-enough")
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+	payload := bytes.Repeat([]byte("x"), 64*1024) // 64 KiB archive
+
+	// Caps derived from the payload so the bracket holds if the payload size
+	// changes: the multipart-wrapped body is >= len(payload), so a half-payload
+	// cap rejects it and a several-times-payload cap admits it.
+	overCap := int64(len(payload) / 2)
+	underCap := int64(len(payload) * 4)
+
+	newHandler := func(t *testing.T, maxUploadBytes int64) http.Handler {
+		t.Helper()
+		storage := NewLocalStorage(t.TempDir())
+		sc, err := MakeStorageClient(logr.Discard(), storage)
+		require.NoError(t, err)
+		ss := MakeStorageService(logr.Discard(), sc, 0, master, nil, maxUploadBytes)
+		return ss.makeHandler()
+	}
+
+	t.Run("upload over the configured cap is rejected with 413", func(t *testing.T) {
+		t.Parallel()
+		rr := httptest.NewRecorder()
+		newHandler(t, overCap).ServeHTTP(rr, signedArchiveUpload(t, keyMaster, payload))
+		require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	})
+
+	t.Run("a cap above the body admits and stores the upload", func(t *testing.T) {
+		t.Parallel()
+		rr := httptest.NewRecorder()
+		newHandler(t, underCap).ServeHTTP(rr, signedArchiveUpload(t, keyMaster, payload))
+		require.Equal(t, http.StatusOK, rr.Code)
+		requireArchiveStored(t, rr)
+	})
+
+	t.Run("a zero cap falls back to the default and admits the upload", func(t *testing.T) {
+		t.Parallel()
+		rr := httptest.NewRecorder()
+		newHandler(t, 0).ServeHTTP(rr, signedArchiveUpload(t, keyMaster, payload))
+		require.Equal(t, http.StatusOK, rr.Code)
+		requireArchiveStored(t, rr)
+	})
+}
+
+// TestMaxUploadBytesFromEnv covers the env parsing: MiB → bytes, with unset,
+// zero, negative, garbage, unit-suffixed, and overflowing values all falling
+// back to 0 (which the verifier resolves to hmacauth.DefaultMaxBodyBytes).
+func TestMaxUploadBytesFromEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want int64
+	}{
+		{"unset", "", 0},
+		{"zero", "0", 0},
+		{"valid", "512", 512 << 20},
+		{"whitespace trimmed", "  300 ", 300 << 20},
+		{"negative", "-1", 0},
+		{"garbage", "abc", 0},
+		{"unit suffix rejected", "512Mi", 0},
+		{"overflow falls back to default", strconv.FormatInt(math.MaxInt64, 10), 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("STORAGE_MAX_ARCHIVE_SIZE_MIB", tc.env)
+			require.Equal(t, tc.want, maxUploadBytesFromEnv(logr.Discard()))
+		})
+	}
+}


### PR DESCRIPTION
## TL;DR

Makes the storagesvc `/v1/archive` upload body-size cap operator-tunable instead of hardcoded, so large package archives upload again.
Default behaviour is unchanged: with no config the cap stays 256 MiB.

Fixes #3538.

## Why

Uploading a package larger than ~256 MiB (e.g. a scientific Python environment) fails with:

```
Error uploading deployment package: Internal error - error uploading zip file: Upload error 413 Request Entity Too Large
```

This is a regression from the StorageSvc HMAC auth work (#3368).
The HMAC signature is computed over `SHA256(body)`, so the verifier must read the whole request body into memory to check it.
To bound the memory an unauthenticated caller can force it to allocate, the verifier rejects bodies over `hmacauth.DefaultMaxBodyBytes` (256 MiB) with **413 before** signature verification — and the storagesvc registration hardcoded that constant.
The internal-auth design (`docs/internal-auth/00-design.md`) already said operators who need larger archives should *"bump the cap rather than disable enforcement"* — but no mechanism to bump it was ever wired up.
That missing knob is the bug.

## What changed

- `pkg/storagesvc/storagesvc.go`: new `maxUploadBytes` field threaded through `MakeStorageService` and passed straight to `VerifierOpts.MaxBodyBytes` (the verifier already resolves `0 → DefaultMaxBodyBytes`).
- `maxUploadBytesFromEnv` reads `STORAGE_MAX_ARCHIVE_SIZE_MIB` as a plain integer number of MiB and falls back to the default on unset / non-integer / negative / `int64`-overflowing values (each logged distinctly).
- `Start` is split into a testable `makeHandler()` so the wiring can be exercised in-process without binding a listener.
- `charts/fission-all`: new documented value `storagesvc.maxArchiveSizeMib` (default `256`), rendered into the storagesvc deployment as `STORAGE_MAX_ARCHIVE_SIZE_MIB`.
- Docs: `values.yaml` + `docs/internal-auth/00-design.md` document the knob, note it only applies when internalAuth is on, and recommend OCI-native delivery (`packageRegistry`) as the better-managed path for very large packages.
- Tests: a signed upload over the cap is rejected `413`, and a cap above the body (or the resolved default) is admitted **and the archive is verified stored**; an env-parsing table covers unset/zero/valid/whitespace/negative/garbage/unit-suffix/overflow.

## Reviewer guide

- **Start here:** `pkg/storagesvc/storagesvc.go` — `makeHandler()` (now sources `MaxBodyBytes`) and `maxUploadBytesFromEnv()` (env validation). This is the whole behaviour change.
- **Mechanical / low-risk:** `authz_test.go` (one-line constructor-arg update), `deployment.yaml` (one gated env var).
- **Docs only:** `values.yaml`, `docs/internal-auth/00-design.md`.
- **Risk:** the cap is now raisable with no hard upper bound, so an operator who raises it must size the storagesvc memory request/limit accordingly — called out in `values.yaml` and the design doc. Existing installs are unaffected (default 256 MiB, byte-identical behaviour). The other four HMAC registrations (fetcher/builder/executor/router-internal) are untouched and keep the default.

## Follow-up

This unblocks large packages but still trades memory for archive size at a high cap.
A deeper fix — stream-hash the body to a temp file so verification memory stays bounded regardless of archive size — is tracked in #3539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
