### PR TITLE
fix(cli): spec apply fails to retrigger build after source change (#3427 regression)

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -668,6 +668,14 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 			// would re-apply unchanged deploy packages on every run.
 			ready := existing.Status.BuildStatus == fv1.BuildStatusSucceeded ||
 				existing.Status.BuildStatus == fv1.BuildStatusNone
+			// A source-build package that has "succeeded" but no deployment
+			// archive is in a broken state (the deploy URL was wiped by a
+			// previous spec apply). Force a re-apply so the update path can
+			// retrigger the build.
+			if ready && existing.Spec.BuildCommand != "" &&
+				!existing.Spec.Source.IsEmpty() && existing.Spec.Deployment.IsEmpty() {
+				ready = false
+			}
 			return specMatches &&
 				isObjectMetaEqual(existing.ObjectMeta, desired.ObjectMeta) &&
 				ready
@@ -690,7 +698,22 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 				console.Warn(fmt.Sprintf("Error waiting for package '%v' build, ignoring", desired.Name))
 				current = existing
 			}
-			retrigger := current.Status.BuildStatus == fv1.BuildStatusFailed
+
+			// Determine whether a build must be (re)triggered after the spec
+			// Update below. With the /status subresource the main-resource
+			// Update cannot touch BuildStatus, so we must issue a separate
+			// UpdateStatus to set it back to "pending".
+			//
+			// A retrigger is needed when:
+			//  1. The previous build failed (existing behaviour), OR
+			//  2. This is a source-build package (has a build command and
+			//     source archive). The spec Update overwrites spec.Deployment
+			//     with the empty value from the spec file, wiping the deploy
+			//     archive URL that the buildermgr wrote on the last successful
+			//     build. Without a retrigger the package would be stuck with
+			//     buildstatus=succeeded but no deploy archive.
+			retrigger := current.Status.BuildStatus == fv1.BuildStatusFailed ||
+				(desired.Spec.BuildCommand != "" && !desired.Spec.Source.IsEmpty())
 
 			// Apply the spec, re-getting on conflict: the buildermgr writes a
 			// package's build status concurrently, which can bump the
@@ -702,10 +725,10 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 			if err != nil {
 				return nil, err
 			}
-			// Re-trigger a build if the previous one failed. This is a status
-			// write; with the /status subresource it must go through
-			// UpdateStatus, separately from the spec Update above (also
-			// conflict-retried).
+			// Re-trigger a build via the /status subresource. This is
+			// separate from the spec Update above because the apiserver
+			// ignores status fields on a main-resource write when the
+			// /status subresource is enabled.
 			if retrigger {
 				if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 					live, gerr := packages(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})

--- a/pkg/fission-cli/cmd/spec/apply_test.go
+++ b/pkg/fission-cli/cmd/spec/apply_test.go
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spec
+
+import (
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// TestPackageEqual exercises the equal() closure used by applyPackages to decide
+// whether a cluster package is up-to-date with the desired spec. This covers the
+// new logic that detects source-build packages stuck with succeeded status but an
+// empty deployment archive.
+func TestPackageEqual(t *testing.T) {
+	t.Parallel()
+
+	// equal is the same closure used in applyPackages — extracted here so we
+	// can test it in isolation without a fake client.
+	equal := func(existing, desired *fv1.Package) bool {
+		specMatches := reflect.DeepEqual(existing.Spec, desired.Spec) ||
+			(reflect.DeepEqual(existing.Spec.Environment, desired.Spec.Environment) &&
+				!existing.Spec.Source.IsEmpty() &&
+				reflect.DeepEqual(existing.Spec.Source, desired.Spec.Source) &&
+				existing.Spec.BuildCommand == desired.Spec.BuildCommand)
+
+		ready := existing.Status.BuildStatus == fv1.BuildStatusSucceeded ||
+			existing.Status.BuildStatus == fv1.BuildStatusNone
+
+		if ready && existing.Spec.BuildCommand != "" &&
+			!existing.Spec.Source.IsEmpty() && existing.Spec.Deployment.IsEmpty() {
+			ready = false
+		}
+
+		return specMatches &&
+			isObjectMetaEqual(existing.ObjectMeta, desired.ObjectMeta) &&
+			ready
+	}
+
+	sourcePkg := func(buildStatus fv1.BuildStatus, deployURL string) *fv1.Package {
+		return &fv1.Package{
+			ObjectMeta: metav1.ObjectMeta{Name: "mypkg", Namespace: "default"},
+			Spec: fv1.PackageSpec{
+				Environment:  fv1.EnvironmentReference{Name: "python", Namespace: "default"},
+				Source:       fv1.Archive{URL: "http://storagesvc/src.zip"},
+				BuildCommand: "pip install -r requirements.txt",
+				Deployment:   fv1.Archive{URL: deployURL},
+			},
+			Status: fv1.PackageStatus{BuildStatus: buildStatus},
+		}
+	}
+
+	desiredSourcePkg := func() *fv1.Package {
+		return &fv1.Package{
+			ObjectMeta: metav1.ObjectMeta{Name: "mypkg", Namespace: "default"},
+			Spec: fv1.PackageSpec{
+				Environment:  fv1.EnvironmentReference{Name: "python", Namespace: "default"},
+				Source:       fv1.Archive{URL: "http://storagesvc/src.zip"},
+				BuildCommand: "pip install -r requirements.txt",
+				// Deployment is empty in the spec file — this is normal for source builds.
+			},
+		}
+	}
+
+	deployPkg := func(buildStatus fv1.BuildStatus) *fv1.Package {
+		return &fv1.Package{
+			ObjectMeta: metav1.ObjectMeta{Name: "deploypkg", Namespace: "default"},
+			Spec: fv1.PackageSpec{
+				Environment: fv1.EnvironmentReference{Name: "python", Namespace: "default"},
+				Deployment:  fv1.Archive{URL: "http://storagesvc/deploy.zip"},
+			},
+			Status: fv1.PackageStatus{BuildStatus: buildStatus},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		existing *fv1.Package
+		desired  *fv1.Package
+		want     bool
+	}{
+		{
+			name:     "source-build succeeded with deploy URL is equal (no rebuild needed)",
+			existing: sourcePkg(fv1.BuildStatusSucceeded, "http://storagesvc/deploy.zip"),
+			desired:  desiredSourcePkg(),
+			want:     true,
+		},
+		{
+			name:     "source-build succeeded but empty deploy is NOT equal (stuck state)",
+			existing: sourcePkg(fv1.BuildStatusSucceeded, ""),
+			desired:  desiredSourcePkg(),
+			want:     false,
+		},
+		{
+			name:     "source-build failed is NOT equal (needs rebuild)",
+			existing: sourcePkg(fv1.BuildStatusFailed, ""),
+			desired:  desiredSourcePkg(),
+			want:     false,
+		},
+		{
+			name:     "source-build pending is NOT equal (build in progress)",
+			existing: sourcePkg(fv1.BuildStatusPending, ""),
+			desired:  desiredSourcePkg(),
+			want:     false,
+		},
+		{
+			name:     "source-build running is NOT equal (build in progress)",
+			existing: sourcePkg(fv1.BuildStatusRunning, ""),
+			desired:  desiredSourcePkg(),
+			want:     false,
+		},
+		{
+			name:     "deploy-archive package with status none is equal",
+			existing: deployPkg(fv1.BuildStatusNone),
+			desired: &fv1.Package{
+				ObjectMeta: metav1.ObjectMeta{Name: "deploypkg", Namespace: "default"},
+				Spec: fv1.PackageSpec{
+					Environment: fv1.EnvironmentReference{Name: "python", Namespace: "default"},
+					Deployment:  fv1.Archive{URL: "http://storagesvc/deploy.zip"},
+				},
+			},
+			want: true,
+		},
+		{
+			name:     "source changed triggers update",
+			existing: sourcePkg(fv1.BuildStatusSucceeded, "http://storagesvc/deploy.zip"),
+			desired: &fv1.Package{
+				ObjectMeta: metav1.ObjectMeta{Name: "mypkg", Namespace: "default"},
+				Spec: fv1.PackageSpec{
+					Environment:  fv1.EnvironmentReference{Name: "python", Namespace: "default"},
+					Source:       fv1.Archive{URL: "http://storagesvc/src-v2.zip"}, // changed
+					BuildCommand: "pip install -r requirements.txt",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "metadata label change triggers update",
+			existing: func() *fv1.Package {
+				p := sourcePkg(fv1.BuildStatusSucceeded, "http://storagesvc/deploy.zip")
+				p.Labels = map[string]string{"version": "1"}
+				return p
+			}(),
+			desired: func() *fv1.Package {
+				p := desiredSourcePkg()
+				p.Labels = map[string]string{"version": "2"}
+				return p
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := equal(tc.existing, tc.desired)
+			if got != tc.want {
+				t.Errorf("equal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPackageRetriggerDecision exercises the retrigger logic that decides whether
+// to issue a separate UpdateStatus call to set BuildStatus=pending after the spec
+// Update. This validates the fix for the #3427 regression.
+func TestPackageRetriggerDecision(t *testing.T) {
+	t.Parallel()
+
+	// retrigger mirrors the logic in applyPackages' update closure.
+	retrigger := func(currentBuildStatus fv1.BuildStatus, desiredBuildCmd string, desiredSourceEmpty bool) bool {
+		desired := &fv1.Package{
+			Spec: fv1.PackageSpec{
+				BuildCommand: desiredBuildCmd,
+			},
+		}
+		if !desiredSourceEmpty {
+			desired.Spec.Source = fv1.Archive{URL: "http://storagesvc/src.zip"}
+		}
+		return currentBuildStatus == fv1.BuildStatusFailed ||
+			(desired.Spec.BuildCommand != "" && !desired.Spec.Source.IsEmpty())
+	}
+
+	tests := []struct {
+		name               string
+		currentBuildStatus fv1.BuildStatus
+		buildCmd           string
+		sourceEmpty        bool
+		want               bool
+	}{
+		{
+			name:               "failed build always retriggers",
+			currentBuildStatus: fv1.BuildStatusFailed,
+			buildCmd:           "",
+			sourceEmpty:        true,
+			want:               true,
+		},
+		{
+			name:               "source-build package retriggers (succeeded)",
+			currentBuildStatus: fv1.BuildStatusSucceeded,
+			buildCmd:           "make",
+			sourceEmpty:        false,
+			want:               true,
+		},
+		{
+			name:               "source-build package retriggers (pending)",
+			currentBuildStatus: fv1.BuildStatusPending,
+			buildCmd:           "make",
+			sourceEmpty:        false,
+			want:               true,
+		},
+		{
+			name:               "deploy-only package does NOT retrigger (succeeded)",
+			currentBuildStatus: fv1.BuildStatusSucceeded,
+			buildCmd:           "",
+			sourceEmpty:        true,
+			want:               false,
+		},
+		{
+			name:               "deploy-only package does NOT retrigger (none)",
+			currentBuildStatus: fv1.BuildStatusNone,
+			buildCmd:           "",
+			sourceEmpty:        true,
+			want:               false,
+		},
+		{
+			name:               "has build command but empty source does NOT retrigger",
+			currentBuildStatus: fv1.BuildStatusSucceeded,
+			buildCmd:           "make",
+			sourceEmpty:        true,
+			want:               false,
+		},
+		{
+			name:               "has source but no build command does NOT retrigger",
+			currentBuildStatus: fv1.BuildStatusSucceeded,
+			buildCmd:           "",
+			sourceEmpty:        false,
+			want:               false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := retrigger(tc.currentBuildStatus, tc.buildCmd, tc.sourceEmpty)
+			if got != tc.want {
+				t.Errorf("retrigger() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`fission spec apply` breaks source-build packages on the second and subsequent deploys when source changes.

When the CLI updates a source-build package, it overwrites `spec.Deployment` with `{checksum: {}}` from the spec file, wiping the deploy archive URL that the buildermgr wrote on the previous successful build. Prior to #3427 (Package /status subresource), the old code set `BuildStatus = pending` in the same `Update` call, which immediately triggered a rebuild. After #3427, the `/status` subresource means the API server silently strips status fields from a main-resource Update, so `BuildStatus` stays at `succeeded` and the buildermgr never rebuilds.

The result is pods crash-looping with `"failed to download url from archive: empty URL"` from the fetcher.

**The fix has two parts:**

1. **Update path**: Always retrigger (set `BuildStatus=pending` via `UpdateStatus`) for source-build packages (non-empty source + build command), not only when `BuildStatus==failed`.

2. **Equality check**: Treat a source-build package with an empty `spec.Deployment` as not-ready even if `BuildStatus==succeeded`. This handles packages left in a stuck state by a previous broken deploy — the CLI will re-apply and retrigger the build.

## Which issue(s) this PR fixes:

Fixes regression introduced in #3427

## Testing

- Deployed a multi-function Fission application (6 source-build packages) using `fission spec apply --wait --delete=true` against a v1.27.0 cluster.
- Without the fix: all packages show `buildstatus: succeeded` with empty `spec.deployment.url` after source changes. Pods fail readiness probes (fetcher: "empty URL"). Verified via `kubectl get packages -o jsonpath` and `kubectl logs` on the fetcher container.
- With the fix: all packages rebuild after `spec apply`, deploy archive URLs are populated, pods start 2/2 healthy.
- Verified idempotency: re-running `spec apply` with no source changes does not trigger unnecessary rebuilds (the `equal()` function correctly identifies packages as up-to-date when both source matches and deploy URL is present).
- Tested the stuck-state recovery: packages previously left with `buildstatus: succeeded` but no deploy URL are correctly detected as not-ready and rebuilt on the next `spec apply`.

## Checklist:

- [ ] I ran tests as well as code linting locally to verify my changes.
- [x] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ ] My changes follow contributing guidelines of Fission.
- [ ] I have signed all of my commits.
