### PR TITLE
Add helm Values.router.svcLabels feature

### DIFF
--- a/charts/fission-all/templates/router/svc.yaml
+++ b/charts/fission-all/templates/router/svc.yaml
@@ -7,7 +7,7 @@ metadata:
     application: fission-router
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     {{- if .Values.router.svcLabels }}
-    {{- toYaml .Values.router.svcLabels | nindent 4 }}
+    {{- toYaml (omit .Values.router.svcLabels "svc" "application" "chart") | nindent 4 }}
     {{- end }}
 {{- if .Values.router.svcAnnotations }}
   annotations:

--- a/charts/fission-all/templates/router/svc.yaml
+++ b/charts/fission-all/templates/router/svc.yaml
@@ -6,6 +6,9 @@ metadata:
     svc: router
     application: fission-router
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- if .Values.router.svcLabels }}
+    {{- toYaml .Values.router.svcLabels | nindent 4 }}
+    {{- end }}
 {{- if .Values.router.svcAnnotations }}
   annotations:
 {{ toYaml .Values.router.svcAnnotations | indent 4 }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -436,6 +436,10 @@ router:
   ## router resource utilization when under heavy workloads.
   ##
   displayAccessLog: false
+  ## svcLabels is the labels to be added to the service resource created for router.
+  ##
+  # svcLabels:
+  #   cloud.google.com/load-balancer-type: Internal
   ## svcAnnotations is the annotations to be added to the service resource created for router.
   ##
   # svcAnnotations:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -436,10 +436,11 @@ router:
   ## router resource utilization when under heavy workloads.
   ##
   displayAccessLog: false
-  ## svcLabels is the labels to be added to the service resource created for router.
+  ## svcLabels is a map of custom labels to add to the router Service metadata.
+  ## Note: avoid overriding reserved keys: svc, application, chart.
   ##
   # svcLabels:
-  #   cloud.google.com/load-balancer-type: Internal
+  #   example.com/custom-label: "true"
   ## svcAnnotations is the annotations to be added to the service resource created for router.
   ##
   # svcAnnotations:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! We request you provide detailed description as much as possible. -->

## Description
Some CNI providers like CIlium use labels and not annotations to match against for applying a LoadBalancer IP. This pr adds in the ability to add custom labels to the router LoadBalancer service .

## Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #3557 `
-->
Fixes #3557

## Testing
Used helm templating commands to verify that a values file containing labels for the router service were applied in the rendered template
```
router:
  svcLabels:
    asdf: jkl
```

## Checklist:
<!-- Please tick following checkboxes as per your understanding. -->
- [x ] I ran tests as well as code linting locally to verify my changes. 
- [x ] I have done manual verification of my changes, changes working as expected.
- [ ] I have added new tests to cover my changes.
- [ x] My changes follow contributing guidelines of Fission.
- [ x] I have signed all of my commits.
