### PR TITLE
Security hardening: preserve router auth secret, scope functionpods NetworkPolicy, fix HMAC signer retry contract

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -247,6 +247,17 @@ http://router-internal.{{ .Release.Namespace }}:{{ include "fission.routerIntern
 {{- end -}}
 
 {{/*
+fission.authenticationSecretName is the Secret the router and MCP deployments
+read auth credentials (username/password) and the JWT signing key from —
+either a user-managed Secret named by authentication.existingSecret (which
+must carry the keys username, password and jwtSigningKey) or the
+chart-generated "router" Secret (templates/router/secret.yaml).
+*/}}
+{{- define "fission.authenticationSecretName" -}}
+{{ .Values.authentication.existingSecret | default "router" }}
+{{- end -}}
+
+{{/*
 fission.podNamespaceEnv injects POD_NAMESPACE via the downward API — the
 namespace fission-bundle's AddressResolver derives sibling-service URL
 defaults from when a URL flag/env is not explicitly set.

--- a/charts/fission-all/templates/executor/networkpolicy-functionpods.yaml
+++ b/charts/fission-all/templates/executor/networkpolicy-functionpods.yaml
@@ -35,11 +35,16 @@ spec:
     # executor → fetcher sidecar (POST /specialize), and executor → env
     # runtime (POST /v2/specialize) for poolmgr image-volume pods
     # (RFC-0001 Path B), which carry no fetcher to relay the load call
-    # (newdeploy Path B pods keep theirs). executor
-    # runs in the release namespace; namespaceSelector: {} permits
-    # cross-ns because this policy lives in functionNamespace.
+    # (newdeploy Path B pods keep theirs). executor runs in the release
+    # namespace, which may differ from functionNamespace (where this
+    # policy lives), so the namespaceSelector names it explicitly. The
+    # namespaceSelector and podSelector are entries of ONE from element,
+    # so they AND: a pod merely labelled `svc: executor` in any other
+    # namespace does not match.
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               svc: executor
@@ -51,9 +56,11 @@ spec:
     # router → env runtime (user-trigger traffic). Router resolves the
     # function's service URL via executor.GetServiceForFunction and then
     # proxies on the env's port (8888). Router is in the release
-    # namespace; same cross-ns rationale as above.
+    # namespace; same AND-of-selectors shape as above.
     - from:
-        - namespaceSelector: {}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
           podSelector:
             matchLabels:
               application: fission-router

--- a/charts/fission-all/templates/mcp/deployment.yaml
+++ b/charts/fission-all/templates/mcp/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: JWT_SIGNING_KEY
           valueFrom:
             secretKeyRef:
-              name: router
+              name: {{ include "fission.authenticationSecretName" . }}
               key: jwtSigningKey
         {{- else if .Values.mcp.allowInsecure }}
         # No signing key: the MCP endpoint runs UNAUTHENTICATED — every caller gets

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -52,17 +52,17 @@ spec:
         - name: AUTH_USERNAME
           valueFrom:
             secretKeyRef:
-              name: router
+              name: {{ include "fission.authenticationSecretName" . }}
               key: username
         - name: AUTH_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: router
+              name: {{ include "fission.authenticationSecretName" . }}
               key: password
         - name: JWT_SIGNING_KEY
           valueFrom:
             secretKeyRef:
-              name: router
+              name: {{ include "fission.authenticationSecretName" . }}
               key: jwtSigningKey
         {{- end }}      
         - name: POD_NAMESPACE

--- a/charts/fission-all/templates/router/secret.yaml
+++ b/charts/fission-all/templates/router/secret.yaml
@@ -1,4 +1,32 @@
-{{- if .Values.authentication.enabled }}
+{{- if and .Values.authentication.enabled (not .Values.authentication.existingSecret) }}
+{{- /*
+This Secret holds the router's auth credentials and the JWT signing key that
+also gates MCP authorization (mcp/deployment.yaml references the same key).
+
+lookup against the install namespace preserves the generated password and
+jwtSigningKey across helm upgrades; randAlphaNum alone would rotate the
+signing key on every upgrade, invalidating every issued token mid-flight.
+An explicitly set .Values.authentication.jwtSigningKey always wins, so
+rotation stays possible by bumping the value and re-running helm upgrade.
+
+lookup returns empty under `helm template` (e.g. Argo CD), where this
+template would still mint fresh material every sync — set
+.Values.authentication.existingSecret (which disables this template
+entirely) on GitOps-rendered installs.
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace "router" -}}
+{{- $password := randAlphaNum 20 | b64enc -}}
+{{- if and $existing $existing.data $existing.data.password -}}
+{{-   $password = $existing.data.password -}}
+{{- end -}}
+{{- $jwtSigningKey := "" -}}
+{{- if .Values.authentication.jwtSigningKey -}}
+{{-   $jwtSigningKey = .Values.authentication.jwtSigningKey | b64enc -}}
+{{- else if and $existing $existing.data $existing.data.jwtSigningKey -}}
+{{-   $jwtSigningKey = $existing.data.jwtSigningKey -}}
+{{- else -}}
+{{-   $jwtSigningKey = randAlphaNum 20 | b64enc -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,6 +37,6 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
 data:
   username: {{ .Values.authentication.authUsername | b64enc | quote }}
-  password: {{ randAlphaNum 20 | b64enc | quote }}
-  jwtSigningKey: {{ default (randAlphaNum 20) .Values.authentication.jwtSigningKey | b64enc | quote }}
+  password: {{ $password | quote }}
+  jwtSigningKey: {{ $jwtSigningKey | quote }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1230,6 +1230,14 @@ authentication:
   ## signing the JWT token
   ##
   jwtSigningKey:
+  ## existingSecret names a pre-created Secret in the release namespace
+  ## carrying the keys username, password and jwtSigningKey. When set, the
+  ## chart does not generate the "router" Secret and the router and MCP
+  ## deployments read from the named Secret instead. Recommended for GitOps
+  ## renderers (e.g. Argo CD), which run `helm template` where the chart's
+  ## lookup-based preservation of generated values cannot work.
+  ##
+  existingSecret:
   ## jwtExpiryTime is the JWT expiry time
   ## in seconds
   ## default '120'

--- a/pkg/auth/hmac/signer.go
+++ b/pkg/auth/hmac/signer.go
@@ -84,6 +84,18 @@ func (s *Signer) RoundTrip(r *http.Request) (*http.Response, error) {
 			return nil, closeErr
 		}
 		r.Body = io.NopCloser(bytes.NewReader(body))
+		// GetBody must be repopulated alongside Body. Rewind-aware
+		// retry layers (net/http's replay after a broken connection,
+		// pkg/utils/httpretry) refuse to retry a request whose GetBody
+		// is nil, so leaving it unset silently makes signed requests
+		// un-retryable; and a naive caller re-submitting the same
+		// *http.Request re-reads the consumed reader above and sends —
+		// re-signed on the second pass through this signer — an EMPTY
+		// body, which the verifier happily accepts: silent success with
+		// an empty payload rather than a 401.
+		r.GetBody = func() (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(body)), nil
+		}
 	}
 	ts := s.now().Unix()
 	// Sign over the request-URI (path + raw query) so query parameters

--- a/pkg/auth/hmac/signer_test.go
+++ b/pkg/auth/hmac/signer_test.go
@@ -63,6 +63,58 @@ func TestSignerHandlesNilBody(t *testing.T) {
 	assert.Equal(t, 200, resp.StatusCode)
 }
 
+// TestSignerRepopulatesGetBody pins the retry contract: the signer buffers
+// and replaces the request body, so it must also repopulate GetBody — the
+// hook net/http and pkg/utils/httpretry use to rewind a request per
+// attempt (both refuse to retry when it is nil, and a naive re-submission
+// of the same *http.Request would re-sign the consumed — empty — reader,
+// which the verifier accepts).
+func TestSignerRepopulatesGetBody(t *testing.T) {
+	secret := []byte("test-secret-must-be-32-bytes-min")
+
+	var gotBodies []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		ts, err := strconv.ParseInt(r.Header.Get(HeaderTimestamp), 10, 64)
+		require.NoError(t, err)
+		require.True(t, Verify(secret, r.Method, r.URL.Path, body, ts, r.Header.Get(HeaderSignature)),
+			"every attempt must carry a signature valid for the body it sent")
+		gotBodies = append(gotBodies, string(body))
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+
+	signer := NewSigner(secret, http.DefaultTransport, time.Now)
+
+	// Build a request whose GetBody is nil, like a caller handing the
+	// transport a bare reader net/http cannot rewind on its own.
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/archive", nil)
+	require.NoError(t, err)
+	req.Body = io.NopCloser(strings.NewReader("payload"))
+	require.Nil(t, req.GetBody, "precondition: the raw request must not be rewindable")
+
+	resp, err := signer.RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	// The signer consumed the original reader, so it must have left a
+	// rewind hook behind for any retry layer above it.
+	require.NotNil(t, req.GetBody, "signer must repopulate GetBody after buffering the body")
+
+	// Simulate a retry the way httpretry does: rewind Body via GetBody,
+	// then run the same request through the signer again. The second
+	// attempt must carry the full payload, freshly signed — not an empty
+	// body from the consumed reader.
+	req.Body, err = req.GetBody()
+	require.NoError(t, err)
+	resp, err = signer.RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, []string{"payload", "payload"}, gotBodies,
+		"the retried attempt must re-send (and re-sign) the original body, never an empty one")
+}
+
 // TestSignerBindsQueryParameter pins the security-critical contract from
 // the design doc (docs/internal-auth/00-design.md): a captured signature
 // for /v1/archive?id=A must NOT verify against /v1/archive?id=B within


### PR DESCRIPTION
## TL;DR

Three small, independent hardening fixes that surfaced while security-reviewing the upgrade/GitOps/config RFC drafts (#3625, #3626, #3628).
Each is a live issue today and stands alone — bundled here as one PR because all three are ~10-line fixes, but each is its own commit and revertable independently.

## Review commit-by-commit

**1. `fix(chart): preserve router auth secret across helm upgrades`** — the one with real user impact today.

`templates/router/secret.yaml` minted `password` and `jwtSigningKey` with bare `randAlphaNum` on every render under a `pre-install,pre-upgrade` hook — so the JWT signing key (which also gates MCP `allowed_namespaces` authorization) silently rotated on **every** `helm upgrade` unless `authentication.jwtSigningKey` was set, invalidating issued tokens mid-flight.

- Both generated values are now preserved via `lookup`, mirroring the existing pattern in `internal-auth-secret.yaml`: explicit value → existing cluster value → fresh random.
- New `authentication.existingSecret` value: when set, the chart renders no `router` Secret and the router + MCP deployments read from the named user-managed Secret (keys `username`, `password`, `jwtSigningKey`) via the new `fission.authenticationSecretName` helper. This is the reliable path for GitOps renderers, where `helm template` leaves `lookup` empty.
- Verified by rendering all three configurations (auth off / auth on / auth on + existingSecret).

**2. `fix(chart): scope functionpods NetworkPolicy ingress to the release namespace`**

Both ingress rules of `functionpods-allow-internal` paired their pod selector with `namespaceSelector: {}` — all namespaces. Any workload able to label its own pod `svc: executor` (or the router labels) in **any** namespace could reach every function pod's fetcher (8000) and env runtime (8888), including the unsigned `/v2/specialize` path. The file's own comment shows the intent was the release namespace.

- Both rules now match `kubernetes.io/metadata.name: {{ .Release.Namespace }}` — an API-server-managed, immutable label (supported k8s floor is 1.32, well past its 1.22 GA), so it cannot be spoofed by a tenant namespace.
- The `namespaceSelector` and `podSelector` are entries of **one** `from` element, so they AND rather than OR — the thing to double-check when reviewing.
- Legitimate flows are unaffected: executor and router run in the release namespace; the policy still renders into `functionNamespace` for split-namespace installs (e.g. the kind-ci profile), which is exactly why the namespace must be named explicitly rather than left `{}`.
- Only exploitable where `networkPolicy.enabled: true` (off by default), hence low urgency — but it is the control the upcoming per-function env/secret work relies on.

**3. `fix(hmac): repopulate GetBody after the signer buffers the request body`**

The HMAC signer reads and closes the original body, replaces it with a `NopCloser` over the consumed bytes — and left `GetBody` unset. Consequences:

- Rewind-aware retry layers (net/http's broken-connection replay, `pkg/utils/httpretry`) refuse to retry a nil-`GetBody` request, so signed body-carrying requests were silently un-retryable.
- A naive caller re-submitting the same `*http.Request` would re-read the consumed reader and re-sign an **empty** body — which the verifier accepts. Silent success with an empty payload, not a 401.

The fix sets `GetBody` to return a fresh reader over the buffered bytes. `TestSignerRepopulatesGetBody` pins the contract: a request whose `GetBody` starts nil is round-tripped, rewound the way `httpretry` does, and retried — both attempts must carry the full, validly-signed payload.

## Risk & testing

- No behavior change for any existing install that pins values explicitly; the secret-preservation commit changes only *when new random material is minted* (never on upgrade anymore).
- Chart: `helm lint` green; all three auth configurations rendered and diffed.
- Go: full `pkg/auth/hmac` suite under `-race`; `make code-checks` green.
- Each commit received a separate security review (no findings) before bundling.
