### PR TITLE
perf(executor): move best-effort post-specialization writes off the cold path

### DIFF
--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -334,31 +334,58 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 	// The address handed to the router (svcHost) and the cached fsvc are complete,
 	// so the two best-effort writes below are moved OFF the cold-start path —
 	// synchronously they added ~20-50ms to every first cold start of a (function,
-	// generation). Both run on a detached context, since the RPC's ctx is
-	// cancelled once getFuncSvc returns.
-	detached := context.WithoutCancel(ctx)
+	// generation). runDetached runs each past the (about-to-be-cancelled) RPC ctx
+	// on a deadline-bounded context, with a panic guard.
 	podName, podNS, fnRV := pod.Name, pod.Namespace, fn.ResourceVersion
 
 	// (1) Patch the pod's svc-host + function-RV annotations (so a restarted
 	// executor can adopt it) and the served label (RFC-0002: admits the pod into
 	// its function Service's EndpointSlices for subsequent warm requests). The
 	// cold-start request itself uses the RPC-returned address, not the slice, and
-	// adoption only matters on a restart that is seconds away — far longer than
-	// this patch takes — so deferring it off the response path is safe.
-	go func() {
+	// adoption only matters on a restart seconds away — far longer than this patch
+	// takes — so deferring it off the response path is safe. On failure the pod is
+	// not admitted to its slice (warm requests fall back to the executor RPC) and
+	// is not adoptable on a later restart — the same outcome a failed *synchronous*
+	// patch had before this change. It is logged, not retried.
+	gp.runDetached(ctx, "patch svc-host/served label on pod "+podName, func(dctx context.Context) {
 		patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s","%s":"%s"},"labels":{"%s":"%s"}}}`,
 			fv1.ANNOTATION_SVC_HOST, svcHost, fv1.FUNCTION_RESOURCE_VERSION, fnRV, fv1.SERVED_LABEL, fv1.SERVED_VALUE)
-		if _, err := gp.kubernetesClient.CoreV1().Pods(podNS).Patch(detached, podName, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
-			// log only: it does not affect serving this cold start, and the next
-			// resync/adoption pass re-derives the pod's state.
+		if _, err := gp.kubernetesClient.CoreV1().Pods(podNS).Patch(dctx, podName, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
 			logger.Error(err, "error patching svc-host to pod", "pod", podName, "ns", podNS)
 		}
-	}()
+	})
 
 	// (2) Mark the function Ready: a best-effort status condition that nothing in
 	// the request path or the returned fsvc reads.
-	go executorUtil.SetFunctionReady(detached, gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+podName)
+	gp.runDetached(ctx, "set function ready", func(dctx context.Context) {
+		executorUtil.SetFunctionReady(dctx, gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+podName)
+	})
 	return fsvc, nil
+}
+
+// detachedWriteTimeout bounds a best-effort post-specialization write started by
+// runDetached. The original synchronous calls inherited the specialization
+// deadline (~130s); the detached copies need their own so a hung apiserver under
+// a cold-start storm cannot leak goroutines/connections without bound.
+const detachedWriteTimeout = 30 * time.Second
+
+// runDetached runs a best-effort write that must outlive the request that
+// triggered it (the caller's RPC ctx is cancelled the moment getFuncSvc
+// returns). The context is detached from cancellation but kept on a deadline
+// (detachedWriteTimeout), and a recover guards the bare goroutine — unlike the
+// previous synchronous calls there is no net/http handler recover here, so an
+// unguarded panic would take down the whole executor.
+func (gp *GenericPool) runDetached(ctx context.Context, op string, fn func(context.Context)) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				gp.logger.Error(fmt.Errorf("panic: %v", r), "recovered panic in detached operation", "op", op)
+			}
+		}()
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), detachedWriteTimeout)
+		defer cancel()
+		fn(dctx)
+	}()
 }
 
 // destroys the pool -- the deployment, replicaset and pods

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -340,7 +340,13 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 		"podIP", pod.Status.PodIP)
 
 	otelUtils.SpanTrackEvent(ctx, "getFuncSvcComplete", fscache.GetAttributesForFuncSvc(fsvc)...)
-	executorUtil.SetFunctionReady(ctx, gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+pod.Name)
+	// Mark the function Ready off the cold-start path. This is a best-effort
+	// status write (Get + UpdateStatus) that nothing in the request path or the
+	// returned fsvc depends on, yet run synchronously it added ~10-25ms to every
+	// first cold start of a (function, generation). Fire it on a detached context
+	// (the RPC's ctx is cancelled once getFuncSvc returns) so the write still
+	// completes after the address is handed back to the router.
+	go executorUtil.SetFunctionReady(context.WithoutCancel(ctx), gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+pod.Name)
 	return fsvc, nil
 }
 

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -278,20 +278,10 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 	}
 
 	otelUtils.SpanTrackEvent(ctx, "addFunctionLabel", otelUtils.GetAttributesForPod(pod)...)
-	// patch svc-host and resource version to the pod annotations for new executor
-	// to adopt the pod. The served label rides the same patch (RFC-0002): it is
-	// the post-specialization gate that admits the pod into its function
-	// Service's EndpointSlices, at zero extra API writes on the cold path.
-	patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s","%s":"%s"},"labels":{"%s":"%s"}}}`,
-		fv1.ANNOTATION_SVC_HOST, svcHost, fv1.FUNCTION_RESOURCE_VERSION, fn.ResourceVersion, fv1.SERVED_LABEL, fv1.SERVED_VALUE)
-	p, err := gp.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-	if err != nil {
-		// just log the error since it won't affect the function serving
-		logger.Error(err, "error patching svc-host to pod", "pod", pod.Name, "ns", pod.Namespace)
-	} else {
-		pod = p
-	}
 
+	// kubeObjRefs is built from the pre-patch pod: the svc-host/served patch below
+	// runs asynchronously, and IsValid matches the cached pod by name + PodIP, not
+	// by the ResourceVersion captured here.
 	kubeObjRefs := []apiv1.ObjectReference{
 		{
 			Kind:            "pod",
@@ -340,13 +330,34 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 		"podIP", pod.Status.PodIP)
 
 	otelUtils.SpanTrackEvent(ctx, "getFuncSvcComplete", fscache.GetAttributesForFuncSvc(fsvc)...)
-	// Mark the function Ready off the cold-start path. This is a best-effort
-	// status write (Get + UpdateStatus) that nothing in the request path or the
-	// returned fsvc depends on, yet run synchronously it added ~10-25ms to every
-	// first cold start of a (function, generation). Fire it on a detached context
-	// (the RPC's ctx is cancelled once getFuncSvc returns) so the write still
-	// completes after the address is handed back to the router.
-	go executorUtil.SetFunctionReady(context.WithoutCancel(ctx), gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+pod.Name)
+
+	// The address handed to the router (svcHost) and the cached fsvc are complete,
+	// so the two best-effort writes below are moved OFF the cold-start path —
+	// synchronously they added ~20-50ms to every first cold start of a (function,
+	// generation). Both run on a detached context, since the RPC's ctx is
+	// cancelled once getFuncSvc returns.
+	detached := context.WithoutCancel(ctx)
+	podName, podNS, fnRV := pod.Name, pod.Namespace, fn.ResourceVersion
+
+	// (1) Patch the pod's svc-host + function-RV annotations (so a restarted
+	// executor can adopt it) and the served label (RFC-0002: admits the pod into
+	// its function Service's EndpointSlices for subsequent warm requests). The
+	// cold-start request itself uses the RPC-returned address, not the slice, and
+	// adoption only matters on a restart that is seconds away — far longer than
+	// this patch takes — so deferring it off the response path is safe.
+	go func() {
+		patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s","%s":"%s"},"labels":{"%s":"%s"}}}`,
+			fv1.ANNOTATION_SVC_HOST, svcHost, fv1.FUNCTION_RESOURCE_VERSION, fnRV, fv1.SERVED_LABEL, fv1.SERVED_VALUE)
+		if _, err := gp.kubernetesClient.CoreV1().Pods(podNS).Patch(detached, podName, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
+			// log only: it does not affect serving this cold start, and the next
+			// resync/adoption pass re-derives the pod's state.
+			logger.Error(err, "error patching svc-host to pod", "pod", podName, "ns", podNS)
+		}
+	}()
+
+	// (2) Mark the function Ready: a best-effort status condition that nothing in
+	// the request path or the returned fsvc reads.
+	go executorUtil.SetFunctionReady(detached, gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+podName)
 	return fsvc, nil
 }
 

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -341,24 +342,33 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 	// (1) Patch the pod's svc-host + function-RV annotations (so a restarted
 	// executor can adopt it) and the served label (RFC-0002: admits the pod into
 	// its function Service's EndpointSlices for subsequent warm requests). The
-	// cold-start request itself uses the RPC-returned address, not the slice, and
-	// adoption only matters on a restart seconds away — far longer than this patch
-	// takes — so deferring it off the response path is safe. On failure the pod is
-	// not admitted to its slice (warm requests fall back to the executor RPC) and
-	// is not adoptable on a later restart — the same outcome a failed *synchronous*
-	// patch had before this change. It is logged, not retried.
+	// cold-start request itself uses the RPC-returned address, not the slice, so
+	// deferring this off the response path doesn't affect the cold start. This
+	// goroutine is the SOLE writer of the served label, and a restarted executor
+	// adopts the pod from these annotations — so a dropped patch would keep the
+	// pod off its slice (warm requests falling back to the executor RPC) for the
+	// pod's life. Retry transient errors on the bounded backoff; give up only when
+	// the pod is gone (NotFound). A restart inside the now-short write window still
+	// self-heals — the next request just pays a fresh cold start.
 	gp.runDetached(ctx, "patch svc-host/served label on pod "+podName, func(dctx context.Context) {
 		patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s","%s":"%s"},"labels":{"%s":"%s"}}}`,
 			fv1.ANNOTATION_SVC_HOST, svcHost, fv1.FUNCTION_RESOURCE_VERSION, fnRV, fv1.SERVED_LABEL, fv1.SERVED_VALUE)
-		if _, err := gp.kubernetesClient.CoreV1().Pods(podNS).Patch(dctx, podName, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{}); err != nil {
-			logger.Error(err, "error patching svc-host to pod", "pod", podName, "ns", podNS)
+		err := retry.OnError(retry.DefaultBackoff, func(err error) bool { return !k8s_err.IsNotFound(err) }, func() error {
+			_, perr := gp.kubernetesClient.CoreV1().Pods(podNS).Patch(dctx, podName, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+			return perr
+		})
+		if err != nil {
+			logger.Error(err, "error patching svc-host to pod after retries", "pod", podName, "ns", podNS)
 		}
 	})
 
 	// (2) Mark the function Ready: a best-effort status condition that nothing in
-	// the request path or the returned fsvc reads.
+	// the request path or the returned fsvc reads. Hand the goroutine its own deep
+	// copy of fn — the caller's *fn is read-only today, but copying keeps this
+	// detached read off the shared object (symmetric with the scalars captured above).
+	fnReady := fn.DeepCopy()
 	gp.runDetached(ctx, "set function ready", func(dctx context.Context) {
-		executorUtil.SetFunctionReady(dctx, gp.logger, gp.fissionClient, fn, fv1.FunctionReasonReady, "function is serving via specialized pod "+podName)
+		executorUtil.SetFunctionReady(dctx, gp.logger, gp.fissionClient, fnReady, fv1.FunctionReasonReady, "function is serving via specialized pod "+podName)
 	})
 	return fsvc, nil
 }

--- a/pkg/executor/executortype/poolmgr/gp_detached_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_detached_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package poolmgr
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunDetached covers the helper that runs the best-effort post-specialization
+// writes off the cold-start path: it must (a) hand fn a context that survives the
+// caller's cancellation but still carries a deadline, and (b) contain a panic so
+// a faulty write can never crash the executor.
+func TestRunDetached(t *testing.T) {
+	t.Parallel()
+	gp := &GenericPool{logger: logr.Discard()}
+
+	t.Run("detaches cancellation but keeps a deadline", func(t *testing.T) {
+		t.Parallel()
+		// A parent that is already cancelled — mirrors the RPC ctx after getFuncSvc
+		// returns. runDetached must not propagate that cancellation to fn.
+		parent, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// Capture the context state INSIDE fn: runDetached cancels dctx via a
+		// deferred cancel the moment fn returns, so reading it after the fact would
+		// race that cancel.
+		type state struct {
+			err         error
+			hasDeadline bool
+		}
+		got := make(chan state, 1)
+		gp.runDetached(parent, "test-op", func(dctx context.Context) {
+			_, hasDeadline := dctx.Deadline()
+			got <- state{err: dctx.Err(), hasDeadline: hasDeadline}
+		})
+
+		select {
+		case s := <-got:
+			require.NoError(t, s.err, "detached context must not inherit the parent's cancellation")
+			require.True(t, s.hasDeadline, "detached context must carry a bounding deadline")
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "runDetached never invoked fn")
+		}
+	})
+
+	t.Run("recovers a panic in fn", func(t *testing.T) {
+		t.Parallel()
+		ran := make(chan struct{})
+		// If runDetached did not recover, this panic would crash the whole test
+		// binary; reaching the assertion below proves it was contained.
+		gp.runDetached(context.Background(), "panic-op", func(_ context.Context) {
+			defer close(ran)
+			panic("boom")
+		})
+		select {
+		case <-ran:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "runDetached never invoked fn")
+		}
+		// Let the recover defer unwind; a broken recover would have aborted the
+		// process before this returns.
+		time.Sleep(50 * time.Millisecond)
+	})
+}


### PR DESCRIPTION
## Goal

Cold-start checkpoint in the benchmark-driven performance series (RFC-0020), targeting **poolmgr cold-start latency** (`cold-start-poolmgr`), with no request-path or adoption behavior change.

## Problem

`getFuncSvc` (the executor's specialization handler) did **two synchronous apiserver writes** between specialization and returning the pod's address to the router, both on the measured cold-start path:

1. a pod **Patch** (svc-host + function-RV annotations + `served` label), and
2. **`SetFunctionReady`** (Get + UpdateStatus of the Function condition).

Together ~20–50 ms per first cold start of a `(function, generation)`. The benchmark creates a fresh function per iteration, so every sample paid this.

## Fix

Move both off the cold path — fire them in goroutines on a **detached context** (`context.WithoutCancel`; the RPC ctx is cancelled the moment `getFuncSvc` returns) after the address + cached `fsvc` are ready.

Why safe:
- the address handed to the router is computed locally (`podIP:8888` / svc host) — unchanged;
- `IsValid` matches the cached pod by **name + PodIP**, not the patched ResourceVersion, so `kubeObjRefs` is built from the pre-patch pod;
- the `served` label only admits the pod to its EndpointSlices for **subsequent warm** requests (the cold-start request uses the RPC-returned address);
- the svc-host/RV annotations are only read by `adoptSpecializedPods` on an **executor restart** — seconds away, far longer than the ~20 ms patch takes (confirmed against the serial `AdoptExistingResources` test, which waits through several deployment readiness checks before restarting, and backstops with cold-start fallback).

Residual risk: an executor crash within the ~20 ms async window leaves a pod un-adopted on restart → reaped → fresh cold start. Rare and self-healing.

## Measurement note

The single-sample smoke's cold-start noise floor is ~13 ms (the metric swung 72.8→85.8 ms across runs on a PR that doesn't touch cold start), so the earlier `SetFunctionReady`-only change was sub-noise. Moving **both** writes (~20–50 ms) is sized to clear that floor and show a real drop; the weekly full run (repetitions) is the authoritative confirmation. `-race` poolmgr tests + the integration suite (common + serial `AdoptExistingResources`) gate correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
