### PR TITLE
fix(executor): verify env IsNotFound against API server before pool cleanup

### DIFF
--- a/pkg/executor/envreconciler/reconciler.go
+++ b/pkg/executor/envreconciler/reconciler.go
@@ -33,16 +33,32 @@ import (
 // still hand the gone object to the handlers' cleanup), matching the per-type
 // reconcilers it replaces.
 type environmentReconciler struct {
-	logger   logr.Logger
-	client   client.Client
-	handlers []executortype.EnvReconciler
-	lastSeen sync.Map // client.ObjectKey -> *fv1.Environment
+	logger    logr.Logger
+	client    client.Client
+	apiReader client.Reader // uncached reader for IsNotFound verification
+	handlers  []executortype.EnvReconciler
+	lastSeen  sync.Map // client.ObjectKey -> *fv1.Environment
 }
 
 func (r *environmentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	env := &fv1.Environment{}
 	if err := r.client.Get(ctx, req.NamespacedName, env); err != nil {
 		if apierrors.IsNotFound(err) {
+			// The informer cache reported NotFound. Before destructive cleanup
+			// (which destroys the pool, reaps specialized pods, and shuts down
+			// the readyPodQueue), verify against the API server — a stale cache
+			// (e.g. watch reconnect on k8s 1.36 ConsistentListFromCache) can
+			// transiently return NotFound for an object that still exists.
+			// See ci-29487828565 v1.36.1 PCL Phase 3 analysis.
+			liveEnv := &fv1.Environment{}
+			if apiErr := r.apiReader.Get(ctx, req.NamespacedName, liveEnv); apiErr == nil {
+				// Environment still exists — cache is stale. Re-store lastSeen
+				// and requeue so a future reconcile sees the cached version.
+				r.lastSeen.Store(req.NamespacedName, liveEnv.DeepCopy())
+				r.logger.V(1).Info("environment IsNotFound from cache but exists in API server, skipping cleanup",
+					"namespace", req.Namespace, "name", req.Name)
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+			}
 			if old, ok := r.lastSeen.LoadAndDelete(req.NamespacedName); ok {
 				for _, h := range r.handlers {
 					h.CleanupEnvironment(ctx, old.(*fv1.Environment))
@@ -107,9 +123,10 @@ func RegisterReconciler(mgr ctrl.Manager, logger logr.Logger, executorTypes map[
 	}
 
 	r := &environmentReconciler{
-		logger:   logger.WithName("environment_reconciler"),
-		client:   mgr.GetClient(),
-		handlers: handlers,
+		logger:    logger.WithName("environment_reconciler"),
+		client:    mgr.GetClient(),
+		apiReader: mgr.GetAPIReader(),
+		handlers:  handlers,
 	}
 	// RegisterTenantScoped adds controller.MembershipPredicate when dynamic
 	// tenancy is on (no-op otherwise), so the cluster-wide cache only reconciles

--- a/pkg/executor/envreconciler/reconciler_test.go
+++ b/pkg/executor/envreconciler/reconciler_test.go
@@ -63,7 +63,8 @@ func TestEnvironmentReconcilerDispatch(t *testing.T) {
 	t.Run("first sight dispatches to every handler with nil old and caches", func(t *testing.T) {
 		h1 := &fakeHandler{requeue: 30 * time.Minute}
 		h2 := &fakeHandler{}
-		r := &environmentReconciler{logger: logr.Discard(), client: crClient(envWithImage("env", "img:1")), handlers: []executortype.EnvReconciler{h1, h2}}
+		c := crClient(envWithImage("env", "img:1"))
+		r := &environmentReconciler{logger: logr.Discard(), client: c, apiReader: c, handlers: []executortype.EnvReconciler{h1, h2}}
 
 		res, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
@@ -76,7 +77,8 @@ func TestEnvironmentReconcilerDispatch(t *testing.T) {
 
 	t.Run("second event hands each handler the cached old object", func(t *testing.T) {
 		h := &fakeHandler{}
-		r := &environmentReconciler{logger: logr.Discard(), client: crClient(envWithImage("env", "img:2")), handlers: []executortype.EnvReconciler{h}}
+		c := crClient(envWithImage("env", "img:2"))
+		r := &environmentReconciler{logger: logr.Discard(), client: c, apiReader: c, handlers: []executortype.EnvReconciler{h}}
 		r.lastSeen.Store(key, envWithImage("env", "img:1"))
 
 		_, err := r.Reconcile(t.Context(), req)
@@ -89,7 +91,8 @@ func TestEnvironmentReconcilerDispatch(t *testing.T) {
 	t.Run("a handler error stops dispatch and does not advance the cache", func(t *testing.T) {
 		h1 := &fakeHandler{reconcErr: assert.AnError}
 		h2 := &fakeHandler{}
-		r := &environmentReconciler{logger: logr.Discard(), client: crClient(envWithImage("env", "img:1")), handlers: []executortype.EnvReconciler{h1, h2}}
+		c := crClient(envWithImage("env", "img:1"))
+		r := &environmentReconciler{logger: logr.Discard(), client: c, apiReader: c, handlers: []executortype.EnvReconciler{h1, h2}}
 
 		_, err := r.Reconcile(t.Context(), req)
 		require.Error(t, err)
@@ -101,7 +104,8 @@ func TestEnvironmentReconcilerDispatch(t *testing.T) {
 	t.Run("delete dispatches cleanup to every handler with the cached object", func(t *testing.T) {
 		h1 := &fakeHandler{}
 		h2 := &fakeHandler{}
-		r := &environmentReconciler{logger: logr.Discard(), client: crClient(), handlers: []executortype.EnvReconciler{h1, h2}} // empty client -> NotFound
+		c := crClient() // empty client -> NotFound from both cache and API reader
+		r := &environmentReconciler{logger: logr.Discard(), client: c, apiReader: c, handlers: []executortype.EnvReconciler{h1, h2}}
 		r.lastSeen.Store(key, envWithImage("env", "img:1"))
 
 		_, err := r.Reconcile(t.Context(), req)
@@ -114,11 +118,29 @@ func TestEnvironmentReconcilerDispatch(t *testing.T) {
 
 	t.Run("delete of an unseen environment is a no-op", func(t *testing.T) {
 		h := &fakeHandler{}
-		r := &environmentReconciler{logger: logr.Discard(), client: crClient(), handlers: []executortype.EnvReconciler{h}}
+		c := crClient()
+		r := &environmentReconciler{logger: logr.Discard(), client: c, apiReader: c, handlers: []executortype.EnvReconciler{h}}
 
 		_, err := r.Reconcile(t.Context(), req)
 		require.NoError(t, err)
 		assert.Empty(t, h.cleaned)
+	})
+
+	t.Run("stale cache NotFound does not trigger cleanup when env exists in API", func(t *testing.T) {
+		h := &fakeHandler{}
+		// Simulate stale cache: client (cache) is empty -> NotFound,
+		// but apiReader has the env -> exists. Use two different fake clients.
+		cacheClient := crClient() // empty -> NotFound from cache
+		apiClient := crClient(envWithImage("env", "img:1"))
+		r := &environmentReconciler{logger: logr.Discard(), client: cacheClient, apiReader: apiClient, handlers: []executortype.EnvReconciler{h}}
+		r.lastSeen.Store(key, envWithImage("env", "img:1"))
+
+		res, err := r.Reconcile(t.Context(), req)
+		require.NoError(t, err)
+		assert.NotZero(t, res.RequeueAfter, "should requeue to retry with fresh cache")
+		assert.Empty(t, h.cleaned, "cleanup must NOT fire when env still exists in API server")
+		cached, _ := r.lastSeen.Load(key)
+		assert.NotNil(t, cached, "lastSeen should be refreshed from API server")
 	})
 }
 


### PR DESCRIPTION
## Summary

- The environment reconciler's `IsNotFound` path destroys the pool, reaps specialized pods, and shuts down the `readyPodQueue` — all destructive and slow to recover (`envResyncPeriod` is 30m)
- On k8s 1.36 where `ConsistentListFromCache` graduated to GA, the informer cache can transiently return `IsNotFound` during watch reconnection for an object that still exists, triggering spurious pool destruction
- Fix: before `CleanupEnvironment`, verify the `IsNotFound` against the uncached API reader (`mgr.GetAPIReader()`). If the env still exists, refresh `lastSeen` from the live object and requeue after 30s instead of destroying the pool

### Why split out

This is a substantive env-reconciler data-plane behavior change (adds a live API read on every environment `NotFound`), unrelated to RFC-0026 provisioned concurrency. Split into its own PR so it's reviewed and revertable on its own merits.

#### Test plan

- [x] `TestEnvironmentReconcilerDispatch/stale_cache_NotFound_does_not_trigger_cleanup_when_env_exists_in_API` — stale cache NotFound + live API env → no cleanup, requeue after 30s
- [x] `TestEnvironmentReconcilerDispatch/delete_dispatches_cleanup_to_every_handler_with_the_cached_object` — true delete (both cache + API NotFound) → cleanup dispatched
- [x] `TestEnvironmentReconcilerDispatch/delete_of_an_unseen_environment_is_a_no_op` — unseen env delete → no-op
- [x] `go build ./pkg/executor/envreconciler/...` passes
- [x] `go test -race -count=1 ./pkg/executor/envreconciler/...` passes