### PR TITLE
perf(router): zero-alloc rendezvous hash on the sticky admit path

### DIFF
--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -11,7 +11,6 @@ package endpointcache
 
 import (
 	"fmt"
-	"hash/fnv"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -359,12 +358,32 @@ const (
 // a pure function, so every router replica ranks endpoints identically with
 // no shared ring state (RFC-0023 S4), and removing an endpoint moves only the
 // keys that ranked it first (S5).
+//
+// Inlined FNV-1a (offset basis 14695981039346656037, prime 1099511628211)
+// over a local uint64 accumulator instead of fnv.New64a(): going through
+// hash.Hash64 heap-allocates the hasher on every call, and this runs once per
+// candidate endpoint per sticky-keyed Admit -- the per-request hot path.
+// Byte-for-byte identical to
+// fnv.New64a().Write([]byte(key)).Write([]byte{0}).Write([]byte(address)).Sum64()
+// for the same inputs (see TestHrwScoreMatchesFNV64a), so existing sticky
+// assignments do not shift on deploy. Mirrors the inline pattern documented
+// on shard() above, the 64-bit multi-segment analog of the same fix.
 func hrwScore(key, address string) uint64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(key))
-	_, _ = h.Write([]byte{0})
-	_, _ = h.Write([]byte(address))
-	return h.Sum64()
+	const (
+		offset64 = 14695981039346656037
+		prime64  = 1099511628211
+	)
+	h := uint64(offset64)
+	for i := 0; i < len(key); i++ {
+		h = (h ^ uint64(key[i])) * prime64
+	}
+	// FNV-1a step for the 0x00 separator byte: h ^ 0 is always h, so only the
+	// multiply survives -- still a required step, not a no-op omission.
+	h *= prime64
+	for i := 0; i < len(address); i++ {
+		h = (h ^ uint64(address[i])) * prime64
+	}
+	return h
 }
 
 // Admit picks a ready, non-quarantined endpoint with free capacity (below

--- a/pkg/router/endpointcache/sticky_test.go
+++ b/pkg/router/endpointcache/sticky_test.go
@@ -6,6 +6,7 @@ package endpointcache
 
 import (
 	"fmt"
+	"hash/fnv"
 	"sync"
 	"testing"
 
@@ -20,6 +21,83 @@ import (
 // only its keys; adding one moves only keys now ranking it first. Stickiness
 // is best-effort (S6): a saturated sticky target overflows to the
 // next-ranked admissible endpoint, never queues.
+
+// TestHrwScoreMatchesFNV64a pins hrwScore's inlined FNV-1a against the
+// standard library's hash/fnv New64a over the identical write sequence (key,
+// a single 0x00 separator byte, address): the inlining (heap-allocation fix,
+// issue #3615) must be byte-for-byte identical, or existing sticky
+// assignments would silently shift the moment it ships.
+func TestHrwScoreMatchesFNV64a(t *testing.T) {
+	t.Parallel()
+
+	stdHrwScore := func(key, address string) uint64 {
+		h := fnv.New64a()
+		_, _ = h.Write([]byte(key))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(address))
+		return h.Sum64()
+	}
+
+	strs := []string{
+		"",
+		"a",
+		"10.0.0.1:8888",
+		"session-abc-1234567890",
+		"тест-utf8",
+		"a-fairly-long-sticky-key-with-several-words-in-it-1234567890",
+		string([]byte{0x00, 0xff, 0x10, 0x7f}),
+		string([]byte{0x00}),
+	}
+	for _, key := range strs {
+		for _, address := range strs {
+			assert.Equalf(t, stdHrwScore(key, address), hrwScore(key, address),
+				"hrwScore(%q, %q)", key, address)
+		}
+	}
+}
+
+// TestHrwScoreAllocs guards the fix itself: hrwScore runs once per candidate
+// endpoint per sticky-keyed Admit call, so any heap allocation here is a
+// per-request cost multiplied by endpoint count.
+func TestHrwScoreAllocs(t *testing.T) {
+	var sink uint64
+	allocs := testing.AllocsPerRun(1000, func() {
+		sink = hrwScore("session-abc-1234567890", "10.0.0.1:8888")
+	})
+	assert.Zero(t, allocs, "hrwScore must not heap-allocate on the per-request hot path")
+	benchSinkU64 = sink
+}
+
+// benchSinkU64 defeats dead-code elimination in the benchmarks below.
+var benchSinkU64 uint64
+
+// BenchmarkHrwScoreNew/Old bracket the fix: New exercises the shipped inline
+// FNV-1a, Old inlines the previous fnv.New64a()-based implementation so a
+// side-by-side allocs/op read shows the delta.
+// Run: go test -run=^$ -bench=HrwScore -benchmem ./pkg/router/endpointcache/
+func BenchmarkHrwScoreNew(b *testing.B) {
+	var sink uint64
+	b.ReportAllocs()
+	for b.Loop() {
+		sink = hrwScore("session-abc-1234567890", "10.0.0.1:8888")
+	}
+	benchSinkU64 = sink
+}
+
+func BenchmarkHrwScoreOld(b *testing.B) {
+	var sink uint64
+	b.ReportAllocs()
+	for b.Loop() {
+		// Previous implementation: fnv.New64a() heap-allocates the hasher
+		// (behind the hash.Hash64 interface) on every call.
+		h := fnv.New64a()
+		_, _ = h.Write([]byte("session-abc-1234567890"))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte("10.0.0.1:8888"))
+		sink = h.Sum64()
+	}
+	benchSinkU64 = sink
+}
 
 // admitAll drains one Admit per key and returns key->address, releasing every
 // admission so load never influences the pick under test.


### PR DESCRIPTION
## What

`hrwScore` (`pkg/router/endpointcache/index.go`) computes the rendezvous (highest-random-weight) hash used to pick the sticky-routed endpoint in `Index.Admit` (RFC-0023 sticky routing).
It went through `fnv.New64a()`, which heap-allocates the hasher behind the `hash.Hash64` interface on every call.

`hrwScore` runs once per **candidate endpoint** per **sticky-keyed request** — inside `Admit`, the router's per-request hot warm-path — so every scan paid an allocation per pod in the function's endpoint set.

## Why

This replaces it with an inlined FNV-1a (offset basis `14695981039346656037`, prime `1099511628211`) over a local `uint64` accumulator, indexing the key/address strings directly (no `[]byte` conversions).
This mirrors the pattern the same file already uses for `shard()`, which documents the identical fix for the 32-bit shard hash.

## Hash-equality guarantee

The inlined hash must produce byte-identical output to the old implementation, or existing sticky assignments would silently reshuffle the moment this ships.
`TestHrwScoreMatchesFNV64a` pins `hrwScore(key, address)` against `fnv.New64a()` fed the same write sequence (key, a single `0x00` separator byte, address) across a matrix of inputs: empty key/address, ASCII, UTF-8, embedded `0x00` bytes, and long strings.
`TestHrwScoreAllocs` additionally guards the fix itself via `testing.AllocsPerRun`.

## Alloc numbers

`BenchmarkHrwScoreNew`/`BenchmarkHrwScoreOld` (Apple M2):

```
BenchmarkHrwScoreNew-8   ~20-54 ns/op    0 B/op   0 allocs/op
BenchmarkHrwScoreOld-8   ~59-184 ns/op  56 B/op   4 allocs/op
```

Roughly 3x faster with the per-call allocation eliminated entirely.

## Tests

- `go build ./...` — green
- `go test -race -count=1 ./pkg/router/endpointcache/...` — green (existing sticky-routing property tests, race detector, plus the two new tests above)
- `golangci-lint run ./pkg/router/endpointcache/...` — 0 issues

Fixes #3615.

🤖 Generated with [Claude Code](https://claude.com/claude-code)