### PR TITLE
fix(cli): retry resource updates on conflict

### DIFF
--- a/pkg/fission-cli/cmd/canaryconfig/update.go
+++ b/pkg/fission-cli/cmd/canaryconfig/update.go
@@ -9,16 +9,21 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 type UpdateSubCommand struct {
 	cmd.CommandActioner
 	canary *fv1.CanaryConfig
+	// rearm is set when a spec field changed, so run() resets the rollout status
+	// to pending (via UpdateStatus) after applying the spec.
+	rearm bool
 }
 
 func Update(input cli.Input) error {
@@ -74,21 +79,38 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 		}
 	}
 
-	// When any spec field changed, re-arm the rollout by resetting the status to
-	// pending so the canary controller re-evaluates from the start.
-	if updateNeeded {
-		canaryCfg.Status.Status = fv1.CanaryConfigStatusPending
-	}
-
+	// When any spec field changed, re-arm the rollout so the canary controller
+	// re-evaluates from the start. The reset is applied in run() via UpdateStatus
+	// (CanaryConfig has a /status subresource, so a plain Update can't carry it).
+	opts.rearm = updateNeeded
 	opts.canary = canaryCfg
 
 	return nil
 }
 
 func (opts *UpdateSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.canary.ObjectMeta.Namespace).Update(input.Context(), opts.canary, metav1.UpdateOptions{})
+	canaries := opts.Client().FissionClientSet.CoreV1().CanaryConfigs(opts.canary.Namespace)
+	_, err := util.UpdateOnConflict(input.Context(), canaries, opts.canary.Name,
+		func(cur *fv1.CanaryConfig) { cur.Spec = opts.canary.Spec })
 	if err != nil {
 		return fmt.Errorf("error updating canary config: %w", err)
+	}
+
+	// Re-arm the rollout when a spec field changed: CanaryConfig has a /status
+	// subresource, so the spec Update above ignores .status — the reset must go
+	// through UpdateStatus (also conflict-retried).
+	if opts.rearm {
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			cur, gerr := canaries.Get(input.Context(), opts.canary.Name, metav1.GetOptions{})
+			if gerr != nil {
+				return gerr
+			}
+			cur.Status.Status = fv1.CanaryConfigStatusPending
+			_, uerr := canaries.UpdateStatus(input.Context(), cur, metav1.UpdateOptions{})
+			return uerr
+		}); err != nil {
+			return fmt.Errorf("error re-arming canary config rollout: %w", err)
+		}
 	}
 	fmt.Printf("canary config '%v' updated\n", opts.canary.Name)
 	return nil

--- a/pkg/fission-cli/cmd/environment/update.go
+++ b/pkg/fission-cli/cmd/environment/update.go
@@ -79,7 +79,20 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		}
 		return nil
 	}
-	enew, err := opts.Client().FissionClientSet.CoreV1().Environments(opts.env.ObjectMeta.Namespace).Update(input.Context(), opts.env, metav1.UpdateOptions{})
+	enew, err := util.UpdateOnConflict(input.Context(),
+		opts.Client().FissionClientSet.CoreV1().Environments(opts.env.Namespace),
+		opts.env.Name, func(cur *fv1.Environment) {
+			cur.Spec = opts.env.Spec
+			// Only overwrite metadata the command was actually given, so an update
+			// without --labels/--annotation keeps whatever is on the freshly
+			// fetched object instead of clobbering it with a stale snapshot.
+			if input.IsSet(flagkey.Labels) {
+				cur.Labels = opts.env.Labels
+			}
+			if input.IsSet(flagkey.Annotation) {
+				cur.Annotations = opts.env.Annotations
+			}
+		})
 	if err != nil {
 		return fmt.Errorf("error updating environment: %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -236,7 +236,19 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		}
 		return nil
 	}
-	_, err := opts.Client().FissionClientSet.CoreV1().Functions(opts.function.Namespace).Update(input.Context(), opts.function, metav1.UpdateOptions{})
+	// The package update already ran in complete(); only the function write is retried here.
+	_, err := util.UpdateOnConflict(input.Context(),
+		opts.Client().FissionClientSet.CoreV1().Functions(opts.function.Namespace),
+		opts.function.Name, func(cur *fv1.Function) {
+			cur.Spec = opts.function.Spec
+			// Only overwrite metadata the command was actually given (see env update).
+			if input.IsSet(flagkey.Labels) {
+				cur.Labels = opts.function.Labels
+			}
+			if input.IsSet(flagkey.Annotation) {
+				cur.Annotations = opts.function.Annotations
+			}
+		})
 	if err != nil {
 		return fmt.Errorf("error updating function: %w", err)
 	}

--- a/pkg/fission-cli/cmd/function/update_container.go
+++ b/pkg/fission-cli/cmd/function/update_container.go
@@ -171,7 +171,18 @@ func (opts *UpdateContainerSubCommand) complete(input cli.Input) error {
 }
 
 func (opts *UpdateContainerSubCommand) run(input cli.Input) error {
-	_, err := opts.Client().FissionClientSet.CoreV1().Functions(opts.function.Namespace).Update(input.Context(), opts.function, metav1.UpdateOptions{})
+	_, err := util.UpdateOnConflict(input.Context(),
+		opts.Client().FissionClientSet.CoreV1().Functions(opts.function.Namespace),
+		opts.function.Name, func(cur *fv1.Function) {
+			cur.Spec = opts.function.Spec
+			// Only overwrite metadata the command was actually given (see env update).
+			if input.IsSet(flagkey.Labels) {
+				cur.Labels = opts.function.Labels
+			}
+			if input.IsSet(flagkey.Annotation) {
+				cur.Annotations = opts.function.Annotations
+			}
+		})
 	if err != nil {
 		return fmt.Errorf("error updating function: %w", err)
 	}

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/util/retry"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
@@ -213,24 +212,9 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		return fmt.Errorf("error while creating HTTP Trigger: %w", err)
 	}
 
-	// Retry on conflict — Fission controllers (router's
-	// markTriggerCondition, etc.) write to HTTPTrigger.Status concurrently
-	// with this CLI command, which bumps ResourceVersion and causes the
-	// straight Update to 409 if the controller writes between our Get
-	// (in complete) and the Update here. On conflict, re-fetch and
-	// re-apply the same Spec — the user's intended changes are already
-	// captured in opts.trigger.Spec; controller-only status mutations
-	// don't affect Spec.
-	tgClient := opts.Client().FissionClientSet.CoreV1().HTTPTriggers(opts.trigger.Namespace)
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cur, getErr := tgClient.Get(input.Context(), opts.trigger.Name, metav1.GetOptions{})
-		if getErr != nil {
-			return getErr
-		}
-		cur.Spec = opts.trigger.Spec
-		_, updErr := tgClient.Update(input.Context(), cur, metav1.UpdateOptions{})
-		return updErr
-	})
+	_, err = util.UpdateOnConflict(input.Context(),
+		opts.Client().FissionClientSet.CoreV1().HTTPTriggers(opts.trigger.Namespace),
+		opts.trigger.Name, func(cur *fv1.HTTPTrigger) { cur.Spec = opts.trigger.Spec })
 	if err != nil {
 		return fmt.Errorf("error updating the HTTP trigger: %w", err)
 	}

--- a/pkg/fission-cli/cmd/mqtrigger/update.go
+++ b/pkg/fission-cli/cmd/mqtrigger/update.go
@@ -151,7 +151,9 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		}
 		return nil
 	}
-	_, err := opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.trigger.ObjectMeta.Namespace).Update(input.Context(), opts.trigger, metav1.UpdateOptions{})
+	_, err := util.UpdateOnConflict(input.Context(),
+		opts.Client().FissionClientSet.CoreV1().MessageQueueTriggers(opts.trigger.Namespace),
+		opts.trigger.Name, func(cur *fv1.MessageQueueTrigger) { cur.Spec = opts.trigger.Spec })
 	if err != nil {
 		return fmt.Errorf("error updating message queue trigger: %w", err)
 	}

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -200,21 +200,9 @@ func UpdatePackage(input cli.Input, client cmd.Client, specFile string, pkg *fv1
 
 	packages := client.FissionClientSet.CoreV1().Packages(pkg.Namespace)
 
-	// Apply the desired spec, re-getting on conflict: the buildermgr writes a
-	// package's initial build status shortly after create, which bumps the
-	// ResourceVersion between our Get and this Update.
-	desiredSpec := pkg.Spec
-	var newPkg *fv1.Package
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		fresh, gerr := packages.Get(input.Context(), pkg.Name, metav1.GetOptions{})
-		if gerr != nil {
-			return gerr
-		}
-		fresh.Spec = desiredSpec
-		var uerr error
-		newPkg, uerr = packages.Update(input.Context(), fresh, metav1.UpdateOptions{})
-		return uerr
-	}); err != nil {
+	newPkg, err := util.UpdateOnConflict(input.Context(), packages, pkg.Name,
+		func(cur *fv1.Package) { cur.Spec = pkg.Spec })
+	if err != nil {
 		return nil, fmt.Errorf("update package: %w", err)
 	}
 
@@ -271,8 +259,9 @@ func UpdateFunctionPackageResourceVersion(ctx context.Context, client cmd.Client
 
 	// update resource version of package reference of functions that shared the same package
 	for _, fn := range fnList {
-		fn.Spec.Package.PackageRef.ResourceVersion = pkgMeta.ResourceVersion
-		_, err := client.FissionClientSet.CoreV1().Functions(fn.Namespace).Update(ctx, &fn, metav1.UpdateOptions{})
+		rv := pkgMeta.ResourceVersion
+		_, err := util.UpdateOnConflict(ctx, client.FissionClientSet.CoreV1().Functions(fn.Namespace), fn.Name,
+			func(cur *fv1.Function) { cur.Spec.Package.PackageRef.ResourceVersion = rv })
 		if err != nil {
 			errs = errors.Join(errs, fmt.Errorf("error updating package resource version of function '%v': %w", fn.Name, err))
 		}

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -695,17 +695,11 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 			// Apply the spec, re-getting on conflict: the buildermgr writes a
 			// package's build status concurrently, which can bump the
 			// ResourceVersion between our read and this Update.
-			var n *fv1.Package
-			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-				live, gerr := packages(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
-				if gerr != nil {
-					return gerr
-				}
-				desired.ResourceVersion = live.ResourceVersion
-				var uerr error
-				n, uerr = packages(desired.Namespace).Update(ctx, desired, metav1.UpdateOptions{})
-				return uerr
-			}); err != nil {
+			n, err := util.UpdateOnConflict(ctx, packages(desired.Namespace), desired.Name, func(cur *fv1.Package) {
+				desired.ResourceVersion = cur.ResourceVersion
+				*cur = *desired
+			})
+			if err != nil {
 				return nil, err
 			}
 			// Re-trigger a build if the previous one failed. This is a status
@@ -758,9 +752,11 @@ func applyFunctions(ctx context.Context, fclient cmd.Client, fr *FissionResource
 			}
 			return &n.ObjectMeta, nil
 		},
-		update: func(ctx context.Context, e, d *fv1.Function) (*metav1.ObjectMeta, error) {
-			d.ResourceVersion = e.ResourceVersion
-			n, err := functions(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
+		update: func(ctx context.Context, _, d *fv1.Function) (*metav1.ObjectMeta, error) {
+			n, err := util.UpdateOnConflict(ctx, functions(d.Namespace), d.Name, func(cur *fv1.Function) {
+				d.ResourceVersion = cur.ResourceVersion
+				*cur = *d
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -796,9 +792,11 @@ func applyEnvironments(ctx context.Context, fclient cmd.Client, fr *FissionResou
 			}
 			return &n.ObjectMeta, nil
 		},
-		update: func(ctx context.Context, e, d *fv1.Environment) (*metav1.ObjectMeta, error) {
-			d.ResourceVersion = e.ResourceVersion
-			n, err := environments(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
+		update: func(ctx context.Context, _, d *fv1.Environment) (*metav1.ObjectMeta, error) {
+			n, err := util.UpdateOnConflict(ctx, environments(d.Namespace), d.Name, func(cur *fv1.Environment) {
+				d.ResourceVersion = cur.ResourceVersion
+				*cur = *d
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -839,9 +837,11 @@ func applyHTTPTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResou
 			}
 			return &n.ObjectMeta, nil
 		},
-		update: func(ctx context.Context, e, d *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
-			d.ResourceVersion = e.ResourceVersion
-			n, err := triggers(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
+		update: func(ctx context.Context, _, d *fv1.HTTPTrigger) (*metav1.ObjectMeta, error) {
+			n, err := util.UpdateOnConflict(ctx, triggers(d.Namespace), d.Name, func(cur *fv1.HTTPTrigger) {
+				d.ResourceVersion = cur.ResourceVersion
+				*cur = *d
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -877,9 +877,11 @@ func applyKubernetesWatchTriggers(ctx context.Context, fclient cmd.Client, fr *F
 			}
 			return &n.ObjectMeta, nil
 		},
-		update: func(ctx context.Context, e, d *fv1.KubernetesWatchTrigger) (*metav1.ObjectMeta, error) {
-			d.ResourceVersion = e.ResourceVersion
-			n, err := watches(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
+		update: func(ctx context.Context, _, d *fv1.KubernetesWatchTrigger) (*metav1.ObjectMeta, error) {
+			n, err := util.UpdateOnConflict(ctx, watches(d.Namespace), d.Name, func(cur *fv1.KubernetesWatchTrigger) {
+				d.ResourceVersion = cur.ResourceVersion
+				*cur = *d
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -915,9 +917,11 @@ func applyTimeTriggers(ctx context.Context, fclient cmd.Client, fr *FissionResou
 			}
 			return &n.ObjectMeta, nil
 		},
-		update: func(ctx context.Context, e, d *fv1.TimeTrigger) (*metav1.ObjectMeta, error) {
-			d.ResourceVersion = e.ResourceVersion
-			n, err := triggers(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
+		update: func(ctx context.Context, _, d *fv1.TimeTrigger) (*metav1.ObjectMeta, error) {
+			n, err := util.UpdateOnConflict(ctx, triggers(d.Namespace), d.Name, func(cur *fv1.TimeTrigger) {
+				d.ResourceVersion = cur.ResourceVersion
+				*cur = *d
+			})
 			if err != nil {
 				return nil, err
 			}
@@ -953,9 +957,11 @@ func applyMessageQueueTriggers(ctx context.Context, fclient cmd.Client, fr *Fiss
 			}
 			return &n.ObjectMeta, nil
 		},
-		update: func(ctx context.Context, e, d *fv1.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
-			d.ResourceVersion = e.ResourceVersion
-			n, err := triggers(d.Namespace).Update(ctx, d, metav1.UpdateOptions{})
+		update: func(ctx context.Context, _, d *fv1.MessageQueueTrigger) (*metav1.ObjectMeta, error) {
+			n, err := util.UpdateOnConflict(ctx, triggers(d.Namespace), d.Name, func(cur *fv1.MessageQueueTrigger) {
+				d.ResourceVersion = cur.ResourceVersion
+				*cur = *d
+			})
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/fission-cli/cmd/spec/resourcetype.go
+++ b/pkg/fission-cli/cmd/spec/resourcetype.go
@@ -40,8 +40,9 @@ type resourceOps[T any, PT Object[T]] struct {
 	// dry-run too, so a preview surfaces errors a real apply would hit.
 	validate func(ctx context.Context, desired PT) error
 	create   func(ctx context.Context, desired PT) (*metav1.ObjectMeta, error)
-	// update receives the existing object so it can carry the ResourceVersion
-	// forward (and, for packages, wait out an in-flight build).
+	// update applies desired to the cluster. It receives the existing (live)
+	// object so the Package closure can wait out an in-flight build; the
+	// ResourceVersion is re-read on conflict inside util.UpdateOnConflict.
 	update func(ctx context.Context, existing, desired PT) (*metav1.ObjectMeta, error)
 	delete func(ctx context.Context, namespace, name string) error
 }

--- a/pkg/fission-cli/cmd/tenant/enable.go
+++ b/pkg/fission-cli/cmd/tenant/enable.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
 )
 
 func Enable(input cli.Input) error {
@@ -46,11 +47,12 @@ func (opts *EnableSubCommand) do(input cli.Input) error {
 		if list.Items[i].Spec.Namespace != namespace {
 			continue
 		}
-		existing := &list.Items[i]
-		existing.Spec.FunctionNamespace = fnNS
-		existing.Spec.BuilderNamespace = builderNS
-		if _, err := tenants.Update(ctx, existing, metav1.UpdateOptions{}); err != nil {
-			return fmt.Errorf("error updating tenant %q: %w", existing.Name, err)
+		name := list.Items[i].Name
+		if _, err := util.UpdateOnConflict(ctx, tenants, name, func(cur *v1.FissionTenant) {
+			cur.Spec.FunctionNamespace = fnNS
+			cur.Spec.BuilderNamespace = builderNS
+		}); err != nil {
+			return fmt.Errorf("error updating tenant %q: %w", name, err)
 		}
 		fmt.Printf("tenant for namespace %q updated\n", namespace)
 		return nil

--- a/pkg/fission-cli/cmd/timetrigger/update.go
+++ b/pkg/fission-cli/cmd/timetrigger/update.go
@@ -98,7 +98,9 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		}
 		return nil
 	}
-	_, err := opts.Client().FissionClientSet.CoreV1().TimeTriggers(opts.trigger.ObjectMeta.Namespace).Update(input.Context(), opts.trigger, metav1.UpdateOptions{})
+	_, err := util.UpdateOnConflict(input.Context(),
+		opts.Client().FissionClientSet.CoreV1().TimeTriggers(opts.trigger.Namespace),
+		opts.trigger.Name, func(cur *fv1.TimeTrigger) { cur.Spec = opts.trigger.Spec })
 	if err != nil {
 		return fmt.Errorf("error updating Time trigger: %w", err)
 	}
@@ -106,9 +108,6 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 	fmt.Printf("trigger '%v' updated\n", opts.trigger.Name)
 
 	t := util.GetServerInfo(input, opts.Client()).ServerTime.CurrentTime.UTC()
-	if err != nil {
-		return err
-	}
 
 	err = getCronNextNActivationTime(opts.trigger.Spec.Cron, t, 1)
 	if err != nil {

--- a/pkg/fission-cli/util/retry.go
+++ b/pkg/fission-cli/util/retry.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+)
+
+// updatableClient is the part of a typed clientset resource client that
+// UpdateOnConflict needs. Every generated Fission/Kubernetes typed client
+// (e.g. TimeTriggers(ns), Functions(ns)) satisfies it with T set to the
+// resource pointer type.
+type updatableClient[T any] interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (T, error)
+	Update(ctx context.Context, obj T, opts metav1.UpdateOptions) (T, error)
+}
+
+// UpdateOnConflict re-fetches the named object, applies mutate to the fresh
+// copy, and Updates it — retrying on optimistic-concurrency conflicts. Fission
+// controllers write to an object's status concurrently with a
+// `fission <resource> update`, bumping its resourceVersion and making a plain
+// Get-modify-Update fail.
+//
+// mutate is invoked once per attempt on the freshly fetched object, so it must
+// derive its change from the caller's inputs (e.g. cur.Spec = desiredSpec), not
+// from a previously fetched copy. Because mutate re-applies the caller's desired
+// state each attempt, a concurrent write to the same field is overwritten
+// (last-write-wins); the common conflict — a controller status write racing a
+// CLI spec write — touches a different field and is resolved cleanly.
+func UpdateOnConflict[T any](ctx context.Context, c updatableClient[T], name string, mutate func(T)) (T, error) {
+	var out T
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cur, err := c.Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		mutate(cur)
+		out, err = c.Update(ctx, cur, metav1.UpdateOptions{})
+		return err
+	})
+	return out, err
+}

--- a/pkg/fission-cli/util/retry_test.go
+++ b/pkg/fission-cli/util/retry_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stesting "k8s.io/client-go/testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+func TestUpdateOnConflictRetriesAndReapplies(t *testing.T) {
+	t.Parallel()
+	tt := &fv1.TimeTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "tt", Namespace: "default"},
+		Spec:       fv1.TimeTriggerSpec{Cron: "@every 1h"},
+	}
+	cs := fissionfake.NewClientset(tt)
+
+	// Fail the first Update with a 409 conflict, then let it through. The helper
+	// must re-Get and re-Update — and the re-applied change must survive.
+	var attempts int
+	cs.PrependReactor("update", "timetriggers", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		attempts++
+		if attempts == 1 {
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: "fission.io", Resource: "timetriggers"},
+				"tt", errors.New("the object has been modified"))
+		}
+		// Echo the submitted object back (handled here rather than falling
+		// through, since the fake tracker's apply/SMD path can't convert CRD
+		// types).
+		return true, action.(k8stesting.UpdateAction).GetObject(), nil
+	})
+
+	out, err := UpdateOnConflict(t.Context(), cs.CoreV1().TimeTriggers("default"), "tt",
+		func(cur *fv1.TimeTrigger) { cur.Spec.Cron = "@every 2h" })
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, attempts, 2, "should have retried after the conflict")
+	assert.Equal(t, "@every 2h", out.Spec.Cron, "re-applied change must be persisted")
+}
+
+func TestUpdateOnConflictPropagatesNonConflict(t *testing.T) {
+	t.Parallel()
+	cs := fissionfake.NewClientset()
+	// Get of a missing object returns NotFound (not a conflict) — must surface,
+	// not retry forever.
+	_, err := UpdateOnConflict(t.Context(), cs.CoreV1().TimeTriggers("default"), "missing",
+		func(*fv1.TimeTrigger) {})
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err), "non-conflict errors propagate unchanged")
+}

--- a/test/integration/suites/common/cli_update_metadata_test.go
+++ b/test/integration/suites/common/cli_update_metadata_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestEnvUpdatePreservesLabels guards the metadata contract of `fission env
+// update`, which does a re-fetch-and-reapply through util.UpdateOnConflict: a
+// `--labels` update must persist, and an update that does NOT pass --labels must
+// leave existing labels untouched (the mutate only overwrites metadata the
+// command was given, not a stale whole-object snapshot). `fn update` and
+// `fn update-container` share the same code path. The conflict-retry mechanics
+// themselves are covered by util.TestUpdateOnConflict* unit tests.
+func TestEnvUpdatePreservesLabels(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	ns := f.NewTestNamespace(t)
+
+	envName := "env-labels-" + ns.ID
+	// The image is only stored on the CR (no pull happens until a function uses
+	// the env), so a placeholder keeps this test image-independent and fast.
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: "fission/python-env"})
+	envs := f.FissionClient().CoreV1().Environments(ns.Name)
+
+	// A --labels update must persist on the CR.
+	ns.CLI(t, ctx, "env", "update", "--name", envName, "--labels", "rfc=retry,team=fission")
+	env, err := envs.Get(ctx, envName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "retry", env.Labels["rfc"], "env update --labels must persist on the CR")
+	assert.Equal(t, "fission", env.Labels["team"], "env update --labels must persist on the CR")
+
+	// A later update that does not mention labels must leave them intact —
+	// proving the mutate doesn't clobber metadata it wasn't asked to change.
+	ns.CLI(t, ctx, "env", "update", "--name", envName, "--graceperiod", "30")
+	env, err = envs.Get(ctx, envName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "retry", env.Labels["rfc"], "a non-label update must preserve existing labels")
+	assert.Equal(t, "fission", env.Labels["team"], "a non-label update must preserve existing labels")
+}


### PR DESCRIPTION
## Problem

Every `fission <resource> update` (and `fission spec apply`) did a `Get` → mutate → `Update` with no retry.
When a Fission controller writes to the object's `.status` between the CLI's read and the CLI's write, the `Update` fails with the optimistic-concurrency error:

```
the object has been modified; please apply your changes to the latest version and try again
```

This is the recurring `TestCLICommands` timetrigger-update CI flake, and a real annoyance for anyone running updates against a live (reconciling) cluster.

## Fix

A single generic helper — `pkg/fission-cli/util/retry.go`:

```go
func UpdateOnConflict[T any](ctx context.Context, c updatableClient[T], name string, mutate func(T)) (T, error)
```

It re-fetches the object and re-applies the caller's mutation inside `retry.RetryOnConflict(retry.DefaultRetry, …)`.
Every spec update routes through it: timetrigger, mqtrigger, canaryconfig, environment, function, function-container, httptrigger, package, tenant enable, and the six `spec apply` resource updaters.
Status writes keep their own `UpdateStatus` retry loops (the helper covers `Update` only).

## Reviewer guide

**Start here:** `pkg/fission-cli/util/retry.go` (the helper + its doc) and `util/retry_test.go` (fake-clientset reactor injects a 409, then asserts the change is re-applied and non-conflict errors propagate).

**Then the call sites** — all mechanical applications of the helper, except two that carry real semantics:

- **Metadata preservation** (`environment`, `function`, `function-container`): the mutate sets `Spec` always, but `Labels`/`Annotations` only when `--labels`/`--annotation` were given — so an unrelated update no longer clobbers metadata a controller set since the read. Locked by `test/integration/suites/common/cli_update_metadata_test.go`.
- **Canary re-arm** (`canaryconfig/update.go`): a latent bug found while touching the closure — `canary update` reset the rollout status via a plain `Update`, which the `/status` subresource silently drops, so the documented re-arm never took effect. It now goes through `UpdateStatus`. *(Pre-existing behavior change; happy to split this out if preferred.)*

## Risk / semantics

- **Last-write-wins:** because the mutate re-applies the caller's desired state on each attempt, a *concurrent edit to the same field* is overwritten rather than (as before) failing loudly with a 409.
  The common conflict — a controller status write racing a CLI spec write — touches a different field and resolves cleanly, which is the whole point.
- **Not changed (deliberate):** the conflict-safe re-`Get` adds one round-trip per object on the happy path of `spec apply` / multi-function updates.
  A seeded "try-then-refetch-on-conflict" helper would avoid it but carries an empty-resourceVersion footgun; left as a possible follow-up.

## Verification

`go build ./...`, `go vet` (incl. `-tags=integration`), `golangci-lint` (0 issues), `gofmt`, `make license-check`, and the fission-cli unit tests — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
