### PR TITLE
feat: RFC-0027 statestore eventing Phase 1 — EventLog AppendAny/Head + topic destinations

### DIFF
--- a/crds/v1/fission.io_functions.yaml
+++ b/crds/v1/fission.io_functions.yaml
@@ -840,12 +840,17 @@ spec:
                           topic.
                         properties:
                           messageQueueType:
-                            description: MessageQueueType selects the broker (e.g.
-                              kafka).
+                            description: |-
+                              MessageQueueType selects the provider: "statestore" (the RFC-0027
+                              built-in, no broker) now; broker types (e.g. kafka) with the egress phase.
                             type: string
                           topic:
-                            description: Topic is the topic the result envelope is
-                              published to.
+                            description: |-
+                              Topic is the topic the result envelope is published to. The schema bounds
+                              mirror ValidateTopicName: a stream-safe charset excluding "/" so the
+                              topic/<namespace>/<topic> mapping cannot alias across namespaces.
+                            maxLength: 249
+                            pattern: ^[a-zA-Z0-9._-]+$
                             type: string
                         required:
                         - messageQueueType
@@ -902,12 +907,17 @@ spec:
                           topic.
                         properties:
                           messageQueueType:
-                            description: MessageQueueType selects the broker (e.g.
-                              kafka).
+                            description: |-
+                              MessageQueueType selects the provider: "statestore" (the RFC-0027
+                              built-in, no broker) now; broker types (e.g. kafka) with the egress phase.
                             type: string
                           topic:
-                            description: Topic is the topic the result envelope is
-                              published to.
+                            description: |-
+                              Topic is the topic the result envelope is published to. The schema bounds
+                              mirror ValidateTopicName: a stream-safe charset excluding "/" so the
+                              topic/<namespace>/<topic> mapping cannot alias across namespaces.
+                            maxLength: 249
+                            pattern: ^[a-zA-Z0-9._-]+$
                             type: string
                         required:
                         - messageQueueType

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -135,6 +135,9 @@ const (
 
 const (
 	MessageQueueTypeKafka = "kafka"
+	// MessageQueueTypeStatestore is the RFC-0027 built-in provider: topics are
+	// EventLog streams on the RFC-0021 statestore — no external broker.
+	MessageQueueTypeStatestore = "statestore"
 )
 
 const (

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -717,8 +717,9 @@ type (
 	// DestinationRef routes an async invocation's result to exactly one target: a
 	// Function (invoked async through the same machinery, depth-capped) or a Topic
 	// (published to a message queue). Exactly one of Function/Topic must be set.
-	// Topic destinations are declared but not yet implemented — the webhook rejects
-	// them until the broker-producer path lands (a later RFC-0024 step).
+	// Topic destinations on the built-in statestore provider are supported
+	// (RFC-0027); broker types are rejected by the webhook until the egress phase
+	// lands.
 	DestinationRef struct {
 		// Function is a same-namespace function destination, invoked asynchronously
 		// with the result envelope as its body (depth-capped to stop runaway chains).
@@ -731,11 +732,18 @@ type (
 	}
 
 	// TopicRef is a message-queue topic destination for an async invocation result.
+	// Topics are namespace-scoped: the destination publishes to the source
+	// function's namespace (RFC-0024 rule R6).
 	TopicRef struct {
-		// MessageQueueType selects the broker (e.g. kafka).
+		// MessageQueueType selects the provider: "statestore" (the RFC-0027
+		// built-in, no broker) now; broker types (e.g. kafka) with the egress phase.
 		MessageQueueType MessageQueueType `json:"messageQueueType"`
 
-		// Topic is the topic the result envelope is published to.
+		// Topic is the topic the result envelope is published to. The schema bounds
+		// mirror ValidateTopicName: a stream-safe charset excluding "/" so the
+		// topic/<namespace>/<topic> mapping cannot alias across namespaces.
+		// +kubebuilder:validation:MaxLength=249
+		// +kubebuilder:validation:Pattern=`^[a-zA-Z0-9._-]+$`
 		Topic string `json:"topic"`
 	}
 

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -448,8 +448,9 @@ func (ic *InvocationConfig) Validate() error {
 
 // Validate checks a destination reference: exactly one of Function/Topic, a
 // function destination that references a single named function (weights make no
-// sense for a destination), and — for now — rejects Topic destinations, which are
-// declared but not yet implemented (the broker-producer path is a later step).
+// sense for a destination), and a topic destination on a supported provider —
+// the built-in statestore (RFC-0027); broker types are rejected honestly until
+// the egress phase lands rather than accepted and dropped.
 func (d *DestinationRef) Validate(field string) error {
 	switch {
 	case d.Function == nil && d.Topic == nil:
@@ -457,13 +458,38 @@ func (d *DestinationRef) Validate(field string) error {
 	case d.Function != nil && d.Topic != nil:
 		return MakeValidationErr(ErrorInvalidObject, field, "", "only one of function or topic may be set")
 	case d.Topic != nil:
-		return MakeValidationErr(ErrorInvalidObject, field+".topic", "", "topic destinations are not yet supported")
+		return d.Topic.Validate(field + ".topic")
 	}
 	if d.Function.Type != FunctionReferenceTypeFunctionName {
 		return MakeValidationErr(ErrorInvalidValue, field+".function.type", d.Function.Type, fmt.Sprintf("must be %q", FunctionReferenceTypeFunctionName))
 	}
 	if strings.TrimSpace(d.Function.Name) == "" {
 		return MakeValidationErr(ErrorInvalidValue, field+".function.name", d.Function.Name, "must not be empty")
+	}
+	return nil
+}
+
+// topicNameRegexp bounds statestore topic names to a stream-safe charset.
+var topicNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
+
+// Validate checks a topic destination: only the built-in statestore provider is
+// supported until the RFC-0027 egress phase lands, and the topic name must be
+// safe in the namespaced stream mapping topic/<ns>/<topic>.
+func (tr *TopicRef) Validate(field string) error {
+	if tr.MessageQueueType != MessageQueueTypeStatestore {
+		return MakeValidationErr(ErrorInvalidValue, field+".messageQueueType", tr.MessageQueueType,
+			fmt.Sprintf("only %q topic destinations are supported (broker topics arrive with the RFC-0027 egress phase)", MessageQueueTypeStatestore))
+	}
+	return ValidateTopicName(field+".topic", tr.Topic)
+}
+
+// ValidateTopicName bounds a statestore topic name: non-empty, at most 249
+// characters (kafka parity), and [a-zA-Z0-9._-] only — critically excluding "/"
+// so the topic/<ns>/<topic> stream mapping cannot alias across namespaces.
+// Exported for the mqtrigger statestore provider's trigger validation.
+func ValidateTopicName(field, topic string) error {
+	if topic == "" || len(topic) > 249 || !topicNameRegexp.MatchString(topic) {
+		return MakeValidationErr(ErrorInvalidValue, field, topic, "must be 1-249 characters of [a-zA-Z0-9._-]")
 	}
 	return nil
 }

--- a/pkg/apis/core/v1/validation_invocation_test.go
+++ b/pkg/apis/core/v1/validation_invocation_test.go
@@ -5,6 +5,7 @@
 package v1
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -115,7 +116,13 @@ func TestDestinationRefValidate(t *testing.T) {
 		{"function ok", DestinationRef{Function: fnRef("next")}, false},
 		{"neither set", DestinationRef{}, true},
 		{"both set", DestinationRef{Function: fnRef("next"), Topic: &TopicRef{MessageQueueType: "kafka", Topic: "t"}}, true},
-		{"topic not yet supported", DestinationRef{Topic: &TopicRef{MessageQueueType: "kafka", Topic: "t"}}, true},
+		{"broker topic not yet supported", DestinationRef{Topic: &TopicRef{MessageQueueType: "kafka", Topic: "t"}}, true},
+		{"statestore topic ok", DestinationRef{Topic: &TopicRef{MessageQueueType: MessageQueueTypeStatestore, Topic: "orders"}}, false},
+		{"statestore topic dotted ok", DestinationRef{Topic: &TopicRef{MessageQueueType: MessageQueueTypeStatestore, Topic: "orders.v2_batch-1"}}, false},
+		{"statestore topic empty name", DestinationRef{Topic: &TopicRef{MessageQueueType: MessageQueueTypeStatestore, Topic: ""}}, true},
+		{"statestore topic slash rejected", DestinationRef{Topic: &TopicRef{MessageQueueType: MessageQueueTypeStatestore, Topic: "a/b"}}, true},
+		{"statestore topic space rejected", DestinationRef{Topic: &TopicRef{MessageQueueType: MessageQueueTypeStatestore, Topic: "a b"}}, true},
+		{"statestore topic overlong rejected", DestinationRef{Topic: &TopicRef{MessageQueueType: MessageQueueTypeStatestore, Topic: strings.Repeat("a", 250)}}, true},
 		{"function weights rejected", DestinationRef{Function: &FunctionReference{Type: FunctionReferenceTypeFunctionWeights, Name: "w"}}, true},
 		{"empty function name", DestinationRef{Function: fnRef("  ")}, true},
 	}

--- a/pkg/generated/applyconfiguration/core/v1/destinationref.go
+++ b/pkg/generated/applyconfiguration/core/v1/destinationref.go
@@ -12,8 +12,9 @@ package v1
 // DestinationRef routes an async invocation's result to exactly one target: a
 // Function (invoked async through the same machinery, depth-capped) or a Topic
 // (published to a message queue). Exactly one of Function/Topic must be set.
-// Topic destinations are declared but not yet implemented — the webhook rejects
-// them until the broker-producer path lands (a later RFC-0024 step).
+// Topic destinations on the built-in statestore provider are supported
+// (RFC-0027); broker types are rejected by the webhook until the egress phase
+// lands.
 type DestinationRefApplyConfiguration struct {
 	// Function is a same-namespace function destination, invoked asynchronously
 	// with the result envelope as its body (depth-capped to stop runaway chains).

--- a/pkg/generated/applyconfiguration/core/v1/topicref.go
+++ b/pkg/generated/applyconfiguration/core/v1/topicref.go
@@ -14,10 +14,15 @@ import (
 // with apply.
 //
 // TopicRef is a message-queue topic destination for an async invocation result.
+// Topics are namespace-scoped: the destination publishes to the source
+// function's namespace (RFC-0024 rule R6).
 type TopicRefApplyConfiguration struct {
-	// MessageQueueType selects the broker (e.g. kafka).
+	// MessageQueueType selects the provider: "statestore" (the RFC-0027
+	// built-in, no broker) now; broker types (e.g. kafka) with the egress phase.
 	MessageQueueType *corev1.MessageQueueType `json:"messageQueueType,omitempty"`
-	// Topic is the topic the result envelope is published to.
+	// Topic is the topic the result envelope is published to. The schema bounds
+	// mirror ValidateTopicName: a stream-safe charset excluding "/" so the
+	// topic/<namespace>/<topic> mapping cannot alias across namespaces.
 	Topic *string `json:"topic,omitempty"`
 }
 

--- a/pkg/mqtrigger/mqpub/metrics.go
+++ b/pkg/mqtrigger/mqpub/metrics.go
@@ -17,7 +17,7 @@ import (
 // meters): every outcome is labeled, so a dropped publish is countable, never
 // silent.
 var eventingPublished = metrics.Int64Counter("fission_eventing_published_total",
-	"Count of topic publishes, labeled by provider and outcome (published/error/unsupported)")
+	"Count of topic publishes, labeled by provider and outcome (published/error/invalid/capped/unsupported)")
 
 func recordPublish(ctx context.Context, provider, outcome string) {
 	eventingPublished.Add(ctx, 1, metric.WithAttributes(

--- a/pkg/mqtrigger/mqpub/metrics.go
+++ b/pkg/mqtrigger/mqpub/metrics.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mqpub
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/fission/fission/pkg/utils/metrics"
+)
+
+// eventingPublished counts topic publishes (RFC-0027 observability, RFC-0019
+// meters): every outcome is labeled, so a dropped publish is countable, never
+// silent.
+var eventingPublished = metrics.Int64Counter("fission_eventing_published_total",
+	"Count of topic publishes, labeled by provider and outcome (published/error/unsupported)")
+
+func recordPublish(ctx context.Context, provider, outcome string) {
+	eventingPublished.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("provider", provider),
+		attribute.String("outcome", outcome),
+	))
+}

--- a/pkg/mqtrigger/mqpub/mqpub.go
+++ b/pkg/mqtrigger/mqpub/mqpub.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/statestore"
@@ -26,6 +27,21 @@ import (
 // does not implement. Until the RFC-0027 egress phase lands, only the statestore
 // provider exists, so broker types map to this error.
 var ErrUnsupportedMQType = errors.New("mqpub: unsupported message-queue type")
+
+// ErrTopicBacklogCap is returned when a topic stream has reached the phase-1
+// backlog cap (see DefaultMaxTopicBacklog).
+var ErrTopicBacklogCap = errors.New("mqpub: topic backlog cap reached")
+
+// DefaultMaxTopicBacklog bounds a topic stream's head in phase 1. Nothing
+// consumes or trims topics until the P2 subscriber + retention reaper land, so
+// every append is permanent — an unbounded stream on the shared store is a
+// cluster-wide resource hazard (a full embedded PVC fails every tenant's
+// enqueue). A publish to a topic at the cap is rejected loudly and counted
+// ("capped"), never silently dropped. The check reads Head first, so the cap is
+// soft under concurrent publishers (bounded overshoot by in-flight appends) —
+// a resource guard, not an exact quota. P2's retention machinery supersedes it
+// with min-cursor trim + age/size backstops and a tunable knob.
+const DefaultMaxTopicBacklog = 10000
 
 // TopicPublisher durably publishes a payload to a namespaced topic on a
 // message-queue provider.
@@ -55,26 +71,53 @@ func StreamForTopic(namespace, topic string) string {
 
 // statestorePublisher publishes topics onto the RFC-0021 EventLog.
 type statestorePublisher struct {
-	el statestore.EventLog
+	el         statestore.EventLog
+	maxBacklog int64
 }
 
 // NewStatestorePublisher builds the built-in, broker-free TopicPublisher over an
-// EventLog capability.
+// EventLog capability, with the phase-1 DefaultMaxTopicBacklog cap.
 func NewStatestorePublisher(el statestore.EventLog) TopicPublisher {
-	return &statestorePublisher{el: el}
+	return &statestorePublisher{el: el, maxBacklog: DefaultMaxTopicBacklog}
 }
 
 // Publish implements TopicPublisher: one AppendAny of one event. AppendAny is a
 // single atomic round-trip (no client CAS loop), and Append returns only after
 // the write is durable, so a nil error IS the durability guarantee (E1).
+//
+// Inputs are re-validated at this sink (defense in depth — admission is the
+// authoritative gate, but the stream-name injectivity that namespace isolation
+// rests on must not depend on a single distant layer).
 func (p *statestorePublisher) Publish(ctx context.Context, namespace, mqType, topic, contentType string, payload []byte) error {
 	if mqType != fv1.MessageQueueTypeStatestore {
-		recordPublish(ctx, mqType, "unsupported")
+		// Fixed label value: mqType is caller-supplied, and raw strings in a
+		// metric label would mint unbounded time series (the error carries the
+		// exact type).
+		recordPublish(ctx, "unknown", "unsupported")
 		return fmt.Errorf("%w: %q (statestore only until the egress phase)", ErrUnsupportedMQType, mqType)
 	}
-	_, err := p.el.Append(ctx, StreamForTopic(namespace, topic), statestore.AppendAny,
-		[]statestore.Event{{Type: contentType, Payload: payload}})
+	if namespace == "" || strings.Contains(namespace, "/") {
+		recordPublish(ctx, mqType, "invalid")
+		return fmt.Errorf("mqpub: invalid namespace %q", namespace)
+	}
+	if err := fv1.ValidateTopicName("topic", topic); err != nil {
+		recordPublish(ctx, mqType, "invalid")
+		return fmt.Errorf("mqpub: invalid topic name: %w", err)
+	}
+	stream := StreamForTopic(namespace, topic)
+	// Phase-1 backlog cap (soft — see DefaultMaxTopicBacklog): reject loudly
+	// rather than grow the shared store unboundedly with no consumer to trim it.
+	head, err := p.el.Head(ctx, stream)
 	if err != nil {
+		recordPublish(ctx, mqType, "error")
+		return fmt.Errorf("mqpub: reading topic head %s/%s: %w", namespace, topic, err)
+	}
+	if head >= p.maxBacklog {
+		recordPublish(ctx, mqType, "capped")
+		return fmt.Errorf("%w: topic %s/%s at %d events", ErrTopicBacklogCap, namespace, topic, head)
+	}
+	if _, err := p.el.Append(ctx, stream, statestore.AppendAny,
+		[]statestore.Event{{Type: contentType, Payload: payload}}); err != nil {
 		recordPublish(ctx, mqType, "error")
 		return fmt.Errorf("mqpub: publishing to topic %s/%s: %w", namespace, topic, err)
 	}

--- a/pkg/mqtrigger/mqpub/mqpub.go
+++ b/pkg/mqtrigger/mqpub/mqpub.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package mqpub provides TopicPublisher — the outbound mirror of the mqtrigger
+// MessageQueue (Subscribe/Unsubscribe) interface (RFC-0027). It is named to stay
+// distinct from pkg/publisher, the router-POST webhook publisher.
+//
+// The statestore implementation makes topics work with zero external brokers:
+// a topic is the EventLog stream "topic/<namespace>/<topic>", published with a
+// single AppendAny (no CAS retry loop — topic events are independent). Broker
+// implementations (kafka et al.) arrive with the RFC-0027 egress phase behind
+// the same interface.
+package mqpub
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/statestore"
+)
+
+// ErrUnsupportedMQType is returned by a publisher handed a message-queue type it
+// does not implement. Until the RFC-0027 egress phase lands, only the statestore
+// provider exists, so broker types map to this error.
+var ErrUnsupportedMQType = errors.New("mqpub: unsupported message-queue type")
+
+// TopicPublisher durably publishes a payload to a namespaced topic on a
+// message-queue provider.
+//
+// The signature is all-strings (no fv1 types) so consumers that must stay free
+// of the CRD package — notably the router's asyncinvoke dispatcher, which takes
+// Publish as an injected function — can depend on it without coupling. The
+// namespace is an argument rather than constructor state (a deliberate
+// flattening of the RFC-0027 sketch) because the async dispatcher publishing
+// destinations is cluster-scoped and serves every namespace from one loop.
+type TopicPublisher interface {
+	// Publish durably hands payload to topic in namespace on the provider
+	// selected by mqType. For the statestore provider it returns only after the
+	// event is appended (RFC-0027 invariant E1 — never a fake accept);
+	// contentType travels as the event's Type so consumers can replay it as the
+	// delivery Content-Type.
+	Publish(ctx context.Context, namespace, mqType, topic, contentType string, payload []byte) error
+}
+
+// StreamForTopic returns the EventLog stream name for a namespaced topic.
+// Topics are namespace-scoped (RFC-0027, mirroring RFC-0024's same-namespace
+// destination rule R6); topic names are admission-validated to exclude "/" so
+// the mapping cannot alias across namespaces.
+func StreamForTopic(namespace, topic string) string {
+	return "topic/" + namespace + "/" + topic
+}
+
+// statestorePublisher publishes topics onto the RFC-0021 EventLog.
+type statestorePublisher struct {
+	el statestore.EventLog
+}
+
+// NewStatestorePublisher builds the built-in, broker-free TopicPublisher over an
+// EventLog capability.
+func NewStatestorePublisher(el statestore.EventLog) TopicPublisher {
+	return &statestorePublisher{el: el}
+}
+
+// Publish implements TopicPublisher: one AppendAny of one event. AppendAny is a
+// single atomic round-trip (no client CAS loop), and Append returns only after
+// the write is durable, so a nil error IS the durability guarantee (E1).
+func (p *statestorePublisher) Publish(ctx context.Context, namespace, mqType, topic, contentType string, payload []byte) error {
+	if mqType != fv1.MessageQueueTypeStatestore {
+		recordPublish(ctx, mqType, "unsupported")
+		return fmt.Errorf("%w: %q (statestore only until the egress phase)", ErrUnsupportedMQType, mqType)
+	}
+	_, err := p.el.Append(ctx, StreamForTopic(namespace, topic), statestore.AppendAny,
+		[]statestore.Event{{Type: contentType, Payload: payload}})
+	if err != nil {
+		recordPublish(ctx, mqType, "error")
+		return fmt.Errorf("mqpub: publishing to topic %s/%s: %w", namespace, topic, err)
+	}
+	recordPublish(ctx, mqType, "published")
+	return nil
+}

--- a/pkg/mqtrigger/mqpub/mqpub_test.go
+++ b/pkg/mqtrigger/mqpub/mqpub_test.go
@@ -1,0 +1,82 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package mqpub
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/statestore"
+	_ "github.com/fission/fission/pkg/statestore/memory"
+)
+
+func memEventLog(t *testing.T) statestore.EventLog {
+	t.Helper()
+	caps, err := statestore.Open(t.Context(), statestore.Config{Driver: "memory"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = caps.Close() })
+	el, err := caps.EventLog()
+	require.NoError(t, err)
+	return el
+}
+
+func TestStreamForTopic(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "topic/ns/orders", StreamForTopic("ns", "orders"))
+}
+
+func TestStatestorePublisherPublish(t *testing.T) {
+	t.Parallel()
+	el := memEventLog(t)
+	p := NewStatestorePublisher(el)
+
+	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "orders", "application/json", []byte(`{"ok":true}`)))
+	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "orders", "text/plain", []byte("second")))
+
+	// Events land in the namespaced stream, ordered, with contentType as Type.
+	evs, err := el.Read(t.Context(), StreamForTopic("ns", "orders"), 0, 0)
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	assert.Equal(t, "application/json", evs[0].Type)
+	assert.Equal(t, []byte(`{"ok":true}`), evs[0].Payload)
+	assert.Equal(t, "text/plain", evs[1].Type)
+	assert.EqualValues(t, 1, evs[0].Seq)
+	assert.EqualValues(t, 2, evs[1].Seq)
+
+	// Namespace isolation: another namespace's same-named topic is a different stream.
+	require.NoError(t, p.Publish(t.Context(), "other", fv1.MessageQueueTypeStatestore, "orders", "text/plain", []byte("x")))
+	evs, err = el.Read(t.Context(), StreamForTopic("other", "orders"), 0, 0)
+	require.NoError(t, err)
+	require.Len(t, evs, 1)
+}
+
+func TestStatestorePublisherUnsupportedType(t *testing.T) {
+	t.Parallel()
+	p := NewStatestorePublisher(memEventLog(t))
+	err := p.Publish(t.Context(), "ns", "kafka", "orders", "application/json", []byte("x"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrUnsupportedMQType)
+}
+
+// erroringEventLog fails every Append, to prove E1: a failed publish surfaces as
+// an error, never a silent accept.
+type erroringEventLog struct{ statestore.EventLog }
+
+func (erroringEventLog) Append(context.Context, string, int64, []statestore.Event) (int64, error) {
+	return 0, errors.New("store down")
+}
+
+func TestStatestorePublisherE1FailsLoud(t *testing.T) {
+	t.Parallel()
+	p := NewStatestorePublisher(erroringEventLog{})
+	err := p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "orders", "application/json", []byte("x"))
+	require.Error(t, err, "a failed append must surface (E1), never a fake accept")
+	assert.Contains(t, err.Error(), "ns/orders")
+}

--- a/pkg/mqtrigger/mqpub/mqpub_test.go
+++ b/pkg/mqtrigger/mqpub/mqpub_test.go
@@ -65,6 +65,37 @@ func TestStatestorePublisherUnsupportedType(t *testing.T) {
 	assert.ErrorIs(t, err, ErrUnsupportedMQType)
 }
 
+func TestStatestorePublisherRejectsInvalidInputs(t *testing.T) {
+	t.Parallel()
+	p := NewStatestorePublisher(memEventLog(t))
+	// Sink-side defense in depth: inputs that would break the stream-name
+	// injectivity are rejected even though admission already validates them.
+	for name, call := range map[string]func() error{
+		"empty namespace": func() error { return p.Publish(t.Context(), "", fv1.MessageQueueTypeStatestore, "t", "", nil) },
+		"slash namespace": func() error { return p.Publish(t.Context(), "a/b", fv1.MessageQueueTypeStatestore, "t", "", nil) },
+		"empty topic":     func() error { return p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "", "", nil) },
+		"slash topic":     func() error { return p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "a/b", "", nil) },
+		"space topic":     func() error { return p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "a b", "", nil) },
+	} {
+		assert.Errorf(t, call(), "%s must be rejected at the sink", name)
+	}
+}
+
+func TestStatestorePublisherBacklogCap(t *testing.T) {
+	t.Parallel()
+	el := memEventLog(t)
+	p := &statestorePublisher{el: el, maxBacklog: 2}
+
+	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "t", "", []byte("1")))
+	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "t", "", []byte("2")))
+	err := p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "t", "", []byte("3"))
+	require.Error(t, err, "a topic at the backlog cap rejects loudly, never grows silently")
+	assert.ErrorIs(t, err, ErrTopicBacklogCap)
+
+	// Other topics are unaffected (the cap is per-stream).
+	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "other", "", []byte("x")))
+}
+
 // erroringEventLog fails every Append, to prove E1: a failed publish surfaces as
 // an error, never a silent accept.
 type erroringEventLog struct{ statestore.EventLog }
@@ -72,6 +103,8 @@ type erroringEventLog struct{ statestore.EventLog }
 func (erroringEventLog) Append(context.Context, string, int64, []statestore.Event) (int64, error) {
 	return 0, errors.New("store down")
 }
+
+func (erroringEventLog) Head(context.Context, string) (int64, error) { return 0, nil }
 
 func TestStatestorePublisherE1FailsLoud(t *testing.T) {
 	t.Parallel()

--- a/pkg/router/async.go
+++ b/pkg/router/async.go
@@ -152,7 +152,9 @@ func destFromRef(ref *fv1.DestinationRef, fnNamespace string) *asyncinvoke.Desti
 	case ref.Function != nil:
 		return &asyncinvoke.Destination{FunctionNamespace: fnNamespace, FunctionName: ref.Function.Name}
 	case ref.Topic != nil:
-		return &asyncinvoke.Destination{Topic: ref.Topic.Topic, MQType: string(ref.Topic.MessageQueueType)}
+		// Topics are namespace-scoped (RFC-0027): the destination inherits the
+		// source function's namespace, exactly like function destinations (R6).
+		return &asyncinvoke.Destination{FunctionNamespace: fnNamespace, Topic: ref.Topic.Topic, MQType: string(ref.Topic.MessageQueueType)}
 	default:
 		return nil
 	}

--- a/pkg/router/async_test.go
+++ b/pkg/router/async_test.go
@@ -218,7 +218,7 @@ func TestDestinationsFromSpec(t *testing.T) {
 
 	ic := &fv1.InvocationConfig{
 		OnSuccess: &fv1.DestinationRef{Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "next"}},
-		OnFailure: &fv1.DestinationRef{Topic: &fv1.TopicRef{MessageQueueType: "kafka", Topic: "errs"}},
+		OnFailure: &fv1.DestinationRef{Topic: &fv1.TopicRef{MessageQueueType: fv1.MessageQueueTypeStatestore, Topic: "errs"}},
 	}
 	onS, onF = destinationsFromSpec(ic, "ns")
 	require.NotNil(t, onS)
@@ -226,8 +226,9 @@ func TestDestinationsFromSpec(t *testing.T) {
 	assert.Equal(t, "next", onS.FunctionName)
 	assert.True(t, onS.IsFunction())
 	require.NotNil(t, onF)
+	assert.Equal(t, "ns", onF.FunctionNamespace, "topic destination inherits the source namespace too (RFC-0027)")
 	assert.Equal(t, "errs", onF.Topic)
-	assert.Equal(t, "kafka", onF.MQType)
+	assert.Equal(t, fv1.MessageQueueTypeStatestore, onF.MQType)
 	assert.True(t, onF.IsTopic())
 }
 

--- a/pkg/router/asyncinvoke/dispatcher.go
+++ b/pkg/router/asyncinvoke/dispatcher.go
@@ -101,6 +101,19 @@ type FunctionConfig struct {
 // destination pointing at a deleted function is dropped rather than looping.
 type FunctionConfigResolver func(ctx context.Context, namespace, name string) (FunctionConfig, bool)
 
+// TopicPublishFunc publishes a settled invocation's result envelope to a
+// namespaced topic (RFC-0027). The signature matches mqpub.TopicPublisher.Publish
+// — all strings, injected as a function so this package stays a pure library
+// (no fv1, no mqpub import). nil → topic destinations are dropped as
+// unsupported, the pre-eventing behavior.
+type TopicPublishFunc func(ctx context.Context, namespace, mqType, topic, contentType string, payload []byte) error
+
+// MQTypeStatestore mirrors fv1.MessageQueueTypeStatestore without importing the
+// CRD package: the RFC-0027 built-in provider, the only topic type the
+// dispatcher publishes in phase 1 (admission enforces it; this is the envelope-
+// level guard against a forged or legacy record).
+const MQTypeStatestore = "statestore"
+
 // Options configures a Dispatcher. Queue, Deliverer, and Logger are required; the
 // rest default. Now and Rand are injected so timing and backoff jitter are
 // deterministic under test.
@@ -117,6 +130,10 @@ type Options struct {
 	// ResolveFunctionConfig resolves a destination function's config when firing a
 	// function destination. nil → function destinations are dropped (logged).
 	ResolveFunctionConfig FunctionConfigResolver
+
+	// PublishTopic publishes a topic destination's result envelope (RFC-0027).
+	// nil → topic destinations are dropped as unsupported (logged + metered).
+	PublishTopic TopicPublishFunc
 
 	Now  func() time.Time // nil → time.Now
 	Rand func() float64   // nil → rand/v2 Float64; returns [0,1) for backoff jitter
@@ -137,6 +154,7 @@ type Dispatcher struct {
 	pollInterval  time.Duration
 	leaseDuration time.Duration
 	resolveFn     FunctionConfigResolver
+	publishFn     TopicPublishFunc
 	now           func() time.Time
 	rand          func() float64
 }
@@ -152,6 +170,7 @@ func New(opts Options) *Dispatcher {
 		pollInterval:  opts.PollInterval,
 		leaseDuration: opts.LeaseDuration,
 		resolveFn:     opts.ResolveFunctionConfig,
+		publishFn:     opts.PublishTopic,
 		now:           opts.Now,
 		rand:          opts.Rand,
 	}
@@ -340,11 +359,7 @@ func (d *Dispatcher) fireDestination(ctx context.Context, dest *Destination, dep
 		return
 	}
 	if dest.IsTopic() {
-		// Topic destinations are rejected at admission (not yet supported); this
-		// guards a forged or pre-validation envelope.
-		recordDestination(ctx, "topic_unsupported")
-		d.logger.Info("async topic destination not yet supported; dropping",
-			"topic", dest.Topic, "mqType", dest.MQType)
+		d.publishTopicDestination(ctx, dest, result)
 		return
 	}
 	next := depth + 1
@@ -400,6 +415,37 @@ func (d *Dispatcher) fireDestination(ctx context.Context, dest *Destination, dep
 		return
 	}
 	recordDestination(ctx, "enqueued")
+}
+
+// publishTopicDestination fires a topic destination: the result envelope is
+// published to the namespaced statestore topic (RFC-0027 phase 1). A topic is a
+// LEAF — it terminates the chain, so the MaxChainDepth accounting does not apply
+// (a function consuming the topic starts a fresh chain at depth 0: it is a new
+// invocation, not a continuation). Broker types stay unsupported until the
+// egress phase; admission enforces that, so a broker type here is a forged or
+// legacy envelope and is dropped, counted, and logged.
+func (d *Dispatcher) publishTopicDestination(ctx context.Context, dest *Destination, result ResultEnvelope) {
+	if d.publishFn == nil || dest.MQType != MQTypeStatestore {
+		recordDestination(ctx, "topic_unsupported")
+		d.logger.Info("async topic destination unsupported; dropping",
+			"namespace", dest.FunctionNamespace, "topic", dest.Topic, "mqType", dest.MQType)
+		return
+	}
+	body, err := result.Encode()
+	if err != nil {
+		recordDestination(ctx, "encode_error")
+		d.logger.Error(err, "encoding destination result envelope", "topic", dest.Topic)
+		return
+	}
+	// The result envelope is JSON by construction, so the delivery Content-Type a
+	// consuming trigger replays is application/json.
+	if err := d.publishFn(ctx, dest.FunctionNamespace, dest.MQType, dest.Topic, "application/json", body); err != nil {
+		recordDestination(ctx, "publish_error")
+		d.logger.Error(err, "publishing destination result to topic",
+			"namespace", dest.FunctionNamespace, "topic", dest.Topic)
+		return
+	}
+	recordDestination(ctx, "published")
 }
 
 // buildResult assembles the Lambda-shaped result envelope for a destination. The

--- a/pkg/router/asyncinvoke/dispatcher.go
+++ b/pkg/router/asyncinvoke/dispatcher.go
@@ -425,16 +425,29 @@ func (d *Dispatcher) fireDestination(ctx context.Context, dest *Destination, dep
 // egress phase; admission enforces that, so a broker type here is a forged or
 // legacy envelope and is dropped, counted, and logged.
 func (d *Dispatcher) publishTopicDestination(ctx context.Context, dest *Destination, result ResultEnvelope) {
-	if d.publishFn == nil || dest.MQType != MQTypeStatestore {
+	if dest.MQType != MQTypeStatestore {
+		// Admission enforces the type, so this is a forged or legacy envelope —
+		// expected-shaped noise, dropped at Info.
 		recordDestination(ctx, "topic_unsupported")
 		d.logger.Info("async topic destination unsupported; dropping",
 			"namespace", dest.FunctionNamespace, "topic", dest.Topic, "mqType", dest.MQType)
 		return
 	}
+	if d.publishFn == nil {
+		// Admission ACCEPTED this destination and the user was promised delivery:
+		// a nil publisher here is a wiring defect in the embedder, not a forged
+		// envelope — a distinct outcome and an Error, so a dashboard never reads
+		// it as expected topic_unsupported noise.
+		recordDestination(ctx, "publisher_unconfigured")
+		d.logger.Error(nil, "async topic destination dropped: no topic publisher wired (dispatcher misconfiguration)",
+			"namespace", dest.FunctionNamespace, "topic", dest.Topic)
+		return
+	}
 	body, err := result.Encode()
 	if err != nil {
 		recordDestination(ctx, "encode_error")
-		d.logger.Error(err, "encoding destination result envelope", "topic", dest.Topic)
+		d.logger.Error(err, "encoding destination result envelope",
+			"namespace", dest.FunctionNamespace, "topic", dest.Topic)
 		return
 	}
 	// The result envelope is JSON by construction, so the delivery Content-Type a
@@ -460,6 +473,7 @@ func (d *Dispatcher) buildResult(env Envelope, msg statestore.LeasedMessage, con
 			FunctionRef:  env.Namespace + "/" + env.Function,
 			Condition:    condition,
 			Attempts:     msg.Attempts,
+			Depth:        env.Depth,
 		},
 		ResponseContext: ResponseContext{StatusCode: res.StatusCode, Truncated: res.BodyTruncated},
 		ResponsePayload: res.Body,

--- a/pkg/router/asyncinvoke/dispatcher_destinations_test.go
+++ b/pkg/router/asyncinvoke/dispatcher_destinations_test.go
@@ -8,7 +8,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"math"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -195,12 +197,99 @@ func TestFireDestinationResolverNotFound(t *testing.T) {
 	assert.Empty(t, l, "a destination to a missing function is dropped")
 }
 
+// publishRecorder is a scripted TopicPublishFunc capturing every publish.
+type publishRecorder struct {
+	mu    sync.Mutex
+	calls []publishCall
+	err   error
+}
+
+type publishCall struct {
+	namespace, mqType, topic, contentType string
+	payload                               []byte
+}
+
+func (p *publishRecorder) publish(_ context.Context, namespace, mqType, topic, contentType string, payload []byte) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, publishCall{namespace, mqType, topic, contentType, payload})
+	return p.err
+}
+
+func (p *publishRecorder) recorded() []publishCall {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]publishCall(nil), p.calls...)
+}
+
+// TestFireDestinationTopicPublishesStatestore: a statestore topic destination
+// publishes the result envelope to the namespaced topic — a LEAF (nothing is
+// enqueued, no chain continues).
+func TestFireDestinationTopicPublishesStatestore(t *testing.T) {
+	t.Parallel()
+	q := memQueue(t)
+	rec := &publishRecorder{}
+	d := destDispatcher(q, scriptedDeliverer{}, time.Unix(1, 0), resolverFor(FunctionConfig{}))
+	d.publishFn = rec.publish
+
+	result := ResultEnvelope{
+		Version:         EnvelopeVersion,
+		RequestContext:  RequestContext{InvocationID: "id-1", FunctionRef: "ns/src", Condition: ConditionSuccess, Attempts: 1},
+		ResponseContext: ResponseContext{StatusCode: 200},
+	}
+	d.fireDestination(context.Background(), &Destination{FunctionNamespace: "ns", Topic: "orders", MQType: MQTypeStatestore}, 0, result)
+
+	calls := rec.recorded()
+	require.Len(t, calls, 1)
+	assert.Equal(t, "ns", calls[0].namespace)
+	assert.Equal(t, MQTypeStatestore, calls[0].mqType)
+	assert.Equal(t, "orders", calls[0].topic)
+	assert.Equal(t, "application/json", calls[0].contentType)
+	var decoded ResultEnvelope
+	require.NoError(t, json.Unmarshal(calls[0].payload, &decoded))
+	assert.Equal(t, "id-1", decoded.RequestContext.InvocationID, "the payload is the result envelope")
+
+	// A topic is a leaf: nothing was enqueued.
+	l, err := q.Lease(t.Context(), DefaultQueue, 1, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, l)
+}
+
+// TestFireDestinationTopicUnsupported: broker types (admission-rejected, so only
+// a forged/legacy envelope carries one) and a nil publisher both drop the
+// destination without publishing or enqueuing.
 func TestFireDestinationTopicUnsupported(t *testing.T) {
 	t.Parallel()
 	q := memQueue(t)
+	rec := &publishRecorder{}
 	d := destDispatcher(q, scriptedDeliverer{}, time.Unix(1, 0), resolverFor(FunctionConfig{}))
-	d.fireDestination(context.Background(), &Destination{Topic: "t", MQType: "kafka"}, 0, ResultEnvelope{})
+	d.publishFn = rec.publish
+
+	// Broker type → dropped, not published.
+	d.fireDestination(context.Background(), &Destination{FunctionNamespace: "ns", Topic: "t", MQType: "kafka"}, 0, ResultEnvelope{})
+	assert.Empty(t, rec.recorded(), "broker topic types are unsupported until the egress phase")
+
+	// No publisher wired (feature off) → statestore topics drop too.
+	d.publishFn = nil
+	d.fireDestination(context.Background(), &Destination{FunctionNamespace: "ns", Topic: "t", MQType: MQTypeStatestore}, 0, ResultEnvelope{})
+
 	l, err := q.Lease(t.Context(), DefaultQueue, 1, time.Minute)
 	require.NoError(t, err)
-	assert.Empty(t, l, "topic destinations are not enqueued (not yet supported)")
+	assert.Empty(t, l, "topic destinations never enqueue")
+}
+
+// TestFireDestinationTopicPublishError: a failing publish is dropped (best-effort
+// destination contract) without panicking or enqueuing.
+func TestFireDestinationTopicPublishError(t *testing.T) {
+	t.Parallel()
+	q := memQueue(t)
+	rec := &publishRecorder{err: errors.New("store down")}
+	d := destDispatcher(q, scriptedDeliverer{}, time.Unix(1, 0), resolverFor(FunctionConfig{}))
+	d.publishFn = rec.publish
+
+	d.fireDestination(context.Background(), &Destination{FunctionNamespace: "ns", Topic: "t", MQType: MQTypeStatestore}, 0, ResultEnvelope{})
+	require.Len(t, rec.recorded(), 1, "the publish was attempted")
+	l, err := q.Lease(t.Context(), DefaultQueue, 1, time.Minute)
+	require.NoError(t, err)
+	assert.Empty(t, l)
 }

--- a/pkg/router/asyncinvoke/dispatcher_destinations_test.go
+++ b/pkg/router/asyncinvoke/dispatcher_destinations_test.go
@@ -145,10 +145,11 @@ func TestBuildResultFlagsTruncationAndOmission(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 
 	big := bytes.Repeat([]byte("a"), MaxPayloadBytes+1)
-	env := Envelope{Version: EnvelopeVersion, Namespace: "ns", Function: "src", EnqueueTime: now, Body: big}
+	env := Envelope{Version: EnvelopeVersion, Namespace: "ns", Function: "src", EnqueueTime: now, Body: big, Depth: 2}
 	_, msg := leaseOne(t, q, env)
 	re := d.buildResult(env, msg, ConditionSuccess, DeliveryResult{StatusCode: 200, Body: []byte("partial"), BodyTruncated: true})
 
+	assert.Equal(t, 2, re.RequestContext.Depth, "the chain depth is stamped for future async consumers (no wire migration)")
 	assert.True(t, re.RequestPayloadOmitted, "over-cap request body is omitted and flagged")
 	assert.Nil(t, re.RequestPayload, "omitted request payload is not embedded")
 	assert.True(t, re.ResponseContext.Truncated, "truncated response is flagged")

--- a/pkg/router/asyncinvoke/envelope.go
+++ b/pkg/router/asyncinvoke/envelope.go
@@ -106,7 +106,10 @@ type Envelope struct {
 
 // Destination is a settled-invocation destination stamped into the envelope: a
 // same-namespace function (FunctionName set) or a message-queue topic (Topic set).
-// It is the envelope-side flat form of fv1.DestinationRef.
+// It is the envelope-side flat form of fv1.DestinationRef. FunctionNamespace is
+// the destination's namespace for BOTH kinds — topics are namespace-scoped too
+// (RFC-0027, mirroring the same-namespace rule R6), the field name predating the
+// topic kind.
 type Destination struct {
 	FunctionNamespace string `json:"fnNs,omitempty"`
 	FunctionName      string `json:"fn,omitempty"`

--- a/pkg/router/asyncinvoke/envelope.go
+++ b/pkg/router/asyncinvoke/envelope.go
@@ -166,6 +166,13 @@ type RequestContext struct {
 	FunctionRef  string `json:"functionRef"` // "<namespace>/<name>"
 	Condition    string `json:"condition"`
 	Attempts     int    `json:"attempts"`
+	// Depth is the source invocation's destination-chain depth. Stamped now so a
+	// future consumer that resumes the chain asynchronously (an RFC-0027 P2+
+	// design choice) can enforce the A6 cap across the topic hop without a wire
+	// migration of already-persisted events. The P2 statestore MQ trigger
+	// delivers synchronously, which fires no destinations — so no loop exists
+	// today; this field is the insurance that keeps it that way if that changes.
+	Depth int `json:"depth"`
 }
 
 // ResponseContext carries the function's delivery response status.

--- a/pkg/router/asyncinvoke/metrics.go
+++ b/pkg/router/asyncinvoke/metrics.go
@@ -25,7 +25,7 @@ var (
 	asyncDLQ = metrics.Int64Counter("fission_async_dlq_total",
 		"Count of async invocations dead-lettered, labeled by reason")
 	asyncDestinations = metrics.Int64Counter("fission_async_destinations_total",
-		"Count of async destination fires, labeled by outcome (enqueued/dropped/depth_capped/topic_unsupported/encode_error/enqueue_error)")
+		"Count of async destination fires, labeled by outcome (enqueued/dropped/depth_capped/published/publish_error/topic_unsupported/encode_error/enqueue_error)")
 	asyncDepthCap = metrics.Int64Counter("fission_async_depth_cap_total",
 		"Count of async destination invocations dropped for exceeding the chain depth cap (A6)")
 )

--- a/pkg/router/asyncinvoke/metrics.go
+++ b/pkg/router/asyncinvoke/metrics.go
@@ -25,7 +25,7 @@ var (
 	asyncDLQ = metrics.Int64Counter("fission_async_dlq_total",
 		"Count of async invocations dead-lettered, labeled by reason")
 	asyncDestinations = metrics.Int64Counter("fission_async_destinations_total",
-		"Count of async destination fires, labeled by outcome (enqueued/dropped/depth_capped/published/publish_error/topic_unsupported/encode_error/enqueue_error)")
+		"Count of async destination fires, labeled by outcome (enqueued/dropped/depth_capped/published/publish_error/publisher_unconfigured/topic_unsupported/encode_error/enqueue_error)")
 	asyncDepthCap = metrics.Int64Counter("fission_async_depth_cap_total",
 		"Count of async destination invocations dropped for exceeding the chain depth cap (A6)")
 )

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -60,6 +60,7 @@ import (
 	"github.com/fission/fission/pkg/crd"
 	eclient "github.com/fission/fission/pkg/executor/client"
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
+	"github.com/fission/fission/pkg/mqtrigger/mqpub"
 	"github.com/fission/fission/pkg/router/asyncinvoke"
 	"github.com/fission/fission/pkg/router/endpointcache"
 	"github.com/fission/fission/pkg/statestore"
@@ -526,6 +527,15 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		}
 		triggers.asyncInvoker = &asyncInvoker{queue: queue, logger: logger.WithName("async_invoker")}
 
+		// Topic destinations publish onto the same store's EventLog (RFC-0027): all
+		// current drivers expose every capability, so an EventLog failure here is a
+		// store misconfiguration and fails startup exactly like the Queue above.
+		eventLog, elerr := caps.EventLog()
+		if elerr != nil {
+			return fmt.Errorf("async invocation: statestore eventlog capability: %w", elerr)
+		}
+		topicPublisher := mqpub.NewStatestorePublisher(eventLog)
+
 		internalURL := svcinfo.NewEnvResolver(svcinfo.FlagValues{}).RouterInternalURL()
 		deliverer := asyncinvoke.NewHTTPDeliverer(internalURL, []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET")), nil)
 		// The dispatcher resolves each destination-chain hop's config from the
@@ -535,6 +545,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 			Deliverer:             deliverer,
 			Logger:                logger.WithName("async_dispatcher"),
 			ResolveFunctionConfig: newFunctionConfigResolver(crMgr.GetClient(), logger),
+			PublishTopic:          topicPublisher.Publish,
 		})
 		if aerr := crMgr.Add(runnableFunc(func(rctx context.Context) error {
 			_ = dispatcher.Run(rctx) // returns only on ctx cancellation

--- a/pkg/statestore/client/client.go
+++ b/pkg/statestore/client/client.go
@@ -174,6 +174,14 @@ func (c *Client) Trim(ctx context.Context, stream string, belowSeq int64) error 
 	return c.post(ctx, httpapi.PathEventTrim, httpapi.EventTrimReq{Stream: stream, BelowSeq: belowSeq}, nil)
 }
 
+func (c *Client) Head(ctx context.Context, stream string) (int64, error) {
+	var resp httpapi.EventHeadResp
+	if err := c.post(ctx, httpapi.PathEventHead, httpapi.EventHeadReq{Stream: stream}, &resp); err != nil {
+		return 0, err
+	}
+	return resp.Head, nil
+}
+
 // --- Queue ---
 
 func (c *Client) Enqueue(ctx context.Context, queue string, msg statestore.Message, o statestore.EnqueueOptions) (string, error) {

--- a/pkg/statestore/httpapi/httpapi.go
+++ b/pkg/statestore/httpapi/httpapi.go
@@ -33,6 +33,7 @@ const (
 	PathEventAppend     = "/v1/eventlog/append"
 	PathEventRead       = "/v1/eventlog/read"
 	PathEventTrim       = "/v1/eventlog/trim"
+	PathEventHead       = "/v1/eventlog/head"
 	PathQueueEnqueue    = "/v1/queue/enqueue"
 	PathQueueLease      = "/v1/queue/lease"
 	PathQueueAck        = "/v1/queue/ack"
@@ -160,6 +161,12 @@ type EventReadResp struct {
 type EventTrimReq struct {
 	Stream   string `json:"stream"`
 	BelowSeq int64  `json:"belowSeq"`
+}
+type EventHeadReq struct {
+	Stream string `json:"stream"`
+}
+type EventHeadResp struct {
+	Head int64 `json:"head"`
 }
 
 // --- Queue ---

--- a/pkg/statestore/httpapi/server.go
+++ b/pkg/statestore/httpapi/server.go
@@ -27,6 +27,7 @@ func NewHandler(caps statestore.Capabilities) http.Handler {
 	mux.HandleFunc("POST "+PathEventAppend, h.eventAppend)
 	mux.HandleFunc("POST "+PathEventRead, h.eventRead)
 	mux.HandleFunc("POST "+PathEventTrim, h.eventTrim)
+	mux.HandleFunc("POST "+PathEventHead, h.eventHead)
 	mux.HandleFunc("POST "+PathQueueEnqueue, h.queueEnqueue)
 	mux.HandleFunc("POST "+PathQueueLease, h.queueLease)
 	mux.HandleFunc("POST "+PathQueueAck, h.queueAck)
@@ -223,6 +224,23 @@ func (h *handler) eventTrim(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func (h *handler) eventHead(w http.ResponseWriter, r *http.Request) {
+	req, ok := decode[EventHeadReq](w, r)
+	if !ok {
+		return
+	}
+	el, ok := h.el(w)
+	if !ok {
+		return
+	}
+	head, err := el.Head(r.Context(), req.Stream)
+	if err != nil {
+		writeErr(w, err)
+		return
+	}
+	writeJSON(w, EventHeadResp{Head: head})
 }
 
 func (h *handler) queueEnqueue(w http.ResponseWriter, r *http.Request) {

--- a/pkg/statestore/interfaces.go
+++ b/pkg/statestore/interfaces.go
@@ -23,16 +23,33 @@ type KVStore interface {
 	List(ctx context.Context, s Scope, prefix string, page Page) (KeyPage, error)
 }
 
+// AppendAny is the sentinel expectedSeq for EventLog.Append that appends
+// unconditionally at the stream's current head — an atomic server-side
+// increment, not a compare-and-swap. Topic publishers use it (RFC-0027): topic
+// events are independent, so serializing publishers through client-side CAS
+// retries would self-inflict contention under fan-in (the eventlogsub.tla
+// model's premise). CAS callers (the RFC-0022 fold, where interleave prevention
+// is the point) keep passing a real head.
+const AppendAny int64 = -1
+
 // EventLog is an append-only, ordered, replayable stream with optimistic
 // concurrency: Append succeeds only when expectedSeq equals the stream head, so
-// concurrent appenders get ErrVersionConflict instead of interleaving.
+// concurrent appenders get ErrVersionConflict instead of interleaving —
+// unless the caller opts out of the CAS with AppendAny.
 type EventLog interface {
 	// Append atomically appends events when expectedSeq equals the current head
 	// sequence, returning the new head sequence. A mismatch returns
-	// ErrVersionConflict and appends nothing.
+	// ErrVersionConflict and appends nothing (use Head to resynchronize).
+	// expectedSeq = AppendAny skips the head check and appends unconditionally
+	// at the current head.
 	Append(ctx context.Context, stream string, expectedSeq int64, events []Event) (int64, error)
 	// Read returns up to limit events with Seq > fromSeq, in order.
 	Read(ctx context.Context, stream string, fromSeq int64, limit int) ([]Event, error)
+	// Head returns the stream's current head sequence (0 for an absent stream),
+	// with no side effects. It backs start-at-head topic subscription and the
+	// consumer-lag gauge (RFC-0027), and lets a CAS caller resynchronize after
+	// ErrVersionConflict without walking the log.
+	Head(ctx context.Context, stream string) (int64, error)
 	// Trim drops events with Seq < belowSeq (history GC).
 	Trim(ctx context.Context, stream string, belowSeq int64) error
 }

--- a/pkg/statestore/interfaces.go
+++ b/pkg/statestore/interfaces.go
@@ -29,7 +29,10 @@ type KVStore interface {
 // events are independent, so serializing publishers through client-side CAS
 // retries would self-inflict contention under fan-in (the eventlogsub.tla
 // model's premise). CAS callers (the RFC-0022 fold, where interleave prevention
-// is the point) keep passing a real head.
+// is the point) keep passing a real head — and their streams' consumers rely on
+// it: AppendAny on a CAS-disciplined stream silently defeats its interleave
+// protection (the wire cannot tell stream kinds apart), so it belongs ONLY on
+// independent-event streams such as topic/*.
 const AppendAny int64 = -1
 
 // EventLog is an append-only, ordered, replayable stream with optimistic
@@ -41,7 +44,8 @@ type EventLog interface {
 	// sequence, returning the new head sequence. A mismatch returns
 	// ErrVersionConflict and appends nothing (use Head to resynchronize).
 	// expectedSeq = AppendAny skips the head check and appends unconditionally
-	// at the current head.
+	// at the current head. The returned head is meaningful only when err is nil
+	// or ErrVersionConflict; on any other error it is 0.
 	Append(ctx context.Context, stream string, expectedSeq int64, events []Event) (int64, error)
 	// Read returns up to limit events with Seq > fromSeq, in order.
 	Read(ctx context.Context, stream string, fromSeq int64, limit int) ([]Event, error)

--- a/pkg/statestore/memory/eventlog.go
+++ b/pkg/statestore/memory/eventlog.go
@@ -22,8 +22,10 @@ type streamState struct {
 // Append implements statestore.EventLog with optimistic concurrency on the head
 // sequence: it succeeds only when expectedSeq equals the current head, so
 // concurrent appenders get ErrVersionConflict instead of interleaving
-// (invariant E1). It assigns each event a sequential Seq and the current time as
-// At, and returns the new head.
+// (invariant E1). expectedSeq = AppendAny skips the check and appends
+// unconditionally at the current head (RFC-0027 topic publishers). It assigns
+// each event a sequential Seq and the current time as At, and returns the new
+// head.
 func (s *Store) Append(_ context.Context, stream string, expectedSeq int64, events []statestore.Event) (int64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -35,7 +37,7 @@ func (s *Store) Append(_ context.Context, stream string, expectedSeq int64, even
 		st = &streamState{}
 		s.streams[stream] = st
 	}
-	if st.head != expectedSeq {
+	if expectedSeq != statestore.AppendAny && st.head != expectedSeq {
 		return st.head, statestore.ErrVersionConflict
 	}
 	now := time.Now()
@@ -77,6 +79,21 @@ func (s *Store) Read(_ context.Context, stream string, fromSeq int64, limit int)
 		}
 	}
 	return out, nil
+}
+
+// Head implements statestore.EventLog: the stream's current head sequence, 0 for
+// an absent stream, with no side effects (it does not create the stream).
+func (s *Store) Head(_ context.Context, stream string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return 0, statestore.ErrClosed
+	}
+	st := s.streams[stream]
+	if st == nil {
+		return 0, nil
+	}
+	return st.head, nil
 }
 
 // Trim implements statestore.EventLog: drop events with Seq < belowSeq. The head

--- a/pkg/statestore/scoped.go
+++ b/pkg/statestore/scoped.go
@@ -174,6 +174,12 @@ func (e *meteredEventLog) Read(ctx context.Context, stream string, fromSeq int64
 	return evs, err
 }
 
+func (e *meteredEventLog) Head(ctx context.Context, stream string) (int64, error) {
+	head, err := e.inner.Head(ctx, stream)
+	observe(ctx, "eventlog", "head", err)
+	return head, err
+}
+
 func (e *meteredEventLog) Trim(ctx context.Context, stream string, belowSeq int64) error {
 	err := e.inner.Trim(ctx, stream, belowSeq)
 	observe(ctx, "eventlog", "trim", err)

--- a/pkg/statestore/sqlstore/eventlog.go
+++ b/pkg/statestore/sqlstore/eventlog.go
@@ -87,6 +87,12 @@ func (e *eventLog) Append(ctx context.Context, stream string, expectedSeq int64,
 		}
 		return nil
 	})
+	if err != nil && !errors.Is(err, statestore.ErrVersionConflict) {
+		// The tx rolled back: a head captured before a failed insert/commit names
+		// a sequence that never existed. The contract defines the returned head
+		// only for nil or ErrVersionConflict.
+		head = 0
+	}
 	return head, err
 }
 

--- a/pkg/statestore/sqlstore/eventlog.go
+++ b/pkg/statestore/sqlstore/eventlog.go
@@ -7,6 +7,7 @@ package sqlstore
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/fission/fission/pkg/statestore"
 )
@@ -23,36 +24,60 @@ type eventLog struct{ s *Store }
 // reserves the [expectedSeq+1, expectedSeq+N] slots (the events then insert with
 // no primary-key contention) and the loser gets ErrVersionConflict — never a raw
 // unique-violation a consumer wouldn't recognize.
+//
+// expectedSeq = AppendAny drops the WHERE head = ? re-check (RFC-0027 topic
+// publishers): the UPDATE is then an unconditional atomic increment, racing
+// appenders serialize on the same row lock, and EVERY writer reserves its own
+// disjoint slot range — no conflict, no client retry loop. The reserved base is
+// read back inside the transaction (own-write visibility), so the insert seqs
+// are exact under concurrency.
 func (e *eventLog) Append(ctx context.Context, stream string, expectedSeq int64, events []statestore.Event) (int64, error) {
 	var head int64
 	err := e.s.inTx(ctx, func(tx *sql.Tx) error {
-		// Ensure the stream row exists (idempotent), then CAS its head.
+		// Ensure the stream row exists (idempotent), then advance its head.
 		if _, ierr := tx.ExecContext(ctx, e.s.rebind(
 			`INSERT INTO state_streams (stream, head) VALUES (?, 0) ON CONFLICT (stream) DO NOTHING`),
 			stream,
 		); ierr != nil {
 			return ierr
 		}
-		res, uerr := tx.ExecContext(ctx, e.s.rebind(
-			`UPDATE state_streams SET head = head + ? WHERE stream = ? AND head = ?`),
-			int64(len(events)), stream, expectedSeq,
-		)
-		if uerr != nil {
-			return uerr
-		}
-		n, aerr := res.RowsAffected()
-		if aerr != nil {
-			return aerr
-		}
-		if n == 0 {
-			// CAS lost: report the current head so the caller can re-read.
-			if serr := tx.QueryRowContext(ctx, e.s.rebind(`SELECT head FROM state_streams WHERE stream = ?`), stream).Scan(&head); serr != nil {
+		var base int64
+		if expectedSeq == statestore.AppendAny {
+			if _, uerr := tx.ExecContext(ctx, e.s.rebind(
+				`UPDATE state_streams SET head = head + ? WHERE stream = ?`),
+				int64(len(events)), stream,
+			); uerr != nil {
+				return uerr
+			}
+			if serr := tx.QueryRowContext(ctx, e.s.rebind(
+				`SELECT head FROM state_streams WHERE stream = ?`), stream).Scan(&head); serr != nil {
 				return serr
 			}
-			return statestore.ErrVersionConflict
+			base = head - int64(len(events))
+		} else {
+			res, uerr := tx.ExecContext(ctx, e.s.rebind(
+				`UPDATE state_streams SET head = head + ? WHERE stream = ? AND head = ?`),
+				int64(len(events)), stream, expectedSeq,
+			)
+			if uerr != nil {
+				return uerr
+			}
+			n, aerr := res.RowsAffected()
+			if aerr != nil {
+				return aerr
+			}
+			if n == 0 {
+				// CAS lost: report the current head so the caller can re-read.
+				if serr := tx.QueryRowContext(ctx, e.s.rebind(`SELECT head FROM state_streams WHERE stream = ?`), stream).Scan(&head); serr != nil {
+					return serr
+				}
+				return statestore.ErrVersionConflict
+			}
+			base = expectedSeq
+			head = expectedSeq + int64(len(events))
 		}
 		now := nowNanos()
-		seq := expectedSeq
+		seq := base
 		insertSQL := e.s.rebind(`INSERT INTO state_events (stream, seq, type, payload, at) VALUES (?, ?, ?, ?, ?)`)
 		for _, ev := range events {
 			seq++
@@ -60,10 +85,23 @@ func (e *eventLog) Append(ctx context.Context, stream string, expectedSeq int64,
 				return ierr
 			}
 		}
-		head = expectedSeq + int64(len(events))
 		return nil
 	})
 	return head, err
+}
+
+// Head implements statestore.EventLog: the stream's current head sequence, 0 for
+// an absent stream, with no side effects (it does not create the stream row).
+func (e *eventLog) Head(ctx context.Context, stream string) (int64, error) {
+	var head int64
+	err := e.s.queryRow(ctx, `SELECT head FROM state_streams WHERE stream = ?`, stream).Scan(&head)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return head, nil
 }
 
 // Read implements statestore.EventLog: up to limit events with seq > fromSeq, in

--- a/pkg/statestore/statestoretest/conformance.go
+++ b/pkg/statestore/statestoretest/conformance.go
@@ -247,6 +247,46 @@ func runEventLog(t *testing.T, newCaps Factory) {
 		require.EqualValues(t, 1, head)
 	})
 
+	t.Run("CASVersusAppendAnyRace", func(t *testing.T) {
+		el := eventLogOrSkip(t, newCaps)
+		ctx := t.Context()
+		// CAS callers keep their interleave protection while AppendAny writers
+		// race them: every AppendAny lands; a CAS at a stale head conflicts. At
+		// most one stale-head CAS can win (only by executing first), and the
+		// final head accounts for exactly the successful writes — gapless.
+		const anyWriters = 8
+		const casWriters = 4
+		var casWins, anyFailures atomic.Int64
+		var wg sync.WaitGroup
+		for range anyWriters {
+			wg.Go(func() {
+				if _, err := el.Append(ctx, "mixedrace", statestore.AppendAny, []statestore.Event{{Type: "any"}}); err != nil {
+					anyFailures.Add(1)
+				}
+			})
+		}
+		for range casWriters {
+			wg.Go(func() {
+				if _, err := el.Append(ctx, "mixedrace", 0, []statestore.Event{{Type: "cas"}}); err == nil {
+					casWins.Add(1)
+				} else {
+					require.ErrorIs(t, err, statestore.ErrVersionConflict, "a losing CAS gets the conflict sentinel, not a raw error")
+				}
+			})
+		}
+		wg.Wait()
+		require.Zero(t, anyFailures.Load(), "AppendAny never conflicts, even racing CAS writers")
+		require.LessOrEqual(t, casWins.Load(), int64(1), "at most one CAS-at-0 can win")
+
+		want := int64(anyWriters) + casWins.Load()
+		head, err := el.Head(ctx, "mixedrace")
+		require.NoError(t, err)
+		require.Equal(t, want, head)
+		evs, err := el.Read(ctx, "mixedrace", 0, 0)
+		require.NoError(t, err)
+		require.Len(t, evs, int(want), "the log holds exactly the successful writes, gapless")
+	})
+
 	t.Run("ConcurrentAppendAnyAllWin", func(t *testing.T) {
 		el := eventLogOrSkip(t, newCaps)
 		ctx := t.Context()

--- a/pkg/statestore/statestoretest/conformance.go
+++ b/pkg/statestore/statestoretest/conformance.go
@@ -257,6 +257,9 @@ func runEventLog(t *testing.T, newCaps Factory) {
 		const anyWriters = 8
 		const casWriters = 4
 		var casWins, anyFailures atomic.Int64
+		// Collected in the workers, asserted after Wait: testify must not run on
+		// non-test goroutines (require.FailNow would Goexit the wrong goroutine).
+		casErrs := make(chan error, casWriters)
 		var wg sync.WaitGroup
 		for range anyWriters {
 			wg.Go(func() {
@@ -270,11 +273,15 @@ func runEventLog(t *testing.T, newCaps Factory) {
 				if _, err := el.Append(ctx, "mixedrace", 0, []statestore.Event{{Type: "cas"}}); err == nil {
 					casWins.Add(1)
 				} else {
-					require.ErrorIs(t, err, statestore.ErrVersionConflict, "a losing CAS gets the conflict sentinel, not a raw error")
+					casErrs <- err
 				}
 			})
 		}
 		wg.Wait()
+		close(casErrs)
+		for err := range casErrs {
+			require.ErrorIs(t, err, statestore.ErrVersionConflict, "a losing CAS gets the conflict sentinel, not a raw error")
+		}
 		require.Zero(t, anyFailures.Load(), "AppendAny never conflicts, even racing CAS writers")
 		require.LessOrEqual(t, casWins.Load(), int64(1), "at most one CAS-at-0 can win")
 

--- a/pkg/statestore/statestoretest/conformance.go
+++ b/pkg/statestore/statestoretest/conformance.go
@@ -201,6 +201,83 @@ func runEventLog(t *testing.T, newCaps Factory) {
 		wg.Wait()
 		require.EqualValues(t, 1, wins.Load())
 	})
+
+	t.Run("AppendAnyAndHead", func(t *testing.T) {
+		el := eventLogOrSkip(t, newCaps)
+		ctx := t.Context()
+		// Head on an absent stream is 0 and has no side effects: a CAS append at
+		// 0 still succeeds afterwards (the stream was not created by the read).
+		head, err := el.Head(ctx, "anyhead")
+		require.NoError(t, err)
+		require.Zero(t, head)
+		head, err = el.Append(ctx, "anyhead", 0, []statestore.Event{{Type: "a"}, {Type: "b"}})
+		require.NoError(t, err)
+		require.EqualValues(t, 2, head)
+		head, err = el.Head(ctx, "anyhead")
+		require.NoError(t, err)
+		require.EqualValues(t, 2, head, "Head reflects the CAS append")
+
+		// AppendAny appends at the current head with no CAS: no conflict even
+		// though the caller never read the head.
+		head, err = el.Append(ctx, "anyhead", statestore.AppendAny, []statestore.Event{{Type: "c"}})
+		require.NoError(t, err)
+		require.EqualValues(t, 3, head)
+
+		// The two modes interoperate: a CAS caller resynchronizes via Head and
+		// appends at the post-AppendAny head.
+		head, err = el.Head(ctx, "anyhead")
+		require.NoError(t, err)
+		require.EqualValues(t, 3, head)
+		head, err = el.Append(ctx, "anyhead", 3, []statestore.Event{{Type: "d"}})
+		require.NoError(t, err)
+		require.EqualValues(t, 4, head)
+
+		// The log is gapless and ordered across both modes.
+		evs, err := el.Read(ctx, "anyhead", 0, 0)
+		require.NoError(t, err)
+		require.Len(t, evs, 4)
+		for i, ev := range evs {
+			require.EqualValues(t, i+1, ev.Seq)
+		}
+		require.Equal(t, "c", evs[2].Type)
+
+		// AppendAny on an absent stream creates it at seq 1.
+		head, err = el.Append(ctx, "anyfresh", statestore.AppendAny, []statestore.Event{{Type: "x"}})
+		require.NoError(t, err)
+		require.EqualValues(t, 1, head)
+	})
+
+	t.Run("ConcurrentAppendAnyAllWin", func(t *testing.T) {
+		el := eventLogOrSkip(t, newCaps)
+		ctx := t.Context()
+		// Independent topic publishers must all land without a retry loop
+		// (RFC-0027): every AppendAny wins, seqs are unique and gapless.
+		const writers = 12
+		var failures atomic.Int64
+		var wg sync.WaitGroup
+		for range writers {
+			wg.Go(func() {
+				if _, err := el.Append(ctx, "anyrace", statestore.AppendAny, []statestore.Event{{Type: "e"}}); err != nil {
+					failures.Add(1)
+				}
+			})
+		}
+		wg.Wait()
+		require.Zero(t, failures.Load(), "AppendAny never conflicts")
+
+		head, err := el.Head(ctx, "anyrace")
+		require.NoError(t, err)
+		require.EqualValues(t, writers, head)
+		evs, err := el.Read(ctx, "anyrace", 0, 0)
+		require.NoError(t, err)
+		require.Len(t, evs, writers)
+		seen := map[int64]bool{}
+		for _, ev := range evs {
+			require.False(t, seen[ev.Seq], "duplicate seq %d", ev.Seq)
+			seen[ev.Seq] = true
+			require.True(t, ev.Seq >= 1 && ev.Seq <= writers, "seq %d out of the gapless range", ev.Seq)
+		}
+	})
 }
 
 func runQueue(t *testing.T, newCaps Factory) {


### PR DESCRIPTION
## RFC-0027 statestore-backed eventing — Phase 1

First implementation phase of [RFC-0027](../blob/main/docs/rfc/0027-statestore-backed-eventing.md) (#3582): the EventLog extension, the `TopicPublisher`, and **statestore topic destinations** — un-deferring RFC-0024's design decision D1 with **zero external brokers**.

### What lands

**EventLog extension** (`pkg/statestore`, protocol pinned by `specs/eventlogsub.tla`)
- `Append(stream, AppendAny, events)`: the `-1` sentinel drops the CAS re-check — the head `UPDATE` becomes an unconditional atomic increment, racing appenders serialize on the row lock and each reserves a disjoint slot range (base read back in-tx for own-write visibility). Topic publishers land in one round-trip with no retry loop.
- `Head(ctx, stream)`: the current head (0 for an absent stream, no side effects) — backs start-at-head subscription, the lag gauge, and CAS-caller resynchronization.
- Across: interface, memory + sqlstore drivers, metered wrapper, the HTTP wire (`/v1/eventlog/head`), the client driver, and conformance — including a 12-writer `AppendAny` race (all win, gapless unique seqs) and a mixed CAS-vs-`AppendAny` race (CAS keeps `ErrVersionConflict` semantics). Returned-head contract documented: meaningful only on `nil`/`ErrVersionConflict`.

**`pkg/mqtrigger/mqpub`** — `TopicPublisher`, the outbound mirror of the `MessageQueue` interface (named to stay distinct from `pkg/publisher`). The statestore impl publishes one event to the stream `topic/<ns>/<topic>` (contentType travels as `Event.Type` for delivery replay); a nil return **is** the durability guarantee (E1). Broker types map to `ErrUnsupportedMQType` until the egress phase.

**Statestore topic destinations** (router + CRD)
- `DestinationRef`/`TopicRef.Validate` accepts `messageQueueType: statestore`; broker types stay honestly rejected. `ValidateTopicName` bounds names to `[a-zA-Z0-9._-]{1,249}` — no `/`, so the namespaced stream mapping cannot alias — with matching kubebuilder `Pattern`/`MaxLength` schema markers (API-server-enforced even without the webhook).
- The dispatcher's `fireDestination` topic arm publishes the result envelope via an injected `TopicPublishFunc` (all-strings — `asyncinvoke` stays a pure library). A topic is a **leaf**: it terminates the chain, no depth accounting; every drop path is counted (`topic_unsupported` / `publisher_unconfigured` / `encode_error` / `publish_error`).
- Topics are namespace-scoped like function destinations (R6): the destination inherits the source function's namespace.

### Review battery applied (code + security + silent-failure)
- **Security (medium, fixed)**: phase-1 topics had no consumer and no `Trim` caller — unbounded growth on the shared store. The publisher now enforces a soft per-topic backlog cap (10k, `Head`-checked, loud `capped` rejection); P2's retention supersedes it.
- Sink-side re-validation of namespace/topic (injectivity must not depend on one distant webhook); chain `Depth` stamped into `RequestContext` now so a future async topic consumer can enforce the A6 cap without a wire migration; `publisher_unconfigured` split from `topic_unsupported` (wiring defect ≠ forged envelope); fixed-value provider label (cardinality); phantom-head zeroing on rolled-back appends; stale CRD doc comment corrected.
- Verified by the lenses: E1 no-fake-accept, AppendAny tx correctness on Postgres + SQLite, `Head` side-effect-freeness, cross-namespace injectivity, `/v1/eventlog/head` behind the HMAC verifier, A3 gate untouched, no SQL/log/label injection.

### Tested
Conformance (memory + SQLite + HTTP client; Postgres via the `statestore-integration` CI job): AppendAny/CAS interop, concurrent races, Head semantics. Unit: publisher (E1 fail-loud, cap, invalid inputs, namespace isolation), dispatcher topic arm (leaf-ness, payload fidelity, drops), admission matrix, depth stamping. `eventlogsub.tla` unchanged — the implementation matches the checked model.

Next: Phase 2 (`messageQueueType: statestore` MQ-trigger provider + chart + kind e2e pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
