### PR TITLE
perf: benchmark-driven wave 2 — cold start, warm start, RPS instruments + levers

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -379,11 +379,10 @@ jobs:
           fail_ci_if_error: false
 
       # github-action-benchmark stores each run on gh-pages and draws a chart;
-      # one direction per file, one series per fission version. Pinned to a
-      # version tag — run bump-ci-tool-versions to SHA-pin before merge.
+      # one direction per file, one series per fission version.
       - name: Publish latency trend (lower is better)
         if: ${{ env.BM_PUBLISH_TREND == 'true' }}
-        uses: benchmark-action/github-action-benchmark@v1 # TODO: SHA-pin (bump-ci-tool-versions)
+        uses: benchmark-action/github-action-benchmark@fd31771ce86cc65eab85653da103f71ab1b4479c # v1.9.0
         with:
           name: "Fission latency (${{ matrix.fission_version }})"
           tool: customSmallerIsBetter
@@ -398,7 +397,7 @@ jobs:
 
       - name: Publish throughput trend (higher is better)
         if: ${{ env.BM_PUBLISH_TREND == 'true' }}
-        uses: benchmark-action/github-action-benchmark@v1 # TODO: SHA-pin (bump-ci-tool-versions)
+        uses: benchmark-action/github-action-benchmark@fd31771ce86cc65eab85653da103f71ab1b4479c # v1.9.0
         with:
           name: "Fission throughput (${{ matrix.fission_version }})"
           tool: customBiggerIsBetter

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -24,6 +24,10 @@ on:
         description: "warm-path concurrency (default: scenario config)"
         default: ""
         type: string
+      repetitions:
+        description: "re-run each scenario N times, report medians (default: 1)"
+        default: ""
+        type: string
       publish_trend:
         description: "publish results to the gh-pages trend"
         default: true
@@ -208,6 +212,7 @@ jobs:
               echo "BM_SCENARIOS=${{ inputs.scenarios }}" >> "$GITHUB_ENV"
               echo "BM_DURATION=${{ inputs.duration }}" >> "$GITHUB_ENV"
               echo "BM_CONCURRENCY=${{ inputs.concurrency }}" >> "$GITHUB_ENV"
+              echo "BM_REPETITIONS=${{ inputs.repetitions }}" >> "$GITHUB_ENV"
               echo "BM_FAIL_ON_BREACH=true" >> "$GITHUB_ENV"
               echo "BM_PUBLISH_TREND=${{ inputs.publish_trend }}" >> "$GITHUB_ENV"
               ;;
@@ -333,7 +338,8 @@ jobs:
             ${BM_TAGS:+--tags "$BM_TAGS"} \
             ${BM_DURATION:+--duration "$BM_DURATION"} \
             ${BM_CONCURRENCY:+--concurrency "$BM_CONCURRENCY"} \
-            ${BM_COLD_ITERATIONS:+--cold-iterations "$BM_COLD_ITERATIONS"}
+            ${BM_COLD_ITERATIONS:+--cold-iterations "$BM_COLD_ITERATIONS"} \
+            ${BM_REPETITIONS:+--repetitions "$BM_REPETITIONS"}
 
       - name: Report and gate
         run: |

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -133,11 +133,8 @@ func main() {
 	// Initialize logger
 	logger := loggerfactory.GetLogger()
 
-	// GOMAXPROCS is deliberately left to the runtime: since Go 1.25 it is
-	// already derived from the cgroup CPU limit (rounded up, floor 2) and
-	// re-evaluated on in-place pod resize. Do not add automaxprocs here — its
-	// Set() floors fractional quotas to 1 and permanently disables the
-	// runtime's dynamic tracking, both strictly worse.
+	// GOMAXPROCS is left to the runtime: Go ≥1.25 derives it from the cgroup
+	// CPU quota (including on in-place resize); automaxprocs would regress that.
 
 	// ctrl.SetLogger targets controller-runtime's process-global logger. Set it
 	// once here, before any subsystem's Start builds its manager, so every

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
+	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/sync/errgroup"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -132,6 +133,17 @@ func main() {
 
 	// Initialize logger
 	logger := loggerfactory.GetLogger()
+
+	// Match GOMAXPROCS to the container's cgroup CPU quota. The Go default is
+	// the node's core count, so under a CPU limit the runtime schedules more
+	// OS threads than the quota allows and the kernel throttles them —
+	// surfacing as tail latency on the router/executor hot paths. No-op when
+	// no limit is set.
+	if _, err := maxprocs.Set(maxprocs.Logger(func(format string, args ...any) {
+		logger.Info(fmt.Sprintf(format, args...))
+	})); err != nil {
+		logger.Error(err, "failed to adjust GOMAXPROCS to cpu quota")
+	}
 
 	// ctrl.SetLogger targets controller-runtime's process-global logger. Set it
 	// once here, before any subsystem's Start builds its manager, so every

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -11,7 +11,6 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
-	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/sync/errgroup"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -134,16 +133,11 @@ func main() {
 	// Initialize logger
 	logger := loggerfactory.GetLogger()
 
-	// Match GOMAXPROCS to the container's cgroup CPU quota. The Go default is
-	// the node's core count, so under a CPU limit the runtime schedules more
-	// OS threads than the quota allows and the kernel throttles them —
-	// surfacing as tail latency on the router/executor hot paths. No-op when
-	// no limit is set.
-	if _, err := maxprocs.Set(maxprocs.Logger(func(format string, args ...any) {
-		logger.Info(fmt.Sprintf(format, args...))
-	})); err != nil {
-		logger.Error(err, "failed to adjust GOMAXPROCS to cpu quota")
-	}
+	// GOMAXPROCS is deliberately left to the runtime: since Go 1.25 it is
+	// already derived from the cgroup CPU limit (rounded up, floor 2) and
+	// re-evaluated on in-place pod resize. Do not add automaxprocs here — its
+	// Set() floors fractional quotas to 1 and permanently disables the
+	// runtime's dynamic tracking, both strictly worse.
 
 	// ctrl.SetLogger targets controller-runtime's process-global logger. Set it
 	// once here, before any subsystem's Start builds its manager, so every

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,6 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/net v0.56.0

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
+	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.28.0
 	golang.org/x/net v0.56.0

--- a/go.sum
+++ b/go.sum
@@ -411,6 +411,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -551,6 +553,8 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
+go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
+go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/go.sum
+++ b/go.sum
@@ -411,8 +411,6 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
-github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -553,8 +551,6 @@ go.opentelemetry.io/otel/trace v1.44.0 h1:jxF5CsGYCe74MCRx2X4g7WsY/VBKRqqpNvXlX/
 go.opentelemetry.io/otel/trace v1.44.0/go.mod h1:oLl1jrMQAVo6v3GAggN+1VH9VIz9iUSvW53sW1Q8PIE=
 go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpuCSL2g=
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
-go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
-go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -843,13 +843,23 @@ func (gpm *GenericPoolManager) processReplicaSet(ctx context.Context, rs *appsv1
 	gpm.poolPodC.processRS(ctx, rs)
 }
 
+// readyPodEnqueueDelay debounces a warm pod's entry into its readyPodQueue.
+// The 2021-era value was 100ms (#1890, an informer-settle guard with no stated
+// derivation); today choosePod re-reads the pod from the cache and claims it
+// with a verified relabel patch, and a pod dequeued too early lands on the
+// not-ready requeue path (expoDelay backoff) and self-corrects — so the delay
+// only needs to cover the common cache-settle case, not guarantee it. Every
+// 10ms here is 10ms of pool-refill latency added to each queued cold start
+// once the pool is exhausted (visible in the cold-burst benchmark scenarios).
+const readyPodEnqueueDelay = 10 * time.Millisecond
+
 // enqueueReadyPod adds a warm pod's key to its pool's readyPodQueue (looked up
 // by pool key — env UID, plus image hash for per-image pools). Driven by the
 // readyPod reconciler. A pool that no longer exists (race with destroy) is
 // simply skipped — its queue is gone and choosePod won't run.
 func (gpm *GenericPoolManager) enqueueReadyPod(queueKey, podKey string) {
 	if q, ok := gpm.readyPodQueues.Load(queueKey); ok {
-		q.(workqueue.TypedDelayingInterface[string]).AddAfter(podKey, 100*time.Millisecond)
+		q.(workqueue.TypedDelayingInterface[string]).AddAfter(podKey, readyPodEnqueueDelay)
 	}
 }
 
@@ -899,7 +909,7 @@ func (gpm *GenericPoolManager) seedReadyPodQueue(ctx context.Context, env *fv1.E
 		if err != nil {
 			continue
 		}
-		queue.AddAfter(key, 100*time.Millisecond)
+		queue.AddAfter(key, readyPodEnqueueDelay)
 	}
 }
 

--- a/pkg/executor/util/deployment.go
+++ b/pkg/executor/util/deployment.go
@@ -47,6 +47,21 @@ func ScaleDeployment(ctx context.Context, kubeClient kubernetes.Interface, logge
 	return err
 }
 
+// waitPollInitialDelay/waitPollMaxDelay shape WaitForDeployment's adaptive
+// poll: scale-from-zero deployments usually become available well under a
+// second, so polling starts fine-grained and backs off ×1.5 to the old 1s
+// interval — a fixed 1s tick quantized every newdeploy/container cold start
+// up to a full second.
+const (
+	waitPollInitialDelay = 50 * time.Millisecond
+	waitPollMaxDelay     = time.Second
+)
+
+// nextWaitPollDelay returns the poll interval following cur.
+func nextWaitPollDelay(cur time.Duration) time.Duration {
+	return min(cur*3/2, waitPollMaxDelay)
+}
+
 // WaitForDeployment polls the deployment until it has at least replicas
 // AvailableReplicas, or until specializationTimeout seconds elapse. Shared by
 // the newdeploy and container managers. specializationTimeout is floored at
@@ -62,12 +77,12 @@ func WaitForDeployment(ctx context.Context, kubeClient kubernetes.Interface, log
 
 	logger = otelUtils.LoggerWithTraceID(ctx, logger)
 
-	// A single Ticker keeps the 1s poll interval without allocating a timer per
-	// iteration (the loop runs up to specializationTimeout times).
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	// The timeout is a wall-clock deadline (the poll interval varies, so an
+	// iteration count would silently shrink or stretch it).
+	deadline := time.Now().Add(time.Duration(specializationTimeout) * time.Second)
+	delay := waitPollInitialDelay
 
-	for i := 0; i < specializationTimeout; i++ {
+	for {
 		latestDepl, err = kubeClient.AppsV1().Deployments(depl.ObjectMeta.Namespace).Get(ctx, depl.Name, metav1.GetOptions{})
 		if err != nil {
 			return nil, err
@@ -77,14 +92,19 @@ func WaitForDeployment(ctx context.Context, kubeClient kubernetes.Interface, log
 			otelUtils.SpanTrackEvent(ctx, "deploymentAvailable", otelUtils.GetAttributesForDeployment(latestDepl)...)
 			return latestDepl, err
 		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			break
+		}
 		// Wait before the next poll, but stay responsive to cancellation
-		// (executor shutdown / loss of leadership) instead of blocking for a
-		// full second.
+		// (executor shutdown / loss of leadership) instead of blocking for the
+		// full interval.
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-ticker.C:
+		case <-time.After(min(delay, remaining)):
 		}
+		delay = nextWaitPollDelay(delay)
 	}
 
 	logger.Error(nil, "Deployment provision failed within timeout window", "name", latestDepl.Name, "old_status", oldStatus,

--- a/pkg/executor/util/deployment.go
+++ b/pkg/executor/util/deployment.go
@@ -81,6 +81,10 @@ func WaitForDeployment(ctx context.Context, kubeClient kubernetes.Interface, log
 	// iteration count would silently shrink or stretch it).
 	deadline := time.Now().Add(time.Duration(specializationTimeout) * time.Second)
 	delay := waitPollInitialDelay
+	// One reusable timer across polls (Reset is safe on Go ≥1.23 timers)
+	// instead of a time.After allocation per iteration.
+	timer := time.NewTimer(time.Hour)
+	defer timer.Stop()
 
 	for {
 		latestDepl, err = kubeClient.AppsV1().Deployments(depl.ObjectMeta.Namespace).Get(ctx, depl.Name, metav1.GetOptions{})
@@ -99,10 +103,11 @@ func WaitForDeployment(ctx context.Context, kubeClient kubernetes.Interface, log
 		// Wait before the next poll, but stay responsive to cancellation
 		// (executor shutdown / loss of leadership) instead of blocking for the
 		// full interval.
+		timer.Reset(min(delay, remaining))
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case <-time.After(min(delay, remaining)):
+		case <-timer.C:
 		}
 		delay = nextWaitPollDelay(delay)
 	}

--- a/pkg/executor/util/deployment_test.go
+++ b/pkg/executor/util/deployment_test.go
@@ -7,6 +7,7 @@ package util
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -177,4 +178,21 @@ func TestWaitForDeployment(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, got)
 	})
+}
+
+func TestNextWaitPollDelay(t *testing.T) {
+	t.Parallel()
+	// ×1.5 growth from the initial delay, capped at the old fixed interval.
+	assert.Equal(t, 75*time.Millisecond, nextWaitPollDelay(waitPollInitialDelay))
+	assert.Equal(t, waitPollMaxDelay, nextWaitPollDelay(900*time.Millisecond))
+	assert.Equal(t, waitPollMaxDelay, nextWaitPollDelay(waitPollMaxDelay))
+	// The schedule reaches its cap quickly, bounding the extra apiserver GETs
+	// an adaptive poll adds over the old 1/s: ~9 in the first ~5s of a wait.
+	d, polls := waitPollInitialDelay, 0
+	for elapsed := time.Duration(0); d < waitPollMaxDelay; polls++ {
+		elapsed += d
+		d = nextWaitPollDelay(d)
+		require.Less(t, elapsed, 6*time.Second)
+	}
+	assert.LessOrEqual(t, polls, 10)
 }

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -749,38 +749,10 @@ func (fetcher *Fetcher) rename(src string, dst string) error {
 	return nil
 }
 
-// pkgNotFoundRetrySchedule is the sleep sequence for the apiserver
-// create-then-get race (a Package created moments ago can still 404). The
-// first hits are cheap (the race usually resolves within tens of ms) while
-// the summed window (≥550ms) covers at least the previous schedule's 500ms.
-var pkgNotFoundRetrySchedule = []time.Duration{
-	10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond,
-	80 * time.Millisecond, 100 * time.Millisecond, 100 * time.Millisecond,
-	100 * time.Millisecond, 100 * time.Millisecond,
-}
-
-// pkgDialRetrySchedule is the sleep sequence for connection errors on the
-// package Get. It exists for istio: envoy blocks all outbound requests during
-// the pod's first seconds, so these waits stay deliberately coarse.
-// For details, see https://github.com/istio/istio/issues/12187
-var pkgDialRetrySchedule = []time.Duration{
-	500 * time.Millisecond, 1000 * time.Millisecond,
-	1500 * time.Millisecond, 2000 * time.Millisecond,
-}
-
-// pkgTransientRetrySchedule is the sleep sequence for every other Get error
-// (apiserver timeouts, connection resets, 429/5xx). The pre-reshape loop
-// retried any error up to 4 more times back-to-back; keep that resilience but
-// space the attempts out instead of hot-looping.
-var pkgTransientRetrySchedule = []time.Duration{
-	50 * time.Millisecond, 100 * time.Millisecond,
-	200 * time.Millisecond, 400 * time.Millisecond,
-}
-
 // getPkgInformation gets package information from k8s api server.
 func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetchRequest) (pkg *fv1.Package, err error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
-	// Each error class consumes its own schedule; when a class's slice is
+	// Each error class consumes its own schedule; when a class's schedule is
 	// empty its budget is spent and the error is returned.
 	notFound, dial, transient := pkgNotFoundRetrySchedule, pkgDialRetrySchedule, pkgTransientRetrySchedule
 	for attempt := 0; ; attempt++ {
@@ -797,22 +769,21 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 			}
 			return pkg, nil
 		}
-		if ctx.Err() != nil {
-			return nil, err
-		}
+		// Classify, then consume from that class's schedule only.
+		sched := &transient
 		switch netErr := network.Adapter(err); {
-		case k8serr.IsNotFound(err) && len(notFound) > 0:
-			time.Sleep(notFound[0])
-			notFound = notFound[1:]
-		case netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) && len(dial) > 0:
-			time.Sleep(dial[0])
-			dial = dial[1:]
-		case !k8serr.IsNotFound(err) && len(transient) > 0:
-			time.Sleep(transient[0])
-			transient = transient[1:]
-		default:
+		case k8serr.IsNotFound(err):
+			sched = &notFound
+		case netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()):
+			sched = &dial
+		}
+		if len(*sched) == 0 {
 			return nil, err
 		}
+		if !sleepCtx(ctx, (*sched)[0]) {
+			return nil, err
+		}
+		*sched = (*sched)[1:]
 	}
 }
 
@@ -886,7 +857,9 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 				if attempt%20 == 0 {
 					logger.Error(netErr, "error connecting to function environment pod for specialization request, retrying")
 				}
-				time.Sleep(envSpecializeRetryDelay(attempt))
+				if !sleepCtx(ctx, envSpecializeRetryDelay(attempt)) {
+					return http.StatusInternalServerError, fmt.Errorf("error specializing function pod: %w", ctx.Err())
+				}
 				continue
 			}
 		}
@@ -902,24 +875,6 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		}
 		return statusCode, fmt.Errorf("error specializing function pod: %w", err)
 	}
-}
-
-// envSpecializeWaitBudget bounds the total wall-clock time SpecializePod waits
-// for the environment container's server to start accepting connections. It
-// covers (with margin) the previous schedule's ~406s worst case, so slow-image
-// environments that survived before still do.
-const envSpecializeWaitBudget = 7 * time.Minute
-
-// envSpecializeRetryDelay returns the sleep before conn-refused retry attempt
-// i (0-based) of the env-specialize wait: 25ms doubling to a 500ms cap. Env
-// servers typically bind tens of milliseconds after the fetcher's first POST;
-// the previous 500*2i ms ramp made that common case cost a full second.
-func envSpecializeRetryDelay(i int) time.Duration {
-	const base, maxDelay = 25 * time.Millisecond, 500 * time.Millisecond
-	if i >= 5 {
-		return maxDelay // 25ms<<5 already exceeds the cap (and huge i would overflow the shift)
-	}
-	return base << i
 }
 
 // WsStartHandler is used to generate websocket events in Kubernetes

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -808,9 +808,6 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 			time.Sleep(dial[0])
 			dial = dial[1:]
 		case !k8serr.IsNotFound(err) && len(transient) > 0:
-			// Any other error class (timeout, reset, throttle) gets the
-			// transient schedule — a single apiserver hiccup must not fail the
-			// cold start.
 			time.Sleep(transient[0])
 			transient = transient[1:]
 		default:
@@ -922,7 +919,7 @@ func envSpecializeRetryDelay(i int) time.Duration {
 	if i >= 5 {
 		return maxDelay // 25ms<<5 already exceeds the cap (and huge i would overflow the shift)
 	}
-	return base << i // 25ms<<4 = 400ms, still under the cap
+	return base << i
 }
 
 // WsStartHandler is used to generate websocket events in Kubernetes

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -780,7 +780,9 @@ var pkgTransientRetrySchedule = []time.Duration{
 // getPkgInformation gets package information from k8s api server.
 func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetchRequest) (pkg *fv1.Package, err error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
-	notFound, dial, transient := 0, 0, 0
+	// Each error class consumes its own schedule; when a class's slice is
+	// empty its budget is spent and the error is returned.
+	notFound, dial, transient := pkgNotFoundRetrySchedule, pkgDialRetrySchedule, pkgTransientRetrySchedule
 	for attempt := 0; ; attempt++ {
 		otelUtils.SpanTrackEvent(ctx, "fetchPkgInfo", otelUtils.MapToAttributes(map[string]string{
 			"package_name":      req.Package.Name,
@@ -799,18 +801,18 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 			return nil, err
 		}
 		switch netErr := network.Adapter(err); {
-		case k8serr.IsNotFound(err) && notFound < len(pkgNotFoundRetrySchedule):
-			time.Sleep(pkgNotFoundRetrySchedule[notFound])
-			notFound++
-		case netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) && dial < len(pkgDialRetrySchedule):
-			time.Sleep(pkgDialRetrySchedule[dial])
-			dial++
-		case !k8serr.IsNotFound(err) && transient < len(pkgTransientRetrySchedule):
+		case k8serr.IsNotFound(err) && len(notFound) > 0:
+			time.Sleep(notFound[0])
+			notFound = notFound[1:]
+		case netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) && len(dial) > 0:
+			time.Sleep(dial[0])
+			dial = dial[1:]
+		case !k8serr.IsNotFound(err) && len(transient) > 0:
 			// Any other error class (timeout, reset, throttle) gets the
 			// transient schedule — a single apiserver hiccup must not fail the
 			// cold start.
-			time.Sleep(pkgTransientRetrySchedule[transient])
-			transient++
+			time.Sleep(transient[0])
+			transient = transient[1:]
 		default:
 			return nil, err
 		}
@@ -918,13 +920,9 @@ const envSpecializeWaitBudget = 7 * time.Minute
 func envSpecializeRetryDelay(i int) time.Duration {
 	const base, maxDelay = 25 * time.Millisecond, 500 * time.Millisecond
 	if i >= 5 {
-		return maxDelay // 25ms<<5 already exceeds the cap
+		return maxDelay // 25ms<<5 already exceeds the cap (and huge i would overflow the shift)
 	}
-	d := base << i
-	if d > maxDelay {
-		return maxDelay
-	}
-	return d
+	return base << i // 25ms<<4 = 400ms, still under the cap
 }
 
 // WsStartHandler is used to generate websocket events in Kubernetes

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -749,15 +749,34 @@ func (fetcher *Fetcher) rename(src string, dst string) error {
 	return nil
 }
 
+// pkgNotFoundRetrySchedule is the sleep sequence for the apiserver
+// create-then-get race (a Package created moments ago can still 404). The
+// first hits are cheap (the race usually resolves within tens of ms) while
+// the summed window (≥550ms) covers at least the previous schedule's 500ms.
+var pkgNotFoundRetrySchedule = []time.Duration{
+	10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond,
+	80 * time.Millisecond, 100 * time.Millisecond, 100 * time.Millisecond,
+	100 * time.Millisecond, 100 * time.Millisecond,
+}
+
+// pkgDialRetrySchedule is the sleep sequence for connection errors on the
+// package Get. It exists for istio: envoy blocks all outbound requests during
+// the pod's first seconds, so these waits stay deliberately coarse.
+// For details, see https://github.com/istio/istio/issues/12187
+var pkgDialRetrySchedule = []time.Duration{
+	500 * time.Millisecond, 1000 * time.Millisecond,
+	1500 * time.Millisecond, 2000 * time.Millisecond,
+}
+
 // getPkgInformation gets package information from k8s api server.
 func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetchRequest) (pkg *fv1.Package, err error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
-	maxRetries := 5
-	for i := range maxRetries {
+	notFound, dial := 0, 0
+	for attempt := 0; ; attempt++ {
 		otelUtils.SpanTrackEvent(ctx, "fetchPkgInfo", otelUtils.MapToAttributes(map[string]string{
 			"package_name":      req.Package.Name,
 			"package_namespace": req.Package.Namespace,
-			"retry_count":       strconv.Itoa(i),
+			"retry_count":       strconv.Itoa(attempt),
 		})...)
 		// TODO: pass resource version in the GetOptions, added warning for now
 		pkg, err = fetcher.fissionClient.CoreV1().Packages(req.Package.Namespace).Get(ctx, req.Package.Name, metav1.GetOptions{})
@@ -767,27 +786,18 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 			}
 			return pkg, nil
 		}
-		if i < maxRetries-1 {
-			// In some cases, creating a package and querying the package info
-			// immediately, the Kubernetes API server will return "not found"
-			// error. So retry the query again after some time.
-
-			if k8serr.IsNotFound(err) {
-				time.Sleep(50 * time.Duration(i+1) * time.Millisecond)
-				continue
-			}
-
-			// All outbound requests are blocked if istio is enabled at the first seconds.
-			// So if an error is a "connection refused" or "dial" error, wait for a while
-			// before retrying so that envoy proxy will start to serve requests.
-			// For details, see https://github.com/istio/istio/issues/12187
-			netErr := network.Adapter(err)
-			if netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) {
-				time.Sleep(500 * time.Duration(i+1) * time.Millisecond)
-			}
+		if k8serr.IsNotFound(err) && notFound < len(pkgNotFoundRetrySchedule) {
+			time.Sleep(pkgNotFoundRetrySchedule[notFound])
+			notFound++
+			continue
 		}
+		if netErr := network.Adapter(err); netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) && dial < len(pkgDialRetrySchedule) {
+			time.Sleep(pkgDialRetrySchedule[dial])
+			dial++
+			continue
+		}
+		return nil, err
 	}
-	return nil, err
 }
 
 func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetchRequest, loadReq FunctionLoadRequest) (int, error) {
@@ -815,7 +825,6 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 
 	// Specialize the pod
 
-	maxRetries := 30
 	var contentType string
 	var specializeURL string
 	var reader *bytes.Reader
@@ -840,7 +849,8 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		logger.Info("calling environment v1 specialization endpoint")
 	}
 
-	for i := range maxRetries {
+	deadline := time.Now().Add(envSpecializeWaitBudget)
+	for attempt := 0; ; attempt++ {
 		otelUtils.SpanTrackEvent(ctx, "specializeCall", otelUtils.MapToAttributes(map[string]string{
 			"url": specializeURL,
 		})...)
@@ -854,9 +864,13 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		netErr := network.Adapter(err)
 		// Only retry for the specific case of a connection error.
 		if netErr != nil && (netErr.IsConnRefusedError() || netErr.IsDialError()) {
-			if i < maxRetries-1 {
-				time.Sleep(500 * time.Duration(2*i) * time.Millisecond)
-				logger.Error(netErr, "error connecting to function environment pod for specialization request, retrying")
+			if ctx.Err() == nil && time.Now().Before(deadline) {
+				// Retries are frequent now, so log the wait once per ~10s of
+				// capped delay instead of once per attempt.
+				if attempt%20 == 0 {
+					logger.Error(netErr, "error connecting to function environment pod for specialization request, retrying")
+				}
+				time.Sleep(envSpecializeRetryDelay(attempt))
 				continue
 			}
 		}
@@ -872,8 +886,28 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		}
 		return statusCode, fmt.Errorf("error specializing function pod: %w", err)
 	}
+}
 
-	return http.StatusInternalServerError, fmt.Errorf("error specializing function pod after %v times: %w", maxRetries, err)
+// envSpecializeWaitBudget bounds the total wall-clock time SpecializePod waits
+// for the environment container's server to start accepting connections. It
+// covers (with margin) the previous schedule's ~406s worst case, so slow-image
+// environments that survived before still do.
+const envSpecializeWaitBudget = 7 * time.Minute
+
+// envSpecializeRetryDelay returns the sleep before conn-refused retry attempt
+// i (0-based) of the env-specialize wait: 25ms doubling to a 500ms cap. Env
+// servers typically bind tens of milliseconds after the fetcher's first POST;
+// the previous 500*2i ms ramp made that common case cost a full second.
+func envSpecializeRetryDelay(i int) time.Duration {
+	const base, maxDelay = 25 * time.Millisecond, 500 * time.Millisecond
+	if i >= 5 {
+		return maxDelay // 25ms<<5 already exceeds the cap
+	}
+	d := base << i
+	if d > maxDelay {
+		return maxDelay
+	}
+	return d
 }
 
 // WsStartHandler is used to generate websocket events in Kubernetes

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -768,10 +768,19 @@ var pkgDialRetrySchedule = []time.Duration{
 	1500 * time.Millisecond, 2000 * time.Millisecond,
 }
 
+// pkgTransientRetrySchedule is the sleep sequence for every other Get error
+// (apiserver timeouts, connection resets, 429/5xx). The pre-reshape loop
+// retried any error up to 4 more times back-to-back; keep that resilience but
+// space the attempts out instead of hot-looping.
+var pkgTransientRetrySchedule = []time.Duration{
+	50 * time.Millisecond, 100 * time.Millisecond,
+	200 * time.Millisecond, 400 * time.Millisecond,
+}
+
 // getPkgInformation gets package information from k8s api server.
 func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetchRequest) (pkg *fv1.Package, err error) {
 	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
-	notFound, dial := 0, 0
+	notFound, dial, transient := 0, 0, 0
 	for attempt := 0; ; attempt++ {
 		otelUtils.SpanTrackEvent(ctx, "fetchPkgInfo", otelUtils.MapToAttributes(map[string]string{
 			"package_name":      req.Package.Name,
@@ -786,17 +795,25 @@ func (fetcher *Fetcher) getPkgInformation(ctx context.Context, req FunctionFetch
 			}
 			return pkg, nil
 		}
-		if k8serr.IsNotFound(err) && notFound < len(pkgNotFoundRetrySchedule) {
+		if ctx.Err() != nil {
+			return nil, err
+		}
+		switch netErr := network.Adapter(err); {
+		case k8serr.IsNotFound(err) && notFound < len(pkgNotFoundRetrySchedule):
 			time.Sleep(pkgNotFoundRetrySchedule[notFound])
 			notFound++
-			continue
-		}
-		if netErr := network.Adapter(err); netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) && dial < len(pkgDialRetrySchedule) {
+		case netErr != nil && (netErr.IsDialError() || netErr.IsConnRefusedError()) && dial < len(pkgDialRetrySchedule):
 			time.Sleep(pkgDialRetrySchedule[dial])
 			dial++
-			continue
+		case !k8serr.IsNotFound(err) && transient < len(pkgTransientRetrySchedule):
+			// Any other error class (timeout, reset, throttle) gets the
+			// transient schedule — a single apiserver hiccup must not fail the
+			// cold start.
+			time.Sleep(pkgTransientRetrySchedule[transient])
+			transient++
+		default:
+			return nil, err
 		}
-		return nil, err
 	}
 }
 

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -150,43 +149,4 @@ func TestFetch(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, http.StatusInternalServerError, code)
 	})
-}
-
-func TestEnvSpecializeRetryDelay(t *testing.T) {
-	t.Parallel()
-	want := []time.Duration{
-		25 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond,
-		200 * time.Millisecond, 400 * time.Millisecond, 500 * time.Millisecond,
-		500 * time.Millisecond,
-	}
-	for i, w := range want {
-		assert.Equalf(t, w, envSpecializeRetryDelay(i), "attempt %d", i)
-	}
-	// Large attempt indices must stay capped (no overflow back below the cap).
-	assert.Equal(t, 500*time.Millisecond, envSpecializeRetryDelay(1000))
-	// The wait budget must cover the previous schedule's worst case
-	// (sum of 500*2i ms for i in [0,29) ≈ 406s) so no environment that
-	// previously had time to start is now cut off.
-	assert.GreaterOrEqual(t, envSpecializeWaitBudget, 406*time.Second)
-}
-
-func TestPkgRetrySchedules(t *testing.T) {
-	t.Parallel()
-	var notFoundTotal time.Duration
-	for _, d := range pkgNotFoundRetrySchedule {
-		notFoundTotal += d
-	}
-	// The summed not-found window guards the apiserver create-then-get race;
-	// it must cover the previous schedule's 500ms (50+100+150+200).
-	assert.GreaterOrEqual(t, notFoundTotal, 500*time.Millisecond)
-	// First retry must stay cheap — that's the point of the reshape.
-	assert.LessOrEqual(t, pkgNotFoundRetrySchedule[0], 25*time.Millisecond)
-
-	var dialTotal time.Duration
-	for _, d := range pkgDialRetrySchedule {
-		dialTotal += d
-	}
-	// The dial schedule exists for istio/envoy warm-up; keep it coarse
-	// (≥ the previous 5s total).
-	assert.GreaterOrEqual(t, dialTotal, 5*time.Second)
 }

--- a/pkg/fetcher/fetcher_test.go
+++ b/pkg/fetcher/fetcher_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -149,4 +150,43 @@ func TestFetch(t *testing.T) {
 		require.Error(t, err)
 		assert.Equal(t, http.StatusInternalServerError, code)
 	})
+}
+
+func TestEnvSpecializeRetryDelay(t *testing.T) {
+	t.Parallel()
+	want := []time.Duration{
+		25 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond,
+		200 * time.Millisecond, 400 * time.Millisecond, 500 * time.Millisecond,
+		500 * time.Millisecond,
+	}
+	for i, w := range want {
+		assert.Equalf(t, w, envSpecializeRetryDelay(i), "attempt %d", i)
+	}
+	// Large attempt indices must stay capped (no overflow back below the cap).
+	assert.Equal(t, 500*time.Millisecond, envSpecializeRetryDelay(1000))
+	// The wait budget must cover the previous schedule's worst case
+	// (sum of 500*2i ms for i in [0,29) ≈ 406s) so no environment that
+	// previously had time to start is now cut off.
+	assert.GreaterOrEqual(t, envSpecializeWaitBudget, 406*time.Second)
+}
+
+func TestPkgRetrySchedules(t *testing.T) {
+	t.Parallel()
+	var notFoundTotal time.Duration
+	for _, d := range pkgNotFoundRetrySchedule {
+		notFoundTotal += d
+	}
+	// The summed not-found window guards the apiserver create-then-get race;
+	// it must cover the previous schedule's 500ms (50+100+150+200).
+	assert.GreaterOrEqual(t, notFoundTotal, 500*time.Millisecond)
+	// First retry must stay cheap — that's the point of the reshape.
+	assert.LessOrEqual(t, pkgNotFoundRetrySchedule[0], 25*time.Millisecond)
+
+	var dialTotal time.Duration
+	for _, d := range pkgDialRetrySchedule {
+		dialTotal += d
+	}
+	// The dial schedule exists for istio/envoy warm-up; keep it coarse
+	// (≥ the previous 5s total).
+	assert.GreaterOrEqual(t, dialTotal, 5*time.Second)
 }

--- a/pkg/fetcher/retry.go
+++ b/pkg/fetcher/retry.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher
+
+import (
+	"context"
+	"time"
+)
+
+// Retry policy for the specialization cold path: per-error-class sleep
+// schedules for the Package fetch, and the bounded wait for the environment
+// container's server to start accepting connections. Kept apart from the
+// fetch mechanics in fetcher.go; the schedules are data so tests can pin the
+// delay sequences and total-budget invariants.
+
+// pkgNotFoundRetrySchedule is the sleep sequence for the apiserver
+// create-then-get race (a Package created moments ago can still 404). The
+// first hits are cheap (the race usually resolves within tens of ms) while
+// the summed window (≥550ms) covers at least the previous schedule's 500ms.
+var pkgNotFoundRetrySchedule = []time.Duration{
+	10 * time.Millisecond, 20 * time.Millisecond, 40 * time.Millisecond,
+	80 * time.Millisecond, 100 * time.Millisecond, 100 * time.Millisecond,
+	100 * time.Millisecond, 100 * time.Millisecond,
+}
+
+// pkgDialRetrySchedule is the sleep sequence for connection errors on the
+// package Get. It exists for istio: envoy blocks all outbound requests during
+// the pod's first seconds, so these waits stay deliberately coarse.
+// For details, see https://github.com/istio/istio/issues/12187
+var pkgDialRetrySchedule = []time.Duration{
+	500 * time.Millisecond, 1000 * time.Millisecond,
+	1500 * time.Millisecond, 2000 * time.Millisecond,
+}
+
+// pkgTransientRetrySchedule is the sleep sequence for every other Get error
+// (apiserver timeouts, connection resets, 429/5xx). The pre-reshape loop
+// retried any error up to 4 more times back-to-back; keep that resilience but
+// space the attempts out instead of hot-looping.
+var pkgTransientRetrySchedule = []time.Duration{
+	50 * time.Millisecond, 100 * time.Millisecond,
+	200 * time.Millisecond, 400 * time.Millisecond,
+}
+
+// envSpecializeWaitBudget bounds the total wall-clock time SpecializePod waits
+// for the environment container's server to start accepting connections. It
+// covers (with margin) the previous schedule's ~406s worst case, so slow-image
+// environments that survived before still do.
+const envSpecializeWaitBudget = 7 * time.Minute
+
+// envSpecializeRetryDelay returns the sleep before conn-refused retry attempt
+// i (0-based) of the env-specialize wait: 25ms doubling to a 500ms cap. Env
+// servers typically bind tens of milliseconds after the fetcher's first POST;
+// the previous 500*2i ms ramp made that common case cost a full second.
+func envSpecializeRetryDelay(i int) time.Duration {
+	const base, maxDelay = 25 * time.Millisecond, 500 * time.Millisecond
+	if i >= 5 {
+		return maxDelay // 25ms<<5 already exceeds the cap (and huge i would overflow the shift)
+	}
+	return base << i
+}
+
+// sleepCtx sleeps for d unless ctx ends first; it reports whether the full
+// sleep elapsed (false means the caller should stop retrying).
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}

--- a/pkg/fetcher/retry_test.go
+++ b/pkg/fetcher/retry_test.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnvSpecializeRetryDelay(t *testing.T) {
+	t.Parallel()
+	want := []time.Duration{
+		25 * time.Millisecond, 50 * time.Millisecond, 100 * time.Millisecond,
+		200 * time.Millisecond, 400 * time.Millisecond, 500 * time.Millisecond,
+		500 * time.Millisecond,
+	}
+	for i, w := range want {
+		assert.Equalf(t, w, envSpecializeRetryDelay(i), "attempt %d", i)
+	}
+	// Large attempt indices must stay capped (no overflow back below the cap).
+	assert.Equal(t, 500*time.Millisecond, envSpecializeRetryDelay(1000))
+	// The wait budget must cover the previous schedule's worst case
+	// (sum of 500*2i ms for i in [0,29) ≈ 406s) so no environment that
+	// previously had time to start is now cut off.
+	assert.GreaterOrEqual(t, envSpecializeWaitBudget, 406*time.Second)
+}
+
+func TestPkgRetrySchedules(t *testing.T) {
+	t.Parallel()
+	var notFoundTotal time.Duration
+	for _, d := range pkgNotFoundRetrySchedule {
+		notFoundTotal += d
+	}
+	// The summed not-found window guards the apiserver create-then-get race;
+	// it must cover the previous schedule's 500ms (50+100+150+200).
+	assert.GreaterOrEqual(t, notFoundTotal, 500*time.Millisecond)
+	// First retry must stay cheap — that's the point of the reshape.
+	assert.LessOrEqual(t, pkgNotFoundRetrySchedule[0], 25*time.Millisecond)
+
+	var dialTotal time.Duration
+	for _, d := range pkgDialRetrySchedule {
+		dialTotal += d
+	}
+	// The dial schedule exists for istio/envoy warm-up; keep it coarse
+	// (≥ the previous 5s total).
+	assert.GreaterOrEqual(t, dialTotal, 5*time.Second)
+}

--- a/pkg/router/requesthHeader.go
+++ b/pkg/router/requesthHeader.go
@@ -5,7 +5,6 @@
 package router
 
 import (
-	"fmt"
 	"net/http"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,9 +36,11 @@ func setFunctionMetadataToHeader(meta *metav1.ObjectMeta, request *http.Request)
 // setPathInfoToHeaders set URL path params and full URL path to request header
 func setPathInfoToHeader(request *http.Request) {
 	// retrieve url params and add them to request header
+	// (string concat, not Sprintf — this runs per path param per request;
+	// Header.Set canonicalizes the name either way)
 	vars := httpmux.Vars(request)
 	for k, v := range vars {
-		request.Header.Set(fmt.Sprintf("X-Fission-Params-%v", k), v)
+		request.Header.Set("X-Fission-Params-"+k, v)
 	}
 	request.Header.Set("X-Fission-Full-Url", request.URL.String())
 }

--- a/pkg/router/requesthHeader.go
+++ b/pkg/router/requesthHeader.go
@@ -36,8 +36,6 @@ func setFunctionMetadataToHeader(meta *metav1.ObjectMeta, request *http.Request)
 // setPathInfoToHeaders set URL path params and full URL path to request header
 func setPathInfoToHeader(request *http.Request) {
 	// retrieve url params and add them to request header
-	// (string concat, not Sprintf — this runs per path param per request;
-	// Header.Set canonicalizes the name either way)
 	vars := httpmux.Vars(request)
 	for k, v := range vars {
 		request.Header.Set("X-Fission-Params-"+k, v)

--- a/pkg/router/rewrite.go
+++ b/pkg/router/rewrite.go
@@ -94,12 +94,14 @@ func addForwardedHostHeader(req *http.Request) {
 		hostname = hostname[1 : len(hostname)-1]
 	}
 
-	// Per RFC 7239 an IPv6 node identifier must be quoted (it contains
-	// colons). The order of To4() and To16() matters: To16() also converts an
-	// IPv4 address, so check To4() first. FQDNs (ParseIP nil) and IPv4 stay
-	// unquoted.
+	// Per RFC 7239 a node identifier that isn't a plain token — anything
+	// carrying ':' or brackets, i.e. every IPv6 textual form including
+	// IPv4-mapped ("::ffff:1.2.3.4") — must be quoted. Keying on the
+	// characters rather than net.ParseIP classification covers the mapped
+	// forms (whose To4() is non-nil despite the colons) and skips a parse.
+	// FQDNs and IPv4 stay unquoted.
 	host := "host=" + req.Host + ";"
-	if ip := net.ParseIP(hostname); ip != nil && ip.To4() == nil && ip.To16() != nil {
+	if strings.ContainsRune(hostname, ':') || strings.HasPrefix(req.Host, "[") {
 		host = `host="` + req.Host + `";`
 	}
 

--- a/pkg/router/rewrite.go
+++ b/pkg/router/rewrite.go
@@ -100,9 +100,11 @@ func addForwardedHostHeader(req *http.Request) {
 	// characters rather than net.ParseIP classification covers the mapped
 	// forms (whose To4() is non-nil despite the colons) and skips a parse.
 	// FQDNs and IPv4 stay unquoted.
-	host := "host=" + req.Host + ";"
+	var host string
 	if strings.ContainsRune(hostname, ':') || strings.HasPrefix(req.Host, "[") {
 		host = `host="` + req.Host + `";`
+	} else {
+		host = "host=" + req.Host + ";"
 	}
 
 	req.Header.Set(FORWARDED, host)

--- a/pkg/router/rewrite.go
+++ b/pkg/router/rewrite.go
@@ -84,14 +84,12 @@ func addForwardedHostHeader(req *http.Request) {
 	}
 
 	// req.Host is <host>[:<port>]. SplitHostPort strips the port and IPv6
-	// brackets; a host without a port fails the split and is used as-is,
-	// except a bracketed port-less IPv6 literal ("[::1]"), whose brackets
-	// must come off for ParseIP below.
+	// brackets; a host without a port fails the split and is used as-is
+	// (a bracketed port-less IPv6 literal like "[::1]" still matches the
+	// quoting test below through its brackets/colons).
 	hostname := req.Host
 	if h, _, err := net.SplitHostPort(req.Host); err == nil {
 		hostname = h
-	} else if strings.HasPrefix(hostname, "[") && strings.HasSuffix(hostname, "]") {
-		hostname = hostname[1 : len(hostname)-1]
 	}
 
 	// Per RFC 7239 a node identifier that isn't a plain token — anything

--- a/pkg/router/rewrite.go
+++ b/pkg/router/rewrite.go
@@ -5,7 +5,6 @@
 package router
 
 import (
-	"fmt"
 	"net"
 	"net/http"
 	"net/url"
@@ -72,40 +71,36 @@ func rewriteFunctionURL(logger logr.Logger, req *http.Request, trigger *fv1.HTTP
 }
 
 // addForwardedHostHeader add "forwarded host" to request header
-func addForwardedHostHeader(logger logr.Logger, req *http.Request) {
-	// for more detailed information, please visit:
-	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded
-
+// (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Forwarded).
+// It runs on every proxied request, so the hostname is extracted with
+// net.SplitHostPort instead of a URL parse — the previous implementation
+// built "<req.Proto>://<req.Host>" ("HTTP/1.1" is not a scheme), which
+// url.Parse silently read as a host-less URL: every request paid the parse,
+// Hostname() was always empty, and the IPv6 quoting below never fired.
+func addForwardedHostHeader(req *http.Request) {
 	if len(req.Header.Get(FORWARDED)) > 0 || len(req.Header.Get(X_FORWARDED_HOST)) > 0 {
 		// forwarded headers were set by external proxy, leave them intact
 		return
 	}
 
-	// Format of req.Host is <host>:<port>
-	// We need to extract hostname from it, than
-	// check whether a host is ipv4 or ipv6 or FQDN
-	reqURL := fmt.Sprintf("%s://%s", req.Proto, req.Host)
-	u, err := url.Parse(reqURL)
-	if err != nil {
-		logger.Error(err, "error parsing request url while adding forwarded host headers", "url", reqURL)
-		return
+	// req.Host is <host>[:<port>]. SplitHostPort strips the port and IPv6
+	// brackets; a host without a port fails the split and is used as-is,
+	// except a bracketed port-less IPv6 literal ("[::1]"), whose brackets
+	// must come off for ParseIP below.
+	hostname := req.Host
+	if h, _, err := net.SplitHostPort(req.Host); err == nil {
+		hostname = h
+	} else if strings.HasPrefix(hostname, "[") && strings.HasSuffix(hostname, "]") {
+		hostname = hostname[1 : len(hostname)-1]
 	}
 
-	var host string
-
-	// ip will be nil if the Hostname is a FQDN string
-	ip := net.ParseIP(u.Hostname())
-
-	// ip == nil -> hostname is FQDN instead of ip address
-	// The order of To4() and To16() here matters, To16() will
-	// converts an IPv4 address to IPv6 format address and may
-	// cause router append wrong host value to header. To prevent
-	// this we need to check whether To4() is nil first.
-	if ip == nil || (ip != nil && ip.To4() != nil) {
-		host = fmt.Sprintf(`host=%s;`, req.Host)
-	} else if ip != nil && ip.To16() != nil {
-		// For the "Forwarded" header, if a host is an IPv6 address it should be quoted
-		host = fmt.Sprintf(`host="%s";`, req.Host)
+	// Per RFC 7239 an IPv6 node identifier must be quoted (it contains
+	// colons). The order of To4() and To16() matters: To16() also converts an
+	// IPv4 address, so check To4() first. FQDNs (ParseIP nil) and IPv4 stay
+	// unquoted.
+	host := "host=" + req.Host + ";"
+	if ip := net.ParseIP(hostname); ip != nil && ip.To4() == nil && ip.To16() != nil {
+		host = `host="` + req.Host + `";`
 	}
 
 	req.Header.Set(FORWARDED, host)

--- a/pkg/router/rewrite_test.go
+++ b/pkg/router/rewrite_test.go
@@ -153,11 +153,7 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		{"fqdn host", "example.com:8888", "host=example.com:8888;"},
 		{"ipv4 host", "10.0.0.1:8888", "host=10.0.0.1:8888;"},
 		{"fqdn host without port", "example.com", "host=example.com;"},
-		// RFC 7239: an IPv6 node identifier contains colons and must be
-		// quoted. (The pre-rewrite implementation never quoted: its hostname
-		// extraction went through url.Parse of a "HTTP/1.1://host" pseudo-URL,
-		// which always yielded an empty hostname, so IPv6 took the FQDN
-		// branch.)
+		// RFC 7239: an IPv6 node identifier contains colons and must be quoted.
 		{"ipv6 host with port is quoted", "[2001:db8::1]:8888", `host="[2001:db8::1]:8888";`},
 		{"bare ipv6 host is quoted", "2001:db8::1", `host="2001:db8::1";`},
 		{"bracketed port-less ipv6 host is quoted", "[2001:db8::1]", `host="[2001:db8::1]";`},

--- a/pkg/router/rewrite_test.go
+++ b/pkg/router/rewrite_test.go
@@ -146,70 +146,31 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		assert.Equal(t, "upstream.example", req.Header.Get(X_FORWARDED_HOST))
 	})
 
-	t.Run("fqdn host", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "example.com:8888"
-		addForwardedHostHeader(req)
-		assert.Equal(t, "host=example.com:8888;", req.Header.Get(FORWARDED))
-		assert.Equal(t, "example.com:8888", req.Header.Get(X_FORWARDED_HOST))
-	})
-
-	t.Run("ipv4 host", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "10.0.0.1:8888"
-		addForwardedHostHeader(req)
-		assert.Equal(t, "host=10.0.0.1:8888;", req.Header.Get(FORWARDED))
-		assert.Equal(t, "10.0.0.1:8888", req.Header.Get(X_FORWARDED_HOST))
-	})
-
-	t.Run("fqdn host without port", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "example.com"
-		addForwardedHostHeader(req)
-		assert.Equal(t, "host=example.com;", req.Header.Get(FORWARDED))
-		assert.Equal(t, "example.com", req.Header.Get(X_FORWARDED_HOST))
-	})
-
-	// RFC 7239: an IPv6 node identifier contains colons and must be quoted.
-	// (The pre-rewrite implementation never quoted: its hostname extraction
-	// went through url.Parse of a "HTTP/1.1://host" pseudo-URL, which always
-	// yielded an empty hostname, so IPv6 took the FQDN branch.)
-	t.Run("ipv6 host with port is quoted", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "[2001:db8::1]:8888"
-		addForwardedHostHeader(req)
-		assert.Equal(t, `host="[2001:db8::1]:8888";`, req.Header.Get(FORWARDED))
-		assert.Equal(t, "[2001:db8::1]:8888", req.Header.Get(X_FORWARDED_HOST))
-	})
-
-	t.Run("bare ipv6 host is quoted", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "2001:db8::1"
-		addForwardedHostHeader(req)
-		assert.Equal(t, `host="2001:db8::1";`, req.Header.Get(FORWARDED))
-		assert.Equal(t, "2001:db8::1", req.Header.Get(X_FORWARDED_HOST))
-	})
-
-	t.Run("bracketed port-less ipv6 host is quoted", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "[2001:db8::1]"
-		addForwardedHostHeader(req)
-		assert.Equal(t, `host="[2001:db8::1]";`, req.Header.Get(FORWARDED))
-		assert.Equal(t, "[2001:db8::1]", req.Header.Get(X_FORWARDED_HOST))
-	})
-
-	t.Run("ipv4-mapped ipv6 host is quoted", func(t *testing.T) {
-		t.Parallel()
-		req := httptest.NewRequest("GET", "http://router.example/x", nil)
-		req.Host = "[::ffff:10.0.0.1]:8888"
-		addForwardedHostHeader(req)
-		assert.Equal(t, `host="[::ffff:10.0.0.1]:8888";`, req.Header.Get(FORWARDED))
-		assert.Equal(t, "[::ffff:10.0.0.1]:8888", req.Header.Get(X_FORWARDED_HOST))
-	})
+	// Host-form cases: same body, varying host and expected quoting.
+	cases := []struct {
+		name, host, wantForwarded string
+	}{
+		{"fqdn host", "example.com:8888", "host=example.com:8888;"},
+		{"ipv4 host", "10.0.0.1:8888", "host=10.0.0.1:8888;"},
+		{"fqdn host without port", "example.com", "host=example.com;"},
+		// RFC 7239: an IPv6 node identifier contains colons and must be
+		// quoted. (The pre-rewrite implementation never quoted: its hostname
+		// extraction went through url.Parse of a "HTTP/1.1://host" pseudo-URL,
+		// which always yielded an empty hostname, so IPv6 took the FQDN
+		// branch.)
+		{"ipv6 host with port is quoted", "[2001:db8::1]:8888", `host="[2001:db8::1]:8888";`},
+		{"bare ipv6 host is quoted", "2001:db8::1", `host="2001:db8::1";`},
+		{"bracketed port-less ipv6 host is quoted", "[2001:db8::1]", `host="[2001:db8::1]";`},
+		{"ipv4-mapped ipv6 host is quoted", "[::ffff:10.0.0.1]:8888", `host="[::ffff:10.0.0.1]:8888";`},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			req := httptest.NewRequest("GET", "http://router.example/x", nil)
+			req.Host = tt.host
+			addForwardedHostHeader(req)
+			assert.Equal(t, tt.wantForwarded, req.Header.Get(FORWARDED))
+			assert.Equal(t, tt.host, req.Header.Get(X_FORWARDED_HOST))
+		})
+	}
 }

--- a/pkg/router/rewrite_test.go
+++ b/pkg/router/rewrite_test.go
@@ -203,4 +203,13 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		assert.Equal(t, `host="[2001:db8::1]";`, req.Header.Get(FORWARDED))
 		assert.Equal(t, "[2001:db8::1]", req.Header.Get(X_FORWARDED_HOST))
 	})
+
+	t.Run("ipv4-mapped ipv6 host is quoted", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "http://router.example/x", nil)
+		req.Host = "[::ffff:10.0.0.1]:8888"
+		addForwardedHostHeader(req)
+		assert.Equal(t, `host="[::ffff:10.0.0.1]:8888";`, req.Header.Get(FORWARDED))
+		assert.Equal(t, "[::ffff:10.0.0.1]:8888", req.Header.Get(X_FORWARDED_HOST))
+	})
 }

--- a/pkg/router/rewrite_test.go
+++ b/pkg/router/rewrite_test.go
@@ -132,7 +132,7 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest("GET", "http://router.example/x", nil)
 		req.Header.Set(FORWARDED, "host=upstream.example;")
-		addForwardedHostHeader(logr.Discard(), req)
+		addForwardedHostHeader(req)
 		assert.Equal(t, "host=upstream.example;", req.Header.Get(FORWARDED))
 		assert.Empty(t, req.Header.Get(X_FORWARDED_HOST))
 	})
@@ -141,7 +141,7 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest("GET", "http://router.example/x", nil)
 		req.Header.Set(X_FORWARDED_HOST, "upstream.example")
-		addForwardedHostHeader(logr.Discard(), req)
+		addForwardedHostHeader(req)
 		assert.Empty(t, req.Header.Get(FORWARDED))
 		assert.Equal(t, "upstream.example", req.Header.Get(X_FORWARDED_HOST))
 	})
@@ -150,7 +150,7 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest("GET", "http://router.example/x", nil)
 		req.Host = "example.com:8888"
-		addForwardedHostHeader(logr.Discard(), req)
+		addForwardedHostHeader(req)
 		assert.Equal(t, "host=example.com:8888;", req.Header.Get(FORWARDED))
 		assert.Equal(t, "example.com:8888", req.Header.Get(X_FORWARDED_HOST))
 	})
@@ -159,8 +159,48 @@ func TestAddForwardedHostHeader(t *testing.T) {
 		t.Parallel()
 		req := httptest.NewRequest("GET", "http://router.example/x", nil)
 		req.Host = "10.0.0.1:8888"
-		addForwardedHostHeader(logr.Discard(), req)
+		addForwardedHostHeader(req)
 		assert.Equal(t, "host=10.0.0.1:8888;", req.Header.Get(FORWARDED))
 		assert.Equal(t, "10.0.0.1:8888", req.Header.Get(X_FORWARDED_HOST))
+	})
+
+	t.Run("fqdn host without port", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "http://router.example/x", nil)
+		req.Host = "example.com"
+		addForwardedHostHeader(req)
+		assert.Equal(t, "host=example.com;", req.Header.Get(FORWARDED))
+		assert.Equal(t, "example.com", req.Header.Get(X_FORWARDED_HOST))
+	})
+
+	// RFC 7239: an IPv6 node identifier contains colons and must be quoted.
+	// (The pre-rewrite implementation never quoted: its hostname extraction
+	// went through url.Parse of a "HTTP/1.1://host" pseudo-URL, which always
+	// yielded an empty hostname, so IPv6 took the FQDN branch.)
+	t.Run("ipv6 host with port is quoted", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "http://router.example/x", nil)
+		req.Host = "[2001:db8::1]:8888"
+		addForwardedHostHeader(req)
+		assert.Equal(t, `host="[2001:db8::1]:8888";`, req.Header.Get(FORWARDED))
+		assert.Equal(t, "[2001:db8::1]:8888", req.Header.Get(X_FORWARDED_HOST))
+	})
+
+	t.Run("bare ipv6 host is quoted", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "http://router.example/x", nil)
+		req.Host = "2001:db8::1"
+		addForwardedHostHeader(req)
+		assert.Equal(t, `host="2001:db8::1";`, req.Header.Get(FORWARDED))
+		assert.Equal(t, "2001:db8::1", req.Header.Get(X_FORWARDED_HOST))
+	})
+
+	t.Run("bracketed port-less ipv6 host is quoted", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest("GET", "http://router.example/x", nil)
+		req.Host = "[2001:db8::1]"
+		addForwardedHostHeader(req)
+		assert.Equal(t, `host="[2001:db8::1]";`, req.Header.Get(FORWARDED))
+		assert.Equal(t, "[2001:db8::1]", req.Header.Get(X_FORWARDED_HOST))
 	})
 }

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -150,7 +150,7 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 	ctx := req.Context()
 
 	// set the timeout for transport context
-	addForwardedHostHeader(roundTripper.logger, req)
+	addForwardedHostHeader(req)
 	transport, otelTransport := roundTripper.params.sharedTransport()
 
 	executingTimeout := roundTripper.params.timeout

--- a/pkg/router/warmpath_alloc_bench_test.go
+++ b/pkg/router/warmpath_alloc_bench_test.go
@@ -7,8 +7,10 @@ package router
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -124,5 +126,59 @@ func BenchmarkWarmPathTrackEventUnguardedOld(b *testing.B) {
 		otelUtils.SpanTrackEvent(ctx, "roundtrip", otelUtils.MapToAttributes(map[string]string{
 			"function-name": "hello", "function-namespace": "default",
 		})...)
+	}
+}
+
+func BenchmarkWarmPathForwardedHostHeaderNew(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	req.Host = "example.com:8888"
+	b.ReportAllocs()
+	for b.Loop() {
+		req.Header.Del(FORWARDED)
+		req.Header.Del(X_FORWARDED_HOST)
+		addForwardedHostHeader(req)
+	}
+}
+
+func BenchmarkWarmPathForwardedHostHeaderOld(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	req.Host = "example.com:8888"
+	b.ReportAllocs()
+	for b.Loop() {
+		req.Header.Del(FORWARDED)
+		req.Header.Del(X_FORWARDED_HOST)
+		// Previous implementation: built a "<proto>://<host>" pseudo-URL and
+		// url.Parse'd it per request just to extract the hostname (which the
+		// bogus scheme made empty anyway — see addForwardedHostHeader).
+		reqURL := fmt.Sprintf("%s://%s", req.Proto, req.Host)
+		u, err := url.Parse(reqURL)
+		if err != nil {
+			b.Fatal(err)
+		}
+		var host string
+		ip := net.ParseIP(u.Hostname())
+		if ip == nil || ip.To4() != nil {
+			host = fmt.Sprintf(`host=%s;`, req.Host)
+		} else if ip.To16() != nil {
+			host = fmt.Sprintf(`host="%s";`, req.Host)
+		}
+		req.Header.Set(FORWARDED, host)
+		req.Header.Set(X_FORWARDED_HOST, req.Host)
+	}
+}
+
+func BenchmarkWarmPathParamsHeaderNew(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		req.Header.Set("X-Fission-Params-"+"name", "value")
+	}
+}
+
+func BenchmarkWarmPathParamsHeaderOld(b *testing.B) {
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	b.ReportAllocs()
+	for b.Loop() {
+		req.Header.Set(fmt.Sprintf("X-Fission-Params-%v", "name"), "value")
 	}
 }

--- a/pkg/utils/httpserver/server.go
+++ b/pkg/utils/httpserver/server.go
@@ -38,6 +38,16 @@ func StartServer(ctx context.Context, log logr.Logger, mgr *errgroup.Group, svc 
 	server := http.Server{
 		Addr:    port,
 		Handler: handler,
+		// ReadHeaderTimeout bounds only the header read (slowloris hardening);
+		// request bodies and long-running/streaming responses are unaffected —
+		// deliberately no ReadTimeout/WriteTimeout, which would cut both.
+		ReadHeaderTimeout: 10 * time.Second,
+		// IdleTimeout reaps idle keep-alive connections. It must exceed the
+		// 90s IdleConnTimeout of http.DefaultTransport (which the internal
+		// pooled clients inherit): if the server closed first, a client could
+		// reuse a connection the server is tearing down and see spurious
+		// failures on non-idempotent internal POSTs.
+		IdleTimeout: 120 * time.Second,
 	}
 	l := log.WithValues("service", svc, "addr", server.Addr)
 	l.Info("starting server")

--- a/test/benchmark/cmd/fission-benchmark/run.go
+++ b/test/benchmark/cmd/fission-benchmark/run.go
@@ -25,6 +25,7 @@ func runCmd() *cobra.Command {
 		runID, fissionVersion, k8sVersion, gitSHA   string
 		duration, warmup                            time.Duration
 		concurrency, coldIterations, poolsize       int
+		repetitions                                 int
 	)
 
 	cmd := &cobra.Command{
@@ -54,6 +55,9 @@ func runCmd() *cobra.Command {
 			if poolsize > 0 {
 				params.Poolsize = poolsize
 			}
+			if repetitions > 0 {
+				params.Repetitions = repetitions
+			}
 
 			selected := scenario.Select(scenario.BuildAll(params), splitCSV(scenariosCSV), splitCSV(tagsCSV))
 			if len(selected) == 0 {
@@ -82,7 +86,7 @@ func runCmd() *cobra.Command {
 			}
 
 			fmt.Fprintf(os.Stderr, "running %d scenario(s): %v\n", len(selected), scenario.Names(selected))
-			run := scenario.Run(ctx, env, selected)
+			run := scenario.Run(ctx, env, selected, params.Repetitions)
 			run.FissionVersion = fissionVersion
 			run.K8sVersion = k8sVersion
 			run.GitSHA = gitSHA
@@ -119,6 +123,7 @@ func runCmd() *cobra.Command {
 	f.DurationVar(&warmup, "warmup", 0, "warm-up window discarded before measuring (overrides config)")
 	f.IntVar(&concurrency, "concurrency", 0, "warm-path concurrency (overrides config)")
 	f.IntVar(&coldIterations, "cold-iterations", 0, "cold-start iterations (overrides config)")
+	f.IntVar(&repetitions, "repetitions", 0, "re-run each scenario N times and report per-metric medians (overrides config)")
 	f.IntVar(&poolsize, "poolsize", 0, "environment pool size (overrides config)")
 	return cmd
 }

--- a/test/benchmark/config/scenarios.default.yaml
+++ b/test/benchmark/config/scenarios.default.yaml
@@ -3,6 +3,10 @@
 # For a quick smoke run, keep this file but pass: --tags smoke --duration 15s --warmup 5s
 poolsize: 3
 coldIterations: 20
+# Re-run every scenario N times (fresh resources each rep) and report per-metric
+# medians with a min..max range in the result meta. Raise for A/B dispatches
+# where a single sample can't clear the cluster noise floor.
+repetitions: 1
 warmDuration: 60s
 warmWarmup: 10s
 warmConcurrency: 50

--- a/test/benchmark/config/scenarios.default.yaml
+++ b/test/benchmark/config/scenarios.default.yaml
@@ -7,6 +7,9 @@ coldIterations: 20
 # medians with a min..max range in the result meta. Raise for A/B dispatches
 # where a single sample can't clear the cluster noise floor.
 repetitions: 1
+# Simultaneous first-requests for the cold-burst scenarios; > poolsize so the
+# burst forces pool exhaustion + refill instead of being absorbed by warm pods.
+burstSize: 10
 warmDuration: 60s
 warmWarmup: 10s
 warmConcurrency: 50

--- a/test/benchmark/config/thresholds.yaml
+++ b/test/benchmark/config/thresholds.yaml
@@ -13,3 +13,9 @@ scenarios:
   cold-start-poolmgr:
     metrics:
       failures: { max: 5 } # at most 5 of N iterations may fail to specialize
+  cold-burst-same-fn:
+    metrics:
+      failures: { max: 3 } # of burstSize concurrent first-requests
+  cold-burst-distinct-fn:
+    metrics:
+      failures: { max: 3 }

--- a/test/benchmark/pkg/cluster/capture.go
+++ b/test/benchmark/pkg/cluster/capture.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -77,7 +78,16 @@ func (c *Capturer) QueryInstant(ctx context.Context, promQL string) (value float
 		return 0, false, fmt.Errorf("unexpected prometheus value type %T", resp.Data.Result[0].Value[1])
 	}
 	v, err := strconv.ParseFloat(s, 64)
-	return v, err == nil, err
+	if err != nil {
+		return 0, false, err
+	}
+	// PromQL yields NaN for 0/0 rate ratios (and ±Inf for x/0); treat those as
+	// "no sample" — a non-finite value poisons the results JSON (json.Marshal
+	// rejects NaN), losing the entire run's output.
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, false, nil
+	}
+	return v, true, nil
 }
 
 // QueryRangeRaw runs a range query and returns the raw JSON response so it can

--- a/test/benchmark/pkg/harness/harness.go
+++ b/test/benchmark/pkg/harness/harness.go
@@ -84,6 +84,10 @@ func New(ctx context.Context, cfg Config) (*Env, error) {
 	}, nil
 }
 
+// FissionNamespace returns the control-plane namespace, for PromQL that targets
+// the Fission components themselves (e.g. client-side apiserver call counters).
+func (e *Env) FissionNamespace() string { return e.fissionNamespace }
+
 // NewScope returns a per-scenario resource scope; label disambiguates resource
 // names and cleanup logs across scenarios sharing the Env.
 func (e *Env) NewScope(label string) *Scope {

--- a/test/benchmark/pkg/harness/resources.go
+++ b/test/benchmark/pkg/harness/resources.go
@@ -51,7 +51,10 @@ func (s *Scope) CreateEnv(ctx context.Context, o EnvOptions) error {
 		},
 	}
 	if o.Builder != "" {
-		env.Spec.Builder = fv1.Builder{Image: o.Builder}
+		// Command must mirror the CLI default ("build", resolved on the builder
+		// image's PATH): with an empty command the builder falls back to /build,
+		// which the env builder images don't ship.
+		env.Spec.Builder = fv1.Builder{Image: o.Builder, Command: "build"}
 	}
 	if _, err := s.env.Clients.Fission.CoreV1().Environments(ns).Create(ctx, env, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("create environment %q: %w", o.Name, err)

--- a/test/benchmark/pkg/harness/scope.go
+++ b/test/benchmark/pkg/harness/scope.go
@@ -31,6 +31,16 @@ type namedCleanup struct {
 // Env returns the shared run context (clients, capturer, router targets).
 func (s *Scope) Env() *Env { return s.env }
 
+// SubScope returns a child scope whose label extends this scope's label with
+// suffix. Scenarios that create per-iteration scopes must derive them from the
+// scope the runner handed them — the runner's label carries the repetition
+// index, so re-deriving names from the scenario name alone would collide
+// across repetitions (the previous rep's detached cleanup may still be
+// deleting same-named resources).
+func (s *Scope) SubScope(suffix string) *Scope {
+	return &Scope{env: s.env, label: s.label + "-" + suffix}
+}
+
 // Name returns a scenario- and run-unique resource name with the given prefix,
 // kept within DNS-1123 limits by the short prefixes/IDs callers use.
 func (s *Scope) Name(prefix string) string {

--- a/test/benchmark/pkg/report/aggregate.go
+++ b/test/benchmark/pkg/report/aggregate.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package report
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+)
+
+// Aggregate folds repetition results for one scenario into a single
+// ScenarioResult, keeping metric names stable for thresholds and the trend:
+// each metric's value is the median across reps, with the observed min..max
+// recorded in Meta["<metric>_range"] so the run's noise floor is visible next
+// to the number. The first non-clean rep is returned as-is (annotated with its
+// rep index) since partial metrics aren't comparable.
+func Aggregate(reps []ScenarioResult) ScenarioResult {
+	last := reps[len(reps)-1]
+	if len(reps) == 1 {
+		return last
+	}
+	if last.Error != "" || last.Skipped {
+		last.SetMeta("failed_repetition", strconv.Itoa(len(reps)-1))
+		return last
+	}
+	// Build the aggregate from scratch (no struct copy — that would alias
+	// rep 0's Meta map and mutate the rep's own result).
+	agg := ScenarioResult{Name: reps[0].Name, Tags: reps[0].Tags}
+	for k, v := range reps[0].Meta {
+		agg.SetMeta(k, v)
+	}
+	agg.SetMeta("repetitions", strconv.Itoa(len(reps)))
+	// Single sweep collecting values per metric name. The metric set is the
+	// union across reps (first-seen order), not rep 0's set: conditionally
+	// emitted metrics (apiserver_calls drops its sample on a counter reset or
+	// scrape miss) must survive one rep missing them.
+	var order []Metric
+	vals := map[string][]float64{}
+	for _, r := range reps {
+		for _, m := range r.Metrics {
+			if _, ok := vals[m.Name]; !ok {
+				order = append(order, m)
+			}
+			vals[m.Name] = append(vals[m.Name], m.Value)
+		}
+	}
+	for _, m := range order {
+		v := vals[m.Name]
+		slices.Sort(v)
+		med := v[len(v)/2]
+		if len(v)%2 == 0 {
+			med = (v[len(v)/2-1] + v[len(v)/2]) / 2
+		}
+		agg.Metrics = append(agg.Metrics, Metric{Name: m.Name, Unit: m.Unit, Value: med, Better: m.Better})
+		agg.SetMeta(m.Name+"_range", fmt.Sprintf("%.3f..%.3f", v[0], v[len(v)-1]))
+	}
+	return agg
+}

--- a/test/benchmark/pkg/report/aggregate_test.go
+++ b/test/benchmark/pkg/report/aggregate_test.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package report
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAggregate(t *testing.T) {
+	t.Parallel()
+	mk := func(p50, rps float64) ScenarioResult {
+		var r ScenarioResult
+		r.Name = "warm-path"
+		r.Add("p50", "ms", Lower, p50)
+		r.Add("throughput", "rps", Higher, rps)
+		return r
+	}
+
+	t.Run("single rep passes through untouched", func(t *testing.T) {
+		t.Parallel()
+		in := mk(10, 100)
+		out := Aggregate([]ScenarioResult{in})
+		assert.Equal(t, in, out)
+		assert.Empty(t, out.Meta)
+	})
+
+	t.Run("odd rep count takes the median and records the range", func(t *testing.T) {
+		t.Parallel()
+		out := Aggregate([]ScenarioResult{mk(30, 90), mk(10, 110), mk(20, 100)})
+		require.Len(t, out.Metrics, 2)
+		assert.Equal(t, 20.0, out.Metrics[0].Value)
+		assert.Equal(t, 100.0, out.Metrics[1].Value)
+		assert.Equal(t, "3", out.Meta["repetitions"])
+		assert.Equal(t, "10.000..30.000", out.Meta["p50_range"])
+		// Direction/unit survive aggregation — thresholds and trend depend on them.
+		assert.Equal(t, Higher, out.Metrics[1].Better)
+		assert.Equal(t, "ms", out.Metrics[0].Unit)
+	})
+
+	t.Run("even rep count averages the middle pair", func(t *testing.T) {
+		t.Parallel()
+		out := Aggregate([]ScenarioResult{mk(10, 0), mk(20, 0), mk(40, 0), mk(30, 0)})
+		assert.Equal(t, 25.0, out.Metrics[0].Value)
+	})
+
+	t.Run("metric missing from rep 0 still aggregates from later reps", func(t *testing.T) {
+		t.Parallel()
+		withCalls := mk(20, 100)
+		withCalls.Add("apiserver_calls", "count", Lower, 42)
+		out := Aggregate([]ScenarioResult{mk(10, 100), withCalls, mk(30, 100)})
+		names := make([]string, 0, len(out.Metrics))
+		for _, m := range out.Metrics {
+			names = append(names, m.Name)
+		}
+		assert.Contains(t, names, "apiserver_calls")
+	})
+
+	t.Run("aggregation does not mutate rep 0's meta", func(t *testing.T) {
+		t.Parallel()
+		rep0 := mk(10, 100)
+		rep0.SetMeta("executor", "poolmgr")
+		_ = Aggregate([]ScenarioResult{rep0, mk(20, 100)})
+		assert.Equal(t, map[string]string{"executor": "poolmgr"}, rep0.Meta)
+	})
+
+	t.Run("an errored rep short-circuits with its rep index", func(t *testing.T) {
+		t.Parallel()
+		bad := ScenarioResult{Name: "warm-path", Error: "boom"}
+		out := Aggregate([]ScenarioResult{mk(10, 100), bad})
+		assert.Equal(t, "boom", out.Error)
+		assert.Equal(t, "1", out.Meta["failed_repetition"])
+		assert.Empty(t, out.Metrics)
+	})
+}

--- a/test/benchmark/pkg/report/result.go
+++ b/test/benchmark/pkg/report/result.go
@@ -37,9 +37,8 @@ type ScenarioResult struct {
 	Error   string            `json:"error,omitempty"`
 }
 
-// Add appends a metric. Non-finite values are dropped: json.Marshal rejects
-// NaN/±Inf, so a single poisoned sample would otherwise lose the entire run's
-// results file.
+// Add appends a metric, dropping non-finite values (json.Marshal rejects
+// NaN/±Inf).
 func (r *ScenarioResult) Add(name, unit, better string, value float64) {
 	if math.IsNaN(value) || math.IsInf(value, 0) {
 		return

--- a/test/benchmark/pkg/report/result.go
+++ b/test/benchmark/pkg/report/result.go
@@ -6,7 +6,10 @@
 // outputs computed from it. It is decoupled from how results are produced.
 package report
 
-import "time"
+import (
+	"math"
+	"time"
+)
 
 // Improvement direction for a metric, used by threshold gating and the trend
 // dashboard to know which way is "better".
@@ -34,8 +37,13 @@ type ScenarioResult struct {
 	Error   string            `json:"error,omitempty"`
 }
 
-// Add appends a metric.
+// Add appends a metric. Non-finite values are dropped: json.Marshal rejects
+// NaN/±Inf, so a single poisoned sample would otherwise lose the entire run's
+// results file.
 func (r *ScenarioResult) Add(name, unit, better string, value float64) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return
+	}
 	r.Metrics = append(r.Metrics, Metric{Name: name, Unit: unit, Value: value, Better: better})
 }
 

--- a/test/benchmark/pkg/scenario/coldburst.go
+++ b/test/benchmark/pkg/scenario/coldburst.go
@@ -64,12 +64,14 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 	}
 
 	// Provision the target function(s) and route(s) before firing anything:
-	// creation must not overlap the measured burst.
-	routes := make([]string, 0, c.burst)
+	// creation must not overlap the measured burst. Provisioning is sequential
+	// (~4 apiserver round trips per function) but sits entirely outside the
+	// measured window, so it costs wall time only, never the numbers.
 	fnCount := 1
 	if c.distinct {
 		fnCount = c.burst
 	}
+	fnRoutes := make([]string, 0, fnCount)
 	for i := range fnCount {
 		fnName := sc.Name(fmt.Sprintf("fn%d", i))
 		route := "/" + fnName
@@ -85,13 +87,12 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 		if err := sc.CreateRoute(ctx, harness.RouteOptions{Name: sc.Name(fmt.Sprintf("route%d", i)), Function: fnName, URL: route}); err != nil {
 			return res, err
 		}
+		fnRoutes = append(fnRoutes, route)
 	}
+	// Burst target list: same-fn replicates the one route; distinct-fn is 1:1.
+	routes := make([]string, 0, c.burst)
 	for i := range c.burst {
-		fnIdx := 0
-		if c.distinct {
-			fnIdx = i
-		}
-		routes = append(routes, "/"+sc.Name(fmt.Sprintf("fn%d", fnIdx)))
+		routes = append(routes, fnRoutes[i%len(fnRoutes)])
 	}
 
 	// Fire the burst: one goroutine per request, each anchored by

--- a/test/benchmark/pkg/scenario/coldburst.go
+++ b/test/benchmark/pkg/scenario/coldburst.go
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scenario
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/benchmark/pkg/harness"
+	"github.com/fission/fission/test/benchmark/pkg/report"
+)
+
+// coldBurst measures poolmgr cold-start latency under N *simultaneous* first
+// requests — the dimension the sequential cold-start scenario cannot see. With
+// the default requestsPerPod=1 every in-flight request wants its own
+// specialized pod, so a burst larger than the pool exercises pool exhaustion
+// and refill (ready-pod queue latency), and concurrent specialization
+// queueing in the executor:
+//
+//   - same-fn: one function, N concurrent first requests — specialization
+//     fan-out for a single function (executor per-function serialization,
+//     pool drain, refill).
+//   - distinct-fn: N functions, one first request each — cross-function pool
+//     contention on a shared environment.
+type coldBurst struct {
+	distinct bool
+	burst    int
+	poolsize int
+}
+
+func (c *coldBurst) Name() string {
+	if c.distinct {
+		return "cold-burst-distinct-fn"
+	}
+	return "cold-burst-same-fn"
+}
+
+func (c *coldBurst) Tags() []string { return []string{"latency", "coldstart", "burst"} }
+
+func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioResult, error) {
+	var res report.ScenarioResult
+	res.SetMeta("burst", fmt.Sprintf("%d", c.burst))
+	res.SetMeta("poolsize", fmt.Sprintf("%d", c.poolsize))
+	env := sc.Env()
+
+	image := env.Images.Python
+	if image == "" {
+		return res, skip("PYTHON_RUNTIME_IMAGE unset")
+	}
+
+	envName := sc.Name("burst-env")
+	if err := sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: image, Version: 1, Poolsize: c.poolsize}); err != nil {
+		return res, err
+	}
+	// Start from a fully warm pool so the measurement is specialization +
+	// refill, not initial pool creation.
+	if err := env.WaitForPoolReady(ctx, envName, c.poolsize, 3*time.Minute); err != nil {
+		return res, fmt.Errorf("pool warm-up: %w", err)
+	}
+
+	// Provision the target function(s) and route(s) before firing anything:
+	// creation must not overlap the measured burst.
+	routes := make([]string, 0, c.burst)
+	fnCount := 1
+	if c.distinct {
+		fnCount = c.burst
+	}
+	for i := range fnCount {
+		fnName := sc.Name(fmt.Sprintf("fn%d", i))
+		route := "/" + fnName
+		if err := sc.CreateCodeFunction(ctx, harness.FunctionOptions{
+			Name: fnName, Env: envName, Code: []byte(pythonHello), Entrypoint: "main",
+			ExecutorType: fv1.ExecutorTypePoolmgr, MaxScale: 1,
+		}); err != nil {
+			return res, err
+		}
+		if err := sc.CreateRoute(ctx, harness.RouteOptions{Function: fnName, URL: route}); err != nil {
+			return res, err
+		}
+	}
+	for i := range c.burst {
+		fnIdx := 0
+		if c.distinct {
+			fnIdx = i
+		}
+		routes = append(routes, "/"+sc.Name(fmt.Sprintf("fn%d", fnIdx)))
+	}
+
+	// Fire the burst: one goroutine per request, each anchored by
+	// measureFirstSuccess's own 404-gated clock (route propagation is excluded
+	// from the measured latency; provisioning 5xx is included).
+	var (
+		mu       sync.Mutex
+		samples  []time.Duration
+		failures int
+	)
+	burstStart := time.Now()
+	var wg sync.WaitGroup
+	for _, route := range routes {
+		wg.Go(func() {
+			d, ok := measureFirstSuccess(ctx, env.RouterURL()+route, 3*time.Minute)
+			mu.Lock()
+			defer mu.Unlock()
+			if ok {
+				samples = append(samples, d)
+			} else {
+				failures++
+			}
+		})
+	}
+	wg.Wait()
+	makespan := time.Since(burstStart)
+
+	if len(samples) == 0 {
+		return res, fmt.Errorf("no successful burst samples (%d failures)", failures)
+	}
+	res.Add("burst_p50", "ms", report.Lower, millis(percentile(samples, 50)))
+	res.Add("burst_p95", "ms", report.Lower, millis(percentile(samples, 95)))
+	res.Add("burst_max", "ms", report.Lower, millis(percentile(samples, 100)))
+	// Makespan is the wall time until the whole burst is served — the number a
+	// user staring at a traffic spike experiences; it captures refill/queueing
+	// serialization that per-request percentiles smear.
+	res.Add("burst_makespan", "ms", report.Lower, millis(makespan))
+	res.Add("samples", "count", report.Higher, float64(len(samples)))
+	res.Add("failures", "count", report.Lower, float64(failures))
+	return res, nil
+}

--- a/test/benchmark/pkg/scenario/coldburst.go
+++ b/test/benchmark/pkg/scenario/coldburst.go
@@ -75,7 +75,7 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 		route := "/" + fnName
 		if err := sc.CreateCodeFunction(ctx, harness.FunctionOptions{
 			Name: fnName, Env: envName, Code: []byte(pythonHello), Entrypoint: "main",
-			ExecutorType: fv1.ExecutorTypePoolmgr, MaxScale: 1,
+			ExecutorType: fv1.ExecutorTypePoolmgr,
 		}); err != nil {
 			return res, err
 		}
@@ -102,7 +102,6 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 		samples  []time.Duration
 		failures int
 	)
-	burstStart := time.Now()
 	var wg sync.WaitGroup
 	for _, route := range routes {
 		wg.Go(func() {
@@ -117,18 +116,18 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 		})
 	}
 	wg.Wait()
-	makespan := time.Since(burstStart)
 
 	if len(samples) == 0 {
 		return res, fmt.Errorf("no successful burst samples (%d failures)", failures)
 	}
+	// burst_max doubles as the makespan-from-propagation: every sample's clock
+	// is anchored by measureFirstSuccess's 404 gate, so the slowest request IS
+	// the wall time the burst took once routes were live. A naive
+	// wall-clock-from-fire makespan was measured and dropped — it absorbed
+	// route-propagation variance the scenario's design explicitly excludes.
 	res.Add("burst_p50", "ms", report.Lower, millis(percentile(samples, 50)))
 	res.Add("burst_p95", "ms", report.Lower, millis(percentile(samples, 95)))
 	res.Add("burst_max", "ms", report.Lower, millis(percentile(samples, 100)))
-	// Makespan is the wall time until the whole burst is served — the number a
-	// user staring at a traffic spike experiences; it captures refill/queueing
-	// serialization that per-request percentiles smear.
-	res.Add("burst_makespan", "ms", report.Lower, millis(makespan))
 	res.Add("samples", "count", report.Higher, float64(len(samples)))
 	res.Add("failures", "count", report.Lower, float64(failures))
 	return res, nil

--- a/test/benchmark/pkg/scenario/coldburst.go
+++ b/test/benchmark/pkg/scenario/coldburst.go
@@ -64,9 +64,7 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 	}
 
 	// Provision the target function(s) and route(s) before firing anything:
-	// creation must not overlap the measured burst. Provisioning is sequential
-	// (~4 apiserver round trips per function) but sits entirely outside the
-	// measured window, so it costs wall time only, never the numbers.
+	// creation must not overlap the measured burst.
 	fnCount := 1
 	if c.distinct {
 		fnCount = c.burst
@@ -123,9 +121,7 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 	}
 	// burst_max doubles as the makespan-from-propagation: every sample's clock
 	// is anchored by measureFirstSuccess's 404 gate, so the slowest request IS
-	// the wall time the burst took once routes were live. A naive
-	// wall-clock-from-fire makespan was measured and dropped — it absorbed
-	// route-propagation variance the scenario's design explicitly excludes.
+	// the wall time the burst took once routes were live.
 	res.Add("burst_p50", "ms", report.Lower, millis(percentile(samples, 50)))
 	res.Add("burst_p95", "ms", report.Lower, millis(percentile(samples, 95)))
 	res.Add("burst_max", "ms", report.Lower, millis(percentile(samples, 100)))

--- a/test/benchmark/pkg/scenario/coldburst.go
+++ b/test/benchmark/pkg/scenario/coldburst.go
@@ -79,7 +79,10 @@ func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 		}); err != nil {
 			return res, err
 		}
-		if err := sc.CreateRoute(ctx, harness.RouteOptions{Function: fnName, URL: route}); err != nil {
+		// Route names must be per-function: CreateRoute's default name is
+		// scope-unique, not call-unique, and the distinct-fn variant creates N
+		// triggers in one scope.
+		if err := sc.CreateRoute(ctx, harness.RouteOptions{Name: sc.Name(fmt.Sprintf("route%d", i)), Function: fnName, URL: route}); err != nil {
 			return res, err
 		}
 	}

--- a/test/benchmark/pkg/scenario/coldburst.go
+++ b/test/benchmark/pkg/scenario/coldburst.go
@@ -7,6 +7,7 @@ package scenario
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -44,8 +45,8 @@ func (c *coldBurst) Tags() []string { return []string{"latency", "coldstart", "b
 
 func (c *coldBurst) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioResult, error) {
 	var res report.ScenarioResult
-	res.SetMeta("burst", fmt.Sprintf("%d", c.burst))
-	res.SetMeta("poolsize", fmt.Sprintf("%d", c.poolsize))
+	res.SetMeta("burst", strconv.Itoa(c.burst))
+	res.SetMeta("poolsize", strconv.Itoa(c.poolsize))
 	env := sc.Env()
 
 	image := env.Images.Python

--- a/test/benchmark/pkg/scenario/coldstart.go
+++ b/test/benchmark/pkg/scenario/coldstart.go
@@ -68,7 +68,7 @@ func (c *coldStart) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 			// Let the pool refill between iterations so each measures a cold pod.
 			_ = env.WaitForPoolReady(ctx, envName, 1, 2*time.Minute)
 		}
-		if d, ok := c.measureOne(ctx, env, envName, i); ok {
+		if d, ok := c.measureOne(ctx, sc, envName, i); ok {
 			samples = append(samples, d)
 		} else {
 			failures++
@@ -87,9 +87,11 @@ func (c *coldStart) Run(ctx context.Context, sc *harness.Scope) (report.Scenario
 }
 
 // measureOne creates one function+route, measures the first successful request,
-// and tears the pair down (its own Scope) regardless of outcome.
-func (c *coldStart) measureOne(ctx context.Context, env *harness.Env, envName string, i int) (time.Duration, bool) {
-	iter := env.NewScope(fmt.Sprintf("%s-i%d", c.Name(), i))
+// and tears the pair down (its own sub-scope, derived from the runner's scope
+// so repetition-unique labels reach the resource names) regardless of outcome.
+func (c *coldStart) measureOne(ctx context.Context, sc *harness.Scope, envName string, i int) (time.Duration, bool) {
+	env := sc.Env()
+	iter := sc.SubScope(fmt.Sprintf("i%d", i))
 	defer iter.CleanupDetached(ctx, time.Minute)
 
 	fnName := iter.Name("fn")

--- a/test/benchmark/pkg/scenario/coldstart_configdeps.go
+++ b/test/benchmark/pkg/scenario/coldstart_configdeps.go
@@ -89,7 +89,7 @@ func (c *coldStartConfigDeps) Run(ctx context.Context, sc *harness.Scope) (repor
 		}
 		// Let the pool refill so each iteration measures a cold pod.
 		_ = env.WaitForPoolReady(ctx, envName, 1, 2*time.Minute)
-		if d, ok := c.measureOne(ctx, env, envName, secrets, configMaps, i); ok {
+		if d, ok := c.measureOne(ctx, sc, envName, secrets, configMaps, i); ok {
 			samples = append(samples, d)
 		} else {
 			failures++
@@ -109,9 +109,11 @@ func (c *coldStartConfigDeps) Run(ctx context.Context, sc *harness.Scope) (repor
 
 // measureOne creates one function (referencing all the scenario's Secrets and
 // ConfigMaps) + route, measures the first successful request, and tears the pair
-// down (its own Scope) regardless of outcome.
-func (c *coldStartConfigDeps) measureOne(ctx context.Context, env *harness.Env, envName string, secrets, configMaps []string, i int) (time.Duration, bool) {
-	iter := env.NewScope(fmt.Sprintf("%s-i%d", c.Name(), i))
+// down (its own sub-scope, derived from the runner's scope so
+// repetition-unique labels reach the resource names) regardless of outcome.
+func (c *coldStartConfigDeps) measureOne(ctx context.Context, sc *harness.Scope, envName string, secrets, configMaps []string, i int) (time.Duration, bool) {
+	env := sc.Env()
+	iter := sc.SubScope(fmt.Sprintf("i%d", i))
 	defer iter.CleanupDetached(ctx, time.Minute)
 
 	fnName := iter.Name("fn")

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -292,8 +292,27 @@ func aggregateReps(reps []report.ScenarioResult) report.ScenarioResult {
 	}
 	agg := reps[0]
 	agg.Metrics = nil
+	// Fresh Meta map: the struct copy above aliases rep 0's map, and SetMeta
+	// below would otherwise mutate the rep's own result.
+	agg.Meta = nil
+	for k, v := range reps[0].Meta {
+		agg.SetMeta(k, v)
+	}
 	agg.SetMeta("repetitions", strconv.Itoa(len(reps)))
-	for _, m := range reps[0].Metrics {
+	// Metric set is the union across reps (first-seen order), not rep 0's set:
+	// conditionally-emitted metrics (apiserver_calls drops its sample on a
+	// counter reset or scrape miss) must survive one rep missing them.
+	var order []report.Metric
+	seen := map[string]bool{}
+	for _, r := range reps {
+		for _, m := range r.Metrics {
+			if !seen[m.Name] {
+				seen[m.Name] = true
+				order = append(order, m)
+			}
+		}
+	}
+	for _, m := range order {
 		vals := make([]float64, 0, len(reps))
 		for _, r := range reps {
 			for _, rm := range r.Metrics {

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -75,8 +75,12 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 // back to DefaultParams via normalize. Field tags let it load directly from the
 // scenarios YAML.
 type Params struct {
-	Poolsize          int                `json:"poolsize"`
-	ColdIterations    int                `json:"coldIterations"`
+	Poolsize       int `json:"poolsize"`
+	ColdIterations int `json:"coldIterations"`
+	// Repetitions re-runs every selected scenario N times (each in a fresh
+	// Scope) and reports the per-metric median plus min..max spread, so a
+	// single noisy cluster sample can't masquerade as a regression or a win.
+	Repetitions       int                `json:"repetitions"`
 	WarmDuration      Duration           `json:"warmDuration"`
 	WarmWarmup        Duration           `json:"warmWarmup"`
 	WarmConcurrency   int                `json:"warmConcurrency"`
@@ -102,6 +106,7 @@ func DefaultParams() Params {
 	return Params{
 		Poolsize:             3,
 		ColdIterations:       20,
+		Repetitions:          1,
 		WarmDuration:         Duration(60 * time.Second),
 		WarmWarmup:           Duration(10 * time.Second),
 		WarmConcurrency:      50,
@@ -126,6 +131,9 @@ func (p Params) normalize() Params {
 	}
 	if p.ColdIterations == 0 {
 		p.ColdIterations = d.ColdIterations
+	}
+	if p.Repetitions == 0 {
+		p.Repetitions = d.Repetitions
 	}
 	if p.WarmDuration == 0 {
 		p.WarmDuration = d.WarmDuration
@@ -225,19 +233,77 @@ func Names(all []Scenario) []string {
 }
 
 // Run executes the scenarios against env, isolating each in its own Scope and
-// always cleaning up. A scenario error or skip is recorded in the result and the
-// run continues (failure budget).
-func Run(ctx context.Context, env *harness.Env, scenarios []Scenario) report.Run {
+// always cleaning up. repetitions > 1 re-runs each scenario in fresh scopes and
+// folds the results via aggregateReps. A scenario error or skip is recorded in
+// the result and the run continues (failure budget).
+func Run(ctx context.Context, env *harness.Env, scenarios []Scenario, repetitions int) report.Run {
+	if repetitions < 1 {
+		repetitions = 1
+	}
 	run := report.Run{RunID: env.RunID, StartedAt: time.Now()}
 	for _, s := range scenarios {
-		run.Scenarios = append(run.Scenarios, runOne(ctx, env, s))
+		reps := make([]report.ScenarioResult, 0, repetitions)
+		for rep := range repetitions {
+			label := s.Name()
+			if repetitions > 1 {
+				// The rep index keeps resource names distinct across reps: the
+				// previous rep's cleanup is detached and may still be deleting
+				// same-named resources when the next rep provisions.
+				label = fmt.Sprintf("%s-r%d", s.Name(), rep)
+			}
+			res := runOne(ctx, env, s, label)
+			reps = append(reps, res)
+			if res.Skipped || res.Error != "" {
+				break // a skip is deterministic; an error already fails the gate
+			}
+		}
+		run.Scenarios = append(run.Scenarios, aggregateReps(reps))
 	}
 	run.FinishedAt = time.Now()
 	return run
 }
 
-func runOne(ctx context.Context, env *harness.Env, s Scenario) (res report.ScenarioResult) {
-	sc := env.NewScope(s.Name())
+// aggregateReps folds repetition results into one ScenarioResult, keeping
+// metric names stable for thresholds and the trend: each metric's value is the
+// median across reps, with the observed min..max recorded in
+// Meta["<metric>_range"] so the run's noise floor is visible next to the
+// number. The first non-clean rep is returned as-is (annotated with its rep
+// index) since partial metrics aren't comparable.
+func aggregateReps(reps []report.ScenarioResult) report.ScenarioResult {
+	last := reps[len(reps)-1]
+	if len(reps) == 1 {
+		return last
+	}
+	if last.Error != "" || last.Skipped {
+		last.SetMeta("failed_repetition", strconv.Itoa(len(reps)-1))
+		return last
+	}
+	agg := reps[0]
+	agg.Metrics = nil
+	agg.SetMeta("repetitions", strconv.Itoa(len(reps)))
+	for _, m := range reps[0].Metrics {
+		vals := make([]float64, 0, len(reps))
+		for _, r := range reps {
+			for _, rm := range r.Metrics {
+				if rm.Name == m.Name {
+					vals = append(vals, rm.Value)
+					break
+				}
+			}
+		}
+		slices.Sort(vals)
+		med := vals[len(vals)/2]
+		if len(vals)%2 == 0 {
+			med = (vals[len(vals)/2-1] + vals[len(vals)/2]) / 2
+		}
+		agg.Metrics = append(agg.Metrics, report.Metric{Name: m.Name, Unit: m.Unit, Value: med, Better: m.Better})
+		agg.SetMeta(m.Name+"_range", fmt.Sprintf("%.3f..%.3f", vals[0], vals[len(vals)-1]))
+	}
+	return agg
+}
+
+func runOne(ctx context.Context, env *harness.Env, s Scenario, scopeLabel string) (res report.ScenarioResult) {
+	sc := env.NewScope(scopeLabel)
 	res.Name = s.Name()
 	res.Tags = s.Tags()
 	defer func() {
@@ -249,6 +315,7 @@ func runOne(ctx context.Context, env *harness.Env, s Scenario) (res report.Scena
 		_ = sc.CleanupDetached(ctx, 2*time.Minute)
 	}()
 
+	before, beforeOK := apiserverCalls(ctx, env)
 	out, err := s.Run(ctx, sc)
 	out.Name = s.Name()
 	out.Tags = s.Tags()
@@ -257,9 +324,32 @@ func runOne(ctx context.Context, env *harness.Env, s Scenario) (res report.Scena
 		out.Skip = err.Error()
 	} else if err != nil {
 		out.Error = err.Error()
+	} else if after, afterOK := apiserverCalls(ctx, env); beforeOK && afterOK && after >= before {
+		// after < before means a counter reset (component restart) — drop the
+		// sample rather than report a bogus delta.
+		out.Add("apiserver_calls", "count", report.Lower, after-before)
 	}
 	res = out
 	return res
+}
+
+// apiserverCalls sums the control-plane components' client-side apiserver
+// request counters. rest_client_requests_total is registered by
+// controller-runtime's metrics registry in every fission binary, so a
+// before/after delta attributes a scenario's apiserver traffic to Fission —
+// something apiserver_request_total (which has no user-agent label) cannot.
+// Prometheus scrapes on an interval, so the delta trails by up to one scrape;
+// treat it as an attribution signal for A/B comparisons, not an exact count.
+func apiserverCalls(ctx context.Context, env *harness.Env) (float64, bool) {
+	if !env.Capturer.PrometheusEnabled() {
+		return 0, false
+	}
+	q := fmt.Sprintf(`sum(rest_client_requests_total{namespace=%q})`, env.FissionNamespace())
+	v, found, err := env.Capturer.QueryInstant(ctx, q)
+	if err != nil || !found {
+		return 0, false
+	}
+	return v, true
 }
 
 func isSkip(err error) bool {

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -246,8 +246,8 @@ func Names(all []Scenario) []string {
 
 // Run executes the scenarios against env, isolating each in its own Scope and
 // always cleaning up. repetitions > 1 re-runs each scenario in fresh scopes and
-// folds the results via aggregateReps. A scenario error or skip is recorded in
-// the result and the run continues (failure budget).
+// folds the results via report.Aggregate. A scenario error or skip is recorded
+// in the result and the run continues (failure budget).
 func Run(ctx context.Context, env *harness.Env, scenarios []Scenario, repetitions int) report.Run {
 	if repetitions < 1 {
 		repetitions = 1
@@ -269,59 +269,10 @@ func Run(ctx context.Context, env *harness.Env, scenarios []Scenario, repetition
 				break // a skip is deterministic; an error already fails the gate
 			}
 		}
-		run.Scenarios = append(run.Scenarios, aggregateReps(reps))
+		run.Scenarios = append(run.Scenarios, report.Aggregate(reps))
 	}
 	run.FinishedAt = time.Now()
 	return run
-}
-
-// aggregateReps folds repetition results into one ScenarioResult, keeping
-// metric names stable for thresholds and the trend: each metric's value is the
-// median across reps, with the observed min..max recorded in
-// Meta["<metric>_range"] so the run's noise floor is visible next to the
-// number. The first non-clean rep is returned as-is (annotated with its rep
-// index) since partial metrics aren't comparable.
-func aggregateReps(reps []report.ScenarioResult) report.ScenarioResult {
-	last := reps[len(reps)-1]
-	if len(reps) == 1 {
-		return last
-	}
-	if last.Error != "" || last.Skipped {
-		last.SetMeta("failed_repetition", strconv.Itoa(len(reps)-1))
-		return last
-	}
-	// Build the aggregate from scratch (no struct copy — that would alias
-	// rep 0's Meta map and mutate the rep's own result).
-	agg := report.ScenarioResult{Name: reps[0].Name, Tags: reps[0].Tags}
-	for k, v := range reps[0].Meta {
-		agg.SetMeta(k, v)
-	}
-	agg.SetMeta("repetitions", strconv.Itoa(len(reps)))
-	// Single sweep collecting values per metric name. The metric set is the
-	// union across reps (first-seen order), not rep 0's set: conditionally
-	// emitted metrics (apiserver_calls drops its sample on a counter reset or
-	// scrape miss) must survive one rep missing them.
-	var order []report.Metric
-	vals := map[string][]float64{}
-	for _, r := range reps {
-		for _, m := range r.Metrics {
-			if _, ok := vals[m.Name]; !ok {
-				order = append(order, m)
-			}
-			vals[m.Name] = append(vals[m.Name], m.Value)
-		}
-	}
-	for _, m := range order {
-		v := vals[m.Name]
-		slices.Sort(v)
-		med := v[len(v)/2]
-		if len(v)%2 == 0 {
-			med = (v[len(v)/2-1] + v[len(v)/2]) / 2
-		}
-		agg.Metrics = append(agg.Metrics, report.Metric{Name: m.Name, Unit: m.Unit, Value: med, Better: m.Better})
-		agg.SetMeta(m.Name+"_range", fmt.Sprintf("%.3f..%.3f", v[0], v[len(v)-1]))
-	}
-	return agg
 }
 
 func runOne(ctx context.Context, env *harness.Env, s Scenario, scopeLabel string) (res report.ScenarioResult) {

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -198,7 +198,9 @@ func BuildAll(p Params) []Scenario {
 	out = append(out, &coldStartConfigDeps{iterations: p.ColdIterations, poolsize: p.Poolsize, secrets: p.ConfigDepsSecrets, configMaps: p.ConfigDepsConfigMaps})
 	out = append(out, &coldBurst{distinct: false, burst: p.BurstSize, poolsize: p.Poolsize})
 	out = append(out, &coldBurst{distinct: true, burst: p.BurstSize, poolsize: p.Poolsize})
-	out = append(out, &warmPath{duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
+	for _, ex := range p.Executors {
+		out = append(out, &warmPath{executor: ex, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
+	}
 	out = append(out, &concurrencySweep{levels: p.ConcurrencyLevels, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), poolsize: p.Poolsize})
 	out = append(out, &rpsSweep{levels: p.RPSLevels, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), poolsize: p.Poolsize})
 	out = append(out, &payloadSweep{sizes: p.PayloadSizes, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
@@ -421,11 +423,13 @@ func addServerMetrics(ctx context.Context, env *harness.Env, res *report.Scenari
 	}
 }
 
-// provisionWarmFunction creates a poolmgr env + code function + route sized to
-// serve concurrent requests from a single warm pod (high requestsPerPod, so the
+// provisionWarmFunction creates an env + code function + route sized to serve
+// concurrent requests from a single warm pod (high requestsPerPod, so the
 // measurement isolates router/proxy overhead), and waits until it is routable —
-// which also warms it. methods controls the route's allowed HTTP methods.
-func provisionWarmFunction(ctx context.Context, sc *harness.Scope, poolsize, requestsPerPod int, methods []string) (route string, err error) {
+// which also warms it. For newdeploy/container the function pins minScale=1 so
+// a backing pod exists before load starts (poolmgr warms via its generic
+// pool). methods controls the route's allowed HTTP methods.
+func provisionWarmFunction(ctx context.Context, sc *harness.Scope, executor fv1.ExecutorType, poolsize, requestsPerPod int, methods []string) (route string, err error) {
 	env := sc.Env()
 	if env.Images.Python == "" {
 		return "", skip("PYTHON_RUNTIME_IMAGE unset")
@@ -434,11 +438,15 @@ func provisionWarmFunction(ctx context.Context, sc *harness.Scope, poolsize, req
 	if err = sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: env.Images.Python, Version: 1, Poolsize: poolsize}); err != nil {
 		return "", err
 	}
+	minScale := 0
+	if executor != fv1.ExecutorTypePoolmgr {
+		minScale = 1
+	}
 	fnName := sc.Name("fn")
 	route = "/" + fnName
 	if err = sc.CreateCodeFunction(ctx, harness.FunctionOptions{
 		Name: fnName, Env: envName, Code: []byte(pythonHello), Entrypoint: "main",
-		ExecutorType: fv1.ExecutorTypePoolmgr, RequestsPerPod: requestsPerPod,
+		ExecutorType: executor, MinScale: minScale, RequestsPerPod: requestsPerPod,
 	}); err != nil {
 		return "", err
 	}

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -80,7 +80,11 @@ type Params struct {
 	// Repetitions re-runs every selected scenario N times (each in a fresh
 	// Scope) and reports the per-metric median plus min..max spread, so a
 	// single noisy cluster sample can't masquerade as a regression or a win.
-	Repetitions       int                `json:"repetitions"`
+	Repetitions int `json:"repetitions"`
+	// BurstSize is the number of simultaneous first-requests the cold-burst
+	// scenarios fire; sized above Poolsize so the burst forces pool exhaustion
+	// and refill rather than being absorbed by warm pods.
+	BurstSize         int                `json:"burstSize"`
 	WarmDuration      Duration           `json:"warmDuration"`
 	WarmWarmup        Duration           `json:"warmWarmup"`
 	WarmConcurrency   int                `json:"warmConcurrency"`
@@ -107,6 +111,7 @@ func DefaultParams() Params {
 		Poolsize:             3,
 		ColdIterations:       20,
 		Repetitions:          1,
+		BurstSize:            10,
 		WarmDuration:         Duration(60 * time.Second),
 		WarmWarmup:           Duration(10 * time.Second),
 		WarmConcurrency:      50,
@@ -134,6 +139,9 @@ func (p Params) normalize() Params {
 	}
 	if p.Repetitions == 0 {
 		p.Repetitions = d.Repetitions
+	}
+	if p.BurstSize == 0 {
+		p.BurstSize = d.BurstSize
 	}
 	if p.WarmDuration == 0 {
 		p.WarmDuration = d.WarmDuration
@@ -188,6 +196,8 @@ func BuildAll(p Params) []Scenario {
 		out = append(out, &coldStart{executor: ex, iterations: p.ColdIterations, poolsize: p.Poolsize})
 	}
 	out = append(out, &coldStartConfigDeps{iterations: p.ColdIterations, poolsize: p.Poolsize, secrets: p.ConfigDepsSecrets, configMaps: p.ConfigDepsConfigMaps})
+	out = append(out, &coldBurst{distinct: false, burst: p.BurstSize, poolsize: p.Poolsize})
+	out = append(out, &coldBurst{distinct: true, burst: p.BurstSize, poolsize: p.Poolsize})
 	out = append(out, &warmPath{duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
 	out = append(out, &concurrencySweep{levels: p.ConcurrencyLevels, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), poolsize: p.Poolsize})
 	out = append(out, &rpsSweep{levels: p.RPSLevels, duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), poolsize: p.Poolsize})

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -290,45 +290,36 @@ func aggregateReps(reps []report.ScenarioResult) report.ScenarioResult {
 		last.SetMeta("failed_repetition", strconv.Itoa(len(reps)-1))
 		return last
 	}
-	agg := reps[0]
-	agg.Metrics = nil
-	// Fresh Meta map: the struct copy above aliases rep 0's map, and SetMeta
-	// below would otherwise mutate the rep's own result.
-	agg.Meta = nil
+	// Build the aggregate from scratch (no struct copy — that would alias
+	// rep 0's Meta map and mutate the rep's own result).
+	agg := report.ScenarioResult{Name: reps[0].Name, Tags: reps[0].Tags}
 	for k, v := range reps[0].Meta {
 		agg.SetMeta(k, v)
 	}
 	agg.SetMeta("repetitions", strconv.Itoa(len(reps)))
-	// Metric set is the union across reps (first-seen order), not rep 0's set:
-	// conditionally-emitted metrics (apiserver_calls drops its sample on a
-	// counter reset or scrape miss) must survive one rep missing them.
+	// Single sweep collecting values per metric name. The metric set is the
+	// union across reps (first-seen order), not rep 0's set: conditionally
+	// emitted metrics (apiserver_calls drops its sample on a counter reset or
+	// scrape miss) must survive one rep missing them.
 	var order []report.Metric
-	seen := map[string]bool{}
+	vals := map[string][]float64{}
 	for _, r := range reps {
 		for _, m := range r.Metrics {
-			if !seen[m.Name] {
-				seen[m.Name] = true
+			if _, ok := vals[m.Name]; !ok {
 				order = append(order, m)
 			}
+			vals[m.Name] = append(vals[m.Name], m.Value)
 		}
 	}
 	for _, m := range order {
-		vals := make([]float64, 0, len(reps))
-		for _, r := range reps {
-			for _, rm := range r.Metrics {
-				if rm.Name == m.Name {
-					vals = append(vals, rm.Value)
-					break
-				}
-			}
-		}
-		slices.Sort(vals)
-		med := vals[len(vals)/2]
-		if len(vals)%2 == 0 {
-			med = (vals[len(vals)/2-1] + vals[len(vals)/2]) / 2
+		v := vals[m.Name]
+		slices.Sort(v)
+		med := v[len(v)/2]
+		if len(v)%2 == 0 {
+			med = (v[len(v)/2-1] + v[len(v)/2]) / 2
 		}
 		agg.Metrics = append(agg.Metrics, report.Metric{Name: m.Name, Unit: m.Unit, Value: med, Better: m.Better})
-		agg.SetMeta(m.Name+"_range", fmt.Sprintf("%.3f..%.3f", vals[0], vals[len(vals)-1]))
+		agg.SetMeta(m.Name+"_range", fmt.Sprintf("%.3f..%.3f", v[0], v[len(v)-1]))
 	}
 	return agg
 }
@@ -355,10 +346,12 @@ func runOne(ctx context.Context, env *harness.Env, s Scenario, scopeLabel string
 		out.Skip = err.Error()
 	} else if err != nil {
 		out.Error = err.Error()
-	} else if after, afterOK := apiserverCalls(ctx, env); beforeOK && afterOK && after >= before {
+	} else if beforeOK {
 		// after < before means a counter reset (component restart) — drop the
 		// sample rather than report a bogus delta.
-		out.Add("apiserver_calls", "count", report.Lower, after-before)
+		if after, afterOK := apiserverCalls(ctx, env); afterOK && after >= before {
+			out.Add("apiserver_calls", "count", report.Lower, after-before)
+		}
 	}
 	res = out
 	return res

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -138,3 +138,14 @@ func TestAggregateReps(t *testing.T) {
 		assert.Empty(t, out.Metrics)
 	})
 }
+
+func TestColdBurstScenariosRegistered(t *testing.T) {
+	t.Parallel()
+	names := Names(BuildAll(DefaultParams()))
+	assert.Contains(t, names, "cold-burst-same-fn")
+	assert.Contains(t, names, "cold-burst-distinct-fn")
+	// The default burst must exceed the default pool, or the scenario silently
+	// stops exercising exhaustion/refill.
+	p := DefaultParams()
+	assert.Greater(t, p.BurstSize, p.Poolsize)
+}

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -129,6 +129,26 @@ func TestAggregateReps(t *testing.T) {
 		assert.Equal(t, 25.0, out.Metrics[0].Value)
 	})
 
+	t.Run("metric missing from rep 0 still aggregates from later reps", func(t *testing.T) {
+		t.Parallel()
+		withCalls := mk(20, 100)
+		withCalls.Add("apiserver_calls", "count", report.Lower, 42)
+		out := aggregateReps([]report.ScenarioResult{mk(10, 100), withCalls, mk(30, 100)})
+		names := make([]string, 0, len(out.Metrics))
+		for _, m := range out.Metrics {
+			names = append(names, m.Name)
+		}
+		assert.Contains(t, names, "apiserver_calls")
+	})
+
+	t.Run("aggregation does not mutate rep 0's meta", func(t *testing.T) {
+		t.Parallel()
+		rep0 := mk(10, 100)
+		rep0.SetMeta("executor", "poolmgr")
+		_ = aggregateReps([]report.ScenarioResult{rep0, mk(20, 100)})
+		assert.Equal(t, map[string]string{"executor": "poolmgr"}, rep0.Meta)
+	})
+
 	t.Run("an errored rep short-circuits with its rep index", func(t *testing.T) {
 		t.Parallel()
 		bad := report.ScenarioResult{Name: "warm-path", Error: "boom"}

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -149,3 +149,16 @@ func TestColdBurstScenariosRegistered(t *testing.T) {
 	p := DefaultParams()
 	assert.Greater(t, p.BurstSize, p.Poolsize)
 }
+
+func TestWarmPathPerExecutor(t *testing.T) {
+	t.Parallel()
+	names := Names(BuildAll(DefaultParams()))
+	assert.Contains(t, names, "warm-path")
+	assert.Contains(t, names, "warm-path-newdeploy")
+	// Only the poolmgr variant runs in the per-PR smoke.
+	for _, s := range BuildAll(DefaultParams()) {
+		if s.Name() == "warm-path-newdeploy" {
+			assert.NotContains(t, s.Tags(), "smoke")
+		}
+	}
+}

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/benchmark/pkg/report"
 )
 
 func TestPercentile(t *testing.T) {
@@ -89,4 +90,51 @@ func TestConfigDepsScenarioRegistered(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 2, cd.secrets)
 	assert.Equal(t, 3, cd.configMaps)
+}
+
+func TestAggregateReps(t *testing.T) {
+	t.Parallel()
+	mk := func(p50, rps float64) report.ScenarioResult {
+		var r report.ScenarioResult
+		r.Name = "warm-path"
+		r.Add("p50", "ms", report.Lower, p50)
+		r.Add("throughput", "rps", report.Higher, rps)
+		return r
+	}
+
+	t.Run("single rep passes through untouched", func(t *testing.T) {
+		t.Parallel()
+		in := mk(10, 100)
+		out := aggregateReps([]report.ScenarioResult{in})
+		assert.Equal(t, in, out)
+		assert.Empty(t, out.Meta)
+	})
+
+	t.Run("odd rep count takes the median and records the range", func(t *testing.T) {
+		t.Parallel()
+		out := aggregateReps([]report.ScenarioResult{mk(30, 90), mk(10, 110), mk(20, 100)})
+		require.Len(t, out.Metrics, 2)
+		assert.Equal(t, 20.0, out.Metrics[0].Value)
+		assert.Equal(t, 100.0, out.Metrics[1].Value)
+		assert.Equal(t, "3", out.Meta["repetitions"])
+		assert.Equal(t, "10.000..30.000", out.Meta["p50_range"])
+		// Direction/unit survive aggregation — thresholds and trend depend on them.
+		assert.Equal(t, report.Higher, out.Metrics[1].Better)
+		assert.Equal(t, "ms", out.Metrics[0].Unit)
+	})
+
+	t.Run("even rep count averages the middle pair", func(t *testing.T) {
+		t.Parallel()
+		out := aggregateReps([]report.ScenarioResult{mk(10, 0), mk(20, 0), mk(40, 0), mk(30, 0)})
+		assert.Equal(t, 25.0, out.Metrics[0].Value)
+	})
+
+	t.Run("an errored rep short-circuits with its rep index", func(t *testing.T) {
+		t.Parallel()
+		bad := report.ScenarioResult{Name: "warm-path", Error: "boom"}
+		out := aggregateReps([]report.ScenarioResult{mk(10, 100), bad})
+		assert.Equal(t, "boom", out.Error)
+		assert.Equal(t, "1", out.Meta["failed_repetition"])
+		assert.Empty(t, out.Metrics)
+	})
 }

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/test/benchmark/pkg/report"
 )
 
 func TestPercentile(t *testing.T) {
@@ -90,73 +89,6 @@ func TestConfigDepsScenarioRegistered(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 2, cd.secrets)
 	assert.Equal(t, 3, cd.configMaps)
-}
-
-func TestAggregateReps(t *testing.T) {
-	t.Parallel()
-	mk := func(p50, rps float64) report.ScenarioResult {
-		var r report.ScenarioResult
-		r.Name = "warm-path"
-		r.Add("p50", "ms", report.Lower, p50)
-		r.Add("throughput", "rps", report.Higher, rps)
-		return r
-	}
-
-	t.Run("single rep passes through untouched", func(t *testing.T) {
-		t.Parallel()
-		in := mk(10, 100)
-		out := aggregateReps([]report.ScenarioResult{in})
-		assert.Equal(t, in, out)
-		assert.Empty(t, out.Meta)
-	})
-
-	t.Run("odd rep count takes the median and records the range", func(t *testing.T) {
-		t.Parallel()
-		out := aggregateReps([]report.ScenarioResult{mk(30, 90), mk(10, 110), mk(20, 100)})
-		require.Len(t, out.Metrics, 2)
-		assert.Equal(t, 20.0, out.Metrics[0].Value)
-		assert.Equal(t, 100.0, out.Metrics[1].Value)
-		assert.Equal(t, "3", out.Meta["repetitions"])
-		assert.Equal(t, "10.000..30.000", out.Meta["p50_range"])
-		// Direction/unit survive aggregation — thresholds and trend depend on them.
-		assert.Equal(t, report.Higher, out.Metrics[1].Better)
-		assert.Equal(t, "ms", out.Metrics[0].Unit)
-	})
-
-	t.Run("even rep count averages the middle pair", func(t *testing.T) {
-		t.Parallel()
-		out := aggregateReps([]report.ScenarioResult{mk(10, 0), mk(20, 0), mk(40, 0), mk(30, 0)})
-		assert.Equal(t, 25.0, out.Metrics[0].Value)
-	})
-
-	t.Run("metric missing from rep 0 still aggregates from later reps", func(t *testing.T) {
-		t.Parallel()
-		withCalls := mk(20, 100)
-		withCalls.Add("apiserver_calls", "count", report.Lower, 42)
-		out := aggregateReps([]report.ScenarioResult{mk(10, 100), withCalls, mk(30, 100)})
-		names := make([]string, 0, len(out.Metrics))
-		for _, m := range out.Metrics {
-			names = append(names, m.Name)
-		}
-		assert.Contains(t, names, "apiserver_calls")
-	})
-
-	t.Run("aggregation does not mutate rep 0's meta", func(t *testing.T) {
-		t.Parallel()
-		rep0 := mk(10, 100)
-		rep0.SetMeta("executor", "poolmgr")
-		_ = aggregateReps([]report.ScenarioResult{rep0, mk(20, 100)})
-		assert.Equal(t, map[string]string{"executor": "poolmgr"}, rep0.Meta)
-	})
-
-	t.Run("an errored rep short-circuits with its rep index", func(t *testing.T) {
-		t.Parallel()
-		bad := report.ScenarioResult{Name: "warm-path", Error: "boom"}
-		out := aggregateReps([]report.ScenarioResult{mk(10, 100), bad})
-		assert.Equal(t, "boom", out.Error)
-		assert.Equal(t, "1", out.Meta["failed_repetition"])
-		assert.Empty(t, out.Metrics)
-	})
 }
 
 func TestColdBurstScenariosRegistered(t *testing.T) {

--- a/test/benchmark/pkg/scenario/sweep.go
+++ b/test/benchmark/pkg/scenario/sweep.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/test/benchmark/pkg/harness"
 	"github.com/fission/fission/test/benchmark/pkg/loadgen"
 	"github.com/fission/fission/test/benchmark/pkg/report"
@@ -33,7 +34,7 @@ func (c *concurrencySweep) Run(ctx context.Context, sc *harness.Scope) (report.S
 	var res report.ScenarioResult
 	env := sc.Env()
 
-	route, err := provisionWarmFunction(ctx, sc, c.poolsize, slices.Max(c.levels)+10, nil)
+	route, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, c.poolsize, slices.Max(c.levels)+10, nil)
 	if err != nil {
 		return res, err
 	}
@@ -69,7 +70,7 @@ func (r *rpsSweep) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioR
 	var res report.ScenarioResult
 	env := sc.Env()
 
-	route, err := provisionWarmFunction(ctx, sc, r.poolsize, slices.Max(r.levels)+10, nil)
+	route, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, r.poolsize, slices.Max(r.levels)+10, nil)
 	if err != nil {
 		return res, err
 	}
@@ -105,7 +106,7 @@ func (p *payloadSweep) Run(ctx context.Context, sc *harness.Scope) (report.Scena
 	var res report.ScenarioResult
 	env := sc.Env()
 
-	route, err := provisionWarmFunction(ctx, sc, p.poolsize, p.concurrency+10, []string{http.MethodGet, http.MethodPost})
+	route, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, p.poolsize, p.concurrency+10, []string{http.MethodGet, http.MethodPost})
 	if err != nil {
 		return res, err
 	}

--- a/test/benchmark/pkg/scenario/warmpath.go
+++ b/test/benchmark/pkg/scenario/warmpath.go
@@ -9,22 +9,39 @@ import (
 	"strconv"
 	"time"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/test/benchmark/pkg/harness"
 	"github.com/fission/fission/test/benchmark/pkg/loadgen"
 	"github.com/fission/fission/test/benchmark/pkg/report"
 )
 
 // warmPath measures steady-state latency and throughput against a pre-warmed
-// function at a fixed concurrency — the router/proxy hot path.
+// function at a fixed concurrency — the router/proxy hot path. The poolmgr
+// variant keeps the historical "warm-path" name (trend-series continuity);
+// other executors get a suffixed name so each data plane has its own
+// steady-state number.
 type warmPath struct {
+	executor    fv1.ExecutorType
 	duration    time.Duration
 	warmup      time.Duration
 	concurrency int
 	poolsize    int
 }
 
-func (w *warmPath) Name() string   { return "warm-path" }
-func (w *warmPath) Tags() []string { return []string{"latency", "warmpath", "throughput", "smoke"} }
+func (w *warmPath) Name() string {
+	if w.executor == fv1.ExecutorTypePoolmgr {
+		return "warm-path"
+	}
+	return "warm-path-" + string(w.executor)
+}
+
+func (w *warmPath) Tags() []string {
+	tags := []string{"latency", "warmpath", "throughput"}
+	if w.executor == fv1.ExecutorTypePoolmgr {
+		tags = append(tags, "smoke")
+	}
+	return tags
+}
 
 func (w *warmPath) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioResult, error) {
 	var res report.ScenarioResult
@@ -32,10 +49,11 @@ func (w *warmPath) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioR
 
 	// requestsPerPod high so all concurrent requests serialize through one warm
 	// pod, isolating router/proxy overhead from pod fan-out.
-	route, err := provisionWarmFunction(ctx, sc, w.poolsize, w.concurrency+10, nil)
+	route, err := provisionWarmFunction(ctx, sc, w.executor, w.poolsize, w.concurrency+10, nil)
 	if err != nil {
 		return res, err
 	}
+	res.SetMeta("executor", string(w.executor))
 	res.SetMeta("concurrency", strconv.Itoa(w.concurrency))
 
 	snapshotPprof(ctx, env, w.Name(), "before")


### PR DESCRIPTION
## TL;DR

Benchmark-driven perf wave 2: first make the benchmark suite able to *measure* what matters (apiserver-call attribution, repetitions with visible noise ranges, burst cold starts, a newdeploy warm baseline, and an actually-green weekly pipeline), then land the deferred cold-start/warm-path levers, each verified by a dispatch A/B. Biggest measured win: **newdeploy cold p50 2848→2664ms (−6.4%)** from the adaptive `WaitForDeployment` poll. Full A/B table in [the results comment](https://github.com/fission/fission/pull/3559#issuecomment-4928825956); the c250/c500 concurrency-collapse investigation (follow-up work, not addressed here) is in [this comment](https://github.com/fission/fission/pull/3559#issuecomment-4928547546).

## Where to start reviewing (risk-ordered)

**Product code — the four files that matter:**
1. `pkg/fetcher/fetcher.go` + `pkg/fetcher/retry.go` (new) — cold-path retry reshape. The env-specialize wait was 0, 1s, 2s… (a late-binding env cost a full second); now 25ms→×2→500ms-cap under a 7-min wall-clock budget covering the old ~406s worst case. Package-Get retries are per-error-class schedules (classify-then-consume; empty schedule = give up); sleeps are ctx-aware. `retry.go` holds the policy + `retry_test.go` pins the schedules and budget invariants.
2. `pkg/executor/util/deployment.go` — `WaitForDeployment` fixed 1s tick → adaptive 50ms→×1.5→1s-cap poll under a wall-clock deadline. Note the old loop conflated iteration count with seconds; the deadline conversion is load-bearing. Shared by newdeploy AND container executors.
3. `pkg/executor/executortype/poolmgr/gpm.go` — ready-pod enqueue debounce 100ms→10ms (`readyPodEnqueueDelay`). Safety: a too-early claim lands on choosePod's not-ready expoDelay requeue; the synchronous relabel Patch (the ownership claim) is deliberately untouched.
4. `pkg/router/rewrite.go` (+`requesthHeader.go`, `transport.go`) — per-request `url.Parse` removal from the forwarded-host header. Also a latent bug fix: the old code parsed `HTTP/1.1://host` (not a scheme), so hostname was always empty and RFC 7239 IPv6 quoting was dead code since inception. FQDN/IPv4 outputs are byte-identical (pinned by pre-existing tests); IPv6 forms are now quoted (new table tests). Microbench: 9→4 allocs/op.

**Low-risk product:** `pkg/utils/httpserver/server.go` (ReadHeaderTimeout 10s + IdleTimeout 120s — deliberately above the 90s client IdleConnTimeout; no Read/WriteTimeout so streaming is unaffected), `cmd/fission-bundle/main.go` (comment only — records the decision NOT to use automaxprocs: Go ≥1.25's runtime cgroup handling is strictly better).

**Test-only (the bulk of the line count):** `test/benchmark/**` — repetitions + `report.Aggregate` (medians, min..max ranges), `apiserver_calls` metric, cold-burst scenarios, `warm-path-newdeploy`, weekly-run fixes (builder `Command`, non-finite-value guards), `.github/workflows/benchmark.yaml` (repetitions input, benchmark-action SHA-pin). One repo-level side effect: the `gh-pages` branch was created (empty orphan) so trend publish can work.

## Review battery already applied

code-review (high-effort workflow; caught a dropped-retry regression, the automaxprocs revert, and three benchmark defects — all fixed in `fix: address code-review findings…`), security-review (no findings; the Forwarded-header quoting change *narrows* a pre-existing unquoted surface), simplify + deslop + code-quality audit (the three `refactor:`/`chore:` commits at the tip; behavior-preserving except the getPkgInformation budget tightening described in its commit). Plan-review ran before implementation.

## Verification

- 18/18 CI checks green (integration matrix ×3, benchmark smoke, CodeQL, lint, codecov ×4, upgrade test).
- Dispatch A/B on this branch (6 scenarios × repetitions=2, zero failures): [results comment](https://github.com/fission/fission/pull/3559#issuecomment-4928825956).
- Unit tests pin every retry schedule, the poll-delay growth, forwarded-host outputs per host form, and the aggregation semantics.

## Assessed and deliberately unchanged

choosePod's synchronous relabel Patch (atomic ownership claim); `setContext` per-retry allocation (fresh deadline per attempt is semantic); per-route ReverseProxy reuse (deferred behind a warm-path allocation profile — touches the Release-closure vs UnTap-RPC settle invariant); sweeps stay poolmgr-pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
