### PR TITLE
fix(publisher): surface the real error on transport failure, retry quietly

### DIFF
--- a/pkg/publisher/publisher_test.go
+++ b/pkg/publisher/publisher_test.go
@@ -144,3 +144,29 @@ func TestWebhookPublisherDoesNotRetryOtherClientErrors(t *testing.T) {
 		return hits > 1
 	}, 3*time.Second, 100*time.Millisecond, "publisher should not retry non-404 client errors")
 }
+
+// TestWebhookPublisherTransportFailureRetriesQuietly verifies that a
+// transport-level failure (nothing listening → connection refused) is retried
+// like a transient 404 — quietly at V(1) per attempt — and surfaces exactly
+// one error on the final give-up, rather than one error per attempt.
+func TestWebhookPublisherTransportFailureRetriesQuietly(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close() // nothing is listening now: POSTs fail at the transport level
+
+	sink := &countingSink{}
+	p := MakeWebhookPublisher(logr.New(sink), url)
+	// Keep the give-up fast: 3 attempts, ~10ms+20ms of backoff.
+	p.maxRetries = 3
+	p.retryDelay = 10 * time.Millisecond
+	p.Publish(t.Context(), "", map[string]string{}, http.MethodPost, "test-fn")
+
+	require.Eventually(t, func() bool {
+		return sink.errorCount() == 1
+	}, 5*time.Second, 10*time.Millisecond,
+		"a transport failure should surface exactly one error on the final give-up")
+	require.Never(t, func() bool {
+		return sink.errorCount() > 1
+	}, 300*time.Millisecond, 30*time.Millisecond,
+		"transport retries must log quietly (V(1)), not one error per attempt")
+}

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -193,8 +193,12 @@ func (p *WebhookPublisher) makeHTTPRequest(r *publishRequest) {
 		var body []byte
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
+			// Response arrived but its body couldn't be read (e.g. the
+			// connection dropped mid-stream). Retry quietly like the transport
+			// and 404 paths rather than logging an error on every attempt.
 			logger = logger.WithValues("error", err)
-			msg = "read response body error"
+			msg = "reading response body failed, will retry"
+			msgType = "retry"
 		} else {
 			logger = logger.WithValues("status_code", resp.StatusCode, "body", string(body))
 			if resp.StatusCode >= 200 && resp.StatusCode < 400 {

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -180,13 +180,20 @@ func (p *WebhookPublisher) makeHTTPRequest(r *publishRequest) {
 	defer cancel()
 	resp, err := ctxhttp.Do(ctx, p.httpClient, req)
 	if err != nil {
-		logger = logger.WithValues("request", r)
+		// Transport-level failure (connection refused, timeout, DNS). Attach the
+		// real error — r marshals to {} because its fields are unexported, so it
+		// carried no information — and retry like the 404 path so a transient
+		// blip (router rollout, route still propagating) doesn't flood the error
+		// log on every attempt; the final give-up surfaces it once.
+		logger = logger.WithValues("error", err)
+		msg = "request failed, will retry"
+		msgType = "retry"
 	} else {
 		defer resp.Body.Close()
 		var body []byte
 		body, err = io.ReadAll(resp.Body)
 		if err != nil {
-			logger = logger.WithValues("request", r)
+			logger = logger.WithValues("error", err)
 			msg = "read response body error"
 		} else {
 			logger = logger.WithValues("status_code", resp.StatusCode, "body", string(body))


### PR DESCRIPTION
## What

The webhook publisher (shared by timer / kubewatcher / mqtrigger) logged a transport-level POST failure with the actual error dropped, and flooded one error per retry.

## Why (found scanning post-merge CI kind-logs)

After #3547 un-hid the previously-silent subsystems' controller-runtime logs, kubewatcher/timer showed a stream of `error`-level lines like:

```
{"level":"error","logger":"webhook_publisher","msg":"making HTTP POST request","url":"http://router-internal.fission:8889/fission-function/...","request":{}}
```

`request` is a `*publishRequest` whose fields are all unexported, so it marshals to `{}` — the line carried no error, no status, no cause.
At `webhookPublisher.go:182-183` the transport-error path attached `WithValues("request", r)` instead of the real `err` (the `NewRequest` path two lines up attaches `err` correctly).
That same path also left `msgType="error"`, so it logged at error level on every retry attempt — unlike the 404 path, which deliberately logs quietly (V(1)) and surfaces only the final give-up.

## Fix

- Attach the actual `err` on the transport-error and read-body-error paths.
- Mark the transport-error path retryable (`msgType="retry"`) so transient blips (router rollout, route still propagating) log quietly per attempt and surface a single error on the final give-up — matching the 404 anti-flood design.
- Add `TestWebhookPublisherTransportFailureRetriesQuietly`: an unreachable target yields exactly one error on give-up, not one per attempt.

Logging/observability only; no change to retry counts or delays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
