### PR TITLE
test(benchmark): cold-start scenario for secret/configmap-bearing functions

### DIFF
--- a/test/benchmark/config/scenarios.default.yaml
+++ b/test/benchmark/config/scenarios.default.yaml
@@ -10,3 +10,7 @@ concurrencyLevels: [10, 50, 100, 250, 500]
 rpsLevels: [100, 250, 500, 1000]
 payloadSizes: [1024, 10240, 102400, 1048576]
 executors: [poolmgr, newdeploy]
+# Secret/ConfigMap references for the cold-start-poolmgr-configdeps scenario,
+# which measures the per-reference specialization-time existence checks.
+configDepsSecrets: 5
+configDepsConfigmaps: 5

--- a/test/benchmark/pkg/harness/resources.go
+++ b/test/benchmark/pkg/harness/resources.go
@@ -77,6 +77,13 @@ type FunctionOptions struct {
 	FunctionTimeout      int // seconds; default 60
 	MinCPU, MaxCPU       int
 	MinMemory, MaxMemory int
+
+	// Secrets/ConfigMaps name objects (in the function namespace) the function
+	// references; the caller is responsible for creating them (see
+	// Scope.CreateSecret / Scope.CreateConfigMap). They drive the executor's
+	// per-reference pre-flight existence check on the specialization path.
+	Secrets    []string
+	ConfigMaps []string
 }
 
 // CreateCodeFunction creates a literal Package and a Function referencing it,
@@ -151,11 +158,53 @@ func (s *Scope) CreateCodeFunction(ctx context.Context, o FunctionOptions) error
 			RequestsPerPod:  o.RequestsPerPod,
 		},
 	}
+	for _, name := range o.Secrets {
+		fn.Spec.Secrets = append(fn.Spec.Secrets, fv1.SecretReference{Namespace: ns, Name: name})
+	}
+	for _, name := range o.ConfigMaps {
+		fn.Spec.ConfigMaps = append(fn.Spec.ConfigMaps, fv1.ConfigMapReference{Namespace: ns, Name: name})
+	}
 	if _, err := s.env.Clients.Fission.CoreV1().Functions(ns).Create(ctx, fn, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("create function %q: %w", o.Name, err)
 	}
 	s.addCleanup("function "+o.Name, func(c context.Context) error {
 		return ignoreNotFound(s.env.Clients.Fission.CoreV1().Functions(ns).Delete(c, o.Name, metav1.DeleteOptions{}))
+	})
+	return nil
+}
+
+// CreateSecret creates an opaque Secret in the scope namespace and registers its
+// cleanup. Scenarios use it to exercise the executor's per-reference existence
+// check on the cold-start path (see FunctionOptions.Secrets).
+func (s *Scope) CreateSecret(ctx context.Context, name string, data map[string]string) error {
+	ns := s.env.Namespace
+	sec := &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Type:       apiv1.SecretTypeOpaque,
+		StringData: data,
+	}
+	if _, err := s.env.Clients.Kube.CoreV1().Secrets(ns).Create(ctx, sec, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create secret %q: %w", name, err)
+	}
+	s.addCleanup("secret "+name, func(c context.Context) error {
+		return ignoreNotFound(s.env.Clients.Kube.CoreV1().Secrets(ns).Delete(c, name, metav1.DeleteOptions{}))
+	})
+	return nil
+}
+
+// CreateConfigMap creates a ConfigMap in the scope namespace and registers its
+// cleanup (the ConfigMap counterpart to CreateSecret).
+func (s *Scope) CreateConfigMap(ctx context.Context, name string, data map[string]string) error {
+	ns := s.env.Namespace
+	cm := &apiv1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       data,
+	}
+	if _, err := s.env.Clients.Kube.CoreV1().ConfigMaps(ns).Create(ctx, cm, metav1.CreateOptions{}); err != nil {
+		return fmt.Errorf("create configmap %q: %w", name, err)
+	}
+	s.addCleanup("configmap "+name, func(c context.Context) error {
+		return ignoreNotFound(s.env.Clients.Kube.CoreV1().ConfigMaps(ns).Delete(c, name, metav1.DeleteOptions{}))
 	})
 	return nil
 }

--- a/test/benchmark/pkg/scenario/coldstart_configdeps.go
+++ b/test/benchmark/pkg/scenario/coldstart_configdeps.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scenario
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/benchmark/pkg/harness"
+	"github.com/fission/fission/test/benchmark/pkg/report"
+)
+
+// coldStartConfigDeps measures poolmgr cold-start latency for a function that
+// references several Secrets and ConfigMaps. During specialization the executor
+// runs a pre-flight existence check for each referenced Secret/ConfigMap in the
+// function namespace, so cold start pays one lookup per reference. The plain
+// cold-start scenario uses a dependency-free function and never exercises that
+// path, so a change to how those lookups are served — e.g. serving them from the
+// executor's informer cache instead of the API server — is invisible to it but
+// shows up here. Poolmgr only: the check lives in poolmgr's specialization path
+// (newdeploy handles its references on a different path).
+type coldStartConfigDeps struct {
+	iterations int
+	poolsize   int
+	secrets    int
+	configMaps int
+}
+
+func (c *coldStartConfigDeps) Name() string { return "cold-start-poolmgr-configdeps" }
+
+// Not tagged "smoke": the per-reference lookup delta is a few-ms structural
+// change that the single-sample smoke run can't resolve above its noise floor,
+// so this belongs in the repeated full/dispatch runs that feed the trend.
+func (c *coldStartConfigDeps) Tags() []string { return []string{"latency", "coldstart"} }
+
+func (c *coldStartConfigDeps) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioResult, error) {
+	var res report.ScenarioResult
+	res.SetMeta("secrets", strconv.Itoa(c.secrets))
+	res.SetMeta("configmaps", strconv.Itoa(c.configMaps))
+	env := sc.Env()
+
+	image := env.Images.Python
+	if image == "" {
+		return res, skip("PYTHON_RUNTIME_IMAGE unset")
+	}
+	if c.secrets == 0 && c.configMaps == 0 {
+		return res, skip("no secret/configmap references configured")
+	}
+
+	envName := sc.Name("cd-env")
+	if err := sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: image, Version: 1, Poolsize: c.poolsize}); err != nil {
+		return res, err
+	}
+
+	// Create the referenced Secrets/ConfigMaps once at the scenario scope; every
+	// iteration's function references the same set, so each specialization
+	// re-runs the per-reference existence checks against them.
+	secrets := make([]string, c.secrets)
+	for i := range secrets {
+		name := sc.Name("cd-secret-" + strconv.Itoa(i))
+		if err := sc.CreateSecret(ctx, name, map[string]string{"key": "value"}); err != nil {
+			return res, err
+		}
+		secrets[i] = name
+	}
+	configMaps := make([]string, c.configMaps)
+	for i := range configMaps {
+		name := sc.Name("cd-cm-" + strconv.Itoa(i))
+		if err := sc.CreateConfigMap(ctx, name, map[string]string{"key": "value"}); err != nil {
+			return res, err
+		}
+		configMaps[i] = name
+	}
+
+	if err := env.WaitForPoolReady(ctx, envName, 1, 3*time.Minute); err != nil {
+		return res, fmt.Errorf("pool warm-up: %w", err)
+	}
+
+	var samples []time.Duration
+	failures := 0
+	for i := range c.iterations {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		// Let the pool refill so each iteration measures a cold pod.
+		_ = env.WaitForPoolReady(ctx, envName, 1, 2*time.Minute)
+		if d, ok := c.measureOne(ctx, env, envName, secrets, configMaps, i); ok {
+			samples = append(samples, d)
+		} else {
+			failures++
+		}
+	}
+
+	if len(samples) == 0 {
+		return res, fmt.Errorf("no successful cold-start samples (%d failures)", failures)
+	}
+	res.Add("cold_p50", "ms", report.Lower, millis(percentile(samples, 50)))
+	res.Add("cold_p95", "ms", report.Lower, millis(percentile(samples, 95)))
+	res.Add("cold_max", "ms", report.Lower, millis(percentile(samples, 100)))
+	res.Add("samples", "count", report.Higher, float64(len(samples)))
+	res.Add("failures", "count", report.Lower, float64(failures))
+	return res, nil
+}
+
+// measureOne creates one function (referencing all the scenario's Secrets and
+// ConfigMaps) + route, measures the first successful request, and tears the pair
+// down (its own Scope) regardless of outcome.
+func (c *coldStartConfigDeps) measureOne(ctx context.Context, env *harness.Env, envName string, secrets, configMaps []string, i int) (time.Duration, bool) {
+	iter := env.NewScope(fmt.Sprintf("%s-i%d", c.Name(), i))
+	defer iter.CleanupDetached(ctx, time.Minute)
+
+	fnName := iter.Name("fn")
+	route := "/" + fnName
+	if err := iter.CreateCodeFunction(ctx, harness.FunctionOptions{
+		Name: fnName, Env: envName, Code: []byte(pythonHello), Entrypoint: "main",
+		ExecutorType: fv1.ExecutorTypePoolmgr, MinScale: 0, MaxScale: 1,
+		Secrets: secrets, ConfigMaps: configMaps,
+	}); err != nil {
+		return 0, false
+	}
+	if err := iter.CreateRoute(ctx, harness.RouteOptions{Function: fnName, URL: route}); err != nil {
+		return 0, false
+	}
+	return measureFirstSuccess(ctx, env.RouterURL()+route, 3*time.Minute)
+}

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -85,6 +85,11 @@ type Params struct {
 	PayloadSizes      []int              `json:"payloadSizes"` // bytes
 	Executors         []fv1.ExecutorType `json:"executors"`
 
+	// Number of Secrets/ConfigMaps the cold-start-poolmgr-configdeps scenario's
+	// function references, sizing the per-reference specialization-time lookups.
+	ConfigDepsSecrets    int `json:"configDepsSecrets"`
+	ConfigDepsConfigMaps int `json:"configDepsConfigmaps"`
+
 	AutoscaleMaxScale int      `json:"autoscaleMaxScale"`
 	AutoscaleObserve  Duration `json:"autoscaleObserve"`
 	IndexScaleCount   int      `json:"indexScaleCount"`
@@ -95,20 +100,22 @@ type Params struct {
 // DefaultParams returns the standard full-run parameters.
 func DefaultParams() Params {
 	return Params{
-		Poolsize:          3,
-		ColdIterations:    20,
-		WarmDuration:      Duration(60 * time.Second),
-		WarmWarmup:        Duration(10 * time.Second),
-		WarmConcurrency:   50,
-		ConcurrencyLevels: []int{10, 50, 100, 250, 500},
-		RPSLevels:         []int{100, 250, 500, 1000},
-		PayloadSizes:      []int{1 << 10, 10 << 10, 100 << 10, 1 << 20},
-		Executors:         []fv1.ExecutorType{fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy},
-		AutoscaleMaxScale: 5,
-		AutoscaleObserve:  Duration(3 * time.Minute),
-		IndexScaleCount:   1000,
-		RouteChurnCount:   500,
-		BuildTimeout:      Duration(5 * time.Minute),
+		Poolsize:             3,
+		ColdIterations:       20,
+		WarmDuration:         Duration(60 * time.Second),
+		WarmWarmup:           Duration(10 * time.Second),
+		WarmConcurrency:      50,
+		ConcurrencyLevels:    []int{10, 50, 100, 250, 500},
+		RPSLevels:            []int{100, 250, 500, 1000},
+		PayloadSizes:         []int{1 << 10, 10 << 10, 100 << 10, 1 << 20},
+		Executors:            []fv1.ExecutorType{fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy},
+		ConfigDepsSecrets:    5,
+		ConfigDepsConfigMaps: 5,
+		AutoscaleMaxScale:    5,
+		AutoscaleObserve:     Duration(3 * time.Minute),
+		IndexScaleCount:      1000,
+		RouteChurnCount:      500,
+		BuildTimeout:         Duration(5 * time.Minute),
 	}
 }
 
@@ -141,6 +148,12 @@ func (p Params) normalize() Params {
 	if len(p.Executors) == 0 {
 		p.Executors = d.Executors
 	}
+	if p.ConfigDepsSecrets == 0 {
+		p.ConfigDepsSecrets = d.ConfigDepsSecrets
+	}
+	if p.ConfigDepsConfigMaps == 0 {
+		p.ConfigDepsConfigMaps = d.ConfigDepsConfigMaps
+	}
 	if p.AutoscaleMaxScale == 0 {
 		p.AutoscaleMaxScale = d.AutoscaleMaxScale
 	}
@@ -166,6 +179,7 @@ func BuildAll(p Params) []Scenario {
 	for _, ex := range p.Executors {
 		out = append(out, &coldStart{executor: ex, iterations: p.ColdIterations, poolsize: p.Poolsize})
 	}
+	out = append(out, &coldStartConfigDeps{iterations: p.ColdIterations, poolsize: p.Poolsize, secrets: p.ConfigDepsSecrets, configMaps: p.ConfigDepsConfigMaps})
 	out = append(out, &warmPath{duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
 	out = append(out, &concurrencySweep{levels: p.ConcurrencyLevels, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), poolsize: p.Poolsize})
 	out = append(out, &rpsSweep{levels: p.RPSLevels, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), poolsize: p.Poolsize})

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -67,4 +67,26 @@ func TestParamsNormalizeFillsDefaults(t *testing.T) {
 	assert.Equal(t, 5, p.ColdIterations, "explicit value preserved")
 	assert.Equal(t, DefaultParams().Poolsize, p.Poolsize, "zero value defaulted")
 	assert.Equal(t, DefaultParams().WarmDuration, p.WarmDuration, "zero duration defaulted")
+	assert.Equal(t, DefaultParams().ConfigDepsSecrets, p.ConfigDepsSecrets, "config-deps secret count defaulted")
+	assert.Equal(t, DefaultParams().ConfigDepsConfigMaps, p.ConfigDepsConfigMaps, "config-deps configmap count defaulted")
+}
+
+// TestConfigDepsScenarioRegistered pins that the secret/configmap cold-start
+// scenario is built and is deliberately excluded from the smoke subset (its
+// few-ms per-reference delta needs the repeated full run to clear the noise
+// floor), and that it carries its configured reference counts.
+func TestConfigDepsScenarioRegistered(t *testing.T) {
+	t.Parallel()
+	all := BuildAll(DefaultParams())
+	assert.Contains(t, Names(all), "cold-start-poolmgr-configdeps")
+	assert.NotContains(t, Names(Select(all, nil, []string{"smoke"})), "cold-start-poolmgr-configdeps",
+		"config-deps scenario must stay out of the noise-sensitive smoke subset")
+
+	built := Select(BuildAll(Params{ConfigDepsSecrets: 2, ConfigDepsConfigMaps: 3}),
+		[]string{"cold-start-poolmgr-configdeps"}, nil)
+	require.Len(t, built, 1)
+	cd, ok := built[0].(*coldStartConfigDeps)
+	require.True(t, ok)
+	assert.Equal(t, 2, cd.secrets)
+	assert.Equal(t, 3, cd.configMaps)
 }


### PR DESCRIPTION
## What

Adds a benchmark scenario that exercises the executor's per-reference Secret/ConfigMap existence checks on the poolmgr specialization (cold-start) path — the path optimized by #3549, which the existing suite could not measure because every scenario used dependency-free functions.

## Scenario

`cold-start-poolmgr-configdeps` — a poolmgr cold-start whose function references N Secrets + N ConfigMaps (default 5 each, via `configDepsSecrets` / `configDepsConfigmaps`).
Each specialization re-runs the per-reference lookups, so the scenario's `cold_p50/p95/max` reflects their cost.
Reports the same distribution shape as the plain `cold-start-poolmgr` scenario.

**Not tagged `smoke`** — the per-reference delta is a few-ms structural change that the single-sample smoke run can't resolve above its noise floor (an identical-warm-path A/B swung ~36% run-to-run).
It runs in the repeated full/dispatch runs that feed the gh-pages trend, which is where the #3549 win becomes visible.

## Harness support

- `FunctionOptions.Secrets` / `.ConfigMaps` wire references onto the Function spec.
- `Scope.CreateSecret` / `Scope.CreateConfigMap` create + clean up the backing objects.

## Why

Closes the measurement gap flagged on #3549: the optimization (serving those checks from the executor informer cache instead of the API server) is real but had no scenario to track it.
With this, a full/dispatch run before-vs-after #3549 — or the weekly trend across the merge — shows the cold-start delta for secret/configmap-bearing functions.

## Tests

`TestConfigDepsScenarioRegistered` (registered, excluded from smoke, honors configured counts) + config-deps defaulting in `TestParamsNormalizeFillsDefaults`.
Lives in the separate `test/benchmark` module → no main-module impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
