### PR TITLE
fix: graceful degradation under function saturation — strike-based quarantine + bounded specializations + honest sweeps

### DIFF
--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -88,6 +88,10 @@ spec:
         - name: EXECUTOR_SPECIALIZATION_CONCURRENCY
           value: {{ .Values.executor.specializationConcurrency | quote }}
         {{- end }}
+        {{- if hasKey .Values.executor "maxPendingSpecializations" }}
+        - name: EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION
+          value: {{ .Values.executor.maxPendingSpecializations | quote }}
+        {{- end }}
         - name: DEBUG_ENV
           value: {{ .Values.debugEnv | quote }}
         - name: PPROF_ENABLED

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -287,6 +287,14 @@ executor:
   ## nodes, and size it generously.
   ##
   specializationConcurrency: 0
+  ## maxPendingSpecializations bounds specializations IN FLIGHT per function on
+  ## the router's ensureCapacity path (EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION).
+  ## Unlike the function Concurrency cap (a total-pods budget, default 500), this
+  ## stops a saturated function from provisioning dozens of pods before any
+  ## becomes ready; excess requests get a fast 429. 0 disables. Unset uses the
+  ## executor default (20).
+  ##
+  # maxPendingSpecializations: 20
   ## podReadyTimeout represents the timeout in seconds for waiting for pod to become ready.
   ## This is applicable to Pool Manager executor type only.
   ##

--- a/pkg/error/httperror.go
+++ b/pkg/error/httperror.go
@@ -115,6 +115,17 @@ func IsNotFound(err error) bool {
 	return fe.Code == ErrorNotFound
 }
 
+// IsTooManyRequests reports whether err is a Fission capacity rejection
+// (surfaced to clients as HTTP 429).
+func IsTooManyRequests(err error) bool {
+	var fe Error
+	if !errors.As(err, &fe) {
+		return false
+	}
+
+	return fe.Code == ErrorTooManyRequests
+}
+
 const (
 	ErrorInternal = iota
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -308,6 +308,12 @@ func (gpm *GenericPoolManager) GetFuncSvc(ctx context.Context, fn *fv1.Function)
 func (gpm *GenericPoolManager) GetFuncSvcFromCache(ctx context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
 	otelUtils.SpanTrackEvent(ctx, "GetFuncSvcFromCache", otelUtils.GetAttributesForFunction(fn)...)
 	fnSvc, err := gpm.fsCache.GetFuncSvc(ctx, &fn.ObjectMeta, fn.GetRequestPerPod(), fn.GetConcurrency())
+	if ferror.IsTooManyRequests(err) {
+		// The legacy data plane's concurrency-cap rejection: count it on the
+		// same series as the ensureCapacity-path rejections so saturation is
+		// visible regardless of which plane served the traffic.
+		metrics.RecordSpecializationRejected(ctx, fn.Name, fn.Namespace)
+	}
 	if err == nil {
 		// Self-healing for the function Service: the one-shot ensure on the
 		// cold start can be lost (executor rolled mid-ensure), and a missing

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -116,6 +116,11 @@ type (
 		// once from POD_READY_TIMEOUT and handed to every pool.
 		podReadyTimeout time.Duration
 
+		// maxPendingSpecializations bounds specializations in flight per
+		// function on the ensureCapacity path (0 disables); parsed once from
+		// EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION. See ReserveCapacity.
+		maxPendingSpecializations int
+
 		// functionServicesEnabled is the RFC-0002 gate (ENABLE_FUNCTION_SERVICES):
 		// when on, every invoked poolmgr function gets a headless selector
 		// Service so the EndpointSlice controller publishes its specialized
@@ -195,6 +200,7 @@ func MakeGenericPoolManager(ctx context.Context,
 		podSpecPatch:               podSpecPatch,
 		objectReaperIntervalSecond: time.Duration(executorUtils.GetObjectReaperInterval(logger, fv1.ExecutorTypePoolmgr, 5)) * time.Second,
 		podReadyTimeout:            podReadyTimeoutFromEnv(gpmLogger),
+		maxPendingSpecializations:  maxPendingSpecializationsFromEnv(gpmLogger),
 		functionServicesEnabled:    functionServicesEnabled() && !enableIstio,
 	}
 
@@ -318,13 +324,41 @@ func (gpm *GenericPoolManager) DeleteFuncSvcFromCache(ctx context.Context, fsvc 
 	gpm.fsCache.DeleteFunctionSvc(ctx, fsvc)
 }
 
+// defaultMaxPendingSpecializations bounds specializations in flight per
+// function when EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION is unset.
+// Sized well above a legitimate cold burst (the benchmark fires 10) and well
+// below the 88-pod saturation storm this bound exists to stop; 0 disables.
+const defaultMaxPendingSpecializations = 20
+
+// maxPendingSpecializationsFromEnv parses
+// EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION, defaulting on a missing
+// or unparsable value. Called once by MakeGenericPoolManager.
+func maxPendingSpecializationsFromEnv(logger logr.Logger) int {
+	v := os.Getenv("EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION")
+	if v == "" {
+		return defaultMaxPendingSpecializations
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		logger.Error(err, "invalid EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION - using default",
+			"value", v, "default", defaultMaxPendingSpecializations)
+		return defaultMaxPendingSpecializations
+	}
+	return n
+}
+
 // ReserveCapacity implements the executor's capacityReserver facet (RFC-0002
 // ensureCapacity): an atomic check-and-reserve against the function's
-// concurrency cap inside the PoolCache — still the capacity authority. The
-// reservation is released by the specialization's setValue on success or
-// MarkSpecializationFailure on failure.
+// concurrency cap AND the per-function in-flight specialization bound inside
+// the PoolCache — still the capacity authority. The reservation is released
+// by the specialization's setValue on success or MarkSpecializationFailure on
+// failure. Rejections surface to the router (and client) as 429s.
 func (gpm *GenericPoolManager) ReserveCapacity(ctx context.Context, fnMeta *metav1.ObjectMeta, concurrency int) error {
-	return gpm.fsCache.ReserveCapacity(crd.CacheKeyURGFromMeta(fnMeta), concurrency)
+	err := gpm.fsCache.ReserveCapacity(crd.CacheKeyURGFromMeta(fnMeta), concurrency, gpm.maxPendingSpecializations)
+	if err != nil {
+		metrics.RecordSpecializationRejected(ctx, fnMeta.Name, fnMeta.Namespace)
+	}
+	return err
 }
 
 func (gpm *GenericPoolManager) UnTapService(ctx context.Context, fnMeta *metav1.ObjectMeta, svcHost string) {

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -345,7 +345,10 @@ func maxPendingSpecializationsFromEnv(logger logr.Logger) int {
 		return defaultMaxPendingSpecializations
 	}
 	n, err := strconv.Atoi(v)
-	if err != nil || n < 0 {
+	if err == nil && n < 0 {
+		err = fmt.Errorf("value must be >= 0, got %d", n)
+	}
+	if err != nil {
 		logger.Error(err, "invalid EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION - using default",
 			"value", v, "default", defaultMaxPendingSpecializations)
 		return defaultMaxPendingSpecializations

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -132,8 +132,8 @@ func (fsc *FunctionServiceCache) GetByFunction(m *metav1.ObjectMeta) (*FuncSvc, 
 // ReserveCapacity atomically checks the function's concurrency cap and
 // reserves one in-flight specialization in the pool cache (RFC-0002
 // ensureCapacity); returns a TooManyRequests ferror at the cap.
-func (fsc *FunctionServiceCache) ReserveCapacity(key crd.CacheKeyURG, concurrency int) error {
-	return fsc.connFunctionCache.ReserveCapacity(key, concurrency)
+func (fsc *FunctionServiceCache) ReserveCapacity(key crd.CacheKeyURG, concurrency, maxPending int) error {
+	return fsc.connFunctionCache.ReserveCapacity(key, concurrency, maxPending)
 }
 
 // GetFuncSvc gets a function service from pool cache using function key and returns number of active instances of function pod

--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -170,7 +170,13 @@ func (c *PoolCache) GetSvcValue(ctx context.Context, function crd.CacheKeyURG, r
 // cap. The svcWaiting reservation is symmetric with GetSvcValue's: a
 // successful specialization decrements it in SetSvcValue, a failed one in
 // MarkSpecializationFailure.
-func (c *PoolCache) ReserveCapacity(function crd.CacheKeyURG, concurrency int) error {
+// maxPending additionally bounds the number of specializations in flight at
+// once (0 disables): the concurrency cap (default 500) is a total-pods
+// budget, far too loose to stop a saturation storm from specializing dozens
+// of pods for one function before any of them becomes ready. Exceeding either
+// bound returns ErrorTooManyRequests, which the router relays to the client
+// as a fast 429 instead of piling more provisioning on.
+func (c *PoolCache) ReserveCapacity(function crd.CacheKeyURG, concurrency, maxPending int) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -179,9 +185,13 @@ func (c *PoolCache) ReserveCapacity(function crd.CacheKeyURG, concurrency int) e
 		grp = NewFuncSvcGroup()
 		c.cache[function] = grp
 	}
-	concurrencyUsed := len(grp.svcs) + (grp.svcWaiting - grp.queue.Len())
+	pending := grp.svcWaiting - grp.queue.Len()
+	concurrencyUsed := len(grp.svcs) + pending
 	if concurrency > 0 && concurrencyUsed >= concurrency {
 		return ferror.MakeError(ferror.ErrorTooManyRequests, fmt.Sprintf("function '%s' concurrency '%d' limit reached.", function, concurrency))
+	}
+	if maxPending > 0 && pending >= maxPending {
+		return ferror.MakeError(ferror.ErrorTooManyRequests, fmt.Sprintf("function '%s' already has %d specializations in flight (cap %d).", function, pending, maxPending))
 	}
 	grp.svcWaiting++
 	return nil

--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -170,12 +170,11 @@ func (c *PoolCache) GetSvcValue(ctx context.Context, function crd.CacheKeyURG, r
 // cap. The svcWaiting reservation is symmetric with GetSvcValue's: a
 // successful specialization decrements it in SetSvcValue, a failed one in
 // MarkSpecializationFailure.
-// maxPending additionally bounds the number of specializations in flight at
-// once (0 disables): the concurrency cap (default 500) is a total-pods
-// budget, far too loose to stop a saturation storm from specializing dozens
-// of pods for one function before any of them becomes ready. Exceeding either
-// bound returns ErrorTooManyRequests, which the router relays to the client
-// as a fast 429 instead of piling more provisioning on.
+// maxPending additionally bounds specializations in flight at once,
+// independently of the concurrency cap (a total-pods budget); 0 disables.
+// Exceeding either bound returns ErrorTooManyRequests, which the router
+// relays to the client as a fast 429. Sizing rationale lives on
+// poolmgr.defaultMaxPendingSpecializations.
 func (c *PoolCache) ReserveCapacity(function crd.CacheKeyURG, concurrency, maxPending int) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()

--- a/pkg/executor/fscache/poolcache_test.go
+++ b/pkg/executor/fscache/poolcache_test.go
@@ -306,9 +306,9 @@ func TestReserveCapacity(t *testing.T) {
 	c := NewPoolCache(logr.Discard())
 
 	// concurrency=2: two reservations succeed, the third hits the cap.
-	require.NoError(t, c.ReserveCapacity(key, 2))
-	require.NoError(t, c.ReserveCapacity(key, 2))
-	err := c.ReserveCapacity(key, 2)
+	require.NoError(t, c.ReserveCapacity(key, 2, 0))
+	require.NoError(t, c.ReserveCapacity(key, 2, 0))
+	err := c.ReserveCapacity(key, 2, 0)
 	require.Error(t, err)
 	fe, ok := err.(ferror.Error)
 	require.True(t, ok)
@@ -316,13 +316,47 @@ func TestReserveCapacity(t *testing.T) {
 
 	// A failed specialization releases its reservation...
 	c.MarkSpecializationFailure(key)
-	require.NoError(t, c.ReserveCapacity(key, 2))
+	require.NoError(t, c.ReserveCapacity(key, 2, 0))
 
 	// ...and a successful one is consumed by setValue (the pod now counts via
 	// len(svcs) instead), keeping the cap exact.
 	c.SetSvcValue(t.Context(), key, "10.0.0.1:8888", &FuncSvc{Function: &metav1.ObjectMeta{Name: "fn"}}, resource.MustParse("45m"), 10, 0)
-	err = c.ReserveCapacity(key, 2)
+	err = c.ReserveCapacity(key, 2, 0)
 	require.Error(t, err, "1 pod + 1 in-flight reservation == cap 2")
+}
+
+// TestReserveCapacityMaxPending locks the saturation-storm bound: in-flight
+// specializations are capped independently of (and far below) the concurrency
+// cap, released symmetrically, and 0 disables the bound (legacy behavior).
+func TestReserveCapacityMaxPending(t *testing.T) {
+	key := crd.CacheKeyURG{UID: "pending-fn", Generation: 1}
+	c := NewPoolCache(logr.Discard())
+
+	// concurrency far above the pending bound: the pending bound must fire
+	// first (the c500-collapse storm sat at 88 in-flight, well under the
+	// default concurrency of 500).
+	require.NoError(t, c.ReserveCapacity(key, 500, 2))
+	require.NoError(t, c.ReserveCapacity(key, 500, 2))
+	err := c.ReserveCapacity(key, 500, 2)
+	require.Error(t, err)
+	fe, ok := err.(ferror.Error)
+	require.True(t, ok)
+	require.EqualValues(t, ferror.ErrorTooManyRequests, fe.Code)
+
+	// A completed specialization frees a pending slot: the pod now counts
+	// toward concurrency (len(svcs)), not the in-flight bound.
+	c.SetSvcValue(t.Context(), key, "10.0.0.2:8888", &FuncSvc{Function: &metav1.ObjectMeta{Name: "fn"}}, resource.MustParse("45m"), 10, 0)
+	require.NoError(t, c.ReserveCapacity(key, 500, 2))
+
+	// A failed one frees it too.
+	c.MarkSpecializationFailure(key)
+	require.NoError(t, c.ReserveCapacity(key, 500, 2))
+
+	// 0 disables the bound.
+	free := crd.CacheKeyURG{UID: "unbounded-fn", Generation: 1}
+	for range 50 {
+		require.NoError(t, c.ReserveCapacity(free, 0, 0))
+	}
 }
 
 // TestMarkSpecializationFailureUnknownKey guards the ensureCapacity error
@@ -332,7 +366,7 @@ func TestMarkSpecializationFailureUnknownKey(t *testing.T) {
 	c := NewPoolCache(logr.Discard())
 	c.MarkSpecializationFailure(crd.CacheKeyURG{UID: "never-seen", Generation: 1})
 	// The cache survives: a follow-up request still gets served.
-	require.NoError(t, c.ReserveCapacity(crd.CacheKeyURG{UID: "never-seen", Generation: 1}, 0))
+	require.NoError(t, c.ReserveCapacity(crd.CacheKeyURG{UID: "never-seen", Generation: 1}, 0, 0))
 }
 
 // TestPoolCacheTouchByAddress locks the RFC-0002 tap-liveness fix: the

--- a/pkg/executor/metrics/metrics.go
+++ b/pkg/executor/metrics/metrics.go
@@ -26,6 +26,10 @@ var (
 		"fission_function_cold_starts_total",
 		"How many cold starts are made by function_name, function_namespace.",
 	)
+	specializationsRejected = metrics.Int64Counter(
+		"fission_executor_specializations_rejected_total",
+		"Specialization requests rejected at a capacity bound (concurrency cap or in-flight limit), by function_name, function_namespace.",
+	)
 	// Histogram instead of Summary: avoids the per-series quantile stream
 	// memory; quantiles are derived with histogram_quantile(). This is a
 	// function lifetime (seconds to hours), so the buckets stay exponential
@@ -61,6 +65,13 @@ var (
 		"Idle-pool reap attempts whose deployment delete failed (deployment orphaned until adoption or restart cleanup).",
 	)
 )
+
+// RecordSpecializationRejected counts one capacity-gated specialization
+// rejection (concurrency cap or in-flight-specialization bound); the router
+// relays these to clients as 429s.
+func RecordSpecializationRejected(ctx context.Context, fnName, fnNamespace string) {
+	specializationsRejected.Add(ctx, 1, functionLabels(fnName, fnNamespace))
+}
 
 // RecordColdStart counts one cold start for the function.
 func RecordColdStart(ctx context.Context, fnName, fnNamespace string) {

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -496,7 +496,9 @@ func (e *fnEntry) quarantineLocked(address string, now time.Time, ttl time.Durat
 // only after dialTimeoutStrikeLimit strikes land within one TTL window (see
 // that constant for the saturation rationale). Strikes are cleared by slice
 // events (like quarantines) and lapse with the window. The return value
-// reports whether this strike escalated to a quarantine.
+// reports whether THIS call stored a new quarantine — false both below the
+// limit and when a concurrent report already quarantined the address, so
+// callers can log escalations without storm-duplicated noise.
 func (ix *Index) ReportDialTimeout(namespace, name, address string) bool {
 	key := FnKey{Namespace: namespace, Name: name}
 	s := ix.shard(key)
@@ -529,7 +531,7 @@ func (ix *Index) ReportDialTimeout(namespace, name, address string) bool {
 		if stored {
 			RecordQuarantine()
 		}
-		return true
+		return stored
 	}
 	e.strikes[address] = rec
 	e.mu.Unlock()

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -510,6 +510,16 @@ func (ix *Index) ReportDialTimeout(namespace, name, address string) bool {
 	}
 	now := time.Now()
 	e.mu.Lock()
+	// Timeouts reported while the address is already quarantined don't count:
+	// in-flight requests keep failing after the first quarantine stores, and
+	// their strikes would outlive the quarantine window and re-quarantine the
+	// endpoint faster than dialTimeoutStrikeLimit once it's admissible again.
+	if cur := e.quarantined.Load(); cur != nil {
+		if expiry, already := (*cur)[address]; already && now.Before(expiry) {
+			e.mu.Unlock()
+			return false
+		}
+	}
 	if e.strikes == nil {
 		e.strikes = make(map[string]dialStrike)
 	}

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -34,6 +34,22 @@ const shardCount = 64
 // a genuinely dead pod just gets re-quarantined by the next dial failure.
 const DefaultQuarantineTTL = 30 * time.Second
 
+// dialTimeoutStrikeLimit is how many dial timeouts an address absorbs within
+// one TTL window before it is quarantined. A dial timeout is how a
+// saturated-but-alive pod presents (SYN backlog full), so a single strike must
+// not remove a function's only endpoint — that turns saturation into an
+// executor-fallback specialization storm. A truly dead-but-Ready pod still
+// quarantines after this many failed dials; connection refusals (port closed,
+// pod gone) skip strikes and quarantine immediately.
+const dialTimeoutStrikeLimit = 3
+
+// dialStrike is one address's soft-failure record; count resets when the
+// window lapses.
+type dialStrike struct {
+	count  int
+	expiry time.Time
+}
+
 type (
 	// FnKey identifies a function by its CR coordinates (the labels mirrored
 	// from the function's Service onto its slices).
@@ -94,6 +110,11 @@ type (
 		// DefaultQuarantineTTL). Copy-on-write (like eps) so Admit reads it
 		// lock-free; writes happen under mu.
 		quarantined atomic.Pointer[map[string]time.Time]
+		// strikes counts soft dial failures (timeouts) per address, escalated
+		// to a quarantine at dialTimeoutStrikeLimit. Only touched on failure
+		// reports (never by Admit), so a plain mu-guarded map suffices;
+		// cleared alongside quarantined on slice events.
+		strikes map[string]dialStrike
 		// eps is the merged endpoint list, swapped copy-on-write. Hot-path
 		// readers load it without taking mu.
 		eps atomic.Pointer[[]Endpoint]
@@ -237,10 +258,11 @@ func (ix *Index) ApplySlice(es *discoveryv1.EndpointSlice) {
 
 	e.mu.Lock()
 	e.slices[sliceKey] = endpointsFromSlice(es)
-	// Any slice event for this function lifts quarantines: dead endpoints have
-	// been (or are being) removed by the slice controller, so survivors are
-	// trustworthy again.
+	// Any slice event for this function lifts quarantines (and pending
+	// strikes): dead endpoints have been (or are being) removed by the slice
+	// controller, so survivors are trustworthy again.
 	e.quarantined.Store(nil)
+	e.strikes = nil
 	e.rebuildLocked()
 	e.mu.Unlock()
 }
@@ -265,6 +287,7 @@ func (ix *Index) DeleteSlice(es *discoveryv1.EndpointSlice) {
 	e.mu.Lock()
 	delete(e.slices, sliceKey)
 	e.quarantined.Store(nil)
+	e.strikes = nil
 	empty := len(e.slices) == 0
 	e.rebuildLocked()
 	e.mu.Unlock()
@@ -430,15 +453,24 @@ func (ix *Index) Quarantine(namespace, name, address string) {
 	if !ok {
 		return
 	}
-	now := time.Now()
 	e.mu.Lock()
+	stored := e.quarantineLocked(address, time.Now(), ix.quarantineTTL)
+	e.mu.Unlock()
+	if stored {
+		RecordQuarantine()
+	}
+}
+
+// quarantineLocked writes address into the copy-on-write quarantine map;
+// callers hold e.mu. It reports whether a new (or expired-and-renewed)
+// quarantine was stored — false means the address was already quarantined
+// (idempotent: a dead-pod storm reports the same address from many in-flight
+// requests, and only the first copy-and-store matters).
+func (e *fnEntry) quarantineLocked(address string, now time.Time, ttl time.Duration) bool {
 	cur := e.quarantined.Load()
 	if cur != nil {
 		if expiry, already := (*cur)[address]; already && now.Before(expiry) {
-			// Idempotent: a dead-pod storm quarantines the same address from
-			// many in-flight requests — only the first copy-and-store matters.
-			e.mu.Unlock()
-			return
+			return false
 		}
 	}
 	next := make(map[string]time.Time)
@@ -451,8 +483,48 @@ func (ix *Index) Quarantine(namespace, name, address string) {
 			}
 		}
 	}
-	next[address] = now.Add(ix.quarantineTTL)
+	next[address] = now.Add(ttl)
 	e.quarantined.Store(&next)
+	return true
+}
+
+// ReportDialTimeout records a soft dial failure (dial timeout) for an address.
+// A timeout is how a saturated-but-alive pod presents, so unlike a connection
+// refusal it does not quarantine on the first report — only after
+// dialTimeoutStrikeLimit strikes land within one TTL window. Strikes are
+// cleared by slice events (like quarantines) and lapse with the window. The
+// return value reports whether this strike escalated to a quarantine.
+func (ix *Index) ReportDialTimeout(namespace, name, address string) bool {
+	key := FnKey{Namespace: namespace, Name: name}
+	s := ix.shard(key)
+	s.mu.RLock()
+	e, ok := s.m[key]
+	s.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	now := time.Now()
+	e.mu.Lock()
+	if e.strikes == nil {
+		e.strikes = make(map[string]dialStrike)
+	}
+	rec := e.strikes[address]
+	if now.After(rec.expiry) {
+		rec.count = 0
+	}
+	rec.count++
+	rec.expiry = now.Add(ix.quarantineTTL)
+	if rec.count >= dialTimeoutStrikeLimit {
+		delete(e.strikes, address)
+		stored := e.quarantineLocked(address, now, ix.quarantineTTL)
+		e.mu.Unlock()
+		if stored {
+			RecordQuarantine()
+		}
+		return true
+	}
+	e.strikes[address] = rec
 	e.mu.Unlock()
-	RecordQuarantine()
+	RecordDialTimeoutStrike()
+	return false
 }

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -492,12 +492,11 @@ func (e *fnEntry) quarantineLocked(address string, now time.Time, ttl time.Durat
 	return true
 }
 
-// ReportDialTimeout records a soft dial failure (dial timeout) for an address.
-// A timeout is how a saturated-but-alive pod presents, so unlike a connection
-// refusal it does not quarantine on the first report — only after
-// dialTimeoutStrikeLimit strikes land within one TTL window. Strikes are
-// cleared by slice events (like quarantines) and lapse with the window. The
-// return value reports whether this strike escalated to a quarantine.
+// ReportDialTimeout records a soft dial failure for an address, quarantining
+// only after dialTimeoutStrikeLimit strikes land within one TTL window (see
+// that constant for the saturation rationale). Strikes are cleared by slice
+// events (like quarantines) and lapse with the window. The return value
+// reports whether this strike escalated to a quarantine.
 func (ix *Index) ReportDialTimeout(namespace, name, address string) bool {
 	key := FnKey{Namespace: namespace, Name: name}
 	s := ix.shard(key)

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -467,6 +467,10 @@ func (ix *Index) Quarantine(namespace, name, address string) {
 // (idempotent: a dead-pod storm reports the same address from many in-flight
 // requests, and only the first copy-and-store matters).
 func (e *fnEntry) quarantineLocked(address string, now time.Time, ttl time.Duration) bool {
+	// A quarantine consumes any pending strikes for the address: without this
+	// a hard quarantine would leave stale strikes behind, and the first soft
+	// failure after the TTL expires could escalate off old state.
+	delete(e.strikes, address)
 	cur := e.quarantined.Load()
 	if cur != nil {
 		if expiry, already := (*cur)[address]; already && now.Before(expiry) {
@@ -513,9 +517,14 @@ func (ix *Index) ReportDialTimeout(namespace, name, address string) bool {
 		rec.count = 0
 	}
 	rec.count++
-	rec.expiry = now.Add(ix.quarantineTTL)
+	if rec.count == 1 {
+		// The window is anchored at the FIRST strike (fixed, not sliding):
+		// refreshing the expiry per strike would let sporadic timeouts —
+		// one every ~TTL, never dialTimeoutStrikeLimit within any single
+		// window — accumulate forever and quarantine a healthy pod.
+		rec.expiry = now.Add(ix.quarantineTTL)
+	}
 	if rec.count >= dialTimeoutStrikeLimit {
-		delete(e.strikes, address)
 		stored := e.quarantineLocked(address, now, ix.quarantineTTL)
 		e.mu.Unlock()
 		if stored {

--- a/pkg/router/endpointcache/index_test.go
+++ b/pkg/router/endpointcache/index_test.go
@@ -328,3 +328,59 @@ func TestAdmit(t *testing.T) {
 		assert.Equal(t, int64(goroutines), admitted.Load()+refused.Load())
 	})
 }
+
+// TestReportDialTimeout pins the strike escalation: a dial timeout is how a
+// saturated-but-alive pod presents, so soft failures must not quarantine a
+// function's only endpoint until the strike limit is reached within one TTL
+// window.
+func TestReportDialTimeout(t *testing.T) {
+	t.Parallel()
+
+	t.Run("quarantines only at the strike limit", func(t *testing.T) {
+		t.Parallel()
+		ix := NewIndex()
+		ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1"))
+
+		for i := 1; i < dialTimeoutStrikeLimit; i++ {
+			assert.Falsef(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"), "strike %d must not quarantine", i)
+			_, release, result := ix.Admit("default", "fn-a", 1)
+			require.Equalf(t, Admitted, result, "endpoint must stay admissible after strike %d", i)
+			release()
+		}
+		assert.True(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"), "the limit-th strike escalates")
+		_, _, result := ix.Admit("default", "fn-a", 1)
+		assert.Equal(t, AllQuarantined, result)
+	})
+
+	t.Run("strikes lapse with the window", func(t *testing.T) {
+		t.Parallel()
+		ix := NewIndex()
+		ix.quarantineTTL = 30 * time.Millisecond
+		ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1"))
+
+		require.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"))
+		require.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"))
+		time.Sleep(60 * time.Millisecond)
+		// The window lapsed: the count restarts, so this is strike 1 again.
+		assert.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"),
+			"stale strikes must not accumulate across windows")
+	})
+
+	t.Run("slice events clear pending strikes", func(t *testing.T) {
+		t.Parallel()
+		ix := NewIndex()
+		ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1"))
+
+		require.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"))
+		require.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"))
+		ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1"))
+		assert.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"),
+			"a slice event resets the strike count")
+	})
+
+	t.Run("unknown function is a no-op", func(t *testing.T) {
+		t.Parallel()
+		ix := NewIndex()
+		assert.False(t, ix.ReportDialTimeout("default", "nope", "10.0.0.1:8888"))
+	})
+}

--- a/pkg/router/endpointcache/index_test.go
+++ b/pkg/router/endpointcache/index_test.go
@@ -384,3 +384,16 @@ func TestReportDialTimeout(t *testing.T) {
 		assert.False(t, ix.ReportDialTimeout("default", "nope", "10.0.0.1:8888"))
 	})
 }
+
+func TestReportDialTimeoutIgnoredWhileQuarantined(t *testing.T) {
+	t.Parallel()
+	ix := NewIndex()
+	ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1"))
+	ix.Quarantine("default", "fn-a", "10.0.0.1:8888")
+
+	// In-flight requests keep timing out after the quarantine stores; those
+	// reports must not bank strikes that outlive the quarantine window.
+	for range dialTimeoutStrikeLimit + 2 {
+		assert.False(t, ix.ReportDialTimeout("default", "fn-a", "10.0.0.1:8888"))
+	}
+}

--- a/pkg/router/endpointcache/metrics.go
+++ b/pkg/router/endpointcache/metrics.go
@@ -51,6 +51,14 @@ var (
 		"fission_router_endpointcache_quarantines_total",
 		"Endpoints quarantined from the index after a dial failure (lifted by the next slice event or the quarantine TTL).",
 	)
+	// dialTimeoutStrikes counts soft dial failures (timeouts) recorded against
+	// endpoints without quarantining them; a burst here with few quarantines
+	// means saturation, sustained strikes escalating to quarantines mean dead
+	// pods.
+	dialTimeoutStrikes = metrics.Int64Counter(
+		"fission_router_endpointcache_dial_timeout_strikes_total",
+		"Soft dial failures (timeouts) recorded against endpoints; quarantine requires several within one TTL window.",
+	)
 	// fallbacks counts warm-path requests routed to the executor for a
 	// specific reason (strict-mode annotation, no endpoints, all endpoints
 	// saturated, or the executor not supporting ensureCapacity).
@@ -82,6 +90,9 @@ func RecordEndpointLBPick() { lbPicks.Add(context.Background(), 1) }
 
 // RecordQuarantine counts one endpoint quarantine.
 func RecordQuarantine() { quarantines.Add(context.Background(), 1) }
+
+// RecordDialTimeoutStrike counts one soft (timeout) dial-failure strike.
+func RecordDialTimeoutStrike() { dialTimeoutStrikes.Add(context.Background(), 1) }
 
 // RegisterModeInfo publishes the constant info gauge exposing the requested and
 // effective endpointslice cache modes. Recorded for EVERY mode (including off)

--- a/pkg/router/resolver.go
+++ b/pkg/router/resolver.go
@@ -41,6 +41,22 @@ func (e ResolvedEntry) tapTarget() *url.URL {
 	return e.SvcURL
 }
 
+// InvalidateReason classifies the dial failure driving an Invalidate call, so
+// the index can tell a dead endpoint from a saturated one.
+type InvalidateReason int
+
+const (
+	// InvalidateHard marks the endpoint presumed dead: connection refused
+	// (port closed / pod gone), a non-timeout dial error, or the executor-
+	// cached path's retry ladder exhausting. Quarantines immediately.
+	InvalidateHard InvalidateReason = iota
+	// InvalidateSoft marks a dial timeout — how a saturated-but-alive pod
+	// presents (full SYN backlog). Quarantining a function's only endpoint on
+	// one of these turns saturation into an executor-fallback specialization
+	// storm, so soft failures only quarantine after repeated strikes.
+	InvalidateSoft
+)
+
 // AddressResolver resolves a function to a dialable service URL. It is the
 // single choke point of the data plane (RFC-0002): the executor-RPC resolver
 // is the legacy path (mode=off, and the fallback target), and the fallback
@@ -50,8 +66,9 @@ type AddressResolver interface {
 	// Resolve returns the service entry for fn.
 	Resolve(ctx context.Context, fn *fv1.Function) (ResolvedEntry, error)
 	// Invalidate drops any cached state for fn's address. The transport calls
-	// it on the FIRST dial failure of an index-admitted endpoint (quarantine),
-	// and after the retry ladder for cached executor-resolved addresses. addr
-	// may be nil when no address had been resolved.
-	Invalidate(fn *fv1.Function, addr *url.URL)
+	// it on dial failure of an index-admitted endpoint (hard -> immediate
+	// quarantine, soft -> strike-counted) and after the retry ladder for
+	// cached executor-resolved addresses (hard). addr may be nil when no
+	// address had been resolved.
+	Invalidate(fn *fv1.Function, addr *url.URL, reason InvalidateReason)
 }

--- a/pkg/router/resolver_executor.go
+++ b/pkg/router/resolver_executor.go
@@ -96,7 +96,7 @@ func (r *executorResolver) Resolve(ctx context.Context, fn *fv1.Function) (Resol
 }
 
 // Invalidate removes the function's service url entry from the cache.
-func (r *executorResolver) Invalidate(fn *fv1.Function, _ *url.URL) {
+func (r *executorResolver) Invalidate(fn *fv1.Function, _ *url.URL, _ InvalidateReason) {
 	r.fmap.remove(&fn.ObjectMeta)
 }
 

--- a/pkg/router/resolver_fallback.go
+++ b/pkg/router/resolver_fallback.go
@@ -177,17 +177,31 @@ func (f *fallbackResolver) resolveDeployBacked(ctx context.Context, fn *fv1.Func
 	return ResolvedEntry{SvcURL: svcURL}, nil
 }
 
-// Invalidate quarantines the failing endpoint (until the next slice event or
-// the quarantine TTL, whichever comes first) and
-// drops the executor resolver's cached address. Logged at Info: dial failures
-// are rare, and a partial quarantine (one bad pod among many) is otherwise
-// invisible — the aggregate fallback metric only fires when every endpoint of
-// a function is out.
-func (f *fallbackResolver) Invalidate(fn *fv1.Function, addr *url.URL) {
+// Invalidate handles a reported dial failure: hard failures (refused, dead
+// endpoint) quarantine immediately; soft failures (dial timeout — how a
+// saturated pod presents) count strikes and quarantine only when the limit is
+// reached, so saturation does not evict a function's only endpoint and cascade
+// into an executor-fallback specialization storm. Both drop the executor
+// resolver's cached address. Quarantines log at Info: they are rare, and a
+// partial quarantine (one bad pod among many) is otherwise invisible — the
+// aggregate fallback metric only fires when every endpoint of a function is
+// out.
+func (f *fallbackResolver) Invalidate(fn *fv1.Function, addr *url.URL, reason InvalidateReason) {
 	if addr != nil {
-		f.logger.Info("quarantining endpoint after dial failure",
-			"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
-		f.index.Quarantine(fn.Namespace, fn.Name, addr.Host)
+		switch reason {
+		case InvalidateSoft:
+			if f.index.ReportDialTimeout(fn.Namespace, fn.Name, addr.Host) {
+				f.logger.Info("quarantining endpoint after repeated dial timeouts",
+					"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
+			} else {
+				f.logger.V(1).Info("dial timeout strike recorded",
+					"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
+			}
+		default:
+			f.logger.Info("quarantining endpoint after dial failure",
+				"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
+			f.index.Quarantine(fn.Namespace, fn.Name, addr.Host)
+		}
 	}
-	f.executor.Invalidate(fn, addr)
+	f.executor.Invalidate(fn, addr, reason)
 }

--- a/pkg/router/resolver_fallback.go
+++ b/pkg/router/resolver_fallback.go
@@ -177,19 +177,15 @@ func (f *fallbackResolver) resolveDeployBacked(ctx context.Context, fn *fv1.Func
 	return ResolvedEntry{SvcURL: svcURL}, nil
 }
 
-// Invalidate handles a reported dial failure: hard failures (refused, dead
-// endpoint) quarantine immediately; soft failures (dial timeout — how a
-// saturated pod presents) count strikes and quarantine only when the limit is
-// reached, so saturation does not evict a function's only endpoint and cascade
-// into an executor-fallback specialization storm. Both drop the executor
-// resolver's cached address. Quarantines log at Info: they are rare, and a
-// partial quarantine (one bad pod among many) is otherwise invisible — the
-// aggregate fallback metric only fires when every endpoint of a function is
-// out.
+// Invalidate handles a reported dial failure: hard failures quarantine the
+// endpoint immediately, soft ones are strike-counted (see
+// endpointcache.ReportDialTimeout). Both drop the executor resolver's cached
+// address. Quarantines log at Info: they are rare, and a partial quarantine
+// (one bad pod among many) is otherwise invisible — the aggregate fallback
+// metric only fires when every endpoint of a function is out.
 func (f *fallbackResolver) Invalidate(fn *fv1.Function, addr *url.URL, reason InvalidateReason) {
 	if addr != nil {
-		switch reason {
-		case InvalidateSoft:
+		if reason == InvalidateSoft {
 			if f.index.ReportDialTimeout(fn.Namespace, fn.Name, addr.Host) {
 				f.logger.Info("quarantining endpoint after repeated dial timeouts",
 					"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
@@ -197,7 +193,7 @@ func (f *fallbackResolver) Invalidate(fn *fv1.Function, addr *url.URL, reason In
 				f.logger.V(1).Info("dial timeout strike recorded",
 					"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
 			}
-		default:
+		} else {
 			f.logger.Info("quarantining endpoint after dial failure",
 				"function", fn.Name, "namespace", fn.Namespace, "address", addr.Host)
 			f.index.Quarantine(fn.Namespace, fn.Name, addr.Host)

--- a/pkg/router/resolver_fallback_test.go
+++ b/pkg/router/resolver_fallback_test.go
@@ -261,7 +261,7 @@ func TestFallbackInvalidateQuarantinesEndpoint(t *testing.T) {
 
 	fn := poolFn("fn-q")
 	addr := mustParseURL(t, "http://10.0.0.1:8888")
-	f.Invalidate(fn, addr)
+	f.Invalidate(fn, addr, InvalidateHard)
 
 	// The quarantined endpoint is unadmissible. With one ready-but-quarantined
 	// endpoint this takes the saturated-fallback branch (ready > 0, nil

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -181,9 +181,11 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 	// than the predefined threshold, reset retryCounter and remove service
 	// cache, then retry to get new svc record from executor again.
 	var retryCounter int
-	// softStruckHost dedups soft (dial-timeout) strikes within this request:
-	// each request contributes at most one strike per endpoint.
-	var softStruckHost string
+	// softStruck dedups soft (dial-timeout) strikes within this request: each
+	// request contributes at most one strike per endpoint, even when
+	// re-resolution cycles between endpoints (A->B->A). Allocated lazily —
+	// most requests never strike.
+	var softStruck map[string]bool
 	var err error
 	var fnMeta = &roundTripper.fn.ObjectMeta
 
@@ -381,10 +383,13 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 			// striking per attempt would let a single saturated request burn
 			// through the whole strike budget in a few hundred ms. Distinct
 			// requests each contribute at most one strike.
-			if reason != InvalidateSoft || roundTripper.serviceURL.Host != softStruckHost {
+			if reason != InvalidateSoft || !softStruck[roundTripper.serviceURL.Host] {
 				roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL, reason)
 				if reason == InvalidateSoft {
-					softStruckHost = roundTripper.serviceURL.Host
+					if softStruck == nil {
+						softStruck = make(map[string]bool, 1)
+					}
+					softStruck[roundTripper.serviceURL.Host] = true
 				}
 			}
 		}

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -181,6 +181,9 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 	// than the predefined threshold, reset retryCounter and remove service
 	// cache, then retry to get new svc record from executor again.
 	var retryCounter int
+	// softStruckHost dedups soft (dial-timeout) strikes within this request:
+	// each request contributes at most one strike per endpoint.
+	var softStruckHost string
 	var err error
 	var fnMeta = &roundTripper.fn.ObjectMeta
 
@@ -376,7 +379,17 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 			if isNetTimeoutErr {
 				reason = InvalidateSoft
 			}
-			roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL, reason)
+			// One soft strike per endpoint per request: the retry ladder
+			// re-dials the SAME admitted endpoint without re-resolving, so
+			// striking per attempt would let a single saturated request burn
+			// through the whole strike budget in a few hundred ms. Distinct
+			// requests each contribute at most one strike.
+			if reason != InvalidateSoft || roundTripper.serviceURL.Host != softStruckHost {
+				roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL, reason)
+				if reason == InvalidateSoft {
+					softStruckHost = roundTripper.serviceURL.Host
+				}
+			}
 		}
 
 		// Check whether an error is an timeout error ("dial tcp i/o timeout").
@@ -391,8 +404,13 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 			logger.V(1).Info(fmt.Sprintf(
 				"retry counter exceeded pre-defined threshold of %v",
 				roundTripper.params.svcAddrRetryCount))
-			if roundTripper.urlFromCache {
-				// Ladder exhausted: repeated failures, treat as hard.
+			// Ladder exhausted: hard-invalidate only executor-cached
+			// addresses (release == nil). Index-admitted endpoints also carry
+			// FromCache=true, but their eviction belongs to the strike
+			// machinery above — a hard invalidate here would let a saturated
+			// endpoint's repeated dial timeouts within ONE request bypass the
+			// strike budget entirely.
+			if roundTripper.urlFromCache && roundTripper.release == nil {
 				roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL, InvalidateHard)
 			}
 			retryCounter = 0

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -368,12 +368,9 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 		// An index-admitted endpoint (release != nil) that fails a dial is
 		// reported: re-resolving the index would happily re-admit the same
 		// endpoint (connection refused never increments retryCounter) until
-		// maxRetries burn out, so the index must be told. Classification
-		// matters — a refused/unreachable dial means the pod is gone
-		// (quarantine now), while a dial TIMEOUT is how a saturated-but-alive
-		// pod presents and only strikes toward quarantine, so saturation
-		// degrades instead of evicting the function's only endpoint. The
-		// quarantine lifts on the next slice event for the function.
+		// maxRetries burn out, so the index must be told. Refused/unreachable
+		// dials quarantine now; dial timeouts are strike-counted (see
+		// endpointcache.dialTimeoutStrikeLimit for the saturation rationale).
 		if roundTripper.release != nil {
 			reason := InvalidateHard
 			if isNetTimeoutErr {

--- a/pkg/router/transport.go
+++ b/pkg/router/transport.go
@@ -362,15 +362,21 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 			resp.Body.Close()
 		}
 
-		// An index-admitted endpoint (release != nil) that fails ANY dial is
-		// quarantined immediately: unlike the executor-RPC path — where only
-		// the timeout ladder below invalidates, because a fresh RPC re-picks a
-		// pod anyway — re-resolving the index would happily re-admit the same
-		// dead endpoint (connection refused never increments retryCounter)
-		// until maxRetries burn out. The quarantine lifts on the next slice
-		// event for the function.
+		// An index-admitted endpoint (release != nil) that fails a dial is
+		// reported: re-resolving the index would happily re-admit the same
+		// endpoint (connection refused never increments retryCounter) until
+		// maxRetries burn out, so the index must be told. Classification
+		// matters — a refused/unreachable dial means the pod is gone
+		// (quarantine now), while a dial TIMEOUT is how a saturated-but-alive
+		// pod presents and only strikes toward quarantine, so saturation
+		// degrades instead of evicting the function's only endpoint. The
+		// quarantine lifts on the next slice event for the function.
 		if roundTripper.release != nil {
-			roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL)
+			reason := InvalidateHard
+			if isNetTimeoutErr {
+				reason = InvalidateSoft
+			}
+			roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL, reason)
 		}
 
 		// Check whether an error is an timeout error ("dial tcp i/o timeout").
@@ -386,7 +392,8 @@ func (roundTripper *RetryingRoundTripper) RoundTrip(req *http.Request) (*http.Re
 				"retry counter exceeded pre-defined threshold of %v",
 				roundTripper.params.svcAddrRetryCount))
 			if roundTripper.urlFromCache {
-				roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL)
+				// Ladder exhausted: repeated failures, treat as hard.
+				roundTripper.resolver.Invalidate(roundTripper.fn, roundTripper.serviceURL, InvalidateHard)
 			}
 			retryCounter = 0
 		}

--- a/pkg/router/transport_test.go
+++ b/pkg/router/transport_test.go
@@ -510,3 +510,48 @@ type timeoutErr struct{}
 func (*timeoutErr) Error() string   { return "synthetic dial timeout" }
 func (*timeoutErr) Timeout() bool   { return true }
 func (*timeoutErr) Temporary() bool { return true }
+
+// reasonRecordingResolver returns the same admitted-style entry (Release set)
+// on every Resolve and tallies Invalidate calls by reason.
+type reasonRecordingResolver struct {
+	answer *url.URL
+	calls  atomic.Int64
+	soft   atomic.Int64
+	hard   atomic.Int64
+}
+
+func (s *reasonRecordingResolver) Resolve(_ context.Context, _ *fv1.Function) (ResolvedEntry, error) {
+	s.calls.Add(1)
+	var once sync.Once
+	return ResolvedEntry{SvcURL: s.answer, FromCache: true, Release: func() { once.Do(func() {}) }}, nil
+}
+
+func (s *reasonRecordingResolver) Invalidate(_ *fv1.Function, _ *url.URL, reason InvalidateReason) {
+	if reason == InvalidateSoft {
+		s.soft.Add(1)
+	} else {
+		s.hard.Add(1)
+	}
+}
+
+// TestSoftStrikeOncePerRequest guards the strike budget: a request's retry
+// ladder re-dials the same admitted endpoint, and must contribute at most ONE
+// soft strike per endpoint — striking per attempt would let a single
+// saturated request burn the whole dialTimeoutStrikeLimit budget and
+// quarantine the function's only endpoint by itself. The ladder-exhausted
+// hard invalidate must also never fire for index-admitted entries
+// (release != nil), even with a low svcAddrRetryCount.
+func TestSoftStrikeOncePerRequest(t *testing.T) {
+	t.Parallel()
+	// Blackholed address (TEST-NET-1, RFC 5737): dials time out (soft class).
+	blackhole := mustParseURL(t, "http://192.0.2.1:80")
+	resolver := &reasonRecordingResolver{answer: blackhole}
+	rrt := newTestRRT(resolver, &nopTapper{}, 4, 1) // retry threshold 1: ladder exhausts on every timeout
+	req := httptest.NewRequest("GET", "http://router.example/fission-function/fn", nil)
+
+	resp, err := rrt.RoundTrip(req) //nolint:bodyclose // resp is nil on error
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, int64(1), resolver.soft.Load(), "one soft strike per endpoint per request")
+	assert.Zero(t, resolver.hard.Load(), "ladder exhaustion must not hard-invalidate index-admitted endpoints")
+}

--- a/pkg/router/transport_test.go
+++ b/pkg/router/transport_test.go
@@ -45,7 +45,9 @@ func (s *scriptedResolver) Resolve(_ context.Context, _ *fv1.Function) (Resolved
 	return ResolvedEntry{SvcURL: s.answers[n], FromCache: s.fromCache}, nil
 }
 
-func (s *scriptedResolver) Invalidate(*fv1.Function, *url.URL) { s.invalidated.Add(1) }
+func (s *scriptedResolver) Invalidate(*fv1.Function, *url.URL, InvalidateReason) {
+	s.invalidated.Add(1)
+}
 
 // nopTapper records taps/untaps and their target URLs.
 type nopTapper struct {
@@ -215,7 +217,9 @@ func (s *releaseTrackingResolver) Resolve(_ context.Context, _ *fv1.Function) (R
 	}, nil
 }
 
-func (s *releaseTrackingResolver) Invalidate(*fv1.Function, *url.URL) { s.invalidated.Add(1) }
+func (s *releaseTrackingResolver) Invalidate(*fv1.Function, *url.URL, InvalidateReason) {
+	s.invalidated.Add(1)
+}
 
 // TestStreamingRetryReleasesAbandonedSlots guards the RFC-0002 admission-slot
 // leak: a streaming request whose first admitted endpoint fails to dial must

--- a/pkg/router/transport_test.go
+++ b/pkg/router/transport_test.go
@@ -515,15 +515,12 @@ func (*timeoutErr) Temporary() bool { return true }
 // on every Resolve and tallies Invalidate calls by reason.
 type reasonRecordingResolver struct {
 	answer *url.URL
-	calls  atomic.Int64
 	soft   atomic.Int64
 	hard   atomic.Int64
 }
 
 func (s *reasonRecordingResolver) Resolve(_ context.Context, _ *fv1.Function) (ResolvedEntry, error) {
-	s.calls.Add(1)
-	var once sync.Once
-	return ResolvedEntry{SvcURL: s.answer, FromCache: true, Release: func() { once.Do(func() {}) }}, nil
+	return ResolvedEntry{SvcURL: s.answer, FromCache: true, Release: func() {}}, nil
 }
 
 func (s *reasonRecordingResolver) Invalidate(_ *fv1.Function, _ *url.URL, reason InvalidateReason) {

--- a/test/benchmark/config/thresholds.yaml
+++ b/test/benchmark/config/thresholds.yaml
@@ -11,8 +11,10 @@ scenarios:
     metrics:
       c50_error_rate: { max: 0.05 }
       # A warm sweep should trigger ~zero specializations; the c500 saturation
-      # storm measured 88 (run 28775891057) — this bar catches its return.
-      specializations: { max: 10 }
+      # storm measured 86-88 (runs 28775891057 / 29085940648) — this bar
+      # catches its return. Optional: the metric is Prometheus-derived and
+      # absent when capture is off or the counter reset mid-run.
+      specializations: { max: 10, optional: true }
   cold-start-poolmgr:
     metrics:
       failures: { max: 5 } # at most 5 of N iterations may fail to specialize

--- a/test/benchmark/config/thresholds.yaml
+++ b/test/benchmark/config/thresholds.yaml
@@ -10,11 +10,17 @@ scenarios:
   concurrency-sweep:
     metrics:
       c50_error_rate: { max: 0.05 }
-      # A warm sweep should trigger ~zero specializations; the c500 saturation
-      # storm measured 86-88 (runs 28775891057 / 29085940648) — this bar
-      # catches its return. Optional: the metric is Prometheus-derived and
-      # absent when capture is off or the counter reset mid-run.
-      specializations: { max: 10, optional: true }
+      # Graceful-degradation gate: pre-fix, c500 collapsed to 29 RPS with 60%
+      # errors (run 29085940648); post-fix it holds ~274 RPS at ~10%. The bar
+      # catches a return of the collapse, with headroom for run-to-run noise.
+      c500_error_rate: { max: 0.25 }
+      # Total specializations over the whole sweep. Under closed-loop 5x
+      # overload the executor keeps replacing saturated pods by design — the
+      # in-flight bound caps amplitude (<=20 pending), not total churn (~86 in
+      # both A/B legs). This is a runaway guard, not a zero bar. Optional: the
+      # metric is Prometheus-derived and absent when capture is off or the
+      # counter reset mid-run.
+      specializations: { max: 150, optional: true }
   cold-start-poolmgr:
     metrics:
       failures: { max: 5 } # at most 5 of N iterations may fail to specialize

--- a/test/benchmark/config/thresholds.yaml
+++ b/test/benchmark/config/thresholds.yaml
@@ -10,6 +10,9 @@ scenarios:
   concurrency-sweep:
     metrics:
       c50_error_rate: { max: 0.05 }
+      # A warm sweep should trigger ~zero specializations; the c500 saturation
+      # storm measured 88 (run 28775891057) — this bar catches its return.
+      specializations: { max: 10 }
   cold-start-poolmgr:
     metrics:
       failures: { max: 5 } # at most 5 of N iterations may fail to specialize

--- a/test/benchmark/pkg/report/thresholds.go
+++ b/test/benchmark/pkg/report/thresholds.go
@@ -61,7 +61,9 @@ func (b Breach) String() string {
 
 // Evaluate checks run against the thresholds and returns every breach. A metric
 // named in the thresholds but absent from the result is reported as a breach so
-// a silently-missing measurement cannot pass the gate.
+// a silently-missing measurement cannot pass the gate — unless the threshold is
+// marked Optional, which tolerates absence (the bounds still apply whenever the
+// metric is present).
 func (t Thresholds) Evaluate(run Run) []Breach {
 	var breaches []Breach
 	byName := make(map[string]ScenarioResult, len(run.Scenarios))

--- a/test/benchmark/pkg/report/thresholds.go
+++ b/test/benchmark/pkg/report/thresholds.go
@@ -16,6 +16,11 @@ import (
 type Threshold struct {
 	Max *float64 `json:"max,omitempty"`
 	Min *float64 `json:"min,omitempty"`
+	// Optional marks a metric that is only emitted when its data source is
+	// reachable (e.g. Prometheus-derived counters): absence is tolerated
+	// instead of reported as a "missing" breach. The bounds still apply
+	// whenever the metric is present.
+	Optional bool `json:"optional,omitempty"`
 }
 
 // ScenarioThresholds maps metric name -> bound for one scenario.
@@ -71,7 +76,9 @@ func (t Thresholds) Evaluate(run Run) []Breach {
 		for metric, th := range st.Metrics {
 			m, found := res.Metric(metric)
 			if !found {
-				breaches = append(breaches, Breach{Scenario: scenario, Metric: metric, Kind: "missing"})
+				if !th.Optional {
+					breaches = append(breaches, Breach{Scenario: scenario, Metric: metric, Kind: "missing"})
+				}
 				continue
 			}
 			if th.Max != nil && m.Value > *th.Max {

--- a/test/benchmark/pkg/scenario/assets.go
+++ b/test/benchmark/pkg/scenario/assets.go
@@ -9,6 +9,16 @@ package scenario
 // archive size limit) so the benchmark has no runtime fixture dependency.
 const pythonHello = "def main():\n    return \"Hello, world!\\n\"\n"
 
+// nodeHello is the Node.js counterpart to pythonHello: a single-file v1
+// function the runtime loads with no entrypoint. The Node server is
+// event-loop-concurrent, so unlike the Python default (single-threaded
+// bjoern) one pod genuinely serves many in-flight requests — which is what
+// the concurrency/RPS sweeps need to measure Fission rather than the
+// runtime's serialization.
+const nodeHello = "module.exports = async function(context) {\n" +
+	"    return { status: 200, body: \"Hello, world!\\n\" };\n" +
+	"}\n"
+
 // pythonCPUBurn does a fixed chunk of CPU work per request so concurrent load
 // drives pod CPU up and the HPA scales — without it a no-op function never
 // triggers autoscaling.

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -448,7 +448,7 @@ func functionColdStarts(ctx context.Context, env *harness.Env, fnName string) (f
 	if !env.Capturer.PrometheusEnabled() {
 		return 0, false
 	}
-	q := fmt.Sprintf(`sum(fission_function_cold_starts_total{function_name=%q})`, fnName)
+	q := fmt.Sprintf(`sum(fission_function_cold_starts_total{function_name=%q,function_namespace=%q})`, fnName, env.Namespace)
 	v, found, err := env.Capturer.QueryInstant(ctx, q)
 	if err != nil {
 		return 0, false

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -386,40 +386,77 @@ func addServerMetrics(ctx context.Context, env *harness.Env, res *report.Scenari
 	}
 }
 
+// warmRuntime selects the language runtime for a warm-path/sweep function.
+// Python's default server is single-threaded (bjoern), so it caps effective
+// pod concurrency at 1; Node's event loop serves many in-flight requests per
+// pod. warm-path stays python for trend continuity; the sweeps use node so
+// concurrency levels above 1 measure Fission, not the runtime.
+type warmRuntime int
+
+const (
+	runtimePython warmRuntime = iota
+	runtimeNode
+)
+
 // provisionWarmFunction creates an env + code function + route sized to serve
 // concurrent requests from a single warm pod (high requestsPerPod, so the
 // measurement isolates router/proxy overhead), and waits until it is routable —
 // which also warms it. For newdeploy/container the function pins minScale=1 so
 // a backing pod exists before load starts (poolmgr warms via its generic
-// pool). methods controls the route's allowed HTTP methods.
-func provisionWarmFunction(ctx context.Context, sc *harness.Scope, executor fv1.ExecutorType, poolsize, requestsPerPod int, methods []string) (route string, err error) {
+// pool). methods controls the route's allowed HTTP methods. The returned
+// fnName feeds per-function PromQL (e.g. the cold-start counter delta).
+func provisionWarmFunction(ctx context.Context, sc *harness.Scope, executor fv1.ExecutorType, runtime warmRuntime, poolsize, requestsPerPod int, methods []string) (route, fnName string, err error) {
 	env := sc.Env()
-	if env.Images.Python == "" {
-		return "", skip("PYTHON_RUNTIME_IMAGE unset")
+	image, code, entrypoint := env.Images.Python, pythonHello, "main"
+	if runtime == runtimeNode {
+		// Node v1 loads a single-file module with no entrypoint.
+		image, code, entrypoint = env.Images.Node, nodeHello, ""
+	}
+	if image == "" {
+		return "", "", skip("runtime image unset (PYTHON_RUNTIME_IMAGE / NODE_RUNTIME_IMAGE)")
 	}
 	envName := sc.Name("env")
-	if err = sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: env.Images.Python, Version: 1, Poolsize: poolsize}); err != nil {
-		return "", err
+	if err = sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: image, Version: 1, Poolsize: poolsize}); err != nil {
+		return "", "", err
 	}
 	minScale := 0
 	if executor != fv1.ExecutorTypePoolmgr {
 		minScale = 1
 	}
-	fnName := sc.Name("fn")
+	fnName = sc.Name("fn")
 	route = "/" + fnName
 	if err = sc.CreateCodeFunction(ctx, harness.FunctionOptions{
-		Name: fnName, Env: envName, Code: []byte(pythonHello), Entrypoint: "main",
+		Name: fnName, Env: envName, Code: []byte(code), Entrypoint: entrypoint,
 		ExecutorType: executor, MinScale: minScale, RequestsPerPod: requestsPerPod,
 	}); err != nil {
-		return "", err
+		return "", "", err
 	}
 	if err = sc.CreateRoute(ctx, harness.RouteOptions{Function: fnName, URL: route, Methods: methods}); err != nil {
-		return "", err
+		return "", "", err
 	}
 	if err = env.WaitForRoutable(ctx, route, 3*time.Minute); err != nil {
-		return "", fmt.Errorf("warm-up: %w", err)
+		return "", "", fmt.Errorf("warm-up: %w", err)
 	}
-	return route, nil
+	return route, fnName, nil
+}
+
+// functionColdStarts reads the executor's per-function specialization counter
+// (fission_function_cold_starts_total). An absent series reads as 0 with
+// ok=true when Prometheus is reachable — a warm function that never
+// specialized simply has no samples yet.
+func functionColdStarts(ctx context.Context, env *harness.Env, fnName string) (float64, bool) {
+	if !env.Capturer.PrometheusEnabled() {
+		return 0, false
+	}
+	q := fmt.Sprintf(`sum(fission_function_cold_starts_total{function_name=%q})`, fnName)
+	v, found, err := env.Capturer.QueryInstant(ctx, q)
+	if err != nil {
+		return 0, false
+	}
+	if !found {
+		return 0, true
+	}
+	return v, true
 }
 
 // snapshotPprof writes a labelled pprof snapshot for the scenario when an

--- a/test/benchmark/pkg/scenario/sweep.go
+++ b/test/benchmark/pkg/scenario/sweep.go
@@ -41,7 +41,9 @@ func (c *concurrencySweep) Run(ctx context.Context, sc *harness.Scope) (report.S
 	// Anchor after provisioning so the delta counts only sweep-triggered
 	// specializations — a warm sweep should stay near zero; a saturation
 	// storm (quarantine → executor fallback → new pod per request) shows up
-	// here directly instead of only as tail latency.
+	// here directly instead of only as tail latency. Prometheus scrapes on an
+	// interval, so the warm-up's own cold start can lag into the delta by ±1;
+	// the threshold bar (10) absorbs that.
 	before, beforeOK := functionColdStarts(ctx, env, fnName)
 	for _, level := range c.levels {
 		if err := ctx.Err(); err != nil {

--- a/test/benchmark/pkg/scenario/sweep.go
+++ b/test/benchmark/pkg/scenario/sweep.go
@@ -34,10 +34,15 @@ func (c *concurrencySweep) Run(ctx context.Context, sc *harness.Scope) (report.S
 	var res report.ScenarioResult
 	env := sc.Env()
 
-	route, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, c.poolsize, slices.Max(c.levels)+10, nil)
+	route, fnName, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, runtimeNode, c.poolsize, slices.Max(c.levels)+10, nil)
 	if err != nil {
 		return res, err
 	}
+	// Anchor after provisioning so the delta counts only sweep-triggered
+	// specializations — a warm sweep should stay near zero; a saturation
+	// storm (quarantine → executor fallback → new pod per request) shows up
+	// here directly instead of only as tail latency.
+	before, beforeOK := functionColdStarts(ctx, env, fnName)
 	for _, level := range c.levels {
 		if err := ctx.Err(); err != nil {
 			return res, err
@@ -49,6 +54,9 @@ func (c *concurrencySweep) Run(ctx context.Context, sc *harness.Scope) (report.S
 			Duration:    c.duration,
 		})
 		latencyMetrics(&res, fmt.Sprintf("c%d_", level), r)
+	}
+	if after, afterOK := functionColdStarts(ctx, env, fnName); beforeOK && afterOK && after >= before {
+		res.Add("specializations", "count", report.Lower, after-before)
 	}
 	return res, nil
 }
@@ -70,7 +78,7 @@ func (r *rpsSweep) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioR
 	var res report.ScenarioResult
 	env := sc.Env()
 
-	route, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, r.poolsize, slices.Max(r.levels)+10, nil)
+	route, _, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, runtimeNode, r.poolsize, slices.Max(r.levels)+10, nil)
 	if err != nil {
 		return res, err
 	}
@@ -106,7 +114,7 @@ func (p *payloadSweep) Run(ctx context.Context, sc *harness.Scope) (report.Scena
 	var res report.ScenarioResult
 	env := sc.Env()
 
-	route, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, p.poolsize, p.concurrency+10, []string{http.MethodGet, http.MethodPost})
+	route, _, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, runtimeNode, p.poolsize, p.concurrency+10, []string{http.MethodGet, http.MethodPost})
 	if err != nil {
 		return res, err
 	}

--- a/test/benchmark/pkg/scenario/warmpath.go
+++ b/test/benchmark/pkg/scenario/warmpath.go
@@ -49,7 +49,7 @@ func (w *warmPath) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioR
 
 	// requestsPerPod high so all concurrent requests serialize through one warm
 	// pod, isolating router/proxy overhead from pod fan-out.
-	route, err := provisionWarmFunction(ctx, sc, w.executor, w.poolsize, w.concurrency+10, nil)
+	route, _, err := provisionWarmFunction(ctx, sc, w.executor, runtimePython, w.poolsize, w.concurrency+10, nil)
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
## TL;DR

Fixes the c250/c500 saturation collapse found by the PR #3559 investigation: **c500 throughput 29 → 274 RPS (+9.4×), errors 60% → 10%**, with pod churn bounded instead of unbounded. Three coordinated changes: the router stops treating a saturated pod as dead, the executor bounds how many pods a storm can provision, and the benchmark sweep now measures Fission instead of a single-threaded runtime.

## The failure chain being fixed

One dial *timeout* (how a saturated-but-alive pod presents — full SYN backlog) quarantined a function's only endpoint exactly like a connection refusal → `Admit` returned AllQuarantined → every request independently hit `/v2/ensureCapacity` (only bound: `Concurrency=500`) → **88 pods specialized for one warm function**, each saturating and re-quarantining in turn → clients died at the 60s timeout (48–60% errors).

## Changes

1. **Router — strike-based quarantine** (`pkg/router/transport.go`, `endpointcache/index.go`, resolvers): dial failures now carry an `InvalidateReason`. Refused/unreachable → quarantine immediately (unchanged). Dial timeout → strike; quarantine only at 3 strikes within one TTL window (fixed window, anchored at the first strike), **at most one strike per endpoint per request** (the retry ladder re-dials the same endpoint), and the ladder-exhausted hard invalidate no longer applies to index-admitted endpoints. Strikes are cleared by slice events and consumed by any quarantine. New counter `fission_router_endpointcache_dial_timeout_strikes_total`; the quarantine counter is unchanged.
2. **Executor — in-flight specialization bound** (`pkg/executor/fscache/poolcache.go`, `gpm.go`): `ReserveCapacity` additionally caps specializations *in flight* per function (`EXECUTOR_MAX_PENDING_SPECIALIZATIONS_PER_FUNCTION`, default 20, 0 disables; helm `executor.maxPendingSpecializations`). Excess returns the existing fast-429 `ErrorTooManyRequests`. New counter `fission_executor_specializations_rejected_total` (also recorded for the legacy plane's concurrency-cap rejections via a new `ferror.IsTooManyRequests`). Known gap, deliberate: the legacy executor-RPC plane's `getSvcValue` arm keeps only the Concurrency bound.
3. **Benchmark — honest sweeps** (`test/benchmark`): sweeps run on nodejs (the python default server is single-threaded bjoern — above c≈100 the old sweep measured runtime serialization, not Fission; `warm-path` stays python for trend continuity). New `specializations` metric (per-function cold-start counter delta) and an `optional` threshold flag (Prometheus-derived metrics tolerate absence). Sweep gate now keys on `c500_error_rate ≤ 0.25` — the discriminating metric — with specializations as a runaway guard (≤150).

## A/B (same branch, nodejs sweeps, single dispatch each)

| Metric | Before fixes ([29085940648](https://github.com/fission/fission/actions/runs/29085940648)) | After fixes ([29088147054](https://github.com/fission/fission/actions/runs/29088147054)) |
|---|---|---|
| c250 throughput / errors | 245 RPS / 0% | **373 RPS / 0%** |
| c500 throughput / errors | 29 RPS / 60% | **274 RPS / 10%** |
| c500 p99.9 / max | 1.9s / 2.1s (60% failed fast) | 11.4s / 31.6s (90% served) |
| specializations (total, sweep) | 86 | 86 — the bound caps *amplitude* (≤20 pending), not total churn at 5× overload; by-design scale-out continues boundedly |
| Regression net | — | cold-start p50 62ms, bursts 0 failures, warm-path 2197 RPS 0 errors — all within noise of #3559 numbers |

(c10–c100 absolute RPS differs between legs by ~±20% — known between-runner variance; error rates and shape are the signal.)

## Review battery

Plan-review before implementation (APPROVE + 7 precision fixes folded in). Workflow code-review at high effort — **5 confirmed findings, all fixed and test-pinned**, including two that materially changed the design: one request's retry ladder could deliver all 3 strikes itself, and a low `ROUTER_SVC_ADDRESS_MAX_RETRIES` bypassed the strike machinery via the ladder-exhausted hard invalidate. Simplify/deslop pass (comment dedup to canonical homes). Security review: clean — the strike keys are server-derived, and the change strictly narrows the pre-existing eviction surface.

## Follow-ups (out of scope)

Bisect the HEAD-vs-v1.27 c250 sensitivity difference; consider a probe-based (rather than TTL-lapse) quarantine re-admission; sweep-level `requestsPerPod` semantics under CPU limits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
