### PR TITLE
fix(canary): defer terminal Succeeded until an evaluated window with traffic

### DIFF
--- a/pkg/canaryconfigmgr/canaryConfigMgr.go
+++ b/pkg/canaryconfigmgr/canaryConfigMgr.go
@@ -150,6 +150,12 @@ type stepOutcome struct {
 // RollForwardOrBack: instead of stopping a ticker or closing a quit channel it
 // returns a stepOutcome the reconciler maps onto a ctrl.Result and a status
 // write.
+//
+// INVARIANT: the terminal Succeeded outcome requires at least one completed
+// evaluation window in which the new function actually carried traffic. The
+// failure evaluation above is skipped while the new function's weight is 0
+// (nothing to observe), so a single tick must never both introduce first
+// traffic and terminally succeed — see rollForward's done gate.
 func (m *canaryConfigMgr) step(ctx context.Context, cfg *fv1.CanaryConfig) (stepOutcome, error) {
 	log := m.logger.WithValues("name", cfg.Name, "namespace", cfg.Namespace)
 
@@ -230,13 +236,25 @@ func (m *canaryConfigMgr) step(ctx context.Context, cfg *fv1.CanaryConfig) (step
 }
 
 // rollForward shifts WeightIncrement percent of traffic from the old function
-// to the new one, clamping at 100/0. It reports whether the new function has
-// reached 100% (the rollout is done).
+// to the new one, clamping at 100/0. It reports whether the rollout is done
+// (the new function has reached 100% AND had traffic during an evaluated
+// window).
+//
+// INVARIANT: the terminal Succeeded outcome requires at least one completed
+// evaluation window in which the new function actually carried traffic.
+// step() skips the failure evaluation while the new function's weight is 0,
+// so a step FROM weight 0 must never report done even when WeightIncrement
+// >= 100 pushes the weight straight to 100 — the rollout stays Pending for
+// one more interval and the next tick's evaluation either confirms
+// (Succeeded) or rolls the traffic back (Failed). Without this gate a
+// WeightIncrement >= 100 canary would write terminal Succeeded — after which
+// the reconciler never re-evaluates or rolls back — with the new function's
+// very first traffic, zero windows observed.
 func (m *canaryConfigMgr) rollForward(ctx context.Context, cfg *fv1.CanaryConfig, trigger *fv1.HTTPTrigger) (bool, error) {
 	weights := trigger.Spec.FunctionReference.FunctionWeights
 	done := false
 	if weights[cfg.Spec.NewFunction]+cfg.Spec.WeightIncrement >= 100 {
-		done = true
+		done = weights[cfg.Spec.NewFunction] > 0
 		weights[cfg.Spec.NewFunction] = 100
 		weights[cfg.Spec.OldFunction] = 0
 	} else {

--- a/pkg/canaryconfigmgr/canaryConfigMgr_test.go
+++ b/pkg/canaryconfigmgr/canaryConfigMgr_test.go
@@ -74,12 +74,18 @@ func TestMakePrometheusClient(t *testing.T) {
 }
 
 // fakeFailureClient is a deterministic failurePercentageGetter for tests.
+// calls, when non-nil, is incremented on every call — used by tests that must
+// assert an evaluation was (or was not) performed in a given tick.
 type fakeFailureClient struct {
-	pct float64
-	err error
+	pct   float64
+	err   error
+	calls *int
 }
 
 func (f fakeFailureClient) GetFunctionFailurePercentage(_ context.Context, _ string, _ []string, _, _, _ string) (float64, error) {
+	if f.calls != nil {
+		*f.calls++
+	}
 	return f.pct, f.err
 }
 
@@ -148,6 +154,35 @@ func TestRollForward(t *testing.T) {
 		done, err := mgr.rollForward(t.Context(), cc, trigger)
 		require.NoError(t, err)
 		assert.True(t, done)
+
+		got := getTrigger(t, c)
+		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["new"])
+		assert.Equal(t, 0, got.Spec.FunctionReference.FunctionWeights["old"])
+	})
+
+	t.Run("increment >= 100 from zero writes 100/0 but is not done", func(t *testing.T) {
+		// The step that INTRODUCES first traffic must never also be the terminal
+		// one: step() skips the failure evaluation at weight 0, so done here
+		// would mean Succeeded with zero observed evaluation windows.
+		trigger, cc := canaryFixtures(map[string]int{"new": 0, "old": 100}, 100)
+		mgr, _, c := newTestEnv(fakeFailureClient{}, trigger, cc)
+
+		done, err := mgr.rollForward(t.Context(), cc, trigger)
+		require.NoError(t, err)
+		assert.False(t, done, "a step from weight 0 must not report done — the next tick must evaluate first")
+
+		got := getTrigger(t, c)
+		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["new"])
+		assert.Equal(t, 0, got.Spec.FunctionReference.FunctionWeights["old"])
+	})
+
+	t.Run("increment >= 100 from nonzero weight is done", func(t *testing.T) {
+		trigger, cc := canaryFixtures(map[string]int{"new": 100, "old": 0}, 100)
+		mgr, _, c := newTestEnv(fakeFailureClient{}, trigger, cc)
+
+		done, err := mgr.rollForward(t.Context(), cc, trigger)
+		require.NoError(t, err)
+		assert.True(t, done, "a step already carrying traffic must still report done")
 
 		got := getTrigger(t, c)
 		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["new"])
@@ -247,6 +282,73 @@ func TestStep(t *testing.T) {
 		out, err := mgr.step(t.Context(), cc)
 		require.NoError(t, err)
 		assert.Equal(t, fv1.CanaryConfigStatusSucceeded, out.terminalStatus)
+
+		got := getTrigger(t, c)
+		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["new"])
+		assert.Equal(t, 0, got.Spec.FunctionReference.FunctionWeights["old"])
+	})
+
+	t.Run("increment >= 100 with failing new function never reports Succeeded", func(t *testing.T) {
+		// Regression for the single-tick promote bug: with WeightIncrement >= 100
+		// the first tick used to shift 0 -> 100 AND report Succeeded — a terminal
+		// status the reconciler never revisits — without ever evaluating the new
+		// function. Now the introducing tick stays Pending and the next tick's
+		// evaluation rolls a failing function back.
+		trigger, cc := canaryFixtures(map[string]int{"new": 0, "old": 100}, 100)
+		var calls int
+		mgr, _, c := newTestEnv(fakeFailureClient{pct: 50, calls: &calls}, trigger, cc) // 50 > threshold 10
+
+		// Tick 1: introduces traffic, no evaluation possible yet, not terminal.
+		out, err := mgr.step(t.Context(), cc)
+		require.NoError(t, err)
+		assert.Equal(t, stepOutcome{requeue: true}, out)
+		assert.Zero(t, calls, "at weight 0 there is nothing to evaluate")
+		assert.Equal(t, 100, getTrigger(t, c).Spec.FunctionReference.FunctionWeights["new"])
+		assert.Equal(t, 0, getTrigger(t, c).Spec.FunctionReference.FunctionWeights["old"])
+
+		// Tick 2: first evaluation window completed — threshold crossed, roll back.
+		out, err = mgr.step(t.Context(), cc)
+		require.NoError(t, err)
+		assert.Equal(t, fv1.CanaryConfigStatusFailed, out.terminalStatus)
+		assert.Equal(t, 1, calls)
+
+		got := getTrigger(t, c)
+		assert.Equal(t, 0, got.Spec.FunctionReference.FunctionWeights["new"])
+		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["old"])
+	})
+
+	t.Run("increment >= 100 with healthy new function succeeds only after an evaluated window", func(t *testing.T) {
+		trigger, cc := canaryFixtures(map[string]int{"new": 0, "old": 100}, 100)
+		var calls int
+		mgr, _, c := newTestEnv(fakeFailureClient{pct: 5, calls: &calls}, trigger, cc) // 5 < threshold 10
+
+		out, err := mgr.step(t.Context(), cc)
+		require.NoError(t, err)
+		assert.Equal(t, stepOutcome{requeue: true}, out, "introducing tick must not be terminal")
+		assert.Zero(t, calls, "at weight 0 there is nothing to evaluate")
+
+		out, err = mgr.step(t.Context(), cc)
+		require.NoError(t, err)
+		assert.Equal(t, fv1.CanaryConfigStatusSucceeded, out.terminalStatus)
+		assert.Equal(t, 1, calls, "exactly one evaluated window before promotion")
+
+		got := getTrigger(t, c)
+		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["new"])
+		assert.Equal(t, 0, got.Spec.FunctionReference.FunctionWeights["old"])
+	})
+
+	t.Run("increment 50 happy path keeps its one-tick shape", func(t *testing.T) {
+		// A terminal step starting from an already-nonzero (already-evaluated)
+		// weight must not be deferred by the invariant gate: it reaches Succeeded
+		// in the SAME tick as the passing evaluation, same as before the fix.
+		trigger, cc := canaryFixtures(map[string]int{"new": 50, "old": 50}, 50)
+		var calls int
+		mgr, _, c := newTestEnv(fakeFailureClient{pct: 5, calls: &calls}, trigger, cc) // 5 < threshold 10
+
+		out, err := mgr.step(t.Context(), cc)
+		require.NoError(t, err)
+		assert.Equal(t, fv1.CanaryConfigStatusSucceeded, out.terminalStatus, "terminal step from nonzero weight must not be deferred")
+		assert.Equal(t, 1, calls)
 
 		got := getTrigger(t, c)
 		assert.Equal(t, 100, got.Spec.FunctionReference.FunctionWeights["new"])


### PR DESCRIPTION
## Bug

In `pkg/canaryconfigmgr/canaryConfigMgr.go`, `step()` skips the Prometheus failure evaluation while `FunctionWeights[NewFunction] == 0` — there is no traffic yet to observe.
`rollForward()`'s reach-100 branch reported `done = true` whenever `weights[new] + WeightIncrement >= 100`, with no check on whether the new function had any weight before the step.

With `WeightIncrement >= 100`, the very first tick would:
1. Skip the failure evaluation (weight was 0 entering the tick).
2. Write weights 100/0.
3. Report `done = true` → terminal `CanaryConfigStatusSucceeded`.

Terminal statuses are never revisited by the reconciler, so a function failing 100% of requests could be promoted to all traffic permanently, with zero evaluation windows ever observed.

## Fix

`rollForward`'s reach-100 branch now gates `done` on the new function already carrying weight before this tick (`weights[cfg.Spec.NewFunction] > 0`), while still writing the 100/0 weights unconditionally. The next tick then sees `weights[new] == 100 != 0`, so the evaluation guard passes and the failure rate is checked at full traffic — either confirming success (`rollForward` called again, weights already 100, `done = 100 > 0 = true`, idempotent) or rolling back via `rollbackWeights` (writes 0/100) → `Failed`.

Progression from an already-evaluated (nonzero) weight — the common case with smaller increments — is unaffected: the terminal step still completes in the same tick it was evaluated in, exactly as before.

Extracted from the RFC-0025 branch (commit `11830206`), legacy `FunctionWeights` path only — that commit also touches an alias-mode path (`stepAlias`/`rollForwardAlias`) that doesn't exist on `main`.

## Tests

Added to `pkg/canaryconfigmgr/canaryConfigMgr_test.go`:
- `TestRollForward`: increment=100 from weight 0 writes 100/0 but reports `done=false`; from nonzero weight reports `done=true`.
- `TestStep`: increment=100 with a failing new function — tick 1 requeues with weights 100/0 and zero Prometheus calls, tick 2 evaluates once and rolls back to `Failed` (never `Succeeded`).
- `TestStep`: increment=100 with a healthy new function — tick 1 requeues, tick 2 evaluates exactly once and reports `Succeeded`.
- `TestStep`: increment=50 from an already-nonzero weight still reaches `Succeeded` in one tick (guards against regressing the unaffected happy path).

`go build ./...` and `go test -race -count=1 ./pkg/canaryconfigmgr/...` are green; `golangci-lint run ./pkg/canaryconfigmgr/...` reports 0 issues.

Fixes #3612

🤖 Generated with [Claude Code](https://claude.com/claude-code)