### PR TITLE
perf(executor): serve cold-path secret/configmap checks from the manager cache

### DIFF
--- a/pkg/executor/executortype/poolmgr/gp_specialize.go
+++ b/pkg/executor/executortype/poolmgr/gp_specialize.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	k8s_err "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apiv1 "k8s.io/api/core/v1"
 
@@ -102,6 +103,29 @@ func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv
 	return err
 }
 
+// existsInFnNamespace confirms a function-referenced Secret/ConfigMap is present
+// in the function namespace. It reads through the executor Manager's cache
+// (crClient) to keep this pre-flight check off the API server on the cold path,
+// and falls back to a direct API read on any cache miss or error — so a
+// just-created object the informer cache hasn't observed yet (or a namespace
+// outside the cache's scope) is confirmed authoritatively rather than spuriously
+// reported missing. cached must be an empty object of the type being checked.
+func (gp *GenericPool) existsInFnNamespace(ctx context.Context, cached client.Object, name string, directGet func(context.Context) error) (bool, error) {
+	if err := gp.crClient.Get(ctx, client.ObjectKey{Namespace: gp.fnNamespace, Name: name}, cached); err == nil {
+		return true, nil
+	}
+	// Cache miss / unwatched namespace / unsynced cache: confirm against the API
+	// server before concluding the object is missing.
+	err := directGet(ctx)
+	if err == nil {
+		return true, nil
+	}
+	if k8s_err.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 // doSpecializePod chooses a pod, copies the required user-defined function to that pod
 // (via fetcher), and calls the function-run container to load it, resulting in a
 // specialized pod.
@@ -124,34 +148,37 @@ func (gp *GenericPool) doSpecializePod(ctx context.Context, pod *apiv1.Pod, fn *
 		return gp.loadOnlySpecialize(ctx, podIP, fn)
 	}
 	for _, cm := range fn.Spec.ConfigMaps {
-		_, err := gp.kubernetesClient.CoreV1().ConfigMaps(gp.fnNamespace).Get(ctx, cm.Name, metav1.GetOptions{})
+		exists, err := gp.existsInFnNamespace(ctx, &apiv1.ConfigMap{}, cm.Name, func(ctx context.Context) error {
+			_, e := gp.kubernetesClient.CoreV1().ConfigMaps(gp.fnNamespace).Get(ctx, cm.Name, metav1.GetOptions{})
+			return e
+		})
 		if err != nil {
-			if k8s_err.IsNotFound(err) {
-				logger.Error(nil, "configmap namespace mismatch", "error", "configmap must be in same namespace as function namespace",
-					"configmap_name", cm.Name,
-					"configmap_namespace", cm.Namespace,
-					"function_name", fn.Name,
-					"function_namespace", gp.fnNamespace)
-				return fmt.Errorf("configmap %s must be in same namespace as function namespace", cm.Name)
-			} else {
-				return err
-			}
+			return err
+		}
+		if !exists {
+			logger.Error(nil, "configmap namespace mismatch", "error", "configmap must be in same namespace as function namespace",
+				"configmap_name", cm.Name,
+				"configmap_namespace", cm.Namespace,
+				"function_name", fn.Name,
+				"function_namespace", gp.fnNamespace)
+			return fmt.Errorf("configmap %s must be in same namespace as function namespace", cm.Name)
 		}
 	}
 	for _, sec := range fn.Spec.Secrets {
-		_, err := gp.kubernetesClient.CoreV1().Secrets(gp.fnNamespace).Get(ctx, sec.Name, metav1.GetOptions{})
+		exists, err := gp.existsInFnNamespace(ctx, &apiv1.Secret{}, sec.Name, func(ctx context.Context) error {
+			_, e := gp.kubernetesClient.CoreV1().Secrets(gp.fnNamespace).Get(ctx, sec.Name, metav1.GetOptions{})
+			return e
+		})
 		if err != nil {
-			if k8s_err.IsNotFound(err) {
-				logger.Error(nil, "secret namespace mismatch", "error", "secret must be in same namespace as function namespace",
-					"secret_name", sec.Name,
-					"secret_namespace", sec.Namespace,
-					"function_name", fn.Name,
-					"function_namespace", gp.fnNamespace)
-				return fmt.Errorf("secret %s must be in same namespace as function namespace", sec.Name)
-			} else {
-				return err
-			}
-
+			return err
+		}
+		if !exists {
+			logger.Error(nil, "secret namespace mismatch", "error", "secret must be in same namespace as function namespace",
+				"secret_name", sec.Name,
+				"secret_namespace", sec.Namespace,
+				"function_name", fn.Name,
+				"function_namespace", gp.fnNamespace)
+			return fmt.Errorf("secret %s must be in same namespace as function namespace", sec.Name)
 		}
 	}
 	// specialize pod with service

--- a/pkg/executor/executortype/poolmgr/gp_specialize_test.go
+++ b/pkg/executor/executortype/poolmgr/gp_specialize_test.go
@@ -5,11 +5,20 @@
 package poolmgr
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/utils"
@@ -89,4 +98,69 @@ func tenancyModeEnv(dynamic bool) string {
 		return "dynamic"
 	}
 	return "static"
+}
+
+// TestExistsInFnNamespace pins the cold-path pre-flight check that confirms a
+// function's Secrets/ConfigMaps live in the function namespace: it must serve
+// from the executor Manager cache (crClient) when possible, but fall back to a
+// direct API read on a cache miss so a just-created object the informer hasn't
+// observed yet is not spuriously reported missing.
+func TestExistsInFnNamespace(t *testing.T) {
+	const ns = "fn-ns"
+	configMap := func(name string) *apiv1.ConfigMap {
+		return &apiv1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name}}
+	}
+	// newGP builds a pool whose cache holds cacheObjs and whose API client holds
+	// apiObjs, so a test can place an object in only one of the two.
+	newGP := func(cacheObjs []client.Object, apiObjs ...*apiv1.ConfigMap) *GenericPool {
+		k8sObjs := make([]runtime.Object, 0, len(apiObjs))
+		for _, o := range apiObjs {
+			k8sObjs = append(k8sObjs, o)
+		}
+		return &GenericPool{
+			logger:           logr.Discard(),
+			fnNamespace:      ns,
+			crClient:         crfake.NewClientBuilder().WithScheme(clientgoscheme.Scheme).WithObjects(cacheObjs...).Build(),
+			kubernetesClient: k8sfake.NewSimpleClientset(k8sObjs...),
+		}
+	}
+	directGet := func(gp *GenericPool, name string) func(context.Context) error {
+		return func(ctx context.Context) error {
+			_, e := gp.kubernetesClient.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+			return e
+		}
+	}
+
+	t.Run("served from cache without touching the API", func(t *testing.T) {
+		// Present only in the cache: a cache hit must short-circuit the API read.
+		gp := newGP([]client.Object{configMap("in-cache")})
+		exists, err := gp.existsInFnNamespace(t.Context(), &apiv1.ConfigMap{}, "in-cache", directGet(gp, "in-cache"))
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("cache miss falls back to a direct read", func(t *testing.T) {
+		// Present only in the API client (not yet observed by the informer): the
+		// fallback must confirm it rather than report it missing.
+		gp := newGP(nil, configMap("only-in-api"))
+		exists, err := gp.existsInFnNamespace(t.Context(), &apiv1.ConfigMap{}, "only-in-api", directGet(gp, "only-in-api"))
+		require.NoError(t, err)
+		assert.True(t, exists)
+	})
+
+	t.Run("absent in both reports not found", func(t *testing.T) {
+		gp := newGP(nil)
+		exists, err := gp.existsInFnNamespace(t.Context(), &apiv1.ConfigMap{}, "ghost", directGet(gp, "ghost"))
+		require.NoError(t, err)
+		assert.False(t, exists)
+	})
+
+	t.Run("a non-not-found read error is propagated", func(t *testing.T) {
+		gp := newGP(nil)
+		boom := errors.New("apiserver unavailable")
+		exists, err := gp.existsInFnNamespace(t.Context(), &apiv1.ConfigMap{}, "x",
+			func(context.Context) error { return boom })
+		require.ErrorIs(t, err, boom)
+		assert.False(t, exists)
+	})
 }


### PR DESCRIPTION
## What

poolmgr's `doSpecializePod` confirms each function-referenced Secret/ConfigMap lives in the function namespace before calling the fetcher.
Those checks ran as direct API GETs (`gp.kubernetesClient`) on the cold path — one round-trip per secret and per configmap — even though the executor Manager already runs informers over Secrets and ConfigMaps in those namespaces.

## Change

Read through the Manager's cache-backed client (`gp.crClient`, already used for cached pod reads) via a new `existsInFnNamespace` helper, falling back to a direct API read on any cache miss or error.

- Cache hit → no API round-trip on the cold path.
- Cache miss (the informer hasn't observed a just-created object yet, or a namespace outside the cache scope) → authoritative direct read, identical to the previous behaviour, so nothing is spuriously reported missing.

No new informer, RBAC, or memory footprint — the cache already exists.

## Effect

Removes the K+M serial API round-trips (K secrets + M configmaps) from the cold-start path for functions that reference Secrets/ConfigMaps.
The benchmark's secret-less hello function doesn't exercise this path, so the smoke cold-start headline is unchanged; the win is for the common secret/configmap-using function shape.

## Tests

`TestExistsInFnNamespace` covers cache hit (no API touch), cache-miss fallback, absent-in-both, and non-not-found error propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
