### PR TITLE
fix(executor): resolve provisioner per-function lock once to survive forget race

### DIFF
--- a/pkg/executor/executortype/poolmgr/provisioner.go
+++ b/pkg/executor/executortype/poolmgr/provisioner.go
@@ -96,6 +96,16 @@ type Provisioner struct {
 	reconcileLocks sync.Map // map[types.UID]*sync.Mutex
 }
 
+// lockFor returns the per-function reconcile lock for fnUID, creating it on
+// first use. Callers MUST resolve it exactly once per critical section and
+// reuse the returned *sync.Mutex for both Lock and the deferred Unlock —
+// e.g. `lock := p.lockFor(fn.UID); lock.Lock(); defer lock.Unlock()`.
+//
+// A second lookup (such as calling lockFor again for the Unlock) is unsafe:
+// forget(fnUID) deletes the map entry on the Function-delete path, and a
+// concurrent lockFor after that delete LoadOrStores a brand-new, never-locked
+// mutex. Unlocking that fresh mutex is a fatal "sync: unlock of unlocked
+// mutex" — this crashed the executor process (see provisioner.go history).
 func (p *Provisioner) lockFor(fnUID types.UID) *sync.Mutex {
 	lock, _ := p.reconcileLocks.LoadOrStore(fnUID, &sync.Mutex{})
 	return lock.(*sync.Mutex)
@@ -229,8 +239,9 @@ func (p *Provisioner) reconcileAll(ctx context.Context) {
 }
 
 func (p *Provisioner) reconcileFunction(ctx context.Context, fn *fv1.Function) {
-	p.lockFor(fn.UID).Lock()
-	defer p.lockFor(fn.UID).Unlock()
+	lock := p.lockFor(fn.UID)
+	lock.Lock()
+	defer lock.Unlock()
 	p.reconcileFunctionLocked(ctx, fn)
 }
 
@@ -474,8 +485,9 @@ func (p *Provisioner) effectiveTarget(fn *fv1.Function) int {
 // status write would race the delete, so DeleteFunction calls
 // clearProvisionedLabels directly.
 func (p *Provisioner) disableProvisioning(ctx context.Context, fn *fv1.Function) {
-	p.lockFor(fn.UID).Lock()
-	defer p.lockFor(fn.UID).Unlock()
+	lock := p.lockFor(fn.UID)
+	lock.Lock()
+	defer lock.Unlock()
 	p.disableProvisioningLocked(ctx, fn)
 }
 

--- a/pkg/executor/executortype/poolmgr/provisioner_test.go
+++ b/pkg/executor/executortype/poolmgr/provisioner_test.go
@@ -931,6 +931,68 @@ func TestFilterOptedFunctions(t *testing.T) {
 	})
 }
 
+// ---------------------------------------------------------------------------
+// lockFor / forget race (regression: fatal "sync: unlock of unlocked mutex")
+// ---------------------------------------------------------------------------
+
+// TestProvisioner_lockForget_race exercises the race that used to crash the
+// executor process: reconcileFunction and disableProvisioning each resolved
+// p.lockFor(fn.UID) twice — once to Lock, once (in the deferred call) to
+// Unlock. A concurrent forget(fn.UID) (the Function-delete path) can Delete
+// the reconcileLocks map entry between those two lookups, so the deferred
+// Unlock resolves a brand-new, never-locked mutex and hits Go's fatal "sync:
+// unlock of unlocked mutex" — not a recoverable panic, it kills the process
+// outright (this is exactly what CI observed at provisioner.go:248 under PC
+// create/delete churn). The fix resolves the lock once and reuses the same
+// *sync.Mutex for both Lock and Unlock, so a forget in between cannot swap
+// out the mutex from under an in-progress critical section.
+//
+// Must be run with -race: besides making any reintroduced unsynchronized
+// access visible, -race slows/serializes scheduling in a way that widens the
+// window for the old bug's interleaving. Run with -count=5 for coverage
+// across scheduling variance — the old code could not reliably survive even
+// one iteration of this loop; the new code must survive all of them.
+func TestProvisioner_lockForget_race(t *testing.T) {
+	const uid = types.UID("racy-fn-uid")
+	// target=0 drives reconcileFunction/disableProvisioning down the fast
+	// disableProvisioningLocked path (list 0 pods, zero the status) so the
+	// loop can run many iterations quickly while still taking the lock.
+	fn := provisionedFnWithUID("racy-fn", string(uid), 0)
+
+	p := newTestProvisionerWithPods(t)
+	p.crClient = crfake.NewClientBuilder().WithScheme(scheme()).WithObjects(fn).Build()
+	p.fissionClient = fClient.NewSimpleClientset(fn) //nolint:staticcheck
+
+	const iterations = 1000
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			p.reconcileFunction(t.Context(), fn)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			p.disableProvisioning(t.Context(), fn)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			p.forget(uid)
+		}
+	}()
+
+	wg.Wait()
+	// Reaching this line is the assertion: the old two-lookup lockFor usage
+	// could fatally crash the test binary partway through this loop (no
+	// recover() catches a runtime fatal error); the fixed single-resolve
+	// usage survives every interleaving forget can produce.
+}
+
 func TestProvisioner_RunZeroIntervalNoPanic(t *testing.T) {
 	p := newTestProvisioner(t)
 	p.config.ReconcileInterval = 0


### PR DESCRIPTION
## Summary

`pkg/executor/executortype/poolmgr/provisioner.go`'s `reconcileFunction` and `disableProvisioning` each resolved `p.lockFor(fn.UID)` twice — once for `Lock()`, once again in the deferred call for `Unlock()`. `lockFor` is a `sync.Map` `LoadOrStore`, and `forget(fn.UID)` (the Function-delete path) can `Delete` the map entry between those two lookups. The second `lockFor` then `LoadOrStore`s a brand-new, never-locked mutex, and unlocking it is a fatal `sync: unlock of unlocked mutex` runtime error — not a recoverable panic, it kills the executor process outright.

## Fix

Resolve the lock exactly once per critical section and reuse it for both `Lock` and the deferred `Unlock`, in both `reconcileFunction` and `disableProvisioning`. Added a doc comment on `lockFor` stating the single-resolve requirement.

## Evidence

Observed as a fatal crash at `provisioner.go:248` under provisioned-concurrency function create/delete churn (RFC-0026 PR1, #3581).

Added `TestProvisioner_lockForget_race`, which races `reconcileFunction`/`disableProvisioning` against `forget` on the same UID for 1000 iterations across 3 goroutines under `-race`. It fatals the test binary against the pre-fix (double-resolve) code and passes cleanly against the fix.

```
go build ./...
go test ./pkg/executor/executortype/poolmgr/... -count=1 -race
ok  	github.com/fission/fission/pkg/executor/executortype/poolmgr	3.683s
```

Fixes #3600

🤖 Generated with [Claude Code](https://claude.com/claude-code)