### PR TITLE
perf(net): dedicated pooled HTTP transports for internal single-host clients

### DIFF
--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -33,6 +33,12 @@ import (
 // switches from a V(1) note to an error log (3 failures = ~15s of lost taps).
 const tapFailureEscalation = 3
 
+// executorIdleConnsPerHost sizes the RPC client's idle connection pool. The
+// router fires many concurrent RPCs (getServiceForFunction, ensureCapacity,
+// batched tap/untap) at the single executor host during cold-start bursts, far
+// above http.DefaultTransport's 2 idle conns/host.
+const executorIdleConnsPerHost = 128
+
 // tapFlushErrors counts failed tap-flush batches. Each failure drops one 5s
 // batch of liveness taps; a sustained non-zero rate means index-admitted pods
 // are invisible to the executor's idle reaper and at risk of being reaped
@@ -112,11 +118,7 @@ type (
 // storagesvcClient.HMACSecretFromEnv(); the same env var
 // (FISSION_INTERNAL_AUTH_SECRET) backs every internal channel.
 func MakeClient(logger logr.Logger, executorURL string, masterSecret []byte) ClientInterface {
-	// Dedicated pooled transport: the router fires many concurrent RPCs
-	// (getServiceForFunction, ensureCapacity, batched tap/untap) at the single
-	// executor host during cold-start bursts; http.DefaultTransport's 2 idle
-	// conns/host would churn connections under that load.
-	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(128))
+	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(executorIdleConnsPerHost))
 	if len(masterSecret) > 0 {
 		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceExecutor, rt, time.Now)
 	}

--- a/pkg/executor/client/client.go
+++ b/pkg/executor/client/client.go
@@ -25,6 +25,7 @@ import (
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/utils/correlation"
 	"github.com/fission/fission/pkg/utils/httpretry"
+	"github.com/fission/fission/pkg/utils/httpx"
 	"github.com/fission/fission/pkg/utils/metrics"
 )
 
@@ -111,7 +112,11 @@ type (
 // storagesvcClient.HMACSecretFromEnv(); the same env var
 // (FISSION_INTERNAL_AUTH_SECRET) backs every internal channel.
 func MakeClient(logger logr.Logger, executorURL string, masterSecret []byte) ClientInterface {
-	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	// Dedicated pooled transport: the router fires many concurrent RPCs
+	// (getServiceForFunction, ensureCapacity, batched tap/untap) at the single
+	// executor host during cold-start bursts; http.DefaultTransport's 2 idle
+	// conns/host would churn connections under that load.
+	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(128))
 	if len(masterSecret) > 0 {
 		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceExecutor, rt, time.Now)
 	}

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -21,6 +21,7 @@ import (
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/httpx"
 )
 
 const (
@@ -58,7 +59,10 @@ type Proxy struct {
 // (HKDF-derived key); empty leaves requests unsigned, matching the verifier's
 // pass-through mode. The transport stack mirrors publisher.newWebhookHTTPClient.
 func NewProxy(routerInternalURL string, hmacMaster []byte, logger logr.Logger) *Proxy {
-	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	// Dedicated pooled transport: the proxy allows defaultMaxConcurrent in-flight
+	// tool calls, all to the single router-internal host; http.DefaultTransport's
+	// 2 idle conns/host would churn connections under concurrent agent load.
+	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(defaultMaxConcurrent))
 	if len(hmacMaster) > 0 {
 		rt = hmacauth.ServiceSigner(hmacMaster, hmacauth.ServiceRouterInternal, rt, time.Now)
 	}

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -57,11 +57,10 @@ type Proxy struct {
 // NewProxy builds a proxy targeting routerInternalURL. When hmacMaster is
 // non-empty the outbound transport signs requests for ServiceRouterInternal
 // (HKDF-derived key); empty leaves requests unsigned, matching the verifier's
-// pass-through mode. The transport stack mirrors publisher.newWebhookHTTPClient.
+// pass-through mode.
 func NewProxy(routerInternalURL string, hmacMaster []byte, logger logr.Logger) *Proxy {
-	// Dedicated pooled transport: the proxy allows defaultMaxConcurrent in-flight
-	// tool calls, all to the single router-internal host; http.DefaultTransport's
-	// 2 idle conns/host would churn connections under concurrent agent load.
+	// Pooled transport sized to defaultMaxConcurrent in-flight tool calls, all to
+	// the single router-internal host (see httpx.PooledTransport).
 	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(defaultMaxConcurrent))
 	if len(hmacMaster) > 0 {
 		rt = hmacauth.ServiceSigner(hmacMaster, hmacauth.ServiceRouterInternal, rt, time.Now)

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -22,6 +22,7 @@ import (
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/mqtrigger"
 	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/httpx"
 )
 
 // newKafkaHTTPClient builds the http.Client used to invoke functions
@@ -34,7 +35,11 @@ import (
 // requests on other Fission internal channels (storagesvc, fetcher,
 // builder, executor). See docs/internal-auth/00-design.md.
 func newKafkaHTTPClient() *http.Client {
-	rt := http.DefaultTransport
+	// Dedicated pooled transport: ConsumeClaim runs one invocation goroutine per
+	// partition, all hitting the single router-internal host; the stdlib default
+	// of 2 idle conns/host would churn connections for any trigger with >2 active
+	// partitions.
+	var rt http.RoundTripper = httpx.PooledTransport(64)
 	if master := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); master != "" {
 		return &http.Client{Transport: hmacauth.ServiceSigner([]byte(master), hmacauth.ServiceRouterInternal, rt, time.Now)}
 	}

--- a/pkg/mqtrigger/messageQueue/kafka/consumer.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer.go
@@ -34,12 +34,21 @@ import (
 // key keeps a leak of this consumer's runtime memory from forging
 // requests on other Fission internal channels (storagesvc, fetcher,
 // builder, executor). See docs/internal-auth/00-design.md.
+// kafkaIdleConnsPerHost sizes the idle connection pool to the single
+// router-internal host. ConsumeClaim runs one invocation goroutine per partition,
+// so the pool must exceed http.DefaultTransport's 2 idle conns/host; 64 covers
+// typical partition counts (the pool only retains what concurrency actually uses).
+const kafkaIdleConnsPerHost = 64
+
+// kafkaTransport is the process-wide pooled transport shared by every Kafka
+// trigger's HTTP client — ONE connection pool to the single router-internal
+// host. Built once (not per trigger) so an mqtrigger pod hosting many triggers
+// keeps a bounded idle-conn footprint and reuses connections across triggers;
+// the per-trigger HMAC signer wraps it without forking the pool.
+var kafkaTransport = httpx.PooledTransport(kafkaIdleConnsPerHost)
+
 func newKafkaHTTPClient() *http.Client {
-	// Dedicated pooled transport: ConsumeClaim runs one invocation goroutine per
-	// partition, all hitting the single router-internal host; the stdlib default
-	// of 2 idle conns/host would churn connections for any trigger with >2 active
-	// partitions.
-	var rt http.RoundTripper = httpx.PooledTransport(64)
+	var rt http.RoundTripper = kafkaTransport
 	if master := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); master != "" {
 		return &http.Client{Transport: hmacauth.ServiceSigner([]byte(master), hmacauth.ServiceRouterInternal, rt, time.Now)}
 	}

--- a/pkg/mqtrigger/messageQueue/kafka/consumer_test.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer_test.go
@@ -28,7 +28,11 @@ func TestNewKafkaHTTPClient(t *testing.T) {
 		tr, ok := c.Transport.(*http.Transport)
 		require.True(t, ok, "expected a *http.Transport")
 		assert.NotSame(t, http.DefaultTransport, c.Transport, "must not share the global default transport")
-		assert.Equal(t, 64, tr.MaxIdleConnsPerHost)
+		assert.Equal(t, kafkaIdleConnsPerHost, tr.MaxIdleConnsPerHost)
+		// The pool is process-wide, not per trigger: every client shares it, so an
+		// mqtrigger pod with many triggers keeps a bounded idle-conn footprint.
+		assert.Same(t, kafkaTransport, c.Transport, "all Kafka clients must share one transport")
+		assert.Same(t, newKafkaHTTPClient().Transport, c.Transport, "repeated construction must reuse the shared transport")
 	})
 
 	t.Run("auth secret wraps the transport with a signer", func(t *testing.T) {

--- a/pkg/mqtrigger/messageQueue/kafka/consumer_test.go
+++ b/pkg/mqtrigger/messageQueue/kafka/consumer_test.go
@@ -19,11 +19,16 @@ import (
 )
 
 func TestNewKafkaHTTPClient(t *testing.T) {
-	t.Run("no auth secret uses the default transport", func(t *testing.T) {
+	t.Run("no auth secret uses an unsigned pooled transport", func(t *testing.T) {
 		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "")
 		c := newKafkaHTTPClient()
 		require.NotNil(t, c)
-		assert.Equal(t, http.DefaultTransport, c.Transport)
+		// A dedicated pooled transport (not the shared 2-conn default) sized for
+		// per-partition concurrency to the single router-internal host.
+		tr, ok := c.Transport.(*http.Transport)
+		require.True(t, ok, "expected a *http.Transport")
+		assert.NotSame(t, http.DefaultTransport, c.Transport, "must not share the global default transport")
+		assert.Equal(t, 64, tr.MaxIdleConnsPerHost)
 	})
 
 	t.Run("auth secret wraps the transport with a signer", func(t *testing.T) {
@@ -31,6 +36,8 @@ func TestNewKafkaHTTPClient(t *testing.T) {
 		c := newKafkaHTTPClient()
 		require.NotNil(t, c)
 		assert.NotEqual(t, http.DefaultTransport, c.Transport)
+		_, isPlainTransport := c.Transport.(*http.Transport)
+		assert.False(t, isPlainTransport, "signer should wrap the transport")
 	})
 }
 

--- a/pkg/utils/httpx/transport.go
+++ b/pkg/utils/httpx/transport.go
@@ -19,8 +19,19 @@ import "net/http"
 // the per-host bound exceeds it, so the global cap can't clamp it). Each call
 // returns an independent transport with its own pool, so give each client its
 // own rather than mutating the process-wide http.DefaultTransport.
+//
+// maxIdleConnsPerHost should be > 0; a non-positive value leaves net/http's
+// default of 2 (the churn this helper exists to avoid), so callers pass a real
+// concurrency-sized bound.
 func PooledTransport(maxIdleConnsPerHost int) *http.Transport {
-	t := http.DefaultTransport.(*http.Transport).Clone()
+	// Clone the stdlib *http.Transport (the normal case) to inherit its dial
+	// timeouts/proxy/HTTP2 attempt; fall back to a zero transport if a dependency
+	// has replaced http.DefaultTransport, so construction never panics at startup.
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		base = &http.Transport{}
+	}
+	t := base.Clone()
 	t.MaxIdleConnsPerHost = maxIdleConnsPerHost
 	if maxIdleConnsPerHost > t.MaxIdleConns {
 		t.MaxIdleConns = maxIdleConnsPerHost

--- a/pkg/utils/httpx/transport.go
+++ b/pkg/utils/httpx/transport.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpx
+
+import "net/http"
+
+// PooledTransport returns a clone of http.DefaultTransport whose idle-connection
+// pool is widened to maxIdleConnsPerHost, for internal clients that drive a
+// SINGLE hot upstream (the executor, the router-internal listener) under
+// concurrency. The stdlib default keeps only 2 idle connections per host, so
+// beyond 2 concurrent requests each extra request dials a fresh TCP connection
+// and discards it after use — connection churn that caps throughput and adds
+// latency under load.
+//
+// Cloning preserves the default dial timeouts, proxy handling, and HTTP/2
+// attempt; only the idle pool is changed (MaxIdleConns is raised to match when
+// the per-host bound exceeds it, so the global cap can't clamp it). Each call
+// returns an independent transport with its own pool, so give each client its
+// own rather than mutating the process-wide http.DefaultTransport.
+func PooledTransport(maxIdleConnsPerHost int) *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.MaxIdleConnsPerHost = maxIdleConnsPerHost
+	if maxIdleConnsPerHost > t.MaxIdleConns {
+		t.MaxIdleConns = maxIdleConnsPerHost
+	}
+	return t
+}

--- a/pkg/utils/httpx/transport_test.go
+++ b/pkg/utils/httpx/transport_test.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package httpx
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPooledTransport(t *testing.T) {
+	t.Parallel()
+	def := http.DefaultTransport.(*http.Transport)
+
+	t.Run("widens the idle pool and raises the global cap to match", func(t *testing.T) {
+		t.Parallel()
+		tr := PooledTransport(128)
+		assert.Equal(t, 128, tr.MaxIdleConnsPerHost)
+		assert.GreaterOrEqual(t, tr.MaxIdleConns, 128, "global cap must not clamp the per-host pool")
+	})
+
+	t.Run("leaves the default global cap untouched when per-host is smaller", func(t *testing.T) {
+		t.Parallel()
+		tr := PooledTransport(16)
+		assert.Equal(t, 16, tr.MaxIdleConnsPerHost)
+		assert.Equal(t, def.MaxIdleConns, tr.MaxIdleConns)
+	})
+
+	t.Run("returns an independent clone preserving the default dial settings", func(t *testing.T) {
+		t.Parallel()
+		tr := PooledTransport(64)
+		assert.NotSame(t, def, tr, "must not return the shared global transport")
+		assert.True(t, tr.ForceAttemptHTTP2)
+		assert.NotNil(t, tr.DialContext)
+		assert.NotNil(t, tr.Proxy)
+	})
+}


### PR DESCRIPTION
## Goal

Performance series (RFC-0020). Removes a connection-pool bottleneck on the internal data-plane HTTP clients.

## Problem

Three internal clients each wrap the shared `http.DefaultTransport`, whose `MaxIdleConnsPerHost` is **2**. Each drives a **single hot upstream** under concurrency, so beyond 2 in-flight requests every extra request opens a fresh TCP connection and discards it after use — connection churn that caps throughput and adds latency:

- **executor RPC client** (`pkg/executor/client`): the router fires many concurrent RPCs (`getServiceForFunction`, `ensureCapacity`, batched tap/untap) at the **one** executor host during cold-start bursts.
- **Kafka consumer** (`pkg/mqtrigger/messageQueue/kafka`): `ConsumeClaim` runs one invocation goroutine **per partition**, all against the **one** router-internal host.
- **MCP proxy** (`pkg/mcp`): allows `defaultMaxConcurrent` (64) concurrent tool calls to the **one** router-internal host.

(The router→function-pod path is already fixed — RFC-0014 gave it a dedicated pooled transport. This PR brings the other single-hot-host clients in line.)

## Change

Add `httpx.PooledTransport(maxIdleConnsPerHost)` — a clone of `http.DefaultTransport` (preserving its dial timeouts, proxy handling, and HTTP/2 attempt) with a widened idle pool (and `MaxIdleConns` raised to match so the global cap can't clamp it). Each client gets its own pooled transport instead of sharing the global default: executor 128, kafka 64, mcp 64.

## Scope / impact

- **No behavior change** beyond connection reuse — the HMAC-signer / retry / otel layering is untouched; only the base transport's idle pool changes.
- Targets **cold-start-burst RPS** (router↔executor) and **MQ/MCP throughput** — dimensions the current `warm-path`/`cold-start` benchmark scenarios (sequential cold start, single-pod warm via the router's own transport) don't exercise, so expect this to show in real-world burst load rather than the smoke. It's a correctness-neutral pool-sizing fix.
- Unit-tested: the helper (pool sizing + clone preserves defaults) and the kafka client (pooled vs signer-wrapped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
