### PR TITLE
feat: RFC-0027 statestore eventing Phase 2 — built-in MQ provider + zero-broker e2e

### DIFF
--- a/charts/fission-all/templates/_fission-component-roles.tpl
+++ b/charts/fission-all/templates/_fission-component-roles.tpl
@@ -104,6 +104,26 @@ rules:
   - update
   - patch
 {{- end }}
+{{- define "statestore-mqt-rules" }}
+rules:
+- apiGroups:
+  - fission.io
+  resources:
+  - messagequeuetriggers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - fission.io
+  resources:
+  - messagequeuetriggers/status
+  verbs:
+  - get
+  - update
+  - patch
+{{- end }}
+
 {{- define "kafka-rules" }}
 rules:
 - apiGroups:

--- a/charts/fission-all/templates/_fission-component-roles.tpl
+++ b/charts/fission-all/templates/_fission-component-roles.tpl
@@ -106,6 +106,17 @@ rules:
 {{- end }}
 {{- define "statestore-mqt-rules" }}
 rules:
+# functions list is required by the boot path (crd.WaitForFunctionCRDs probes
+# CRD readiness with a Functions List; Forbidden there crash-loops the head).
+# Delivery itself is HTTP via the router, so no environments/packages needed.
+- apiGroups:
+  - fission.io
+  resources:
+  - functions
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - fission.io
   resources:

--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -248,6 +248,18 @@ rules:
   - list
   - watch
 {{- end }}
+{{- define "statestore-mqt-kuberules" }}
+rules:
+{{- include "leases-kuberules" . }}
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+{{- end }}
+
 {{- define "kafka-kuberules" }}
 rules:
 {{- include "leases-kuberules" . }}

--- a/charts/fission-all/templates/_fission-kuberntes-role-generator.tpl
+++ b/charts/fission-all/templates/_fission-kuberntes-role-generator.tpl
@@ -26,6 +26,9 @@ metadata:
 {{- if eq "kafka" .component }}
 {{- include "kafka-kuberules" . }}
 {{- end }}
+{{- if eq "statestore-mqt" .component }}
+{{- include "statestore-mqt-kuberules" . }}
+{{- end }}
 {{- if eq "keda" .component }}
 {{- include "keda-kuberules" . }}
 {{- end }}

--- a/charts/fission-all/templates/_fission-role-generator.tpl
+++ b/charts/fission-all/templates/_fission-role-generator.tpl
@@ -112,6 +112,9 @@ metadata:
 {{- if eq "executor" .component }}
 {{- include "executor-rules" . }}
 {{- end }}
+{{- if eq "statestore-mqt" .component }}
+{{- include "statestore-mqt-rules" . }}
+{{- end }}
 # Read FissionTenant (cluster-scoped) so the component's resolver-sync keeps its
 # live tenant set current and a runtime-onboarded namespace reaches its
 # membership predicate without a restart. Appended to the same rules list above.

--- a/charts/fission-all/templates/_fission-role-generator.tpl
+++ b/charts/fission-all/templates/_fission-role-generator.tpl
@@ -26,6 +26,9 @@ metadata:
 {{- if eq "kafka" .component }}
 {{- include "kafka-rules" . }}
 {{- end }}
+{{- if eq "statestore-mqt" .component }}
+{{- include "statestore-mqt-rules" . }}
+{{- end }}
 {{- if eq "keda" .component }}
 {{- include "keda-rules" . }}
 {{- end }}

--- a/charts/fission-all/templates/mqt-fission-statestore/deployment.yaml
+++ b/charts/fission-all/templates/mqt-fission-statestore/deployment.yaml
@@ -1,0 +1,95 @@
+{{- if and .Values.statestore.enabled .Values.eventing.enabled }}
+# RFC-0027 built-in eventing head: the statestore MessageQueue provider.
+# messageQueueType: statestore triggers consume topics (EventLog streams written
+# by async destinations or other publishers) with zero external brokers. One
+# classic mqt deployment per MQ type, per the mqt-fission-kafka convention.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mqtrigger-statestore
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: mqtrigger
+    messagequeue: statestore
+spec:
+  replicas: {{ dig "replicas" 1 (.Values.eventing | default dict) }}
+  selector:
+    matchLabels:
+      svc: mqtrigger
+      messagequeue: statestore
+  template:
+    metadata:
+      labels:
+        svc: mqtrigger
+        messagequeue: statestore
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "8080"
+    spec:
+      containers:
+      - name: mqtrigger
+        image: {{ include "fission-bundleImage" . | quote }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command: ["/fission-bundle"]
+        args: ["--mqt", "--routerUrl", "http://router.{{ .Release.Namespace }}"]
+        ports:
+          - containerPort: 8080
+            name: metrics
+        env:
+        {{- include "fission.podNamespaceEnv" . | nindent 8 }}
+        {{- include "leaderElection.envs" (dict "enabled" (dig "leaderElection" "enabled" false (.Values.eventing | default dict))) | indent 8 }}
+        - name: MESSAGE_QUEUE_TYPE
+          value: statestore
+        # The provider opens the statestore exactly like the router's async path:
+        # embedded -> the capability service over HTTP, external -> Postgres.
+        {{- if eq .Values.statestore.mode "embedded" }}
+        - name: STATESTORE_DRIVER
+          value: "client"
+        - name: STATESTORE_DSN
+          value: "http://statestore.{{ .Release.Namespace }}:{{ include "fission.statestorePort" . }}"
+        {{- else if eq .Values.statestore.mode "external" }}
+        - name: STATESTORE_DRIVER
+          value: "postgres"
+        - name: STATESTORE_DSN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.statestore.external.existingSecret | default "statestore-postgres" }}
+              key: dsn
+        {{- end }}
+        - name: DEBUG_ENV
+          value: {{ .Values.debugEnv | quote }}
+        - name: PPROF_ENABLED
+          value: {{ .Values.pprof.enabled | quote }}
+        # /fission-function/<ns>/<name> lives only on the router's internal
+        # listener (GHSA-3g33-6vg6-27m8). The consumer signs each invocation when
+        # FISSION_INTERNAL_AUTH_SECRET is set (mounted by internalAuth.envs).
+        - name: ROUTER_INTERNAL_URL
+          value: {{ include "fission.routerInternalURL" . | quote }}
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
+        {{- include "opentelemtry.envs" . | indent 8 }}
+        {{- include "internalAuth.envs" . | indent 8 }}
+        {{- include "coverage.envs" . | indent 8 }}
+        {{- if .Values.coverage.enabled }}
+        volumeMounts:
+        {{- include "coverage.volumemount" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.terminationMessagePath }}
+        terminationMessagePath: {{ .Values.terminationMessagePath }}
+        {{- end }}
+        {{- if .Values.terminationMessagePolicy }}
+        terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
+        {{- end }}
+      serviceAccountName: fission-statestore-mqt
+      {{- if .Values.coverage.enabled }}
+      volumes:
+      {{- include "coverage.volume" . | indent 6 }}
+      {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.extraCoreComponentPodConfig }}
+{{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
+{{- end }}
+{{- end }}

--- a/charts/fission-all/templates/mqt-fission-statestore/serviceaccount.yaml
+++ b/charts/fission-all/templates/mqt-fission-statestore/serviceaccount.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.statestore.enabled .Values.eventing.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fission-statestore-mqt
+  namespace: {{ .Release.Namespace }}
+{{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "statestore-mqt") .) }}
+
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
+{{- range $namespace := $.Values.additionalFissionNamespaces }}
+{{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "statestore-mqt") $) }}
+{{- end }}
+{{- end }}
+{{- include "kubernetes-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "statestore-mqt") .) }}
+
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
+{{- range $namespace := $.Values.additionalFissionNamespaces }}
+{{ include "kubernetes-role-generator" (merge (dict "namespace" $namespace "component" "statestore-mqt") $) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fission-all/templates/statestore/networkpolicy.yaml
+++ b/charts/fission-all/templates/statestore/networkpolicy.yaml
@@ -22,6 +22,7 @@ spec:
         - podSelector: { matchLabels: { svc: workflow } }
         - podSelector: { matchLabels: { svc: statesvc } }
         - podSelector: { matchLabels: { svc: router } }
+        - podSelector: { matchLabels: { svc: mqtrigger } }
       ports:
         - port: {{ include "fission.statestorePort" . }}
           protocol: TCP

--- a/charts/fission-all/templates/statestore/networkpolicy.yaml
+++ b/charts/fission-all/templates/statestore/networkpolicy.yaml
@@ -22,7 +22,9 @@ spec:
         - podSelector: { matchLabels: { svc: workflow } }
         - podSelector: { matchLabels: { svc: statesvc } }
         - podSelector: { matchLabels: { svc: router } }
-        - podSelector: { matchLabels: { svc: mqtrigger } }
+        # Only the statestore mqt head — svc: mqtrigger alone would also admit
+        # the kafka head, which has no statestore code path (least privilege).
+        - podSelector: { matchLabels: { svc: mqtrigger, messagequeue: statestore } }
       ports:
         - port: {{ include "fission.statestorePort" . }}
           protocol: TCP

--- a/charts/fission-all/templates/tenant-controller/dynamic-cluster-roles.yaml
+++ b/charts/fission-all/templates/tenant-controller/dynamic-cluster-roles.yaml
@@ -8,7 +8,7 @@
 # namespace-scoped (per-namespace Roles + scoped cache); cluster mode grants those
 # cluster-wide via the separate cluster-mode-bindings.yaml. The per-namespace Roles
 # remain for the static path.
-{{- range $component := list "buildermgr" "kubewatcher" "mcp" "kafka" "keda" "router" "timer" "canaryconfig" "executor" }}
+{{- range $component := list "buildermgr" "kubewatcher" "mcp" "kafka" "keda" "router" "timer" "canaryconfig" "executor" "statestore-mqt" }}
 {{- include "fission-cluster-role-generator" (merge (dict "component" $component) $) }}
 {{- end }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -764,6 +764,17 @@ statestore:
 asyncInvocation:
   enabled: false
 
+## RFC-0027 statestore-backed eventing: the built-in MessageQueue provider
+## (messageQueueType: statestore) — topics on the statestore EventLog, consumed
+## by the mqtrigger-statestore head with zero external brokers. Effective only
+## when statestore.enabled (the deployment gates on both); enabled by default so
+## a statestore-enabled install gets the full eventing loop out of the box.
+eventing:
+  enabled: true
+  replicas: 1
+  leaderElection:
+    enabled: false
+
 ## Multi-namespace tenancy (docs/multiple-namespace).
 ##
 tenancy:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -771,6 +771,9 @@ asyncInvocation:
 ## a statestore-enabled install gets the full eventing loop out of the box.
 eventing:
   enabled: true
+  ## replicas > 1 REQUIRES leaderElection.enabled: true — without election every
+  ## replica is a live consumer of every trigger (permanent duplicate delivery
+  ## and cursor churn, not HA).
   replicas: 1
   leaderElection:
     enabled: false

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -21,6 +21,7 @@ import (
 	"github.com/fission/fission/pkg/mqtrigger/factory"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/kafka"
+	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/statestore"
 	"github.com/fission/fission/pkg/utils/crmanager"
 	"github.com/fission/fission/pkg/utils/metrics"
 )

--- a/cmd/fission-bundle/mqtrigger/mqtrigger.go
+++ b/cmd/fission-bundle/mqtrigger/mqtrigger.go
@@ -22,6 +22,13 @@ import (
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/kafka"
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/statestore"
+
+	// Statestore drivers the statestore MQ provider opens via STATESTORE_DRIVER:
+	// the HTTP client (embedded mode → svc/statestore) and Postgres (external
+	// mode → the DB directly). Registered here, not in the provider package, so
+	// importing the provider for its validator (fission CLI) links no drivers.
+	_ "github.com/fission/fission/pkg/statestore/client"
+	_ "github.com/fission/fission/pkg/statestore/postgres"
 	"github.com/fission/fission/pkg/utils/crmanager"
 	"github.com/fission/fission/pkg/utils/metrics"
 )

--- a/cmd/fission-cli/app/app.go
+++ b/cmd/fission-cli/app/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/flag"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/kafka"
+	_ "github.com/fission/fission/pkg/mqtrigger/messageQueue/statestore"
 )
 
 const (

--- a/pkg/apis/core/v1/conditions.go
+++ b/pkg/apis/core/v1/conditions.go
@@ -117,6 +117,11 @@ const (
 
 	// MessageQueueTrigger condition reasons
 	MessageQueueTriggerReasonSubscribed = "Subscribed"
+	// MessageQueueTriggerReasonNotOwned: the head that held this trigger's
+	// subscription tore it down because a spec change moved the trigger to a
+	// different MQ type/kind — whether another head picks it up depends on that
+	// head being deployed.
+	MessageQueueTriggerReasonNotOwned = "NotOwned"
 
 	// CanaryConfig condition reasons (mirror Status string enum)
 	CanaryConfigReasonInProgress = "InProgress"

--- a/pkg/apis/core/v1/validation.go
+++ b/pkg/apis/core/v1/validation.go
@@ -975,6 +975,13 @@ func (spec MessageQueueTriggerSpec) validateForAdmission() error {
 		if len(spec.ResponseTopic) > 0 && !validator.IsValidTopic((string)(spec.MessageQueueType), spec.ResponseTopic, spec.MqtKind) {
 			errs = errors.Join(errs, MakeValidationErr(ErrorInvalidValue, "MessageQueueTriggerSpec.ResponseTopic", spec.ResponseTopic, "not a valid topic"))
 		}
+
+		// An invalid ErrorTopic is worse than an invalid ResponseTopic: the
+		// consumer refuses to advance past a poison event whose error-topic
+		// publish keeps failing (E5), so the trigger wedges re-delivering it.
+		if len(spec.ErrorTopic) > 0 && !validator.IsValidTopic((string)(spec.MessageQueueType), spec.ErrorTopic, spec.MqtKind) {
+			errs = errors.Join(errs, MakeValidationErr(ErrorInvalidValue, "MessageQueueTriggerSpec.ErrorTopic", spec.ErrorTopic, "not a valid topic"))
+		}
 	}
 
 	return errs

--- a/pkg/apis/core/v1/validation_validators_test.go
+++ b/pkg/apis/core/v1/validation_validators_test.go
@@ -10,7 +10,39 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/mqtrigger/validator"
 )
+
+// TestMessageQueueTriggerSpecValidateForAdmission: Topic, ResponseTopic AND
+// ErrorTopic are all validated for a classic-kind trigger — an invalid
+// ErrorTopic is the worst of the three to admit, since the consumer refuses to
+// advance past a poison event whose error-topic publish keeps failing (E5) and
+// the trigger wedges.
+func TestMessageQueueTriggerSpecValidateForAdmission(t *testing.T) {
+	t.Parallel()
+	validator.Register("test-classic-mq", func(topic string) bool { return !strings.Contains(topic, "/") })
+
+	base := func(mutate func(*MessageQueueTriggerSpec)) MessageQueueTriggerSpec {
+		spec := MessageQueueTriggerSpec{
+			FunctionReference: FunctionReference{Type: FunctionReferenceTypeFunctionName, Name: "fn"},
+			MessageQueueType:  "test-classic-mq",
+			MqtKind:           "fission",
+			Topic:             "orders",
+		}
+		if mutate != nil {
+			mutate(&spec)
+		}
+		return spec
+	}
+
+	require.NoError(t, base(nil).validateForAdmission())
+	require.NoError(t, base(func(s *MessageQueueTriggerSpec) { s.ResponseTopic, s.ErrorTopic = "replies", "errs" }).validateForAdmission())
+	require.Error(t, base(func(s *MessageQueueTriggerSpec) { s.Topic = "bad/topic" }).validateForAdmission())
+	require.Error(t, base(func(s *MessageQueueTriggerSpec) { s.ResponseTopic = "bad/topic" }).validateForAdmission())
+	require.Error(t, base(func(s *MessageQueueTriggerSpec) { s.ErrorTopic = "bad/topic" }).validateForAdmission())
+	require.Error(t, base(func(s *MessageQueueTriggerSpec) { s.MessageQueueType = "unregistered" }).validateForAdmission())
+}
 
 func TestValidateKubeName(t *testing.T) {
 	t.Parallel()

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -29,6 +29,7 @@ func Commands() *cobra.Command {
 			flag.FnToolInputSchema, flag.FnToolName,
 			flag.FnAsyncMaxAttempts, flag.FnAsyncMaxAge,
 			flag.FnAsyncOnSuccess, flag.FnAsyncOnFailure,
+			flag.FnAsyncOnSuccessTopic, flag.FnAsyncOnFailureTopic,
 			flag.FnOnceOnly, flag.Labels, flag.Annotation, flag.FnRetainPods,
 
 			// TODO retired pkg & trigger related flags from function cmd
@@ -89,6 +90,7 @@ func Commands() *cobra.Command {
 			flag.FnToolInputSchema, flag.FnToolName,
 			flag.FnAsyncMaxAttempts, flag.FnAsyncMaxAge,
 			flag.FnAsyncOnSuccess, flag.FnAsyncOnFailure,
+			flag.FnAsyncOnSuccessTopic, flag.FnAsyncOnFailureTopic,
 			flag.FnOnceOnly, flag.Labels, flag.Annotation, flag.FnRetainPods,
 
 			flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -92,14 +92,16 @@ func getToolConfig(input cli.Input, existing *fv1.ToolConfig) (*fv1.ToolConfig, 
 // getInvocationConfig builds the RFC-0024 async InvocationConfig from the
 // --async-* flags, merging onto existing (the function's current config, or nil on
 // create) so an `fn update` that sets only one field keeps the rest. It returns nil
-// when nothing is configured. An empty --async-on-success/--async-on-failure clears
-// that destination. Field bounds and the destination shape are validated server-side
-// by the Function admission webhook, so the CLI stays thin.
-func getInvocationConfig(input cli.Input, existing *fv1.InvocationConfig) *fv1.InvocationConfig {
+// when nothing is configured. An empty --async-on-success/--async-on-failure (or
+// their -topic variants) clears that destination. Field bounds and the destination
+// shape are validated server-side by the Function admission webhook, so the CLI
+// stays thin.
+func getInvocationConfig(input cli.Input, existing *fv1.InvocationConfig) (*fv1.InvocationConfig, error) {
 	set := input.IsSet(flagkey.FnAsyncMaxAttempts) || input.IsSet(flagkey.FnAsyncMaxAge) ||
-		input.IsSet(flagkey.FnAsyncOnSuccess) || input.IsSet(flagkey.FnAsyncOnFailure)
+		input.IsSet(flagkey.FnAsyncOnSuccess) || input.IsSet(flagkey.FnAsyncOnFailure) ||
+		input.IsSet(flagkey.FnAsyncOnSuccessTopic) || input.IsSet(flagkey.FnAsyncOnFailureTopic)
 	if !set {
-		return existing
+		return existing, nil
 	}
 	ic := &fv1.InvocationConfig{}
 	if existing != nil {
@@ -111,23 +113,40 @@ func getInvocationConfig(input cli.Input, existing *fv1.InvocationConfig) *fv1.I
 	if input.IsSet(flagkey.FnAsyncMaxAge) {
 		ic.MaxAge = &metav1.Duration{Duration: input.Duration(flagkey.FnAsyncMaxAge)}
 	}
-	if input.IsSet(flagkey.FnAsyncOnSuccess) {
-		ic.OnSuccess = functionDestination(input.String(flagkey.FnAsyncOnSuccess))
+	var err error
+	if ic.OnSuccess, err = destinationFromFlags(input, flagkey.FnAsyncOnSuccess, flagkey.FnAsyncOnSuccessTopic, ic.OnSuccess); err != nil {
+		return nil, err
 	}
-	if input.IsSet(flagkey.FnAsyncOnFailure) {
-		ic.OnFailure = functionDestination(input.String(flagkey.FnAsyncOnFailure))
+	if ic.OnFailure, err = destinationFromFlags(input, flagkey.FnAsyncOnFailure, flagkey.FnAsyncOnFailureTopic, ic.OnFailure); err != nil {
+		return nil, err
 	}
-	return ic
+	return ic, nil
 }
 
-// functionDestination builds a same-namespace function DestinationRef, or nil for
-// an empty name (clearing the destination).
-func functionDestination(name string) *fv1.DestinationRef {
-	if name == "" {
-		return nil
+// destinationFromFlags resolves one destination condition from its flag pair —
+// a same-namespace function (fnKey) or a statestore topic (topicKey). A
+// DestinationRef holds exactly one kind, so setting both non-empty is an
+// error; setting either to "" clears the destination; setting neither keeps
+// current.
+func destinationFromFlags(input cli.Input, fnKey, topicKey string, current *fv1.DestinationRef) (*fv1.DestinationRef, error) {
+	if !input.IsSet(fnKey) && !input.IsSet(topicKey) {
+		return current, nil
 	}
-	return &fv1.DestinationRef{
-		Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: name},
+	fnName, topic := input.String(fnKey), input.String(topicKey)
+	if fnName != "" && topic != "" {
+		return nil, fmt.Errorf("--%s and --%s are mutually exclusive (a destination is a function OR a topic)", fnKey, topicKey)
+	}
+	switch {
+	case fnName != "":
+		return &fv1.DestinationRef{
+			Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: fnName},
+		}, nil
+	case topic != "":
+		return &fv1.DestinationRef{
+			Topic: &fv1.TopicRef{MessageQueueType: fv1.MessageQueueTypeStatestore, Topic: topic},
+		}, nil
+	default:
+		return nil, nil // explicit empty clears the destination
 	}
 }
 
@@ -330,6 +349,11 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		return err
 	}
 
+	invocation, err := getInvocationConfig(input, nil)
+	if err != nil {
+		return err
+	}
+
 	opts.function = &fv1.Function{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fnName,
@@ -344,7 +368,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			IdleTimeout:     &fnIdleTimeout,
 			Streaming:       getStreamingConfig(input),
 			Tool:            toolConfig,
-			Invocation:      getInvocationConfig(input, nil),
+			Invocation:      invocation,
 			Concurrency:     fnConcurrency,
 			RequestsPerPod:  requestsPerPod,
 			RetainPods:      retainPods,

--- a/pkg/fission-cli/cmd/function/invocation_config_test.go
+++ b/pkg/fission-cli/cmd/function/invocation_config_test.go
@@ -35,12 +35,16 @@ func TestGetInvocationConfig(t *testing.T) {
 	t.Parallel()
 
 	t.Run("nothing set, no existing → nil", func(t *testing.T) {
-		assert.Nil(t, getInvocationConfig(fakeInvInput{}, nil))
+		ic, err := getInvocationConfig(fakeInvInput{}, nil)
+		require.NoError(t, err)
+		assert.Nil(t, ic)
 	})
 
 	t.Run("nothing set keeps existing untouched", func(t *testing.T) {
 		existing := &fv1.InvocationConfig{MaxAge: &metav1.Duration{Duration: time.Hour}}
-		assert.Same(t, existing, getInvocationConfig(fakeInvInput{}, existing))
+		ic, err := getInvocationConfig(fakeInvInput{}, existing)
+		require.NoError(t, err)
+		assert.Same(t, existing, ic)
 	})
 
 	t.Run("all fields from flags", func(t *testing.T) {
@@ -50,7 +54,8 @@ func TestGetInvocationConfig(t *testing.T) {
 			d:   map[string]time.Duration{flagkey.FnAsyncMaxAge: 2 * time.Hour},
 			s:   map[string]string{flagkey.FnAsyncOnSuccess: "notify", flagkey.FnAsyncOnFailure: "alert"},
 		}
-		ic := getInvocationConfig(in, nil)
+		ic, err := getInvocationConfig(in, nil)
+		require.NoError(t, err)
 		require.NotNil(t, ic)
 		require.NotNil(t, ic.Retry.MaxAttempts)
 		assert.Equal(t, 3, *ic.Retry.MaxAttempts)
@@ -71,7 +76,8 @@ func TestGetInvocationConfig(t *testing.T) {
 			set: map[string]bool{flagkey.FnAsyncMaxAttempts: true},
 			i:   map[string]int{flagkey.FnAsyncMaxAttempts: 5},
 		}
-		ic := getInvocationConfig(in, existing)
+		ic, err := getInvocationConfig(in, existing)
+		require.NoError(t, err)
 		require.NotNil(t, ic.Retry.MaxAttempts)
 		assert.Equal(t, 5, *ic.Retry.MaxAttempts)
 		require.NotNil(t, ic.OnSuccess, "existing OnSuccess preserved")
@@ -88,7 +94,70 @@ func TestGetInvocationConfig(t *testing.T) {
 			set: map[string]bool{flagkey.FnAsyncOnFailure: true},
 			s:   map[string]string{flagkey.FnAsyncOnFailure: ""},
 		}
-		ic := getInvocationConfig(in, existing)
+		ic, err := getInvocationConfig(in, existing)
+		require.NoError(t, err)
 		assert.Nil(t, ic.OnFailure, "empty --async-on-failure clears the destination")
+	})
+
+	t.Run("topic destination from flags (RFC-0027)", func(t *testing.T) {
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncOnSuccessTopic: true},
+			s:   map[string]string{flagkey.FnAsyncOnSuccessTopic: "orders"},
+		}
+		ic, err := getInvocationConfig(in, nil)
+		require.NoError(t, err)
+		require.NotNil(t, ic)
+		require.NotNil(t, ic.OnSuccess)
+		require.NotNil(t, ic.OnSuccess.Topic)
+		assert.Equal(t, "orders", ic.OnSuccess.Topic.Topic)
+		assert.EqualValues(t, fv1.MessageQueueTypeStatestore, ic.OnSuccess.Topic.MessageQueueType)
+		assert.Nil(t, ic.OnSuccess.Function, "a destination is a function XOR a topic")
+	})
+
+	t.Run("topic flag replaces an existing function destination", func(t *testing.T) {
+		existing := &fv1.InvocationConfig{
+			OnSuccess: &fv1.DestinationRef{Function: &fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "old"}},
+		}
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncOnSuccessTopic: true},
+			s:   map[string]string{flagkey.FnAsyncOnSuccessTopic: "orders"},
+		}
+		ic, err := getInvocationConfig(in, existing)
+		require.NoError(t, err)
+		require.NotNil(t, ic.OnSuccess.Topic)
+		assert.Nil(t, ic.OnSuccess.Function, "switching kinds must not leave a two-kind DestinationRef")
+	})
+
+	t.Run("empty topic flag clears the destination", func(t *testing.T) {
+		existing := &fv1.InvocationConfig{
+			OnFailure: &fv1.DestinationRef{Topic: &fv1.TopicRef{MessageQueueType: fv1.MessageQueueTypeStatestore, Topic: "errs"}},
+		}
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncOnFailureTopic: true},
+			s:   map[string]string{flagkey.FnAsyncOnFailureTopic: ""},
+		}
+		ic, err := getInvocationConfig(in, existing)
+		require.NoError(t, err)
+		assert.Nil(t, ic.OnFailure)
+	})
+
+	t.Run("function and topic flags for one condition are mutually exclusive", func(t *testing.T) {
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncOnSuccess: true, flagkey.FnAsyncOnSuccessTopic: true},
+			s:   map[string]string{flagkey.FnAsyncOnSuccess: "fn", flagkey.FnAsyncOnSuccessTopic: "orders"},
+		}
+		_, err := getInvocationConfig(in, nil)
+		require.ErrorContains(t, err, "mutually exclusive")
+	})
+
+	t.Run("different conditions may use different kinds", func(t *testing.T) {
+		in := fakeInvInput{
+			set: map[string]bool{flagkey.FnAsyncOnSuccess: true, flagkey.FnAsyncOnFailureTopic: true},
+			s:   map[string]string{flagkey.FnAsyncOnSuccess: "notify", flagkey.FnAsyncOnFailureTopic: "errs"},
+		}
+		ic, err := getInvocationConfig(in, nil)
+		require.NoError(t, err)
+		require.NotNil(t, ic.OnSuccess.Function)
+		require.NotNil(t, ic.OnFailure.Topic)
 	})
 }

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -123,8 +123,12 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	}
 
 	// The --async-* flags merge onto the existing InvocationConfig (only set fields
-	// change); an empty --async-on-success/--async-on-failure clears that destination.
-	function.Spec.Invocation = getInvocationConfig(input, function.Spec.Invocation)
+	// change); an empty --async-on-success/--async-on-failure (or -topic variant)
+	// clears that destination.
+	function.Spec.Invocation, err = getInvocationConfig(input, function.Spec.Invocation)
+	if err != nil {
+		return err
+	}
 
 	err = checkExecutorPoolManager(input, function.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType)
 	if err != nil {

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -150,6 +150,10 @@ var (
 	FnAsyncMaxAge      = Flag{Type: Duration, Name: flagkey.FnAsyncMaxAge, Usage: "Max time an async invocation may wait for successful delivery before it is dead-lettered (RFC-0024)"}
 	FnAsyncOnSuccess   = Flag{Type: String, Name: flagkey.FnAsyncOnSuccess, Usage: "Same-namespace function to invoke with the result after a successful async delivery (RFC-0024); empty clears it"}
 	FnAsyncOnFailure   = Flag{Type: String, Name: flagkey.FnAsyncOnFailure, Usage: "Same-namespace function to invoke with the result after a permanent async failure (RFC-0024); empty clears it"}
+	// RFC-0027 statestore topic destinations. Mutually exclusive per condition
+	// with the function-destination flag above.
+	FnAsyncOnSuccessTopic = Flag{Type: String, Name: flagkey.FnAsyncOnSuccessTopic, Usage: "Statestore topic to publish the result envelope to after a successful async delivery (RFC-0027); empty clears it"}
+	FnAsyncOnFailureTopic = Flag{Type: String, Name: flagkey.FnAsyncOnFailureTopic, Usage: "Statestore topic to publish the result envelope to after a permanent async failure (RFC-0027); empty clears it"}
 	// Termination Grace Period configurable at function creation/update only for container functions
 	FnTerminationGracePeriod = Flag{Type: Int64, Name: flagkey.FnGracePeriod, Usage: "Grace time (in seconds) for pod to perform connection draining before termination (only non-negative values considered)", DefaultValue: 360}
 
@@ -186,7 +190,7 @@ var (
 
 	MqtName            = Flag{Type: String, Name: flagkey.MqtName, Usage: "Message queue trigger name"}
 	MqtFnName          = Flag{Type: String, Name: flagkey.MqtFnName, Usage: "Function name"}
-	MqtMQType          = Flag{Type: String, Name: flagkey.MqtMQType, Usage: "For mqtype \"fission\" => kafka\n\t\t\t\t\t For mqtype \"keda\" => kafka, aws-sqs-queue, aws-kinesis-stream, gcp-pubsub, stan, nats-jetstream, rabbitmq, redis", DefaultValue: "kafka"}
+	MqtMQType          = Flag{Type: String, Name: flagkey.MqtMQType, Usage: "For mqtkind \"fission\" => kafka, statestore (the RFC-0027 built-in, no broker)\n\t\t\t\t\t For mqtkind \"keda\" => kafka, aws-sqs-queue, aws-kinesis-stream, gcp-pubsub, stan, nats-jetstream, rabbitmq, redis", DefaultValue: "kafka"}
 	MqtTopic           = Flag{Type: String, Name: flagkey.MqtTopic, Usage: "Message queue Topic the trigger listens on"}
 	MqtRespTopic       = Flag{Type: String, Name: flagkey.MqtRespTopic, Usage: "Topic that the function response is sent on (response discarded if unspecified)"}
 	MqtErrorTopic      = Flag{Type: String, Name: flagkey.MqtErrorTopic, Usage: "Topic that the function error messages are sent to (errors discarded if unspecified"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -101,6 +101,9 @@ const (
 	FnAsyncMaxAge      = "async-max-age"
 	FnAsyncOnSuccess   = "async-on-success"
 	FnAsyncOnFailure   = "async-on-failure"
+	// RFC-0027 topic destinations (statestore built-in eventing).
+	FnAsyncOnSuccessTopic = "async-on-success-topic"
+	FnAsyncOnFailureTopic = "async-on-failure-topic"
 
 	HtName              = resourceName
 	HtMethod            = "method"

--- a/pkg/mqtrigger/messageQueue/statestore/metrics.go
+++ b/pkg/mqtrigger/messageQueue/statestore/metrics.go
@@ -25,6 +25,10 @@ var (
 		"Count of exhausted events routed to the error topic, labeled by outcome (published/error/dropped — dropped = no error topic configured)")
 	eventingTrimmed = metrics.Int64Counter("fission_eventing_trimmed_total",
 		"Count of topic events trimmed by retention, labeled by reason (mincursor/age/size)")
+	eventingResponseTopic = metrics.Int64Counter("fission_eventing_responsetopic_total",
+		"Count of best-effort response-topic publishes after successful deliveries, labeled by outcome (published/error)")
+	eventingGaps = metrics.Int64Counter("fission_eventing_gap_events_total",
+		"Count of topic events a subscription found already trimmed when it resumed — retention loss observed at the subscriber that suffered it")
 )
 
 func recordDelivery(ctx context.Context, condition string) {
@@ -41,4 +45,12 @@ func recordErrorTopic(ctx context.Context, outcome string) {
 
 func recordTrimmed(ctx context.Context, reason string, n int64) {
 	eventingTrimmed.Add(ctx, n, metric.WithAttributes(attribute.String("reason", reason)))
+}
+
+func recordResponseTopic(ctx context.Context, outcome string) {
+	eventingResponseTopic.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+func recordGap(ctx context.Context, n int64) {
+	eventingGaps.Add(ctx, n)
 }

--- a/pkg/mqtrigger/messageQueue/statestore/metrics.go
+++ b/pkg/mqtrigger/messageQueue/statestore/metrics.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package statestore
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/fission/fission/pkg/utils/metrics"
+)
+
+// RFC-0027 eventing consumer meters (RFC-0019 style). Publishes are counted by
+// mqpub (fission_eventing_published_total); this side counts deliveries,
+// retries, error-topic routing, and retention — every drop path is countable.
+var (
+	eventingDelivered = metrics.Int64Counter("fission_eventing_delivered_total",
+		"Count of topic-event deliveries reaching terminal handling, labeled by condition (success/exhausted)")
+	eventingRetries = metrics.Int64Counter("fission_eventing_retries_total",
+		"Count of topic-event delivery retries")
+	eventingErrorTopic = metrics.Int64Counter("fission_eventing_errortopic_total",
+		"Count of exhausted events routed to the error topic, labeled by outcome (published/error/dropped — dropped = no error topic configured)")
+	eventingTrimmed = metrics.Int64Counter("fission_eventing_trimmed_total",
+		"Count of topic events trimmed by retention, labeled by reason (mincursor/age/size)")
+)
+
+func recordDelivery(ctx context.Context, condition string) {
+	eventingDelivered.Add(ctx, 1, metric.WithAttributes(attribute.String("condition", condition)))
+}
+
+func recordRetry(ctx context.Context) {
+	eventingRetries.Add(ctx, 1)
+}
+
+func recordErrorTopic(ctx context.Context, outcome string) {
+	eventingErrorTopic.Add(ctx, 1, metric.WithAttributes(attribute.String("outcome", outcome)))
+}
+
+func recordTrimmed(ctx context.Context, reason string, n int64) {
+	eventingTrimmed.Add(ctx, n, metric.WithAttributes(attribute.String("reason", reason)))
+}

--- a/pkg/mqtrigger/messageQueue/statestore/reaper.go
+++ b/pkg/mqtrigger/messageQueue/statestore/reaper.go
@@ -27,6 +27,11 @@ const (
 	// ageScanPages bounds the age-backstop scan per stream per tick, so one huge
 	// backlog cannot monopolize a tick (the scan resumes next tick).
 	ageScanPages = 10
+	// reaperTickTimeout deadlines one tick's store calls: the embedded client
+	// driver has its own HTTP timeout, but the external Postgres driver would
+	// otherwise inherit no deadline — one hung connection would wedge the single
+	// reaper goroutine forever and silently stall retention.
+	reaperTickTimeout = 30 * time.Second
 )
 
 // subscriptionSet tracks the provider's live subscriptions for the reaper.
@@ -51,18 +56,29 @@ func (ss *subscriptionSet) remove(s *subscription) {
 	delete(ss.subs, s)
 }
 
-// byStream snapshots the minimum committed cursor per stream over STARTED
-// subscriptions (one stream can have several triggers).
+// noMinCursor marks a stream whose loss-free floor is unknown this tick; the
+// min-cursor trim candidate is skipped (any floor >= 0 exceeds it) and only the
+// documented-loss backstops apply.
+const noMinCursor = int64(-1)
+
+// byStream snapshots the minimum committed cursor per subscribed stream (one
+// stream can have several triggers). A subscription that has not yet
+// established its cursor (started == false — e.g. stuck retrying a KV read
+// after a failover) has an unknown durable floor that may lie BELOW every
+// started sibling's cursor, so its stream gets noMinCursor: trimming to the
+// started-only minimum there would delete events the latecomer has not
+// consumed and mislabel the loss "mincursor" (invariant E3).
 func (ss *subscriptionSet) byStream() map[string]int64 {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 	min := map[string]int64{}
 	for s := range ss.subs {
 		if !s.started.Load() {
+			min[s.stream] = noMinCursor
 			continue
 		}
 		c := s.committed.Load()
-		if cur, ok := min[s.stream]; !ok || c < cur {
+		if cur, ok := min[s.stream]; !ok || (cur != noMinCursor && c < cur) {
 			min[s.stream] = c
 		}
 	}
@@ -89,14 +105,20 @@ func (s *Statestore) runReaper() {
 		case <-s.reaperStop:
 			return
 		case <-ticker.C:
-			s.reapTick(context.Background())
+			ctx, cancel := context.WithTimeout(context.Background(), reaperTickTimeout)
+			s.reapTick(ctx)
+			cancel()
 		}
 	}
 }
 
 // reapTick trims every subscribed stream. Per stream, the trim point is the max
-// of three candidates: the min committed cursor (exact, loss-free), the age
-// backstop, and the size backstop (both documented loss for stalled consumers).
+// of three candidates: the min committed cursor (exact, loss-free; noMinCursor
+// disables it while a subscription's floor is unknown), the age backstop, and
+// the size backstop (both documented loss for stalled consumers). Streams whose
+// last trigger was deleted are no longer reaped — their residue is bounded by
+// the publisher's backlog cap; a subscription-free age sweep is the egress
+// phase's problem (needs stream listing).
 func (s *Statestore) reapTick(ctx context.Context) {
 	for stream, minCursor := range s.subs.byStream() {
 		s.reapStream(ctx, stream, minCursor)

--- a/pkg/mqtrigger/messageQueue/statestore/reaper.go
+++ b/pkg/mqtrigger/messageQueue/statestore/reaper.go
@@ -1,0 +1,171 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package statestore
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Retention tuning (RFC-0027). The reaper trims each subscribed stream to the
+// minimum committed cursor (E3: no live subscriber loses an unconsumed event),
+// with two backstops that deliberately override a stalled subscriber's floor —
+// documented, bounded loss, identical in kind to a broker's retention evicting
+// a lagging consumer group:
+const (
+	// reaperInterval paces retention ticks.
+	reaperInterval = time.Minute
+	// maxStreamAge is the age backstop: events older than this are trimmed even
+	// if a stalled subscriber has not consumed them.
+	maxStreamAge = 7 * 24 * time.Hour
+	// maxStreamEvents is the size backstop: a stream's retained backlog never
+	// exceeds this many events.
+	maxStreamEvents = 100_000
+	// ageScanPages bounds the age-backstop scan per stream per tick, so one huge
+	// backlog cannot monopolize a tick (the scan resumes next tick).
+	ageScanPages = 10
+)
+
+// subscriptionSet tracks the provider's live subscriptions for the reaper.
+type subscriptionSet struct {
+	mu   sync.Mutex
+	subs map[*subscription]struct{}
+}
+
+func newSubscriptionSet() *subscriptionSet {
+	return &subscriptionSet{subs: map[*subscription]struct{}{}}
+}
+
+func (ss *subscriptionSet) add(s *subscription) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	ss.subs[s] = struct{}{}
+}
+
+func (ss *subscriptionSet) remove(s *subscription) {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	delete(ss.subs, s)
+}
+
+// byStream snapshots the minimum committed cursor per stream over STARTED
+// subscriptions (one stream can have several triggers).
+func (ss *subscriptionSet) byStream() map[string]int64 {
+	ss.mu.Lock()
+	defer ss.mu.Unlock()
+	min := map[string]int64{}
+	for s := range ss.subs {
+		if !s.started.Load() {
+			continue
+		}
+		c := s.committed.Load()
+		if cur, ok := min[s.stream]; !ok || c < cur {
+			min[s.stream] = c
+		}
+	}
+	return min
+}
+
+// reaperOnce starts the retention loop the first time a subscription appears.
+// The loop is bound to the provider's lifetime via the given context's PARENT
+// semantics deliberately not being used: it runs on its own stop channel so a
+// leadership transition (which cancels subscription contexts) does not kill
+// retention while the process lives; with no live subscriptions a tick is a
+// no-op.
+func (s *Statestore) reaperOnce(_ context.Context) {
+	s.reaperStart.Do(func() {
+		go s.runReaper()
+	})
+}
+
+func (s *Statestore) runReaper() {
+	ticker := time.NewTicker(reaperInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.reaperStop:
+			return
+		case <-ticker.C:
+			s.reapTick(context.Background())
+		}
+	}
+}
+
+// reapTick trims every subscribed stream. Per stream, the trim point is the max
+// of three candidates: the min committed cursor (exact, loss-free), the age
+// backstop, and the size backstop (both documented loss for stalled consumers).
+func (s *Statestore) reapTick(ctx context.Context) {
+	for stream, minCursor := range s.subs.byStream() {
+		s.reapStream(ctx, stream, minCursor)
+	}
+}
+
+func (s *Statestore) reapStream(ctx context.Context, stream string, minCursor int64) {
+	// Current floor: the seq just below the first retained event (== head when
+	// the stream is fully trimmed or empty).
+	head, err := s.el.Head(ctx, stream)
+	if err != nil {
+		s.logger.Error(err, "reaper: reading stream head", "stream", stream)
+		return
+	}
+	first, err := s.el.Read(ctx, stream, 0, 1)
+	if err != nil {
+		s.logger.Error(err, "reaper: reading stream floor", "stream", stream)
+		return
+	}
+	floor := head
+	if len(first) == 1 {
+		floor = first[0].Seq - 1
+	}
+
+	// Candidate 1 — min-cursor (loss-free): everything at or below the slowest
+	// subscriber's committed cursor is consumed.
+	trimTo := minCursor // trim events with Seq <= trimTo
+	reason := "mincursor"
+
+	// Candidate 2 — size backstop.
+	if sizeTo := head - s.reaperMaxEvents; sizeTo > trimTo {
+		trimTo, reason = sizeTo, "size"
+	}
+
+	// Candidate 3 — age backstop: bounded forward scan for events older than the
+	// cutoff (resumes next tick if the backlog is huge).
+	cutoff := time.Now().Add(-s.reaperMaxAge)
+	ageTo := floor
+	from := floor
+scan:
+	for range ageScanPages {
+		evs, rerr := s.el.Read(ctx, stream, from, readBatch)
+		if rerr != nil {
+			s.logger.Error(rerr, "reaper: age scan", "stream", stream)
+			break
+		}
+		if len(evs) == 0 {
+			break
+		}
+		for _, ev := range evs {
+			if !ev.At.Before(cutoff) {
+				break scan
+			}
+			ageTo = ev.Seq
+		}
+		from = evs[len(evs)-1].Seq
+	}
+	if ageTo > trimTo {
+		trimTo, reason = ageTo, "age"
+	}
+
+	if trimTo <= floor {
+		return // nothing new to trim
+	}
+	if err := s.el.Trim(ctx, stream, trimTo+1); err != nil {
+		s.logger.Error(err, "reaper: trimming stream", "stream", stream, "below", trimTo+1)
+		return
+	}
+	recordTrimmed(ctx, reason, trimTo-floor)
+	s.logger.V(1).Info("reaper: trimmed topic stream",
+		"stream", stream, "events", trimTo-floor, "reason", reason)
+}

--- a/pkg/mqtrigger/messageQueue/statestore/statestore.go
+++ b/pkg/mqtrigger/messageQueue/statestore/statestore.go
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package statestore implements the RFC-0027 built-in MessageQueue provider:
+// topics are EventLog streams on the RFC-0021 statestore (topic/<ns>/<topic>,
+// written by mqpub), so MessageQueueTriggers work with zero external brokers.
+//
+// The provider mirrors the kafka provider's shape — one classic mqt head per MQ
+// type, leader-only subscriptions, HMAC-signed delivery to the router internal
+// listener, MaxRetries → ErrorTopic, ResponseTopic on success — but consumes a
+// per-trigger durable cursor instead of a consumer group. The subscription
+// protocol (cursor CAS, poison isolation, min-cursor retention) is the
+// TLC-checked docs/rfc/specs/eventlogsub.tla model.
+package statestore
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/mqtrigger/factory"
+	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
+	"github.com/fission/fission/pkg/mqtrigger/mqpub"
+	"github.com/fission/fission/pkg/mqtrigger/validator"
+	"github.com/fission/fission/pkg/statestore"
+
+	// Register the statestore drivers this head opens: the HTTP client
+	// (embedded mode → svc/statestore) and Postgres (external mode → the DB
+	// directly). STATESTORE_DRIVER selects at runtime, exactly as in the router.
+	_ "github.com/fission/fission/pkg/statestore/client"
+	_ "github.com/fission/fission/pkg/statestore/postgres"
+)
+
+func init() {
+	factory.Register(fv1.MessageQueueTypeStatestore, &Factory{})
+	// Topic names must be stream-safe (no "/" — the namespaced stream mapping's
+	// injectivity); reuse the CRD-side rule so the trigger and destination
+	// grammars cannot drift.
+	validator.Register(fv1.MessageQueueTypeStatestore, func(topic string) bool {
+		return fv1.ValidateTopicName("topic", topic) == nil
+	})
+}
+
+// Subscription-loop tuning. Modest constants for the classic head; the KEDA
+// lag-scaler phase revisits throughput.
+const (
+	// defaultPollInterval paces Read polls on an idle topic;
+	// MessageQueueTriggerSpec.PollingInterval (seconds) overrides per trigger.
+	defaultPollInterval = time.Second
+	// readBatch bounds one Read — also the redelivery tail bound on a crash
+	// between delivery and cursor commit (at-least-once).
+	readBatch = 32
+	// retryBackoff spaces delivery retries. A deliberate (small) deviation from
+	// the kafka provider's immediate retries: hammering a failing function
+	// serves nobody.
+	retryBackoff = 500 * time.Millisecond
+)
+
+// Factory builds the provider; registered for fv1.MessageQueueTypeStatestore.
+type Factory struct{}
+
+// Create implements factory.MessageQueueFactory.
+func (f *Factory) Create(logger logr.Logger, mqCfg messageQueue.Config, routerURL string) (messageQueue.MessageQueue, error) {
+	return New(logger, mqCfg, routerURL)
+}
+
+// Statestore is the provider: it owns the store handles, the signed HTTP client
+// for router-internal delivery, and the live-subscription set the retention
+// reaper trims from.
+type Statestore struct {
+	logger    logr.Logger
+	routerURL string
+	caps      statestore.Capabilities
+	el        statestore.EventLog
+	kv        statestore.KVStore
+	pub       mqpub.TopicPublisher
+	client    *http.Client
+
+	subs *subscriptionSet
+
+	reaperStart sync.Once
+	// reaperStop ends the retention loop (tests; the head otherwise runs it for
+	// the process lifetime).
+	reaperStop chan struct{}
+	// reaperMaxAge/reaperMaxEvents default from the retention consts; fields so
+	// tests can exercise the backstops.
+	reaperMaxAge    time.Duration
+	reaperMaxEvents int64
+	// pollOverride, when positive, replaces every subscription's poll interval
+	// (tests only — set before any Subscribe).
+	pollOverride time.Duration
+}
+
+// New opens the statestore exactly like the router's async path does — the
+// driver and DSN come from STATESTORE_DRIVER / STATESTORE_DSN (the chart wires
+// embedded → "client" → svc/statestore, external → "postgres" → the secret DSN).
+// Open does not dial, so an unreachable store does not block startup; the
+// subscription loops surface read errors and retry.
+func New(logger logr.Logger, _ messageQueue.Config, routerURL string) (messageQueue.MessageQueue, error) {
+	if routerURL == "" {
+		return nil, fmt.Errorf("statestore mq provider: router URL is required")
+	}
+	driver := os.Getenv("STATESTORE_DRIVER")
+	if driver == "" {
+		return nil, fmt.Errorf("statestore mq provider: STATESTORE_DRIVER is required")
+	}
+	opened, err := statestore.Open(context.Background(), statestore.Config{Driver: driver, DSN: os.Getenv("STATESTORE_DSN")})
+	if err != nil {
+		return nil, fmt.Errorf("statestore mq provider: opening statestore: %w", err)
+	}
+	// NewScoped adds the op metrics (and, in external mode, the conservation
+	// reporter) — the same wrapping the router applies.
+	caps := statestore.NewScoped(opened, nil)
+	el, err := caps.EventLog()
+	if err != nil {
+		return nil, fmt.Errorf("statestore mq provider: eventlog capability: %w", err)
+	}
+	kv, err := caps.KV()
+	if err != nil {
+		return nil, fmt.Errorf("statestore mq provider: kv capability: %w", err)
+	}
+	s := &Statestore{
+		logger:     logger.WithName("statestore_mq"),
+		routerURL:  routerURL,
+		caps:       caps,
+		el:         el,
+		kv:         kv,
+		pub:        mqpub.NewStatestorePublisher(el),
+		client:     newSignedHTTPClient(),
+		subs:       newSubscriptionSet(),
+		reaperStop: make(chan struct{}),
+
+		reaperMaxAge:    maxStreamAge,
+		reaperMaxEvents: maxStreamEvents,
+	}
+	return s, nil
+}
+
+// newSignedHTTPClient mirrors the kafka provider's delivery client:
+// /fission-function/<ns>/<name> lives only on the router's internal listener
+// (GHSA-3g33-6vg6-27m8), so requests are HMAC-signed with the
+// ServiceRouterInternal key when FISSION_INTERNAL_AUTH_SECRET is set (empty =
+// the verifier's pass-through mode). The pooled transport outlives individual
+// subscriptions.
+func newSignedHTTPClient() *http.Client {
+	transport := &http.Transport{
+		DialContext:         (&net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}).DialContext,
+		MaxIdleConns:        64,
+		MaxIdleConnsPerHost: 64,
+		IdleConnTimeout:     90 * time.Second,
+	}
+	var rt http.RoundTripper = transport
+	if master := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); master != "" {
+		rt = hmacauth.ServiceSigner([]byte(master), hmacauth.ServiceRouterInternal, rt, time.Now)
+	}
+	return &http.Client{Transport: rt}
+}
+
+// Subscribe implements messageQueue.MessageQueue: it starts one durable-cursor
+// consumer loop for the trigger. Subscriptions run only on the elected leader
+// (the mqt manager binds them to the leader-scoped context), so cursor CAS
+// conflicts are confined to leadership transitions — which at-least-once
+// delivery already tolerates (eventlogsub.tla).
+func (s *Statestore) Subscribe(ctx context.Context, trigger *fv1.MessageQueueTrigger) (messageQueue.Subscription, error) {
+	if trigger.Spec.FunctionReference.Type != fv1.FunctionReferenceTypeFunctionName {
+		return nil, fmt.Errorf("statestore mq provider: unsupported function reference type %q for trigger %s",
+			trigger.Spec.FunctionReference.Type, trigger.Name)
+	}
+	if err := fv1.ValidateTopicName("spec.topic", trigger.Spec.Topic); err != nil {
+		return nil, fmt.Errorf("statestore mq provider: %w", err)
+	}
+	sub := newSubscription(s, trigger)
+	s.subs.add(sub)
+	subCtx, cancel := context.WithCancel(ctx)
+	sub.cancel = cancel
+	go func() {
+		defer close(sub.done)
+		defer s.subs.remove(sub)
+		sub.run(subCtx)
+	}()
+	s.reaperOnce(ctx)
+	return sub, nil
+}
+
+// Unsubscribe implements messageQueue.MessageQueue.
+func (s *Statestore) Unsubscribe(sub messageQueue.Subscription) error {
+	return sub.Stop()
+}

--- a/pkg/mqtrigger/messageQueue/statestore/statestore.go
+++ b/pkg/mqtrigger/messageQueue/statestore/statestore.go
@@ -32,12 +32,6 @@ import (
 	"github.com/fission/fission/pkg/mqtrigger/mqpub"
 	"github.com/fission/fission/pkg/mqtrigger/validator"
 	"github.com/fission/fission/pkg/statestore"
-
-	// Register the statestore drivers this head opens: the HTTP client
-	// (embedded mode → svc/statestore) and Postgres (external mode → the DB
-	// directly). STATESTORE_DRIVER selects at runtime, exactly as in the router.
-	_ "github.com/fission/fission/pkg/statestore/client"
-	_ "github.com/fission/fission/pkg/statestore/postgres"
 )
 
 func init() {
@@ -56,8 +50,11 @@ const (
 	// defaultPollInterval paces Read polls on an idle topic;
 	// MessageQueueTriggerSpec.PollingInterval (seconds) overrides per trigger.
 	defaultPollInterval = time.Second
-	// readBatch bounds one Read — also the redelivery tail bound on a crash
-	// between delivery and cursor commit (at-least-once).
+	// readBatch bounds one Read — and, while cursor commits are succeeding, the
+	// redelivery tail on a crash between delivery and commit (at-least-once).
+	// Under persistent commit failure the loop keeps delivering past the failed
+	// commit, so the crash-redelivery tail is bounded by the outage, not by
+	// readBatch.
 	readBatch = 32
 	// retryBackoff spaces delivery retries. A deliberate (small) deviation from
 	// the kafka provider's immediate retries: hammering a failing function
@@ -105,6 +102,11 @@ type Statestore struct {
 // embedded → "client" → svc/statestore, external → "postgres" → the secret DSN).
 // Open does not dial, so an unreachable store does not block startup; the
 // subscription loops surface read errors and retry.
+//
+// Driver registration is the BINARY's job (cmd/fission-bundle/mqtrigger blank-
+// imports statestore/client and statestore/postgres): this package stays
+// driver-free so the fission CLI, which imports it only for the init()
+// validator/factory registration, does not link pgx and the HTTP store client.
 func New(logger logr.Logger, _ messageQueue.Config, routerURL string) (messageQueue.MessageQueue, error) {
 	if routerURL == "" {
 		return nil, fmt.Errorf("statestore mq provider: router URL is required")
@@ -179,6 +181,12 @@ func (s *Statestore) Subscribe(ctx context.Context, trigger *fv1.MessageQueueTri
 		return nil, fmt.Errorf("statestore mq provider: %w", err)
 	}
 	sub := newSubscription(s, trigger)
+	// Fail a malformed delivery URL (bad routerURL) HERE, where the reconciler
+	// surfaces and retries the error — inside the loop it would deterministically
+	// burn the retry budget of every event on the topic.
+	if _, err := http.NewRequest(http.MethodPost, sub.fnURL, nil); err != nil {
+		return nil, fmt.Errorf("statestore mq provider: invalid delivery URL %q: %w", sub.fnURL, err)
+	}
 	s.subs.add(sub)
 	subCtx, cancel := context.WithCancel(ctx)
 	sub.cancel = cancel

--- a/pkg/mqtrigger/messageQueue/statestore/subscription.go
+++ b/pkg/mqtrigger/messageQueue/statestore/subscription.go
@@ -1,0 +1,322 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package statestore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/mqtrigger/mqpub"
+	"github.com/fission/fission/pkg/statestore"
+	"github.com/fission/fission/pkg/utils"
+
+	"github.com/go-logr/logr"
+)
+
+// cursorScope returns the KV scope of a trigger's durable cursor, per the house
+// Scope convention (Owner = <kind>/<name>).
+func cursorScope(trigger *fv1.MessageQueueTrigger) statestore.Scope {
+	return statestore.Scope{
+		Namespace: trigger.Namespace,
+		Owner:     "messagequeuetrigger/" + trigger.Name,
+		Keyspace:  "cursor",
+	}
+}
+
+const cursorKey = "cursor"
+
+// subscription is one trigger's consumer loop over its topic stream: read from
+// the durable cursor, deliver in order, publish ResponseTopic/ErrorTopic, and
+// CAS-advance the cursor (the eventlogsub.tla protocol).
+type subscription struct {
+	logger  logr.Logger
+	s       *Statestore
+	trigger *fv1.MessageQueueTrigger
+	stream  string
+	fnURL   string
+
+	// committed is the last CAS-persisted cursor, read by the retention reaper
+	// (trim never passes it — invariant E3).
+	committed atomic.Int64
+	// started flips once the first cursor load/init succeeded; the reaper skips
+	// subscriptions that have not established their floor yet.
+	started atomic.Bool
+
+	// poll paces idle reads and error retries; from the trigger's
+	// PollingInterval (seconds) or defaultPollInterval (a field so tests can
+	// tighten it).
+	poll time.Duration
+
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+func newSubscription(s *Statestore, trigger *fv1.MessageQueueTrigger) *subscription {
+	poll := defaultPollInterval
+	if p := trigger.Spec.PollingInterval; p != nil && *p > 0 {
+		poll = time.Duration(*p) * time.Second
+	}
+	if s.pollOverride > 0 {
+		poll = s.pollOverride
+	}
+	return &subscription{
+		logger:  s.logger.WithName(trigger.Name),
+		s:       s,
+		trigger: trigger,
+		stream:  mqpub.StreamForTopic(trigger.Namespace, trigger.Spec.Topic),
+		fnURL:   s.routerURL + "/" + strings.TrimPrefix(utils.UrlForFunction(trigger.Spec.FunctionReference.Name, trigger.Namespace), "/"),
+		poll:    poll,
+		done:    make(chan struct{}),
+	}
+}
+
+// Stop implements messageQueue.Subscription.
+func (sub *subscription) Stop() error {
+	if sub.cancel != nil {
+		sub.cancel()
+	}
+	<-sub.done
+	return nil
+}
+
+// Done implements messageQueue.Subscription.
+func (sub *subscription) Done() <-chan struct{} { return sub.done }
+
+// run is the consumer loop. It returns only when ctx is cancelled (trigger
+// deleted, leadership lost, shutdown). Errors are logged and retried — a broken
+// store or function must never kill the subscription.
+func (sub *subscription) run(ctx context.Context) {
+	cursor, version, err := sub.loadOrInitCursor(ctx)
+	for err != nil {
+		sub.logger.Error(err, "initializing topic cursor; retrying", "stream", sub.stream)
+		if !sleepCtx(ctx, sub.poll) {
+			return
+		}
+		cursor, version, err = sub.loadOrInitCursor(ctx)
+	}
+	sub.committed.Store(cursor)
+	sub.started.Store(true)
+	sub.logger.Info("topic subscription started", "stream", sub.stream, "cursor", cursor)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		events, err := sub.s.el.Read(ctx, sub.stream, cursor, readBatch)
+		if err != nil {
+			if ctx.Err() == nil {
+				sub.logger.Error(err, "reading topic stream", "stream", sub.stream, "cursor", cursor)
+			}
+			if !sleepCtx(ctx, sub.poll) {
+				return
+			}
+			continue
+		}
+		if len(events) == 0 {
+			if !sleepCtx(ctx, sub.poll) {
+				return
+			}
+			continue
+		}
+		progressed := false
+		for _, ev := range events {
+			if ctx.Err() != nil {
+				break
+			}
+			if !sub.handle(ctx, ev) {
+				// Terminal handling incomplete (e.g. the ErrorTopic publish
+				// failed): do NOT advance past the event (E5) — re-read and
+				// retry it after a pause.
+				break
+			}
+			cursor = ev.Seq
+			progressed = true
+		}
+		if progressed {
+			cursor, version = sub.commit(ctx, cursor, version)
+		} else if !sleepCtx(ctx, sub.poll) {
+			return
+		}
+	}
+}
+
+// loadOrInitCursor reads the durable cursor, or initializes it at the stream
+// head (start-at-head subscription) with a CAS create so racing instances
+// converge on one record.
+func (sub *subscription) loadOrInitCursor(ctx context.Context) (cursor, version int64, err error) {
+	val, err := sub.s.kv.Get(ctx, cursorScope(sub.trigger), cursorKey)
+	if err == nil {
+		c, perr := strconv.ParseInt(string(val.Data), 10, 64)
+		if perr != nil {
+			// A corrupt cursor record is unrecoverable ambiguity: fail loud and
+			// keep retrying rather than guessing a position.
+			return 0, 0, fmt.Errorf("corrupt cursor record %q: %w", string(val.Data), perr)
+		}
+		return c, val.Version, nil
+	}
+	if !errors.Is(err, statestore.ErrNotFound) {
+		return 0, 0, err
+	}
+	head, err := sub.s.el.Head(ctx, sub.stream)
+	if err != nil {
+		return 0, 0, err
+	}
+	// CAS create (absent key = version 0): the loser of a racing create re-reads
+	// the winner's record.
+	err = sub.s.kv.Set(ctx, cursorScope(sub.trigger), cursorKey,
+		[]byte(strconv.FormatInt(head, 10)), statestore.SetOptions{IfVersion: new(int64(0))})
+	if err != nil && !errors.Is(err, statestore.ErrVersionConflict) {
+		return 0, 0, err
+	}
+	val, err = sub.s.kv.Get(ctx, cursorScope(sub.trigger), cursorKey)
+	if err != nil {
+		return 0, 0, err
+	}
+	c, perr := strconv.ParseInt(string(val.Data), 10, 64)
+	if perr != nil {
+		return 0, 0, fmt.Errorf("corrupt cursor record %q: %w", string(val.Data), perr)
+	}
+	return c, val.Version, nil
+}
+
+// commit CAS-persists the cursor. On a version conflict (an overlapping
+// instance advanced it — leadership transition), it adopts the persisted record
+// and resumes from there: the cursor never regresses (CursorMonotonic), and any
+// re-read tail is at-least-once redelivery.
+func (sub *subscription) commit(ctx context.Context, cursor, version int64) (int64, int64) {
+	err := sub.s.kv.Set(ctx, cursorScope(sub.trigger), cursorKey,
+		[]byte(strconv.FormatInt(cursor, 10)), statestore.SetOptions{IfVersion: new(version)})
+	if err == nil {
+		sub.committed.Store(cursor)
+		return cursor, version + 1
+	}
+	if errors.Is(err, statestore.ErrVersionConflict) {
+		if c, v, lerr := sub.loadOrInitCursor(ctx); lerr == nil {
+			sub.logger.V(1).Info("cursor commit raced a newer instance; resuming from the persisted cursor",
+				"local", cursor, "persisted", c)
+			sub.committed.Store(c)
+			return c, v
+		}
+	}
+	if ctx.Err() == nil {
+		sub.logger.Error(err, "persisting topic cursor; will retry after redelivery", "stream", sub.stream, "cursor", cursor)
+	}
+	// Keep the local position for this session; the next commit retries the CAS.
+	return cursor, version
+}
+
+// handle delivers one event with the trigger's retry budget. It returns true
+// when the event reached TERMINAL handling — delivered, or exhausted-and-
+// error-published (E5) — and false when handling must be retried (the cursor
+// must not advance).
+func (sub *subscription) handle(ctx context.Context, ev statestore.Event) bool {
+	ok := sub.deliver(ctx, ev)
+	if ok {
+		recordDelivery(ctx, "success")
+		return true
+	}
+	if ctx.Err() != nil {
+		return false // shutting down: leave the event for redelivery
+	}
+	recordDelivery(ctx, "exhausted")
+	// Poison isolation (E5): route to the ErrorTopic BEFORE advancing, so a
+	// crash in between redelivers the event rather than skipping it. Without an
+	// ErrorTopic the event is dropped-with-log (kafka-provider parity).
+	if sub.trigger.Spec.ErrorTopic != "" {
+		err := sub.s.pub.Publish(ctx, sub.trigger.Namespace, fv1.MessageQueueTypeStatestore,
+			sub.trigger.Spec.ErrorTopic, ev.Type, ev.Payload)
+		if err != nil {
+			recordErrorTopic(ctx, "error")
+			sub.logger.Error(err, "publishing exhausted event to error topic; will retry",
+				"errorTopic", sub.trigger.Spec.ErrorTopic, "seq", ev.Seq)
+			return false
+		}
+		recordErrorTopic(ctx, "published")
+	} else {
+		sub.logger.Error(nil, "event exhausted retries and no error topic is set; dropping",
+			"stream", sub.stream, "seq", ev.Seq, "maxRetries", sub.trigger.Spec.MaxRetries)
+		recordErrorTopic(ctx, "dropped")
+	}
+	return true
+}
+
+// deliver POSTs the event to the function via the router internal listener,
+// retrying up to MaxRetries. Success is any 2xx — a deliberate deviation from
+// the kafka provider's strict 200, consistent with the RFC-0024 settle matrix.
+// On success it best-effort publishes the response body to the ResponseTopic.
+func (sub *subscription) deliver(ctx context.Context, ev statestore.Event) bool {
+	contentType := ev.Type
+	if contentType == "" {
+		contentType = sub.trigger.Spec.ContentType
+	}
+	for attempt := 0; attempt <= sub.trigger.Spec.MaxRetries; attempt++ {
+		if attempt > 0 {
+			recordRetry(ctx)
+			if !sleepCtx(ctx, retryBackoff) {
+				return false
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.fnURL, bytes.NewReader(ev.Payload))
+		if err != nil {
+			sub.logger.Error(err, "building delivery request", "url", sub.fnURL)
+			return false
+		}
+		if contentType != "" {
+			req.Header.Set("Content-Type", contentType)
+		}
+		req.Header.Set("X-Fission-MQTrigger-Topic", sub.trigger.Spec.Topic)
+		req.Header.Set("X-Fission-MQTrigger-RespTopic", sub.trigger.Spec.ResponseTopic)
+		req.Header.Set("X-Fission-MQTrigger-ErrorTopic", sub.trigger.Spec.ErrorTopic)
+
+		resp, err := sub.s.client.Do(req)
+		if err != nil {
+			if ctx.Err() != nil {
+				return false
+			}
+			sub.logger.Error(err, "delivering topic event", "url", sub.fnURL, "seq", ev.Seq, "attempt", attempt)
+			continue
+		}
+		body, rerr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+		_ = resp.Body.Close()
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			sub.logger.V(1).Info("topic delivery failed",
+				"status", resp.StatusCode, "seq", ev.Seq, "attempt", attempt)
+			continue
+		}
+		if rerr != nil {
+			sub.logger.Error(rerr, "reading delivery response; response topic skipped", "seq", ev.Seq)
+			return true // the function succeeded; the response read is best-effort
+		}
+		if sub.trigger.Spec.ResponseTopic != "" {
+			respCT := resp.Header.Get("Content-Type")
+			if err := sub.s.pub.Publish(ctx, sub.trigger.Namespace, fv1.MessageQueueTypeStatestore,
+				sub.trigger.Spec.ResponseTopic, respCT, body); err != nil {
+				sub.logger.Error(err, "publishing response to response topic (best-effort)",
+					"responseTopic", sub.trigger.Spec.ResponseTopic, "seq", ev.Seq)
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// sleepCtx sleeps d or returns false when ctx ends first.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}

--- a/pkg/mqtrigger/messageQueue/statestore/subscription.go
+++ b/pkg/mqtrigger/messageQueue/statestore/subscription.go
@@ -129,6 +129,16 @@ func (sub *subscription) run(ctx context.Context) {
 			}
 			continue
 		}
+		// Gap detection: a first event above cursor+1 means retention trimmed
+		// events this subscription never delivered (an age/size backstop
+		// overriding a stalled floor). The loss already happened — surface it
+		// HERE, at the subscriber that suffered it, or "my function missed
+		// events" is undebuggable later.
+		if gap := events[0].Seq - cursor - 1; gap > 0 {
+			recordGap(ctx, gap)
+			sub.logger.Error(nil, "topic events were trimmed before delivery to this subscription",
+				"stream", sub.stream, "cursor", cursor, "resumedAt", events[0].Seq, "missed", gap)
+		}
 		progressed := false
 		for _, ev := range events {
 			if ctx.Err() != nil {
@@ -229,10 +239,12 @@ func (sub *subscription) handle(ctx context.Context, ev statestore.Event) bool {
 	if ctx.Err() != nil {
 		return false // shutting down: leave the event for redelivery
 	}
-	recordDelivery(ctx, "exhausted")
 	// Poison isolation (E5): route to the ErrorTopic BEFORE advancing, so a
 	// crash in between redelivers the event rather than skipping it. Without an
 	// ErrorTopic the event is dropped-with-log (kafka-provider parity).
+	// While the ErrorTopic publish keeps failing, each re-read re-runs the full
+	// delivery budget against the (already failing) function — E5 deliberately
+	// prices re-delivery below losing the event.
 	if sub.trigger.Spec.ErrorTopic != "" {
 		err := sub.s.pub.Publish(ctx, sub.trigger.Namespace, fv1.MessageQueueTypeStatestore,
 			sub.trigger.Spec.ErrorTopic, ev.Type, ev.Payload)
@@ -243,11 +255,18 @@ func (sub *subscription) handle(ctx context.Context, ev statestore.Event) bool {
 			return false
 		}
 		recordErrorTopic(ctx, "published")
+		sub.logger.Info("event exhausted retries; routed to error topic",
+			"stream", sub.stream, "seq", ev.Seq, "errorTopic", sub.trigger.Spec.ErrorTopic,
+			"maxRetries", sub.trigger.Spec.MaxRetries)
 	} else {
 		sub.logger.Error(nil, "event exhausted retries and no error topic is set; dropping",
 			"stream", sub.stream, "seq", ev.Seq, "maxRetries", sub.trigger.Spec.MaxRetries)
 		recordErrorTopic(ctx, "dropped")
 	}
+	// Counted only once terminal handling is secured: counting before the
+	// ErrorTopic publish would inflate "exhausted" once per retry cycle while
+	// that publish is broken — dashboards would lie mid-incident.
+	recordDelivery(ctx, "exhausted")
 	return true
 }
 
@@ -267,10 +286,15 @@ func (sub *subscription) deliver(ctx context.Context, ev statestore.Event) bool 
 				return false
 			}
 		}
+		// fnURL is validated at Subscribe time, so this branch is
+		// defense-in-depth; continue treats it like any other failed attempt
+		// rather than short-circuiting a "terminal" verdict the event never
+		// earned (zero real attempts must not read as exhausted-and-error-
+		// topic'd in the normal way retries do).
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, sub.fnURL, bytes.NewReader(ev.Payload))
 		if err != nil {
-			sub.logger.Error(err, "building delivery request", "url", sub.fnURL)
-			return false
+			sub.logger.Error(err, "building delivery request", "url", sub.fnURL, "seq", ev.Seq, "attempt", attempt)
+			continue
 		}
 		if contentType != "" {
 			req.Header.Set("Content-Type", contentType)
@@ -290,7 +314,10 @@ func (sub *subscription) deliver(ctx context.Context, ev statestore.Event) bool 
 		body, rerr := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 		_ = resp.Body.Close()
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			sub.logger.V(1).Info("topic delivery failed",
+			// Error level for kafka-provider parity: a function 500-ing on every
+			// event must be visible in the head's logs at default verbosity, not
+			// quieter than a connection failure.
+			sub.logger.Error(nil, "topic delivery failed",
 				"status", resp.StatusCode, "seq", ev.Seq, "attempt", attempt)
 			continue
 		}
@@ -302,8 +329,11 @@ func (sub *subscription) deliver(ctx context.Context, ev statestore.Event) bool 
 			respCT := resp.Header.Get("Content-Type")
 			if err := sub.s.pub.Publish(ctx, sub.trigger.Namespace, fv1.MessageQueueTypeStatestore,
 				sub.trigger.Spec.ResponseTopic, respCT, body); err != nil {
+				recordResponseTopic(ctx, "error")
 				sub.logger.Error(err, "publishing response to response topic (best-effort)",
 					"responseTopic", sub.trigger.Spec.ResponseTopic, "seq", ev.Seq)
+			} else {
+				recordResponseTopic(ctx, "published")
 			}
 		}
 		return true

--- a/pkg/mqtrigger/messageQueue/statestore/subscription_test.go
+++ b/pkg/mqtrigger/messageQueue/statestore/subscription_test.go
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package statestore
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/mqtrigger/mqpub"
+	"github.com/fission/fission/pkg/statestore"
+	_ "github.com/fission/fission/pkg/statestore/memory"
+)
+
+// received is one delivery the scripted function endpoint captured.
+type received struct {
+	Body        string
+	ContentType string
+	Topic       string
+	RespTopic   string
+}
+
+// fnEndpoint is a scripted stand-in for the router-internal function URL.
+type fnEndpoint struct {
+	mu     sync.Mutex
+	got    []received
+	status int    // response status (default 200)
+	body   string // response body
+	failN  int    // fail the first N requests with 500
+}
+
+func (f *fnEndpoint) handler(w http.ResponseWriter, r *http.Request) {
+	b, _ := io.ReadAll(r.Body)
+	f.mu.Lock()
+	f.got = append(f.got, received{
+		Body:        string(b),
+		ContentType: r.Header.Get("Content-Type"),
+		Topic:       r.Header.Get("X-Fission-MQTrigger-Topic"),
+		RespTopic:   r.Header.Get("X-Fission-MQTrigger-RespTopic"),
+	})
+	n := len(f.got)
+	failN, status, body := f.failN, f.status, f.body
+	f.mu.Unlock()
+	if n <= failN {
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if status == 0 {
+		status = http.StatusOK
+	}
+	w.Header().Set("Content-Type", "text/plain")
+	w.WriteHeader(status)
+	_, _ = io.WriteString(w, body)
+}
+
+func (f *fnEndpoint) deliveries() []received {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]received(nil), f.got...)
+}
+
+// newTestProvider builds a Statestore over the memory driver pointed at the
+// scripted endpoint (its URL stands in for the router internal listener).
+func newTestProvider(t *testing.T, routerURL string) *Statestore {
+	t.Helper()
+	caps, err := statestore.Open(t.Context(), statestore.Config{Driver: "memory"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = caps.Close() })
+	el, err := caps.EventLog()
+	require.NoError(t, err)
+	kv, err := caps.KV()
+	require.NoError(t, err)
+	logger := logr.Discard()
+	if testing.Verbose() {
+		logger = funcr.New(func(prefix, args string) { t.Log(prefix, args) }, funcr.Options{Verbosity: 2})
+	}
+	return &Statestore{
+		logger:          logger,
+		routerURL:       routerURL,
+		caps:            caps,
+		el:              el,
+		kv:              kv,
+		pub:             mqpub.NewStatestorePublisher(el),
+		client:          http.DefaultClient,
+		subs:            newSubscriptionSet(),
+		reaperStop:      make(chan struct{}),
+		reaperMaxAge:    maxStreamAge,
+		reaperMaxEvents: maxStreamEvents,
+		pollOverride:    10 * time.Millisecond,
+	}
+}
+
+func testTrigger(name, topic string, mutate func(*fv1.MessageQueueTrigger)) *fv1.MessageQueueTrigger {
+	tr := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "ns"},
+		Spec: fv1.MessageQueueTriggerSpec{
+			FunctionReference: fv1.FunctionReference{Type: fv1.FunctionReferenceTypeFunctionName, Name: "fn"},
+			MessageQueueType:  fv1.MessageQueueTypeStatestore,
+			Topic:             topic,
+			MaxRetries:        1,
+			ContentType:       "application/json",
+		},
+	}
+	if mutate != nil {
+		mutate(tr)
+	}
+	return tr
+}
+
+// startSub subscribes and WAITS for the loop to establish its start-at-head
+// cursor before returning: Subscribe's goroutine snapshots the head
+// asynchronously, so a publish racing that snapshot is legitimately "before the
+// subscription" — tests must sequence after startup to be deterministic.
+func startSub(t *testing.T, s *Statestore, trigger *fv1.MessageQueueTrigger) *subscription {
+	t.Helper()
+	msub, err := s.Subscribe(t.Context(), trigger)
+	require.NoError(t, err)
+	sub := msub.(*subscription)
+	t.Cleanup(func() { _ = sub.Stop() })
+	require.Eventually(t, sub.started.Load, 5*time.Second, 5*time.Millisecond, "subscription must establish its cursor")
+	return sub
+}
+
+func publish(t *testing.T, s *Statestore, topic, contentType, payload string) {
+	t.Helper()
+	require.NoError(t, s.pub.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, topic, contentType, []byte(payload)))
+}
+
+func TestSubscriptionDeliversInOrder(t *testing.T) {
+	t.Parallel()
+	fn := &fnEndpoint{}
+	srv := httptest.NewServer(http.HandlerFunc(fn.handler))
+	defer srv.Close()
+	s := newTestProvider(t, srv.URL)
+
+	sub := startSub(t, s, testTrigger("t1", "orders", nil))
+
+	publish(t, s, "orders", "application/json", `{"n":1}`)
+	publish(t, s, "orders", "text/plain", "two")
+
+	require.Eventually(t, func() bool { return len(fn.deliveries()) == 2 }, 5*time.Second, 10*time.Millisecond)
+	got := fn.deliveries()
+	assert.Equal(t, `{"n":1}`, got[0].Body)
+	assert.Equal(t, "application/json", got[0].ContentType, "the published contentType is replayed")
+	assert.Equal(t, "orders", got[0].Topic)
+	assert.Equal(t, "two", got[1].Body)
+	assert.Equal(t, "text/plain", got[1].ContentType)
+
+	// The cursor durably reaches the last delivered seq.
+	require.Eventually(t, func() bool { return sub.committed.Load() == 2 }, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestSubscriptionStartsAtHead(t *testing.T) {
+	t.Parallel()
+	fn := &fnEndpoint{}
+	srv := httptest.NewServer(http.HandlerFunc(fn.handler))
+	defer srv.Close()
+	s := newTestProvider(t, srv.URL)
+
+	// Published BEFORE the subscription exists: not delivered (start-at-head).
+	publish(t, s, "orders", "", "before")
+
+	startSub(t, s, testTrigger("t1", "orders", nil))
+	publish(t, s, "orders", "", "after")
+
+	require.Eventually(t, func() bool { return len(fn.deliveries()) == 1 }, 5*time.Second, 10*time.Millisecond)
+	assert.Equal(t, "after", fn.deliveries()[0].Body)
+	// Give the loop a beat: "before" must never arrive.
+	time.Sleep(50 * time.Millisecond)
+	assert.Len(t, fn.deliveries(), 1)
+}
+
+func TestSubscriptionPoisonToErrorTopicAndContinues(t *testing.T) {
+	t.Parallel()
+	fn := &fnEndpoint{failN: 1 << 30} // every delivery fails
+	srv := httptest.NewServer(http.HandlerFunc(fn.handler))
+	defer srv.Close()
+	s := newTestProvider(t, srv.URL)
+
+	sub := startSub(t, s, testTrigger("t1", "orders", func(tr *fv1.MessageQueueTrigger) {
+		tr.Spec.MaxRetries = 1
+		tr.Spec.ErrorTopic = "orders-errors"
+	}))
+
+	publish(t, s, "orders", "application/json", "poison")
+
+	// The poison event lands on the error topic (E5) and the cursor advances.
+	errStream := mqpub.StreamForTopic("ns", "orders-errors")
+	require.Eventually(t, func() bool {
+		evs, err := s.el.Read(t.Context(), errStream, 0, 10)
+		return err == nil && len(evs) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+	evs, err := s.el.Read(t.Context(), errStream, 0, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("poison"), evs[0].Payload, "the ORIGINAL payload is routed to the error topic")
+	require.Eventually(t, func() bool { return sub.committed.Load() == 1 }, 5*time.Second, 10*time.Millisecond,
+		"the cursor advances past the poison event — one bad event cannot wedge the topic")
+
+	// MaxRetries=1 → exactly 2 attempts were made.
+	assert.Len(t, fn.deliveries(), 2)
+}
+
+func TestSubscriptionResponseTopic(t *testing.T) {
+	t.Parallel()
+	fn := &fnEndpoint{body: "fn-response"}
+	srv := httptest.NewServer(http.HandlerFunc(fn.handler))
+	defer srv.Close()
+	s := newTestProvider(t, srv.URL)
+
+	startSub(t, s, testTrigger("t1", "orders", func(tr *fv1.MessageQueueTrigger) {
+		tr.Spec.ResponseTopic = "orders-replies"
+	}))
+	publish(t, s, "orders", "", "req")
+
+	respStream := mqpub.StreamForTopic("ns", "orders-replies")
+	require.Eventually(t, func() bool {
+		evs, err := s.el.Read(t.Context(), respStream, 0, 10)
+		return err == nil && len(evs) == 1
+	}, 5*time.Second, 10*time.Millisecond)
+	evs, err := s.el.Read(t.Context(), respStream, 0, 10)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("fn-response"), evs[0].Payload)
+	assert.Equal(t, "text/plain", evs[0].Type, "the function's response Content-Type travels")
+}
+
+func TestSubscriptionResumesFromDurableCursor(t *testing.T) {
+	t.Parallel()
+	fn := &fnEndpoint{}
+	srv := httptest.NewServer(http.HandlerFunc(fn.handler))
+	defer srv.Close()
+	s := newTestProvider(t, srv.URL)
+	trigger := testTrigger("t1", "orders", nil)
+
+	sub := startSub(t, s, trigger)
+	publish(t, s, "orders", "", "one")
+	require.Eventually(t, func() bool { return sub.committed.Load() == 1 }, 5*time.Second, 10*time.Millisecond)
+	require.NoError(t, sub.Stop())
+
+	// Published while no consumer runs; the restart must resume from the durable
+	// cursor — deliver "two", never redeliver "one".
+	publish(t, s, "orders", "", "two")
+	startSub(t, s, trigger)
+
+	require.Eventually(t, func() bool { return len(fn.deliveries()) == 2 }, 5*time.Second, 10*time.Millisecond)
+	got := fn.deliveries()
+	assert.Equal(t, "one", got[0].Body)
+	assert.Equal(t, "two", got[1].Body)
+	time.Sleep(50 * time.Millisecond)
+	assert.Len(t, fn.deliveries(), 2, "no redelivery of already-committed events")
+}
+
+func TestReapStreamMinCursorAndBackstops(t *testing.T) {
+	t.Parallel()
+	s := newTestProvider(t, "http://unused")
+
+	// 5 events on the stream; a subscriber committed through 3.
+	for range 5 {
+		publish(t, s, "orders", "", "x")
+	}
+	stream := mqpub.StreamForTopic("ns", "orders")
+
+	// Min-cursor trim: events 1..3 go, 4..5 stay.
+	s.reapStream(t.Context(), stream, 3)
+	evs, err := s.el.Read(t.Context(), stream, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, evs, 2)
+	assert.EqualValues(t, 4, evs[0].Seq)
+
+	// Size backstop: cap of 1 retained event overrides a stalled cursor (0).
+	s.reaperMaxEvents = 1
+	s.reapStream(t.Context(), stream, 0)
+	evs, err = s.el.Read(t.Context(), stream, 0, 10)
+	require.NoError(t, err)
+	require.Len(t, evs, 1)
+	assert.EqualValues(t, 5, evs[0].Seq)
+
+	// Age backstop: everything is "old" with a zero max age.
+	s.reaperMaxAge = -time.Hour
+	s.reapStream(t.Context(), stream, 0)
+	evs, err = s.el.Read(t.Context(), stream, 0, 10)
+	require.NoError(t, err)
+	assert.Empty(t, evs, "age backstop trims events older than the cutoff")
+
+	// Idempotent when nothing to trim.
+	s.reapStream(t.Context(), stream, 0)
+}

--- a/pkg/mqtrigger/messageQueue/statestore/subscription_test.go
+++ b/pkg/mqtrigger/messageQueue/statestore/subscription_test.go
@@ -296,3 +296,39 @@ func TestReapStreamMinCursorAndBackstops(t *testing.T) {
 	// Idempotent when nothing to trim.
 	s.reapStream(t.Context(), stream, 0)
 }
+
+// TestByStreamBlocksUnstartedSubscriptions: a subscription that has not
+// established its cursor yet has an unknown durable floor that may lie below
+// every started sibling's — its stream must lose the loss-free min-cursor trim
+// candidate entirely (invariant E3), regardless of map iteration order.
+func TestByStreamBlocksUnstartedSubscriptions(t *testing.T) {
+	t.Parallel()
+	started := func(stream string, committed int64) *subscription {
+		s := &subscription{stream: stream}
+		s.committed.Store(committed)
+		s.started.Store(true)
+		return s
+	}
+	unstarted := func(stream string) *subscription { return &subscription{stream: stream} }
+
+	ss := newSubscriptionSet()
+	ss.add(started("topic/ns/a", 100))
+	ss.add(unstarted("topic/ns/a"))
+	ss.add(started("topic/ns/b", 7))
+
+	got := ss.byStream()
+	assert.EqualValues(t, noMinCursor, got["topic/ns/a"],
+		"an unstarted subscription must block min-cursor trimming for its stream")
+	assert.EqualValues(t, 7, got["topic/ns/b"], "unrelated streams keep their floor")
+
+	// noMinCursor disables candidate 1 in reapStream: nothing may be trimmed.
+	s := newTestProvider(t, "http://unused")
+	for range 3 {
+		publish(t, s, "orders", "", "x")
+	}
+	stream := mqpub.StreamForTopic("ns", "orders")
+	s.reapStream(t.Context(), stream, noMinCursor)
+	evs, err := s.el.Read(t.Context(), stream, 0, 10)
+	require.NoError(t, err)
+	assert.Len(t, evs, 3, "no loss-free trim while any floor is unknown")
+}

--- a/pkg/mqtrigger/mqpub/mqpub.go
+++ b/pkg/mqtrigger/mqpub/mqpub.go
@@ -32,15 +32,17 @@ var ErrUnsupportedMQType = errors.New("mqpub: unsupported message-queue type")
 // backlog cap (see DefaultMaxTopicBacklog).
 var ErrTopicBacklogCap = errors.New("mqpub: topic backlog cap reached")
 
-// DefaultMaxTopicBacklog bounds a topic stream's head in phase 1. Nothing
-// consumes or trims topics until the P2 subscriber + retention reaper land, so
-// every append is permanent — an unbounded stream on the shared store is a
-// cluster-wide resource hazard (a full embedded PVC fails every tenant's
-// enqueue). A publish to a topic at the cap is rejected loudly and counted
-// ("capped"), never silently dropped. The check reads Head first, so the cap is
-// soft under concurrent publishers (bounded overshoot by in-flight appends) —
-// a resource guard, not an exact quota. P2's retention machinery supersedes it
-// with min-cursor trim + age/size backstops and a tunable knob.
+// DefaultMaxTopicBacklog bounds a topic stream's RETAINED BACKLOG (head minus
+// the trim floor). An unbounded stream on the shared store is a cluster-wide
+// resource hazard (a full embedded PVC fails every tenant's enqueue), so a
+// publish to a topic at the cap is rejected loudly and counted ("capped"),
+// never silently dropped. The cap composes with retention: the reaper's
+// min-cursor/age/size trims raise the floor of consumed topics so their
+// publishes keep flowing, while a topic nobody consumes is never trimmed —
+// backlog equals lifetime head — and the cap bounds it exactly. The check is
+// two reads (Head + first retained event) before the append, so it is soft
+// under concurrent publishers (bounded overshoot) — a resource guard, not an
+// exact quota.
 const DefaultMaxTopicBacklog = 10000
 
 // TopicPublisher durably publishes a payload to a namespaced topic on a
@@ -105,16 +107,30 @@ func (p *statestorePublisher) Publish(ctx context.Context, namespace, mqType, to
 		return fmt.Errorf("mqpub: invalid topic name: %w", err)
 	}
 	stream := StreamForTopic(namespace, topic)
-	// Phase-1 backlog cap (soft — see DefaultMaxTopicBacklog): reject loudly
-	// rather than grow the shared store unboundedly with no consumer to trim it.
+	// Backlog cap (soft — see DefaultMaxTopicBacklog): reject loudly rather than
+	// grow the shared store unboundedly. backlog = head − trim floor, where the
+	// floor is one below the first retained event (== head when fully trimmed).
 	head, err := p.el.Head(ctx, stream)
 	if err != nil {
 		recordPublish(ctx, mqType, "error")
 		return fmt.Errorf("mqpub: reading topic head %s/%s: %w", namespace, topic, err)
 	}
 	if head >= p.maxBacklog {
-		recordPublish(ctx, mqType, "capped")
-		return fmt.Errorf("%w: topic %s/%s at %d events", ErrTopicBacklogCap, namespace, topic, head)
+		// Only pay the floor read once the lifetime head could possibly exceed
+		// the cap; below that, backlog <= head < cap always.
+		first, rerr := p.el.Read(ctx, stream, 0, 1)
+		if rerr != nil {
+			recordPublish(ctx, mqType, "error")
+			return fmt.Errorf("mqpub: reading topic floor %s/%s: %w", namespace, topic, rerr)
+		}
+		floor := head
+		if len(first) == 1 {
+			floor = first[0].Seq - 1
+		}
+		if head-floor >= p.maxBacklog {
+			recordPublish(ctx, mqType, "capped")
+			return fmt.Errorf("%w: topic %s/%s backlog %d", ErrTopicBacklogCap, namespace, topic, head-floor)
+		}
 	}
 	if _, err := p.el.Append(ctx, stream, statestore.AppendAny,
 		[]statestore.Event{{Type: contentType, Payload: payload}}); err != nil {

--- a/pkg/mqtrigger/mqpub/mqpub_test.go
+++ b/pkg/mqtrigger/mqpub/mqpub_test.go
@@ -94,6 +94,11 @@ func TestStatestorePublisherBacklogCap(t *testing.T) {
 
 	// Other topics are unaffected (the cap is per-stream).
 	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "other", "", []byte("x")))
+
+	// The cap is on the RETAINED backlog: retention trimming the stream lets
+	// publishes flow again (a consumed topic never bricks).
+	require.NoError(t, el.Trim(t.Context(), StreamForTopic("ns", "t"), 3))
+	require.NoError(t, p.Publish(t.Context(), "ns", fv1.MessageQueueTypeStatestore, "t", "", []byte("4")))
 }
 
 // erroringEventLog fails every Append, to prove E1: a failed publish surfaces as

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -233,6 +233,16 @@ func (mqt *MessageQueueTriggerManager) updateTrigger(trigger *fv1.MessageQueueTr
 	return nil
 }
 
+// Owns reports whether this head's manager consumes trigger: a classic
+// (non-KEDA) trigger of this head's MESSAGE_QUEUE_TYPE. One classic head runs
+// per MQ type (mqtrigger-kafka, mqtrigger-statestore, ...) and all of them
+// watch the same CRD, so each must claim only its own type — and never a
+// KEDA-kind trigger, which the --mqt_keda scaler manager owns.
+func (mqt *MessageQueueTriggerManager) Owns(trigger *fv1.MessageQueueTrigger) bool {
+	return trigger.Spec.MqtKind != MqtKindKeda &&
+		trigger.Spec.MessageQueueType == mqt.messageQueueType
+}
+
 // RegisterTrigger subscribes to (or re-subscribes, on a spec change) the message
 // queue for trigger and records the subscription. It is the create/update path
 // the reconciler calls; the delete path is unsubscribe. Subscriptions use the

--- a/pkg/mqtrigger/mqtmanager.go
+++ b/pkg/mqtrigger/mqtmanager.go
@@ -291,25 +291,67 @@ func (mqt *MessageQueueTriggerManager) RegisterTrigger(trigger *fv1.MessageQueue
 	return nil
 }
 
-// unsubscribe tears down the subscription for a deleted MessageQueueTrigger,
-// identified by name (a delete reconcile only has the NamespacedName). It is a
-// no-op if no subscription is recorded for the key.
-func (mqt *MessageQueueTriggerManager) unsubscribe(key types.NamespacedName) error {
+// unsubscribe tears down the subscription for a deleted (or no-longer-owned)
+// MessageQueueTrigger, identified by name (a delete reconcile only has the
+// NamespacedName). It reports whether a subscription was actually removed —
+// false with a nil error is the no-op case (this head never held one).
+func (mqt *MessageQueueTriggerManager) unsubscribe(key types.NamespacedName) (bool, error) {
 	stub := &fv1.MessageQueueTrigger{ObjectMeta: metav1.ObjectMeta{Namespace: key.Namespace, Name: key.Name}}
 	sub := mqt.getTriggerSubscription(stub)
 	if sub == nil {
-		return nil
+		return false, nil
 	}
 	if err := mqt.messageQueue.Unsubscribe(sub.subscription); err != nil {
 		mqt.logger.Error(err, "failed to unsubscribe from message queue trigger", "trigger_name", key.Name)
-		return err
+		return false, err
 	}
 	if err := mqt.delTriggerSubscription(stub); err != nil {
 		mqt.logger.Error(err, "error deleting message queue trigger subscription", "trigger_name", key.Name)
-		return err
+		return false, err
 	}
 	mqt.logger.Info("message queue trigger deleted", "trigger_name", key.Name)
-	return nil
+	return true, nil
+}
+
+// markMessageQueueTriggerNotOwned overwrites the Subscribed conditions this
+// head wrote after it tears down the subscription of a trigger it no longer
+// owns (spec moved to another MQ type/kind). Without this the CR keeps a stale
+// Ready=True — for delivery infrastructure, an affirmative lie. Best-effort,
+// like markMessageQueueTriggerBound.
+func (mqt *MessageQueueTriggerManager) markMessageQueueTriggerNotOwned(ctx context.Context, trigger *fv1.MessageQueueTrigger) {
+	if mqt.fissionClient == nil {
+		return
+	}
+	wantBind := metav1.Condition{
+		Type: fv1.MessageQueueTriggerConditionBindingReady, Status: metav1.ConditionFalse,
+		ObservedGeneration: trigger.Generation,
+		Reason:             fv1.MessageQueueTriggerReasonNotOwned,
+		Message:            "subscription released: trigger moved to MQ type " + string(trigger.Spec.MessageQueueType) + "/" + trigger.Spec.MqtKind,
+	}
+	wantReady := metav1.Condition{
+		Type: fv1.MessageQueueTriggerConditionReady, Status: metav1.ConditionFalse,
+		ObservedGeneration: trigger.Generation,
+		Reason:             fv1.MessageQueueTriggerReasonNotOwned,
+		Message:            "not dispatching: waiting for the owning head to subscribe",
+	}
+	if conditions.IsAt(trigger.Status.Conditions, wantBind) && conditions.IsAt(trigger.Status.Conditions, wantReady) {
+		return
+	}
+	cur, err := mqt.fissionClient.CoreV1().MessageQueueTriggers(trigger.Namespace).Get(ctx, trigger.Name, metav1.GetOptions{})
+	if err != nil {
+		mqt.logger.V(1).Info("mqtrigger status: get failed", "name", trigger.Name, "namespace", trigger.Namespace, "error", err)
+		return
+	}
+	wantBind.ObservedGeneration = cur.Generation
+	wantReady.ObservedGeneration = cur.Generation
+	if conditions.IsAt(cur.Status.Conditions, wantBind) && conditions.IsAt(cur.Status.Conditions, wantReady) {
+		return
+	}
+	conditions.Set(&cur.Status.Conditions, wantBind)
+	conditions.Set(&cur.Status.Conditions, wantReady)
+	if _, err := mqt.fissionClient.CoreV1().MessageQueueTriggers(trigger.Namespace).UpdateStatus(ctx, cur, metav1.UpdateOptions{}); err != nil {
+		mqt.logger.V(1).Info("mqtrigger status: update failed", "name", trigger.Name, "namespace", trigger.Namespace, "error", err)
+	}
 }
 
 // markMessageQueueTriggerBound writes BindingReady + Ready on a

--- a/pkg/mqtrigger/mqtmanager_test.go
+++ b/pkg/mqtrigger/mqtmanager_test.go
@@ -146,7 +146,7 @@ func TestMessageQueueTriggerReconciler(t *testing.T) {
 	ctx := t.Context()
 	mqt := &fv1.MessageQueueTrigger{
 		ObjectMeta: metav1.ObjectMeta{Name: "mqt1", Namespace: metav1.NamespaceDefault, Generation: 1},
-		Spec:       fv1.MessageQueueTriggerSpec{Topic: "topic-a"},
+		Spec:       fv1.MessageQueueTriggerSpec{Topic: "topic-a", MessageQueueType: fv1.MessageQueueTypeKafka},
 	}
 	c := crfake.NewClientBuilder().
 		WithScheme(scheme.Scheme).
@@ -181,4 +181,56 @@ func TestMessageQueueTriggerReconciler(t *testing.T) {
 	// Unsubscribing an unknown trigger is a no-op, not an error.
 	_, err = r.Reconcile(ctx, req)
 	require.NoError(t, err)
+}
+
+// TestReconcilerOwnership: every classic head watches the same CRD, so each
+// must subscribe only its own MQ type and never a KEDA-kind trigger — and a
+// spec update that moves a trigger away from this head must tear its
+// subscription down.
+func TestReconcilerOwnership(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	ctx := t.Context()
+	kafkaMqt := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "kafka-mqt", Namespace: metav1.NamespaceDefault, Generation: 1},
+		Spec:       fv1.MessageQueueTriggerSpec{Topic: "topic-a", MessageQueueType: fv1.MessageQueueTypeKafka},
+	}
+	otherType := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "ss-mqt", Namespace: metav1.NamespaceDefault, Generation: 1},
+		Spec:       fv1.MessageQueueTriggerSpec{Topic: "topic-b", MessageQueueType: fv1.MessageQueueTypeStatestore},
+	}
+	kedaKind := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "keda-mqt", Namespace: metav1.NamespaceDefault, Generation: 1},
+		Spec:       fv1.MessageQueueTriggerSpec{Topic: "topic-c", MessageQueueType: fv1.MessageQueueTypeKafka, MqtKind: MqtKindKeda},
+	}
+	c := crfake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(kafkaMqt, otherType, kedaKind).
+		WithStatusSubresource(&fv1.MessageQueueTrigger{}).
+		Build()
+
+	mgr := MakeMessageQueueTriggerManager(logger, nil, fv1.MessageQueueTypeKafka, fakeMessageQueue{})
+	mgr.bind(ctx)
+	r := NewMessageQueueTriggerReconciler(logger, c, mgr)
+
+	reconcile := func(name string) {
+		t.Helper()
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: name}})
+		require.NoError(t, err)
+	}
+
+	reconcile("kafka-mqt")
+	reconcile("ss-mqt")
+	reconcile("keda-mqt")
+	assert.True(t, mgr.checkTriggerSubscription(kafkaMqt), "own type: subscribed")
+	assert.False(t, mgr.checkTriggerSubscription(otherType), "another head's MQ type: not subscribed")
+	assert.False(t, mgr.checkTriggerSubscription(kedaKind), "KEDA-kind: the scaler manager owns it")
+
+	// A spec update that changes the MQ type moves the trigger to another head:
+	// this head must drop its subscription.
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "kafka-mqt"}, kafkaMqt))
+	kafkaMqt.Spec.MessageQueueType = fv1.MessageQueueTypeStatestore
+	kafkaMqt.Generation = 2
+	require.NoError(t, c.Update(ctx, kafkaMqt))
+	reconcile("kafka-mqt")
+	assert.False(t, mgr.checkTriggerSubscription(kafkaMqt), "type change away from this head unsubscribes")
 }

--- a/pkg/mqtrigger/mqtmanager_test.go
+++ b/pkg/mqtrigger/mqtmanager_test.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
 	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
 	"github.com/fission/fission/pkg/mqtrigger/messageQueue"
 	"github.com/fission/fission/pkg/utils/loggerfactory"
@@ -208,7 +210,10 @@ func TestReconcilerOwnership(t *testing.T) {
 		WithStatusSubresource(&fv1.MessageQueueTrigger{}).
 		Build()
 
-	mgr := MakeMessageQueueTriggerManager(logger, nil, fv1.MessageQueueTypeKafka, fakeMessageQueue{})
+	// A real (fake) fissionClient so the status writes (Subscribed on register,
+	// NotOwned on release) are assertable.
+	fissionClient := fissionfake.NewSimpleClientset(kafkaMqt.DeepCopy(), otherType.DeepCopy(), kedaKind.DeepCopy())
+	mgr := MakeMessageQueueTriggerManager(logger, fissionClient, fv1.MessageQueueTypeKafka, fakeMessageQueue{})
 	mgr.bind(ctx)
 	r := NewMessageQueueTriggerReconciler(logger, c, mgr)
 
@@ -226,11 +231,23 @@ func TestReconcilerOwnership(t *testing.T) {
 	assert.False(t, mgr.checkTriggerSubscription(kedaKind), "KEDA-kind: the scaler manager owns it")
 
 	// A spec update that changes the MQ type moves the trigger to another head:
-	// this head must drop its subscription.
+	// this head must drop its subscription AND flip the Subscribed conditions it
+	// wrote — a released trigger keeping Ready=True would claim delivery while
+	// nothing consumes its topic.
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: metav1.NamespaceDefault, Name: "kafka-mqt"}, kafkaMqt))
 	kafkaMqt.Spec.MessageQueueType = fv1.MessageQueueTypeStatestore
 	kafkaMqt.Generation = 2
 	require.NoError(t, c.Update(ctx, kafkaMqt))
 	reconcile("kafka-mqt")
 	assert.False(t, mgr.checkTriggerSubscription(kafkaMqt), "type change away from this head unsubscribes")
+
+	cur, err := fissionClient.CoreV1().MessageQueueTriggers(metav1.NamespaceDefault).Get(ctx, "kafka-mqt", metav1.GetOptions{})
+	require.NoError(t, err)
+	bind := meta.FindStatusCondition(cur.Status.Conditions, fv1.MessageQueueTriggerConditionBindingReady)
+	require.NotNil(t, bind, "released trigger carries a BindingReady condition")
+	assert.Equal(t, metav1.ConditionFalse, bind.Status)
+	assert.Equal(t, fv1.MessageQueueTriggerReasonNotOwned, bind.Reason)
+	ready := meta.FindStatusCondition(cur.Status.Conditions, fv1.MessageQueueTriggerConditionReady)
+	require.NotNil(t, ready)
+	assert.Equal(t, metav1.ConditionFalse, ready.Status)
 }

--- a/pkg/mqtrigger/reconciler.go
+++ b/pkg/mqtrigger/reconciler.go
@@ -57,7 +57,7 @@ func (r *MessageQueueTriggerReconciler) Reconcile(ctx context.Context, req ctrl.
 		if apierrors.IsNotFound(err) {
 			// Deleted: tear down the subscription. Identified by name only —
 			// the object is already gone.
-			if err := r.mqtMgr.unsubscribe(req.NamespacedName); err != nil {
+			if _, err := r.mqtMgr.unsubscribe(req.NamespacedName); err != nil {
 				return ctrl.Result{}, err
 			}
 			return ctrl.Result{}, nil
@@ -68,9 +68,21 @@ func (r *MessageQueueTriggerReconciler) Reconcile(ctx context.Context, req ctrl.
 	// Not this head's trigger: a different MQ type (another classic head owns
 	// it) or a KEDA-kind trigger (the scaler manager owns it). Unsubscribe
 	// rather than plain skip — a spec update can move a trigger away from this
-	// head, and unsubscribe is a no-op when we never held a subscription.
+	// head, and unsubscribe is a no-op when we never held a subscription. When
+	// we DID hold one, flip the Subscribed conditions we wrote to
+	// NotOwned=False so the CR doesn't keep claiming Ready while nothing
+	// consumes its topic. (A trigger whose owning head is not deployed at all
+	// keeps an empty status — no head exists to write one; that is inherent to
+	// the head-per-type layout, kafka included.)
 	if !r.mqtMgr.Owns(mqt) {
-		return ctrl.Result{}, r.mqtMgr.unsubscribe(req.NamespacedName)
+		removed, err := r.mqtMgr.unsubscribe(req.NamespacedName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if removed {
+			r.mqtMgr.markMessageQueueTriggerNotOwned(ctx, mqt)
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// RegisterTrigger subscribes on first sight and re-subscribes on a spec

--- a/pkg/mqtrigger/reconciler.go
+++ b/pkg/mqtrigger/reconciler.go
@@ -65,6 +65,14 @@ func (r *MessageQueueTriggerReconciler) Reconcile(ctx context.Context, req ctrl.
 		return ctrl.Result{}, err
 	}
 
+	// Not this head's trigger: a different MQ type (another classic head owns
+	// it) or a KEDA-kind trigger (the scaler manager owns it). Unsubscribe
+	// rather than plain skip — a spec update can move a trigger away from this
+	// head, and unsubscribe is a no-op when we never held a subscription.
+	if !r.mqtMgr.Owns(mqt) {
+		return ctrl.Result{}, r.mqtMgr.unsubscribe(req.NamespacedName)
+	}
+
 	// RegisterTrigger subscribes on first sight and re-subscribes on a spec
 	// change (it checks the in-memory map). A failure returns an error so the
 	// workqueue requeues with backoff.

--- a/test/integration/framework/function.go
+++ b/test/integration/framework/function.go
@@ -8,6 +8,7 @@ package framework
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"strconv"
 	"strings"
@@ -287,13 +288,28 @@ func (ns *TestNamespace) WaitForFunction(t *testing.T, ctx context.Context, name
 //   - builder pods (separate deployment): `envName=<env>` (legacy label).
 func (ns *TestNamespace) FunctionLogs(t *testing.T, ctx context.Context, fnName string) string {
 	t.Helper()
+	logs, err := ns.FunctionLogsE(t, ctx, fnName)
+	require.NoErrorf(t, err, "FunctionLogs: %s", fnName)
+	return logs
+}
+
+// FunctionLogsE is FunctionLogs without the fatal require: inside a polling
+// closure (require.Eventually and friends) a transient apiserver error must
+// surface as "retry", not fail the test from a goroutine the retry loop cannot
+// recover. Per-pod stream errors are still tolerated (churned pods).
+func (ns *TestNamespace) FunctionLogsE(t *testing.T, ctx context.Context, fnName string) (string, error) {
+	t.Helper()
 	pods, err := ns.f.kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{
 		LabelSelector: "functionName=" + fnName,
 	})
-	require.NoErrorf(t, err, "FunctionLogs: list pods (functionName=%s)", fnName)
+	if err != nil {
+		return "", fmt.Errorf("list pods (functionName=%s): %w", fnName, err)
+	}
 
 	fn, err := ns.f.fissionClient.CoreV1().Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
-	require.NoErrorf(t, err, "FunctionLogs: get function %q", fnName)
+	if err != nil {
+		return "", fmt.Errorf("get function %q: %w", fnName, err)
+	}
 	envName := fn.Spec.Environment.Name
 
 	var combined strings.Builder
@@ -312,7 +328,7 @@ func (ns *TestNamespace) FunctionLogs(t *testing.T, ctx context.Context, fnName 
 		}
 		combined.Write(b)
 	}
-	return combined.String()
+	return combined.String(), nil
 }
 
 // GetFunction returns the live Function CR by name. Use it to assert on

--- a/test/integration/framework/mqtrigger.go
+++ b/test/integration/framework/mqtrigger.go
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package framework
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MessageQueueTriggerOptions are the inputs to
+// TestNamespace.CreateMessageQueueTrigger.
+type MessageQueueTriggerOptions struct {
+	// Name of the MessageQueueTrigger CR. Required.
+	Name string
+	// Function the trigger delivers topic events to. Required.
+	Function string
+	// MQType selects the provider (e.g. "statestore", "kafka"). Required.
+	MQType string
+	// Topic the trigger consumes. Required.
+	Topic string
+	// MqtKind is "fission" (a classic per-type consumer head) or "keda".
+	// Defaults to "fission" — the CLI's own default is "keda", which rejects
+	// non-KEDA types like statestore.
+	MqtKind string
+	// ResponseTopic and ErrorTopic are optional publish-back topics.
+	ResponseTopic string
+	ErrorTopic    string
+	// MaxRetries is the delivery retry budget (0 = deliver once).
+	MaxRetries int
+}
+
+// CreateMessageQueueTrigger creates a MessageQueueTrigger CR via the CLI. The
+// matching mqt head (mqtrigger-<type> for classic kinds) then delivers each
+// topic event to Function on the router's internal listener. Cleanup deletes
+// the trigger, which tears down the head's subscription.
+func (ns *TestNamespace) CreateMessageQueueTrigger(t *testing.T, ctx context.Context, opts MessageQueueTriggerOptions) {
+	t.Helper()
+	require.NotEmpty(t, opts.Name, "MessageQueueTriggerOptions.Name")
+	require.NotEmpty(t, opts.Function, "MessageQueueTriggerOptions.Function")
+	require.NotEmpty(t, opts.MQType, "MessageQueueTriggerOptions.MQType")
+	require.NotEmpty(t, opts.Topic, "MessageQueueTriggerOptions.Topic")
+	kind := opts.MqtKind
+	if kind == "" {
+		kind = "fission"
+	}
+
+	args := []string{
+		"mqt", "create",
+		"--name", opts.Name,
+		"--function", opts.Function,
+		"--mqtype", opts.MQType,
+		"--mqtkind", kind,
+		"--topic", opts.Topic,
+		"--maxretries", strconv.Itoa(opts.MaxRetries),
+	}
+	if opts.ResponseTopic != "" {
+		args = append(args, "--resptopic", opts.ResponseTopic)
+	}
+	if opts.ErrorTopic != "" {
+		args = append(args, "--errortopic", opts.ErrorTopic)
+	}
+	ns.CLI(t, ctx, args...)
+
+	ns.addCleanup("messagequeuetrigger "+opts.Name, func(c context.Context) error {
+		err := ns.f.fissionClient.CoreV1().MessageQueueTriggers(ns.Name).Delete(c, opts.Name, metav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	})
+}

--- a/test/integration/suites/serial/async_destinations_test.go
+++ b/test/integration/suites/serial/async_destinations_test.go
@@ -89,9 +89,12 @@ func TestAsyncInvocationOnSuccessFunctionDestination(t *testing.T) {
 	route := "/async-src-" + ns.ID
 
 	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: env, Image: image})
-	code := framework.WriteTestData(t, "nodejs/log/log.js")
-	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: dstFn, Env: env, Code: code, ExecutorType: "poolmgr"})
-	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: srcFn, Env: env, Code: code, ExecutorType: "poolmgr"})
+	// The destination logs its request body: the result envelope's functionRef
+	// ("<ns>/<srcFn>", unique per test run) is asserted with Contains — a
+	// count-over-baseline assertion is sensitive to pod churn re-baselining the
+	// visible logs (a CI flake this test used to have).
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: dstFn, Env: env, Code: framework.WriteTestData(t, "nodejs/log/logbody.js"), ExecutorType: "poolmgr"})
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: srcFn, Env: env, Code: framework.WriteTestData(t, "nodejs/log/log.js"), ExecutorType: "poolmgr"})
 	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: srcFn, URL: route, Method: http.MethodPost})
 
 	setInvocation(t, ctx, f, ns, srcFn, &fv1.InvocationConfig{
@@ -100,7 +103,6 @@ func TestAsyncInvocationOnSuccessFunctionDestination(t *testing.T) {
 
 	warmRoute(t, ctx, f, route)
 	warmInternal(t, ctx, f, dstFn)
-	baseline := strings.Count(ns.FunctionLogs(t, ctx, dstFn), logMarker)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		status, id := asyncPost(t, ctx, f, route, "dest-once-"+ns.ID)
@@ -108,9 +110,10 @@ func TestAsyncInvocationOnSuccessFunctionDestination(t *testing.T) {
 		assert.NotEmpty(c, id)
 	}, 2*time.Minute, 2*time.Second)
 
+	marker := ns.Name + "/" + srcFn
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		got := strings.Count(ns.FunctionLogs(t, ctx, dstFn), logMarker)
-		assert.Greater(c, got, baseline, "onSuccess destination function must execute out-of-band")
+		assert.Contains(c, ns.FunctionLogs(t, ctx, dstFn), marker,
+			"onSuccess destination function must execute out-of-band with the result envelope")
 	}, 3*time.Minute, 3*time.Second)
 }
 

--- a/test/integration/suites/serial/async_destinations_test.go
+++ b/test/integration/suites/serial/async_destinations_test.go
@@ -111,10 +111,15 @@ func TestAsyncInvocationOnSuccessFunctionDestination(t *testing.T) {
 	}, 2*time.Minute, 2*time.Second)
 
 	marker := ns.Name + "/" + srcFn
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Contains(c, ns.FunctionLogs(t, ctx, dstFn), marker,
-			"onSuccess destination function must execute out-of-band with the result envelope")
-	}, 3*time.Minute, 3*time.Second)
+	require.Eventually(t, func() bool {
+		logs, err := ns.FunctionLogsE(t, ctx, dstFn)
+		if err != nil {
+			t.Logf("destination logs: %v (retrying)", err)
+			return false
+		}
+		return strings.Contains(logs, marker)
+	}, 3*time.Minute, 3*time.Second,
+		"onSuccess destination function must execute out-of-band with the result envelope (marker %q)", marker)
 }
 
 // TestAsyncInvocationDepthCapBounds: a function whose onSuccess points back at

--- a/test/integration/suites/serial/async_invocation_test.go
+++ b/test/integration/suites/serial/async_invocation_test.go
@@ -77,16 +77,29 @@ func scaleDeployment(t *testing.T, ctx context.Context, f *framework.Framework, 
 // returns the status and the X-Fission-Invocation-Id header.
 func asyncPost(t *testing.T, ctx context.Context, f *framework.Framework, route, dedupKey string) (int, string) {
 	t.Helper()
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.Router(t).BaseURL()+route, strings.NewReader("payload"))
+	status, id, err := asyncPostE(t, ctx, f, route, dedupKey)
 	require.NoError(t, err)
+	return status, id
+}
+
+// asyncPostE is asyncPost without the fatal require, for use inside polling
+// closures where a transient error must mean "retry this tick" (t is only
+// forwarded to Router for its Helper bookkeeping — never failed).
+func asyncPostE(t *testing.T, ctx context.Context, f *framework.Framework, route, dedupKey string) (int, string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, f.Router(t).BaseURL()+route, strings.NewReader("payload"))
+	if err != nil {
+		return 0, "", err
+	}
 	req.Header.Set(asyncinvoke.HeaderInvokeMode, asyncinvoke.InvokeModeAsync)
 	if dedupKey != "" {
 		req.Header.Set(asyncinvoke.HeaderDedupKey, dedupKey)
 	}
 	resp, err := f.HTTPClient().Do(req)
-	require.NoError(t, err)
+	if err != nil {
+		return 0, "", err
+	}
 	defer func() { _ = resp.Body.Close() }()
-	return resp.StatusCode, resp.Header.Get(asyncinvoke.HeaderInvocationID)
+	return resp.StatusCode, resp.Header.Get(asyncinvoke.HeaderInvocationID), nil
 }
 
 // TestAsyncInvocationExecutes: an async request returns 202 + an invocation id

--- a/test/integration/suites/serial/statestore_eventing_test.go
+++ b/test/integration/suites/serial/statestore_eventing_test.go
@@ -9,6 +9,7 @@ package serial_test
 import (
 	"context"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,12 +92,22 @@ func TestStatestoreEventingPipeline(t *testing.T) {
 	// publish (fresh invocation per poll, no dedup key) makes the test immune to
 	// the ms-scale race between BindingReady and the consumer's start-at-head
 	// cursor snapshot; the Contains assertion is idempotent under the extra
-	// deliveries at-least-once implies anyway.
+	// deliveries at-least-once implies anyway. Everything inside the closure is
+	// non-fatal (asyncPostE/FunctionLogsE) so a transient apiserver or router
+	// hiccup is a retried tick, not a test failure from inside the retry loop.
 	marker := ns.Name + "/" + srcFn
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		status, _ := asyncPost(t, ctx, f, route, "")
-		assert.Equal(c, http.StatusAccepted, status)
-		assert.Contains(c, ns.FunctionLogs(t, ctx, dstFn), marker,
-			"the result envelope must flow src → topic → statestore mqt → dst")
-	}, 4*time.Minute, 5*time.Second)
+	require.Eventually(t, func() bool {
+		status, _, err := asyncPostE(t, ctx, f, route, "")
+		if err != nil || status != http.StatusAccepted {
+			t.Logf("async post: status=%d err=%v (retrying)", status, err)
+			return false
+		}
+		logs, err := ns.FunctionLogsE(t, ctx, dstFn)
+		if err != nil {
+			t.Logf("destination logs: %v (retrying)", err)
+			return false
+		}
+		return strings.Contains(logs, marker)
+	}, 4*time.Minute, 5*time.Second,
+		"the result envelope must flow src → topic → statestore mqt → dst (marker %q in %s logs)", marker, dstFn)
 }

--- a/test/integration/suites/serial/statestore_eventing_test.go
+++ b/test/integration/suites/serial/statestore_eventing_test.go
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package serial_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// requireEventingEnabled skips the test unless the built-in statestore MQ head
+// (RFC-0027, chart gate statestore.enabled && eventing.enabled) is deployed.
+func requireEventingEnabled(t *testing.T, ctx context.Context, f *framework.Framework) {
+	t.Helper()
+	_, err := f.KubeClient().AppsV1().Deployments(f.FissionNamespace()).Get(ctx, "mqtrigger-statestore", metav1.GetOptions{})
+	if err != nil {
+		t.Skipf("statestore eventing head is not deployed (mqtrigger-statestore: %v); skipping", err)
+	}
+}
+
+// TestStatestoreEventingPipeline: the RFC-0027 zero-broker eventing loop
+// end-to-end — an async invocation of function A publishes its result envelope
+// to a statestore topic (onSuccess topic destination), and a
+// messageQueueType: statestore MessageQueueTrigger consumes the topic and
+// delivers the envelope to function B. No external broker anywhere.
+func TestStatestoreEventingPipeline(t *testing.T) {
+	f := framework.Connect(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	requireAsyncEnabled(t, ctx, f)
+	requireEventingEnabled(t, ctx, f)
+	image := f.Images().RequireNode(t)
+	ns := f.NewTestNamespace(t)
+
+	env := "node-evt-" + ns.ID
+	srcFn := "evt-src-" + ns.ID
+	dstFn := "evt-dst-" + ns.ID
+	route := "/evt-src-" + ns.ID
+	topic := "evt-orders-" + ns.ID
+	mqtName := "evt-mqt-" + ns.ID
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: env, Image: image})
+	// A logs a fixed marker; B logs its request body, so the result envelope's
+	// functionRef ("<ns>/<srcFn>", unique per test run) is assertable in B's
+	// logs with a churn-insensitive Contains.
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: srcFn, Env: env, Code: framework.WriteTestData(t, "nodejs/log/log.js"), ExecutorType: "poolmgr"})
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: dstFn, Env: env, Code: framework.WriteTestData(t, "nodejs/log/logbody.js"), ExecutorType: "poolmgr"})
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: srcFn, URL: route, Method: http.MethodPost})
+	ns.CreateMessageQueueTrigger(t, ctx, framework.MessageQueueTriggerOptions{
+		Name:       mqtName,
+		Function:   dstFn,
+		MQType:     string(fv1.MessageQueueTypeStatestore),
+		Topic:      topic,
+		MaxRetries: 2,
+	})
+
+	setInvocation(t, ctx, f, ns, srcFn, &fv1.InvocationConfig{
+		OnSuccess: &fv1.DestinationRef{Topic: &fv1.TopicRef{
+			MessageQueueType: fv1.MessageQueueTypeStatestore,
+			Topic:            topic,
+		}},
+	})
+
+	// The statestore head marks the trigger BindingReady once its consumer loop
+	// is subscribed — events published before that are legitimately unseen
+	// (start-at-head subscription).
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		conds := ns.GetMessageQueueTriggerConditions(t, ctx, mqtName)
+		assert.True(c, meta.IsStatusConditionTrue(conds, fv1.MessageQueueTriggerConditionBindingReady),
+			"statestore head must subscribe the trigger")
+	}, 2*time.Minute, 2*time.Second)
+
+	warmRoute(t, ctx, f, route)
+	warmInternal(t, ctx, f, dstFn)
+
+	// Fire async invocations until the pipeline visibly completes. Retrying the
+	// publish (fresh invocation per poll, no dedup key) makes the test immune to
+	// the ms-scale race between BindingReady and the consumer's start-at-head
+	// cursor snapshot; the Contains assertion is idempotent under the extra
+	// deliveries at-least-once implies anyway.
+	marker := ns.Name + "/" + srcFn
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		status, _ := asyncPost(t, ctx, f, route, "")
+		assert.Equal(c, http.StatusAccepted, status)
+		assert.Contains(c, ns.FunctionLogs(t, ctx, dstFn), marker,
+			"the result envelope must flow src → topic → statestore mqt → dst")
+	}, 4*time.Minute, 5*time.Second)
+}

--- a/test/integration/testdata/nodejs/log/logbody.js
+++ b/test/integration/testdata/nodejs/log/logbody.js
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// logbody.js logs the request body it received, so tests can assert a unique
+// per-test marker appears in the function logs (strings.Contains) instead of
+// counting a fixed marker — count-based assertions are sensitive to pod churn
+// re-baselining the visible logs.
+module.exports = async function (context) {
+    const body = context.request.body;
+    const text = typeof body === "string" ? body : JSON.stringify(body);
+    console.log("logbody:", text);
+    return {
+        status: 200,
+        body: "logbody\n",
+    };
+};


### PR DESCRIPTION
## RFC-0027 Phase 2 — the built-in MessageQueue provider (`messageQueueType: statestore`)

Completes the zero-broker eventing loop RFC-0027 promised: with Phase 1's topic destinations (#3583) publishing result envelopes to statestore topics, this phase adds the consumer side — a `MessageQueueTrigger` with `messageQueueType: statestore` delivers those topic events to functions with **no external broker anywhere**:

```
fn A --(async, onSuccess topic)--> topic/<ns>/<topic> --(statestore mqt)--> fn B
```

### Provider (`pkg/mqtrigger/messageQueue/statestore/`)

Mirrors the kafka provider's shape (classic head per MQ type, leader-only subscriptions, HMAC-signed delivery to the router internal listener, MaxRetries → ErrorTopic, ResponseTopic on success), consuming a **per-trigger durable cursor** (KV CAS) instead of a consumer group. The subscription protocol — cursor CAS with conflict adoption, poison→ErrorTopic-before-advance (E5), min-cursor retention (E3) — is the TLC-checked `docs/rfc/specs/eventlogsub.tla` model, merged with the RFC.

- Start-at-head subscriptions; at-least-once delivery; cursor never regresses (CursorMonotonic).
- Retention reaper: per subscribed stream, trim to max(min committed cursor [loss-free], 7d age backstop, 100k size backstop), bounded age scan per tick, 30s tick deadline. A registered-but-unstarted subscription blocks the loss-free candidate entirely (its durable floor is unknown).
- Full observability: deliveries/retries/error-topic/response-topic/trim/gap counters; a consumer that resumes past trimmed events logs and meters the gap it suffered.

### Ownership fix (`pkg/mqtrigger/`)

Every classic mqt head watches the same CRD, and the reconciler subscribed **all** triggers regardless of `messageQueueType`/`mqtKind` — latent while kafka was the only classic head, live the moment two coexist. Heads now claim only their own type (never KEDA-kind), a spec change that moves a trigger away tears down the stale subscription, and the releasing head flips its `Subscribed` conditions to `NotOwned=False` instead of leaving a stale `Ready=True`.

### Chart

- `mqt-fission-statestore` deployment, gated `statestore.enabled && eventing.enabled` (`eventing.enabled` defaults **on**, so a statestore install gets the loop out of the box; renders nothing while statestore is off).
- Minimal RBAC component (`statestore-mqt`): functions + messagequeuetriggers read, mqt status write, leases/events — strictly narrower than the kafka head's.
- Statestore NetworkPolicy allowlists exactly `{svc: mqtrigger, messagequeue: statestore}` (not the kafka head).

### mqpub cap evolution

Phase 1's lifetime-head cap would brick topics once retention exists (heads are monotonic). The cap is now on **retained backlog** (head − trim floor, floor read only when head ≥ cap): retention trims let consumed topics breathe; unconsumed topics stay capped at 10k.

### CLI

`fn create/update --async-on-success-topic` / `--async-on-failure-topic` (statestore TopicRef; per-condition XOR with the function-destination flags; empty clears; kind-switch replaces the ref wholesale). `mqt create --mqtype statestore --mqtkind fission` validates via the registered validator. Admission now validates `ErrorTopic` like `ResponseTopic` (an invalid one wedges the consumer on the first poison event, E5). The provider package registers no statestore drivers — the bundle head does — so the CLI links no pgx.

### Tests

- 9 provider `-race` unit tests (in-order delivery, start-at-head, poison→ErrorTopic-and-continue, ResponseTopic, durable-cursor resume, reaper backstops + unstarted-subscription guard).
- Ownership: reconciler claims own type only, ignores other types/KEDA, unsubscribes + writes NotOwned on type change.
- Serial e2e `TestStatestoreEventingPipeline`: the full fn A → topic → statestore mqt → fn B loop on kind; BindingReady-gated, publish-retry-per-poll (immune to the start-at-head race), churn-insensitive Contains assertion on the envelope's unique functionRef.
- Also hardens the flaky `TestAsyncInvocationOnSuccessFunctionDestination` (count-over-baseline → unique-marker Contains) and adds non-fatal `FunctionLogsE`/`asyncPostE` so polling closures retry transient errors.

Review battery (code-review + silent-failure + security agents) findings are all addressed in the last commit — including the statestore-mqt RBAC boot permission (functions list, required by `crd.WaitForFunctionCRDs`) and the reaper E3 guard.

Remaining RFC-0027 phases (broker egress, KEDA lag scaler, `fission topic` CLI, bench) follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
