### PR TITLE
fix(executor): MarkFuncDeleted marks every generation group

### DIFF
--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -74,6 +74,15 @@ func NewFuncSvcGroup() *funcSvcGroup {
 	}
 }
 
+// MarkFuncDeleted marks EVERY cache group belonging to the function's UID as
+// deleted, whatever Generation each group is keyed at. The cache is keyed by
+// (UID, Generation), and during a rolling function update two generations'
+// groups can legitimately coexist for one function — the old generation's
+// specialized pods draining while the new generation serves traffic. A
+// Function delete landing in that window must mark both groups; stopping at
+// the first UID match (map-iteration order, so effectively random) would
+// leave the other group unmarked, and its pods would linger past the delete
+// until ordinary idle reaping caught up with them.
 func (c *PoolCache) MarkFuncDeleted(function crd.CacheKeyUG) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
@@ -81,7 +90,6 @@ func (c *PoolCache) MarkFuncDeleted(function crd.CacheKeyUG) {
 	for key := range c.cache {
 		if key.UID == function.UID {
 			c.cache[key].deleted = true
-			break
 		}
 	}
 }

--- a/pkg/executor/fscache/poolcache_test.go
+++ b/pkg/executor/fscache/poolcache_test.go
@@ -139,6 +139,32 @@ func TestPoolCache(t *testing.T) {
 			log.Panicf("found value when expected it to be nil")
 		}
 	})
+
+	t.Run("Test mark deleted marks every generation group sharing the UID", func(t *testing.T) {
+		// The cache is keyed by (UID, Generation); during a rolling function
+		// update the old and new generations' groups coexist for one function
+		// (old gen's pods draining while the new gen serves). A delete landing
+		// in that window must mark BOTH groups, not just whichever one the map
+		// iteration happens to visit first.
+		c6 := NewPoolCache(logger)
+		oldGenKey := crd.CacheKeyUG{UID: "func6", Generation: 1}
+		newGenKey := crd.CacheKeyUG{UID: "func6", Generation: 2}
+
+		c6.SetSvcValue(ctx, oldGenKey, "ip-old", &FuncSvc{
+			Name: "old",
+		}, resource.MustParse("45m"), 10, 0)
+		c6.SetSvcValue(ctx, newGenKey, "ip-new", &FuncSvc{
+			Name: "new",
+		}, resource.MustParse("45m"), 10, 0)
+
+		c6.MarkFuncDeleted(crd.CacheKeyUG{UID: "func6"})
+
+		// Iterate the whole cache so the assertion doesn't depend on map order.
+		require.Len(t, c6.cache, 2)
+		for key, grp := range c6.cache {
+			require.True(t, grp.deleted, "group at generation %d must be marked deleted", key.Generation)
+		}
+	})
 }
 
 func TestPoolCacheRequests(t *testing.T) {


### PR DESCRIPTION
## Bug

`PoolCache.MarkFuncDeleted` (`pkg/executor/fscache/poolcache.go`) stopped at the first cache group whose key matched the function's UID:

```go
for key := range c.cache {
	if key.UID == function.UID {
		c.cache[key].deleted = true
		break
	}
}
```

The pool cache is keyed by `(UID, Generation)`. During a rolling function update, two generations' groups legitimately coexist for one function at once: the old generation's group (its specialized pods draining) and the new generation's group (serving live traffic).

If a Function delete lands in that window, only one of the two groups gets marked `deleted` — which one is decided by Go's randomized map iteration order, not by which generation is "current." The other group's pods stay reaper-exempt and linger until an executor restart, instead of draining as part of the delete.

## Fix

Drop the `break` so every cache group sharing the function's UID is marked deleted, regardless of which generation it's keyed at. Added a doc comment on `MarkFuncDeleted` stating the all-groups contract explicitly, since multiple `(UID, Generation)` groups per function are a legitimate steady state during update windows, not an edge case to special-case away.

## Test

Extended `pkg/executor/fscache/poolcache_test.go` (`TestPoolCache`) with a new subtest that seeds two groups sharing a UID at generations 1 and 2 via the cache's normal `SetSvcValue` path, calls `MarkFuncDeleted`, and asserts both groups' `deleted` flags by iterating the whole cache — so the assertion is map-order independent rather than checking a single expected survivor.

Verified the test actually catches the regression: temporarily restored the `break` and ran `go test -race -count=5 -run .../Test_mark_deleted_marks_every_generation_group_sharing_the_UID`. It failed deterministically on all 5 runs, alternating between "generation 1 must be marked deleted" and "generation 2 must be marked deleted" depending on map iteration order — exactly the bug being fixed. Reverted to the fix afterward and reconfirmed green.

Fixes #3614

🤖 Generated with [Claude Code](https://claude.com/claude-code)