### PR TITLE
feat(storagesvc): stream-verify large /v1/archive uploads (bounded HMAC memory)

### DIFF
--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -57,8 +57,8 @@ spec:
           value: {{ .Values.storagesvc.maxArchiveSizeMib | quote }}
         {{- end }}
         # Stream-verify large uploads to a dedicated writable, size-limited
-        # volume so verification RAM stays bounded and it works under a
-        # read-only root filesystem.
+        # volume so verification RAM stays bounded, the spill disk is capped,
+        # and it keeps working if the root filesystem is later made read-only.
         - name: STORAGE_SPILL_DIR
           value: {{ .Values.storagesvc.uploadSpill.dir | default "/tmp/fission-spill" | quote }}
         {{- if .Values.storagesvc.uploadSpill.thresholdMib }}

--- a/charts/fission-all/templates/storagesvc/deployment.yaml
+++ b/charts/fission-all/templates/storagesvc/deployment.yaml
@@ -56,6 +56,15 @@ spec:
         - name: STORAGE_MAX_ARCHIVE_SIZE_MIB
           value: {{ .Values.storagesvc.maxArchiveSizeMib | quote }}
         {{- end }}
+        # Stream-verify large uploads to a dedicated writable, size-limited
+        # volume so verification RAM stays bounded and it works under a
+        # read-only root filesystem.
+        - name: STORAGE_SPILL_DIR
+          value: {{ .Values.storagesvc.uploadSpill.dir | default "/tmp/fission-spill" | quote }}
+        {{- if .Values.storagesvc.uploadSpill.thresholdMib }}
+        - name: STORAGE_UPLOAD_SPILL_THRESHOLD_MIB
+          value: {{ .Values.storagesvc.uploadSpill.thresholdMib | quote }}
+        {{- end }}
         {{- if and (.Values.persistence.enabled) (eq (.Values.persistence.storageType | default "local") "s3") }}
         - name: STORAGE_S3_ENDPOINT
           value: {{ .Values.persistence.s3.endPoint }}
@@ -77,14 +86,14 @@ spec:
         {{- include "coverage.envs" . | indent 8 }}
         resources:
           {{- toYaml .Values.storagesvc.resources | nindent 10 }}
-        {{- if or (ne (.Values.persistence.storageType | default "local") "s3") .Values.coverage.enabled }}
         volumeMounts:
+        - name: fission-spill
+          mountPath: {{ .Values.storagesvc.uploadSpill.dir | default "/tmp/fission-spill" }}
         {{- if ne (.Values.persistence.storageType | default "local") "s3" }}
         - name: fission-storage
           mountPath: /fission
         {{- end }}
         {{- include "coverage.volumemount" . | indent 8 }}
-        {{- end }}
         readinessProbe:
           httpGet:
             path: "/healthz"
@@ -114,13 +123,17 @@ spec:
         terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
         {{- end }}
       serviceAccountName: fission-storagesvc
-      {{- if and (.Values.persistence.enabled) (ne (.Values.persistence.storageType | default "local") "s3") }}
       volumes:
+      - name: fission-spill
+        emptyDir:
+          {{- if .Values.storagesvc.uploadSpill.sizeLimit }}
+          sizeLimit: {{ .Values.storagesvc.uploadSpill.sizeLimit }}
+          {{- end }}
+      {{- if and (.Values.persistence.enabled) (ne (.Values.persistence.storageType | default "local") "s3") }}
       - name: fission-storage
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default "fission-storage-pvc" }}
       {{- else }}
-      volumes:
       - name: fission-storage
         emptyDir: {}
       {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -796,7 +796,8 @@ storagesvc:
   ## Above thresholdMib the HMAC verifier streams the upload body through a temp
   ## file in a dedicated emptyDir (mounted at dir) instead of buffering it in
   ## RAM, so verification memory stays bounded regardless of archive size and
-  ## works under a read-only root filesystem. sizeLimit caps that volume (the
+  ## it keeps working if the root filesystem is later made read-only. sizeLimit
+  ## caps that volume (the
   ## pod is evicted if exceeded) — bounding the disk a burst of concurrent
   ## uploads can consume; raise it if you raise maxArchiveSizeMib. Set sizeLimit
   ## to "" to leave the volume unbounded.

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -792,6 +792,19 @@ storagesvc:
   ## through storagesvc, which scales and manages better.
   maxArchiveSizeMib: 256
 
+  ## uploadSpill controls stream-verification of large /v1/archive uploads.
+  ## Above thresholdMib the HMAC verifier streams the upload body through a temp
+  ## file in a dedicated emptyDir (mounted at dir) instead of buffering it in
+  ## RAM, so verification memory stays bounded regardless of archive size and
+  ## works under a read-only root filesystem. sizeLimit caps that volume (the
+  ## pod is evicted if exceeded) — bounding the disk a burst of concurrent
+  ## uploads can consume; raise it if you raise maxArchiveSizeMib. Set sizeLimit
+  ## to "" to leave the volume unbounded.
+  uploadSpill:
+    thresholdMib: 32
+    dir: /tmp/fission-spill
+    sizeLimit: 2Gi
+
   ## Security Context
   ## It holds pod-level and container level security configuration.
   ## This is an experimental section, please verify before enabling in production.

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -774,15 +774,17 @@ storagesvc:
 
   ## maxArchiveSizeMib caps the size (in MiB) of a single package archive
   ## uploaded to /v1/archive. With internalAuth enabled, the HMAC verifier
-  ## buffers the upload body in memory to check its signature and rejects
-  ## anything larger with 413 Request Entity Too Large. (With internalAuth
-  ## disabled there is no verifier, so this cap has no effect.)
+  ## checks the upload's signature and rejects anything larger with 413
+  ## Request Entity Too Large. (With internalAuth disabled there is no
+  ## verifier, so this cap has no effect.)
   ## Use a plain integer number of MiB — no unit suffix (512, not 512Mi).
   ## 0 or unset means the 256 MiB default; there is no "unlimited" setting.
-  ## Raise it for large packages instead of disabling internalAuth, and size
-  ## the storagesvc memory request/limit to match, since the body is held in
-  ## memory during verification. The cap applies to the multipart-wrapped
-  ## request body, which is marginally larger than the raw archive.
+  ## Raise it for large packages instead of disabling internalAuth. Uploads
+  ## above ~32 MiB are stream-verified through a temporary file, so verification
+  ## holds only a bounded amount in memory regardless of archive size (it does
+  ## use ephemeral disk); the cap then bounds disk rather than RAM. The cap
+  ## applies to the multipart-wrapped request body, marginally larger than the
+  ## raw archive.
   ##
   ## For very large packages, prefer publishing them as OCI images
   ## (packageRegistry.enabled + repositoryPrefix) over raising this cap: the

--- a/pkg/auth/hmac/hmac.go
+++ b/pkg/auth/hmac/hmac.go
@@ -40,15 +40,30 @@ import (
 // services like storagesvc that key on `?id=`.
 func Canonical(method, requestURI string, body []byte, timestampSec int64) string {
 	bodyHash := sha256.Sum256(body)
+	return CanonicalFromBodyHash(method, requestURI, hex.EncodeToString(bodyHash[:]), timestampSec)
+}
+
+// CanonicalFromBodyHash is Canonical for callers that have already computed
+// hex(SHA-256(body)) — e.g. by streaming the body through a hasher rather than
+// holding it in memory. `bodyHashHex` MUST be the lowercase hex SHA-256 of the
+// exact body bytes; the result is byte-identical to Canonical for that body.
+func CanonicalFromBodyHash(method, requestURI, bodyHashHex string, timestampSec int64) string {
 	minute := timestampSec - (timestampSec % 60)
-	return fmt.Sprintf("%s\n%s\n%s\n%d", method, requestURI, hex.EncodeToString(bodyHash[:]), minute)
+	return fmt.Sprintf("%s\n%s\n%s\n%d", method, requestURI, bodyHashHex, minute)
 }
 
 // Sign returns hex(HMAC-SHA256(secret, Canonical(...))). `requestURI`
 // is path + raw query (see Canonical).
 func Sign(secret []byte, method, requestURI string, body []byte, timestampSec int64) string {
+	bodyHash := sha256.Sum256(body)
+	return SignWithBodyHash(secret, method, requestURI, hex.EncodeToString(bodyHash[:]), timestampSec)
+}
+
+// SignWithBodyHash is Sign for callers that supply hex(SHA-256(body)) directly
+// (see CanonicalFromBodyHash). The signature is identical to Sign over the same body.
+func SignWithBodyHash(secret []byte, method, requestURI, bodyHashHex string, timestampSec int64) string {
 	mac := cryptohmac.New(sha256.New, secret)
-	mac.Write([]byte(Canonical(method, requestURI, body, timestampSec)))
+	mac.Write([]byte(CanonicalFromBodyHash(method, requestURI, bodyHashHex, timestampSec)))
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
@@ -57,7 +72,14 @@ func Sign(secret []byte, method, requestURI string, body []byte, timestampSec in
 // callers that have already validated freshness (e.g. unit tests).
 // `requestURI` is path + raw query (see Canonical).
 func Verify(secret []byte, method, requestURI string, body []byte, timestampSec int64, sig string) bool {
-	want := Sign(secret, method, requestURI, body, timestampSec)
+	bodyHash := sha256.Sum256(body)
+	return VerifyWithBodyHash(secret, method, requestURI, hex.EncodeToString(bodyHash[:]), timestampSec, sig)
+}
+
+// VerifyWithBodyHash is Verify for callers that supply hex(SHA-256(body))
+// directly (see CanonicalFromBodyHash). It is a constant-time check.
+func VerifyWithBodyHash(secret []byte, method, requestURI, bodyHashHex string, timestampSec int64, sig string) bool {
+	want := SignWithBodyHash(secret, method, requestURI, bodyHashHex, timestampSec)
 	return cryptohmac.Equal([]byte(want), []byte(sig))
 }
 

--- a/pkg/auth/hmac/hmac_test.go
+++ b/pkg/auth/hmac/hmac_test.go
@@ -5,10 +5,46 @@
 package hmac
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestBodyHashPrimitivesMatchSliceForms locks in the backward-compat invariant:
+// the *WithBodyHash forms (used by the streaming verifier/signer) produce a
+// byte-identical canonical string, signature, and verification result to the
+// slice-based Canonical/Sign/Verify when fed hex(sha256(body)).
+func TestBodyHashPrimitivesMatchSliceForms(t *testing.T) {
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	bodies := map[string][]byte{
+		"nil":   nil,
+		"empty": {},
+		"small": []byte("hello"),
+		"large": make([]byte, 5<<20), // 5 MiB of zeros
+	}
+	for name, body := range bodies {
+		t.Run(name, func(t *testing.T) {
+			h := sha256.Sum256(body)
+			bodyHashHex := hex.EncodeToString(h[:])
+			const (
+				method = "POST"
+				uri    = "/v1/archive?id=abc"
+				ts     = int64(1715000000)
+			)
+
+			assert.Equal(t, Canonical(method, uri, body, ts),
+				CanonicalFromBodyHash(method, uri, bodyHashHex, ts))
+
+			sliceSig := Sign(secret, method, uri, body, ts)
+			assert.Equal(t, sliceSig, SignWithBodyHash(secret, method, uri, bodyHashHex, ts))
+
+			assert.True(t, VerifyWithBodyHash(secret, method, uri, bodyHashHex, ts, sliceSig))
+			assert.False(t, VerifyWithBodyHash(secret, method, uri, bodyHashHex, ts, sliceSig+"00"))
+		})
+	}
+}
 
 func TestCanonicalString(t *testing.T) {
 	got := Canonical("POST", "/v1/archive", []byte("hello"), 1715000000)

--- a/pkg/auth/hmac/signer.go
+++ b/pkg/auth/hmac/signer.go
@@ -6,6 +6,8 @@ package hmac
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"strconv"
@@ -68,6 +70,30 @@ func (s *Signer) RoundTrip(r *http.Request) (*http.Response, error) {
 	if len(s.secret) == 0 {
 		return s.rt.RoundTrip(r)
 	}
+	ts := s.now().Unix()
+
+	// Sign over the request-URI (path + raw query) so query parameters like
+	// ?id= are bound to the signature. Signing the path alone would let an
+	// attacker replay a captured /v1/archive?id=A signature against ?id=B
+	// within the skew window.
+	uri := r.URL.RequestURI()
+
+	// When GetBody is available, hash a fresh copy from it and forward the
+	// original r.Body untouched, so a streamed body stays streaming (bounded
+	// memory — used by the storagesvc archive-upload client). GetBody is
+	// contractually a faithful reproduction of the body, so the signature is
+	// identical to hashing r.Body itself.
+	if r.Body != nil && r.GetBody != nil {
+		bodyHashHex, err := hashFromGetBody(r.GetBody)
+		if err != nil {
+			return nil, err
+		}
+		r.Header.Set(HeaderTimestamp, strconv.FormatInt(ts, 10))
+		r.Header.Set(HeaderSignature, SignWithBodyHash(s.secret, r.Method, uri, bodyHashHex, ts))
+		return s.rt.RoundTrip(r)
+	}
+
+	// No GetBody: buffer the body to hash it, then re-inject for the transport.
 	var body []byte
 	if r.Body != nil {
 		original := r.Body
@@ -85,13 +111,22 @@ func (s *Signer) RoundTrip(r *http.Request) (*http.Response, error) {
 		}
 		r.Body = io.NopCloser(bytes.NewReader(body))
 	}
-	ts := s.now().Unix()
-	// Sign over the request-URI (path + raw query) so query parameters
-	// like ?id= are bound to the signature. Signing the path alone would
-	// let an attacker replay a captured /v1/archive?id=A signature
-	// against a different ?id=B within the skew window.
-	sig := Sign(s.secret, r.Method, r.URL.RequestURI(), body, ts)
 	r.Header.Set(HeaderTimestamp, strconv.FormatInt(ts, 10))
-	r.Header.Set(HeaderSignature, sig)
+	r.Header.Set(HeaderSignature, Sign(s.secret, r.Method, uri, body, ts))
 	return s.rt.RoundTrip(r)
+}
+
+// hashFromGetBody returns hex(SHA-256) of the body produced by getBody,
+// streaming it through the hasher without buffering it in memory.
+func hashFromGetBody(getBody func() (io.ReadCloser, error)) (string, error) {
+	rc, err := getBody()
+	if err != nil {
+		return "", err
+	}
+	defer rc.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, rc); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/pkg/auth/hmac/signer_getbody_test.go
+++ b/pkg/auth/hmac/signer_getbody_test.go
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingRT captures the request the signer forwards.
+type recordingRT struct {
+	body io.ReadCloser
+	sig  string
+	ts   string
+}
+
+func (r *recordingRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.body = req.Body
+	r.sig = req.Header.Get(HeaderSignature)
+	r.ts = req.Header.Get(HeaderTimestamp)
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(bytes.NewReader(nil))}, nil
+}
+
+type trackReadCloser struct{ r io.Reader }
+
+func (t *trackReadCloser) Read(p []byte) (int, error) { return t.r.Read(p) }
+func (t *trackReadCloser) Close() error               { return nil }
+
+// TestSignerHashesViaGetBodyAndLeavesBodyUntouched: when GetBody is set, the
+// signer hashes a fresh copy from GetBody and forwards the ORIGINAL req.Body
+// untouched (no io.ReadAll, no re-injection), so a streaming body stays
+// streaming. Signature is identical to the slice form.
+func TestSignerHashesViaGetBodyAndLeavesBodyUntouched(t *testing.T) {
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	payload := []byte("streamed-payload-bytes")
+	now := func() time.Time { return time.Unix(1715000000, 0) }
+
+	orig := &trackReadCloser{r: bytes.NewReader(payload)}
+	req, err := http.NewRequest("POST", "http://example/v1/archive?id=x", orig)
+	require.NoError(t, err)
+	req.GetBody = func() (io.ReadCloser, error) { return io.NopCloser(bytes.NewReader(payload)), nil }
+
+	rt := &recordingRT{}
+	resp, err := NewSigner(secret, rt, now).RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Same(t, orig, rt.body, "signer must forward the original body untouched, not a buffered copy")
+	assert.Equal(t, Sign(secret, "POST", "/v1/archive?id=x", payload, 1715000000), rt.sig)
+	assert.Equal(t, "1715000000", rt.ts)
+}
+
+// TestSignerBuffersWhenNoGetBody: with no GetBody (a bare ReadCloser), the
+// signer keeps the buffered path — transport still receives the full body and
+// the signature is correct.
+func TestSignerBuffersWhenNoGetBody(t *testing.T) {
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	payload := []byte("buffered-payload")
+	now := func() time.Time { return time.Unix(1715000000, 0) }
+
+	req, err := http.NewRequest("POST", "http://example/v1/archive", io.NopCloser(bytes.NewReader(payload)))
+	require.NoError(t, err)
+	req.GetBody = nil // force the no-GetBody path
+
+	rt := &recordingRT{}
+	resp, err := NewSigner(secret, rt, now).RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	got, _ := io.ReadAll(rt.body)
+	assert.Equal(t, payload, got, "transport must still receive the full body")
+	assert.Equal(t, Sign(secret, "POST", "/v1/archive", payload, 1715000000), rt.sig)
+}

--- a/pkg/auth/hmac/spill.go
+++ b/pkg/auth/hmac/spill.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"hash"
+	"io"
+	"os"
+)
+
+// spillChunkSize is the read granularity while staging a body.
+const spillChunkSize = 32 * 1024
+
+// spillReader stages a request body while computing its SHA-256, holding it in
+// memory up to a threshold and spilling to a temp file beyond it, then replays
+// the staged bytes for the downstream handler. It lets the HMAC verifier check
+// a body-bound signature on an arbitrarily large body with bounded memory.
+//
+// Lifecycle: newSpillReader consumes src fully (staging + hashing); the caller
+// then reads BodyHashHex() and may Read() the body back. Close() releases the
+// temp file and MUST be called on every path — the http server closes the
+// re-injected request body on the success path, and the verifier closes it
+// itself on any non-handoff exit (signature mismatch, etc.). Close is idempotent.
+type spillReader struct {
+	hasher hash.Hash
+	file   *os.File  // non-nil once spilled; the staged body lives here
+	buf    []byte    // retained in-memory body when never spilled
+	reader io.Reader // replay source (bytes.Reader or the seeked file)
+}
+
+// newSpillReader reads src to completion, teeing every byte through SHA-256 and
+// staging it in memory until it would exceed threshold, after which it spills to
+// an os.CreateTemp file. A read error (including *http.MaxBytesError from a
+// MaxBytesReader-wrapped src) is returned after cleaning up any temp file, so
+// the caller can map it to the right status before any handler runs.
+func newSpillReader(src io.Reader, threshold int64) (*spillReader, error) {
+	sr := &spillReader{hasher: sha256.New()}
+	mem := &bytes.Buffer{}
+	chunk := make([]byte, spillChunkSize)
+	var size int64
+	for {
+		n, err := src.Read(chunk)
+		if n > 0 {
+			sr.hasher.Write(chunk[:n])
+			size += int64(n)
+			if sr.file == nil && size > threshold {
+				f, ferr := os.CreateTemp("", "fission-hmac-body-*")
+				if ferr != nil {
+					return nil, ferr
+				}
+				sr.file = f
+				if _, werr := f.Write(mem.Bytes()); werr != nil {
+					_ = sr.discard()
+					return nil, werr
+				}
+				mem.Reset()
+			}
+			if sr.file != nil {
+				if _, werr := sr.file.Write(chunk[:n]); werr != nil {
+					_ = sr.discard()
+					return nil, werr
+				}
+			} else {
+				mem.Write(chunk[:n])
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			_ = sr.discard()
+			return nil, err
+		}
+	}
+	if sr.file != nil {
+		if _, err := sr.file.Seek(0, io.SeekStart); err != nil {
+			_ = sr.discard()
+			return nil, err
+		}
+		sr.reader = sr.file
+	} else {
+		sr.buf = mem.Bytes()
+		sr.reader = bytes.NewReader(sr.buf)
+	}
+	return sr, nil
+}
+
+// BodyHashHex returns hex(SHA-256(body)) of the fully-staged body.
+func (sr *spillReader) BodyHashHex() string {
+	return hex.EncodeToString(sr.hasher.Sum(nil))
+}
+
+func (sr *spillReader) Read(p []byte) (int, error) {
+	if sr.reader == nil {
+		return 0, io.EOF
+	}
+	return sr.reader.Read(p)
+}
+
+// Close releases the temp file (if any). Idempotent.
+func (sr *spillReader) Close() error {
+	return sr.discard()
+}
+
+func (sr *spillReader) discard() error {
+	if sr.file == nil {
+		return nil
+	}
+	name := sr.file.Name()
+	closeErr := sr.file.Close()
+	sr.file = nil
+	sr.reader = nil
+	if rmErr := os.Remove(name); rmErr != nil && !os.IsNotExist(rmErr) {
+		return rmErr
+	}
+	return closeErr
+}

--- a/pkg/auth/hmac/spill.go
+++ b/pkg/auth/hmac/spill.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"hash"
 	"io"
 	"os"
@@ -23,22 +24,23 @@ const spillChunkSize = 32 * 1024
 //
 // Lifecycle: newSpillReader consumes src fully (staging + hashing); the caller
 // then reads BodyHashHex() and may Read() the body back. Close() releases the
-// temp file and MUST be called on every path — the http server closes the
-// re-injected request body on the success path, and the verifier closes it
-// itself on any non-handoff exit (signature mismatch, etc.). Close is idempotent.
+// temp file and MUST be called on every path. The net/http server closes the
+// ORIGINAL captured request body, not the spillReader the verifier re-injects,
+// so the verifier owns this lifetime and defers Close() on every exit. Close is
+// idempotent.
 type spillReader struct {
 	hasher hash.Hash
 	file   *os.File  // non-nil once spilled; the staged body lives here
-	buf    []byte    // retained in-memory body when never spilled
 	reader io.Reader // replay source (bytes.Reader or the seeked file)
 }
 
 // newSpillReader reads src to completion, teeing every byte through SHA-256 and
 // staging it in memory until it would exceed threshold, after which it spills to
-// an os.CreateTemp file. A read error (including *http.MaxBytesError from a
-// MaxBytesReader-wrapped src) is returned after cleaning up any temp file, so
-// the caller can map it to the right status before any handler runs.
-func newSpillReader(src io.Reader, threshold int64) (*spillReader, error) {
+// an os.CreateTemp file in dir (empty dir → os.TempDir()). A read error
+// (including *http.MaxBytesError from a MaxBytesReader-wrapped src) is returned
+// after cleaning up any temp file, so the caller can map it to the right status
+// before any handler runs.
+func newSpillReader(src io.Reader, threshold int64, dir string) (*spillReader, error) {
 	sr := &spillReader{hasher: sha256.New()}
 	mem := &bytes.Buffer{}
 	chunk := make([]byte, spillChunkSize)
@@ -49,7 +51,7 @@ func newSpillReader(src io.Reader, threshold int64) (*spillReader, error) {
 			sr.hasher.Write(chunk[:n])
 			size += int64(n)
 			if sr.file == nil && size > threshold {
-				f, ferr := os.CreateTemp("", "fission-hmac-body-*")
+				f, ferr := os.CreateTemp(dir, "fission-hmac-body-*")
 				if ferr != nil {
 					return nil, ferr
 				}
@@ -84,8 +86,7 @@ func newSpillReader(src io.Reader, threshold int64) (*spillReader, error) {
 		}
 		sr.reader = sr.file
 	} else {
-		sr.buf = mem.Bytes()
-		sr.reader = bytes.NewReader(sr.buf)
+		sr.reader = bytes.NewReader(mem.Bytes())
 	}
 	return sr, nil
 }
@@ -115,8 +116,9 @@ func (sr *spillReader) discard() error {
 	closeErr := sr.file.Close()
 	sr.file = nil
 	sr.reader = nil
-	if rmErr := os.Remove(name); rmErr != nil && !os.IsNotExist(rmErr) {
-		return rmErr
+	rmErr := os.Remove(name)
+	if os.IsNotExist(rmErr) {
+		rmErr = nil
 	}
-	return closeErr
+	return errors.Join(closeErr, rmErr)
 }

--- a/pkg/auth/hmac/spill_test.go
+++ b/pkg/auth/hmac/spill_test.go
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSpillReader(t *testing.T) {
+	cases := []struct {
+		name      string
+		size      int
+		threshold int64
+		wantSpill bool
+	}{
+		{"empty stays in memory", 0, 1024, false},
+		{"under threshold stays in memory", 500, 1024, false},
+		{"at threshold stays in memory", 1024, 1024, false},
+		{"over threshold spills to disk", 4096, 1024, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("TMPDIR", tmp) // redirect os.CreateTemp("") so we can assert cleanup
+
+			payload := bytes.Repeat([]byte("x"), tc.size)
+			want := sha256.Sum256(payload)
+
+			sr, err := newSpillReader(bytes.NewReader(payload), tc.threshold)
+			require.NoError(t, err)
+
+			// Hash matches the slice SHA-256 of the full body.
+			assert.Equal(t, hex.EncodeToString(want[:]), sr.BodyHashHex())
+
+			// A temp file exists iff we expected to spill.
+			entries, _ := os.ReadDir(tmp)
+			if tc.wantSpill {
+				assert.NotEmpty(t, entries, "expected a spill temp file")
+			} else {
+				assert.Empty(t, entries, "did not expect a temp file for an in-memory body")
+			}
+
+			// Body replays byte-identically.
+			got, err := io.ReadAll(sr)
+			require.NoError(t, err)
+			assert.Equal(t, payload, got)
+
+			// Close removes any temp file.
+			require.NoError(t, sr.Close())
+			entries, _ = os.ReadDir(tmp)
+			assert.Empty(t, entries, "Close must remove the spill temp file")
+		})
+	}
+}
+
+// TestSpillReaderCrossesThresholdAcrossChunks feeds the body in small reads so
+// the threshold is crossed mid-stream (prefix in memory, remainder to disk),
+// proving the prefix is flushed and the hash spans both.
+func TestSpillReaderCrossesThresholdAcrossChunks(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	payload := bytes.Repeat([]byte("ab"), 1000) // 2000 bytes
+	want := sha256.Sum256(payload)
+
+	sr, err := newSpillReader(iotest1ByteReader(payload), 512)
+	require.NoError(t, err)
+	assert.Equal(t, hex.EncodeToString(want[:]), sr.BodyHashHex())
+	got, err := io.ReadAll(sr)
+	require.NoError(t, err)
+	assert.Equal(t, payload, got)
+	require.NoError(t, sr.Close())
+}
+
+// iotest1ByteReader returns a reader that yields one byte per Read, forcing the
+// spill loop to cross its threshold across many small chunks.
+func iotest1ByteReader(b []byte) io.Reader {
+	return &oneByteReader{b: b}
+}
+
+type oneByteReader struct {
+	b []byte
+	i int
+}
+
+func (r *oneByteReader) Read(p []byte) (int, error) {
+	if r.i >= len(r.b) {
+		return 0, io.EOF
+	}
+	p[0] = r.b[r.i]
+	r.i++
+	return 1, nil
+}

--- a/pkg/auth/hmac/spill_test.go
+++ b/pkg/auth/hmac/spill_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -30,20 +31,19 @@ func TestSpillReader(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			tmp := t.TempDir()
-			t.Setenv("TMPDIR", tmp) // redirect os.CreateTemp("") so we can assert cleanup
+			dir := t.TempDir()
 
 			payload := bytes.Repeat([]byte("x"), tc.size)
 			want := sha256.Sum256(payload)
 
-			sr, err := newSpillReader(bytes.NewReader(payload), tc.threshold)
+			sr, err := newSpillReader(bytes.NewReader(payload), tc.threshold, dir)
 			require.NoError(t, err)
 
 			// Hash matches the slice SHA-256 of the full body.
 			assert.Equal(t, hex.EncodeToString(want[:]), sr.BodyHashHex())
 
 			// A temp file exists iff we expected to spill.
-			entries, _ := os.ReadDir(tmp)
+			entries, _ := os.ReadDir(dir)
 			if tc.wantSpill {
 				assert.NotEmpty(t, entries, "expected a spill temp file")
 			} else {
@@ -57,45 +57,24 @@ func TestSpillReader(t *testing.T) {
 
 			// Close removes any temp file.
 			require.NoError(t, sr.Close())
-			entries, _ = os.ReadDir(tmp)
+			entries, _ = os.ReadDir(dir)
 			assert.Empty(t, entries, "Close must remove the spill temp file")
 		})
 	}
 }
 
-// TestSpillReaderCrossesThresholdAcrossChunks feeds the body in small reads so
-// the threshold is crossed mid-stream (prefix in memory, remainder to disk),
+// TestSpillReaderCrossesThresholdAcrossChunks feeds the body one byte per read
+// so the threshold is crossed mid-stream (prefix in memory, remainder to disk),
 // proving the prefix is flushed and the hash spans both.
 func TestSpillReaderCrossesThresholdAcrossChunks(t *testing.T) {
-	t.Setenv("TMPDIR", t.TempDir())
 	payload := bytes.Repeat([]byte("ab"), 1000) // 2000 bytes
 	want := sha256.Sum256(payload)
 
-	sr, err := newSpillReader(iotest1ByteReader(payload), 512)
+	sr, err := newSpillReader(iotest.OneByteReader(bytes.NewReader(payload)), 512, t.TempDir())
 	require.NoError(t, err)
 	assert.Equal(t, hex.EncodeToString(want[:]), sr.BodyHashHex())
 	got, err := io.ReadAll(sr)
 	require.NoError(t, err)
 	assert.Equal(t, payload, got)
 	require.NoError(t, sr.Close())
-}
-
-// iotest1ByteReader returns a reader that yields one byte per Read, forcing the
-// spill loop to cross its threshold across many small chunks.
-func iotest1ByteReader(b []byte) io.Reader {
-	return &oneByteReader{b: b}
-}
-
-type oneByteReader struct {
-	b []byte
-	i int
-}
-
-func (r *oneByteReader) Read(p []byte) (int, error) {
-	if r.i >= len(r.b) {
-		return 0, io.EOF
-	}
-	p[0] = r.b[r.i]
-	r.i++
-	return 1, nil
 }

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -83,6 +83,11 @@ type VerifierOpts struct {
 	// path it bounds disk, not RAM. Intended for the one bulk-data endpoint
 	// (storagesvc /v1/archive); other registrations leave it 0.
 	SpillThreshold int64
+	// SpillDir is the directory for spill temp files (empty → os.TempDir()).
+	// Point this at a writable, size-limited volume so spilling works under a
+	// read-only root filesystem and the spill bytes land on provisioned storage
+	// rather than the container root FS. Only consulted on the spill path.
+	SpillDir string
 	// Logger receives V(1) messages on each rejection. The zero value is
 	// substituted with logr.Discard() at construction so callers that don't
 	// care about audit logs don't crash. Rejection log lines deliberately
@@ -207,35 +212,40 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 				w.WriteHeader(http.StatusUnauthorized)
 			}
 
-			// verifyBody checks a candidate key against the staged body;
-			// onMismatch releases any spill resources before a 401. The two
+			// Apply the body cap once, before the staging-path split, so the
+			// MaxBodyBytes invariant is provably enforced on both paths.
+			if r.Body != nil && opts.MaxBodyBytes > 0 {
+				r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
+			}
+
+			// verifyBody checks a candidate key against the staged body. The two
 			// staging paths differ only in memory cost: the spill path streams
 			// the body through a hasher into memory-or-tempfile (bounded RAM),
 			// the default path buffers it with io.ReadAll (unchanged behaviour).
+			// Spill only when there is actually a body to stream — a bodyless
+			// request (GET/list/HEAD, ContentLength 0) takes the cheap path and
+			// never allocates a hasher or temp file.
 			var verifyBody func(key []byte) bool
-			onMismatch := func() {}
 
-			if opts.SpillThreshold > 0 && r.Body != nil {
-				if opts.MaxBodyBytes > 0 {
-					r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
-				}
-				sr, serr := newSpillReader(r.Body, opts.SpillThreshold)
+			if opts.SpillThreshold > 0 && r.Body != nil && r.ContentLength != 0 {
+				sr, serr := newSpillReader(r.Body, opts.SpillThreshold, opts.SpillDir)
 				if serr != nil {
 					writeBodyErr(serr)
 					return
 				}
+				// The net/http server closes the ORIGINAL captured request body,
+				// not the spillReader we re-inject, so the verifier owns the
+				// temp file's lifetime: defer Close so it is removed on every
+				// exit — after the handler returns (success) or after a 401.
+				defer func() { _ = sr.Close() }()
 				bodyHashHex := sr.BodyHashHex()
-				r.Body = sr // re-injected; closed by the server on success, by onMismatch otherwise
+				r.Body = sr
 				verifyBody = func(key []byte) bool {
 					return VerifyWithBodyHash(key, r.Method, ru, bodyHashHex, tsNum, sig)
 				}
-				onMismatch = func() { _ = sr.Close() }
 			} else {
 				var body []byte
 				if r.Body != nil {
-					if opts.MaxBodyBytes > 0 {
-						r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
-					}
 					body, err = io.ReadAll(r.Body)
 					if err != nil {
 						writeBodyErr(err)
@@ -260,7 +270,6 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 					return
 				}
 			}
-			onMismatch()
 			opts.Logger.V(1).Info("HMAC verification failed",
 				"reason", "signature mismatch",
 				"method", r.Method, "path", r.URL.Path,

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -7,6 +7,8 @@ package hmac
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
 	"net/http"
@@ -253,8 +255,12 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 					}
 					r.Body = io.NopCloser(bytes.NewReader(body))
 				}
+				// Hash once (not per candidate key) and verify via the same
+				// primitive as the spill path, so both staging paths converge.
+				h := sha256.Sum256(body)
+				bodyHashHex := hex.EncodeToString(h[:])
 				verifyBody = func(key []byte) bool {
-					return Verify(key, r.Method, ru, body, tsNum, sig)
+					return VerifyWithBodyHash(key, r.Method, ru, bodyHashHex, tsNum, sig)
 				}
 			}
 

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -74,6 +74,15 @@ type VerifierOpts struct {
 	// The cap is only applied when enforcement is on (Secret non-empty); the
 	// pass-through short-circuit deliberately leaves the body untouched.
 	MaxBodyBytes int64
+	// SpillThreshold, when > 0, switches verification to the streaming path: the
+	// body is read through a SHA-256 hasher, staged in memory up to this many
+	// bytes and spilled to a temp file beyond it (removed when the re-injected
+	// body is closed), so verification memory stays bounded regardless of body
+	// size. Zero (the default) keeps the in-memory io.ReadAll path, byte-for-byte
+	// unchanged. MaxBodyBytes still applies as the hard ceiling — on the spill
+	// path it bounds disk, not RAM. Intended for the one bulk-data endpoint
+	// (storagesvc /v1/archive); other registrations leave it 0.
+	SpillThreshold int64
 	// Logger receives V(1) messages on each rejection. The zero value is
 	// substituted with logr.Discard() at construction so callers that don't
 	// care about audit logs don't crash. Rejection log lines deliberately
@@ -176,40 +185,73 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 				return
 			}
 
-			var body []byte
-			if r.Body != nil {
+			// Sign over RequestURI (path + raw query) so query parameters
+			// like ?id= are bound to the signature.
+			ru := r.URL.RequestURI()
+
+			// writeBodyErr maps a body-read failure to its response: a
+			// MaxBytesReader overflow → 413, anything else → 401.
+			writeBodyErr := func(e error) {
+				var maxErr *http.MaxBytesError
+				if errors.As(e, &maxErr) {
+					opts.Logger.V(1).Info("HMAC verification failed",
+						"reason", "body exceeds MaxBodyBytes",
+						"method", r.Method, "path", r.URL.Path,
+						"remoteAddr", r.RemoteAddr, "limit", maxErr.Limit)
+					w.WriteHeader(http.StatusRequestEntityTooLarge)
+					return
+				}
+				opts.Logger.V(1).Info("HMAC verification failed",
+					"reason", "body read error",
+					"method", r.Method, "path", r.URL.Path, "remoteAddr", r.RemoteAddr)
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+
+			// verifyBody checks a candidate key against the staged body;
+			// onMismatch releases any spill resources before a 401. The two
+			// staging paths differ only in memory cost: the spill path streams
+			// the body through a hasher into memory-or-tempfile (bounded RAM),
+			// the default path buffers it with io.ReadAll (unchanged behaviour).
+			var verifyBody func(key []byte) bool
+			onMismatch := func() {}
+
+			if opts.SpillThreshold > 0 && r.Body != nil {
 				if opts.MaxBodyBytes > 0 {
 					r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
 				}
-				body, err = io.ReadAll(r.Body)
-				if err != nil {
-					var maxErr *http.MaxBytesError
-					if errors.As(err, &maxErr) {
-						opts.Logger.V(1).Info("HMAC verification failed",
-							"reason", "body exceeds MaxBodyBytes",
-							"method", r.Method, "path", r.URL.Path,
-							"remoteAddr", r.RemoteAddr,
-							"limit", maxErr.Limit)
-						w.WriteHeader(http.StatusRequestEntityTooLarge)
-						return
-					}
-					opts.Logger.V(1).Info("HMAC verification failed",
-						"reason", "body read error",
-						"method", r.Method, "path", r.URL.Path,
-						"remoteAddr", r.RemoteAddr)
-					w.WriteHeader(http.StatusUnauthorized)
+				sr, serr := newSpillReader(r.Body, opts.SpillThreshold)
+				if serr != nil {
+					writeBodyErr(serr)
 					return
 				}
-				r.Body = io.NopCloser(bytes.NewReader(body))
+				bodyHashHex := sr.BodyHashHex()
+				r.Body = sr // re-injected; closed by the server on success, by onMismatch otherwise
+				verifyBody = func(key []byte) bool {
+					return VerifyWithBodyHash(key, r.Method, ru, bodyHashHex, tsNum, sig)
+				}
+				onMismatch = func() { _ = sr.Close() }
+			} else {
+				var body []byte
+				if r.Body != nil {
+					if opts.MaxBodyBytes > 0 {
+						r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
+					}
+					body, err = io.ReadAll(r.Body)
+					if err != nil {
+						writeBodyErr(err)
+						return
+					}
+					r.Body = io.NopCloser(bytes.NewReader(body))
+				}
+				verifyBody = func(key []byte) bool {
+					return Verify(key, r.Method, ru, body, tsNum, sig)
+				}
 			}
 
-			// Sign over RequestURI (path + raw query) so query parameters
-			// like ?id= are bound to the signature. Try each candidate key in
-			// order (active, then rotation, or the per-request namespace keys);
-			// constant-time compare happens inside Verify per candidate.
-			ru := r.URL.RequestURI()
+			// Try each candidate key in order (active, then rotation, or the
+			// per-request namespace keys); constant-time compare per candidate.
 			for _, c := range opts.labeledCandidates(r) {
-				if len(c.Key) > 0 && Verify(c.Key, r.Method, ru, body, tsNum, sig) {
+				if len(c.Key) > 0 && verifyBody(c.Key) {
 					// Record the principal whose key matched so downstream
 					// handlers authorize on the authenticated namespace rather
 					// than a caller-controlled header.
@@ -218,6 +260,7 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 					return
 				}
 			}
+			onMismatch()
 			opts.Logger.V(1).Info("HMAC verification failed",
 				"reason", "signature mismatch",
 				"method", r.Method, "path", r.URL.Path,

--- a/pkg/auth/hmac/verifier_interop_test.go
+++ b/pkg/auth/hmac/verifier_interop_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignerVerifierInterop is the backward-compatibility proof for a rolling
+// upgrade: every combination of a {buffered, GetBody-streaming} signer talking
+// to a {in-memory, spill} verifier interoperates and delivers the body intact.
+// The wire signature is identical across all four, so old/new clients and
+// servers mix freely.
+func TestSignerVerifierInterop(t *testing.T) {
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	payload := bytes.Repeat([]byte("interop-"), 8192) // 64 KiB, above the spill threshold below
+
+	cases := []struct {
+		name        string
+		spill       int64
+		withGetBody bool
+	}{
+		{"buffered signer -> in-memory verifier (old client, old server)", 0, false},
+		{"buffered signer -> spill verifier (old client, new server)", 4096, false},
+		{"getbody signer -> in-memory verifier (new client, old server)", 0, true},
+		{"getbody signer -> spill verifier (new client, new server)", 4096, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody []byte
+			srv := httptest.NewServer(Verifier(VerifierOpts{
+				Secret: secret, SkewSec: 60, Now: time.Now, SpillThreshold: tc.spill,
+			})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				w.WriteHeader(200)
+			})))
+			defer srv.Close()
+
+			client := &http.Client{Transport: NewSigner(secret, http.DefaultTransport, time.Now)}
+
+			var req *http.Request
+			var err error
+			if tc.withGetBody {
+				req, err = http.NewRequest(http.MethodPost, srv.URL+"/v1/archive", bytes.NewReader(payload))
+			} else {
+				req, err = http.NewRequest(http.MethodPost, srv.URL+"/v1/archive", io.NopCloser(bytes.NewReader(payload)))
+				if req != nil {
+					req.GetBody = nil // force the buffered signer path
+					req.ContentLength = int64(len(payload))
+				}
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.withGetBody, req.GetBody != nil, "test precondition: GetBody presence")
+
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, 200, resp.StatusCode)
+			assert.Equal(t, payload, gotBody, "body must arrive intact regardless of signer/verifier combination")
+		})
+	}
+}

--- a/pkg/auth/hmac/verifier_spill_test.go
+++ b/pkg/auth/hmac/verifier_spill_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const spillTestSecret = "test-secret-must-be-32-bytes-min"
+
+func spillNow() time.Time { return time.Unix(1715000000, 0) }
+
+// assertNoSpillLeak fails if any verifier spill temp file is left in os.TempDir()
+// (which the caller has pointed at a per-test dir via TMPDIR).
+func assertNoSpillLeak(t *testing.T) {
+	t.Helper()
+	entries, err := os.ReadDir(os.TempDir())
+	require.NoError(t, err)
+	for _, e := range entries {
+		assert.NotContains(t, e.Name(), "fission-hmac-body-", "spill temp file leaked")
+	}
+}
+
+func signedReq(method, uri string, body []byte, ts int64, sigBody []byte) *http.Request {
+	req := httptest.NewRequest(method, uri, bytes.NewReader(body))
+	sig := Sign([]byte(spillTestSecret), method, req.URL.RequestURI(), sigBody, ts)
+	req.Header.Set(HeaderTimestamp, strconv.FormatInt(ts, 10))
+	req.Header.Set(HeaderSignature, sig)
+	return req
+}
+
+func TestVerifierSpillAcceptsLargeSignedBody(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	body := bytes.Repeat([]byte("z"), 4096) // > SpillThreshold below
+	var gotBody []byte
+	h := Verifier(VerifierOpts{
+		Secret: []byte(spillTestSecret), SkewSec: 60, Now: spillNow, SpillThreshold: 1024,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close() // simulate the net/http server closing the request body
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+	}))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, signedReq("POST", "/v1/archive", body, 1715000000, body))
+	require.Equal(t, 200, rr.Code)
+	assert.Equal(t, body, gotBody, "downstream must re-read the spilled body byte-for-byte")
+	assertNoSpillLeak(t)
+}
+
+func TestVerifierSpillRejectsTamperedBody(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	signed := bytes.Repeat([]byte("z"), 4096)
+	tampered := bytes.Repeat([]byte("y"), 4096)
+	h := Verifier(VerifierOpts{
+		Secret: []byte(spillTestSecret), SkewSec: 60, Now: spillNow, SpillThreshold: 1024,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	rr := httptest.NewRecorder()
+	// sign over `signed` but send `tampered`
+	h.ServeHTTP(rr, signedReq("POST", "/v1/archive", tampered, 1715000000, signed))
+	require.Equal(t, 401, rr.Code)
+	assertNoSpillLeak(t)
+}
+
+func TestVerifierSpillRejectsOversizeBody(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	body := bytes.Repeat([]byte("z"), 4096)
+	h := Verifier(VerifierOpts{
+		Secret: []byte(spillTestSecret), SkewSec: 60, Now: spillNow,
+		SpillThreshold: 1024, MaxBodyBytes: 2048,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) }))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, signedReq("POST", "/v1/archive", body, 1715000000, body))
+	require.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	assertNoSpillLeak(t)
+}
+
+// TestVerifierSpillSmallBodyStaysInMemory exercises the spill path with a body
+// under the threshold: it verifies (no temp file involved) and re-reads.
+func TestVerifierSpillSmallBodyStaysInMemory(t *testing.T) {
+	t.Setenv("TMPDIR", t.TempDir())
+	body := []byte("small")
+	var gotBody []byte
+	h := Verifier(VerifierOpts{
+		Secret: []byte(spillTestSecret), SkewSec: 60, Now: spillNow, SpillThreshold: 1 << 20,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(200)
+	}))
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, signedReq("POST", "/v1/archive", body, 1715000000, body))
+	require.Equal(t, 200, rr.Code)
+	assert.Equal(t, body, gotBody)
+	assert.Equal(t, "small", strings.TrimSpace(string(gotBody)))
+	assertNoSpillLeak(t)
+}

--- a/pkg/auth/hmac/verifier_spill_test.go
+++ b/pkg/auth/hmac/verifier_spill_test.go
@@ -49,7 +49,9 @@ func TestVerifierSpillAcceptsLargeSignedBody(t *testing.T) {
 	h := Verifier(VerifierOpts{
 		Secret: []byte(spillTestSecret), SkewSec: 60, Now: spillNow, SpillThreshold: 1024,
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close() // simulate the net/http server closing the request body
+		// Deliberately do NOT close r.Body — the real uploadHandler doesn't, and
+		// net/http closes the ORIGINAL request body, not the re-injected
+		// spillReader. The verifier must clean up its own temp file regardless.
 		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(200)
 	}))
@@ -96,7 +98,6 @@ func TestVerifierSpillSmallBodyStaysInMemory(t *testing.T) {
 	h := Verifier(VerifierOpts{
 		Secret: []byte(spillTestSecret), SkewSec: 60, Now: spillNow, SpillThreshold: 1 << 20,
 	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
 		gotBody, _ = io.ReadAll(r.Body)
 		w.WriteHeader(200)
 	}))

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -186,27 +187,10 @@ func (c *client) Upload(ctx context.Context, filePath string, metadata *map[stri
 // example through an os.Root on the server-side fetch path — passes the open
 // file directly so no second, path-based open is needed.
 func (c *client) UploadReader(ctx context.Context, fileName string, r io.Reader, fileSize int64, metadata *map[string]string) (string, error) {
-	buf := &bytes.Buffer{}
-	bodyWriter := multipart.NewWriter(buf)
-	fileWriter, err := bodyWriter.CreateFormFile("uploadfile", fileName)
+	req, err := newUploadRequest(ctx, c.url+"/archive", fileName, r, fileSize)
 	if err != nil {
 		return "", err
 	}
-
-	_, err = io.Copy(fileWriter, r)
-	if err != nil {
-		return "", err
-	}
-
-	contentType := bodyWriter.FormDataContentType()
-	bodyWriter.Close()
-
-	req, err := http.NewRequest(http.MethodPost, c.url+"/archive", buf)
-	if err != nil {
-		return "", err
-	}
-	req.Header["X-File-Size"] = []string{fmt.Sprintf("%v", fileSize)}
-	req.Header["Content-Type"] = []string{contentType}
 
 	resp, err := ctxhttp.Do(ctx, c.httpClient, req)
 	if err != nil {
@@ -230,6 +214,96 @@ func (c *client) UploadReader(ctx context.Context, fileName string, r io.Reader,
 
 	return ur.ID, nil
 }
+
+// newUploadRequest builds the POST /archive multipart request for fileName +
+// the contents of r (fileSize bytes). When r is an io.ReadSeeker (the common
+// case — an *os.File), the body is streamed: the multipart envelope is assembled
+// around the file without buffering it, and req.GetBody re-streams it (seeking
+// back to the start) so the HMAC signer can hash without buffering either.
+// A non-seekable r falls back to buffering the whole multipart body in memory.
+func newUploadRequest(ctx context.Context, archiveURL, fileName string, r io.Reader, fileSize int64) (*http.Request, error) {
+	var (
+		req         *http.Request
+		contentType string
+		err         error
+	)
+
+	if rs, ok := r.(io.ReadSeeker); ok {
+		start, serr := rs.Seek(0, io.SeekCurrent)
+		if serr != nil {
+			return nil, serr
+		}
+		// Assemble the multipart envelope once (part header + closing boundary)
+		// using multipart.Writer's own boundary, then stream prefix + file +
+		// suffix. The bytes are identical to multipart.Writer's output for that
+		// boundary, but the file is never copied into memory.
+		var hdr bytes.Buffer
+		mw := multipart.NewWriter(&hdr)
+		if _, err = mw.CreateFormFile("uploadfile", fileName); err != nil {
+			return nil, err
+		}
+		prefix := append([]byte(nil), hdr.Bytes()...)
+		suffix := []byte("\r\n--" + mw.Boundary() + "--\r\n")
+		contentType = mw.FormDataContentType()
+
+		newBody := func() io.ReadCloser {
+			return &seekingMultipartBody{prefix: prefix, suffix: suffix, rs: rs, start: start}
+		}
+		if req, err = http.NewRequestWithContext(ctx, http.MethodPost, archiveURL, newBody()); err != nil {
+			return nil, err
+		}
+		req.GetBody = func() (io.ReadCloser, error) { return newBody(), nil }
+		req.ContentLength = int64(len(prefix)) + fileSize + int64(len(suffix))
+	} else {
+		buf := &bytes.Buffer{}
+		mw := multipart.NewWriter(buf)
+		fw, ferr := mw.CreateFormFile("uploadfile", fileName)
+		if ferr != nil {
+			return nil, ferr
+		}
+		if _, ferr = io.Copy(fw, r); ferr != nil {
+			return nil, ferr
+		}
+		contentType = mw.FormDataContentType()
+		if ferr = mw.Close(); ferr != nil {
+			return nil, ferr
+		}
+		if req, err = http.NewRequestWithContext(ctx, http.MethodPost, archiveURL, buf); err != nil {
+			return nil, err
+		}
+	}
+
+	// The backend needs the original file size (distinct from the encoded
+	// multipart Content-Length); see uploadHandler's X-File-Size handling.
+	req.Header.Set("X-File-Size", strconv.FormatInt(fileSize, 10))
+	req.Header.Set("Content-Type", contentType)
+	return req, nil
+}
+
+// seekingMultipartBody streams a single-file multipart body — prefix + the
+// seekable file + closing boundary — seeking the file to its captured start
+// offset on the first read. A fresh instance is used for req.Body and for each
+// req.GetBody call, so the sign pass and the send pass each replay the body from
+// the start without buffering it or interfering with one another (they run
+// sequentially: the signer hashes GetBody fully before the transport sends Body).
+type seekingMultipartBody struct {
+	prefix, suffix []byte
+	rs             io.ReadSeeker
+	start          int64
+	mr             io.Reader // assembled on first Read, after seeking
+}
+
+func (b *seekingMultipartBody) Read(p []byte) (int, error) {
+	if b.mr == nil {
+		if _, err := b.rs.Seek(b.start, io.SeekStart); err != nil {
+			return 0, err
+		}
+		b.mr = io.MultiReader(bytes.NewReader(b.prefix), b.rs, bytes.NewReader(b.suffix))
+	}
+	return b.mr.Read(p)
+}
+
+func (b *seekingMultipartBody) Close() error { return nil }
 
 // GetUrl returns an HTTP URL that can be used to download the file pointed to by ID
 func (c *client) GetUrl(id string) string {

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -243,11 +243,16 @@ func newUploadRequest(ctx context.Context, archiveURL, fileName string, r io.Rea
 			return nil, err
 		}
 		prefix := append([]byte(nil), hdr.Bytes()...)
+		// multipart.Writer.Close() can't emit the closing boundary here because
+		// using the Writer would mean io.Copy-ing the file through it (buffering
+		// — the exact thing this path avoids), so reconstruct the delimiter by
+		// hand. The streamed bytes are asserted byte-identical to the Writer's
+		// output in client_request_test.go.
 		suffix := []byte("\r\n--" + mw.Boundary() + "--\r\n")
 		contentType = mw.FormDataContentType()
 
 		newBody := func() io.ReadCloser {
-			return &seekingMultipartBody{prefix: prefix, suffix: suffix, rs: rs, start: start}
+			return &seekingMultipartBody{prefix: prefix, suffix: suffix, rs: rs, start: start, limit: fileSize}
 		}
 		if req, err = http.NewRequestWithContext(ctx, http.MethodPost, archiveURL, newBody()); err != nil {
 			return nil, err
@@ -281,16 +286,21 @@ func newUploadRequest(ctx context.Context, archiveURL, fileName string, r io.Rea
 }
 
 // seekingMultipartBody streams a single-file multipart body — prefix + the
-// seekable file + closing boundary — seeking the file to its captured start
-// offset on the first read. A fresh instance is used for req.Body and for each
-// req.GetBody call, so the sign pass and the send pass each replay the body from
-// the start without buffering it or interfering with one another (they run
-// sequentially: the signer hashes GetBody fully before the transport sends Body).
+// seekable file (capped at limit bytes) + closing boundary — seeking the file
+// to its captured start offset on the first read. A fresh instance is used for
+// req.Body and for each req.GetBody call, so the sign pass and the send pass
+// each replay the body from the start without buffering it.
+//
+// NOT safe for concurrent reads: req.Body and the GetBody instances share one
+// underlying *os.File and seek the same offset. Correctness relies on the passes
+// being strictly sequential — the signer hashes GetBody to EOF before the
+// transport reads req.Body. The streaming round-trip test is the guardrail.
 type seekingMultipartBody struct {
 	prefix, suffix []byte
 	rs             io.ReadSeeker
 	start          int64
-	mr             io.Reader // assembled on first Read, after seeking
+	limit          int64 // bytes of rs to stream (the stat-time file size)
+	mr             io.Reader
 }
 
 func (b *seekingMultipartBody) Read(p []byte) (int, error) {
@@ -298,7 +308,9 @@ func (b *seekingMultipartBody) Read(p []byte) (int, error) {
 		if _, err := b.rs.Seek(b.start, io.SeekStart); err != nil {
 			return 0, err
 		}
-		b.mr = io.MultiReader(bytes.NewReader(b.prefix), b.rs, bytes.NewReader(b.suffix))
+		// Cap the file read to limit so the streamed length always matches the
+		// ContentLength derived from it, even if the file grew after stat.
+		b.mr = io.MultiReader(bytes.NewReader(b.prefix), io.LimitReader(b.rs, b.limit), bytes.NewReader(b.suffix))
 	}
 	return b.mr.Read(p)
 }

--- a/pkg/storagesvc/client/client_request_test.go
+++ b/pkg/storagesvc/client/client_request_test.go
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"mime"
+	"mime/multipart"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// referenceMultipart builds the multipart body multipart.Writer would produce
+// for the given boundary, so a streamed body can be asserted byte-identical.
+func referenceMultipart(t *testing.T, boundary, fileName string, content []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	require.NoError(t, mw.SetBoundary(boundary))
+	fw, err := mw.CreateFormFile("uploadfile", fileName)
+	require.NoError(t, err)
+	_, err = fw.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, mw.Close())
+	return buf.Bytes()
+}
+
+// TestNewUploadRequestStreamsSeekableBody: for a seekable body, newUploadRequest
+// produces a request whose Body streams the exact multipart bytes (not a
+// buffered copy), with a re-readable GetBody, correct ContentLength, and the
+// X-File-Size header — without ever holding the body in a bytes.Buffer.
+func TestNewUploadRequestStreamsSeekableBody(t *testing.T) {
+	content := bytes.Repeat([]byte("payload-"), 4096) // 32 KiB
+	req, err := newUploadRequest(context.Background(), "http://storage/archive", "deploy.zip", bytes.NewReader(content), int64(len(content)))
+	require.NoError(t, err)
+	require.NotNil(t, req.GetBody, "streamed upload must set GetBody for the signer")
+
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	want := referenceMultipart(t, params["boundary"], "deploy.zip", content)
+
+	// Body streams the exact multipart bytes.
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, want, got, "streamed multipart must match multipart.Writer output")
+	assert.Equal(t, int64(len(want)), req.ContentLength)
+	assert.Equal(t, strconv.Itoa(len(content)), req.Header.Get("X-File-Size"))
+
+	// GetBody yields a fresh, identical stream (re-reads the seekable source).
+	rc, err := req.GetBody()
+	require.NoError(t, err)
+	regot, err := io.ReadAll(rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+	assert.Equal(t, want, regot, "GetBody must reproduce the body byte-for-byte")
+}
+
+// nonSeekableReader wraps a Reader so it is not an io.ReadSeeker, forcing the
+// buffered fallback.
+type nonSeekableReader struct{ r io.Reader }
+
+func (n nonSeekableReader) Read(p []byte) (int, error) { return n.r.Read(p) }
+
+// TestNewUploadRequestBuffersNonSeekableBody: a non-seekable body falls back to
+// the buffered path but still produces a correct, re-readable multipart request.
+func TestNewUploadRequestBuffersNonSeekableBody(t *testing.T) {
+	content := []byte("non-seekable-content")
+	req, err := newUploadRequest(context.Background(), "http://storage/archive", "x.zip", nonSeekableReader{bytes.NewReader(content)}, int64(len(content)))
+	require.NoError(t, err)
+
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	want := referenceMultipart(t, params["boundary"], "x.zip", content)
+
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+	assert.Equal(t, strconv.Itoa(len(content)), req.Header.Get("X-File-Size"))
+}

--- a/pkg/storagesvc/client/client_request_test.go
+++ b/pkg/storagesvc/client/client_request_test.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -38,7 +37,7 @@ func referenceMultipart(t *testing.T, boundary, fileName string, content []byte)
 // X-File-Size header — without ever holding the body in a bytes.Buffer.
 func TestNewUploadRequestStreamsSeekableBody(t *testing.T) {
 	content := bytes.Repeat([]byte("payload-"), 4096) // 32 KiB
-	req, err := newUploadRequest(context.Background(), "http://storage/archive", "deploy.zip", bytes.NewReader(content), int64(len(content)))
+	req, err := newUploadRequest(t.Context(), "http://storage/archive", "deploy.zip", bytes.NewReader(content), int64(len(content)))
 	require.NoError(t, err)
 	require.NotNil(t, req.GetBody, "streamed upload must set GetBody for the signer")
 
@@ -62,6 +61,25 @@ func TestNewUploadRequestStreamsSeekableBody(t *testing.T) {
 	assert.Equal(t, want, regot, "GetBody must reproduce the body byte-for-byte")
 }
 
+// TestNewUploadRequestCapsBodyToFileSize: the streamed file portion is capped to
+// the declared fileSize, so the body length always equals the derived
+// ContentLength even if the file grew after it was stat'd (F3 — avoids the
+// transport's "ContentLength=N with Body length M" abort).
+func TestNewUploadRequestCapsBodyToFileSize(t *testing.T) {
+	full := bytes.Repeat([]byte("Z"), 1000)
+	const declared = int64(600) // file was 600 bytes when stat'd; it then grew
+	req, err := newUploadRequest(t.Context(), "http://storage/archive", "x.zip", bytes.NewReader(full), declared)
+	require.NoError(t, err)
+
+	got, err := io.ReadAll(req.Body)
+	require.NoError(t, err)
+	assert.Equal(t, req.ContentLength, int64(len(got)), "streamed length must equal ContentLength")
+
+	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	assert.Equal(t, referenceMultipart(t, params["boundary"], "x.zip", full[:declared]), got)
+}
+
 // nonSeekableReader wraps a Reader so it is not an io.ReadSeeker, forcing the
 // buffered fallback.
 type nonSeekableReader struct{ r io.Reader }
@@ -72,7 +90,7 @@ func (n nonSeekableReader) Read(p []byte) (int, error) { return n.r.Read(p) }
 // the buffered path but still produces a correct, re-readable multipart request.
 func TestNewUploadRequestBuffersNonSeekableBody(t *testing.T) {
 	content := []byte("non-seekable-content")
-	req, err := newUploadRequest(context.Background(), "http://storage/archive", "x.zip", nonSeekableReader{bytes.NewReader(content)}, int64(len(content)))
+	req, err := newUploadRequest(t.Context(), "http://storage/archive", "x.zip", nonSeekableReader{bytes.NewReader(content)}, int64(len(content)))
 	require.NoError(t, err)
 
 	_, params, err := mime.ParseMediaType(req.Header.Get("Content-Type"))

--- a/pkg/storagesvc/client/streaming_roundtrip_test.go
+++ b/pkg/storagesvc/client/streaming_roundtrip_test.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/storagesvc"
+)
+
+// TestUploadStreamingRoundTripThroughSpillVerifier closes the full loop: a
+// file-backed Upload streams the multipart body, the signer hashes it via
+// GetBody, the ServiceStoragesvc-derived spill verifier stream-verifies it, and
+// the handler parses the multipart and recovers the exact file bytes.
+func TestUploadStreamingRoundTripThroughSpillVerifier(t *testing.T) {
+	master := []byte("storagesvc-e2e-master-key-32bytes")
+	content := bytes.Repeat([]byte("archive-data-"), 8192) // ~104 KiB, above the spill threshold
+
+	var gotFile []byte
+	verifier := hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
+		hmacauth.VerifierOpts{SkewSec: 60, Now: time.Now, SpillThreshold: 16 * 1024})
+	srv := httptest.NewServer(verifier(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseMultipartForm(0))
+		f, _, err := r.FormFile("uploadfile")
+		require.NoError(t, err)
+		defer f.Close()
+		gotFile, err = io.ReadAll(f)
+		require.NoError(t, err)
+		require.NoError(t, json.NewEncoder(w).Encode(storagesvc.UploadResponse{ID: "stored-id"}))
+	})))
+	defer srv.Close()
+
+	fp := filepath.Join(t.TempDir(), "deploy.zip")
+	require.NoError(t, os.WriteFile(fp, content, 0o600))
+
+	c := MakeClient(srv.URL, master)
+	id, err := c.Upload(context.Background(), fp, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "stored-id", id)
+	assert.Equal(t, content, gotFile, "server must receive the streamed file intact")
+}

--- a/pkg/storagesvc/client/streaming_roundtrip_test.go
+++ b/pkg/storagesvc/client/streaming_roundtrip_test.go
@@ -6,7 +6,6 @@ package client
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -49,7 +48,7 @@ func TestUploadStreamingRoundTripThroughSpillVerifier(t *testing.T) {
 	require.NoError(t, os.WriteFile(fp, content, 0o600))
 
 	c := MakeClient(srv.URL, master)
-	id, err := c.Upload(context.Background(), fp, nil)
+	id, err := c.Upload(t.Context(), fp, nil)
 	require.NoError(t, err)
 	assert.Equal(t, "stored-id", id)
 	assert.Equal(t, content, gotFile, "server must receive the streamed file intact")

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -55,6 +55,11 @@ type (
 		// 0 (the default, and the only non-positive value maxUploadBytesFromEnv
 		// produces) means hmacauth.DefaultMaxBodyBytes (256 MiB).
 		maxUploadBytes int64
+		// uploadSpillThreshold is the VerifierOpts.SpillThreshold for /v1/archive:
+		// bodies above it are streamed through a temp file during verification
+		// rather than buffered in RAM. 0 means defaultUploadSpillThresholdBytes;
+		// tests lower it to exercise the spill path without a multi-MiB body.
+		uploadSpillThreshold int64
 	}
 
 	UploadResponse struct {
@@ -347,6 +352,10 @@ func (ss *StorageService) makeHandler() http.Handler {
 		// master-derived key for callers that send no namespace header (existing
 		// fetchers, the CLI, the pruner), so this is safe to adopt unconditionally
 		// — multi-namespace tenancy doesn't have to be enabled for it to be inert.
+		spillThreshold := ss.uploadSpillThreshold
+		if spillThreshold <= 0 {
+			spillThreshold = defaultUploadSpillThresholdBytes
+		}
 		opts = append(opts, httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(ss.authSecret, ss.authSecretOld, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
 			SkewSec: 60,
 			Bypass:  []string{"/healthz"},
@@ -354,7 +363,11 @@ func (ss *StorageService) makeHandler() http.Handler {
 			// verifier resolves 0 to 256 MiB. Operator-tunable via
 			// STORAGE_MAX_ARCHIVE_SIZE_MIB — see the maxUploadBytes field and values.yaml.
 			MaxBodyBytes: ss.maxUploadBytes,
-			Logger:       ss.logger.WithName("hmac"),
+			// Stream-verify bodies above the threshold (spill to a temp file)
+			// so verification RAM stays bounded regardless of archive size; the
+			// cap above then bounds disk, not memory.
+			SpillThreshold: spillThreshold,
+			Logger:         ss.logger.WithName("hmac"),
 		})))
 	}
 	m := httpmux.New(opts...)
@@ -383,6 +396,12 @@ func (ss *StorageService) makeHandler() http.Handler {
 // before the `<< 20` MiB→bytes conversion would overflow int64; larger values
 // are treated as misconfiguration and fall back to the default cap.
 const maxArchiveSizeMiBCeil = math.MaxInt64 >> 20
+
+// defaultUploadSpillThresholdBytes is the VerifierOpts.SpillThreshold used for
+// /v1/archive uploads: bodies above it are stream-verified through a temp file
+// instead of buffered in RAM. 32 MiB keeps typical small uploads fully in
+// memory while bounding verification RAM for large archives.
+const defaultUploadSpillThresholdBytes int64 = 32 << 20
 
 // maxUploadBytesFromEnv reads STORAGE_MAX_ARCHIVE_SIZE_MIB — a plain integer
 // number of MiB, no unit suffix — and returns the corresponding /v1/archive

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -57,9 +57,14 @@ type (
 		maxUploadBytes int64
 		// uploadSpillThreshold is the VerifierOpts.SpillThreshold for /v1/archive:
 		// bodies above it are streamed through a temp file during verification
-		// rather than buffered in RAM. 0 means defaultUploadSpillThresholdBytes;
-		// tests lower it to exercise the spill path without a multi-MiB body.
+		// rather than buffered in RAM. 0 means defaultUploadSpillThresholdBytes.
+		// Set from STORAGE_UPLOAD_SPILL_THRESHOLD_MIB; tests lower it to exercise
+		// the spill path without a multi-MiB body.
 		uploadSpillThreshold int64
+		// uploadSpillDir is the VerifierOpts.SpillDir — the directory for spill
+		// temp files (empty → os.TempDir()). Set from STORAGE_SPILL_DIR to a
+		// writable, size-limited volume so spill works under a read-only root FS.
+		uploadSpillDir string
 	}
 
 	UploadResponse struct {
@@ -363,10 +368,11 @@ func (ss *StorageService) makeHandler() http.Handler {
 			// verifier resolves 0 to 256 MiB. Operator-tunable via
 			// STORAGE_MAX_ARCHIVE_SIZE_MIB — see the maxUploadBytes field and values.yaml.
 			MaxBodyBytes: ss.maxUploadBytes,
-			// Stream-verify bodies above the threshold (spill to a temp file)
-			// so verification RAM stays bounded regardless of archive size; the
-			// cap above then bounds disk, not memory.
+			// Stream-verify bodies above the threshold (spill to a temp file in
+			// SpillDir) so verification RAM stays bounded regardless of archive
+			// size; the cap above then bounds disk, not memory.
 			SpillThreshold: spillThreshold,
+			SpillDir:       ss.uploadSpillDir,
 			Logger:         ss.logger.WithName("hmac"),
 		})))
 	}
@@ -403,33 +409,43 @@ const maxArchiveSizeMiBCeil = math.MaxInt64 >> 20
 // memory while bounding verification RAM for large archives.
 const defaultUploadSpillThresholdBytes int64 = 32 << 20
 
-// maxUploadBytesFromEnv reads STORAGE_MAX_ARCHIVE_SIZE_MIB — a plain integer
-// number of MiB, no unit suffix — and returns the corresponding /v1/archive
-// upload body cap in bytes. Unset, zero, or invalid values return 0, which the
-// verifier resolves to hmacauth.DefaultMaxBodyBytes (256 MiB). The cap bounds
-// the multipart-wrapped request body, marginally larger than the raw archive.
-func maxUploadBytesFromEnv(logger logr.Logger) int64 {
-	v := strings.TrimSpace(os.Getenv("STORAGE_MAX_ARCHIVE_SIZE_MIB"))
+// mibEnvToBytes reads envVar as a plain integer number of MiB (no unit suffix)
+// and returns it in bytes. Unset, zero, negative, non-integer, or
+// int64-overflowing values return 0, which callers resolve to their own
+// default. Each rejection is logged distinctly.
+func mibEnvToBytes(logger logr.Logger, envVar string) int64 {
+	v := strings.TrimSpace(os.Getenv(envVar))
 	if v == "" {
 		return 0
 	}
-	defaultMiB := hmacauth.DefaultMaxBodyBytes >> 20
 	mib, err := strconv.ParseInt(v, 10, 64)
 	switch {
 	case err != nil:
-		logger.Error(err, "STORAGE_MAX_ARCHIVE_SIZE_MIB is not a plain integer number of MiB; using the default upload cap",
-			"value", v, "defaultMiB", defaultMiB)
+		logger.Error(err, "env var is not a plain integer number of MiB; using the default", "envVar", envVar, "value", v)
 		return 0
 	case mib < 0:
-		logger.Info("ignoring negative STORAGE_MAX_ARCHIVE_SIZE_MIB; using the default upload cap",
-			"value", v, "defaultMiB", defaultMiB)
+		logger.Info("ignoring negative env var; using the default", "envVar", envVar, "value", v)
 		return 0
 	case mib > maxArchiveSizeMiBCeil:
-		logger.Info("STORAGE_MAX_ARCHIVE_SIZE_MIB is too large; using the default upload cap",
-			"value", v, "maxMiB", maxArchiveSizeMiBCeil, "defaultMiB", defaultMiB)
+		logger.Info("env var too large; using the default", "envVar", envVar, "value", v, "maxMiB", maxArchiveSizeMiBCeil)
 		return 0
 	}
 	return mib << 20
+}
+
+// maxUploadBytesFromEnv reads STORAGE_MAX_ARCHIVE_SIZE_MIB and returns the
+// /v1/archive upload body cap in bytes; 0 (unset/invalid) → the verifier's
+// hmacauth.DefaultMaxBodyBytes (256 MiB). The cap bounds the multipart-wrapped
+// request body, marginally larger than the raw archive.
+func maxUploadBytesFromEnv(logger logr.Logger) int64 {
+	return mibEnvToBytes(logger, "STORAGE_MAX_ARCHIVE_SIZE_MIB")
+}
+
+// uploadSpillThresholdFromEnv reads STORAGE_UPLOAD_SPILL_THRESHOLD_MIB and
+// returns the spill threshold in bytes; 0 (unset/invalid) → makeHandler's
+// defaultUploadSpillThresholdBytes (32 MiB).
+func uploadSpillThresholdFromEnv(logger logr.Logger) int64 {
+	return mibEnvToBytes(logger, "STORAGE_UPLOAD_SPILL_THRESHOLD_MIB")
 }
 
 // Start runs storage service
@@ -452,6 +468,10 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 
 	// create http handlers
 	storageService := MakeStorageService(logger, storageClient, port, authSecret, authSecretOld, maxUploadBytesFromEnv(logger))
+	// Spill config for stream-verification of large uploads (0 dir/threshold
+	// resolve to os.TempDir() and the 32 MiB default respectively).
+	storageService.uploadSpillThreshold = uploadSpillThresholdFromEnv(logger)
+	storageService.uploadSpillDir = strings.TrimSpace(os.Getenv("STORAGE_SPILL_DIR"))
 	mgr.Go(func() error {
 		metrics.ServeMetrics(ctx, "storagesvc", logger, mgr)
 		return nil

--- a/pkg/storagesvc/upload_bodysize_test.go
+++ b/pkg/storagesvc/upload_bodysize_test.go
@@ -98,6 +98,19 @@ func TestUploadBodySizeCapConfigurable(t *testing.T) {
 		requireArchiveStored(t, rr)
 	})
 
+	t.Run("an upload larger than the spill threshold is streamed, admitted and stored", func(t *testing.T) {
+		t.Parallel()
+		storage := NewLocalStorage(t.TempDir())
+		sc, err := MakeStorageClient(logr.Discard(), storage)
+		require.NoError(t, err)
+		ss := MakeStorageService(logr.Discard(), sc, 0, master, nil, underCap)
+		ss.uploadSpillThreshold = 16 * 1024 // < 64 KiB payload, so the verifier spills to disk
+		rr := httptest.NewRecorder()
+		ss.makeHandler().ServeHTTP(rr, signedArchiveUpload(t, keyMaster, payload))
+		require.Equal(t, http.StatusOK, rr.Code)
+		requireArchiveStored(t, rr)
+	})
+
 	t.Run("a zero cap falls back to the default and admits the upload", func(t *testing.T) {
 		t.Parallel()
 		rr := httptest.NewRecorder()


### PR DESCRIPTION
## TL;DR

Bounds HMAC verification memory on storagesvc — and upload-client memory — regardless of archive size, so large package uploads no longer scale RAM 1:1 with the archive.
The wire format and HMAC signature stay **byte-identical**, so old/new clients and servers interoperate in any combination during a rolling upgrade.

Closes #3539. Follows #3540 (which made the cap operator-tunable).

## Why

The HMAC signature is over `SHA256(body)`, so the verifier must read the whole request body to check it.
Today it `io.ReadAll`s the body into memory; #3540 made the cap tunable, but a high cap means storagesvc transiently buffers the whole archive in RAM (a single large upload can OOM the shared service), and the upload client buffers it twice.
The storage write itself already streams (minio-go `PutObject` does S3 multipart internally; local uses `io.Copy`), so the verifier is the only place holding the entire body.

## What changed (commits are reviewable in order)

**Feature (TDD, commits 1–6):**
1. **`hmac`: body-hash-in primitives** — `CanonicalFromBodyHash` / `SignWithBodyHash` / `VerifyWithBodyHash`; the slice-based `Sign`/`Verify` delegate to them (byte-identical output).
2. **`hmac`: opt-in spill verifier** — `VerifierOpts.SpillThreshold`; above it the verifier streams the body through SHA-256 into a memory-then-tempfile `spillReader` so verification RAM stays bounded. `0` (default) keeps the in-memory path unchanged; `MaxBodyBytes` still applies (bounds disk on the spill path).
3. **`storagesvc`: opt in** — sets `SpillThreshold` (32 MiB) on the `/v1/archive` verifier; only this bulk-data endpoint changes.
4. **`hmac`: signer hashes via `GetBody`** — hashes a fresh streamed copy and forwards `req.Body` untouched; no-`GetBody` callers unchanged.
5. **`storagesvc/client`: stream file-backed uploads** — `newUploadRequest` streams the multipart envelope around the seekable file with a re-readable `GetBody`, byte-identical to `multipart.Writer` output.
6. **tests** — backward-compat interop matrix + full client→spill-verifier round trip.

**Hardening from review (commits 7–9):**
- **Temp-file lifetime (was a leak):** net/http closes the *original* request body, not the re-injected `spillReader`, so the verifier now owns the temp file and `defer`s `Close()` on every exit (success **and** 401). A test that previously closed the body in its handler masked this — it no longer does.
- **Spill location is configurable + bounded:** `VerifierOpts.SpillDir` + env `STORAGE_SPILL_DIR` / `STORAGE_UPLOAD_SPILL_THRESHOLD_MIB`, and a dedicated size-limited `fission-spill` emptyDir (default 2Gi at `/tmp/fission-spill`, both backends) — so spill is disk-bounded and keeps working if the root FS is made read-only.
- **Client body cap:** the streamed file read is capped to the stat-time `fileSize` (`io.LimitReader`) so the body length always matches `ContentLength`.
- Bodyless requests (GET/list) skip the spill path; `MaxBytesReader` hoisted so the cap is applied once; minor cleanups (joined cleanup errors, dropped a dead field, `t.Context()`, `iotest.OneByteReader`).

## Reviewer guide

- **Security-critical core:** `pkg/auth/hmac/spill.go` (staging + temp-file cleanup) and the `verifier.go` spill branch. The cleanup contract — temp file removed on success (verifier `defer`), mismatch, 413, and mid-stream error — is covered by `verifier_spill_test.go` (asserts the spill dir is empty after each).
- **Equivalence / interop invariant:** `hmac_test.go` proves the `*WithBodyHash` forms equal the slice forms; `verifier_interop_test.go` proves all four signer×verifier combinations interoperate with an identical signature — the backward-compat guarantee.
- **Client:** `client.go` `newUploadRequest` + `seekingMultipartBody`; `client_request_test.go` asserts byte-identical framing and the `ContentLength` cap.
- **Ops:** `charts/fission-all` — the `fission-spill` volume + `storagesvc.uploadSpill` values.
- **Risk:** opt-in via `SpillThreshold>0` (only storagesvc) and `GetBody` (only the streaming client), so every other signed channel is byte-identical. Adds transient temp-file disk during verification, bounded by the sized volume.

## Not in scope (documented in the design)

- The verifier→multipart double-spill (a later optimization).
- A chunked/multipart-upload protocol (S3-style) — cleaner end-state but RFC-sized; recorded as an alternative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
