### PR TITLE
refactor: injectable listeners — services accept pre-bound net.Listeners

### DIFF
--- a/cmd/builder/app/server.go
+++ b/cmd/builder/app/server.go
@@ -60,5 +60,5 @@ func Run(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, shareVolu
 	// Builder is a pod-local sidecar with no Service; no legitimate
 	// browser caller. SecurityHeaders + DenyAllCORS as defense-in-depth.
 	handler := httpsecurity.SecurityHeaders(httpsecurity.DenyAllCORS(verifier(mux)))
-	httpserver.StartServer(ctx, logger, mgr, "builder", strconv.Itoa(svcinfo.PortBuilder), handler)
+	httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{Name: "builder", Addr: strconv.Itoa(svcinfo.PortBuilder), Handler: handler})
 }

--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -152,7 +152,7 @@ func Run(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger log
 			otelUtils.GetHandlerWithOTEL(verifier(mux), "fission-fetcher", otelUtils.UrlsToIgnore("/healthz", "/readiness-healthz")),
 		),
 	)
-	httpserver.StartServer(ctx, logger, mgr, "fetcher", port, handler)
+	httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{Name: "fetcher", Addr: port, Handler: handler})
 	return nil
 }
 

--- a/pkg/buildermgr/buildermgr.go
+++ b/pkg/buildermgr/buildermgr.go
@@ -98,13 +98,6 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 
 	metricsBind := httpserver.BindAddrFromEnv("METRICS_ADDR", svcinfo.PortMetrics)
 	healthBind := httpserver.BindAddrFromEnv("HEALTH_PROBE_ADDR", svcinfo.PortHealthProbe)
-	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
-		// The e2e framework runs every Fission service in one process sharing
-		// METRICS_ADDR, which is fine for the fail-soft ServeMetrics servers but
-		// clashes with the Manager's hard-binding servers. Bind ephemeral ports
-		// (OS-assigned, race-free) in that mode. Never set in production.
-		metricsBind, healthBind = ":0", ":0"
-	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: scheme.Scheme,

--- a/pkg/executor/api.go
+++ b/pkg/executor/api.go
@@ -11,8 +11,10 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 
 	"golang.org/x/sync/errgroup"
@@ -393,7 +395,7 @@ func (executor *Executor) GetHandler() http.Handler {
 // charts/fission-all/templates/executor/networkpolicy.yaml); the CORS
 // deny is defense-in-depth if a future regression exposes this port via
 // Ingress.
-func (executor *Executor) Serve(ctx context.Context, mgr *errgroup.Group, port int) {
+func (executor *Executor) Serve(ctx context.Context, mgr *errgroup.Group, port int, listener net.Listener) {
 	// correlation.Middleware (inside OTEL, outside the HMAC verifier which lives
 	// in GetHandler) extracts the inbound X-Fission-Request-ID into the request
 	// context so a cold-start specialization and its fetcher call carry the same
@@ -404,5 +406,7 @@ func (executor *Executor) Serve(ctx context.Context, mgr *errgroup.Group, port i
 			otelUtils.GetHandlerWithOTEL(correlation.Middleware(executor.GetHandler()), "fission-executor", otelUtils.UrlsToIgnore("/healthz")),
 		),
 	)
-	httpserver.StartServer(ctx, executor.logger, mgr, "executor", fmt.Sprintf("%d", port), handler)
+	httpserver.Serve(ctx, executor.logger, mgr, httpserver.ServerOptions{
+		Name: "executor", Addr: strconv.Itoa(port), Listener: listener, Handler: handler,
+	})
 }

--- a/pkg/executor/start.go
+++ b/pkg/executor/start.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -211,15 +212,16 @@ func (c *executorControllers) markSyncedWhenCachesWarm(ctx context.Context) {
 // /healthz and /readyz probes) on every replica, so non-leaders report
 // not-ready and are kept out of the Service endpoints.
 type executorAPIServer struct {
-	api  *Executor
-	port int
+	api      *Executor
+	port     int
+	listener net.Listener
 }
 
 func (a *executorAPIServer) NeedLeaderElection() bool { return false }
 
 func (a *executorAPIServer) Start(ctx context.Context) error {
 	gm := &errgroup.Group{}
-	a.api.Serve(ctx, gm, a.port)
+	a.api.Serve(ctx, gm, a.port, a.listener)
 	_ = gm.Wait()
 	return nil
 }
@@ -261,6 +263,21 @@ func runAdoptCleanup(ctx context.Context, executorTypes map[fv1.ExecutorType]exe
 // StartExecutor Starts executor and the executor components such as Poolmgr,
 // deploymgr and potential future executor types
 func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr *errgroup.Group, port int) error {
+	return StartExecutorWithOptions(ctx, clientGen, logger, mgr, Options{Port: port})
+}
+
+// Options configures StartExecutorWithOptions. The API listener is either
+// pre-bound by the caller (Listener — e.g. a test harness binding
+// 127.0.0.1:0) or bound here from Port.
+type Options struct {
+	// Port is the executor API port. Ignored when Listener is set.
+	Port int
+	// Listener optionally pre-binds the API listener.
+	Listener net.Listener
+}
+
+// StartExecutorWithOptions is StartExecutor with an injectable listener.
+func StartExecutorWithOptions(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr *errgroup.Group, opts Options) error {
 
 	fissionClient, err := clientGen.GetFissionClient()
 	if err != nil {
@@ -358,10 +375,6 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	}
 
 	metricsBind := httpserver.BindAddrFromEnv("METRICS_ADDR", svcinfo.PortMetrics)
-	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
-		// In-process e2e harness: bind an ephemeral metrics port to avoid clashes.
-		metricsBind = ":0"
-	}
 
 	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: executorScheme,
@@ -453,7 +466,7 @@ func StartExecutor(ctx context.Context, clientGen crd.ClientGeneratorInterface, 
 	if err := crMgr.Add(controllers); err != nil {
 		return fmt.Errorf("unable to add executor controllers: %w", err)
 	}
-	if err := crMgr.Add(&executorAPIServer{api: api, port: port}); err != nil {
+	if err := crMgr.Add(&executorAPIServer{api: api, port: opts.Port, listener: opts.Listener}); err != nil {
 		return fmt.Errorf("unable to add executor api server: %w", err)
 	}
 

--- a/pkg/mcp/main.go
+++ b/pkg/mcp/main.go
@@ -13,6 +13,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -49,6 +50,22 @@ const envAllowInsecure = "MCP_ALLOW_INSECURE"
 // constructors stay deterministic for unit tests.
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger,
 	mgr *errgroup.Group, port int, routerInternalURL string) error {
+	return StartWithOptions(ctx, clientGen, logger, mgr, Options{Port: port}, routerInternalURL)
+}
+
+// Options configures StartWithOptions. The listener is either pre-bound by
+// the caller (Listener — e.g. a test harness binding 127.0.0.1:0) or bound
+// here from Port.
+type Options struct {
+	// Port is the MCP server port. Ignored when Listener is set.
+	Port int
+	// Listener optionally pre-binds the listener.
+	Listener net.Listener
+}
+
+// StartWithOptions is Start with an injectable listener.
+func StartWithOptions(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger,
+	mgr *errgroup.Group, opts Options, routerInternalURL string) error {
 	logger = logger.WithName("mcp")
 
 	fissionClient, err := clientGen.GetFissionClient()
@@ -133,17 +150,19 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	})
 	mux.Handle("/mcp", server.HTTPHandler())
 	mgr.Go(func() error {
-		httpserver.StartServer(ctx, logger, mgr, "mcp", strconv.Itoa(port), mux)
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{
+			Name: "mcp", Addr: strconv.Itoa(opts.Port), Listener: opts.Listener, Handler: mux,
+		})
 		return nil
 	})
 
 	if authz.Enabled() {
-		logger.Info("starting mcp server", "port", port, "authEnabled", true)
+		logger.Info("starting mcp server", "port", opts.Port, "authEnabled", true)
 	} else {
 		// Pass-through mode grants every caller a wildcard scope. Explicitly
 		// opted in via MCP_ALLOW_INSECURE; loud so it is never mistaken for a
 		// scoped deployment.
-		logger.Info("WARNING: starting mcp server with authentication DISABLED — every caller can list and invoke all tools (set JWT_SIGNING_KEY to scope access)", "port", port)
+		logger.Info("WARNING: starting mcp server with authentication DISABLED — every caller can list and invoke all tools (set JWT_SIGNING_KEY to scope access)", "port", opts.Port)
 	}
 	return crMgr.Start(ctx)
 }

--- a/pkg/router/auth_test.go
+++ b/pkg/router/auth_test.go
@@ -70,7 +70,7 @@ func TestRouterAuth(t *testing.T) {
 	testmux := GetRouterWithAuth()
 
 	mgr.Go(func() error {
-		httpserver.StartServer(ctx, logger, mgr, "test", "8990", testmux)
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{Name: "test", Addr: "8990", Handler: testmux})
 		return nil
 	})
 

--- a/pkg/router/mutablemux_test.go
+++ b/pkg/router/mutablemux_test.go
@@ -74,7 +74,7 @@ func TestMutableMux(t *testing.T) {
 
 	// start http server
 	mgr.Go(func() error {
-		httpserver.StartServer(ctx, logger, mgr, "router", "3333", mr)
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{Name: "router", Addr: "3333", Handler: mr})
 		return nil
 	})
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"time"
@@ -220,7 +221,7 @@ func router(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, httpTr
 	return publicMR, internalMR, nil
 }
 
-func serve(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, port int, internalPort int,
+func serve(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, opts Options,
 	httpTriggerSet *HTTPTriggerSet) error {
 	publicMR, internalMR, err := router(ctx, logger, mgr, httpTriggerSet)
 	if err != nil {
@@ -241,7 +242,9 @@ func serve(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, port in
 		otelUtils.GetHandlerWithOTEL(correlation.Middleware(publicMR), "fission-router", otelUtils.UrlsToIgnore("/router-healthz")),
 	)
 	mgr.Go(func() error {
-		httpserver.StartServer(ctx, logger, mgr, "router", fmt.Sprintf("%d", port), publicHandler)
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{
+			Name: "router", Addr: strconv.Itoa(opts.Port), Listener: opts.Listener, Handler: publicHandler,
+		})
 		return nil
 	})
 
@@ -283,26 +286,51 @@ func serve(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, port in
 		httpsecurity.DenyAllCORS(verifier(internalHandlerInner)),
 	)
 	mgr.Go(func() error {
-		httpserver.StartServer(ctx, logger, mgr, "router-internal", fmt.Sprintf("%d", internalPort), internalHandler)
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{
+			Name: "router-internal", Addr: strconv.Itoa(opts.InternalPort), Listener: opts.InternalListener, Handler: internalHandler,
+		})
 		return nil
 	})
 
 	return nil
 }
 
-// Start starts a router. internalPort is the listener that serves
-// /fission-function/<ns>/<name> and is wrapped with the HMAC verifier;
-// pass svcinfo.PortRouterInternal to use the default. Zero or
-// negative values are silently substituted with svcinfo.PortRouterInternal
-// so callers can omit the flag and still get the GHSA-3g33-6vg6-27m8
-// listener split — the public listener no longer registers those
-// routes, so the internal listener is mandatory.
+// Options configures StartWithOptions. Each listener is either pre-bound by
+// the caller (Listener/InternalListener — e.g. a test harness binding
+// 127.0.0.1:0) or bound here from the corresponding port.
+type Options struct {
+	// Port is the public listener port (user HTTPTriggers, /router-healthz,
+	// /_version). Ignored when Listener is set.
+	Port int
+	// InternalPort is the port for the listener serving
+	// /fission-function/<ns>/<name> behind the HMAC verifier
+	// (GHSA-3g33-6vg6-27m8 split). Zero or negative values default to
+	// svcinfo.PortRouterInternal. Ignored when InternalListener is set.
+	InternalPort int
+	// Listener optionally pre-binds the public listener.
+	Listener net.Listener
+	// InternalListener optionally pre-binds the internal listener.
+	InternalListener net.Listener
+	// Executor is the executor API client used on cache misses.
+	Executor eclient.ClientInterface
+}
+
+// Start starts a router on the given ports. See StartWithOptions.
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr *errgroup.Group, port int, internalPort int, executor eclient.ClientInterface) error {
-	if internalPort <= 0 {
-		internalPort = svcinfo.PortRouterInternal
+	return StartWithOptions(ctx, clientGen, logger, mgr, Options{Port: port, InternalPort: internalPort, Executor: executor})
+}
+
+// StartWithOptions starts a router. The internal listener is mandatory —
+// the public listener no longer registers /fission-function/... routes.
+func StartWithOptions(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, mgr *errgroup.Group, opts Options) error {
+	executor := opts.Executor
+	if opts.InternalListener == nil && opts.InternalPort <= 0 {
+		opts.InternalPort = svcinfo.PortRouterInternal
 	}
-	if internalPort == port {
-		return fmt.Errorf("router internal port (%d) must differ from public port (%d)", internalPort, port)
+	// Same-port collision is only possible when both listeners are bound
+	// here from ports; pre-bound listeners are distinct by construction.
+	if opts.Listener == nil && opts.InternalListener == nil && opts.InternalPort == opts.Port {
+		return fmt.Errorf("router internal port (%d) must differ from public port (%d)", opts.InternalPort, opts.Port)
 	}
 	fmap := makeFunctionServiceMap(logger, time.Minute)
 
@@ -372,10 +400,6 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	}
 
 	metricsBind := httpserver.BindAddrFromEnv("METRICS_ADDR", svcinfo.PortMetrics)
-	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
-		// In-process e2e harness: bind an ephemeral metrics port to avoid clashes.
-		metricsBind = ":0"
-	}
 
 	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme: routerScheme,
@@ -481,7 +505,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return fmt.Errorf("error registering tenant resolver-sync: %w", err)
 	}
 
-	logger.Info("starting router", "port", port, "internalPort", internalPort)
+	logger.Info("starting router", "port", opts.Port, "internalPort", opts.InternalPort)
 
 	// The public/internal listeners run on an internal GroupManager, hosted by a
 	// single Manager runnable.
@@ -490,7 +514,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		tracer := otel.Tracer("router")
 		rctx, span := tracer.Start(rctx, "router/serve")
 		defer span.End()
-		if err := serve(rctx, logger, gm, port, internalPort, triggers); err != nil {
+		if err := serve(rctx, logger, gm, opts, triggers); err != nil {
 			return err
 		}
 		// Kick the initial mux build once the cache has synced, so router-owned

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -318,8 +319,10 @@ func MakeStorageService(logger logr.Logger, storageClient *StorageClient, port i
 	}
 }
 
-func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port int) {
-	httpserver.StartServer(ctx, ss.logger, mgr, "storagesvc", fmt.Sprintf("%d", port), ss.makeHandler())
+func (ss *StorageService) Start(ctx context.Context, mgr *errgroup.Group, port int, listener net.Listener) {
+	httpserver.Serve(ctx, ss.logger, mgr, httpserver.ServerOptions{
+		Name: "storagesvc", Addr: strconv.Itoa(port), Listener: listener, Handler: ss.makeHandler(),
+	})
 }
 
 // makeHandler builds the storagesvc HTTP handler chain (auth + routes +
@@ -413,8 +416,23 @@ func maxUploadBytesFromEnv(logger logr.Logger) int64 {
 	return mib << 20
 }
 
-// Start runs storage service
+// Start runs storage service on the given port. See StartWithOptions.
 func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, storage Storage, mgr *errgroup.Group, port int) error {
+	return StartWithOptions(ctx, clientGen, logger, storage, mgr, Options{Port: port})
+}
+
+// Options configures StartWithOptions. The API listener is either pre-bound
+// by the caller (Listener — e.g. a test harness binding 127.0.0.1:0) or
+// bound here from Port.
+type Options struct {
+	// Port is the storage service API port. Ignored when Listener is set.
+	Port int
+	// Listener optionally pre-binds the API listener.
+	Listener net.Listener
+}
+
+// StartWithOptions runs the storage service with an injectable listener.
+func StartWithOptions(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger, storage Storage, mgr *errgroup.Group, opts Options) error {
 	enablePruner, err := strconv.ParseBool(os.Getenv("PRUNE_ENABLED"))
 	if err != nil {
 		logger.Error(err, "PRUNE_ENABLED value not set. Enabling archive pruner by default.")
@@ -432,14 +450,14 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	authSecretOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
 
 	// create http handlers
-	storageService := MakeStorageService(logger, storageClient, port, authSecret, authSecretOld, maxUploadBytesFromEnv(logger))
+	storageService := MakeStorageService(logger, storageClient, opts.Port, authSecret, authSecretOld, maxUploadBytesFromEnv(logger))
 	mgr.Go(func() error {
 		metrics.ServeMetrics(ctx, "storagesvc", logger, mgr)
 		return nil
 	})
 
 	mgr.Go(func() error {
-		storageService.Start(ctx, mgr, port)
+		storageService.Start(ctx, mgr, opts.Port, opts.Listener)
 		return nil
 	})
 

--- a/pkg/utils/httpserver/server.go
+++ b/pkg/utils/httpserver/server.go
@@ -7,6 +7,7 @@ package httpserver
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -47,13 +48,33 @@ func BindAddrFromEnv(env string, defPort int) string {
 	return addr
 }
 
-func StartServer(ctx context.Context, log logr.Logger, mgr *errgroup.Group, svc string, port string, handler http.Handler) {
-	if !strings.Contains(port, ":") {
-		port = fmt.Sprintf(":%s", port)
+// ServerOptions configures Serve. Exactly one of Addr or Listener supplies
+// the bind: a non-nil Listener takes precedence (the caller pre-bound it —
+// e.g. a test harness on 127.0.0.1:0), otherwise Addr is bound here.
+type ServerOptions struct {
+	// Name identifies the service in logs.
+	Name string
+	// Addr is the listen address; a bare port ("8888") is prefixed with ":".
+	// Ignored when Listener is set.
+	Addr string
+	// Listener is an optional pre-bound listener the server serves on. The
+	// server takes ownership and closes it on shutdown.
+	Listener net.Listener
+	// Handler is the HTTP handler to serve.
+	Handler http.Handler
+}
+
+// Serve runs an HTTP server until ctx is cancelled, then drains in-flight
+// requests (bounded by GRACEFUL_SHUTDOWN_TIMEOUT, default 30s) before
+// returning.
+func Serve(ctx context.Context, log logr.Logger, mgr *errgroup.Group, opts ServerOptions) {
+	addr := opts.Addr
+	if !strings.Contains(addr, ":") {
+		addr = fmt.Sprintf(":%s", addr)
 	}
 	server := http.Server{
-		Addr:    port,
-		Handler: handler,
+		Addr:    addr,
+		Handler: opts.Handler,
 		// ReadHeaderTimeout bounds only the header read (slowloris hardening);
 		// request bodies and long-running/streaming responses are unaffected —
 		// deliberately no ReadTimeout/WriteTimeout, which would cut both.
@@ -65,13 +86,21 @@ func StartServer(ctx context.Context, log logr.Logger, mgr *errgroup.Group, svc 
 		// failures on non-idempotent internal POSTs.
 		IdleTimeout: 120 * time.Second,
 	}
-	l := log.WithValues("service", svc, "addr", server.Addr)
+	displayAddr := server.Addr
+	if opts.Listener != nil {
+		displayAddr = opts.Listener.Addr().String()
+	}
+	l := log.WithValues("service", opts.Name, "addr", displayAddr)
 	l.Info("starting server")
 	mgr.Go(func() error {
-		if err := server.ListenAndServe(); err != nil {
-			if err != http.ErrServerClosed {
-				l.Error(err, "server error")
-			}
+		var err error
+		if opts.Listener != nil {
+			err = server.Serve(opts.Listener)
+		} else {
+			err = server.ListenAndServe()
+		}
+		if err != nil && err != http.ErrServerClosed {
+			l.Error(err, "server error")
 		}
 		return nil
 	})

--- a/pkg/utils/httpserver/server_test.go
+++ b/pkg/utils/httpserver/server_test.go
@@ -41,7 +41,7 @@ func TestStartServer(t *testing.T) {
 	}))
 
 	mgr.Go(func() error {
-		StartServer(ctx, logger, mgr, "test", addr, m.Handler())
+		Serve(ctx, logger, mgr, ServerOptions{Name: "test", Addr: addr, Handler: m.Handler()})
 		return nil
 	})
 
@@ -115,7 +115,7 @@ func TestStartServerDrainsInFlightRequest(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	mgr := &errgroup.Group{}
-	go StartServer(ctx, logr.Discard(), mgr, "test", addr, m)
+	go Serve(ctx, logr.Discard(), mgr, ServerOptions{Name: "test", Addr: addr, Handler: m})
 
 	require.Eventually(t, func() bool {
 		c, err := net.DialTimeout("tcp", addr, 50*time.Millisecond)
@@ -188,4 +188,37 @@ func TestBindAddrFromEnv(t *testing.T) {
 
 	t.Setenv("METRICS_ADDR", "0")
 	assert.Equal(t, ":0", BindAddrFromEnv("METRICS_ADDR", 8080))
+}
+
+// TestServeInjectedListener pins the listener-injection path: a caller-bound
+// 127.0.0.1:0 listener is served directly (no second bind), so harnesses can
+// let the kernel assign ports instead of pre-picking them.
+func TestServeInjectedListener(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	mgr := &errgroup.Group{}
+	m := httpmux.New()
+	m.Handle("/ping", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, "pong")
+	}))
+	go Serve(ctx, logr.Discard(), mgr, ServerOptions{Name: "test", Listener: l, Handler: m.Handler()})
+
+	var body string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := http.Get(fmt.Sprintf("http://%s/ping", l.Addr()))
+		if !assert.NoError(c, err) {
+			return
+		}
+		defer resp.Body.Close()
+		b, err := io.ReadAll(resp.Body)
+		if !assert.NoError(c, err) {
+			return
+		}
+		body = string(b)
+	}, 5*time.Second, 50*time.Millisecond)
+	assert.Equal(t, "pong", body)
+	cancel()
+	_ = mgr.Wait()
 }

--- a/pkg/utils/metrics/server.go
+++ b/pkg/utils/metrics/server.go
@@ -31,5 +31,5 @@ func ServeMetrics(ctx context.Context, parent string, logger logr.Logger, mgr *e
 			EnableOpenMetrics: true,
 		},
 	))
-	httpserver.StartServer(ctx, logger, mgr, parent+"/metrics", metricsAddr, mux)
+	httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{Name: parent + "/metrics", Addr: metricsAddr, Handler: mux})
 }

--- a/pkg/utils/profile/profile.go
+++ b/pkg/utils/profile/profile.go
@@ -37,7 +37,7 @@ func ProfileIfEnabled(ctx context.Context, logger logr.Logger, mgr *errgroup.Gro
 	http.DefaultServeMux = http.NewServeMux()
 
 	mgr.Go(func() error {
-		httpserver.StartServer(ctx, logger, mgr, "pprof", pprofPort, pprofMux)
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{Name: "pprof", Addr: pprofPort, Handler: pprofMux})
 		return nil
 	})
 }

--- a/pkg/webhook/service.go
+++ b/pkg/webhook/service.go
@@ -6,8 +6,6 @@ package webhook
 
 import (
 	"context"
-	"os"
-	"strconv"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -37,12 +35,6 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	wLogger := logger.WithName("webhook")
 
 	metricsAddr := httpserver.BindAddrFromEnv("METRICS_ADDR", svcinfo.PortMetrics)
-	if ephemeral, _ := strconv.ParseBool(os.Getenv("FISSION_TEST_EPHEMERAL_SERVERS")); ephemeral {
-		// In-process e2e harness: bind an ephemeral metrics port so the manager
-		// can't lose a TOCTOU race for a fixed port against the other in-process
-		// managers — matching executor/buildermgr/router (pkg/.../start.go).
-		metricsAddr = ":0"
-	}
 	mgrOpt := manager.Options{
 		Scheme: scheme.Scheme,
 		Metrics: metricsserver.Options{

--- a/test/e2e/fetcher/fetcher_test.go
+++ b/test/e2e/fetcher/fetcher_test.go
@@ -111,7 +111,7 @@ func (f *FetcherTestSuite) SetupSuite() {
 	mux.Handle("/files/", http.StripPrefix("/files/", http.FileServer(http.Dir("."))))
 
 	f.mgr.Go(func() error {
-		httpserver.StartServer(ctx, f.logger, f.mgr, "specialize", "8888", mux)
+		httpserver.Serve(ctx, f.logger, f.mgr, httpserver.ServerOptions{Name: "specialize", Addr: "8888", Handler: mux})
 		return nil
 	})
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -7,6 +7,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,27 +21,13 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/fission/fission/pkg/crd"
-	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
-
-// Ports holds every fixed port the harness assigns, reserved together in one
-// FindFreePorts call at framework construction — the single place port
-// discovery happens — and passed down explicitly from there. (The subsystem
-// Start functions take port ints, so ports must be pre-picked; reserving them
-// atomically is what keeps them distinct.)
-type Ports struct {
-	Executor       int
-	StorageSvc     int
-	Router         int
-	RouterInternal int
-}
 
 type Framework struct {
 	env    *envtest.Environment
 	config *rest.Config
 	logger logr.Logger
-	ports  Ports
 	// reg maps service names to their local TCP addresses; dialing a
 	// registered name blocks until the backend accepts, so readiness
 	// waits happen inside the dial instead of in caller poll loops, and
@@ -72,21 +59,11 @@ func NewFramework() *Framework {
 	if err != nil {
 		panic(err)
 	}
-	servicePorts, err := utils.FindFreePorts(4)
-	if err != nil {
-		panic(fmt.Errorf("error reserving service ports: %w", err))
-	}
 	_, filename, _, _ := runtime.Caller(0) //nolint
 	root := filepath.Dir(filename)
 	crdPath := filepath.Join(root, "..", "..", "..", "crds", "v1")
 
 	return &Framework{
-		ports: Ports{
-			Executor:       servicePorts[0],
-			StorageSvc:     servicePorts[1],
-			Router:         servicePorts[2],
-			RouterInternal: servicePorts[3],
-		},
 		logger: loggerfactory.GetLogger(),
 		env: &envtest.Environment{
 			CRDDirectoryPaths:     []string{crdPath},
@@ -117,11 +94,6 @@ func (f *Framework) Start(ctx context.Context) error {
 	return nil
 }
 
-// Ports returns the harness's pre-reserved service ports.
-func (f *Framework) Ports() Ports {
-	return f.ports
-}
-
 func (f *Framework) RestConfig() *rest.Config {
 	return f.config
 }
@@ -146,7 +118,8 @@ func (f *Framework) Stop() error {
 	return nil
 }
 
-// RegisterService names a locally-bound service in the portless registry.
+// RegisterService names a locally-bound service in the portless registry by
+// port (used for the envtest webhook, whose port controller-runtime assigns).
 // The service may still be starting: dials through the registry (WaitReady)
 // retry until the port accepts (and any route health check passes).
 func (f *Framework) RegisterService(name string, port int, opts ...portless.RouteOption) error {
@@ -155,6 +128,23 @@ func (f *Framework) RegisterService(name string, port int, opts ...portless.Rout
 	}
 	f.logger.Info("Registered service", "name", name, "port", port)
 	return nil
+}
+
+// ListenAndRegister binds a fresh 127.0.0.1:0 listener, registers it under
+// name, and returns it for injection into the service's StartWithOptions.
+// The service owns the listener; the kernel picked its port, so there is no
+// pre-pick race and nothing to reserve.
+func (f *Framework) ListenAndRegister(name string) (net.Listener, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, fmt.Errorf("error binding listener for %s: %w", name, err)
+	}
+	if _, err := f.reg.Add(context.Background(), name, backend.Listener(l)); err != nil {
+		_ = l.Close()
+		return nil, fmt.Errorf("error registering service %s: %w", name, err)
+	}
+	f.logger.Info("Registered service", "name", name, "addr", l.Addr().String())
+	return l, nil
 }
 
 // WithTLSReadyCheck gates a route's readiness on a completed TLS handshake,

--- a/test/e2e/framework/services/services.go
+++ b/test/e2e/framework/services/services.go
@@ -52,25 +52,13 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	}
 
 	os.Setenv("DEBUG_ENV", "true")
-	// The executor and buildermgr run under controller-runtime Managers whose
-	// metrics server binds hard (and buildermgr's health-probe server too;
-	// the executor keeps health on its API mux), unlike the fail-soft
-	// ServeMetrics the other in-process services use. In this single-process
-	// harness METRICS_ADDR is shared and racy, so tell them to bind ephemeral
-	// ports. Set once and never mutated, so their goroutines read it
-	// deterministically.
-	os.Setenv("FISSION_TEST_EPHEMERAL_SERVERS", "true")
-	// Every metrics server binds an ephemeral port: the manager-based
-	// services force :0 under FISSION_TEST_EPHEMERAL_SERVERS, and the
-	// fail-soft ServeMetrics consumers read METRICS_ADDR verbatim — "0"
-	// makes the kernel assign per-listener, so no pre-picked metrics ports
-	// and no collisions, ever.
+	// Every metrics/health server binds an ephemeral port: all consumers
+	// resolve their bind through httpserver.BindAddrFromEnv, and "0" makes
+	// the kernel assign per-listener — no pre-picked ports, no collisions.
 	os.Setenv("METRICS_ADDR", "0")
+	os.Setenv("HEALTH_PROBE_ADDR", "0")
 	env := f.GetEnv()
 	webhookPort := env.WebhookInstallOptions.LocalServingPort
-	// Service ports were reserved together at framework construction
-	// (framework.Ports) — the only port-discovery call in the harness.
-	ports := f.Ports()
 	runService("webhook", func() error {
 		return webhook.Start(ctx, f.ClientGen(), f.Logger(), cnwebhook.Options{
 			Port:    webhookPort,
@@ -94,27 +82,33 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	})
 
 	os.Setenv("POD_READY_TIMEOUT", "300s")
-	// executor now runs under a controller-runtime Manager, so StartExecutor
+	// executor now runs under a controller-runtime Manager, so its Start
 	// blocks (like webhook.Start). Run it in a goroutine so the remaining
-	// services still come up.
-	runService("executor", func() error {
-		return executor.StartExecutor(ctx, f.ClientGen(), f.Logger(), mgr, ports.Executor)
-	})
-	if err := f.RegisterService("executor", ports.Executor); err != nil {
+	// services still come up. The harness binds each service's listener
+	// itself (kernel-assigned port) and injects it, so no port is ever
+	// pre-picked.
+	executorListener, err := f.ListenAndRegister("executor")
+	if err != nil {
 		return err
 	}
+	runService("executor", func() error {
+		return executor.StartExecutorWithOptions(ctx, f.ClientGen(), f.Logger(), mgr, executor.Options{Listener: executorListener})
+	})
 
 	os.Setenv("PRUNE_ENABLED", "true")
 	os.Setenv("PRUNE_INTERVAL", "60")
 
-	if err := StartStorageSvc(ctx, f, mgr, ports.StorageSvc); err != nil {
+	if err := StartStorageSvc(ctx, f, mgr); err != nil {
 		return err
 	}
 
 	// buildermgr's Start blocks (controller-runtime Manager), so run it in a
-	// goroutine; FISSION_TEST_EPHEMERAL_SERVERS (set at the top) makes its
+	// goroutine; METRICS_ADDR/HEALTH_PROBE_ADDR=0 (set at the top) make its
 	// Manager servers bind ephemeral ports.
-	storageSvcURL := fmt.Sprintf("http://localhost:%d", ports.StorageSvc)
+	storageSvcURL, err := f.GetServiceURL("storagesvc")
+	if err != nil {
+		return err
+	}
 	runService("builder manager", func() error {
 		return buildermgr.Start(ctx, f.ClientGen(), f.Logger(), mgr, storageSvcURL)
 	})
@@ -135,19 +129,28 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	// flows into both ends of this client/verifier pair via
 	// HMACSecretFromEnv (returns nil when unset, leaving the channel
 	// unsigned).
-	executor := eclient.MakeClient(f.Logger(), fmt.Sprintf("http://localhost:%d", ports.Executor), storagesvcClient.HMACSecretFromEnv())
-	// router now runs under a controller-runtime Manager, so Start blocks. Run
-	// it in a goroutine so the harness can continue; FISSION_TEST_EPHEMERAL_SERVERS
-	// (set at the top) makes its Manager metrics server bind an ephemeral port.
+	executorURL, err := f.GetServiceURL("executor")
+	if err != nil {
+		return err
+	}
+	executorClient := eclient.MakeClient(f.Logger(), executorURL, storagesvcClient.HMACSecretFromEnv())
+	routerListener, err := f.ListenAndRegister("router")
+	if err != nil {
+		return err
+	}
+	internalListener, err := f.ListenAndRegister("router-internal")
+	if err != nil {
+		return err
+	}
+	// router now runs under a controller-runtime Manager, so its Start
+	// blocks. Run it in a goroutine so the harness can continue.
 	runService("router", func() error {
-		return router.Start(ctx, f.ClientGen(), f.Logger(), mgr, ports.Router, ports.RouterInternal, executor)
+		return router.StartWithOptions(ctx, f.ClientGen(), f.Logger(), mgr, router.Options{
+			Listener:         routerListener,
+			InternalListener: internalListener,
+			Executor:         executorClient,
+		})
 	})
-	if err := f.RegisterService("router", ports.Router); err != nil {
-		return err
-	}
-	if err := f.RegisterService("router-internal", ports.RouterInternal); err != nil {
-		return err
-	}
 	routerURL, err := f.GetServiceURL("router")
 	if err != nil {
 		return fmt.Errorf("error getting router URL: %w", err)
@@ -186,18 +189,19 @@ func StartServices(ctx context.Context, f *framework.Framework, mgr *errgroup.Gr
 	return nil
 }
 
-func StartStorageSvc(ctx context.Context, f *framework.Framework, mgr *errgroup.Group, storageSvcPort int) error {
+func StartStorageSvc(ctx context.Context, f *framework.Framework, mgr *errgroup.Group) error {
 	storageDir, err := os.MkdirTemp("/tmp", "storagesvc")
 	if err != nil {
 		return fmt.Errorf("error creating temp directory: %w", err)
 	}
 
-	err = storagesvc.Start(ctx, f.ClientGen(), f.Logger(), storagesvc.NewLocalStorage(storageDir), mgr, storageSvcPort)
+	listener, err := f.ListenAndRegister("storagesvc")
+	if err != nil {
+		return err
+	}
+	err = storagesvc.StartWithOptions(ctx, f.ClientGen(), f.Logger(), storagesvc.NewLocalStorage(storageDir), mgr, storagesvc.Options{Listener: listener})
 	if err != nil {
 		return fmt.Errorf("error starting storage service: %w", err)
-	}
-	if err := f.RegisterService("storagesvc", storageSvcPort); err != nil {
-		return err
 	}
 	storagesvcURL, err := f.GetServiceURL("storagesvc")
 	if err != nil {


### PR DESCRIPTION
## TL;DR

**Stacked on #3562** (svcinfo). Subsystem servers accept **pre-bound `net.Listener`s** via small options structs, `httpserver.StartServer` becomes `Serve(…, ServerOptions{Addr | Listener})`, and the in-process e2e harness now binds `127.0.0.1:0` itself and injects the listeners — killing the port pre-pick pattern (and its race, which CI caught live in #3561's follow-ups), the `framework.Ports` reservation, and the `FISSION_TEST_EPHEMERAL_SERVERS` test-mode env entirely.

Production behavior is unchanged: the port-based `Start` signatures remain and delegate, so `fission-bundle` flags and the chart are untouched.

## Review guide

1. `pkg/utils/httpserver/server.go` — `ServerOptions` + the `server.Serve(l)` path; the deprecated wrapper is deleted and every caller (router, executor, storagesvc, mcp, metrics, pprof, fetcher, builder, tests) migrated. New `TestServeInjectedListener` pins the injection path.
2. `pkg/{router,executor,storagesvc,mcp}` — `Options{Port, Listener…}` + `StartWithOptions`; `router.Options` carries both listeners and the executor client. The router's same-port validation only applies when both listeners are port-bound (pre-bound listeners are distinct by construction).
3. **`FISSION_TEST_EPHEMERAL_SERVERS` deletion** (router/executor/buildermgr/webhook): every metrics/health bind already resolves through `BindAddrFromEnv`, so the harness's `METRICS_ADDR=0` + `HEALTH_PROBE_ADDR=0` give kernel-assigned ports without a special mode. The env was test-only, never chart-set.
4. `test/e2e/framework` — `ListenAndRegister` (bind + portless `backend.Listener` route) replaces the atomic port reservation; production consumers still get real URLs via `Route.Addr()`.

## Testing

- `make code-checks` (0 issues), license, gomod.
- e2e cli + fetcher suites, router/executor/storagesvc/mcp packages pass locally; new httpserver listener-path test.
- Local `-race` runs were blocked by disk exhaustion on this machine (0 races observed before the builds died); CI's `make test-run` provides the race leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
