### PR TITLE
fix(build): locate fission-cli dist dir by target instead of hardcoded _v1 suffix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,15 @@ build-fission-cli:
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) GOAMD64=$(GOAMD64) GORELEASER_CURRENT_TAG=$(VERSION) goreleaser build --snapshot --clean --single-target --id fission-cli
 
 install-fission-cli:
-	# TODO: Fix this hack, replace v1 with GOAMD64
-	mv dist/fission-cli_$(GOOS)_$(GOARCH)_v1/fission$(FISSION-CLI-SUFFIX) /usr/local/bin/fission
+	# goreleaser suffixes the dist dir with the arch microarchitecture level
+	# (GOAMD64 for amd64 e.g. _v1, GOARM64 for arm64 e.g. _v8.0, GOARM for arm),
+	# which varies per machine -- resolve the dir by glob instead of hardcoding it.
+	@dir="$$(ls -d dist/fission-cli_$(GOOS)_$(GOARCH)*/ 2>/dev/null | head -n1)"; \
+	if [ -z "$$dir" ]; then \
+		echo "install-fission-cli: no dist/fission-cli_$(GOOS)_$(GOARCH)* directory found; run 'make build-fission-cli' first" >&2; \
+		exit 1; \
+	fi; \
+	mv "$$dir/fission$(FISSION-CLI-SUFFIX)" /usr/local/bin/fission
 
 ### Codegen
 codegen:


### PR DESCRIPTION
## Summary

`make install-fission-cli` hardcoded `dist/fission-cli_$(GOOS)_$(GOARCH)_v1`. `_v1` is goreleaser's GOAMD64 microarchitecture-level suffix, which only applies to `amd64` builds. On other architectures goreleaser suffixes the dist dir differently — on `darwin/arm64` it uses the GOARM64 level (`_v8.0`), so the hardcoded path never exists and `install-fission-cli` fails right after a successful `build-fission-cli`.

## Fix

Resolve the dist dir by glob on `dist/fission-cli_$(GOOS)_$(GOARCH)*` instead of a hardcoded suffix, with a clear error if the glob comes up empty (e.g. build wasn't run first).

## Verification (darwin/arm64, this machine — the real repro)

```
$ go env GOOS GOARCH GOARM64
darwin
arm64
v8.0

$ make build-fission-cli
...
    • building                                       paths=cmd/fission-cli binaries=fission target=darwin_arm64_v8.0

$ ls dist/
fission-cli_darwin_arm64_v8.0   # not _v1 -- this is exactly what broke the old hardcoded path
```

`make install-fission-cli` now correctly resolves `dist/fission-cli_darwin_arm64_v8.0/fission` (confirmed by running the binary: `fission version` reports the right client `GitCommit`/`BuildDate`). The final `mv` into `/usr/local/bin/fission` on this machine is separately blocked by a pre-existing root-owned `/usr/local/bin` (interactive `sudo` password required, unrelated to this bug) — verified instead that the resolved path exists, is executable, and runs correctly, and reproduced the same glob resolution against a synthetic `linux_amd64_v1` layout to confirm CI's target is unaffected.

```
go build ./...   # unaffected, no Go changes
```

Fixes #3602

🤖 Generated with [Claude Code](https://claude.com/claude-code)