### PR TITLE
fix(crd): drop ResourceVersion from CacheKeyURG

### DIFF
--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -200,7 +200,7 @@ const (
 	// FUNCTION_GENERATION labels a specialized pool pod with the Function
 	// generation it was specialized from. The per-function Service selector
 	// includes it so stale-generation pods drop out of the EndpointSlices on a
-	// function update (the executor-side equivalent is CacheKeyURG keying).
+	// function update (the executor-side equivalent is CacheKeyUG keying).
 	FUNCTION_GENERATION = "fission.io/function-generation"
 	// SERVED_LABEL gates a specialized pod's membership in its function
 	// Service: pool pods pass readiness probes before specialization, so the

--- a/pkg/crd/key.go
+++ b/pkg/crd/key.go
@@ -20,12 +20,12 @@ func (ck CacheKeyUR) String() string {
 	return fmt.Sprintf("%v_%v", ck.UID, ck.ResourceVersion)
 }
 
-type CacheKeyURG struct {
+type CacheKeyUG struct {
 	UID        types.UID
 	Generation int64
 }
 
-func (ck CacheKeyURG) String() string {
+func (ck CacheKeyUG) String() string {
 	return fmt.Sprintf("%v_%v", ck.UID, ck.Generation)
 }
 
@@ -56,15 +56,15 @@ func CacheKeyURFromObject(obj metav1.Object) CacheKeyUR {
 	}
 }
 
-// CacheKeyURGFromMeta creates a cache key that uniquely identifies the
+// CacheKeyUGFromMeta creates a cache key that uniquely identifies the
 // function's content version. UID is stable for the function's
 // lifetime; Generation increments on spec changes. ResourceVersion is
 // intentionally excluded: it changes on status updates (not just spec
 // changes), and the router's informer cache may lag the executor's
 // view, causing UnTapService to miss the cache entry and leak
 // activeRequests.
-func CacheKeyURGFromMeta(metadata *metav1.ObjectMeta) CacheKeyURG {
-	return CacheKeyURG{
+func CacheKeyUGFromMeta(metadata *metav1.ObjectMeta) CacheKeyUG {
+	return CacheKeyUG{
 		UID:        metadata.UID,
 		Generation: metadata.Generation,
 	}

--- a/pkg/crd/key.go
+++ b/pkg/crd/key.go
@@ -21,13 +21,12 @@ func (ck CacheKeyUR) String() string {
 }
 
 type CacheKeyURG struct {
-	UID             types.UID
-	ResourceVersion string
-	Generation      int64
+	UID        types.UID
+	Generation int64
 }
 
 func (ck CacheKeyURG) String() string {
-	return fmt.Sprintf("%v_%v_%v", ck.UID, ck.ResourceVersion, ck.Generation)
+	return fmt.Sprintf("%v_%v", ck.UID, ck.Generation)
 }
 
 // CacheKeyUIDFromMeta create a key that uniquely identifies the
@@ -57,15 +56,16 @@ func CacheKeyURFromObject(obj metav1.Object) CacheKeyUR {
 	}
 }
 
-// CacheKeyURGFromMeta : Given metadata, create a key that uniquely identifies the contents
-// of the object. Since resourceVersion changes on every update and
-// UIDs are unique, uid+resourceVersion identifies the
-// content.
-// Generation is also included to identify latest generation of the object.
+// CacheKeyURGFromMeta creates a cache key that uniquely identifies the
+// function's content version. UID is stable for the function's
+// lifetime; Generation increments on spec changes. ResourceVersion is
+// intentionally excluded: it changes on status updates (not just spec
+// changes), and the router's informer cache may lag the executor's
+// view, causing UnTapService to miss the cache entry and leak
+// activeRequests.
 func CacheKeyURGFromMeta(metadata *metav1.ObjectMeta) CacheKeyURG {
 	return CacheKeyURG{
-		UID:             metadata.UID,
-		ResourceVersion: metadata.ResourceVersion,
-		Generation:      metadata.Generation,
+		UID:        metadata.UID,
+		Generation: metadata.Generation,
 	}
 }

--- a/pkg/crd/key_test.go
+++ b/pkg/crd/key_test.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package crd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestCacheKeyURGFromMeta_StableAcrossStatusUpdates(t *testing.T) {
+	t.Parallel()
+
+	// A function's metadata at two points in time: same UID + Generation
+	// (no spec change), but different ResourceVersion (a status update
+	// bumped it). The cache key MUST be identical — otherwise
+	// UnTapService (keyed on CacheKeyURG) misses the entry created by
+	// SetSvcValue and leaks activeRequests.
+	uid := types.UID("fn-uid-1")
+	gen := int64(3)
+
+	before := &metav1.ObjectMeta{
+		UID:             uid,
+		Generation:      gen,
+		ResourceVersion: "100",
+	}
+	after := &metav1.ObjectMeta{
+		UID:             uid,
+		Generation:      gen,
+		ResourceVersion: "200", // status update bumped RV
+	}
+
+	keyBefore := CacheKeyURGFromMeta(before)
+	keyAfter := CacheKeyURGFromMeta(after)
+
+	assert.Equal(t, keyBefore, keyAfter,
+		"CacheKeyURG must be stable across status-only updates (RV change, same UID+Generation)")
+	assert.Equal(t, keyBefore.String(), keyAfter.String(),
+		"CacheKeyURG.String() must be stable across status-only updates")
+}
+
+func TestCacheKeyURGFromMeta_ChangesOnSpecUpdate(t *testing.T) {
+	t.Parallel()
+
+	// A spec update increments Generation. The cache key MUST change —
+	// the old generation's specialized pods are stale and should not be
+	// reused under the new key.
+	uid := types.UID("fn-uid-1")
+
+	before := &metav1.ObjectMeta{
+		UID:             uid,
+		Generation:      3,
+		ResourceVersion: "100",
+	}
+	after := &metav1.ObjectMeta{
+		UID:             uid,
+		Generation:      4, // spec update bumped Generation
+		ResourceVersion: "101",
+	}
+
+	keyBefore := CacheKeyURGFromMeta(before)
+	keyAfter := CacheKeyURGFromMeta(after)
+
+	assert.NotEqual(t, keyBefore, keyAfter,
+		"CacheKeyURG must change on spec updates (Generation increment)")
+}
+
+func TestCacheKeyURGFromMeta_ChangesOnUIDChange(t *testing.T) {
+	t.Parallel()
+
+	// Different function (different UID) — different key, even if
+	// Generation and ResourceVersion happen to match.
+	meta1 := &metav1.ObjectMeta{
+		UID:             types.UID("fn-uid-1"),
+		Generation:      1,
+		ResourceVersion: "100",
+	}
+	meta2 := &metav1.ObjectMeta{
+		UID:             types.UID("fn-uid-2"),
+		Generation:      1,
+		ResourceVersion: "100",
+	}
+
+	assert.NotEqual(t, CacheKeyURGFromMeta(meta1), CacheKeyURGFromMeta(meta2),
+		"CacheKeyURG must differ for different UIDs")
+}
+
+func TestCacheKeyURG_String(t *testing.T) {
+	t.Parallel()
+
+	ck := CacheKeyURG{UID: types.UID("abc"), Generation: 7}
+	assert.Equal(t, "abc_7", ck.String())
+}

--- a/pkg/crd/key_test.go
+++ b/pkg/crd/key_test.go
@@ -12,13 +12,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestCacheKeyURGFromMeta_StableAcrossStatusUpdates(t *testing.T) {
+func TestCacheKeyUGFromMeta_StableAcrossStatusUpdates(t *testing.T) {
 	t.Parallel()
 
 	// A function's metadata at two points in time: same UID + Generation
 	// (no spec change), but different ResourceVersion (a status update
 	// bumped it). The cache key MUST be identical — otherwise
-	// UnTapService (keyed on CacheKeyURG) misses the entry created by
+	// UnTapService (keyed on CacheKeyUG) misses the entry created by
 	// SetSvcValue and leaks activeRequests.
 	uid := types.UID("fn-uid-1")
 	gen := int64(3)
@@ -34,16 +34,16 @@ func TestCacheKeyURGFromMeta_StableAcrossStatusUpdates(t *testing.T) {
 		ResourceVersion: "200", // status update bumped RV
 	}
 
-	keyBefore := CacheKeyURGFromMeta(before)
-	keyAfter := CacheKeyURGFromMeta(after)
+	keyBefore := CacheKeyUGFromMeta(before)
+	keyAfter := CacheKeyUGFromMeta(after)
 
 	assert.Equal(t, keyBefore, keyAfter,
-		"CacheKeyURG must be stable across status-only updates (RV change, same UID+Generation)")
+		"CacheKeyUG must be stable across status-only updates (RV change, same UID+Generation)")
 	assert.Equal(t, keyBefore.String(), keyAfter.String(),
-		"CacheKeyURG.String() must be stable across status-only updates")
+		"CacheKeyUG.String() must be stable across status-only updates")
 }
 
-func TestCacheKeyURGFromMeta_ChangesOnSpecUpdate(t *testing.T) {
+func TestCacheKeyUGFromMeta_ChangesOnSpecUpdate(t *testing.T) {
 	t.Parallel()
 
 	// A spec update increments Generation. The cache key MUST change —
@@ -62,14 +62,14 @@ func TestCacheKeyURGFromMeta_ChangesOnSpecUpdate(t *testing.T) {
 		ResourceVersion: "101",
 	}
 
-	keyBefore := CacheKeyURGFromMeta(before)
-	keyAfter := CacheKeyURGFromMeta(after)
+	keyBefore := CacheKeyUGFromMeta(before)
+	keyAfter := CacheKeyUGFromMeta(after)
 
 	assert.NotEqual(t, keyBefore, keyAfter,
-		"CacheKeyURG must change on spec updates (Generation increment)")
+		"CacheKeyUG must change on spec updates (Generation increment)")
 }
 
-func TestCacheKeyURGFromMeta_ChangesOnUIDChange(t *testing.T) {
+func TestCacheKeyUGFromMeta_ChangesOnUIDChange(t *testing.T) {
 	t.Parallel()
 
 	// Different function (different UID) — different key, even if
@@ -85,13 +85,13 @@ func TestCacheKeyURGFromMeta_ChangesOnUIDChange(t *testing.T) {
 		ResourceVersion: "100",
 	}
 
-	assert.NotEqual(t, CacheKeyURGFromMeta(meta1), CacheKeyURGFromMeta(meta2),
-		"CacheKeyURG must differ for different UIDs")
+	assert.NotEqual(t, CacheKeyUGFromMeta(meta1), CacheKeyUGFromMeta(meta2),
+		"CacheKeyUG must differ for different UIDs")
 }
 
-func TestCacheKeyURG_String(t *testing.T) {
+func TestCacheKeyUG_String(t *testing.T) {
 	t.Parallel()
 
-	ck := CacheKeyURG{UID: types.UID("abc"), Generation: 7}
+	ck := CacheKeyUG{UID: types.UID("abc"), Generation: 7}
 	assert.Equal(t, "abc_7", ck.String())
 }

--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -322,7 +322,7 @@ func (gp *GenericPool) getFuncSvc(ctx context.Context, fn *fv1.Function) (*fscac
 	}
 
 	gp.fsCache.PodToFsvc.Store(pod.GetObjectMeta().GetName(), fsvc)
-	gp.podFSVCMap.Store(pod.Name, []any{crd.CacheKeyURGFromMeta(fsvc.Function), fsvc.Address})
+	gp.podFSVCMap.Store(pod.Name, []any{crd.CacheKeyUGFromMeta(fsvc.Function), fsvc.Address})
 	gp.fsCache.AddFunc(ctx, *fsvc, fn.GetRequestPerPod(), fn.GetRetainPods())
 
 	logger.Info("added function service",

--- a/pkg/executor/executortype/poolmgr/gp_metrics.go
+++ b/pkg/executor/executortype/poolmgr/gp_metrics.go
@@ -52,7 +52,7 @@ func (gp *GenericPool) updateCPUUtilizationSvc(ctx context.Context) {
 			}
 			if value, ok := gp.podFSVCMap.Load(val.Name); ok {
 				if valArray, ok1 := value.([]any); ok1 {
-					function, ok2 := valArray[0].(crd.CacheKeyURG)
+					function, ok2 := valArray[0].(crd.CacheKeyUG)
 					if !ok2 {
 						gp.logger.Error(nil, "failed to convert function to type", "function", function)
 						return

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -363,7 +363,7 @@ func maxPendingSpecializationsFromEnv(logger logr.Logger) int {
 // by the specialization's setValue on success or MarkSpecializationFailure on
 // failure. Rejections surface to the router (and client) as 429s.
 func (gpm *GenericPoolManager) ReserveCapacity(ctx context.Context, fnMeta *metav1.ObjectMeta, concurrency int) error {
-	err := gpm.fsCache.ReserveCapacity(crd.CacheKeyURGFromMeta(fnMeta), concurrency, gpm.maxPendingSpecializations)
+	err := gpm.fsCache.ReserveCapacity(crd.CacheKeyUGFromMeta(fnMeta), concurrency, gpm.maxPendingSpecializations)
 	if err != nil {
 		metrics.RecordSpecializationRejected(ctx, fnMeta.Name, fnMeta.Namespace)
 	}
@@ -371,7 +371,7 @@ func (gpm *GenericPoolManager) ReserveCapacity(ctx context.Context, fnMeta *meta
 }
 
 func (gpm *GenericPoolManager) UnTapService(ctx context.Context, fnMeta *metav1.ObjectMeta, svcHost string) {
-	key := crd.CacheKeyURGFromMeta(fnMeta)
+	key := crd.CacheKeyUGFromMeta(fnMeta)
 	otelUtils.SpanTrackEvent(ctx, "UnTapService",
 		attribute.KeyValue{Key: "key", Value: attribute.StringValue(key.String())},
 		attribute.KeyValue{Key: "svcHost", Value: attribute.StringValue(svcHost)})
@@ -389,7 +389,7 @@ func (gpm *GenericPoolManager) TapService(ctx context.Context, svcHost string) e
 }
 
 func (gpm *GenericPoolManager) MarkSpecializationFailure(ctx context.Context, fnMeta *metav1.ObjectMeta) {
-	key := crd.CacheKeyURGFromMeta(fnMeta)
+	key := crd.CacheKeyUGFromMeta(fnMeta)
 	otelUtils.SpanTrackEvent(ctx, "MarkSpecializationFailure",
 		attribute.KeyValue{Key: "key", Value: attribute.StringValue(key.String())})
 	// Mark the active cold-start span errored so a failed specialization shows
@@ -874,7 +874,7 @@ func (gpm *GenericPoolManager) cleanupPool(ctx context.Context, env *fv1.Environ
 // markFuncDeleted marks a function's pool service entries deleted in the fsCache
 // so the idle reaper recycles its specialized pods. Driven by the Function
 // reconciler on delete.
-func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyURG) {
+func (gpm *GenericPoolManager) markFuncDeleted(key crd.CacheKeyUG) {
 	gpm.fsCache.MarkFuncDeleted(key)
 	gpm.fnSvcEnsured.Delete(key.UID)
 }

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -30,7 +30,7 @@ const envResyncPeriod = 30 * time.Minute
 // funcManager is the subset of *GenericPoolManager the Function handlers drive.
 // An interface so the reconcile routing is unit-testable with a fake.
 type funcManager interface {
-	markFuncDeleted(crd.CacheKeyURG)
+	markFuncDeleted(crd.CacheKeyUG)
 	refreshFuncPods(ctx context.Context, fn *fv1.Function) error
 	createIstioServiceForFunction(ctx context.Context, fn *fv1.Function) error
 	deleteIstioServiceForFunction(ctx context.Context, fn *fv1.Function) error
@@ -166,7 +166,7 @@ func reconcilePoolmgrFunc(ctx context.Context, mgr funcManager, enableIstio bool
 
 // cleanupPoolmgrFunc holds the teardown routing, split out for unit testing.
 func cleanupPoolmgrFunc(ctx context.Context, mgr funcManager, enableIstio, functionServices bool, fn *fv1.Function) error {
-	mgr.markFuncDeleted(crd.CacheKeyURGFromMeta(&fn.ObjectMeta))
+	mgr.markFuncDeleted(crd.CacheKeyUGFromMeta(&fn.ObjectMeta))
 	if enableIstio {
 		return mgr.deleteIstioServiceForFunction(ctx, fn)
 	}

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 type fakeFuncMgr struct {
-	deleted      []crd.CacheKeyURG
+	deleted      []crd.CacheKeyUG
 	refreshed    []string
 	istioCreated []string
 	istioDeleted []string
 	fnSvcDeleted []string
 }
 
-func (f *fakeFuncMgr) markFuncDeleted(k crd.CacheKeyURG) { f.deleted = append(f.deleted, k) }
+func (f *fakeFuncMgr) markFuncDeleted(k crd.CacheKeyUG) { f.deleted = append(f.deleted, k) }
 func (f *fakeFuncMgr) refreshFuncPods(_ context.Context, fn *fv1.Function) error {
 	f.refreshed = append(f.refreshed, fn.Name)
 	return nil
@@ -107,7 +107,7 @@ func TestCleanupPoolmgrFunc(t *testing.T) {
 		m := &fakeFuncMgr{}
 		require.NoError(t, cleanupPoolmgrFunc(t.Context(), m, true, false, fn))
 		require.Len(t, m.deleted, 1)
-		assert.Equal(t, crd.CacheKeyURGFromMeta(&fn.ObjectMeta), m.deleted[0])
+		assert.Equal(t, crd.CacheKeyUGFromMeta(&fn.ObjectMeta), m.deleted[0])
 		assert.Equal(t, []string{"fn"}, m.istioDeleted)
 		assert.Empty(t, m.fnSvcDeleted)
 	})

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -132,13 +132,13 @@ func (fsc *FunctionServiceCache) GetByFunction(m *metav1.ObjectMeta) (*FuncSvc, 
 // ReserveCapacity atomically checks the function's concurrency cap and
 // reserves one in-flight specialization in the pool cache (RFC-0002
 // ensureCapacity); returns a TooManyRequests ferror at the cap.
-func (fsc *FunctionServiceCache) ReserveCapacity(key crd.CacheKeyURG, concurrency, maxPending int) error {
+func (fsc *FunctionServiceCache) ReserveCapacity(key crd.CacheKeyUG, concurrency, maxPending int) error {
 	return fsc.connFunctionCache.ReserveCapacity(key, concurrency, maxPending)
 }
 
 // GetFuncSvc gets a function service from pool cache using function key and returns number of active instances of function pod
 func (fsc *FunctionServiceCache) GetFuncSvc(ctx context.Context, m *metav1.ObjectMeta, requestsPerPod int, concurrency int) (*FuncSvc, error) {
-	key := crd.CacheKeyURGFromMeta(m)
+	key := crd.CacheKeyUGFromMeta(m)
 
 	fsvc, err := fsc.connFunctionCache.GetSvcValue(ctx, key, requestsPerPod, concurrency)
 	if err != nil {
@@ -174,27 +174,27 @@ func (fsc *FunctionServiceCache) GetByFunctionUID(uid types.UID) (*FuncSvc, erro
 
 // AddFunc adds a function service to pool cache.
 func (fsc *FunctionServiceCache) AddFunc(ctx context.Context, fsvc FuncSvc, requestsPerPod, svcsRetain int) {
-	fsc.connFunctionCache.SetSvcValue(ctx, crd.CacheKeyURGFromMeta(fsvc.Function), fsvc.Address, &fsvc, fsvc.CPULimit, requestsPerPod, svcsRetain)
+	fsc.connFunctionCache.SetSvcValue(ctx, crd.CacheKeyUGFromMeta(fsvc.Function), fsvc.Address, &fsvc, fsvc.CPULimit, requestsPerPod, svcsRetain)
 	now := time.Now()
 	fsvc.Ctime = now
 	fsvc.Atime = now
 }
 
-func (fsc *FunctionServiceCache) MarkFuncDeleted(key crd.CacheKeyURG) {
+func (fsc *FunctionServiceCache) MarkFuncDeleted(key crd.CacheKeyUG) {
 	fsc.connFunctionCache.MarkFuncDeleted(key)
 }
 
 // SetCPUUtilizaton updates/sets CPUutilization in the pool cache
-func (fsc *FunctionServiceCache) SetCPUUtilizaton(key crd.CacheKeyURG, svcHost string, cpuUsage resource.Quantity) {
+func (fsc *FunctionServiceCache) SetCPUUtilizaton(key crd.CacheKeyUG, svcHost string, cpuUsage resource.Quantity) {
 	fsc.connFunctionCache.SetCPUUtilization(key, svcHost, cpuUsage)
 }
 
 // MarkAvailable marks the value at key [function][address] as available.
-func (fsc *FunctionServiceCache) MarkAvailable(key crd.CacheKeyURG, svcHost string) {
+func (fsc *FunctionServiceCache) MarkAvailable(key crd.CacheKeyUG, svcHost string) {
 	fsc.connFunctionCache.MarkAvailable(key, svcHost)
 }
 
-func (fsc *FunctionServiceCache) MarkSpecializationFailure(key crd.CacheKeyURG) {
+func (fsc *FunctionServiceCache) MarkSpecializationFailure(key crd.CacheKeyUG) {
 	fsc.connFunctionCache.MarkSpecializationFailure(key)
 }
 
@@ -273,7 +273,7 @@ func (fsc *FunctionServiceCache) DeleteEntry(fsvc *FuncSvc) {
 
 // DeleteFunctionSvc deletes a function service at key composed of [function][address].
 func (fsc *FunctionServiceCache) DeleteFunctionSvc(ctx context.Context, fsvc *FuncSvc) {
-	err := fsc.connFunctionCache.DeleteValue(ctx, crd.CacheKeyURGFromMeta(fsvc.Function), fsvc.Address)
+	err := fsc.connFunctionCache.DeleteValue(ctx, crd.CacheKeyUGFromMeta(fsvc.Function), fsvc.Address)
 	if err != nil {
 		fsc.logger.Error(err,
 			"error deleting function service", "function", fsvc.Function.Name,

--- a/pkg/executor/fscache/functionServiceCache_test.go
+++ b/pkg/executor/fscache/functionServiceCache_test.go
@@ -158,7 +158,7 @@ func TestFunctionServiceNewCache(t *testing.T) {
 	_, err := fsc.GetFuncSvc(ctx, fsvc.Function, 5, concurrency)
 	require.NoError(t, err)
 
-	key := crd.CacheKeyURGFromMeta(&fn.ObjectMeta)
+	key := crd.CacheKeyUGFromMeta(&fn.ObjectMeta)
 	fsc.MarkAvailable(key, fsvc.Address)
 
 	_, err = fsc.GetFuncSvc(ctx, fsvc.Function, 5, concurrency)
@@ -205,7 +205,7 @@ func TestFunctionServiceCacheConcurrentTouchAndList(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		poolKey := crd.CacheKeyURG{UID: types.UID(fmt.Sprintf("pool-%d", i)), Generation: 1}
+		poolKey := crd.CacheKeyUG{UID: types.UID(fmt.Sprintf("pool-%d", i)), Generation: 1}
 		poolAddr := fmt.Sprintf("10.1.0.%d:8888", i)
 		fsc.connFunctionCache.SetSvcValue(t.Context(), poolKey, poolAddr,
 			&FuncSvc{Function: &metav1.ObjectMeta{Name: fmt.Sprintf("pool-fn-%d", i)}, Address: poolAddr, Atime: now},
@@ -276,7 +276,7 @@ func TestTouchByAddressPoolCacheFallback(t *testing.T) {
 	fsc := MakeFunctionServiceCache(loggerfactory.GetLogger())
 	require.NotNil(t, fsc)
 
-	key := crd.CacheKeyURG{UID: "pool-only-fn", Generation: 1}
+	key := crd.CacheKeyUG{UID: "pool-only-fn", Generation: 1}
 	old := time.Now().Add(-time.Hour)
 	fsvc := &FuncSvc{Function: &metav1.ObjectMeta{Name: "fn"}, Address: "10.3.4.5:8888", Atime: old}
 	fsc.connFunctionCache.SetSvcValue(t.Context(), key, fsvc.Address, fsvc, resource.MustParse("45m"), 10, 0)

--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -49,7 +49,7 @@ type (
 	// or the channel round-trip on the tap/specialization hot path.
 	PoolCache struct {
 		lock   sync.Mutex
-		cache  map[crd.CacheKeyURG]*funcSvcGroup
+		cache  map[crd.CacheKeyUG]*funcSvcGroup
 		logger logr.Logger
 	}
 
@@ -62,7 +62,7 @@ type (
 // NewPoolCache create a Cache object
 func NewPoolCache(logger logr.Logger) *PoolCache {
 	return &PoolCache{
-		cache:  make(map[crd.CacheKeyURG]*funcSvcGroup),
+		cache:  make(map[crd.CacheKeyUG]*funcSvcGroup),
 		logger: logger,
 	}
 }
@@ -74,7 +74,7 @@ func NewFuncSvcGroup() *funcSvcGroup {
 	}
 }
 
-func (c *PoolCache) MarkFuncDeleted(function crd.CacheKeyURG) {
+func (c *PoolCache) MarkFuncDeleted(function crd.CacheKeyUG) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -90,7 +90,7 @@ func (c *PoolCache) MarkFuncDeleted(function crd.CacheKeyURG) {
 // request is parked for capacity it returns a non-nil svcWait; the caller waits
 // on its channel *after* the lock is released (the matching setValue send must
 // be able to acquire the lock).
-func (c *PoolCache) getSvcValue(ctx context.Context, function crd.CacheKeyURG, requestsPerPod int, concurrency int) (*FuncSvc, *svcWait, error) {
+func (c *PoolCache) getSvcValue(ctx context.Context, function crd.CacheKeyUG, requestsPerPod int, concurrency int) (*FuncSvc, *svcWait, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -145,7 +145,7 @@ func (c *PoolCache) getSvcValue(ctx context.Context, function crd.CacheKeyURG, r
 }
 
 // GetSvcValue returns a function service with status in Active else return error
-func (c *PoolCache) GetSvcValue(ctx context.Context, function crd.CacheKeyURG, requestsPerPod int, concurrency int) (*FuncSvc, error) {
+func (c *PoolCache) GetSvcValue(ctx context.Context, function crd.CacheKeyUG, requestsPerPod int, concurrency int) (*FuncSvc, error) {
 	value, svcWaitValue, err := c.getSvcValue(ctx, function, requestsPerPod, concurrency)
 	if svcWaitValue != nil {
 		select {
@@ -175,7 +175,7 @@ func (c *PoolCache) GetSvcValue(ctx context.Context, function crd.CacheKeyURG, r
 // Exceeding either bound returns ErrorTooManyRequests, which the router
 // relays to the client as a fast 429. Sizing rationale lives on
 // poolmgr.defaultMaxPendingSpecializations.
-func (c *PoolCache) ReserveCapacity(function crd.CacheKeyURG, concurrency, maxPending int) error {
+func (c *PoolCache) ReserveCapacity(function crd.CacheKeyUG, concurrency, maxPending int) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -266,7 +266,7 @@ func (c *PoolCache) ListAvailableValue() []*FuncSvc {
 }
 
 // SetSvcValue marks the value at key [function][address] as active(begin used)
-func (c *PoolCache) SetSvcValue(ctx context.Context, function crd.CacheKeyURG, address string, value *FuncSvc, cpuLimit resource.Quantity, requestsPerPod, svcsRetain int) {
+func (c *PoolCache) SetSvcValue(ctx context.Context, function crd.CacheKeyUG, address string, value *FuncSvc, cpuLimit resource.Quantity, requestsPerPod, svcsRetain int) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -316,7 +316,7 @@ func (c *PoolCache) SetSvcValue(ctx context.Context, function crd.CacheKeyURG, a
 }
 
 // SetCPUUtilization updates/sets the CPU utilization limit for the pod
-func (c *PoolCache) SetCPUUtilization(function crd.CacheKeyURG, address string, cpuUsage resource.Quantity) {
+func (c *PoolCache) SetCPUUtilization(function crd.CacheKeyUG, address string, cpuUsage resource.Quantity) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -329,7 +329,7 @@ func (c *PoolCache) SetCPUUtilization(function crd.CacheKeyURG, address string, 
 }
 
 // MarkAvailable marks the value at key [function][address] as available
-func (c *PoolCache) MarkAvailable(function crd.CacheKeyURG, address string) {
+func (c *PoolCache) MarkAvailable(function crd.CacheKeyUG, address string) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -348,7 +348,7 @@ func (c *PoolCache) MarkAvailable(function crd.CacheKeyURG, address string) {
 }
 
 // DeleteValue deletes the value at key composed of [function][address]
-func (c *PoolCache) DeleteValue(ctx context.Context, function crd.CacheKeyURG, address string) error {
+func (c *PoolCache) DeleteValue(ctx context.Context, function crd.CacheKeyUG, address string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -362,7 +362,7 @@ func (c *PoolCache) DeleteValue(ctx context.Context, function crd.CacheKeyURG, a
 }
 
 // MarkSpecializationFailure reduces the svcWaiting count
-func (c *PoolCache) MarkSpecializationFailure(function crd.CacheKeyURG) {
+func (c *PoolCache) MarkSpecializationFailure(function crd.CacheKeyUG) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 

--- a/pkg/executor/fscache/poolcache_test.go
+++ b/pkg/executor/fscache/poolcache_test.go
@@ -36,10 +36,10 @@ func TestPoolCache(t *testing.T) {
 	concurrency := 5
 	requestsPerPod := 2
 
-	keyFunc := crd.CacheKeyURG{
+	keyFunc := crd.CacheKeyUG{
 		UID: "func",
 	}
-	keyFunc2 := crd.CacheKeyURG{
+	keyFunc2 := crd.CacheKeyUG{
 		UID: "func2",
 	}
 
@@ -142,7 +142,7 @@ func TestPoolCache(t *testing.T) {
 }
 
 func TestPoolCacheRequests(t *testing.T) {
-	key := crd.CacheKeyURG{
+	key := crd.CacheKeyUG{
 		UID:        "func",
 		Generation: 1,
 	}
@@ -279,7 +279,7 @@ func TestPoolCacheRequests(t *testing.T) {
 			}
 			wg.Wait()
 			if tt.generationUpdate {
-				newKey := crd.CacheKeyURG{
+				newKey := crd.CacheKeyUG{
 					UID:        "func",
 					Generation: 2,
 				}
@@ -302,7 +302,7 @@ func TestPoolCacheRequests(t *testing.T) {
 // concurrency cap, and the reservation is symmetric with SetSvcValue /
 // MarkSpecializationFailure.
 func TestReserveCapacity(t *testing.T) {
-	key := crd.CacheKeyURG{UID: "reserve-fn", Generation: 1}
+	key := crd.CacheKeyUG{UID: "reserve-fn", Generation: 1}
 	c := NewPoolCache(logr.Discard())
 
 	// concurrency=2: two reservations succeed, the third hits the cap.
@@ -329,7 +329,7 @@ func TestReserveCapacity(t *testing.T) {
 // specializations are capped independently of (and far below) the concurrency
 // cap, released symmetrically, and 0 disables the bound (legacy behavior).
 func TestReserveCapacityMaxPending(t *testing.T) {
-	key := crd.CacheKeyURG{UID: "pending-fn", Generation: 1}
+	key := crd.CacheKeyUG{UID: "pending-fn", Generation: 1}
 	c := NewPoolCache(logr.Discard())
 
 	// concurrency far above the pending bound: the pending bound must fire
@@ -353,7 +353,7 @@ func TestReserveCapacityMaxPending(t *testing.T) {
 	require.NoError(t, c.ReserveCapacity(key, 500, 2))
 
 	// 0 disables the bound.
-	free := crd.CacheKeyURG{UID: "unbounded-fn", Generation: 1}
+	free := crd.CacheKeyUG{UID: "unbounded-fn", Generation: 1}
 	for range 50 {
 		require.NoError(t, c.ReserveCapacity(free, 0, 0))
 	}
@@ -364,16 +364,16 @@ func TestReserveCapacityMaxPending(t *testing.T) {
 // be a no-op, not a nil-map panic that takes the executor down.
 func TestMarkSpecializationFailureUnknownKey(t *testing.T) {
 	c := NewPoolCache(logr.Discard())
-	c.MarkSpecializationFailure(crd.CacheKeyURG{UID: "never-seen", Generation: 1})
+	c.MarkSpecializationFailure(crd.CacheKeyUG{UID: "never-seen", Generation: 1})
 	// The cache survives: a follow-up request still gets served.
-	require.NoError(t, c.ReserveCapacity(crd.CacheKeyURG{UID: "never-seen", Generation: 1}, 0, 0))
+	require.NoError(t, c.ReserveCapacity(crd.CacheKeyUG{UID: "never-seen", Generation: 1}, 0, 0))
 }
 
 // TestPoolCacheTouchByAddress locks the RFC-0002 tap-liveness fix: the
 // router's batched taps must refresh the Atime of pool-cache entries (the
 // idle reaper ages on it once the warm path stops calling the executor).
 func TestPoolCacheTouchByAddress(t *testing.T) {
-	key := crd.CacheKeyURG{UID: "touch-fn", Generation: 1}
+	key := crd.CacheKeyUG{UID: "touch-fn", Generation: 1}
 	c := NewPoolCache(logr.Discard())
 
 	old := time.Now().Add(-time.Hour)


### PR DESCRIPTION
## Summary

- Drops `ResourceVersion` from `CacheKeyURG`, relying on `UID + Generation` only
- Fixes an `activeRequests` leak: when the executor writes a function status update (bumping RV) and the router later calls `UnTapService` with the stale RV from its informer cache, the key doesn't match the entry created by `SetSvcValue` — `UnTapService` misses the cache entry, `activeRequests` is never decremented, and the idle reaper refuses to delete the pod (`activeRequests > 0`)
- Status-only updates no longer re-key the cache; `SetSvcValue`/`UnTapService` agree on the key regardless of informer cache lag

### Blast radius

This re-keys the entire poolmgr↔router data plane (concurrency accounting, `UnTapService`) for **all** functions, not just provisioned ones. No caller accesses `.ResourceVersion` on a `CacheKeyURG` — the struct is used solely as a map key. Split out from PR #3581 (RFC-0026 provisioned concurrency) so it's reviewable and revertable independently of the feature.

#### Test plan

- [x] `TestCacheKeyURGFromMeta_StableAcrossStatusUpdates` — key is identical across RV-only changes (same UID+Generation)
- [x] `TestCacheKeyURGFromMeta_ChangesOnSpecUpdate` — key changes on Generation increment
- [x] `TestCacheKeyURGFromMeta_ChangesOnUIDChange` — key differs for different UIDs
- [x] `TestCacheKeyURG_String` — format is `UID_Generation`
- [x] `go build ./...` passes
- [x] `go test -race -count=1 ./pkg/crd/...` passes