### PR TITLE
fix(executor): guard nil PodSpec and TerminationGracePeriodSeconds in container getDeploymentSpec

### DIFF
--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -123,8 +123,12 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 		replicas = *targetReplicas
 	}
 
+	if fn.Spec.PodSpec == nil {
+		return nil, fmt.Errorf("podSpec is not set for function %s", fn.Name)
+	}
+
 	gracePeriodSeconds := int64(6 * 60)
-	if *fn.Spec.PodSpec.TerminationGracePeriodSeconds >= 0 {
+	if fn.Spec.PodSpec.TerminationGracePeriodSeconds != nil && *fn.Spec.PodSpec.TerminationGracePeriodSeconds >= 0 {
 		gracePeriodSeconds = *fn.Spec.PodSpec.TerminationGracePeriodSeconds
 	}
 
@@ -166,10 +170,6 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 	rvCount, err := util.ReferencedResourcesRVSum(ctx, cn.kubernetesClient, fn.Namespace, fn.Spec.Secrets, fn.Spec.ConfigMaps)
 	if err != nil {
 		return nil, err
-	}
-
-	if fn.Spec.PodSpec == nil {
-		return nil, fmt.Errorf("podSpec is not set for function %s", fn.Name)
 	}
 
 	container := &apiv1.Container{

--- a/pkg/executor/executortype/container/deployment_test.go
+++ b/pkg/executor/executortype/container/deployment_test.go
@@ -100,6 +100,30 @@ func TestContainerGetDeploymentSpec(t *testing.T) {
 		assert.Equal(t, int32(2), *deployment.Spec.Replicas)
 	})
 
+	t.Run("nil TerminationGracePeriodSeconds falls back to the default", func(t *testing.T) {
+		cn := newTestContainer()
+		fn := newTestContainerFunction()
+		fn.Spec.PodSpec.TerminationGracePeriodSeconds = nil
+		replicas := int32(1)
+
+		deployment, err := cn.getDeploymentSpec(t.Context(), fn, &replicas, "ctr-fn", "default", nil, nil)
+		require.NoError(t, err)
+
+		pod := deployment.Spec.Template.Spec
+		require.NotNil(t, pod.TerminationGracePeriodSeconds)
+		assert.Equal(t, int64(6*60), *pod.TerminationGracePeriodSeconds)
+	})
+
+	t.Run("nil PodSpec returns an error instead of panicking", func(t *testing.T) {
+		cn := newTestContainer()
+		fn := newTestContainerFunction()
+		fn.Spec.PodSpec = nil
+		replicas := int32(1)
+
+		_, err := cn.getDeploymentSpec(t.Context(), fn, &replicas, "ctr-fn", "default", nil, nil)
+		require.Error(t, err)
+	})
+
 	t.Run("istio disables sidecar injection", func(t *testing.T) {
 		cn := newTestContainer()
 		cn.useIstio = true


### PR DESCRIPTION
## Description
`getDeploymentSpec` dereferences `*fn.Spec.PodSpec.TerminationGracePeriodSeconds` at the top of the function, before the `PodSpec == nil` guard that lives further down. `TerminationGracePeriodSeconds` is an optional `*int64` in a core `PodSpec`, so a valid Function whose `podspec` omits it makes the executor panic and the function never gets a Deployment (router then returns `specialization_failed` / connection refused).

This moves the existing `PodSpec == nil` check to the top of the function and nil-checks the pointer before dereferencing it, falling back to the 6 minute default when the field is unset. The later duplicate `PodSpec == nil` guard is removed.

## Which issue(s) this PR fixes:
Fixes #3590

## Testing
Added two sub-tests to `TestContainerGetDeploymentSpec`: one asserting a nil `TerminationGracePeriodSeconds` falls back to the 360s default, and one asserting a nil `PodSpec` returns an error instead of panicking. Both fail (panic at `deployment.go:127`) without the change and pass with it.

```
go test ./pkg/executor/executortype/container/ -run TestContainerGetDeploymentSpec
```

## Checklist:
- [x] I ran tests as well as code linting locally to verify my changes. 
- [x] I have done manual verification of my changes, changes working as expected.
- [x] I have added new tests to cover my changes.
- [x] My changes follow contributing guidelines of Fission.
- [x] I have signed all of my commits.
