### PR TITLE
fix(router): refresh async settle budget after delivery

### DIFF
--- a/pkg/router/asyncinvoke/dispatcher.go
+++ b/pkg/router/asyncinvoke/dispatcher.go
@@ -265,6 +265,23 @@ func (d *Dispatcher) process(ctx context.Context, msg statestore.LeasedMessage) 
 	dctx, dcancel := context.WithTimeout(ctx, d.deliveryTimeout(env))
 	res := d.deliverer.Deliver(dctx, env, msg.ID, msg.Attempts)
 	dcancel()
+
+	// Refresh the settle budget now that delivery has returned: settleTimeout
+	// must bound the settle op itself (Ack/Nack/Kill), not delivery. A function
+	// can legitimately run for minutes (up to FunctionTimeout), which can exceed
+	// settleTimeout many times over — settling against the pre-delivery sctx
+	// would find it already expired, so every settle call below would fail with
+	// "context deadline exceeded". That leaves the message leased until
+	// DefaultLeaseDuration: a failed slow delivery can't retry promptly, and a
+	// SUCCESSFUL slow delivery gets duplicate-delivered at lease expiry. The
+	// killReason/settleFail calls above (undecodable envelope, MaxAge already
+	// exceeded) both return before any delivery is attempted, so they fire
+	// within ms of the lease and are unaffected — they keep using the
+	// pre-delivery sctx.
+	scancel()
+	sctx, scancel = context.WithTimeout(context.WithoutCancel(ctx), settleTimeout)
+	defer scancel()
+
 	recordDelivery(sctx, deliveryCondition(res))
 
 	action := classify(res)

--- a/pkg/router/asyncinvoke/dispatcher_run_test.go
+++ b/pkg/router/asyncinvoke/dispatcher_run_test.go
@@ -168,3 +168,81 @@ func TestBackoffDelaysRedelivery(t *testing.T) {
 		synctest.Wait()
 	})
 }
+
+// ctxCheckingQueue wraps recordingQueue but, like a real statestore backend
+// (a DB call bound to its context), fails a settle call whose context has
+// already expired instead of silently ignoring ctx like recordingQueue does.
+// This is what makes TestSettleSurvivesSlowDelivery actually exercise the
+// pre-delivery-vs-post-delivery sctx bug: recordingQueue's settle methods
+// never look at ctx, so they can't distinguish a fresh settle context from an
+// expired one.
+type ctxCheckingQueue struct {
+	*recordingQueue
+}
+
+func (q ctxCheckingQueue) Ack(ctx context.Context, receipt string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return q.recordingQueue.Ack(ctx, receipt)
+}
+
+func (q ctxCheckingQueue) Nack(ctx context.Context, receipt string, retryAfter time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return q.recordingQueue.Nack(ctx, receipt, retryAfter)
+}
+
+func (q ctxCheckingQueue) Kill(ctx context.Context, receipt, reason string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return q.recordingQueue.Kill(ctx, receipt, reason)
+}
+
+// TestSettleSurvivesSlowDelivery proves the settle budget is refreshed after
+// delivery returns (not consumed by delivery itself): a delivery slower than
+// settleTimeout that ultimately fails must still settle (Nack) rather than
+// finding its settle context already expired. Before the fix, sctx was created
+// once before Deliver and never refreshed, so a delivery outliving
+// settleTimeout left every settle call (Ack/Nack/Kill) racing an
+// already-expired context, and the Nack below was silently dropped
+// (logSettle logs it at V(1) as a store error and returns) — the message then
+// sat leased until DefaultLeaseDuration instead of retrying promptly.
+func TestSettleSurvivesSlowDelivery(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		rq := ctxCheckingQueue{&recordingQueue{}}
+		now := time.Now()
+		d := newTestDispatcher(rq, delivererFunc(func(ctx context.Context, _ Envelope, _ string, _ int) DeliveryResult {
+			// Sleep well past settleTimeout before the delivery "returns" — this
+			// models a legitimate slow function (minutes-long timeouts), not a
+			// delivery-context cancellation.
+			time.Sleep(settleTimeout * 3)
+			return DeliveryResult{StatusCode: 500}
+		}), now)
+
+		env := Envelope{
+			EnqueueTime: now, Function: "fn", Namespace: "ns",
+			FunctionTimeout: int((settleTimeout * 10).Seconds()),
+			Policy:          Policy{NoJitter: true, BackoffBase: time.Millisecond, BackoffCap: time.Millisecond, MaxAge: time.Hour},
+		}
+		msg := leasedMsg(t, env, 1)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			d.process(t.Context(), msg)
+		}()
+
+		// Advance virtual time past the deliverer's sleep so it actually returns,
+		// then let process() run to completion.
+		time.Sleep(settleTimeout * 4)
+		synctest.Wait()
+
+		require.Empty(t, rq.acks)
+		require.Empty(t, rq.kills)
+		require.Len(t, rq.nacks, 1, "the post-delivery settle must land on a fresh, unexpired context")
+		assert.Equal(t, "receipt-x", rq.nacks[0].receipt)
+	})
+}


### PR DESCRIPTION
## Summary

`pkg/router/asyncinvoke/dispatcher.go`'s `process()` created the settle context (`sctx`, `settleTimeout=15s`) before delivery, then reused it for Ack/Nack/Kill after `Deliver` returned. Any delivery slower than 15s — legitimate, since function timeouts run into minutes — left `sctx` already expired by the time settle ran.

## Impact

- Every settle call after a slow delivery failed with `context deadline exceeded`, so the message stayed leased until `DefaultLeaseDuration` (5m).
- A **failed** slow delivery couldn't Nack promptly, ballooning retry latency.
- A **successful** slow delivery couldn't Ack, guaranteeing duplicate delivery at lease expiry for every async function slower than the settle budget.

## Fix

Refresh `sctx` after `Deliver` returns, so `settleTimeout` bounds the settle operation itself rather than delivery. Pre-delivery uses of `sctx` (undecodable envelope, `MaxAge` already exceeded) both return before any delivery is attempted and are unaffected.

## Test

Added `TestSettleSurvivesSlowDelivery` (`testing/synctest`), with a `ctxCheckingQueue` test double that — like a real statestore backend — fails a settle call whose context has already expired, so the test actually exercises the pre- vs post-delivery `sctx` distinction (the existing `recordingQueue` ignores `ctx` entirely). A deliverer that sleeps `3×settleTimeout` before returning must still land a Nack.

- **Red** on the pre-fix code: the settle call finds `sctx` already expired, the Nack is silently dropped (`logSettle` logs it at V(1) and returns), `rq.nacks` stays empty.
- **Green** on the fix: `rq.nacks` gets exactly one entry.

```
go build ./...
go test ./pkg/router/asyncinvoke/... -count=1 -race
ok  	github.com/fission/fission/pkg/router/asyncinvoke	2.177s
```

Fixes #3601

🤖 Generated with [Claude Code](https://claude.com/claude-code)