### PR TITLE
feat: RFC-0024 async invocation Phases 3-4 + CLI/test surface

### DIFF
--- a/charts/fission-all/templates/router/scaledobject.yaml
+++ b/charts/fission-all/templates/router/scaledobject.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.router.keda.enabled }}
+{{- /*
+RFC-0024 async-invocation autoscaling for the router (opt-in). KEDA scales the
+router Deployment on the statestore async queue backlog via the postgresql scaler.
+Render gates below fail fast on an unsupported combination.
+*/ -}}
+{{- if not (dig "enabled" false (.Values.asyncInvocation | default dict)) }}
+{{ required "router.keda.enabled requires asyncInvocation.enabled." nil }}
+{{- end }}
+{{- if ne .Values.statestore.mode "external" }}
+{{ required "router.keda.enabled requires statestore.mode=external (the postgresql scaler cannot reach an embedded SQLite store)." nil }}
+{{- end }}
+{{- if .Values.router.autoscaling.enabled }}
+{{ required "router.keda.enabled conflicts with router.autoscaling.enabled — KEDA manages its own HPA on the router; disable router.autoscaling." nil }}
+{{- end }}
+{{- $secret := .Values.statestore.external.existingSecret | default "statestore-postgres" }}
+apiVersion: keda.sh/v1alpha1
+kind: TriggerAuthentication
+metadata:
+  name: router-async-scaler
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: router
+    application: fission-router
+spec:
+  secretTargetRef:
+    - parameter: connection
+      name: {{ $secret }}
+      key: dsn
+---
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: router-async
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: router
+    application: fission-router
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: router
+  minReplicaCount: {{ .Values.router.keda.minReplicas | default 1 }}
+  maxReplicaCount: {{ .Values.router.keda.maxReplicas | default 10 }}
+  pollingInterval: {{ .Values.router.keda.pollingInterval | default 15 }}
+  cooldownPeriod: {{ .Values.router.keda.cooldownPeriod | default 120 }}
+  triggers:
+    - type: postgresql
+      metadata:
+        # Scale toward ceil(visible_backlog / targetQueryValue). The query counts
+        # visible (not yet leased, past their visible_at) messages on the single
+        # global async queue; visible_at is stored as bigint nanoseconds.
+        targetQueryValue: "{{ .Values.router.keda.targetBacklogPerReplica | default 50 }}"
+        query: "SELECT COUNT(*) FROM state_queue WHERE queue = 'asyncinv' AND state = 'queued' AND visible_at <= (extract(epoch from now()) * 1000000000)::bigint"
+      authenticationRef:
+        name: router-async-scaler
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -396,6 +396,23 @@ router:
     minReplicas: 1
     maxReplicas: 3
     targetCPUUtilizationPercentage: 80
+  ## keda (opt-in) scales the router on the RFC-0024 async-invocation backlog via a
+  ## KEDA ScaledObject using the postgresql scaler on the statestore queue depth.
+  ## Requires KEDA installed, asyncInvocation.enabled, and statestore.mode=external
+  ## (the postgresql scaler cannot reach an embedded SQLite store). It is mutually
+  ## exclusive with router.autoscaling (KEDA manages its own HPA on the router).
+  ## The Prometheus-scaler variant (mode-agnostic, needs an external Prometheus +
+  ## the router ServiceMonitor) is a documented follow-up.
+  ##
+  keda:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 10
+    ## Desired visible async backlog per router replica; replicas scale toward
+    ## ceil(backlog / targetBacklogPerReplica).
+    targetBacklogPerReplica: 50
+    pollingInterval: 15
+    cooldownPeriod: 120
   ## router priorityClassName
   ## Ref. https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/
   ## Recommended to use system-cluster-critical for router pods.

--- a/docs/rfc/0024-async-invocation-retries-dlq-destinations.md
+++ b/docs/rfc/0024-async-invocation-retries-dlq-destinations.md
@@ -61,8 +61,10 @@ Webhook validation: destination exclusivity, backoff bounds, a destination-chain
 
 ### Enqueue path (router)
 
-- Trigger: request header `X-Fission-Invoke-Mode: async` on either listener, or `httptrigger.spec.invocationMode: async` forcing it per trigger (webhooks from third parties cannot set headers).
-- The router handler (a thin branch where the proxy handoff happens today, after route/auth/admission resolution so async requests still respect trigger auth) serializes `{fnRef, method, path, headers-allowlist, body, enqueueTime, depth}` and calls `Queue.Enqueue("asyncinv/<ns>", msg, {DedupKey: X-Fission-Dedup-Key})`, returning `202 {"invocationId": id}` or `503` if the statestore is unreachable (fail loud, never fake-accept).
+- Trigger: request header `X-Fission-Invoke-Mode: async`, or `httptrigger.spec.invocationMode: async` forcing it per trigger (webhooks from third parties cannot set headers).
+- The trigger works on **both** the public HTTPTrigger path and the internal direct-function path (`/fission-function/<ns>/<name>`), so a signed direct caller — notably `fission function test --async` — can enqueue too (`functionHandler.asyncRequested`).
+  The one request that must never re-enqueue is the dispatcher's own delivery, which carries `X-Fission-Invocation-Id`; that header gates it back to a synchronous proxy regardless of any other header (the replay allowlist already strips `X-Fission-*`, so this is belt-and-suspenders).
+- The router handler (a thin branch where the proxy handoff happens today, after route/auth/admission resolution so async requests still respect trigger auth) serializes `{fnRef, method, path, headers-allowlist, body, enqueueTime, depth}` and calls `Queue.Enqueue("asyncinv", msg, {DedupKey: X-Fission-Dedup-Key})`, returning `202 {"invocationId": id}` or `503` if the statestore is unreachable (fail loud, never fake-accept).
 - Body cap enforced before buffering completes (wrap with `http.MaxBytesReader`), so oversized requests cannot balloon router memory — the same concern class the #3539/#3541 spill work handled for uploads, solved here by rejection instead of spilling.
 - Async on a non-existent function 404s at enqueue time (route resolution already happened).
 
@@ -90,15 +92,19 @@ Webhook validation: destination exclusivity, backoff bounds, a destination-chain
 
 Function destinations are themselves enqueued async (depth+1); topic destinations go through the existing `publisher.MakeWebhookPublisher`-family mqtrigger publishers (deterministic constructors, no env reads — the established contract).
 
-### DLQ and CLI
+### CLI
 
-- Default DLQ is the statestore dead-letter table (`Queue.DeadLetters`/`Redrive`), so the feature is complete with zero brokers.
-- `fission fn dlq list --name <fn>` (id, reason, attempts, age), `show <id>` (full envelope), `redrive <id>|--all` (re-enqueue with attempts reset, depth preserved), `purge`.
-  Served by a small authenticated admin endpoint on the dispatcher (operator JWT when `authentication.enabled`, internal-auth otherwise — fail closed).
+- **Invoke:** `fission function test --async` invokes asynchronously — it POSTs to the router internal listener with the async header, HMAC-signing the request (`ServiceRouterInternal`, from `FISSION_INTERNAL_AUTH_SECRET`) so the internal verifier accepts it, and prints the invocation id from the `202` instead of awaiting a response.
+- **Configure:** `fission function create|update` sets `FunctionSpec.Invocation` via `--async-retry-max-attempts`, `--async-max-age`, `--async-on-success <fn>`, `--async-on-failure <fn>` (update merges onto the existing config; an empty destination clears it).
+- **Trigger mode:** `fission route create|update --invocation-mode async` sets `httptrigger.spec.invocationMode`, forcing async for every request through that trigger (for callers that cannot set the header).
+- **DLQ:** default DLQ is the statestore dead-letter table (`Queue.DeadLetters`/`Redrive`/`Purge`), so the feature is complete with zero brokers.
+  `fission function dlq list [--namespace <ns>] [--limit N]` (id, namespace, function, reason, attempts, died), `show --id <id>` (full envelope), `redrive --id <id>|--all` (re-enqueue with attempts reset), `purge`.
+  Served by the router admin endpoints `/v1/async/dlq/{list,show,redrive,purge}` on the public listener, gated by the same JWT `authMiddleware` as the login endpoint (operator JWT when `authentication.enabled`; the paths are deliberately not in the auth exemption list) — a coarse gate, with per-namespace JWT scoping a follow-up.
 
 ### Observability
 
-`fission_async_queue_depth`, `_oldest_age_seconds`, `_deliveries_total{condition}`, `_retries_total`, `_dlq_total{reason}` via RFC-0019 meters; queue depth is the KEDA `postgresql` scaler hook for router replicas later.
+`fission_async_queue_depth`, `_oldest_age_seconds`, `_deliveries_total{condition}`, `_retries_total`, `_dlq_total{reason}`, `_destinations_total{outcome}`, `_depth_cap_total` via RFC-0019 meters.
+Queue depth is the KEDA scaling hook: an opt-in `router.keda.enabled` ScaledObject scales the router Deployment on the visible backlog via the `postgresql` scaler (requires `statestore.mode=external`, mutually exclusive with `router.autoscaling`).
 Invocation id joins the RFC-0015 correlation story (one id from 202 through delivery attempts to destination).
 
 ## Invariants & verification
@@ -144,9 +150,10 @@ Render-gated on `statestore.enabled` (`asyncInvocation.enabled` Helm flag, off b
 ## Rollout phases (one PR each, bisectable)
 
 1. `InvocationConfig` CRD field + codegen + webhook validation; enqueue path in the router (202 + id, caps, dedup); dispatcher with retry/backoff and statestore DLQ; defaults-only (no destinations); metrics.
-2. Destinations (function + topic) with the result envelope and depth cap; `httptrigger.invocationMode`.
-3. CLI `fission fn dlq` suite + admin endpoint + auth.
-4. KEDA-scaled router replicas on queue depth; RFC-0020 bench scenario (enqueue overhead, drain throughput, DLQ under saturation — reusing the c500 saturation harness from wave 3).
+2. Destinations (function-only; topic declared but admission-rejected) with the result envelope and depth cap; `httptrigger.invocationMode` CEL enum.
+3. `Queue.Purge`; router DLQ admin endpoints `/v1/async/dlq/{list,show,redrive,purge}`; CLI `fission function dlq` suite.
+4. Opt-in KEDA `postgresql` ScaledObject scaling the router on queue depth; RFC-0020 async bench scenario (enqueue overhead, drain throughput, DLQ under saturation).
+5. CLI/test integration: direct-path async in the router (`functionHandler.asyncRequested`), `fission function test --async`, `fn create|update --async-*` config flags, `route --invocation-mode`.
 
 ## Verification / test plan
 

--- a/docs/rfc/0024-async-invocation-retries-dlq-destinations.md
+++ b/docs/rfc/0024-async-invocation-retries-dlq-destinations.md
@@ -98,8 +98,8 @@ Function destinations are themselves enqueued async (depth+1); topic destination
 - **Configure:** `fission function create|update` sets `FunctionSpec.Invocation` via `--async-retry-max-attempts`, `--async-max-age`, `--async-on-success <fn>`, `--async-on-failure <fn>` (update merges onto the existing config; an empty destination clears it).
 - **Trigger mode:** `fission route create|update --invocation-mode async` sets `httptrigger.spec.invocationMode`, forcing async for every request through that trigger (for callers that cannot set the header).
 - **DLQ:** default DLQ is the statestore dead-letter table (`Queue.DeadLetters`/`Redrive`/`Purge`), so the feature is complete with zero brokers.
-  `fission function dlq list [--namespace <ns>] [--limit N]` (id, namespace, function, reason, attempts, died), `show --id <id>` (full envelope), `redrive --id <id>|--all` (re-enqueue with attempts reset), `purge`.
-  Served by the router admin endpoints `/v1/async/dlq/{list,show,redrive,purge}` on the public listener, gated by the same JWT `authMiddleware` as the login endpoint (operator JWT when `authentication.enabled`; the paths are deliberately not in the auth exemption list) — a coarse gate, with per-namespace JWT scoping a follow-up.
+  `fission function dlq list [--namespace <ns>] [--limit N]` (id, namespace, function, reason, attempts, died; pages the API so a large DLQ is fully traversed), `show --id <id>` (full envelope), `redrive --id <id>|--all` (re-enqueue with attempts reset; reports the count actually re-enqueued), `purge`.
+  Served by the router admin endpoints `/v1/async/dlq/{list,show,redrive,purge}` on the **internal** listener (ClusterIP-only `svc/router-internal`), so every request is HMAC-verified (`ServiceRouterInternal`) and NetworkPolicy-gated — fail-closed by construction and independent of the public listener's optional JWT auth (which defaults off; putting the admin API on the public listener would have exposed an unauthenticated cross-namespace read/redrive/purge surface). The CLI signs with `FISSION_INTERNAL_AUTH_SECRET`, exactly as `test --async` does. Per-namespace scoping of access is a follow-up.
 
 ### Observability
 

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -27,6 +27,8 @@ func Commands() *cobra.Command {
 			flag.FnStreamingIdleTimeout, flag.FnStreamingMaxDuration,
 			flag.FnExposeAsMCP, flag.FnToolDescription,
 			flag.FnToolInputSchema, flag.FnToolName,
+			flag.FnAsyncMaxAttempts, flag.FnAsyncMaxAge,
+			flag.FnAsyncOnSuccess, flag.FnAsyncOnFailure,
 			flag.FnOnceOnly, flag.Labels, flag.Annotation, flag.FnRetainPods,
 
 			// TODO retired pkg & trigger related flags from function cmd
@@ -85,6 +87,8 @@ func Commands() *cobra.Command {
 			flag.FnStreamingIdleTimeout, flag.FnStreamingMaxDuration,
 			flag.FnExposeAsMCP, flag.FnToolDescription,
 			flag.FnToolInputSchema, flag.FnToolName,
+			flag.FnAsyncMaxAttempts, flag.FnAsyncMaxAge,
+			flag.FnAsyncOnSuccess, flag.FnAsyncOnFailure,
 			flag.FnOnceOnly, flag.Labels, flag.Annotation, flag.FnRetainPods,
 
 			flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -136,7 +136,7 @@ func Commands() *cobra.Command {
 	}, Test, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{flag.HtMethod, flag.FnTestHeader, flag.FnTestBody,
-			flag.FnTestQuery, flag.FnTestTimeout,
+			flag.FnTestQuery, flag.FnTestTimeout, flag.FnTestAsync,
 			// for getting log from log database if we failed to get logs from function pod.
 			flag.FnLogDBType,
 			flag.FnSubPath,

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -244,7 +244,7 @@ func Commands() *cobra.Command {
 		Short:   "Create, update and manage functions",
 	}
 	command.AddCommand(createCmd, getCmd, getmetaCmd, describeCmd, updateCmd, deleteCmd, listCmd, logsCmd, testCmd,
-		runLocalCmd, runContainerCmd, updateContainerCmd, listPodsCmd, waitCmd, toolsCmd)
+		runLocalCmd, runContainerCmd, updateContainerCmd, listPodsCmd, waitCmd, toolsCmd, DLQCommands())
 
 	return command
 }

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -89,6 +89,48 @@ func getToolConfig(input cli.Input, existing *fv1.ToolConfig) (*fv1.ToolConfig, 
 	return tc, nil
 }
 
+// getInvocationConfig builds the RFC-0024 async InvocationConfig from the
+// --async-* flags, merging onto existing (the function's current config, or nil on
+// create) so an `fn update` that sets only one field keeps the rest. It returns nil
+// when nothing is configured. An empty --async-on-success/--async-on-failure clears
+// that destination. Field bounds and the destination shape are validated server-side
+// by the Function admission webhook, so the CLI stays thin.
+func getInvocationConfig(input cli.Input, existing *fv1.InvocationConfig) *fv1.InvocationConfig {
+	set := input.IsSet(flagkey.FnAsyncMaxAttempts) || input.IsSet(flagkey.FnAsyncMaxAge) ||
+		input.IsSet(flagkey.FnAsyncOnSuccess) || input.IsSet(flagkey.FnAsyncOnFailure)
+	if !set {
+		return existing
+	}
+	ic := &fv1.InvocationConfig{}
+	if existing != nil {
+		ic = existing.DeepCopy()
+	}
+	if input.IsSet(flagkey.FnAsyncMaxAttempts) {
+		ic.Retry.MaxAttempts = new(input.Int(flagkey.FnAsyncMaxAttempts))
+	}
+	if input.IsSet(flagkey.FnAsyncMaxAge) {
+		ic.MaxAge = &metav1.Duration{Duration: input.Duration(flagkey.FnAsyncMaxAge)}
+	}
+	if input.IsSet(flagkey.FnAsyncOnSuccess) {
+		ic.OnSuccess = functionDestination(input.String(flagkey.FnAsyncOnSuccess))
+	}
+	if input.IsSet(flagkey.FnAsyncOnFailure) {
+		ic.OnFailure = functionDestination(input.String(flagkey.FnAsyncOnFailure))
+	}
+	return ic
+}
+
+// functionDestination builds a same-namespace function DestinationRef, or nil for
+// an empty name (clearing the destination).
+func functionDestination(name string) *fv1.DestinationRef {
+	if name == "" {
+		return nil
+	}
+	return &fv1.DestinationRef{
+		Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: name},
+	}
+}
+
 func (opts *CreateSubCommand) do(input cli.Input) error {
 	err := opts.complete(input)
 	if err != nil {
@@ -302,6 +344,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			IdleTimeout:     &fnIdleTimeout,
 			Streaming:       getStreamingConfig(input),
 			Tool:            toolConfig,
+			Invocation:      getInvocationConfig(input, nil),
 			Concurrency:     fnConcurrency,
 			RequestsPerPod:  requestsPerPod,
 			RetainPods:      retainPods,

--- a/pkg/fission-cli/cmd/function/dlq.go
+++ b/pkg/fission-cli/cmd/function/dlq.go
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package function
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	wrapper "github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/flag"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+// RFC-0024 async dead-letter-queue admin CLI. It drives the router's DLQ admin API
+// over HTTP (util.GetRouterURL + a Bearer FISSION_AUTH_TOKEN) rather than the
+// Kubernetes clientset, because the dead-lettered state lives in the statestore
+// behind the router, not in a CRD. These are the wire paths the router registers.
+const (
+	dlqAPIList    = "/v1/async/dlq/list"
+	dlqAPIShow    = "/v1/async/dlq/show"
+	dlqAPIRedrive = "/v1/async/dlq/redrive"
+	dlqAPIPurge   = "/v1/async/dlq/purge"
+)
+
+type dlqMessage struct {
+	ID         string    `json:"id"`
+	Namespace  string    `json:"namespace"`
+	Function   string    `json:"function"`
+	Reason     string    `json:"reason"`
+	Attempts   int       `json:"attempts"`
+	EnqueuedAt time.Time `json:"enqueuedAt"`
+	DiedAt     time.Time `json:"diedAt"`
+}
+
+type dlqListResp struct {
+	Messages  []dlqMessage `json:"messages"`
+	NextToken string       `json:"nextToken"`
+}
+
+type dlqShowResp struct {
+	dlqMessage
+	Envelope json.RawMessage `json:"envelope"`
+}
+
+type dlqRedriveReq struct {
+	IDs []string `json:"ids"`
+}
+
+type dlqMutateResp struct {
+	Count int64 `json:"count"`
+}
+
+// DLQCommands builds the `fission function dlq` sub-group.
+func DLQCommands() *cobra.Command {
+	listCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "list",
+		Short: "List dead-lettered async invocations",
+	}, DLQList, flag.FlagSet{
+		Optional: []flag.Flag{flag.Namespace, flag.DlqLimit, flag.Output},
+	})
+	showCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "show",
+		Short: "Show the full envelope of one dead-lettered async invocation",
+	}, DLQShow, flag.FlagSet{
+		Required: []flag.Flag{flag.DlqID},
+	})
+	redriveCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "redrive",
+		Short: "Re-enqueue dead-lettered async invocations for another delivery",
+	}, DLQRedrive, flag.FlagSet{
+		Optional: []flag.Flag{flag.DlqID, flag.DlqAll},
+	})
+	purgeCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "purge",
+		Short: "Permanently delete every dead-lettered async invocation",
+	}, DLQPurge, flag.FlagSet{})
+
+	command := &cobra.Command{
+		Use:   "dlq",
+		Short: "Inspect and manage the async invocation dead-letter queue",
+	}
+	command.AddCommand(listCmd, showCmd, redriveCmd, purgeCmd)
+	return command
+}
+
+type dlqSubCommand struct {
+	cmd.CommandActioner
+}
+
+func DLQList(input cli.Input) error    { return (&dlqSubCommand{}).list(input) }
+func DLQShow(input cli.Input) error    { return (&dlqSubCommand{}).show(input) }
+func DLQRedrive(input cli.Input) error { return (&dlqSubCommand{}).redrive(input) }
+func DLQPurge(input cli.Input) error   { return (&dlqSubCommand{}).purge(input) }
+
+func (opts *dlqSubCommand) list(input cli.Input) error {
+	format, err := util.ParseOutputFormat(input.String(flagkey.Output))
+	if err != nil {
+		return err
+	}
+	q := url.Values{}
+	if ns := input.String(flagkey.Namespace); ns != "" {
+		q.Set("namespace", ns)
+	}
+	if input.IsSet(flagkey.DlqLimit) {
+		q.Set("limit", strconv.Itoa(input.Int(flagkey.DlqLimit)))
+	}
+	var resp dlqListResp
+	if err := opts.call(input, http.MethodGet, dlqAPIList, q, nil, &resp); err != nil {
+		return err
+	}
+	headers := []string{"ID", "NAMESPACE", "FUNCTION", "REASON", "ATTEMPTS", "DIED"}
+	row := func(m dlqMessage) []string {
+		return []string{m.ID, m.Namespace, m.Function, m.Reason, strconv.Itoa(m.Attempts), util.AgeOf(metav1.NewTime(m.DiedAt))}
+	}
+	if err := util.PrintObjects(format, resp.Messages, headers, row, nil, func(dlqMessage) []string { return nil }); err != nil {
+		return err
+	}
+	if resp.NextToken != "" {
+		fmt.Printf("\nMore results available; narrow with a smaller page or re-run to continue.\n")
+	}
+	return nil
+}
+
+func (opts *dlqSubCommand) show(input cli.Input) error {
+	q := url.Values{}
+	q.Set("id", input.String(flagkey.DlqID))
+	var resp dlqShowResp
+	if err := opts.call(input, http.MethodGet, dlqAPIShow, q, nil, &resp); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	return nil
+}
+
+func (opts *dlqSubCommand) redrive(input cli.Input) error {
+	ids, err := opts.redriveIDs(input)
+	if err != nil {
+		return err
+	}
+	if len(ids) == 0 {
+		return errors.New("nothing to redrive")
+	}
+	var resp dlqMutateResp
+	if err := opts.call(input, http.MethodPost, dlqAPIRedrive, nil, dlqRedriveReq{IDs: ids}, &resp); err != nil {
+		return err
+	}
+	fmt.Printf("redrove %d dead-lettered invocation(s)\n", resp.Count)
+	return nil
+}
+
+// redriveIDs resolves the ids to redrive: a single --id, or every dead-lettered id
+// under --all (paged from the list API). The two are mutually exclusive.
+func (opts *dlqSubCommand) redriveIDs(input cli.Input) ([]string, error) {
+	id := input.String(flagkey.DlqID)
+	all := input.Bool(flagkey.DlqAll)
+	switch {
+	case id != "" && all:
+		return nil, errors.New("--id and --all are mutually exclusive")
+	case id != "":
+		return []string{id}, nil
+	case all:
+		var ids []string
+		var resp dlqListResp
+		if err := opts.call(input, http.MethodGet, dlqAPIList, url.Values{"limit": {"1000"}}, nil, &resp); err != nil {
+			return nil, err
+		}
+		for _, m := range resp.Messages {
+			ids = append(ids, m.ID)
+		}
+		return ids, nil
+	default:
+		return nil, errors.New("one of --id or --all is required")
+	}
+}
+
+func (opts *dlqSubCommand) purge(input cli.Input) error {
+	var resp dlqMutateResp
+	if err := opts.call(input, http.MethodPost, dlqAPIPurge, nil, nil, &resp); err != nil {
+		return err
+	}
+	fmt.Printf("purged %d dead-lettered invocation(s)\n", resp.Count)
+	return nil
+}
+
+// call performs one router DLQ API request, signing it with the Bearer auth token
+// (empty when auth is disabled) and decoding a JSON response into out (nil to
+// ignore the body).
+func (opts *dlqSubCommand) call(input cli.Input, method, path string, query url.Values, reqBody, out any) error {
+	routerURL, err := util.GetRouterURL(input.Context(), opts.Client())
+	if err != nil {
+		return fmt.Errorf("connecting to the Fission router: %w", err)
+	}
+	u := *routerURL
+	u.Path = path
+	if len(query) > 0 {
+		u.RawQuery = query.Encode()
+	}
+	var body io.Reader
+	if reqBody != nil {
+		b, err := json.Marshal(reqBody)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(input.Context(), method, u.String(), body)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+os.Getenv(util.FISSION_AUTH_TOKEN))
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling the router DLQ API: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusNotImplemented:
+		return errors.New("async invocation is not enabled on this cluster")
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return fmt.Errorf("router DLQ API rejected the request (%s); set %s if authentication is enabled", resp.Status, util.FISSION_AUTH_TOKEN)
+	case resp.StatusCode != http.StatusOK:
+		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return fmt.Errorf("router DLQ API returned %s: %s", resp.Status, strings.TrimSpace(string(msg)))
+	}
+	if out != nil {
+		if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+			return fmt.Errorf("decoding router DLQ response: %w", err)
+		}
+	}
+	return nil
+}

--- a/pkg/fission-cli/cmd/function/dlq.go
+++ b/pkg/fission-cli/cmd/function/dlq.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	wrapper "github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/cobra"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
@@ -29,14 +30,20 @@ import (
 )
 
 // RFC-0024 async dead-letter-queue admin CLI. It drives the router's DLQ admin API
-// over HTTP (util.GetRouterURL + a Bearer FISSION_AUTH_TOKEN) rather than the
-// Kubernetes clientset, because the dead-lettered state lives in the statestore
-// behind the router, not in a CRD. These are the wire paths the router registers.
+// on the INTERNAL listener (HMAC-signed with FISSION_INTERNAL_AUTH_SECRET) rather
+// than the Kubernetes clientset, because the dead-lettered state lives in the
+// statestore behind the router, not in a CRD. These are the wire paths the router
+// registers.
 const (
 	dlqAPIList    = "/v1/async/dlq/list"
 	dlqAPIShow    = "/v1/async/dlq/show"
 	dlqAPIRedrive = "/v1/async/dlq/redrive"
 	dlqAPIPurge   = "/v1/async/dlq/purge"
+
+	// dlqPageSize is the per-request page the CLI fetches while paging the list API
+	// (matches the router's max limit), so list/redrive --all see the whole DLQ,
+	// not just the first page.
+	dlqPageSize = 1000
 )
 
 type dlqMessage struct {
@@ -114,28 +121,56 @@ func (opts *dlqSubCommand) list(input cli.Input) error {
 	if err != nil {
 		return err
 	}
-	q := url.Values{}
-	if ns := input.String(flagkey.Namespace); ns != "" {
-		q.Set("namespace", ns)
-	}
-	if input.IsSet(flagkey.DlqLimit) {
-		q.Set("limit", strconv.Itoa(input.Int(flagkey.DlqLimit)))
-	}
-	var resp dlqListResp
-	if err := opts.call(input, http.MethodGet, dlqAPIList, q, nil, &resp); err != nil {
+	limit := input.Int(flagkey.DlqLimit)
+	msgs, more, err := opts.fetchDeadLetters(input, input.String(flagkey.Namespace), limit)
+	if err != nil {
 		return err
 	}
 	headers := []string{"ID", "NAMESPACE", "FUNCTION", "REASON", "ATTEMPTS", "DIED"}
 	row := func(m dlqMessage) []string {
 		return []string{m.ID, m.Namespace, m.Function, m.Reason, strconv.Itoa(m.Attempts), util.AgeOf(metav1.NewTime(m.DiedAt))}
 	}
-	if err := util.PrintObjects(format, resp.Messages, headers, row, nil, func(dlqMessage) []string { return nil }); err != nil {
+	if err := util.PrintObjects(format, msgs, headers, row, nil, func(dlqMessage) []string { return nil }); err != nil {
 		return err
 	}
-	if resp.NextToken != "" {
-		fmt.Printf("\nMore results available; narrow with a smaller page or re-run to continue.\n")
+	if more {
+		fmt.Printf("\nShowing the first %d; raise --limit to see more.\n", len(msgs))
 	}
 	return nil
+}
+
+// fetchDeadLetters pages the DLQ list API, accumulating up to max messages (max <= 0
+// means every one), filtered to namespace when set. It follows the API's nextToken
+// so a large DLQ is fully traversed, not just its first page. The bool reports
+// whether more messages remain beyond what was returned (only when max capped it).
+func (opts *dlqSubCommand) fetchDeadLetters(input cli.Input, namespace string, max int) ([]dlqMessage, bool, error) {
+	pageSize := dlqPageSize
+	if max > 0 && max < pageSize {
+		pageSize = max
+	}
+	var all []dlqMessage
+	token := ""
+	for {
+		q := url.Values{"limit": {strconv.Itoa(pageSize)}}
+		if namespace != "" {
+			q.Set("namespace", namespace)
+		}
+		if token != "" {
+			q.Set("token", token)
+		}
+		var resp dlqListResp
+		if err := opts.call(input, http.MethodGet, dlqAPIList, q, nil, &resp); err != nil {
+			return nil, false, err
+		}
+		all = append(all, resp.Messages...)
+		if max > 0 && len(all) >= max {
+			return all[:max], resp.NextToken != "" || len(all) > max, nil
+		}
+		if resp.NextToken == "" {
+			return all, false, nil
+		}
+		token = resp.NextToken
+	}
 }
 
 func (opts *dlqSubCommand) show(input cli.Input) error {
@@ -180,12 +215,12 @@ func (opts *dlqSubCommand) redriveIDs(input cli.Input) ([]string, error) {
 	case id != "":
 		return []string{id}, nil
 	case all:
-		var ids []string
-		var resp dlqListResp
-		if err := opts.call(input, http.MethodGet, dlqAPIList, url.Values{"limit": {"1000"}}, nil, &resp); err != nil {
+		msgs, _, err := opts.fetchDeadLetters(input, "", 0) // 0 = every dead letter, all pages
+		if err != nil {
 			return nil, err
 		}
-		for _, m := range resp.Messages {
+		ids := make([]string, 0, len(msgs))
+		for _, m := range msgs {
 			ids = append(ids, m.ID)
 		}
 		return ids, nil
@@ -203,15 +238,17 @@ func (opts *dlqSubCommand) purge(input cli.Input) error {
 	return nil
 }
 
-// call performs one router DLQ API request, signing it with the Bearer auth token
-// (empty when auth is disabled) and decoding a JSON response into out (nil to
-// ignore the body).
+// call performs one DLQ API request against the router INTERNAL listener,
+// HMAC-signing it with the ServiceRouterInternal key (from FISSION_INTERNAL_AUTH_SECRET,
+// empty → pass-through) the same way `test --async` does, and decoding a JSON
+// response into out (nil to ignore the body). The endpoints are on the internal
+// listener precisely so they are never an unauthenticated public surface.
 func (opts *dlqSubCommand) call(input cli.Input, method, path string, query url.Values, reqBody, out any) error {
-	routerURL, err := util.GetRouterURL(input.Context(), opts.Client())
+	internalURL, err := util.GetRouterInternalURL(input.Context(), opts.Client())
 	if err != nil {
-		return fmt.Errorf("connecting to the Fission router: %w", err)
+		return fmt.Errorf("connecting to the Fission router internal listener: %w", err)
 	}
-	u := *routerURL
+	u := *internalURL
 	u.Path = path
 	if len(query) > 0 {
 		u.RawQuery = query.Encode()
@@ -231,9 +268,12 @@ func (opts *dlqSubCommand) call(input cli.Input, method, path string, query url.
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	req.Header.Set("Authorization", "Bearer "+os.Getenv(util.FISSION_AUTH_TOKEN))
 
-	resp, err := http.DefaultClient.Do(req)
+	transport := http.DefaultTransport
+	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {
+		transport = hmacauth.NewServiceSigningTransport([]byte(secret), hmacauth.ServiceRouterInternal, transport, "/v1/async/dlq/")
+	}
+	resp, err := (&http.Client{Transport: transport}).Do(req)
 	if err != nil {
 		return fmt.Errorf("calling the router DLQ API: %w", err)
 	}
@@ -243,7 +283,7 @@ func (opts *dlqSubCommand) call(input cli.Input, method, path string, query url.
 	case resp.StatusCode == http.StatusNotImplemented:
 		return errors.New("async invocation is not enabled on this cluster")
 	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
-		return fmt.Errorf("router DLQ API rejected the request (%s); set %s if authentication is enabled", resp.Status, util.FISSION_AUTH_TOKEN)
+		return fmt.Errorf("router DLQ API rejected the request (%s); set FISSION_INTERNAL_AUTH_SECRET when authentication is enabled", resp.Status)
 	case resp.StatusCode != http.StatusOK:
 		msg, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
 		return fmt.Errorf("router DLQ API returned %s: %s", resp.Status, strings.TrimSpace(string(msg)))

--- a/pkg/fission-cli/cmd/function/dlq_test.go
+++ b/pkg/fission-cli/cmd/function/dlq_test.go
@@ -1,0 +1,170 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package function
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+// fakeDLQInput embeds cli.Input (nil) and overrides only the accessors the DLQ
+// actioners use.
+type fakeDLQInput struct {
+	cli.Input
+	s   map[string]string
+	b   map[string]bool
+	i   map[string]int
+	set map[string]bool
+}
+
+func (f fakeDLQInput) String(k string) string   { return f.s[k] }
+func (f fakeDLQInput) Bool(k string) bool       { return f.b[k] }
+func (f fakeDLQInput) Int(k string) int         { return f.i[k] }
+func (f fakeDLQInput) IsSet(k string) bool      { return f.set[k] }
+func (f fakeDLQInput) Context() context.Context { return context.Background() }
+
+// recordedReq captures one request the mock router received.
+type recordedReq struct {
+	Method string
+	Path   string
+	Query  string
+	Auth   string
+	Body   string
+}
+
+// mockRouter starts an httptest.Server standing in for the router DLQ API, points
+// FISSION_ROUTER_URL at it, and records every request. handler returns the JSON
+// body per path.
+func mockRouter(t *testing.T, handler func(r *http.Request) (int, string)) *[]recordedReq {
+	t.Helper()
+	var got []recordedReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		got = append(got, recordedReq{
+			Method: r.Method, Path: r.URL.Path, Query: r.URL.RawQuery,
+			Auth: r.Header.Get("Authorization"), Body: string(body),
+		})
+		code, resp := handler(r)
+		w.WriteHeader(code)
+		_, _ = io.WriteString(w, resp)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("FISSION_ROUTER_URL", srv.URL)
+	return &got
+}
+
+func TestDLQCLIList(t *testing.T) {
+	got := mockRouter(t, func(*http.Request) (int, string) {
+		return http.StatusOK, `{"messages":[{"id":"asyncinv/1","namespace":"ns","function":"fn","reason":"http_4xx","attempts":3}]}`
+	})
+	t.Setenv("FISSION_AUTH_TOKEN", "tok")
+	in := fakeDLQInput{
+		s:   map[string]string{flagkey.Namespace: "ns"},
+		i:   map[string]int{flagkey.DlqLimit: 50},
+		set: map[string]bool{flagkey.DlqLimit: true},
+	}
+	require.NoError(t, (&dlqSubCommand{}).list(in))
+
+	require.Len(t, *got, 1)
+	req := (*got)[0]
+	assert.Equal(t, http.MethodGet, req.Method)
+	assert.Equal(t, dlqAPIList, req.Path)
+	assert.Contains(t, req.Query, "namespace=ns")
+	assert.Contains(t, req.Query, "limit=50")
+	assert.Equal(t, "Bearer tok", req.Auth, "the auth token is sent")
+}
+
+func TestDLQCLIShow(t *testing.T) {
+	got := mockRouter(t, func(*http.Request) (int, string) {
+		return http.StatusOK, `{"id":"asyncinv/7","namespace":"ns","function":"fn","envelope":{"function":"fn"}}`
+	})
+	in := fakeDLQInput{s: map[string]string{flagkey.DlqID: "asyncinv/7"}}
+	require.NoError(t, (&dlqSubCommand{}).show(in))
+
+	require.Len(t, *got, 1)
+	assert.Equal(t, dlqAPIShow, (*got)[0].Path)
+	assert.Contains(t, (*got)[0].Query, "id=asyncinv%2F7")
+}
+
+func TestDLQCLIRedriveByID(t *testing.T) {
+	got := mockRouter(t, func(*http.Request) (int, string) {
+		return http.StatusOK, `{"count":1}`
+	})
+	in := fakeDLQInput{s: map[string]string{flagkey.DlqID: "asyncinv/3"}}
+	require.NoError(t, (&dlqSubCommand{}).redrive(in))
+
+	require.Len(t, *got, 1)
+	req := (*got)[0]
+	assert.Equal(t, http.MethodPost, req.Method)
+	assert.Equal(t, dlqAPIRedrive, req.Path)
+	var body dlqRedriveReq
+	require.NoError(t, json.Unmarshal([]byte(req.Body), &body))
+	assert.Equal(t, []string{"asyncinv/3"}, body.IDs)
+}
+
+func TestDLQCLIRedriveAll(t *testing.T) {
+	got := mockRouter(t, func(r *http.Request) (int, string) {
+		if r.Method == http.MethodGet {
+			return http.StatusOK, `{"messages":[{"id":"a"},{"id":"b"}]}`
+		}
+		return http.StatusOK, `{"count":2}`
+	})
+	in := fakeDLQInput{b: map[string]bool{flagkey.DlqAll: true}}
+	require.NoError(t, (&dlqSubCommand{}).redrive(in))
+
+	require.Len(t, *got, 2, "redrive --all lists then redrives")
+	assert.Equal(t, http.MethodGet, (*got)[0].Method)
+	assert.Equal(t, http.MethodPost, (*got)[1].Method)
+	var body dlqRedriveReq
+	require.NoError(t, json.Unmarshal([]byte((*got)[1].Body), &body))
+	assert.Equal(t, []string{"a", "b"}, body.IDs)
+}
+
+func TestDLQCLIRedriveArgErrors(t *testing.T) {
+	mockRouter(t, func(*http.Request) (int, string) { return http.StatusOK, `{}` })
+	// Neither --id nor --all.
+	err := (&dlqSubCommand{}).redrive(fakeDLQInput{})
+	assert.ErrorContains(t, err, "one of --id or --all")
+	// Both.
+	err = (&dlqSubCommand{}).redrive(fakeDLQInput{
+		s: map[string]string{flagkey.DlqID: "x"}, b: map[string]bool{flagkey.DlqAll: true},
+	})
+	assert.ErrorContains(t, err, "mutually exclusive")
+}
+
+func TestDLQCLIPurge(t *testing.T) {
+	got := mockRouter(t, func(*http.Request) (int, string) { return http.StatusOK, `{"count":5}` })
+	require.NoError(t, (&dlqSubCommand{}).purge(fakeDLQInput{}))
+	require.Len(t, *got, 1)
+	assert.Equal(t, http.MethodPost, (*got)[0].Method)
+	assert.Equal(t, dlqAPIPurge, (*got)[0].Path)
+}
+
+func TestDLQCLIDisabled501(t *testing.T) {
+	mockRouter(t, func(*http.Request) (int, string) {
+		return http.StatusNotImplemented, "async invocation is not enabled on this cluster\n"
+	})
+	err := (&dlqSubCommand{}).purge(fakeDLQInput{})
+	assert.ErrorContains(t, err, "not enabled")
+}
+
+func TestDLQCLIServerError(t *testing.T) {
+	mockRouter(t, func(*http.Request) (int, string) {
+		return http.StatusInternalServerError, "boom\n"
+	})
+	err := (&dlqSubCommand{}).purge(fakeDLQInput{})
+	assert.ErrorContains(t, err, "500")
+	assert.ErrorContains(t, err, "boom")
+}

--- a/pkg/fission-cli/cmd/function/dlq_test.go
+++ b/pkg/fission-cli/cmd/function/dlq_test.go
@@ -44,9 +44,9 @@ type recordedReq struct {
 	Body   string
 }
 
-// mockRouter starts an httptest.Server standing in for the router DLQ API, points
-// FISSION_ROUTER_URL at it, and records every request. handler returns the JSON
-// body per path.
+// mockRouter starts an httptest.Server standing in for the router internal DLQ API,
+// points FISSION_ROUTER_INTERNAL_URL at it, and records every request. handler
+// returns the JSON body per request.
 func mockRouter(t *testing.T, handler func(r *http.Request) (int, string)) *[]recordedReq {
 	t.Helper()
 	var got []recordedReq
@@ -61,7 +61,7 @@ func mockRouter(t *testing.T, handler func(r *http.Request) (int, string)) *[]re
 		_, _ = io.WriteString(w, resp)
 	}))
 	t.Cleanup(srv.Close)
-	t.Setenv("FISSION_ROUTER_URL", srv.URL)
+	t.Setenv("FISSION_ROUTER_INTERNAL_URL", srv.URL)
 	return &got
 }
 
@@ -69,7 +69,6 @@ func TestDLQCLIList(t *testing.T) {
 	got := mockRouter(t, func(*http.Request) (int, string) {
 		return http.StatusOK, `{"messages":[{"id":"asyncinv/1","namespace":"ns","function":"fn","reason":"http_4xx","attempts":3}]}`
 	})
-	t.Setenv("FISSION_AUTH_TOKEN", "tok")
 	in := fakeDLQInput{
 		s:   map[string]string{flagkey.Namespace: "ns"},
 		i:   map[string]int{flagkey.DlqLimit: 50},
@@ -82,8 +81,27 @@ func TestDLQCLIList(t *testing.T) {
 	assert.Equal(t, http.MethodGet, req.Method)
 	assert.Equal(t, dlqAPIList, req.Path)
 	assert.Contains(t, req.Query, "namespace=ns")
-	assert.Contains(t, req.Query, "limit=50")
-	assert.Equal(t, "Bearer tok", req.Auth, "the auth token is sent")
+	assert.Contains(t, req.Query, "limit=50", "per-page limit is capped to the requested max")
+}
+
+// TestDLQCLIListPagesAllResults proves list follows nextToken across pages rather
+// than showing only the first — the operator sees the whole (large) DLQ.
+func TestDLQCLIListPagesAllResults(t *testing.T) {
+	page := 0
+	got := mockRouter(t, func(*http.Request) (int, string) {
+		page++
+		if page == 1 {
+			return http.StatusOK, `{"messages":[{"id":"a"},{"id":"b"}],"nextToken":"b"}`
+		}
+		return http.StatusOK, `{"messages":[{"id":"c"}]}`
+	})
+	// max=0 (no --limit) → fetch every page.
+	msgs, more, err := (&dlqSubCommand{}).fetchDeadLetters(fakeDLQInput{}, "", 0)
+	require.NoError(t, err)
+	assert.False(t, more)
+	assert.Len(t, msgs, 3, "both pages accumulated")
+	require.Len(t, *got, 2, "followed nextToken to the second page")
+	assert.Contains(t, (*got)[1].Query, "token=b", "second page continues from nextToken")
 }
 
 func TestDLQCLIShow(t *testing.T) {

--- a/pkg/fission-cli/cmd/function/invocation_config_test.go
+++ b/pkg/fission-cli/cmd/function/invocation_config_test.go
@@ -1,0 +1,94 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package function
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+)
+
+// fakeInvInput overrides the accessors getInvocationConfig reads.
+type fakeInvInput struct {
+	cli.Input
+	set map[string]bool
+	i   map[string]int
+	d   map[string]time.Duration
+	s   map[string]string
+}
+
+func (f fakeInvInput) IsSet(k string) bool             { return f.set[k] }
+func (f fakeInvInput) Int(k string) int                { return f.i[k] }
+func (f fakeInvInput) Duration(k string) time.Duration { return f.d[k] }
+func (f fakeInvInput) String(k string) string          { return f.s[k] }
+
+func TestGetInvocationConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nothing set, no existing → nil", func(t *testing.T) {
+		assert.Nil(t, getInvocationConfig(fakeInvInput{}, nil))
+	})
+
+	t.Run("nothing set keeps existing untouched", func(t *testing.T) {
+		existing := &fv1.InvocationConfig{MaxAge: &metav1.Duration{Duration: time.Hour}}
+		assert.Same(t, existing, getInvocationConfig(fakeInvInput{}, existing))
+	})
+
+	t.Run("all fields from flags", func(t *testing.T) {
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncMaxAttempts: true, flagkey.FnAsyncMaxAge: true, flagkey.FnAsyncOnSuccess: true, flagkey.FnAsyncOnFailure: true},
+			i:   map[string]int{flagkey.FnAsyncMaxAttempts: 3},
+			d:   map[string]time.Duration{flagkey.FnAsyncMaxAge: 2 * time.Hour},
+			s:   map[string]string{flagkey.FnAsyncOnSuccess: "notify", flagkey.FnAsyncOnFailure: "alert"},
+		}
+		ic := getInvocationConfig(in, nil)
+		require.NotNil(t, ic)
+		require.NotNil(t, ic.Retry.MaxAttempts)
+		assert.Equal(t, 3, *ic.Retry.MaxAttempts)
+		require.NotNil(t, ic.MaxAge)
+		assert.Equal(t, 2*time.Hour, ic.MaxAge.Duration)
+		require.NotNil(t, ic.OnSuccess.Function)
+		assert.Equal(t, "notify", ic.OnSuccess.Function.Name)
+		assert.EqualValues(t, fv1.FunctionReferenceTypeFunctionName, ic.OnSuccess.Function.Type)
+		assert.Equal(t, "alert", ic.OnFailure.Function.Name)
+	})
+
+	t.Run("merge onto existing keeps unset fields", func(t *testing.T) {
+		existing := &fv1.InvocationConfig{
+			OnSuccess: &fv1.DestinationRef{Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "keep"}},
+			MaxAge:    &metav1.Duration{Duration: time.Hour},
+		}
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncMaxAttempts: true},
+			i:   map[string]int{flagkey.FnAsyncMaxAttempts: 5},
+		}
+		ic := getInvocationConfig(in, existing)
+		require.NotNil(t, ic.Retry.MaxAttempts)
+		assert.Equal(t, 5, *ic.Retry.MaxAttempts)
+		require.NotNil(t, ic.OnSuccess, "existing OnSuccess preserved")
+		assert.Equal(t, "keep", ic.OnSuccess.Function.Name)
+		assert.Equal(t, time.Hour, ic.MaxAge.Duration, "existing MaxAge preserved")
+		assert.Nil(t, existing.Retry.MaxAttempts, "the original is not mutated")
+	})
+
+	t.Run("empty destination clears it", func(t *testing.T) {
+		existing := &fv1.InvocationConfig{
+			OnFailure: &fv1.DestinationRef{Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "old"}},
+		}
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncOnFailure: true},
+			s:   map[string]string{flagkey.FnAsyncOnFailure: ""},
+		}
+		ic := getInvocationConfig(in, existing)
+		assert.Nil(t, ic.OnFailure, "empty --async-on-failure clears the destination")
+	})
+}

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -207,12 +207,14 @@ func (opts *TestSubCommand) invokeAsync(ctx context.Context, input cli.Input, m 
 	if err != nil {
 		return err
 	}
-	req.Header.Set(asyncinvoke.HeaderInvokeMode, asyncinvoke.InvokeModeAsync)
 	for _, h := range input.StringSlice(flagkey.FnTestHeader) {
 		if k, v, ok := strings.Cut(h, ":"); ok {
 			req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
 		}
 	}
+	// Set the async mode header LAST so --async is authoritative: a user --header
+	// (e.g. -H "X-Fission-Invoke-Mode: sync") cannot silently downgrade the request.
+	req.Header.Set(asyncinvoke.HeaderInvokeMode, asyncinvoke.InvokeModeAsync)
 
 	var transport http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
 	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
@@ -31,6 +32,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/console"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
+	"github.com/fission/fission/pkg/router/asyncinvoke"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/correlation"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
@@ -130,6 +132,9 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+	if input.Bool(flagkey.FnTestAsync) {
+		return opts.invokeAsync(ctx, input, m, method)
+	}
 	resp, err := DoHTTPRequest(ctx, fnURL.String(),
 		input.StringSlice(flagkey.FnTestHeader),
 		method,
@@ -173,6 +178,84 @@ func (opts *TestSubCommand) do(input cli.Input) error {
 		fmt.Fprintf(os.Stderr, "Correlated logs: fission function logs --name %s --request-id %s --dbtype loki\n", m.Name, reqID)
 	}
 	return errors.New("error getting function response")
+}
+
+// invokeAsync runs `fission function test --async` (RFC-0024): it POSTs to the
+// function on the router INTERNAL listener with X-Fission-Invoke-Mode: async,
+// HMAC-signing the request (ServiceRouterInternal) when FISSION_INTERNAL_AUTH_SECRET
+// is set so the internal verifier accepts it. The router returns 202 with the
+// durable invocation id, which is printed; the response body is not awaited.
+func (opts *TestSubCommand) invokeAsync(ctx context.Context, input cli.Input, m *metav1.ObjectMeta, method string) error {
+	internalURL, err := util.GetRouterInternalURL(input.Context(), opts.Client())
+	if err != nil {
+		return fmt.Errorf("resolving the router internal listener: %w", err)
+	}
+	fnURI := utils.UrlForFunction(m.Name, m.Namespace)
+	if input.IsSet(flagkey.FnSubPath) {
+		subPath := input.String(flagkey.FnSubPath)
+		if !strings.HasPrefix(subPath, "/") {
+			fnURI += "/"
+		}
+		fnURI += subPath
+	}
+	fnURL := internalURL.JoinPath(fnURI)
+	if q := testQueryValues(input); len(q) > 0 {
+		fnURL.RawQuery = q.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fnURL.String(), strings.NewReader(input.String(flagkey.FnTestBody)))
+	if err != nil {
+		return err
+	}
+	req.Header.Set(asyncinvoke.HeaderInvokeMode, asyncinvoke.InvokeModeAsync)
+	for _, h := range input.StringSlice(flagkey.FnTestHeader) {
+		if k, v, ok := strings.Cut(h, ":"); ok {
+			req.Header.Set(strings.TrimSpace(k), strings.TrimSpace(v))
+		}
+	}
+
+	var transport http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	if secret := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); secret != "" {
+		transport = hmacauth.NewServiceSigningTransport([]byte(secret), hmacauth.ServiceRouterInternal, transport, "/fission-function/")
+	}
+	resp, err := (&http.Client{Transport: transport}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 8<<10))
+
+	switch resp.StatusCode {
+	case http.StatusAccepted:
+		id := resp.Header.Get(asyncinvoke.HeaderInvocationID)
+		if id == "" {
+			var decoded map[string]string
+			if json.Unmarshal(body, &decoded) == nil {
+				id = decoded["invocationId"]
+			}
+		}
+		fmt.Printf("Accepted (202)\ninvocationId: %s\n", id)
+		return nil
+	case http.StatusNotImplemented:
+		return errors.New("async invocation is not enabled on this cluster")
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return fmt.Errorf("router rejected the async request (%s); set FISSION_INTERNAL_AUTH_SECRET when authentication is enabled", resp.Status)
+	default:
+		return fmt.Errorf("async invocation failed (%s): %s", resp.Status, strings.TrimSpace(string(body)))
+	}
+}
+
+// testQueryValues builds the request query from repeated --query key=value flags.
+func testQueryValues(input cli.Input) url.Values {
+	query := url.Values{}
+	for _, q := range input.StringSlice(flagkey.FnTestQuery) {
+		key, value, _ := strings.Cut(q, "=")
+		if key == "" {
+			continue
+		}
+		query.Set(key, value)
+	}
+	return query
 }
 
 // renderInvocationFailure writes a one-line diagnosis for a failed `function

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -234,6 +234,12 @@ func (opts *TestSubCommand) invokeAsync(ctx context.Context, input cli.Input, m 
 				id = decoded["invocationId"]
 			}
 		}
+		if id == "" {
+			// The router always returns an id (invariant A1); an empty one means a
+			// proxy stripped the header and mangled the body — accepted, but untrackable.
+			fmt.Fprintln(os.Stderr, "warning: accepted (202) but no invocation id was returned")
+			return nil
+		}
 		fmt.Printf("Accepted (202)\ninvocationId: %s\n", id)
 		return nil
 	case http.StatusNotImplemented:

--- a/pkg/fission-cli/cmd/function/test_async_test.go
+++ b/pkg/fission-cli/cmd/function/test_async_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package function
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/router/asyncinvoke"
+)
+
+// fakeTestInput overrides only the accessors invokeAsync/testQueryValues read.
+type fakeTestInput struct {
+	fakeDLQInput
+	ss map[string][]string
+}
+
+func (f fakeTestInput) StringSlice(k string) []string { return f.ss[k] }
+func (f fakeTestInput) Context() context.Context      { return context.Background() }
+
+func TestInvokeAsyncSendsAsyncHeaderAndPrintsID(t *testing.T) {
+	var got struct {
+		method, path, body, invokeMode, hdr string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		got.method, got.path, got.body = r.Method, r.URL.Path, string(b)
+		got.invokeMode = r.Header.Get(asyncinvoke.HeaderInvokeMode)
+		got.hdr = r.Header.Get("X-Custom")
+		w.Header().Set(asyncinvoke.HeaderInvocationID, "asyncinv/9")
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer srv.Close()
+	t.Setenv("FISSION_ROUTER_INTERNAL_URL", srv.URL)
+
+	in := fakeTestInput{
+		fakeDLQInput: fakeDLQInput{s: map[string]string{flagkey.FnTestBody: "hello"}},
+		ss:           map[string][]string{flagkey.FnTestHeader: {"X-Custom: v"}},
+	}
+	err := (&TestSubCommand{}).invokeAsync(context.Background(), in, &metav1.ObjectMeta{Name: "fn", Namespace: "ns"}, http.MethodPost)
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, got.method)
+	assert.Equal(t, "/fission-function/ns/fn", got.path)
+	assert.Equal(t, "hello", got.body)
+	assert.Equal(t, asyncinvoke.InvokeModeAsync, got.invokeMode, "async mode header is set")
+	assert.Equal(t, "v", got.hdr, "user headers are forwarded")
+}
+
+func TestInvokeAsyncDisabledAndErrorStatuses(t *testing.T) {
+	cases := map[string]struct {
+		status int
+		errSub string
+	}{
+		"disabled 501":     {http.StatusNotImplemented, "not enabled"},
+		"unauthorized 401": {http.StatusUnauthorized, "FISSION_INTERNAL_AUTH_SECRET"},
+		"server 500":       {http.StatusInternalServerError, "500"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+			}))
+			defer srv.Close()
+			t.Setenv("FISSION_ROUTER_INTERNAL_URL", srv.URL)
+			err := (&TestSubCommand{}).invokeAsync(context.Background(), fakeTestInput{}, &metav1.ObjectMeta{Name: "fn", Namespace: "ns"}, http.MethodPost)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.errSub)
+		})
+	}
+}
+
+func TestTestQueryValues(t *testing.T) {
+	t.Parallel()
+	in := fakeTestInput{ss: map[string][]string{flagkey.FnTestQuery: {"a=1", "b=2", "novalue", "=skip"}}}
+	q := testQueryValues(in)
+	assert.Equal(t, "1", q.Get("a"))
+	assert.Equal(t, "2", q.Get("b"))
+	assert.Equal(t, "", q.Get("novalue"), "a key with no = still parses to an empty value")
+	assert.True(t, q.Has("novalue"))
+	assert.False(t, q.Has(""), "an empty key is dropped")
+}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -122,6 +122,10 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 		function.Spec.Tool = toolConfig
 	}
 
+	// The --async-* flags merge onto the existing InvocationConfig (only set fields
+	// change); an empty --async-on-success/--async-on-failure clears that destination.
+	function.Spec.Invocation = getInvocationConfig(input, function.Spec.Invocation)
+
 	err = checkExecutorPoolManager(input, function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType)
 	if err != nil {
 		return err

--- a/pkg/fission-cli/cmd/httptrigger/command.go
+++ b/pkg/fission-cli/cmd/httptrigger/command.go
@@ -22,7 +22,7 @@ func Commands() *cobra.Command {
 			flag.HtRouteProvider, flag.HtRouteHost, flag.HtRoutePath, flag.HtRouteAnnotation,
 			flag.HtRouteTLS, flag.HtGateway,
 			flag.HtFnWeight, flag.HtHost, flag.SpecSave, flag.SpecDry,
-			flag.HtPrefix, flag.HtKeepPrefix},
+			flag.HtPrefix, flag.HtKeepPrefix, flag.HtInvocationMode},
 	})
 
 	getCmd := wrapper.SubCommand(&cobra.Command{
@@ -44,7 +44,7 @@ func Commands() *cobra.Command {
 			flag.HtMethod, flag.HtIngress, flag.HtIngressRule, flag.HtIngressAnnotation,
 			flag.HtIngressTLS, flag.HtRouteProvider, flag.HtRouteHost, flag.HtRoutePath,
 			flag.HtRouteAnnotation, flag.HtRouteTLS, flag.HtGateway,
-			flag.HtFnWeight, flag.HtHost, flag.HtPrefix, flag.HtKeepPrefix},
+			flag.HtFnWeight, flag.HtHost, flag.HtPrefix, flag.HtKeepPrefix, flag.HtInvocationMode},
 	})
 
 	deleteCmd := wrapper.SubCommand(&cobra.Command{

--- a/pkg/fission-cli/cmd/httptrigger/create.go
+++ b/pkg/fission-cli/cmd/httptrigger/create.go
@@ -160,6 +160,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			RouteConfig:       routeConfig,
 			Prefix:            &prefix,
 			KeepPrefix:        input.Bool(flagkey.HtKeepPrefix),
+			InvocationMode:    input.String(flagkey.HtInvocationMode),
 		},
 	}
 

--- a/pkg/fission-cli/cmd/httptrigger/update.go
+++ b/pkg/fission-cli/cmd/httptrigger/update.go
@@ -75,6 +75,10 @@ func (opts *UpdateSubCommand) complete(input cli.Input) (err error) {
 		ht.Spec.KeepPrefix = input.Bool(flagkey.HtKeepPrefix)
 	}
 
+	if input.IsSet(flagkey.HtInvocationMode) {
+		ht.Spec.InvocationMode = input.String(flagkey.HtInvocationMode)
+	}
+
 	methods := input.StringSlice(flagkey.HtMethod)
 	if len(methods) > 0 {
 		for _, method := range methods {

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -144,6 +144,12 @@ var (
 	DlqID    = Flag{Type: String, Name: flagkey.DlqID, Usage: "Durable invocation id of a dead-lettered async invocation"}
 	DlqAll   = Flag{Type: Bool, Name: flagkey.DlqAll, Usage: "Apply to every dead-lettered invocation"}
 	DlqLimit = Flag{Type: Int, Name: flagkey.DlqLimit, Usage: "Maximum number of dead-lettered invocations to list", DefaultValue: 100}
+
+	// RFC-0024 async invocation config (fn create/update).
+	FnAsyncMaxAttempts = Flag{Type: Int, Name: flagkey.FnAsyncMaxAttempts, Usage: "Async delivery attempt budget before dead-lettering (RFC-0024)"}
+	FnAsyncMaxAge      = Flag{Type: Duration, Name: flagkey.FnAsyncMaxAge, Usage: "Max time an async invocation may wait for successful delivery before it is dead-lettered (RFC-0024)"}
+	FnAsyncOnSuccess   = Flag{Type: String, Name: flagkey.FnAsyncOnSuccess, Usage: "Same-namespace function to invoke with the result after a successful async delivery (RFC-0024); empty clears it"}
+	FnAsyncOnFailure   = Flag{Type: String, Name: flagkey.FnAsyncOnFailure, Usage: "Same-namespace function to invoke with the result after a permanent async failure (RFC-0024); empty clears it"}
 	// Termination Grace Period configurable at function creation/update only for container functions
 	FnTerminationGracePeriod = Flag{Type: Int64, Name: flagkey.FnGracePeriod, Usage: "Grace time (in seconds) for pod to perform connection draining before termination (only non-negative values considered)", DefaultValue: 360}
 

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -115,6 +115,7 @@ var (
 	FnTestTimeout           = Flag{Type: Duration, Name: flagkey.FnTestTimeout, Short: "t", Usage: "Length of time to wait for the response. If set to zero or negative number, no timeout is set", DefaultValue: 60 * time.Second}
 	FnTestHeader            = Flag{Type: StringSlice, Name: flagkey.FnTestHeader, Short: "H", Usage: "Request headers"}
 	FnTestQuery             = Flag{Type: StringSlice, Name: flagkey.FnTestQuery, Short: "q", Usage: "Request query parameters: -q key1=value1 -q key2=value2"}
+	FnTestAsync             = Flag{Type: Bool, Name: flagkey.FnTestAsync, Usage: "RFC-0024: invoke asynchronously (X-Fission-Invoke-Mode: async); prints the invocation id instead of waiting for the response. Set FISSION_INTERNAL_AUTH_SECRET when authentication is enabled."}
 	FnIdleTimeout           = Flag{Type: Int, Name: flagkey.FnIdleTimeout, Usage: "The length of time (in seconds) that a function is idle before pod(s) are eligible for recycling", DefaultValue: 120}
 	FnStreaming             = Flag{Type: Bool, Name: flagkey.FnStreaming, Usage: "Enable streaming (SSE/chunked/WebSocket) responses for this function; the response is flushed incrementally and not cut by the function timeout"}
 	FnStreamingProtocol     = Flag{Type: String, Name: flagkey.FnStreamingProtocol, Usage: "Streaming protocol when --streaming is set; one of 'auto', 'sse', 'chunked', 'websocket'", DefaultValue: "auto"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -138,6 +138,11 @@ var (
 	FnRunBuilderImage       = Flag{Type: String, Name: flagkey.FnRunBuilderImage, Usage: "Builder image to use with --build when running cluster-less (defaults to the environment's builder image)"}
 	FnLogAllPods            = Flag{Type: Bool, Name: flagkey.FnLogAllPods, Usage: "Get all pod's logs in the function."}
 	FnRetainPods            = Flag{Type: Int, Name: flagkey.FnRetainPods, Usage: "Number of pods to retain after pods specialization.", DefaultValue: 0}
+
+	// RFC-0024 async dead-letter-queue admin flags.
+	DlqID    = Flag{Type: String, Name: flagkey.DlqID, Usage: "Durable invocation id of a dead-lettered async invocation"}
+	DlqAll   = Flag{Type: Bool, Name: flagkey.DlqAll, Usage: "Apply to every dead-lettered invocation"}
+	DlqLimit = Flag{Type: Int, Name: flagkey.DlqLimit, Usage: "Maximum number of dead-lettered invocations to list", DefaultValue: 100}
 	// Termination Grace Period configurable at function creation/update only for container functions
 	FnTerminationGracePeriod = Flag{Type: Int64, Name: flagkey.FnGracePeriod, Usage: "Grace time (in seconds) for pod to perform connection draining before termination (only non-negative values considered)", DefaultValue: 360}
 

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -155,6 +155,7 @@ var (
 
 	HtName              = Flag{Type: String, Name: flagkey.HtName, Usage: "HTTP trigger name"}
 	HtMethod            = Flag{Type: StringSlice, Name: flagkey.HtMethod, Usage: "HTTP Methods: GET,POST,PUT,DELETE,HEAD. To mention single method: --method GET and for multiple methods --method GET --method POST. [DEPRECATED for 'fn create', use 'route create' instead]", DefaultValue: []string{http.MethodGet}}
+	HtInvocationMode    = Flag{Type: String, Name: flagkey.HtInvocationMode, Usage: "RFC-0024: 'async' makes every request through this trigger asynchronous (durable 202 + invocation id); empty is the default synchronous mode"}
 	HtUrl               = Flag{Type: String, Name: flagkey.HtUrl, Usage: "URL pattern (supports {var} and {var:regexp} path templates) [DEPRECATED for 'fn create', use 'route create' instead]"}
 	HtHost              = Flag{Type: String, Name: flagkey.HtHost, Usage: "Use --ingressrule instead", Deprecated: true, Substitute: flagkey.HtIngressRule}
 	HtIngress           = Flag{Type: Bool, Name: flagkey.HtIngress, Usage: "Creates ingress with same URL [DEPRECATED: the Kubernetes Ingress API is frozen, use --route-provider gateway instead]"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -104,6 +104,7 @@ const (
 
 	HtName              = resourceName
 	HtMethod            = "method"
+	HtInvocationMode    = "invocation-mode"
 	HtUrl               = "url"
 	HtHost              = "host"
 	HtIngress           = "createingress"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -96,6 +96,12 @@ const (
 
 	FnTestAsync = "async"
 
+	// RFC-0024 async invocation config (fn create/update).
+	FnAsyncMaxAttempts = "async-retry-max-attempts"
+	FnAsyncMaxAge      = "async-max-age"
+	FnAsyncOnSuccess   = "async-on-success"
+	FnAsyncOnFailure   = "async-on-failure"
+
 	HtName              = resourceName
 	HtMethod            = "method"
 	HtUrl               = "url"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -94,6 +94,8 @@ const (
 	DlqAll   = "all"
 	DlqLimit = "limit"
 
+	FnTestAsync = "async"
+
 	HtName              = resourceName
 	HtMethod            = "method"
 	HtUrl               = "url"

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -90,6 +90,10 @@ const (
 	FnLogAllPods            = "all-pods"
 	FnRetainPods            = "retainpods"
 
+	DlqID    = "id"
+	DlqAll   = "all"
+	DlqLimit = "limit"
+
 	HtName              = resourceName
 	HtMethod            = "method"
 	HtUrl               = "url"

--- a/pkg/fission-cli/util/portless.go
+++ b/pkg/fission-cli/util/portless.go
@@ -96,6 +96,44 @@ func SetupPortForward(ctx context.Context, client cmd.Client, namespace, labelSe
 // forward to. It preserves the CLI's disambiguation UX: an empty namespace
 // searches everywhere, and matches across several namespaces are an error
 // telling the user to set FISSION_NAMESPACE.
+// SetupPortForwardToPort is SetupPortForward pinned to an explicit pod target
+// port. It exists for a listener whose Service selector is ambiguous: the router
+// pods back BOTH the public svc/router and the ClusterIP-only svc/router-internal
+// under the same application=fission-router label, so the internal listener must
+// be addressed by port rather than by the Service's (public) targetPort.
+func SetupPortForwardToPort(ctx context.Context, client cmd.Client, namespace, labelSelector string, port int) (string, error) {
+	pfMu.Lock()
+	defer pfMu.Unlock()
+
+	key := fmt.Sprintf("%s/%s/%d", namespace, labelSelector, port)
+	if p, ok := pfBridges[key]; ok {
+		return p, nil
+	}
+	ns, _, err := resolveFissionService(ctx, client.KubernetesClient, namespace, labelSelector)
+	if err != nil {
+		return "", err
+	}
+	backend, err := portlessk8s.PortForward(client.RestConfig,
+		portlessk8s.LabelSelector(ns, labelSelector), portlessk8s.TargetPort(intstr.FromInt(port)))
+	if err != nil {
+		return "", fmt.Errorf("error creating port-forward backend for %v: %w", labelSelector, err)
+	}
+	if pfReg == nil {
+		pfReg = portless.New()
+	}
+	if _, err := pfReg.AddReady(ctx, key, backend); err != nil {
+		return "", fmt.Errorf("error setting up %v port-forward: %w", labelSelector, err)
+	}
+	l, err := pfReg.ListenLocal(key)
+	if err != nil {
+		_ = pfReg.Remove(ctx, key)
+		return "", fmt.Errorf("error bridging %v port-forward locally: %w", labelSelector, err)
+	}
+	localPort := strconv.Itoa(l.Addr().(*net.TCPAddr).Port)
+	pfBridges[key] = localPort
+	return localPort, nil
+}
+
 func resolveFissionService(ctx context.Context, kube kubernetes.Interface, namespace, labelSelector string) (string, intstr.IntOrString, error) {
 	none := intstr.IntOrString{}
 	ns := namespace

--- a/pkg/fission-cli/util/util.go
+++ b/pkg/fission-cli/util/util.go
@@ -36,6 +36,7 @@ import (
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/info"
 	"github.com/fission/fission/pkg/plugin"
+	"github.com/fission/fission/pkg/svcinfo"
 )
 
 const (
@@ -217,6 +218,25 @@ func GetRouterURL(ctx context.Context, cmdClient cmd.Client) (serverURL *url.URL
 		return serverURL, err
 	}
 	return serverURL, err
+}
+
+// GetRouterInternalURL resolves the router's internal listener — the ClusterIP-only
+// svc/router-internal that serves /fission-function/<ns>/<name>. Requests to it are
+// HMAC-signed (ServiceRouterInternal) when authentication is enabled, so it is used
+// by the RFC-0024 async direct-invocation path (`fission function test --async`).
+// FISSION_ROUTER_INTERNAL_URL overrides it (a hand-managed forward or non-default
+// install); otherwise it port-forwards to the router pods on the internal port,
+// which must be addressed explicitly because the public and internal Services share
+// the application=fission-router selector.
+func GetRouterInternalURL(ctx context.Context, cmdClient cmd.Client) (*url.URL, error) {
+	if u := os.Getenv("FISSION_ROUTER_INTERNAL_URL"); u != "" {
+		return url.Parse(u)
+	}
+	localPort, err := SetupPortForwardToPort(ctx, cmdClient, GetFissionNamespace(), "application=fission-router", svcinfo.PortRouterInternal)
+	if err != nil {
+		return nil, err
+	}
+	return url.Parse(fmt.Sprintf("%s%s", localhostURL, localPort))
 }
 
 func GetResourceReqs(input cli.Input, resReqs *v1.ResourceRequirements) (*v1.ResourceRequirements, error) {

--- a/pkg/router/async_dlq.go
+++ b/pkg/router/async_dlq.go
@@ -13,15 +13,19 @@ import (
 	"github.com/fission/fission/pkg/router/asyncinvoke"
 	"github.com/fission/fission/pkg/statestore"
 	"github.com/fission/fission/pkg/utils/httpmux"
-	"github.com/fission/fission/pkg/utils/httpsecurity"
 )
 
-// RFC-0024 async dead-letter-queue admin API. It lives on the PUBLIC listener so
-// it is gated by the same JWT authMiddleware as the auth-login endpoint (these
-// paths are deliberately NOT in auth.go's exemption list) — a coarse operator
-// gate; per-namespace scoping of the JWT is a follow-up. When async invocation is
-// disabled the handlers return 501 rather than 404, so the surface is
-// discoverable. All operate on the single global asyncinvoke.DefaultQueue.
+// RFC-0024 async dead-letter-queue admin API. It lives on the INTERNAL listener
+// (ClusterIP-only svc/router-internal), so every request is HMAC-verified with the
+// ServiceRouterInternal key and gated by the internal NetworkPolicy allowlist —
+// fail-closed by construction and independent of the public listener's optional
+// JWT auth. It is NOT on the public listener, where an operator running with the
+// default authentication.enabled=false would otherwise expose an unauthenticated
+// cross-namespace read/redrive/purge surface. `fission function dlq` signs its
+// requests with FISSION_INTERNAL_AUTH_SECRET the same way `test --async` does. When
+// async invocation is disabled the handlers return 501 rather than 404, so the
+// surface is discoverable. All operate on the single global asyncinvoke.DefaultQueue;
+// per-namespace scoping of access is a follow-up.
 const (
 	dlqPathList    = "/v1/async/dlq/list"
 	dlqPathShow    = "/v1/async/dlq/show"
@@ -69,15 +73,15 @@ type dlqMutateResp struct {
 	Count int64 `json:"count"`
 }
 
-// registerAsyncDLQRoutes adds the DLQ admin endpoints to the public mux. Called
-// from registerRouterOwnedRoutes so both the full and incremental mux builders
-// register them identically.
-func (ts *HTTPTriggerSet) registerAsyncDLQRoutes(public *httpmux.Mux) {
-	deny := httpsecurity.DenyAllCORS
-	public.Handle(dlqPathList, deny(http.HandlerFunc(ts.dlqList))).Methods(http.MethodGet, http.MethodOptions)
-	public.Handle(dlqPathShow, deny(http.HandlerFunc(ts.dlqShow))).Methods(http.MethodGet, http.MethodOptions)
-	public.Handle(dlqPathRedrive, deny(http.HandlerFunc(ts.dlqRedrive))).Methods(http.MethodPost, http.MethodOptions)
-	public.Handle(dlqPathPurge, deny(http.HandlerFunc(ts.dlqPurge))).Methods(http.MethodPost, http.MethodOptions)
+// registerAsyncDLQRoutes adds the DLQ admin endpoints to the INTERNAL mux, where
+// the listener-level HMAC verifier + DenyAllCORS + SecurityHeaders already wrap
+// every handler. Called from both the full and incremental mux builders so they
+// register identically.
+func (ts *HTTPTriggerSet) registerAsyncDLQRoutes(internal *httpmux.Mux) {
+	internal.HandleFunc(dlqPathList, ts.dlqList).Methods(http.MethodGet)
+	internal.HandleFunc(dlqPathShow, ts.dlqShow).Methods(http.MethodGet)
+	internal.HandleFunc(dlqPathRedrive, ts.dlqRedrive).Methods(http.MethodPost)
+	internal.HandleFunc(dlqPathPurge, ts.dlqPurge).Methods(http.MethodPost)
 }
 
 // dlqQueue returns the async DLQ queue, or writes 501 and returns false when async
@@ -163,12 +167,18 @@ func (ts *HTTPTriggerSet) dlqShow(w http.ResponseWriter, r *http.Request) {
 		}
 		token = dead[len(dead)-1].ID
 	}
+	if scanned >= dlqShowScanCap {
+		// Distinguish "absent" from "beyond the scan bound" so an operator does not
+		// conclude a still-present message is gone.
+		http.Error(w, "dead-lettered message not found within the first "+strconv.Itoa(dlqShowScanCap)+" scanned; narrow the dead set (redrive/purge) and retry", http.StatusNotFound)
+		return
+	}
 	http.Error(w, "dead-lettered message not found", http.StatusNotFound)
 }
 
 // dlqRedrive re-enqueues the given dead-lettered invocations (attempts reset) so
-// they are delivered again. Ids that are not currently dead are silently skipped
-// by the store; Count reports the number requested.
+// they are delivered again. Ids that are not currently dead are skipped by the
+// store; Count reports the number actually re-enqueued (may be < len(ids)).
 func (ts *HTTPTriggerSet) dlqRedrive(w http.ResponseWriter, r *http.Request) {
 	q, ok := ts.dlqQueue(w)
 	if !ok {
@@ -182,12 +192,13 @@ func (ts *HTTPTriggerSet) dlqRedrive(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "ids must not be empty", http.StatusBadRequest)
 		return
 	}
-	if err := q.Redrive(r.Context(), asyncinvoke.DefaultQueue, req.IDs); err != nil {
+	n, err := q.Redrive(r.Context(), asyncinvoke.DefaultQueue, req.IDs)
+	if err != nil {
 		ts.logger.Error(err, "redriving async dead letters")
 		http.Error(w, "redriving dead letters", http.StatusInternalServerError)
 		return
 	}
-	dlqWriteJSON(w, ts, dlqMutateResp{Count: int64(len(req.IDs))})
+	dlqWriteJSON(w, ts, dlqMutateResp{Count: n})
 }
 
 // dlqPurge permanently deletes every dead-lettered invocation and reports the

--- a/pkg/router/async_dlq.go
+++ b/pkg/router/async_dlq.go
@@ -95,9 +95,9 @@ func (ts *HTTPTriggerSet) dlqQueue(w http.ResponseWriter) (statestore.Queue, boo
 }
 
 // dlqList returns a page of dead-lettered invocations, optionally filtered to one
-// namespace (a display convenience, not an authorization boundary — the JWT gate
-// is coarse in phase 3). ?limit bounds the page; ?token continues from a prior
-// page's nextToken.
+// namespace (a display convenience, not an authorization boundary — the internal
+// listener's HMAC gate is coarse in phase 3). ?limit bounds the page; ?token
+// continues from a prior page's nextToken.
 func (ts *HTTPTriggerSet) dlqList(w http.ResponseWriter, r *http.Request) {
 	q, ok := ts.dlqQueue(w)
 	if !ok {

--- a/pkg/router/async_dlq.go
+++ b/pkg/router/async_dlq.go
@@ -6,6 +6,7 @@ package router
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
 	"time"
@@ -258,6 +259,12 @@ func dlqParseLimit(raw string) int {
 func dlqDecodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
 	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, dlqMaxBodyBytes))
 	if err := dec.Decode(v); err != nil {
+		// Distinguish an over-limit body (the explicit dlqMaxBodyBytes bound → 413)
+		// from malformed JSON (400), mirroring the async enqueue path's mapping.
+		if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			http.Error(w, "request body exceeds the DLQ API limit", http.StatusRequestEntityTooLarge)
+			return false
+		}
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return false
 	}

--- a/pkg/router/async_dlq.go
+++ b/pkg/router/async_dlq.go
@@ -1,0 +1,261 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/fission/fission/pkg/router/asyncinvoke"
+	"github.com/fission/fission/pkg/statestore"
+	"github.com/fission/fission/pkg/utils/httpmux"
+	"github.com/fission/fission/pkg/utils/httpsecurity"
+)
+
+// RFC-0024 async dead-letter-queue admin API. It lives on the PUBLIC listener so
+// it is gated by the same JWT authMiddleware as the auth-login endpoint (these
+// paths are deliberately NOT in auth.go's exemption list) — a coarse operator
+// gate; per-namespace scoping of the JWT is a follow-up. When async invocation is
+// disabled the handlers return 501 rather than 404, so the surface is
+// discoverable. All operate on the single global asyncinvoke.DefaultQueue.
+const (
+	dlqPathList    = "/v1/async/dlq/list"
+	dlqPathShow    = "/v1/async/dlq/show"
+	dlqPathRedrive = "/v1/async/dlq/redrive"
+	dlqPathPurge   = "/v1/async/dlq/purge"
+
+	// dlqDefaultLimit / dlqMaxLimit bound a list page; dlqShowScanCap bounds the
+	// scan a show performs looking for one id (the Queue has no get-by-id), so a
+	// large dead set cannot turn a single show into unbounded work.
+	dlqDefaultLimit = 100
+	dlqMaxLimit     = 1000
+	dlqShowScanCap  = 10000
+	dlqMaxBodyBytes = 1 << 20
+)
+
+// dlqMessage is the list/show summary of one dead-lettered async invocation. The
+// namespace/function are decoded from the envelope for display and filtering; a
+// message whose envelope will not decode still lists (with them empty) so a
+// corrupt record is visible, not hidden.
+type dlqMessage struct {
+	ID         string    `json:"id"`
+	Namespace  string    `json:"namespace,omitempty"`
+	Function   string    `json:"function,omitempty"`
+	Reason     string    `json:"reason,omitempty"`
+	Attempts   int       `json:"attempts"`
+	EnqueuedAt time.Time `json:"enqueuedAt"`
+	DiedAt     time.Time `json:"diedAt"`
+}
+
+type dlqListResp struct {
+	Messages  []dlqMessage `json:"messages"`
+	NextToken string       `json:"nextToken,omitempty"`
+}
+
+type dlqShowResp struct {
+	dlqMessage
+	Envelope *asyncinvoke.Envelope `json:"envelope,omitempty"`
+}
+
+type dlqRedriveReq struct {
+	IDs []string `json:"ids"`
+}
+
+type dlqMutateResp struct {
+	Count int64 `json:"count"`
+}
+
+// registerAsyncDLQRoutes adds the DLQ admin endpoints to the public mux. Called
+// from registerRouterOwnedRoutes so both the full and incremental mux builders
+// register them identically.
+func (ts *HTTPTriggerSet) registerAsyncDLQRoutes(public *httpmux.Mux) {
+	deny := httpsecurity.DenyAllCORS
+	public.Handle(dlqPathList, deny(http.HandlerFunc(ts.dlqList))).Methods(http.MethodGet, http.MethodOptions)
+	public.Handle(dlqPathShow, deny(http.HandlerFunc(ts.dlqShow))).Methods(http.MethodGet, http.MethodOptions)
+	public.Handle(dlqPathRedrive, deny(http.HandlerFunc(ts.dlqRedrive))).Methods(http.MethodPost, http.MethodOptions)
+	public.Handle(dlqPathPurge, deny(http.HandlerFunc(ts.dlqPurge))).Methods(http.MethodPost, http.MethodOptions)
+}
+
+// dlqQueue returns the async DLQ queue, or writes 501 and returns false when async
+// invocation is not enabled on this router.
+func (ts *HTTPTriggerSet) dlqQueue(w http.ResponseWriter) (statestore.Queue, bool) {
+	if ts.asyncInvoker == nil || !ts.asyncInvoker.enabled() {
+		http.Error(w, "async invocation is not enabled on this cluster", http.StatusNotImplemented)
+		return nil, false
+	}
+	return ts.asyncInvoker.queue, true
+}
+
+// dlqList returns a page of dead-lettered invocations, optionally filtered to one
+// namespace (a display convenience, not an authorization boundary — the JWT gate
+// is coarse in phase 3). ?limit bounds the page; ?token continues from a prior
+// page's nextToken.
+func (ts *HTTPTriggerSet) dlqList(w http.ResponseWriter, r *http.Request) {
+	q, ok := ts.dlqQueue(w)
+	if !ok {
+		return
+	}
+	limit := dlqParseLimit(r.URL.Query().Get("limit"))
+	nsFilter := r.URL.Query().Get("namespace")
+	dead, err := q.DeadLetters(r.Context(), asyncinvoke.DefaultQueue, statestore.Page{
+		Token: r.URL.Query().Get("token"),
+		Limit: limit,
+	})
+	if err != nil {
+		ts.logger.Error(err, "listing async dead letters")
+		http.Error(w, "listing dead letters", http.StatusInternalServerError)
+		return
+	}
+	resp := dlqListResp{}
+	for _, d := range dead {
+		m := dlqSummary(d)
+		if nsFilter != "" && m.Namespace != nsFilter {
+			continue
+		}
+		resp.Messages = append(resp.Messages, m)
+	}
+	// A full page implies there may be more; the last raw id is the continuation
+	// token (paging keys on the id regardless of the namespace filter).
+	if len(dead) == limit && len(dead) > 0 {
+		resp.NextToken = dead[len(dead)-1].ID
+	}
+	dlqWriteJSON(w, ts, resp)
+}
+
+// dlqShow returns the full decoded envelope for one dead-lettered invocation by
+// id. The Queue has no get-by-id, so it scans the dead set (bounded by
+// dlqShowScanCap) — a rare operator action on a set operators keep small.
+func (ts *HTTPTriggerSet) dlqShow(w http.ResponseWriter, r *http.Request) {
+	q, ok := ts.dlqQueue(w)
+	if !ok {
+		return
+	}
+	id := r.URL.Query().Get("id")
+	if id == "" {
+		http.Error(w, "id query parameter is required", http.StatusBadRequest)
+		return
+	}
+	token := ""
+	scanned := 0
+	for scanned < dlqShowScanCap {
+		dead, err := q.DeadLetters(r.Context(), asyncinvoke.DefaultQueue, statestore.Page{Token: token, Limit: dlqDefaultLimit})
+		if err != nil {
+			ts.logger.Error(err, "reading async dead letters")
+			http.Error(w, "reading dead letters", http.StatusInternalServerError)
+			return
+		}
+		if len(dead) == 0 {
+			break
+		}
+		for i := range dead {
+			if dead[i].ID == id {
+				dlqWriteShow(w, ts, dead[i])
+				return
+			}
+		}
+		scanned += len(dead)
+		if len(dead) < dlqDefaultLimit {
+			break
+		}
+		token = dead[len(dead)-1].ID
+	}
+	http.Error(w, "dead-lettered message not found", http.StatusNotFound)
+}
+
+// dlqRedrive re-enqueues the given dead-lettered invocations (attempts reset) so
+// they are delivered again. Ids that are not currently dead are silently skipped
+// by the store; Count reports the number requested.
+func (ts *HTTPTriggerSet) dlqRedrive(w http.ResponseWriter, r *http.Request) {
+	q, ok := ts.dlqQueue(w)
+	if !ok {
+		return
+	}
+	var req dlqRedriveReq
+	if !dlqDecodeJSON(w, r, &req) {
+		return
+	}
+	if len(req.IDs) == 0 {
+		http.Error(w, "ids must not be empty", http.StatusBadRequest)
+		return
+	}
+	if err := q.Redrive(r.Context(), asyncinvoke.DefaultQueue, req.IDs); err != nil {
+		ts.logger.Error(err, "redriving async dead letters")
+		http.Error(w, "redriving dead letters", http.StatusInternalServerError)
+		return
+	}
+	dlqWriteJSON(w, ts, dlqMutateResp{Count: int64(len(req.IDs))})
+}
+
+// dlqPurge permanently deletes every dead-lettered invocation and reports the
+// count removed.
+func (ts *HTTPTriggerSet) dlqPurge(w http.ResponseWriter, r *http.Request) {
+	q, ok := ts.dlqQueue(w)
+	if !ok {
+		return
+	}
+	n, err := q.Purge(r.Context(), asyncinvoke.DefaultQueue)
+	if err != nil {
+		ts.logger.Error(err, "purging async dead letters")
+		http.Error(w, "purging dead letters", http.StatusInternalServerError)
+		return
+	}
+	dlqWriteJSON(w, ts, dlqMutateResp{Count: n})
+}
+
+// dlqSummary maps a DeadMessage to the list summary, decoding the envelope for the
+// namespace/function (best-effort — a corrupt record still lists).
+func dlqSummary(d statestore.DeadMessage) dlqMessage {
+	m := dlqMessage{
+		ID:         d.ID,
+		Reason:     d.Reason,
+		Attempts:   d.Attempts,
+		EnqueuedAt: d.EnqueuedAt,
+		DiedAt:     d.DiedAt,
+	}
+	if env, err := asyncinvoke.Decode(d.Body); err == nil {
+		m.Namespace, m.Function = env.Namespace, env.Function
+	}
+	return m
+}
+
+func dlqWriteShow(w http.ResponseWriter, ts *HTTPTriggerSet, d statestore.DeadMessage) {
+	resp := dlqShowResp{dlqMessage: dlqSummary(d)}
+	if env, err := asyncinvoke.Decode(d.Body); err == nil {
+		resp.Envelope = &env
+	}
+	dlqWriteJSON(w, ts, resp)
+}
+
+func dlqParseLimit(raw string) int {
+	if raw == "" {
+		return dlqDefaultLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n <= 0 {
+		return dlqDefaultLimit
+	}
+	if n > dlqMaxLimit {
+		return dlqMaxLimit
+	}
+	return n
+}
+
+func dlqDecodeJSON(w http.ResponseWriter, r *http.Request, v any) bool {
+	dec := json.NewDecoder(http.MaxBytesReader(w, r.Body, dlqMaxBodyBytes))
+	if err := dec.Decode(v); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func dlqWriteJSON(w http.ResponseWriter, ts *HTTPTriggerSet, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		ts.logger.Error(err, "encoding async DLQ response")
+	}
+}

--- a/pkg/router/async_dlq_test.go
+++ b/pkg/router/async_dlq_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	config "github.com/fission/fission/pkg/featureconfig"
 	"github.com/fission/fission/pkg/router/asyncinvoke"
 	"github.com/fission/fission/pkg/statestore"
 	_ "github.com/fission/fission/pkg/statestore/memory"
@@ -176,39 +175,26 @@ func TestDLQDisabledReturns501(t *testing.T) {
 	}
 }
 
-// TestDLQRoutesRegistered asserts the four DLQ paths are registered in the built
-// public mux with the right methods (via the shared helper, so both mux builders
-// register them).
-func TestDLQRoutesRegistered(t *testing.T) {
+// TestDLQRoutesOnInternalListenerNotPublic asserts the four DLQ admin paths are
+// registered on the INTERNAL mux (where the listener-level HMAC verifier gates
+// them) and are absent from the PUBLIC mux — so an operator running with the
+// default authentication.enabled=false does not expose an unauthenticated
+// cross-namespace read/redrive/purge surface on the public router.
+func TestDLQRoutesOnInternalListenerNotPublic(t *testing.T) {
 	t.Parallel()
 	ts := newShapeTS(t, []fv1.Function{shapeFn("fn")}, nil)
-	public, _, err := ts.buildMuxes(t.Context(), nil)
+	public, internal, err := ts.buildMuxes(t.Context(), nil)
 	require.NoError(t, err)
 
-	assert.True(t, muxMatches(public, http.MethodGet, dlqPathList), "GET list registered")
-	assert.True(t, muxMatches(public, http.MethodGet, dlqPathShow), "GET show registered")
-	assert.True(t, muxMatches(public, http.MethodPost, dlqPathRedrive), "POST redrive registered")
-	assert.True(t, muxMatches(public, http.MethodPost, dlqPathPurge), "POST purge registered")
-}
-
-// TestDLQRoutesAuthGated proves the DLQ paths are NOT in authMiddleware's exemption
-// list: with auth enabled a tokenless DLQ request is rejected 401, while the
-// exempt /router-healthz probe passes through.
-func TestDLQRoutesAuthGated(t *testing.T) {
-	t.Setenv("JWT_SIGNING_KEY", "test-key")
-	featureConfig := &config.FeatureConfig{}
-	featureConfig.AuthConfig.AuthUriPath = "/auth/login"
-	gated := authMiddleware(featureConfig)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	for _, p := range []string{dlqPathList, dlqPathShow, dlqPathRedrive, dlqPathPurge} {
-		rr := httptest.NewRecorder()
-		gated.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
-		assert.Equalf(t, http.StatusUnauthorized, rr.Code, "%s must require a JWT", p)
+	for _, tc := range []struct {
+		method, path string
+	}{
+		{http.MethodGet, dlqPathList},
+		{http.MethodGet, dlqPathShow},
+		{http.MethodPost, dlqPathRedrive},
+		{http.MethodPost, dlqPathPurge},
+	} {
+		assert.Truef(t, muxMatches(internal, tc.method, tc.path), "%s %s must be on the internal mux", tc.method, tc.path)
+		assert.Falsef(t, muxMatches(public, tc.method, tc.path), "%s %s must NOT be on the public mux", tc.method, tc.path)
 	}
-	// The exempt probe still passes without a token.
-	rr := httptest.NewRecorder()
-	gated.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/router-healthz", nil))
-	assert.Equal(t, http.StatusOK, rr.Code, "/router-healthz stays exempt")
 }

--- a/pkg/router/async_dlq_test.go
+++ b/pkg/router/async_dlq_test.go
@@ -1,0 +1,214 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	config "github.com/fission/fission/pkg/featureconfig"
+	"github.com/fission/fission/pkg/router/asyncinvoke"
+	"github.com/fission/fission/pkg/statestore"
+	_ "github.com/fission/fission/pkg/statestore/memory"
+)
+
+// dlqTestSet builds an HTTPTriggerSet whose asyncInvoker is backed by a fresh
+// in-memory queue, and dead-letters one invocation per (namespace, function) pair
+// so the DLQ handlers have data. It returns the set and the durable ids in order.
+func dlqTestSet(t *testing.T, fns ...[2]string) (*HTTPTriggerSet, statestore.Queue, []string) {
+	t.Helper()
+	caps, err := statestore.Open(t.Context(), statestore.Config{Driver: "memory"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = caps.Close() })
+	q, err := caps.Queue()
+	require.NoError(t, err)
+
+	var ids []string
+	for _, nf := range fns {
+		body, err := asyncinvoke.Envelope{
+			Version: asyncinvoke.EnvelopeVersion, Namespace: nf[0], Function: nf[1],
+			Body: []byte("payload-" + nf[1]), EnqueueTime: time.Unix(1_000_000, 0),
+		}.Encode()
+		require.NoError(t, err)
+		id, err := q.Enqueue(t.Context(), asyncinvoke.DefaultQueue, statestore.Message{Body: body}, statestore.EnqueueOptions{})
+		require.NoError(t, err)
+		l, err := q.Lease(t.Context(), asyncinvoke.DefaultQueue, 1, time.Minute)
+		require.NoError(t, err)
+		require.Len(t, l, 1)
+		require.NoError(t, q.Kill(t.Context(), l[0].Receipt, "permanent"))
+		ids = append(ids, id)
+	}
+	ts := &HTTPTriggerSet{logger: logr.Discard(), asyncInvoker: &asyncInvoker{queue: q, logger: logr.Discard()}}
+	return ts, q, ids
+}
+
+func TestDLQList(t *testing.T) {
+	t.Parallel()
+	ts, _, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"}, [2]string{"ns2", "fn-b"})
+
+	rr := httptest.NewRecorder()
+	ts.dlqList(rr, httptest.NewRequest(http.MethodGet, dlqPathList, nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp dlqListResp
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Messages, 2)
+	// The envelope's namespace/function are surfaced, and the dead-letter reason.
+	byFn := map[string]dlqMessage{}
+	for _, m := range resp.Messages {
+		byFn[m.Function] = m
+	}
+	assert.Equal(t, "ns1", byFn["fn-a"].Namespace)
+	assert.Equal(t, "permanent", byFn["fn-a"].Reason)
+	assert.Equal(t, "ns2", byFn["fn-b"].Namespace)
+}
+
+func TestDLQListNamespaceFilter(t *testing.T) {
+	t.Parallel()
+	ts, _, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"}, [2]string{"ns2", "fn-b"})
+
+	rr := httptest.NewRecorder()
+	ts.dlqList(rr, httptest.NewRequest(http.MethodGet, dlqPathList+"?namespace=ns2", nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp dlqListResp
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Len(t, resp.Messages, 1, "namespace filter narrows the list")
+	assert.Equal(t, "fn-b", resp.Messages[0].Function)
+}
+
+func TestDLQShow(t *testing.T) {
+	t.Parallel()
+	ts, _, ids := dlqTestSet(t, [2]string{"ns1", "fn-a"})
+
+	rr := httptest.NewRecorder()
+	ts.dlqShow(rr, httptest.NewRequest(http.MethodGet, dlqPathShow+"?id="+ids[0], nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp dlqShowResp
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.Equal(t, ids[0], resp.ID)
+	require.NotNil(t, resp.Envelope, "show decodes the full envelope")
+	assert.Equal(t, "fn-a", resp.Envelope.Function)
+	assert.Equal(t, []byte("payload-fn-a"), resp.Envelope.Body)
+}
+
+func TestDLQShowNotFound(t *testing.T) {
+	t.Parallel()
+	ts, _, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"})
+
+	rr := httptest.NewRecorder()
+	ts.dlqShow(rr, httptest.NewRequest(http.MethodGet, dlqPathShow+"?id=nope", nil))
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+
+	rrNoID := httptest.NewRecorder()
+	ts.dlqShow(rrNoID, httptest.NewRequest(http.MethodGet, dlqPathShow, nil))
+	assert.Equal(t, http.StatusBadRequest, rrNoID.Code, "id is required")
+}
+
+func TestDLQRedrive(t *testing.T) {
+	t.Parallel()
+	ts, q, ids := dlqTestSet(t, [2]string{"ns1", "fn-a"}, [2]string{"ns2", "fn-b"})
+
+	rr := httptest.NewRecorder()
+	body := strings.NewReader(`{"ids":["` + ids[0] + `"]}`)
+	ts.dlqRedrive(rr, httptest.NewRequest(http.MethodPost, dlqPathRedrive, body))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp dlqMutateResp
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.EqualValues(t, 1, resp.Count)
+
+	// The redriven message left the dead set (and is leasable again); the other stays.
+	dead, err := q.DeadLetters(t.Context(), asyncinvoke.DefaultQueue, statestore.Page{})
+	require.NoError(t, err)
+	require.Len(t, dead, 1)
+	assert.Equal(t, ids[1], dead[0].ID)
+}
+
+func TestDLQRedriveEmptyIDs(t *testing.T) {
+	t.Parallel()
+	ts, _, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"})
+	rr := httptest.NewRecorder()
+	ts.dlqRedrive(rr, httptest.NewRequest(http.MethodPost, dlqPathRedrive, strings.NewReader(`{"ids":[]}`)))
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestDLQPurge(t *testing.T) {
+	t.Parallel()
+	ts, q, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"}, [2]string{"ns2", "fn-b"})
+
+	rr := httptest.NewRecorder()
+	ts.dlqPurge(rr, httptest.NewRequest(http.MethodPost, dlqPathPurge, nil))
+	require.Equal(t, http.StatusOK, rr.Code)
+	var resp dlqMutateResp
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	assert.EqualValues(t, 2, resp.Count)
+
+	dead, err := q.DeadLetters(t.Context(), asyncinvoke.DefaultQueue, statestore.Page{})
+	require.NoError(t, err)
+	assert.Empty(t, dead, "purge emptied the dead set")
+}
+
+// TestDLQDisabledReturns501 asserts every DLQ handler fails closed with 501 when
+// async invocation is not enabled (nil invoker or nil queue), not a 404/500.
+func TestDLQDisabledReturns501(t *testing.T) {
+	t.Parallel()
+	cases := map[string]*HTTPTriggerSet{
+		"nil invoker": {logger: logr.Discard()},
+		"nil queue":   {logger: logr.Discard(), asyncInvoker: &asyncInvoker{logger: logr.Discard()}},
+	}
+	for name, ts := range cases {
+		t.Run(name, func(t *testing.T) {
+			for _, h := range []http.HandlerFunc{ts.dlqList, ts.dlqShow, ts.dlqRedrive, ts.dlqPurge} {
+				rr := httptest.NewRecorder()
+				h(rr, httptest.NewRequest(http.MethodGet, "/", strings.NewReader(`{"ids":["x"]}`)))
+				assert.Equal(t, http.StatusNotImplemented, rr.Code)
+			}
+		})
+	}
+}
+
+// TestDLQRoutesRegistered asserts the four DLQ paths are registered in the built
+// public mux with the right methods (via the shared helper, so both mux builders
+// register them).
+func TestDLQRoutesRegistered(t *testing.T) {
+	t.Parallel()
+	ts := newShapeTS(t, []fv1.Function{shapeFn("fn")}, nil)
+	public, _, err := ts.buildMuxes(t.Context(), nil)
+	require.NoError(t, err)
+
+	assert.True(t, muxMatches(public, http.MethodGet, dlqPathList), "GET list registered")
+	assert.True(t, muxMatches(public, http.MethodGet, dlqPathShow), "GET show registered")
+	assert.True(t, muxMatches(public, http.MethodPost, dlqPathRedrive), "POST redrive registered")
+	assert.True(t, muxMatches(public, http.MethodPost, dlqPathPurge), "POST purge registered")
+}
+
+// TestDLQRoutesAuthGated proves the DLQ paths are NOT in authMiddleware's exemption
+// list: with auth enabled a tokenless DLQ request is rejected 401, while the
+// exempt /router-healthz probe passes through.
+func TestDLQRoutesAuthGated(t *testing.T) {
+	t.Setenv("JWT_SIGNING_KEY", "test-key")
+	featureConfig := &config.FeatureConfig{}
+	featureConfig.AuthConfig.AuthUriPath = "/auth/login"
+	gated := authMiddleware(featureConfig)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	for _, p := range []string{dlqPathList, dlqPathShow, dlqPathRedrive, dlqPathPurge} {
+		rr := httptest.NewRecorder()
+		gated.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, p, nil))
+		assert.Equalf(t, http.StatusUnauthorized, rr.Code, "%s must require a JWT", p)
+	}
+	// The exempt probe still passes without a token.
+	rr := httptest.NewRecorder()
+	gated.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/router-healthz", nil))
+	assert.Equal(t, http.StatusOK, rr.Code, "/router-healthz stays exempt")
+}

--- a/pkg/router/async_dlq_test.go
+++ b/pkg/router/async_dlq_test.go
@@ -140,6 +140,22 @@ func TestDLQRedriveEmptyIDs(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }
 
+// TestDLQRedriveBodyStatuses pins the decode error mapping: an over-limit body is
+// 413 (the explicit dlqMaxBodyBytes bound), malformed JSON is 400.
+func TestDLQRedriveBodyStatuses(t *testing.T) {
+	t.Parallel()
+	ts, _, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"})
+
+	big := `{"ids":["` + strings.Repeat("a", dlqMaxBodyBytes+1) + `"]}`
+	rr := httptest.NewRecorder()
+	ts.dlqRedrive(rr, httptest.NewRequest(http.MethodPost, dlqPathRedrive, strings.NewReader(big)))
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code, "over-limit body → 413")
+
+	rrBad := httptest.NewRecorder()
+	ts.dlqRedrive(rrBad, httptest.NewRequest(http.MethodPost, dlqPathRedrive, strings.NewReader(`not json`)))
+	assert.Equal(t, http.StatusBadRequest, rrBad.Code, "malformed JSON → 400")
+}
+
 func TestDLQPurge(t *testing.T) {
 	t.Parallel()
 	ts, q, _ := dlqTestSet(t, [2]string{"ns1", "fn-a"}, [2]string{"ns2", "fn-b"})

--- a/pkg/router/async_test.go
+++ b/pkg/router/async_test.go
@@ -139,8 +139,12 @@ func TestAsyncRequested(t *testing.T) {
 		{"public async header enqueues", publicTrigger, "async", "", true},
 		{"trigger invocationMode enqueues", triggerModeAsync, "", "", true},
 		{"no async signal proxies", nil, "", "", false},
-		{"dispatcher delivery never enqueues (header)", nil, "async", "inv-1", false},
-		{"dispatcher delivery never enqueues (trigger mode)", triggerModeAsync, "", "inv-1", false},
+		// Internal path: the dispatcher's own delivery (invocation-id set) proxies sync.
+		{"internal dispatcher delivery never enqueues", nil, "async", "inv-1", false},
+		// Public path: a user-spoofed invocation-id must NOT bypass async — the guard
+		// is internal-only (the dispatcher never delivers on the public path).
+		{"public spoofed invocation-id can't bypass trigger mode", triggerModeAsync, "", "inv-1", true},
+		{"public spoofed invocation-id can't bypass async header", publicTrigger, "async", "inv-1", true},
 		{"case-insensitive header", nil, "ASYNC", "", true},
 	}
 	for _, tc := range cases {

--- a/pkg/router/async_test.go
+++ b/pkg/router/async_test.go
@@ -121,6 +121,66 @@ func TestHandlerAsyncBranchPublicOnly(t *testing.T) {
 	require.Len(t, l, 1)
 }
 
+// TestAsyncRequested pins the async-vs-proxy decision across the public trigger
+// path, the internal direct-function path, and the dispatcher-delivery exclusion.
+func TestAsyncRequested(t *testing.T) {
+	t.Parallel()
+	publicTrigger := &fv1.HTTPTrigger{}
+	triggerModeAsync := &fv1.HTTPTrigger{Spec: fv1.HTTPTriggerSpec{InvocationMode: asyncinvoke.InvokeModeAsync}}
+
+	cases := []struct {
+		name    string
+		trigger *fv1.HTTPTrigger // nil = internal direct-function handler
+		mode    string           // X-Fission-Invoke-Mode header
+		invID   string           // X-Fission-Invocation-Id (set ⇒ dispatcher delivery)
+		want    bool
+	}{
+		{"direct async header enqueues", nil, "async", "", true},
+		{"public async header enqueues", publicTrigger, "async", "", true},
+		{"trigger invocationMode enqueues", triggerModeAsync, "", "", true},
+		{"no async signal proxies", nil, "", "", false},
+		{"dispatcher delivery never enqueues (header)", nil, "async", "inv-1", false},
+		{"dispatcher delivery never enqueues (trigger mode)", triggerModeAsync, "", "inv-1", false},
+		{"case-insensitive header", nil, "ASYNC", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fh := functionHandler{httpTrigger: tc.trigger}
+			r := httptest.NewRequest("POST", "/x", nil)
+			if tc.mode != "" {
+				r.Header.Set(asyncinvoke.HeaderInvokeMode, tc.mode)
+			}
+			if tc.invID != "" {
+				r.Header.Set(asyncinvoke.HeaderInvocationID, tc.invID)
+			}
+			assert.Equal(t, tc.want, fh.asyncRequested(r))
+		})
+	}
+}
+
+// TestHandlerAsyncBranchDirectPath asserts the internal direct-function handler
+// (no httpTrigger) enqueues an async-header request — the `fission function test
+// --async` path — while a dispatcher delivery (X-Fission-Invocation-Id set) is NOT
+// enqueued.
+func TestHandlerAsyncBranchDirectPath(t *testing.T) {
+	t.Parallel()
+	q := routerMemQueue(t)
+	inv := &asyncInvoker{queue: q, logger: logr.Discard()}
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "ns"}}
+
+	// Direct path, async header, no invocation id → enqueues.
+	fh := functionHandler{logger: logr.Discard(), function: fn, asyncInvoker: inv} // httpTrigger nil
+	r := httptest.NewRequest("POST", "/fission-function/ns/fn", strings.NewReader("body"))
+	r.Header.Set(asyncinvoke.HeaderInvokeMode, asyncinvoke.InvokeModeAsync)
+	w := httptest.NewRecorder()
+	fh.handler(w, r)
+	assert.Equal(t, 202, w.Code, "direct caller enqueues async")
+
+	l, err := q.Lease(t.Context(), asyncinvoke.DefaultQueue, 10, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, l, 1, "exactly one message enqueued")
+}
+
 // TestHandlerAsyncBranchTriggerMode asserts a trigger with
 // spec.invocationMode=async enqueues even without the X-Fission-Invoke-Mode header
 // (for callers that cannot set headers).

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -65,10 +65,11 @@ type functionHandler struct {
 	// canary path selects the backend per request, hence per-UID).
 	rtLogger    logr.Logger
 	policyByUID map[k8stypes.UID]proxyPolicy
-	// asyncInvoker enqueues RFC-0024 async invocations. Set only on public
-	// HTTPTrigger handlers (buildTriggerHandler); nil on internal function
-	// handlers so a dispatcher delivery is always a synchronous proxy and can
-	// never re-enqueue. May be nil (or hold a nil queue) when the feature is off.
+	// asyncInvoker enqueues RFC-0024 async invocations. Set on both the public
+	// HTTPTrigger handlers and the internal direct-function handlers, so a signed
+	// direct caller can go async; the dispatcher's own deliveries are excluded by
+	// the X-Fission-Invocation-Id guard in handler(), not by a nil invoker. May be
+	// nil (or hold a nil queue) when the feature is off.
 	asyncInvoker *asyncInvoker
 }
 
@@ -88,6 +89,28 @@ func (fh *functionHandler) roundTripperLogger() logr.Logger {
 		return fh.rtLogger
 	}
 	return fh.logger.WithName("roundtripper")
+}
+
+// asyncRequested reports whether request should be enqueued for RFC-0024 async
+// delivery rather than proxied. A request is async when it carries
+// X-Fission-Invoke-Mode: async, or a public trigger forces it via
+// spec.invocationMode=async (for callers that cannot set headers, e.g. third-party
+// webhooks). It fires on BOTH the public trigger path and the internal
+// direct-function path (/fission-function/...), so a signed direct caller — e.g.
+// `fission function test --async` — can enqueue too.
+//
+// The one request that must NEVER re-enqueue is the dispatcher's own delivery: it
+// carries X-Fission-Invocation-Id, so it always proxies synchronously regardless of
+// any header (the header allowlist already strips X-Fission-* from a replay, so
+// this check is belt-and-suspenders against a future allowlist change).
+func (fh functionHandler) asyncRequested(request *http.Request) bool {
+	if request.Header.Get(asyncinvoke.HeaderInvocationID) != "" {
+		return false // the dispatcher's own delivery — never re-enqueue
+	}
+	if strings.EqualFold(request.Header.Get(asyncinvoke.HeaderInvokeMode), asyncinvoke.InvokeModeAsync) {
+		return true
+	}
+	return fh.httpTrigger != nil && strings.EqualFold(fh.httpTrigger.Spec.InvocationMode, asyncinvoke.InvokeModeAsync)
 }
 
 func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {
@@ -111,17 +134,9 @@ func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *h
 	// system params
 	setFunctionMetadataToHeader(&fh.function.ObjectMeta, request)
 
-	// RFC-0024: async invocation. Only public HTTPTrigger handlers
-	// (httpTrigger != nil) honor async mode — the dispatcher's delivery lands on
-	// the internal function handler (httpTrigger == nil), which skips this branch
-	// and proxies synchronously, so a delivery never re-enqueues. A request is
-	// async when it carries X-Fission-Invoke-Mode: async OR the trigger forces it
-	// via spec.invocationMode=async (for callers, e.g. third-party webhooks, that
-	// cannot set headers). handle() writes 501 when the feature is off (nil
-	// invoker/queue), so an async-mode request is answered honestly.
-	if fh.httpTrigger != nil &&
-		(strings.EqualFold(request.Header.Get(asyncinvoke.HeaderInvokeMode), asyncinvoke.InvokeModeAsync) ||
-			strings.EqualFold(fh.httpTrigger.Spec.InvocationMode, asyncinvoke.InvokeModeAsync)) {
+	// RFC-0024: async invocation. handle() writes 501 when the feature is off (nil
+	// invoker/queue), answering an async-mode request honestly.
+	if fh.asyncRequested(request) {
 		fh.asyncInvoker.handle(responseWriter, request, fh.function)
 		return
 	}

--- a/pkg/router/functionHandler.go
+++ b/pkg/router/functionHandler.go
@@ -99,18 +99,23 @@ func (fh *functionHandler) roundTripperLogger() logr.Logger {
 // direct-function path (/fission-function/...), so a signed direct caller — e.g.
 // `fission function test --async` — can enqueue too.
 //
-// The one request that must NEVER re-enqueue is the dispatcher's own delivery: it
-// carries X-Fission-Invocation-Id, so it always proxies synchronously regardless of
-// any header (the header allowlist already strips X-Fission-* from a replay, so
-// this check is belt-and-suspenders against a future allowlist change).
+// The X-Fission-Invocation-Id guard applies ONLY on the internal direct-function
+// path (httpTrigger == nil): that is where the dispatcher delivers, and its own
+// delivery — which carries that header — must proxy synchronously so it can never
+// re-enqueue. On the public trigger path the dispatcher never delivers, so the
+// header is not a delivery signal there; it is also user-spoofable, so honoring it
+// would let a caller bypass spec.invocationMode=async and force a sync invocation.
+// Hence the public path decides purely on the header / trigger mode.
 func (fh functionHandler) asyncRequested(request *http.Request) bool {
+	headerAsync := strings.EqualFold(request.Header.Get(asyncinvoke.HeaderInvokeMode), asyncinvoke.InvokeModeAsync)
+	if fh.httpTrigger != nil {
+		return headerAsync || strings.EqualFold(fh.httpTrigger.Spec.InvocationMode, asyncinvoke.InvokeModeAsync)
+	}
+	// Internal direct-function path: never re-enqueue the dispatcher's own delivery.
 	if request.Header.Get(asyncinvoke.HeaderInvocationID) != "" {
-		return false // the dispatcher's own delivery — never re-enqueue
+		return false
 	}
-	if strings.EqualFold(request.Header.Get(asyncinvoke.HeaderInvokeMode), asyncinvoke.InvokeModeAsync) {
-		return true
-	}
-	return fh.httpTrigger != nil && strings.EqualFold(fh.httpTrigger.Spec.InvocationMode, asyncinvoke.InvokeModeAsync)
+	return headerAsync
 }
 
 func (fh functionHandler) handler(responseWriter http.ResponseWriter, request *http.Request) {

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -358,6 +358,7 @@ func (ts *HTTPTriggerSet) buildMuxes(ctx context.Context, fnTimeoutMap map[types
 	}
 
 	ts.registerRouterOwnedRoutes(publicMux, featureConfig, homeHandled)
+	ts.registerAsyncDLQRoutes(internalMux)
 
 	return publicMux, internalMux, nil
 }

--- a/pkg/router/incremental.go
+++ b/pkg/router/incremental.go
@@ -331,6 +331,7 @@ func (ts *HTTPTriggerSet) buildIncrementalMuxes(featureConfig *config.FeatureCon
 	}
 
 	ts.registerRouterOwnedRoutes(publicMux, featureConfig, m.HomeClaimed)
+	ts.registerAsyncDLQRoutes(internalMux)
 	return publicMux, internalMux
 }
 

--- a/pkg/router/routeshape.go
+++ b/pkg/router/routeshape.go
@@ -310,8 +310,4 @@ func (ts *HTTPTriggerSet) registerRouterOwnedRoutes(public *httpmux.Mux, feature
 	// Readiness: 200 only once the first mux build succeeded.
 	public.Handle("/readyz", httpsecurity.DenyAllCORS(http.HandlerFunc(ts.routerReadinessHandler))).Methods(http.MethodGet, http.MethodOptions)
 	public.Handle("/_version", httpsecurity.DenyAllCORS(http.HandlerFunc(versionHandler))).Methods(http.MethodGet, http.MethodOptions)
-
-	// RFC-0024 async DLQ admin API (JWT-gated by authMiddleware; 501 when async is
-	// disabled). Registered in both mux builders via this shared helper.
-	ts.registerAsyncDLQRoutes(public)
 }

--- a/pkg/router/routeshape.go
+++ b/pkg/router/routeshape.go
@@ -306,4 +306,8 @@ func (ts *HTTPTriggerSet) registerRouterOwnedRoutes(public *httpmux.Mux, feature
 	// Readiness: 200 only once the first mux build succeeded.
 	public.Handle("/readyz", httpsecurity.DenyAllCORS(http.HandlerFunc(ts.routerReadinessHandler))).Methods(http.MethodGet, http.MethodOptions)
 	public.Handle("/_version", httpsecurity.DenyAllCORS(http.HandlerFunc(versionHandler))).Methods(http.MethodGet, http.MethodOptions)
+
+	// RFC-0024 async DLQ admin API (JWT-gated by authMiddleware; 501 when async is
+	// disabled). Registered in both mux builders via this shared helper.
+	ts.registerAsyncDLQRoutes(public)
 }

--- a/pkg/router/routeshape.go
+++ b/pkg/router/routeshape.go
@@ -231,6 +231,10 @@ func (ts *HTTPTriggerSet) buildInternalFunctionHandler(fn *fv1.Function, fnTimeo
 		rtLogger:             routeLogger.WithName("roundtripper"),
 		policyByUID: precomputePolicies(map[string]*fv1.Function{fn.Name: fn},
 			fnTimeoutMap, streamIdleDefault),
+		// Direct callers can go async on this path too (RFC-0024); the dispatcher's
+		// own deliveries are gated out by the X-Fission-Invocation-Id guard in
+		// handler(), so they still proxy synchronously and never re-enqueue.
+		asyncInvoker: ts.asyncInvoker,
 	}
 	return http.HandlerFunc(fh.handler)
 }

--- a/pkg/statestore/client/client.go
+++ b/pkg/statestore/client/client.go
@@ -218,6 +218,14 @@ func (c *Client) Redrive(ctx context.Context, queue string, ids []string) error 
 	return c.post(ctx, httpapi.PathQueueRedrive, httpapi.QueueRedriveReq{Queue: queue, IDs: ids}, nil)
 }
 
+func (c *Client) Purge(ctx context.Context, queue string) (int64, error) {
+	var resp httpapi.QueuePurgeResp
+	if err := c.post(ctx, httpapi.PathQueuePurge, httpapi.QueuePurgeReq{Queue: queue}, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Purged, nil
+}
+
 func (c *Client) Stats(ctx context.Context, queue string) (statestore.QueueStats, error) {
 	var resp httpapi.QueueStatsResp
 	if err := c.post(ctx, httpapi.PathQueueStats, httpapi.QueueStatsReq{Queue: queue}, &resp); err != nil {

--- a/pkg/statestore/client/client.go
+++ b/pkg/statestore/client/client.go
@@ -214,8 +214,12 @@ func (c *Client) DeadLetters(ctx context.Context, queue string, page statestore.
 	return resp.Messages, nil
 }
 
-func (c *Client) Redrive(ctx context.Context, queue string, ids []string) error {
-	return c.post(ctx, httpapi.PathQueueRedrive, httpapi.QueueRedriveReq{Queue: queue, IDs: ids}, nil)
+func (c *Client) Redrive(ctx context.Context, queue string, ids []string) (int64, error) {
+	var resp httpapi.QueueRedriveResp
+	if err := c.post(ctx, httpapi.PathQueueRedrive, httpapi.QueueRedriveReq{Queue: queue, IDs: ids}, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Redriven, nil
 }
 
 func (c *Client) Purge(ctx context.Context, queue string) (int64, error) {

--- a/pkg/statestore/httpapi/httpapi.go
+++ b/pkg/statestore/httpapi/httpapi.go
@@ -40,6 +40,7 @@ const (
 	PathQueueKill       = "/v1/queue/kill"
 	PathQueueDeadLetter = "/v1/queue/deadletters"
 	PathQueueRedrive    = "/v1/queue/redrive"
+	PathQueuePurge      = "/v1/queue/purge"
 	PathQueueStats      = "/v1/queue/stats"
 )
 
@@ -201,6 +202,12 @@ type QueueDeadLettersResp struct {
 type QueueRedriveReq struct {
 	Queue string   `json:"queue"`
 	IDs   []string `json:"ids"`
+}
+type QueuePurgeReq struct {
+	Queue string `json:"queue"`
+}
+type QueuePurgeResp struct {
+	Purged int64 `json:"purged"`
 }
 type QueueStatsReq struct {
 	Queue string `json:"queue"`

--- a/pkg/statestore/httpapi/httpapi.go
+++ b/pkg/statestore/httpapi/httpapi.go
@@ -203,6 +203,9 @@ type QueueRedriveReq struct {
 	Queue string   `json:"queue"`
 	IDs   []string `json:"ids"`
 }
+type QueueRedriveResp struct {
+	Redriven int64 `json:"redriven"`
+}
 type QueuePurgeReq struct {
 	Queue string `json:"queue"`
 }

--- a/pkg/statestore/httpapi/server.go
+++ b/pkg/statestore/httpapi/server.go
@@ -336,11 +336,12 @@ func (h *handler) queueRedrive(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if err := q.Redrive(r.Context(), req.Queue, req.IDs); err != nil {
+	n, err := q.Redrive(r.Context(), req.Queue, req.IDs)
+	if err != nil {
 		writeErr(w, err)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+	writeJSON(w, QueueRedriveResp{Redriven: n})
 }
 
 func (h *handler) queuePurge(w http.ResponseWriter, r *http.Request) {

--- a/pkg/statestore/httpapi/server.go
+++ b/pkg/statestore/httpapi/server.go
@@ -34,6 +34,7 @@ func NewHandler(caps statestore.Capabilities) http.Handler {
 	mux.HandleFunc("POST "+PathQueueKill, h.queueKill)
 	mux.HandleFunc("POST "+PathQueueDeadLetter, h.queueDeadLetters)
 	mux.HandleFunc("POST "+PathQueueRedrive, h.queueRedrive)
+	mux.HandleFunc("POST "+PathQueuePurge, h.queuePurge)
 	mux.HandleFunc("POST "+PathQueueStats, h.queueStats)
 	return mux
 }
@@ -340,6 +341,23 @@ func (h *handler) queueRedrive(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func (h *handler) queuePurge(w http.ResponseWriter, r *http.Request) {
+	req, ok := decode[QueuePurgeReq](w, r)
+	if !ok {
+		return
+	}
+	q, ok := h.q(w)
+	if !ok {
+		return
+	}
+	n, err := q.Purge(r.Context(), req.Queue)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, QueuePurgeResp{Purged: n})
 }
 
 func (h *handler) queueStats(w http.ResponseWriter, r *http.Request) {

--- a/pkg/statestore/interfaces.go
+++ b/pkg/statestore/interfaces.go
@@ -71,6 +71,11 @@ type Queue interface {
 	// Redrive re-enqueues dead-lettered messages by durable id with attempts
 	// reset.
 	Redrive(ctx context.Context, queue string, ids []string) error
+	// Purge permanently deletes every dead-lettered message for queue and returns
+	// the number removed. It touches only the dead set (never queued/leased/acked
+	// work), so it drops the conservation Enqueued and Dead counts equally and the
+	// T1 drift invariant is preserved by construction.
+	Purge(ctx context.Context, queue string) (int64, error)
 	// Stats returns a point-in-time snapshot of queue's backlog (visible / leased
 	// / dead counts and the oldest visible message's age), for the RFC-0024 async
 	// depth/oldest-age metrics and DLQ dashboards. It does not reap expired leases.

--- a/pkg/statestore/interfaces.go
+++ b/pkg/statestore/interfaces.go
@@ -69,8 +69,9 @@ type Queue interface {
 	// DeadLetters returns a page of dead-lettered messages for queue.
 	DeadLetters(ctx context.Context, queue string, page Page) ([]DeadMessage, error)
 	// Redrive re-enqueues dead-lettered messages by durable id with attempts
-	// reset.
-	Redrive(ctx context.Context, queue string, ids []string) error
+	// reset, returning the number actually re-enqueued — ids that are not currently
+	// dead-lettered are skipped, so the count can be less than len(ids).
+	Redrive(ctx context.Context, queue string, ids []string) (int64, error)
 	// Purge permanently deletes every dead-lettered message for queue and returns
 	// the number removed. It touches only the dead set (never queued/leased/acked
 	// work), so it drops the conservation Enqueued and Dead counts equally and the

--- a/pkg/statestore/memory/queue.go
+++ b/pkg/statestore/memory/queue.go
@@ -321,6 +321,12 @@ func (s *Store) Purge(_ context.Context, queue string) (int64, error) {
 		}
 		kept = append(kept, m)
 	}
+	// Clear the tail of the backing array so the removed *qmsg (and their body
+	// buffers) are unreferenced and can be GC'd, rather than lingering past
+	// len(kept) in the shared array.
+	for i := len(kept); i < len(q.msgs); i++ {
+		q.msgs[i] = nil
+	}
 	q.msgs = kept
 	return removed, nil
 }

--- a/pkg/statestore/memory/queue.go
+++ b/pkg/statestore/memory/queue.go
@@ -299,6 +299,30 @@ func (s *Store) Redrive(_ context.Context, queue string, ids []string) error {
 	return nil
 }
 
+// Purge implements statestore.Queue: permanently drop every dead-lettered message
+// for queue, returning the count removed. Removing the dead rows lowers both the
+// live-row total (Enqueued) and Dead by the same amount, so conservation drift
+// stays zero (invariant T1).
+func (s *Store) Purge(_ context.Context, queue string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, statestore.ErrClosed
+	}
+	q := s.queue(queue)
+	kept := q.msgs[:0]
+	var removed int64
+	for _, m := range q.msgs {
+		if m.state == qDead {
+			removed++
+			continue
+		}
+		kept = append(kept, m)
+	}
+	q.msgs = kept
+	return removed, nil
+}
+
 // Stats implements statestore.Queue: a read-only snapshot of the queue's backlog.
 // It does not reap expired leases (see statestore.QueueStats), and it does not
 // create the queue if absent — an unknown queue reports a zero snapshot.

--- a/pkg/statestore/memory/queue.go
+++ b/pkg/statestore/memory/queue.go
@@ -275,11 +275,11 @@ func (s *Store) DeadLetters(_ context.Context, queue string, page statestore.Pag
 
 // Redrive implements statestore.Queue: return dead-lettered messages to the
 // queue with attempts reset.
-func (s *Store) Redrive(_ context.Context, queue string, ids []string) error {
+func (s *Store) Redrive(_ context.Context, queue string, ids []string) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.closed {
-		return statestore.ErrClosed
+		return 0, statestore.ErrClosed
 	}
 	q := s.queue(queue)
 	want := make(map[string]bool, len(ids))
@@ -287,6 +287,7 @@ func (s *Store) Redrive(_ context.Context, queue string, ids []string) error {
 		want[id] = true
 	}
 	now := time.Now()
+	var redriven int64
 	for _, m := range q.msgs {
 		if m.state == qDead && want[m.id] {
 			m.state = qQueued
@@ -294,9 +295,10 @@ func (s *Store) Redrive(_ context.Context, queue string, ids []string) error {
 			m.visibleAt = now
 			m.reason = ""
 			m.diedAt = time.Time{}
+			redriven++
 		}
 	}
-	return nil
+	return redriven, nil
 }
 
 // Purge implements statestore.Queue: permanently drop every dead-lettered message

--- a/pkg/statestore/memory/queue_test.go
+++ b/pkg/statestore/memory/queue_test.go
@@ -173,6 +173,40 @@ func TestMemoryQueue_T1_Conservation(t *testing.T) {
 	assert.Zero(t, st.Enqueued-(st.Queued+st.Leased+st.Acked+st.Dead), "conservation drift must be zero")
 }
 
+// Purge deletes dead rows; because Enqueued is the live-row total, dropping the
+// dead rows lowers Enqueued and Dead equally, so conservation drift stays zero.
+func TestMemoryQueue_T1_ConservationAfterPurge(t *testing.T) {
+	t.Parallel()
+	q, s := newQueue(t)
+	ctx := t.Context()
+
+	for i := range 4 {
+		_, err := q.Enqueue(ctx, qn, statestore.Message{Body: []byte{byte('a' + i)}}, statestore.EnqueueOptions{})
+		require.NoError(t, err)
+	}
+	l, err := q.Lease(ctx, qn, 2, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, l, 2)
+	require.NoError(t, q.Kill(ctx, l[0].Receipt, "boom")) // one dead
+	require.NoError(t, q.Ack(ctx, l[1].Receipt))          // one acked; two still queued
+
+	before := s.ConservationStats(ctx)
+	require.EqualValues(t, 4, before.Enqueued)
+	require.EqualValues(t, 1, before.Dead)
+	require.Zero(t, before.Drift())
+
+	n, err := q.Purge(ctx, qn)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+
+	after := s.ConservationStats(ctx)
+	assert.EqualValues(t, 3, after.Enqueued, "Enqueued drops by the purged count")
+	assert.Zero(t, after.Dead, "dead rows are gone")
+	assert.EqualValues(t, 1, after.Acked, "acked row untouched")
+	assert.EqualValues(t, 2, after.Queued, "queued rows untouched")
+	assert.Zero(t, after.Drift(), "conservation drift stays zero after purge")
+}
+
 // A message whose whole attempt budget is consumed by lease expiry (a worker
 // that keeps crashing before settling) must be dead-lettered, not stranded in
 // leased forever. This is the DLQ-completeness property RFC-0024 relies on.

--- a/pkg/statestore/memory/queue_test.go
+++ b/pkg/statestore/memory/queue_test.go
@@ -304,7 +304,9 @@ func TestMemoryQueue_KillImmediateAndRedrive(t *testing.T) {
 	require.Equal(t, "http_4xx", dl[0].Reason)
 
 	// Redrive returns it to the queue with attempts reset.
-	require.NoError(t, q.Redrive(ctx, qn, []string{id}))
+	n, err := q.Redrive(ctx, qn, []string{id})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
 	dl, err = q.DeadLetters(ctx, qn, statestore.Page{})
 	require.NoError(t, err)
 	require.Empty(t, dl)

--- a/pkg/statestore/scoped.go
+++ b/pkg/statestore/scoped.go
@@ -219,10 +219,10 @@ func (q *meteredQueue) DeadLetters(ctx context.Context, queue string, page Page)
 	return dl, err
 }
 
-func (q *meteredQueue) Redrive(ctx context.Context, queue string, ids []string) error {
-	err := q.inner.Redrive(ctx, queue, ids)
+func (q *meteredQueue) Redrive(ctx context.Context, queue string, ids []string) (int64, error) {
+	n, err := q.inner.Redrive(ctx, queue, ids)
 	observe(ctx, "queue", "redrive", err)
-	return err
+	return n, err
 }
 
 func (q *meteredQueue) Purge(ctx context.Context, queue string) (int64, error) {

--- a/pkg/statestore/scoped.go
+++ b/pkg/statestore/scoped.go
@@ -225,6 +225,12 @@ func (q *meteredQueue) Redrive(ctx context.Context, queue string, ids []string) 
 	return err
 }
 
+func (q *meteredQueue) Purge(ctx context.Context, queue string) (int64, error) {
+	n, err := q.inner.Purge(ctx, queue)
+	observe(ctx, "queue", "purge", err)
+	return n, err
+}
+
 func (q *meteredQueue) Stats(ctx context.Context, queue string) (QueueStats, error) {
 	st, err := q.inner.Stats(ctx, queue)
 	observe(ctx, "queue", "stats", err)

--- a/pkg/statestore/sqlstore/queue.go
+++ b/pkg/statestore/sqlstore/queue.go
@@ -283,21 +283,24 @@ func (q *queueStore) DeadLetters(ctx context.Context, queue string, page statest
 
 // Redrive implements statestore.Queue: return dead messages to the queue with
 // attempts reset.
-func (q *queueStore) Redrive(ctx context.Context, queue string, ids []string) error {
+func (q *queueStore) Redrive(ctx context.Context, queue string, ids []string) (int64, error) {
 	if len(ids) == 0 {
-		return nil
+		return 0, nil
 	}
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(ids)), ",")
 	args := []any{stQueued, nowNanos(), queue, stDead}
 	for _, id := range ids {
 		args = append(args, id)
 	}
-	_, err := q.s.exec(ctx,
+	res, err := q.s.exec(ctx,
 		`UPDATE state_queue SET state = ?, attempts = 0, visible_at = ?, reason = NULL, died_at = NULL
 		 WHERE queue = ? AND state = ? AND id IN (`+placeholders+`)`,
 		args...,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }
 
 // Purge implements statestore.Queue: delete every dead-lettered row for queue and

--- a/pkg/statestore/sqlstore/queue.go
+++ b/pkg/statestore/sqlstore/queue.go
@@ -300,6 +300,24 @@ func (q *queueStore) Redrive(ctx context.Context, queue string, ids []string) er
 	return err
 }
 
+// Purge implements statestore.Queue: delete every dead-lettered row for queue and
+// return the count removed. Deleting only dead rows lowers the live-row total
+// (Enqueued) and Dead equally, so conservation drift stays zero (invariant T1).
+func (q *queueStore) Purge(ctx context.Context, queue string) (int64, error) {
+	res, err := q.s.exec(ctx,
+		`DELETE FROM state_queue WHERE queue = ? AND state = ?`,
+		queue, stDead,
+	)
+	if err != nil {
+		return 0, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
 // Stats implements statestore.Queue: a read-only aggregate snapshot of the
 // queue's backlog. It does not reap expired leases (see statestore.QueueStats),
 // so the counts reflect stored state; the dispatcher's lease loop reaps

--- a/pkg/statestore/statestoretest/conformance.go
+++ b/pkg/statestore/statestoretest/conformance.go
@@ -263,6 +263,50 @@ func runQueue(t *testing.T, newCaps Factory) {
 		assert.Equal(t, 1, l[0].Attempts, "attempts reset on redrive")
 	})
 
+	t.Run("PurgeDeadLetters", func(t *testing.T) {
+		q := queueOrSkip(t, newCaps)
+		ctx := t.Context()
+		const pq = "purgeq"
+		// Kill two to the dead set, leave one visible (Purge must touch only the dead).
+		for range 2 {
+			_, err := q.Enqueue(ctx, pq, statestore.Message{Body: []byte("d")}, statestore.EnqueueOptions{})
+			require.NoError(t, err)
+			l, err := q.Lease(ctx, pq, 1, time.Minute)
+			require.NoError(t, err)
+			require.Len(t, l, 1)
+			require.NoError(t, q.Kill(ctx, l[0].Receipt, "permanent"))
+		}
+		liveID, err := q.Enqueue(ctx, pq, statestore.Message{Body: []byte("live")}, statestore.EnqueueOptions{})
+		require.NoError(t, err)
+
+		dead, err := q.DeadLetters(ctx, pq, statestore.Page{})
+		require.NoError(t, err)
+		require.Len(t, dead, 2)
+
+		n, err := q.Purge(ctx, pq)
+		require.NoError(t, err)
+		assert.EqualValues(t, 2, n, "Purge returns the count removed")
+
+		dead, err = q.DeadLetters(ctx, pq, statestore.Page{})
+		require.NoError(t, err)
+		assert.Empty(t, dead, "dead set is empty after Purge")
+		st, err := q.Stats(ctx, pq)
+		require.NoError(t, err)
+		assert.Zero(t, st.Dead)
+		assert.EqualValues(t, 1, st.Visible, "Purge leaves visible work untouched")
+
+		// The still-visible message is leasable — the purge did not disturb it.
+		l, err := q.Lease(ctx, pq, 1, time.Minute)
+		require.NoError(t, err)
+		require.Len(t, l, 1)
+		assert.Equal(t, liveID, l[0].ID)
+
+		// Purging an empty dead set is a no-op that removes nothing.
+		n, err = q.Purge(ctx, pq)
+		require.NoError(t, err)
+		assert.Zero(t, n)
+	})
+
 	t.Run("Stats", func(t *testing.T) {
 		q := queueOrSkip(t, newCaps)
 		ctx := t.Context()

--- a/pkg/statestore/statestoretest/conformance.go
+++ b/pkg/statestore/statestoretest/conformance.go
@@ -253,7 +253,13 @@ func runQueue(t *testing.T, newCaps Factory) {
 		require.Len(t, dead, 1)
 		require.Equal(t, id, dead[0].ID)
 
-		require.NoError(t, q.Redrive(ctx, "cq", []string{id}))
+		n, err := q.Redrive(ctx, "cq", []string{id})
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, n, "Redrive reports the count actually re-enqueued")
+		// A second redrive of the same (now-requeued, not dead) id re-enqueues nothing.
+		n, err = q.Redrive(ctx, "cq", []string{id})
+		require.NoError(t, err)
+		assert.Zero(t, n, "an id that is not dead-lettered is not redriven")
 		dead, err = q.DeadLetters(ctx, "cq", statestore.Page{})
 		require.NoError(t, err)
 		require.Empty(t, dead)

--- a/test/benchmark/pkg/scenario/asyncinvoke.go
+++ b/test/benchmark/pkg/scenario/asyncinvoke.go
@@ -133,13 +133,17 @@ func asyncQueryFloat(ctx context.Context, env *harness.Env, query string) float6
 }
 
 // asyncDrainSeconds polls the async queue-depth gauge until it reaches zero,
-// returning the elapsed time. ok is false if the deadline elapses with a nonzero
-// backlog (a stuck dispatcher) so the caller records no misleading drain number.
+// returning the elapsed time. It concludes "drained" ONLY on a successful read of a
+// non-positive depth; a query error or an absent/not-yet-scraped sample is treated
+// as "not yet drained" (keep polling), never as drained — so a transient Prometheus
+// hiccup can't fabricate a ~0s drain. ok is false when the deadline elapses without
+// a confirmed zero (a stuck dispatcher, or Prometheus never answering), so the
+// caller records no misleading drain number.
 func asyncDrainSeconds(ctx context.Context, env *harness.Env, timeout time.Duration) (float64, bool) {
 	start := time.Now()
 	deadline := start.Add(timeout)
 	for {
-		if asyncQueryFloat(ctx, env, asyncQueueDepthQuery) <= 0 {
+		if v, found, err := env.Capturer.QueryInstant(ctx, asyncQueueDepthQuery); err == nil && found && v <= 0 {
 			return time.Since(start).Seconds(), true
 		}
 		if time.Now().After(deadline) {

--- a/test/benchmark/pkg/scenario/asyncinvoke.go
+++ b/test/benchmark/pkg/scenario/asyncinvoke.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scenario
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/router/asyncinvoke"
+	"github.com/fission/fission/test/benchmark/pkg/harness"
+	"github.com/fission/fission/test/benchmark/pkg/loadgen"
+	"github.com/fission/fission/test/benchmark/pkg/report"
+)
+
+// PromQL for the RFC-0024 async signals (summed across router replicas).
+const (
+	asyncQueueDepthQuery = `sum(fission_async_queue_depth)`
+	asyncDLQTotalQuery   = `sum(fission_async_dlq_total)`
+)
+
+// asyncInvoke measures the RFC-0024 asynchronous invocation path: the router
+// accepts each request with a durable 202 (X-Fission-Invoke-Mode: async) and an
+// in-router dispatcher drains the statestore queue out-of-band. It reports three
+// distinct metric families so they never collide on the trend series:
+//   - enqueue_*  : the 202-accept latency/throughput under closed-loop load
+//   - drain_*    : how fast the dispatcher clears the backlog after load stops
+//   - dlq_total  : dead-letters accrued during the run
+//
+// It skips cleanly when async invocation is not enabled on the cluster (a 501),
+// and the drain/dlq families are best-effort — emitted only when Prometheus is
+// wired. It is deliberately OFF the smoke subset (it needs a warm drain window),
+// so it runs in the weekly/dispatch suite, not per-PR.
+type asyncInvoke struct {
+	duration    time.Duration
+	warmup      time.Duration
+	concurrency int
+	poolsize    int
+}
+
+func (a *asyncInvoke) Name() string   { return "async-invoke" }
+func (a *asyncInvoke) Tags() []string { return []string{"async", "throughput", "queue"} }
+
+func (a *asyncInvoke) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioResult, error) {
+	var res report.ScenarioResult
+	env := sc.Env()
+
+	// Node (multi-request-per-pod) on a POST route — async invocation runs on the
+	// public listener and the enqueue path is what we measure, not pod fan-out.
+	route, fnName, err := provisionWarmFunction(ctx, sc, fv1.ExecutorTypePoolmgr, runtimeNode, a.poolsize, a.concurrency+10, []string{http.MethodPost})
+	if err != nil {
+		return res, err
+	}
+	res.SetMeta("function", fnName)
+
+	asyncHeaders := http.Header{}
+	asyncHeaders.Set(asyncinvoke.HeaderInvokeMode, asyncinvoke.InvokeModeAsync)
+
+	// Probe once: a 501 means async invocation is not enabled — skip rather than
+	// record a run of errors.
+	switch code, perr := probeStatus(ctx, env.RouterURL()+route, asyncHeaders); {
+	case perr != nil:
+		return res, perr
+	case code == http.StatusNotImplemented:
+		return res, skip("async invocation not enabled (X-Fission-Invoke-Mode returns 501)")
+	}
+
+	// Baseline the DLQ counter so dlq_total reflects only this run.
+	dlqBefore := asyncQueryFloat(ctx, env, asyncDLQTotalQuery)
+
+	target := loadgen.NewHTTPTarget(loadgen.HTTPTargetConfig{
+		URL:         env.RouterURL() + route,
+		Method:      http.MethodPost,
+		Headers:     asyncHeaders,
+		Concurrency: a.concurrency,
+		KeepAlive:   true,
+		Timeout:     60 * time.Second,
+	})
+	r := loadgen.RunClosedLoop(ctx, loadgen.ClosedLoopConfig{
+		Doer:        target.Do,
+		Concurrency: a.concurrency,
+		WarmUp:      a.warmup,
+		Duration:    a.duration,
+	})
+	// enqueue_* is the durable-accept latency: the 202 is returned once the message
+	// is persisted, so this is the caller-visible async overhead.
+	latencyMetrics(&res, "enqueue_", r)
+
+	// drain_* : after the load stops, time the backlog to zero and derive the
+	// dispatcher's drain throughput. Best-effort — needs the queue-depth gauge.
+	if env.Capturer.PrometheusEnabled() {
+		accepted := r.Total - r.Errors
+		if secs, ok := asyncDrainSeconds(ctx, env, 3*time.Minute); ok {
+			res.Add("drain_seconds", "s", report.Lower, secs)
+			if secs > 0 {
+				res.Add("drain_throughput", "rps", report.Higher, float64(accepted)/secs)
+			}
+		}
+		res.Add("dlq_total", "count", report.Lower, asyncQueryFloat(ctx, env, asyncDLQTotalQuery)-dlqBefore)
+	}
+	return res, nil
+}
+
+// probeStatus fires one request and returns its HTTP status, so a scenario can
+// detect a disabled feature (501) before running a full load.
+func probeStatus(ctx context.Context, url string, headers http.Header) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, http.NoBody)
+	if err != nil {
+		return 0, err
+	}
+	req.Header = headers.Clone()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode, nil
+}
+
+// asyncQueryFloat reads an instant PromQL scalar, returning 0 when Prometheus is
+// disabled or the sample is absent (best-effort, never fails the scenario).
+func asyncQueryFloat(ctx context.Context, env *harness.Env, query string) float64 {
+	if !env.Capturer.PrometheusEnabled() {
+		return 0
+	}
+	if v, found, err := env.Capturer.QueryInstant(ctx, query); err == nil && found {
+		return v
+	}
+	return 0
+}
+
+// asyncDrainSeconds polls the async queue-depth gauge until it reaches zero,
+// returning the elapsed time. ok is false if the deadline elapses with a nonzero
+// backlog (a stuck dispatcher) so the caller records no misleading drain number.
+func asyncDrainSeconds(ctx context.Context, env *harness.Env, timeout time.Duration) (float64, bool) {
+	start := time.Now()
+	deadline := start.Add(timeout)
+	for {
+		if asyncQueryFloat(ctx, env, asyncQueueDepthQuery) <= 0 {
+			return time.Since(start).Seconds(), true
+		}
+		if time.Now().After(deadline) {
+			return 0, false
+		}
+		select {
+		case <-ctx.Done():
+			return 0, false
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/test/benchmark/pkg/scenario/asyncinvoke.go
+++ b/test/benchmark/pkg/scenario/asyncinvoke.go
@@ -69,7 +69,7 @@ func (a *asyncInvoke) Run(ctx context.Context, sc *harness.Scope) (report.Scenar
 	}
 
 	// Baseline the DLQ counter so dlq_total reflects only this run.
-	dlqBefore := asyncQueryFloat(ctx, env, asyncDLQTotalQuery)
+	dlqBefore, dlqBaselineOK := asyncQueryValue(ctx, env, asyncDLQTotalQuery)
 
 	target := loadgen.NewHTTPTarget(loadgen.HTTPTargetConfig{
 		URL:         env.RouterURL() + route,
@@ -99,7 +99,16 @@ func (a *asyncInvoke) Run(ctx context.Context, sc *harness.Scope) (report.Scenar
 				res.Add("drain_throughput", "rps", report.Higher, float64(accepted)/secs)
 			}
 		}
-		res.Add("dlq_total", "count", report.Lower, asyncQueryFloat(ctx, env, asyncDLQTotalQuery)-dlqBefore)
+		// dlq_total is recorded only when BOTH the baseline and post-run reads
+		// succeed, so a failed/absent post-run query can't fabricate a bogus (even
+		// negative) delta. The counter is monotonic, so clamp at zero defensively.
+		if dlqAfter, ok := asyncQueryValue(ctx, env, asyncDLQTotalQuery); ok && dlqBaselineOK {
+			delta := dlqAfter - dlqBefore
+			if delta < 0 {
+				delta = 0
+			}
+			res.Add("dlq_total", "count", report.Lower, delta)
+		}
 	}
 	return res, nil
 }
@@ -120,16 +129,19 @@ func probeStatus(ctx context.Context, url string, headers http.Header) (int, err
 	return resp.StatusCode, nil
 }
 
-// asyncQueryFloat reads an instant PromQL scalar, returning 0 when Prometheus is
-// disabled or the sample is absent (best-effort, never fails the scenario).
-func asyncQueryFloat(ctx context.Context, env *harness.Env, query string) float64 {
+// asyncQueryValue reads an instant PromQL scalar, returning (value, true) only on a
+// successful read of a present sample; (0, false) when Prometheus is disabled, the
+// query errors, or the sample is absent. The ok flag lets callers distinguish a
+// genuine 0 from a failed read, so a metric delta is never computed against a
+// fabricated baseline (best-effort — it never fails the scenario).
+func asyncQueryValue(ctx context.Context, env *harness.Env, query string) (float64, bool) {
 	if !env.Capturer.PrometheusEnabled() {
-		return 0
+		return 0, false
 	}
 	if v, found, err := env.Capturer.QueryInstant(ctx, query); err == nil && found {
-		return v
+		return v, true
 	}
-	return 0
+	return 0, false
 }
 
 // asyncDrainSeconds polls the async queue-depth gauge until it reaches zero,

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -208,6 +208,7 @@ func BuildAll(p Params) []Scenario {
 	out = append(out, &buildTime{timeout: p.BuildTimeout.D()})
 	out = append(out, &routerIndexScale{count: p.IndexScaleCount})
 	out = append(out, &routeChurn{count: p.RouteChurnCount})
+	out = append(out, &asyncInvoke{duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
 	return out
 }
 

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -91,6 +91,17 @@ func TestConfigDepsScenarioRegistered(t *testing.T) {
 	assert.Equal(t, 3, cd.configMaps)
 }
 
+// TestAsyncInvokeScenarioRegistered pins that the RFC-0024 async scenario is built
+// and is deliberately OFF the smoke subset (it needs a warm drain window, so it
+// runs in the weekly/dispatch suite, not per-PR).
+func TestAsyncInvokeScenarioRegistered(t *testing.T) {
+	t.Parallel()
+	all := BuildAll(DefaultParams())
+	assert.Contains(t, Names(all), "async-invoke")
+	assert.NotContains(t, Names(Select(all, nil, []string{"smoke"})), "async-invoke",
+		"async-invoke must stay out of the fast per-PR smoke subset")
+}
+
 func TestColdBurstScenariosRegistered(t *testing.T) {
 	t.Parallel()
 	names := Names(BuildAll(DefaultParams()))


### PR DESCRIPTION
## RFC-0024 async invocation — Phases 3–4 + CLI/test surface

Stacked on #3578 (P1) and #3579 (P2 destinations) — **base is the P2 branch**, so this diff is only the new work; GitHub retargets it to `main` once #3579 merges.

This lands the operational + CLI surface for async invocation: DLQ management, KEDA autoscaling, a benchmark scenario, and the `fission function test --async` / config-flag / trigger-mode CLI.

### Phase 3 — DLQ management
- **`Queue.Purge(ctx, queue) (int64, error)`** across the RFC-0021 Queue interface + all drivers (memory, sqlstore, HTTP client + `/v1/queue/purge`, metered wrapper) + conformance. Deletes dead-lettered rows; because `Enqueued` is the live-row total, dropping the dead rows keeps the T1 conservation drift at zero by construction. `Queue.Redrive` likewise now returns the count actually re-enqueued.
- **Router DLQ admin API** `/v1/async/dlq/{list,show,redrive,purge}` on the **internal** listener (ClusterIP-only `svc/router-internal`), HMAC-verified + NetworkPolicy-gated — fail-closed, independent of the public listener's optional JWT auth. 501 when async is disabled.
- **`fission function dlq`** sub-group (list/show/redrive/purge) — drives the internal API, HMAC-signing with `FISSION_INTERNAL_AUTH_SECRET`. `list` and `redrive --all` page the API so a large DLQ is fully traversed.

### Phase 4 — autoscaling + benchmark
- **Opt-in KEDA ScaledObject** (`router.keda.enabled`) scaling the router on the async backlog via the `postgresql` scaler. Render-gated: requires `asyncInvocation.enabled` + `statestore.mode=external`, mutually exclusive with `router.autoscaling`.
- **`async-invoke` benchmark scenario** — enqueue latency, drain throughput, DLQ under saturation; off the per-PR smoke subset (weekly/dispatch).

### CLI / test surface (requested mid-review)
- **Router direct-path async** (`functionHandler.asyncRequested`): async now fires on the internal `/fission-function` path too, gated so the dispatcher's own delivery (carries `X-Fission-Invocation-Id`) never re-enqueues.
- **`fission function test --async`** — POSTs to the internal listener with the async header, HMAC-signed; prints the invocation id from the 202.
- **`fission function create|update --async-*`** — set `FunctionSpec.Invocation` (retry max-attempts, max-age, on-success/on-failure function destinations) from the CLI.
- **`fission route create|update --invocation-mode async`** — set `HTTPTriggerSpec.InvocationMode`.

### Review battery applied
code-review + security + silent-failure ran on the diff. The security lens caught a **critical**: the DLQ admin API had landed on the public listener, which is unauthenticated by default (`authentication.enabled=false`) — an unauthenticated cross-namespace read/redrive/**purge** surface. Fixed by moving it to the HMAC-gated internal listener (this PR). Also fixed: `redrive --all` first-page truncation, honest redrive count, and a benchmark drain-probe that read a Prometheus error as "drained".

### Tested
Unit: Purge/Redrive conservation + conformance; DLQ handlers + internal-listener registration; direct-path async (`asyncRequested` matrix + dispatcher-delivery exclusion); DLQ CLI (paging, HMAC, 501/5xx) + `test --async` + invocation-config flags. Chart: helm-template gate matrix for the KEDA ScaledObject. Bench: scenario registration (off-smoke). All local: build ./..., -race, code-checks 0 issues, license clean, helm lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
