### PR TITLE
fix(fission-bundle): set the controller-runtime logger for all subsystems

### DIFF
--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	cnwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -131,6 +132,15 @@ func main() {
 
 	// Initialize logger
 	logger := loggerfactory.GetLogger()
+
+	// Route controller-runtime's own logs (manager cache-sync, reconcile,
+	// leader-election) through our logger for EVERY subsystem. Each subsystem
+	// builds its own controller-runtime manager in its Start; without a global
+	// logger the ones that don't set it themselves (kubewatcher, timer,
+	// mqtrigger, mqt_keda, canaryconfig, buildermgr, mcp) silently drop those
+	// logs and print a one-off "log.SetLogger was never called" stack trace.
+	// Setting it once here, before any Start, covers them all.
+	ctrl.SetLogger(logger.WithName("controller-runtime"))
 
 	// Set up signal handling for graceful shutdown
 	ctx := signals.SetupSignalHandler()

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -133,13 +133,11 @@ func main() {
 	// Initialize logger
 	logger := loggerfactory.GetLogger()
 
-	// Route controller-runtime's own logs (manager cache-sync, reconcile,
-	// leader-election) through our logger for EVERY subsystem. Each subsystem
-	// builds its own controller-runtime manager in its Start; without a global
-	// logger the ones that don't set it themselves (kubewatcher, timer,
-	// mqtrigger, mqt_keda, canaryconfig, buildermgr, mcp) silently drop those
-	// logs and print a one-off "log.SetLogger was never called" stack trace.
-	// Setting it once here, before any Start, covers them all.
+	// ctrl.SetLogger targets controller-runtime's process-global logger. Set it
+	// once here, before any subsystem's Start builds its manager, so every
+	// subsystem routes controller-runtime's own logs (cache-sync, reconcile,
+	// leader-election) through our logger instead of dropping them with a one-off
+	// "log.SetLogger was never called" stack trace.
 	ctrl.SetLogger(logger.WithName("controller-runtime"))
 
 	// Set up signal handling for graceful shutdown

--- a/pkg/executor/start.go
+++ b/pkg/executor/start.go
@@ -374,11 +374,6 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 		metricsBind = ":0"
 	}
 
-	// controller-runtime's global logger (reflector list/watch failures, cache
-	// sync problems) is set once by the process entrypoint — cmd/fission-bundle
-	// main() for the binary, StartServices for the in-process e2e harness — not
-	// here, so multiple managers sharing a process don't each re-set the global.
-
 	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: executorScheme,
 		// Scope the cache to the executor's watched namespaces (builder +

--- a/pkg/executor/start.go
+++ b/pkg/executor/start.go
@@ -374,10 +374,10 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 		metricsBind = ":0"
 	}
 
-	// Route controller-runtime's internal logs (reflector list/watch failures,
-	// cache sync problems) through the executor logger — otherwise they are
-	// suppressed and informer problems manifest only as a not-ready pod.
-	ctrl.SetLogger(logger.WithName("controller-runtime"))
+	// controller-runtime's global logger (reflector list/watch failures, cache
+	// sync problems) is set once by the process entrypoint — cmd/fission-bundle
+	// main() for the binary, StartServices for the in-process e2e harness — not
+	// here, so multiple managers sharing a process don't each re-set the global.
 
 	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: executorScheme,

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -347,11 +347,10 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return err
 	}
 
-	// Route controller-runtime's internal logs (reflector list/watch failures,
-	// cache sync problems) through the router logger. Without this they are
-	// suppressed entirely — a forbidden informer LIST then manifests only as
-	// the router hanging not-ready, with nothing in the logs to say why.
-	ctrl.SetLogger(logger.WithName("controller-runtime"))
+	// controller-runtime's global logger (reflector list/watch failures, cache
+	// sync problems) is set once by the process entrypoint — cmd/fission-bundle
+	// main() for the binary, StartServices for the in-process e2e harness — not
+	// here, so multiple managers sharing a process don't each re-set the global.
 
 	// The slice informer needs read RBAC in the function namespaces (the chart
 	// renders it when the mode isn't off). A missing grant would wedge the

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -347,11 +347,6 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return err
 	}
 
-	// controller-runtime's global logger (reflector list/watch failures, cache
-	// sync problems) is set once by the process entrypoint — cmd/fission-bundle
-	// main() for the binary, StartServices for the in-process e2e harness — not
-	// here, so multiple managers sharing a process don't each re-set the global.
-
 	// The slice informer needs read RBAC in the function namespaces (the chart
 	// renders it when the mode isn't off). A missing grant would wedge the
 	// manager cache sync and hang the router not-ready, so degrade to the

--- a/pkg/webhook/service.go
+++ b/pkg/webhook/service.go
@@ -31,10 +31,6 @@ type WebhookInjector interface {
 
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, options webhook.Options) (err error) {
 	wLogger := logger.WithName("webhook")
-	// controller-runtime's global logger is set once by the process entrypoint
-	// (cmd/fission-bundle main(), or StartServices for the in-process e2e
-	// harness), not here — so it isn't re-set when several managers share a
-	// process.
 
 	metricsAddr := os.Getenv("METRICS_ADDR")
 	if metricsAddr == "" {

--- a/pkg/webhook/service.go
+++ b/pkg/webhook/service.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/go-logr/logr"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -32,7 +31,10 @@ type WebhookInjector interface {
 
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, options webhook.Options) (err error) {
 	wLogger := logger.WithName("webhook")
-	log.SetLogger(wLogger)
+	// controller-runtime's global logger is set once by the process entrypoint
+	// (cmd/fission-bundle main(), or StartServices for the in-process e2e
+	// harness), not here — so it isn't re-set when several managers share a
+	// process.
 
 	metricsAddr := os.Getenv("METRICS_ADDR")
 	if metricsAddr == "" {

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -34,6 +34,23 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	// re-set the global per manager). Mirrors cmd/fission-bundle main().
 	ctrl.SetLogger(f.Logger().WithName("controller-runtime"))
 
+	// runService runs a blocking subsystem Start in the harness errgroup. A
+	// subsystem that fails to come up must abort the run immediately (os.Exit).
+	// But once ctx is cancelled the run is tearing down, and a Start returning
+	// then is shutdown noise — e.g. a controller-runtime manager whose runnables
+	// exceed the 30s graceful-shutdown grace period under CI load — so it must
+	// not fail the test. The ctx.Err() guard also drops a data race on the
+	// shared err that the inline goroutines used to write.
+	runService := func(name string, start func() error) {
+		mgr.Go(func() error {
+			if err := start(); err != nil && ctx.Err() == nil {
+				f.Logger().Error(err, "error starting "+name)
+				os.Exit(1)
+			}
+			return nil
+		})
+	}
+
 	os.Setenv("DEBUG_ENV", "true")
 	// The executor and buildermgr run under controller-runtime Managers whose
 	// metrics server binds hard (and buildermgr's health-probe server too;
@@ -49,16 +66,11 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	if err != nil {
 		return fmt.Errorf("error toggling metric address: %w", err)
 	}
-	mgr.Go(func() error {
-		err = webhook.Start(ctx, f.ClientGen(), f.Logger(), cnwebhook.Options{
+	runService("webhook", func() error {
+		return webhook.Start(ctx, f.ClientGen(), f.Logger(), cnwebhook.Options{
 			Port:    webhookPort,
 			CertDir: env.WebhookInstallOptions.LocalServingCertDir,
 		})
-		if err != nil {
-			f.Logger().Error(err, "error starting webhook")
-			os.Exit(1)
-		}
-		return nil
 	})
 	f.AddServiceInfo("webhook", framework.ServiceInfo{Port: webhookPort})
 
@@ -85,12 +97,8 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	// executor now runs under a controller-runtime Manager, so StartExecutor
 	// blocks (like webhook.Start). Run it in a goroutine so the remaining
 	// services still come up.
-	mgr.Go(func() error {
-		if err := executor.StartExecutor(ctx, f.ClientGen(), f.Logger(), mgr, executorPort); err != nil {
-			f.Logger().Error(err, "error starting executor")
-			os.Exit(1)
-		}
-		return nil
+	runService("executor", func() error {
+		return executor.StartExecutor(ctx, f.ClientGen(), f.Logger(), mgr, executorPort)
 	})
 	f.AddServiceInfo("executor", framework.ServiceInfo{Port: executorPort})
 
@@ -116,12 +124,8 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	// goroutine; FISSION_TEST_EPHEMERAL_SERVERS (set at the top) makes its
 	// Manager servers bind ephemeral ports.
 	storageSvcURL := fmt.Sprintf("http://localhost:%d", storageSvcPort)
-	mgr.Go(func() error {
-		if err := buildermgr.Start(ctx, f.ClientGen(), f.Logger(), mgr, storageSvcURL); err != nil {
-			f.Logger().Error(err, "error starting builder manager")
-			os.Exit(1)
-		}
-		return nil
+	runService("builder manager", func() error {
+		return buildermgr.Start(ctx, f.ClientGen(), f.Logger(), mgr, storageSvcURL)
 	})
 	f.AddServiceInfo("buildermgr", framework.ServiceInfo{})
 
@@ -158,12 +162,8 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	// router now runs under a controller-runtime Manager, so Start blocks. Run
 	// it in a goroutine so the harness can continue; FISSION_TEST_EPHEMERAL_SERVERS
 	// (set at the top) makes its Manager metrics server bind an ephemeral port.
-	mgr.Go(func() error {
-		if err := router.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerPort, internalRouterPort, executor); err != nil {
-			f.Logger().Error(err, "error starting router")
-			os.Exit(1)
-		}
-		return nil
+	runService("router", func() error {
+		return router.Start(ctx, f.ClientGen(), f.Logger(), mgr, routerPort, internalRouterPort, executor)
 	})
 	f.AddServiceInfo("router", framework.ServiceInfo{Port: routerPort})
 	f.AddServiceInfo("router-internal", framework.ServiceInfo{Port: internalRouterPort})
@@ -190,30 +190,18 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	// timer, mqt_keda and kubewatcher now run under controller-runtime Managers,
 	// so their Start funcs block until ctx is cancelled. Run each in a goroutine
 	// so the harness can continue.
-	mgr.Go(func() error {
-		if err := timer.Start(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL); err != nil {
-			f.Logger().Error(err, "error starting timer")
-			os.Exit(1)
-		}
-		return nil
+	runService("timer", func() error {
+		return timer.Start(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL)
 	})
 	f.AddServiceInfo("timer", framework.ServiceInfo{})
 
-	mgr.Go(func() error {
-		if err := mqtrigger.StartScalerManager(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL); err != nil {
-			f.Logger().Error(err, "error starting mqt scaler manager")
-			os.Exit(1)
-		}
-		return nil
+	runService("mqt scaler manager", func() error {
+		return mqtrigger.StartScalerManager(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL)
 	})
 	f.AddServiceInfo("mqtrigger-keda", framework.ServiceInfo{})
 
-	mgr.Go(func() error {
-		if err := kubewatcher.Start(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL); err != nil {
-			f.Logger().Error(err, "error starting kubewatcher")
-			os.Exit(1)
-		}
-		return nil
+	runService("kubewatcher", func() error {
+		return kubewatcher.Start(ctx, f.ClientGen(), f.Logger(), mgr, internalRouterURL)
 	})
 	f.AddServiceInfo("kubewatcher", framework.ServiceInfo{})
 

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -10,6 +10,7 @@ import (
 	"os"
 
 	"golang.org/x/sync/errgroup"
+	ctrl "sigs.k8s.io/controller-runtime"
 	cnwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/fission/fission/pkg/buildermgr"
@@ -27,6 +28,12 @@ import (
 )
 
 func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Group) error {
+	// This harness runs several controller-runtime managers (webhook, executor,
+	// router, ...) in ONE process, so set controller-runtime's global logger once
+	// here — the entrypoint — rather than in each subsystem's Start (which would
+	// re-set the global per manager). Mirrors cmd/fission-bundle main().
+	ctrl.SetLogger(f.Logger().WithName("controller-runtime"))
+
 	os.Setenv("DEBUG_ENV", "true")
 	// The executor and buildermgr run under controller-runtime Managers whose
 	// metrics server binds hard (and buildermgr's health-probe server too;


### PR DESCRIPTION
## What

Set controller-runtime's process-global logger exactly once per process, at the entrypoint, instead of in each subsystem's `Start`.

- `cmd/fission-bundle/main.go` sets it before dispatching to any subsystem.
- `test/e2e/framework/services/services.go` (`StartServices`) sets it for the in-process e2e harness, which starts webhook + executor + router + the others in one process.
- The per-`Start` calls in `router`, `executor`, and `webhook` are removed (they were re-setting the same global).

## Why (found while scanning CI kind-logs)

Six control-plane subsystems each emit this at startup:

```
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
  >  goroutine N [running]
  >  runtime/debug.Stack() ...
```

Seen in **kubewatcher, timer, mqtrigger, mqt_keda, canaryconfig, buildermgr, mcp**.
Each builds a controller-runtime manager in its `Start` but never sets the logger, so controller-runtime's own logs — **manager cache-sync, reconcile errors, leader-election** — are silently dropped, and a one-off stack trace is printed.
Only `router`/`executor`/`webhook` set it before, each in its own `Start`.

`ctrl.SetLogger` targets controller-runtime's **global** logger, so it only needs to be set once per process.
The `mgr` threaded through `main.go` is an `errgroup.Group`, not a controller-runtime manager — each subsystem makes its own — so there is no single manager to attach a logger to; the global is the right seam.
`fission-bundle` runs exactly one subsystem per process, so a single call in `main()` before the dispatch covers whichever subsystem runs.
The e2e harness is the one place that runs several managers in a single process, so it gets its own entrypoint call.

## Effect

- Restores controller-runtime diagnostics (cache-sync/reconcile/leader-election) for the six subsystems that were dropping them — a real observability gain (these were invisible in production logs).
- Removes the noisy stack-trace warning.
- Unifies the controller-runtime logger name to `controller-runtime` across subsystems (webhook previously named it `webhook`) — a harmless naming change.

No behavior change beyond logging.
`go build ./...`, `vet`, `golangci-lint`, `license-check` clean.

## Also: e2e harness teardown robustness (same file)

While verifying the `services.go` change I traced a pre-existing flake on the `lint` job's `test/e2e/cli` leg to this harness.
Each subsystem's `Start` ran in the errgroup and `os.Exit(1)`'d on any error — including at teardown, where a controller-runtime manager whose runnables exceed the 30s graceful-shutdown grace period (poolmgr/newdeploy cleanup draining slowly under CI load) makes `mgr.Start` return `"failed waiting for all runnables to end within grace period of 30s"`, aborting the whole package with no `--- FAIL` line.
All subsystem Starts now go through a `runService` helper that only `os.Exit`s when `ctx` hasn't been cancelled (a genuine startup failure), not on teardown shutdown noise.
The helper also collapses seven near-identical goroutine blocks and removes a data race on the shared `err` the webhook goroutine wrote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
