### PR TITLE
fix(executor): key remaining executor caches by (UID, Generation)

### DIFF
--- a/pkg/executor/executor.go
+++ b/pkg/executor/executor.go
@@ -114,7 +114,13 @@ func (executor *Executor) dispatchCreateFuncService(ctx context.Context, fn *fv1
 			return createFrom(cctx)
 		})
 	}
-	return executor.dispatcher.Do(ctx, crd.CacheKeyURFromObject(fn).String(), func(cctx context.Context) (*fscache.FuncSvc, error) {
+	// Dedup key is UID+Generation, not ResourceVersion (see #3596): keying
+	// on RV here (which the router-side migration alone would not fix)
+	// would reintroduce status-churn duplication on the executor side —
+	// two concurrent createServiceForFunction callers that observed
+	// different RVs of the same spec would each get their own dedup
+	// bucket instead of coalescing onto one specialization.
+	return executor.dispatcher.Do(ctx, crd.CacheKeyUGFromMeta(&fn.ObjectMeta).String(), func(cctx context.Context) (*fscache.FuncSvc, error) {
 		return createFrom(context.WithoutCancel(cctx))
 	})
 }

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -625,10 +625,12 @@ func (caaf *Container) updateFuncDeployment(ctx context.Context, fn *fv1.Functio
 func (caaf *Container) fnDelete(ctx context.Context, fn *fv1.Function) error {
 	var multierr error
 
-	// GetByFunction uses resource version as part of cache key, however,
-	// the resource version in function metadata will be changed when a function
-	// is deleted and cause Container backend fails to delete the entry.
-	// Use GetByFunctionUID instead of GetByFunction here to find correct
+	// GetByFunction now keys on UID+Generation (see #3596), not
+	// ResourceVersion, but the fn passed in on delete can still carry a
+	// Generation the cache entry was never keyed under (e.g. a delete
+	// racing a spec update, or a stale informer snapshot) — GetByFunctionUID
+	// is the UID-only lookup that doesn't depend on the caller's metadata
+	// matching the cached entry's, so it's used here to find the correct
 	// fsvc entry.
 	objName := caaf.getObjName(fn)
 	fsvc, err := caaf.fsCache.GetByFunctionUID(fn.UID)

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -814,10 +814,12 @@ func (deploy *NewDeploy) updateFuncDeployment(ctx context.Context, fn *fv1.Funct
 func (deploy *NewDeploy) fnDelete(ctx context.Context, fn *fv1.Function) error {
 	var errs error
 
-	// GetByFunction uses resource version as part of cache key, however,
-	// the resource version in function metadata will be changed when a function
-	// is deleted and cause newdeploy backend fails to delete the entry.
-	// Use GetByFunctionUID instead of GetByFunction here to find correct
+	// GetByFunction now keys on UID+Generation (see #3596), not
+	// ResourceVersion, but the fn passed in on delete can still carry a
+	// Generation the cache entry was never keyed under (e.g. a delete
+	// racing a spec update, or a stale informer snapshot) — GetByFunctionUID
+	// is the UID-only lookup that doesn't depend on the caller's metadata
+	// matching the cached entry's, so it's used here to find the correct
 	// fsvc entry.
 	objName := deploy.getObjName(fn)
 	fsvc, err := deploy.fsCache.GetByFunctionUID(fn.UID)

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -77,7 +77,7 @@ type (
 		nsResolver       *utils.NamespaceResolver
 
 		fissionClient  versioned.Interface
-		functionEnv    *cache.Cache[crd.CacheKeyUR, *fv1.Environment]
+		functionEnv    *cache.Cache[crd.CacheKeyUG, *fv1.Environment]
 		fsCache        *fscache.FunctionServiceCache
 		instanceID     string
 		requestChannel chan *request
@@ -194,7 +194,7 @@ func MakeGenericPoolManager(ctx context.Context,
 		nsResolver:                 utils.DefaultNSResolver(),
 		metricsClient:              metricsClient,
 		fissionClient:              fissionClient,
-		functionEnv:                cache.MakeCache[crd.CacheKeyUR, *fv1.Environment](10*time.Second, 0),
+		functionEnv:                cache.MakeCache[crd.CacheKeyUG, *fv1.Environment](10*time.Second, 0),
 		fsCache:                    fscache.MakeFunctionServiceCache(gpmLogger),
 		instanceID:                 instanceID,
 		requestChannel:             make(chan *request),
@@ -658,11 +658,34 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 				envNS, ok6 := pod.Labels[fv1.ENVIRONMENT_NAMESPACE]
 				svcHost, ok7 := pod.Annotations[fv1.ANNOTATION_SVC_HOST]
 				env, ok8 := envMap[fmt.Sprintf("%s/%s", envNS, envName)]
+				fnGenStr, ok9 := pod.Labels[fv1.FUNCTION_GENERATION]
 
-				if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 || !ok8 {
+				if !ok1 || !ok2 || !ok3 || !ok4 || !ok5 || !ok6 || !ok7 || !ok8 || !ok9 {
 					gpm.logger.Info("failed to adopt pod for function due to lack of necessary information",
 						"pod", pod.Name, "labels", pod.Labels, "annotations", pod.Annotations,
 						"env", env.Name)
+					return
+				}
+
+				// fsCache keys on (UID, Generation), not ResourceVersion (see
+				// #3596 and functionServiceCache.go's UR->UG migration). A synthetic
+				// ObjectMeta left at the zero-value Generation would key this
+				// entry as (UID, 0), which no live Function (Generation >= 1)
+				// can ever match — GetByFunction would deterministically miss
+				// every adopted pod, leaking stale byFunction/byAddress
+				// entries until TTL reap. Parse it from the pod's
+				// FUNCTION_GENERATION label (stamped at specialization time,
+				// gp_pod.go's specializedPodLabels) and, like every other
+				// required field above, skip adoption rather than guess if
+				// it's missing or malformed — e.g. a pre-migration pod still
+				// alive during a rolling upgrade. A skipped pod isn't lost:
+				// it stays in the cluster and either gets adopted by an
+				// executor replica still running the old code, or is reaped
+				// as idle and replaced by a fresh cold start.
+				fnGen, perr := strconv.ParseInt(fnGenStr, 10, 64)
+				if perr != nil {
+					gpm.logger.Error(perr, "failed to adopt pod for function: unparsable function-generation label",
+						"pod", pod.Name, "value", fnGenStr)
 					return
 				}
 
@@ -673,6 +696,7 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 						Namespace:       fnNS,
 						UID:             k8sTypes.UID(fnUID),
 						ResourceVersion: fnRV,
+						Generation:      fnGen,
 					},
 					Environment: &env,
 					Address:     svcHost,
@@ -1032,7 +1056,12 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 
 	// Cached ?
 	// TODO: the cache should be able to search by <env name, fn namespace> instead of function metadata.
-	result, err := gpm.functionEnv.Get(crd.CacheKeyURFromMeta(&fn.ObjectMeta))
+	// Keyed on UID+Generation, not ResourceVersion (see #3596): the
+	// function's environment reference only changes on a spec update, so
+	// keying on RV (which also moves on status-only writes) would miss
+	// this cache on every status update and re-fetch the environment for
+	// no reason.
+	result, err := gpm.functionEnv.Get(crd.CacheKeyUGFromMeta(&fn.ObjectMeta))
 	if err == nil {
 		return result, nil
 	}
@@ -1049,7 +1078,7 @@ func (gpm *GenericPoolManager) getFunctionEnv(ctx context.Context, fn *fv1.Funct
 
 	// cache for future lookups
 	m := fn.ObjectMeta
-	_, err = gpm.functionEnv.Set(crd.CacheKeyURFromMeta(&m), env)
+	_, err = gpm.functionEnv.Set(crd.CacheKeyUGFromMeta(&m), env)
 	if err != nil {
 		gpm.logger.Error(err,
 			"failed to set the key", "function", fn.Name,

--- a/pkg/executor/executortype/poolmgr/gpm_adopt_test.go
+++ b/pkg/executor/executortype/poolmgr/gpm_adopt_test.go
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package poolmgr
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/utils"
+)
+
+// specializedAdoptPod builds a ready, specialized (managed=false) poolmgr pod
+// carrying the labels/annotations adoptSpecializedPods reads to re-register a
+// function service into the fsCache after an executor restart. generation, if
+// non-empty, is stamped as the fv1.FUNCTION_GENERATION label (set on real pods
+// at specialization time — gp_pod.go's specializedPodLabels).
+func specializedAdoptPod(name, ns, fnUID, generation string) *apiv1.Pod {
+	labels := map[string]string{
+		fv1.EXECUTOR_TYPE:         string(fv1.ExecutorTypePoolmgr),
+		"managed":                 "false",
+		fv1.FUNCTION_NAME:         "fn1",
+		fv1.FUNCTION_NAMESPACE:    ns,
+		fv1.FUNCTION_UID:          fnUID,
+		fv1.ENVIRONMENT_NAME:      "env1",
+		fv1.ENVIRONMENT_NAMESPACE: ns,
+	}
+	if generation != "" {
+		labels[fv1.FUNCTION_GENERATION] = generation
+	}
+	return &apiv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+			Annotations: map[string]string{
+				fv1.FUNCTION_RESOURCE_VERSION: "100",
+				fv1.ANNOTATION_SVC_HOST:       "10.9.9.9:8888",
+			},
+		},
+		Status: apiv1.PodStatus{
+			PodIP:             "10.9.9.9",
+			ContainerStatuses: []apiv1.ContainerStatus{{Ready: true}},
+		},
+	}
+}
+
+// runAdopt wires a GenericPoolManager against a fake kubernetesClient seeded
+// with pod, runs adoptSpecializedPods to completion, and returns the fsCache
+// it populated.
+func runAdopt(t *testing.T, pod *apiv1.Pod) *fscache.FunctionServiceCache {
+	t.Helper()
+	gpm := &GenericPoolManager{
+		logger:           logr.Discard(),
+		kubernetesClient: k8sfake.NewSimpleClientset(pod),
+		nsResolver:       utils.DefaultNSResolver(),
+		instanceID:       "inst-1",
+		fsCache:          fscache.MakeFunctionServiceCache(logr.Discard()),
+	}
+	envMap := map[string]fv1.Environment{
+		pod.Namespace + "/env1": {ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: pod.Namespace}},
+	}
+	var wg sync.WaitGroup
+	gpm.adoptSpecializedPods(t.Context(), &wg, envMap)
+	wg.Wait()
+	return gpm.fsCache
+}
+
+// TestAdoptSpecializedPodsPopulatesGeneration is the regression test for the
+// coordinator-flagged gap: the synthetic ObjectMeta adoptSpecializedPods
+// builds from pod labels/annotations must carry Generation (read from the
+// fv1.FUNCTION_GENERATION pod label) so the resulting fsCache entry is keyed
+// the same way (crd.CacheKeyUG = UID+Generation) as a live Function's
+// GetByFunction lookup. Pre-migration, the synthetic ObjectMeta's zero-value
+// Generation keyed the entry as (UID, 0), which no live Function
+// (Generation >= 1) could ever match — RefreshFuncPods' GetByFunction would
+// deterministically miss adopted pods, leaving stale byFunction/byAddress
+// entries with dead addresses until TTL reap.
+func TestAdoptSpecializedPodsPopulatesGeneration(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	fsCache := runAdopt(t, pod)
+
+	liveFnMeta := &metav1.ObjectMeta{
+		Name:       "fn1",
+		Namespace:  "default",
+		UID:        "fn-uid-1",
+		Generation: 3, // matches the pod's FUNCTION_GENERATION label
+	}
+	got, err := fsCache.GetByFunction(liveFnMeta)
+	require.NoError(t, err, "adopted entry must be retrievable via GetByFunction keyed on the live Function's Generation")
+	require.Equal(t, "10.9.9.9:8888", got.Address)
+}
+
+// TestAdoptSpecializedPodsSkipsMissingGeneration locks the chosen error
+// posture for a pre-migration pod (rolling-upgrade window) that lacks the
+// fv1.FUNCTION_GENERATION label: adoptSpecializedPods must skip adopting it
+// — the same posture the surrounding code already uses for any other
+// missing required label/annotation (ok1..ok8) — rather than silently
+// keying it at Generation 0, which would produce an entry no live Function
+// can ever look up.
+func TestAdoptSpecializedPodsSkipsMissingGeneration(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "")
+	fsCache := runAdopt(t, pod)
+
+	_, err := fsCache.GetByFunctionUID("fn-uid-1")
+	require.Error(t, err, "a pod without the function-generation label must not be adopted into the cache")
+}
+
+// TestAdoptSpecializedPodsSkipsUnparsableGeneration mirrors the missing-label
+// case for a label present but not a valid int64 — treated the same way
+// (skip, don't adopt with a garbage Generation).
+func TestAdoptSpecializedPodsSkipsUnparsableGeneration(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "not-a-number")
+	fsCache := runAdopt(t, pod)
+
+	_, err := fsCache.GetByFunctionUID("fn-uid-1")
+	require.Error(t, err, "a pod with an unparsable function-generation label must not be adopted into the cache")
+}

--- a/pkg/executor/executortype/poolmgr/gpm_functionenv_test.go
+++ b/pkg/executor/executortype/poolmgr/gpm_functionenv_test.go
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package poolmgr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/cache"
+	"github.com/fission/fission/pkg/crd"
+)
+
+// TestGetFunctionEnvStatusOnlyResourceVersionBump locks the #3596
+// status-churn fix for the poolmgr's functionEnv cache: a Function
+// status-only update bumps ResourceVersion but not Generation, and must
+// not miss the cache entry populated for an earlier RV of the same spec
+// (which would force an unnecessary re-fetch of the Environment via
+// crClient on every status update).
+func TestGetFunctionEnvStatusOnlyResourceVersionBump(t *testing.T) {
+	t.Parallel()
+
+	env := &fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"},
+	}
+	crClient := crfake.NewClientBuilder().WithScheme(scheme()).WithObjects(env).Build()
+
+	gpm := &GenericPoolManager{
+		logger:      logr.Discard(),
+		crClient:    crClient,
+		functionEnv: cache.MakeCache[crd.CacheKeyUG, *fv1.Environment](10*time.Second, 0),
+	}
+
+	fn := &fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "fn1",
+			Namespace:       "default",
+			UID:             "fn-uid-1",
+			Generation:      1,
+			ResourceVersion: "100",
+		},
+		Spec: fv1.FunctionSpec{
+			Environment: fv1.EnvironmentReference{Name: "env1", Namespace: "default"},
+		},
+	}
+
+	ctx := t.Context()
+	got, err := gpm.getFunctionEnv(ctx, fn)
+	require.NoError(t, err)
+	require.Equal(t, "env1", got.Name)
+
+	// Simulate a status-only update observed by a later caller: same
+	// UID+Generation, bumped ResourceVersion.
+	fnAfterStatusUpdate := fn.DeepCopy()
+	fnAfterStatusUpdate.ResourceVersion = "200"
+
+	// Remove the Environment from the crClient so a cache miss would be
+	// detectable (Get would fail / return a not-found error instead of
+	// silently succeeding a second time).
+	require.NoError(t, crClient.Delete(ctx, env))
+
+	got2, err := gpm.getFunctionEnv(ctx, fnAfterStatusUpdate)
+	require.NoError(t, err, "status-only RV bump must hit the cache, not re-fetch from crClient")
+	require.Equal(t, "env1", got2.Name)
+}

--- a/pkg/executor/fscache/functionServiceCache.go
+++ b/pkg/executor/fscache/functionServiceCache.go
@@ -44,7 +44,7 @@ type (
 	// FunctionServiceCache represents the function service cache
 	FunctionServiceCache struct {
 		logger            logr.Logger
-		byFunction        *cache.Cache[crd.CacheKeyUR, *FuncSvc]
+		byFunction        *cache.Cache[crd.CacheKeyUG, *FuncSvc]
 		byAddress         *cache.Cache[string, metav1.ObjectMeta]
 		byFunctionUID     *cache.Cache[types.UID, metav1.ObjectMeta]
 		connFunctionCache *PoolCache // function-key -> funcSvc : map[string]*funcSvc
@@ -85,7 +85,7 @@ func IsNameExistError(err error) bool {
 func MakeFunctionServiceCache(logger logr.Logger) *FunctionServiceCache {
 	return &FunctionServiceCache{
 		logger:            logger.WithName("function_service_cache"),
-		byFunction:        cache.MakeCache[crd.CacheKeyUR, *FuncSvc](0, 0),
+		byFunction:        cache.MakeCache[crd.CacheKeyUG, *FuncSvc](0, 0),
 		byAddress:         cache.MakeCache[string, metav1.ObjectMeta](0, 0),
 		byFunctionUID:     cache.MakeCache[types.UID, metav1.ObjectMeta](0, 0),
 		connFunctionCache: NewPoolCache(logger.WithName("conn_function_cache")),
@@ -114,8 +114,14 @@ func (fsc *FunctionServiceCache) DumpDebugInfo(ctx context.Context) error {
 }
 
 // GetByFunction gets a function service from cache using function key.
+//
+// The key is UID+Generation, not ResourceVersion (see #3596): RV moves on
+// status-only writes (not just spec changes), and a caller's view of the
+// function can lag the writer's (informer cache lag across components) —
+// an RV-keyed lookup would miss the entry Add()/DeleteEntry() operate on,
+// splitting one function's cache entry across RV churn.
 func (fsc *FunctionServiceCache) GetByFunction(m *metav1.ObjectMeta) (*FuncSvc, error) {
-	key := crd.CacheKeyURFromMeta(m)
+	key := crd.CacheKeyUGFromMeta(m)
 
 	fsvc, err := fsc.byFunction.Get(key)
 	if err != nil {
@@ -160,7 +166,7 @@ func (fsc *FunctionServiceCache) GetByFunctionUID(uid types.UID) (*FuncSvc, erro
 		return nil, err
 	}
 
-	fsvc, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
+	fsvc, err := fsc.byFunction.Get(crd.CacheKeyUGFromMeta(&m))
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +206,7 @@ func (fsc *FunctionServiceCache) MarkSpecializationFailure(key crd.CacheKeyUG) {
 
 // Add adds a function service to cache if it does not exist already.
 func (fsc *FunctionServiceCache) Add(fsvc FuncSvc) (*FuncSvc, error) {
-	existing, err := fsc.byFunction.Set(crd.CacheKeyURFromMeta(fsvc.Function), &fsvc)
+	existing, err := fsc.byFunction.Set(crd.CacheKeyUGFromMeta(fsvc.Function), &fsvc)
 	if err != nil {
 		if IsNameExistError(err) {
 			err2 := fsc.TouchByAddress(existing.Address)
@@ -255,7 +261,7 @@ func (fsc *FunctionServiceCache) _touchByAddress(address string) error {
 	if err != nil {
 		return err
 	}
-	fsvc, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
+	fsvc, err := fsc.byFunction.Get(crd.CacheKeyUGFromMeta(&m))
 	if err != nil {
 		return err
 	}
@@ -265,7 +271,7 @@ func (fsc *FunctionServiceCache) _touchByAddress(address string) error {
 
 // DeleteEntry deletes a function service from cache.
 func (fsc *FunctionServiceCache) DeleteEntry(fsvc *FuncSvc) {
-	fsc.byFunction.Delete(crd.CacheKeyURFromMeta(fsvc.Function))
+	fsc.byFunction.Delete(crd.CacheKeyUGFromMeta(fsvc.Function))
 	fsc.byAddress.Delete(fsvc.Address)
 	fsc.byFunctionUID.Delete(fsvc.Function.UID)
 	metrics.ObserveFunctionRunningSeconds(context.Background(), fsvc.Function.Name, fsvc.Function.Namespace, fsvc.Atime.Sub(fsvc.Ctime).Seconds())
@@ -319,7 +325,7 @@ func (fsc *FunctionServiceCache) ListOld(age time.Duration) ([]*FuncSvc, error) 
 	fscs := fsc.byFunctionUID.Copy()
 	funcObjects := make([]*FuncSvc, 0, len(fscs))
 	for _, m := range fscs {
-		fsvc, err := fsc.byFunction.Get(crd.CacheKeyURFromMeta(&m))
+		fsvc, err := fsc.byFunction.Get(crd.CacheKeyUGFromMeta(&m))
 		if err != nil {
 			// A byFunctionUID entry without a byFunction entry is a transient
 			// TOCTOU gap (concurrent delete). Skip it and return what we have;

--- a/pkg/executor/fscache/functionServiceCache_test.go
+++ b/pkg/executor/fscache/functionServiceCache_test.go
@@ -266,6 +266,55 @@ func TestListOldPartialReturnOnDanglingIndex(t *testing.T) {
 	}
 }
 
+// TestGetByFunctionStatusOnlyResourceVersionBump locks the #3596
+// status-churn fix at the byFunction cache: ResourceVersion moves on
+// status-only writes (not just spec changes), so a status-only bump
+// observed by a later caller must still hit the entry Add() populated for
+// an earlier RV of the same UID+Generation — an RV-keyed lookup would miss
+// it and, worse, Add() would create a second entry for the "same" function.
+func TestGetByFunctionStatusOnlyResourceVersionBump(t *testing.T) {
+	fsc := MakeFunctionServiceCache(loggerfactory.GetLogger())
+	require.NotNil(t, fsc)
+
+	before := &metav1.ObjectMeta{
+		Name:            "foo",
+		UID:             types.UID("fn-uid-1"),
+		Generation:      1,
+		ResourceVersion: "100",
+	}
+	now := time.Now()
+	fsvc := FuncSvc{
+		Function: before,
+		Address:  "10.5.5.5:8888",
+		Ctime:    now,
+		Atime:    now,
+	}
+	_, err := fsc.Add(fsvc)
+	require.NoError(t, err)
+
+	// Same object, later observed with a bumped ResourceVersion (a
+	// status-only update) but unchanged UID+Generation.
+	after := &metav1.ObjectMeta{
+		Name:            "foo",
+		UID:             types.UID("fn-uid-1"),
+		Generation:      1,
+		ResourceVersion: "200",
+	}
+
+	got, err := fsc.GetByFunction(after)
+	require.NoError(t, err, "status-only RV bump must not miss the byFunction cache entry")
+	require.Equal(t, fsvc.Address, got.Address)
+
+	// Adding again under the post-status-update metadata must overwrite the
+	// existing entry (IsNameExistError / Add's existing-entry path), not
+	// create a second one.
+	fsvc2 := fsvc
+	fsvc2.Function = after
+	existing, err := fsc.Add(fsvc2)
+	require.NoError(t, err)
+	require.NotNil(t, existing, "Add under a status-only-bumped RV must report the pre-existing entry, not silently create a duplicate")
+}
+
 // TestTouchByAddressPoolCacheFallback locks the RFC-0002 tap-liveness fix at
 // the FunctionServiceCache layer: poolmgr registers specialized pods only in
 // the pool cache (never byAddress), so a byAddress miss MUST fall through to


### PR DESCRIPTION
## Why

#3596 moved the poolmgr pool cache to `(UID, Generation)` keys because ResourceVersion also bumps on status-only writes (not just spec changes), and informer lag across components can make an RV-keyed lookup miss the entry a concurrent writer just set.

This PR extends the same fix to every other executor-side cache still keyed on ResourceVersion:

- `pkg/executor/fscache/functionServiceCache.go` — the `byFunction` cache (`GetByFunction`, `GetByFunctionUID`, `Add`, `_touchByAddress`, `DeleteEntry`, `ListOld`) migrated `CacheKeyUR` -> `CacheKeyUG`, with a new test proving a status-only RV bump (same UID+Generation, different ResourceVersion) hits the existing entry instead of missing/duplicating it.
- `pkg/executor/executortype/poolmgr/gpm.go` — the `functionEnv` (Function -> Environment) memoization cache migrated the same way, with an equivalent test.
- `pkg/executor/executor.go` — `dispatchCreateFuncService`'s newdeploy/container dispatcher dedup key migrated to `CacheKeyUGFromMeta`, so two concurrent specialization requests that observed different RVs of the same spec still coalesce onto one specialization instead of duplicating work.
- `pkg/executor/executortype/{container,newdeploy}mgr.go` — updated stale comments referencing the old RV-keyed `GetByFunction`.

## Adopt-path fix

Also included is a fix the keying migration exposed: `adoptSpecializedPods` (the post-restart `AdoptExistingResources` path) built its synthetic `ObjectMeta` from pod labels/annotations without `Generation`. Under `CacheKeyUG` that synthetic entry keys as `(UID, 0)`, which no live Function (`Generation >= 1`) can ever match — `RefreshFuncPods`' `GetByFunction` -> `DeleteEntry` would deterministically miss every adopted pod and leak stale `byFunction`/`byAddress` entries with dead addresses until TTL reap.

`adoptSpecializedPods` now reads `pod.Labels[fv1.FUNCTION_GENERATION]` (stamped at specialization time) alongside the existing required-field reads and populates `Generation`. A missing or unparsable label is treated like any other missing required field: log and skip adoption, rather than adopt at Generation 0 (an entry no live Function could ever retrieve). Covered by new tests in `gpm_adopt_test.go`.

## Standalone benefit

This closes the same class of bug #3596 fixed, just in the caches #3596 didn't touch: without it, a status-only write to a `Function` (e.g. a status-condition update from a controller) can still split or miss entries in the executor's `byFunction`, `functionEnv`, and dispatch-dedup caches, causing redundant environment fetches, duplicate specializations, or (post-restart) permanently orphaned pool-cache entries for adopted pods.

`pkg/crd/key.go` is untouched: `CacheKeyUR` and its constructors stay in place — the router still uses them, and its own `(UID, Generation)` migration is intentionally out of scope here and lands separately in #3599.

Extracted from #3599.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/executor/... ./pkg/crd/... -count=1 -race -timeout=600s`
- [x] `golangci-lint run ./pkg/executor/... ./pkg/crd/...`
- [x] `make license-check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)