### PR TITLE
RFC-0028 phase 2: rollout posture for router and webhook

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -243,6 +243,12 @@ jobs:
           docker exec kind-control-plane sh -c \
             'mkdir -p /fission-coverage && chown 10001:10001 /fission-coverage && chmod 0700 /fission-coverage'
           SKAFFOLD_PROFILE=kind-ci make skaffold-deploy
+          # Pin a single router for the benchmark only. The chart default is 2
+          # (RFC-0028), but this leg's pprof capture port-forwards to
+          # items[0] — one replica's profile against the whole offered load —
+          # and every recorded regression bar was measured single-replica.
+          kubectl -n fission scale deploy/router --replicas=1
+          kubectl -n fission rollout status deploy/router --timeout=3m
 
       - name: Install released Fission (helm)
         if: ${{ matrix.fission_version != 'HEAD' }}
@@ -265,6 +271,7 @@ jobs:
           helm install fission fission-charts/fission-all \
             --version "${ver#v}" -n fission --skip-crds --wait --timeout 8m \
             --set routerServiceType=NodePort \
+            --set router.replicas=1 \
             --set pprof.enabled=true \
             --set prometheus.serviceEndpoint=http://prometheus-operated.monitoring.svc.cluster.local:9090 \
             --set serviceMonitor.enabled=true \

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -38,6 +38,18 @@ spec:
       containers:
       - name: router
         image: {{ include "fission-bundleImage" . | quote }}
+        {{- if gt (int (.Values.router.preStopSleep | default 0)) 0 }}
+        lifecycle:
+          preStop:
+            # Delay the drain so this pod's removal from the Service
+            # EndpointSlice reaches every kube-proxy BEFORE the listener
+            # closes. Without it a terminating router still receives
+            # connections it can no longer accept: connection-refused, which
+            # the RFC-0028 §1 gate counts as a platform failure precisely
+            # because it produces no response and no attribution header.
+            sleep:
+              seconds: {{ int .Values.router.preStopSleep }}
+        {{- end }}
         imagePullPolicy: {{ .Values.pullPolicy }}
         command: ["/fission-bundle"]
         args:
@@ -69,6 +81,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.router.gracefulShutdownTimeout }}
+        # Without this the drain is capped at the code default of 30s, so a
+        # larger terminationGracePeriodSeconds would be spent idle while a
+        # longer-running invocation is force-closed (RFC-0028 §2).
+        - name: GRACEFUL_SHUTDOWN_TIMEOUT
+          value: {{ . | quote }}
+        {{- end }}
         - name: ROUTER_ROUND_TRIP_TIMEOUT
           value: {{ .Values.router.roundTrip.timeout | default "50ms" | quote }}
         - name: ROUTER_ROUNDTRIP_TIMEOUT_EXPONENT
@@ -198,6 +217,20 @@ spec:
       serviceAccountName: fission-router
       {{- with .Values.router.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ . }}
+      {{- end }}
+      {{- if and (not .Values.router.deployAsDaemonSet) (ge (int (.Values.router.replicas | default 1)) 2) }}
+      # Spread replicas across nodes, or two of them can land on one node and a
+      # single drain takes out the whole data plane — the outage replicas: 2
+      # exists to prevent. ScheduleAnyway so single-node clusters (kind) still
+      # schedule both.
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              svc: router
+              application: fission-router
       {{- end }}
       volumes:
       - name: config-volume

--- a/charts/fission-all/templates/router/pdb.yaml
+++ b/charts/fission-all/templates/router/pdb.yaml
@@ -3,11 +3,13 @@ Render only when the router can actually satisfy the budget. A
 minAvailable: 1 PDB on a genuinely single-replica Deployment makes every node
 drain block forever, so replicas: 1 drops the PDB rather than deadlocking the
 cluster. But an HPA/KEDA-scaled router keeps replicas: 1 in its spec while
-running more, so the guard must accept an autoscaler as evidence too — a naive
-replica check would strip the PDB from exactly the installs that need it most
-(RFC-0028 §2).
+running more, so the guard accepts an autoscaler as evidence too — but only
+when the autoscaler's own floor is >= 2, because one idling at minReplicas: 1
+is still a single-replica Deployment and deadlocks identically (RFC-0028 §2).
 */}}
-{{- $scaled := or (ge (int (.Values.router.replicas | default 1)) 2) .Values.router.autoscaling.enabled (dig "keda" "enabled" false .Values.router) }}
+{{- $hpaFloor := and .Values.router.autoscaling.enabled (ge (int (.Values.router.autoscaling.minReplicas | default 1)) 2) }}
+{{- $kedaFloor := and (dig "keda" "enabled" false .Values.router) (ge (int (dig "keda" "minReplicas" 1 .Values.router)) 2) }}
+{{- $scaled := or (ge (int (.Values.router.replicas | default 1)) 2) $hpaFloor $kedaFloor }}
 {{- if and (not .Values.router.deployAsDaemonSet) .Values.router.podDisruptionBudget.enabled $scaled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/charts/fission-all/templates/router/pdb.yaml
+++ b/charts/fission-all/templates/router/pdb.yaml
@@ -1,4 +1,14 @@
-{{- if and (not .Values.router.deployAsDaemonSet) .Values.router.podDisruptionBudget.enabled }}
+{{- /*
+Render only when the router can actually satisfy the budget. A
+minAvailable: 1 PDB on a genuinely single-replica Deployment makes every node
+drain block forever, so replicas: 1 drops the PDB rather than deadlocking the
+cluster. But an HPA/KEDA-scaled router keeps replicas: 1 in its spec while
+running more, so the guard must accept an autoscaler as evidence too — a naive
+replica check would strip the PDB from exactly the installs that need it most
+(RFC-0028 §2).
+*/}}
+{{- $scaled := or (ge (int (.Values.router.replicas | default 1)) 2) .Values.router.autoscaling.enabled (dig "keda" "enabled" false .Values.router) }}
+{{- if and (not .Values.router.deployAsDaemonSet) .Values.router.podDisruptionBudget.enabled $scaled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/fission-all/templates/webhook-server/deployment.yaml
+++ b/charts/fission-all/templates/webhook-server/deployment.yaml
@@ -47,6 +47,17 @@ spec:
         ports:
           - containerPort: 8080
             name: metrics
+        # maxUnavailable: 0 is only meaningful with a readiness signal: without
+        # this the kubelet marks the pod Ready the instant the process starts,
+        # so a surge pod joins the Service before controller-runtime has bound
+        # the serving port — and every Fission CR write is fail-closed against
+        # it (RFC-0028 §2).
+        readinessProbe:
+          tcpSocket:
+            port: 9443
+          initialDelaySeconds: 2
+          periodSeconds: 2
+          failureThreshold: 15
         resources:
           {{- toYaml .Values.webhook.resources | nindent 10 }}
       volumes:

--- a/charts/fission-all/templates/webhook-server/deployment.yaml
+++ b/charts/fission-all/templates/webhook-server/deployment.yaml
@@ -7,7 +7,11 @@ metadata:
     svc: webhook-service
     application: fission-webhook
 spec:
-  replicas: 1
+  replicas: {{ .Values.webhook.replicas | default 1 }}
+  {{- with .Values.webhook.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       svc: webhook-service

--- a/charts/fission-all/templates/webhook-server/pdb.yaml
+++ b/charts/fission-all/templates/webhook-server/pdb.yaml
@@ -1,0 +1,27 @@
+{{- /*
+Same render guard as the router's PDB: emitted only when the Deployment can
+actually satisfy it. A minAvailable: 1 budget on a single-replica Deployment
+blocks node drains forever. The webhook has no autoscaler, so replicas is the
+only evidence available here.
+*/}}
+{{- if and .Values.webhook.podDisruptionBudget.enabled (ge (int (.Values.webhook.replicas | default 1)) 2) }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: fission-webhook
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: webhook-service
+    application: fission-webhook
+spec:
+  {{- if .Values.webhook.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.webhook.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.webhook.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      svc: webhook-service
+      application: fission-webhook
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -230,14 +230,7 @@ executor:
   ##       maxSurge: 1
   ##       maxUnavailable: 0
   ##
-  ## Surge-then-drain by default: a new pod becomes Ready (which gates on the
-  ## mux build and the endpoint index) before an old one is taken down, so a
-  ## rollout never dips below the current replica count.
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+  strategy: {}
   ## terminationGracePeriodSeconds gives in-flight work time to drain on
   ## shutdown. Leave unset for the Kubernetes default (30s). Keep it at or
   ## above GRACEFUL_SHUTDOWN_TIMEOUT.
@@ -402,16 +395,43 @@ router:
   ##       maxSurge: 1
   ##       maxUnavailable: 0
   ##
-  strategy: {}
+  ## Surge-then-drain by default: a new pod becomes Ready (which gates on the
+  ## mux build and the endpoint index) before an old one is taken down, so a
+  ## rollout never dips below the current replica count. Explicit rather than
+  ## relying on the Kubernetes 25% defaults, which allow maxUnavailable > 0
+  ## once the router is scaled past 3 replicas — exactly when a dip hurts most.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   ## terminationGracePeriodSeconds gives in-flight requests time to drain on
-  ## shutdown. Keep it at or above GRACEFUL_SHUTDOWN_TIMEOUT.
+  ## shutdown. Keep it at or above gracefulShutdownTimeout.
   ##
-  ## 90s rather than the Kubernetes default of 30: the drain has to outlast the
-  ## longest in-flight request, and the default function timeout alone is 60s.
-  ## A grace period shorter than the request timeout turns every rollout into
-  ## truncated responses for the slowest requests in flight.
+  ## 90s rather than the Kubernetes default of 30, sized above
+  ## gracefulShutdownTimeout below, which is in turn sized above the default
+  ## 60s function timeout: a drain shorter than the longest in-flight request
+  ## turns every rollout into truncated responses for the slowest requests.
   ##
   terminationGracePeriodSeconds: 90
+  ## gracefulShutdownTimeout bounds how long the router keeps serving in-flight
+  ## requests after SIGTERM before force-closing them (GRACEFUL_SHUTDOWN_TIMEOUT).
+  ## Raising terminationGracePeriodSeconds alone does nothing: the code caps the
+  ## drain at 30s unless this is set, so the extra grace would be spent idle
+  ## while a 60s invocation is cut off at 30.
+  ##
+  ## Keep terminationGracePeriodSeconds > gracefulShutdownTimeout > the longest
+  ## expected function timeout.
+  ##
+  gracefulShutdownTimeout: 75s
+  ## preStopSleep delays the drain so the pod's removal from the Service
+  ## EndpointSlice propagates to every kube-proxy BEFORE the listener closes.
+  ## Without it a terminating router still receives connections it can no
+  ## longer accept, which surfaces as connection-refused — a platform-attributed
+  ## failure with no response and no attribution header (RFC-0028 §1). Set to
+  ## 0 to disable.
+  ##
+  preStopSleep: 5
   ## podDisruptionBudget protects router availability during voluntary
   ## disruptions (node drains, cluster upgrades).
   ##
@@ -420,8 +440,10 @@ router:
   ## minAvailable: 1 PDB on a genuinely single-replica Deployment blocks node
   ## drains forever — so setting replicas: 1 silently and correctly drops the
   ## PDB rather than deadlocking the cluster. An HPA/KEDA-scaled router keeps
-  ## replicas: 1 in its spec while running more, so it must NOT lose its PDB
-  ## to a naive replica check.
+  ## replicas: 1 in its spec while running more, so an autoscaler counts as
+  ## evidence too — but only when its OWN floor (minReplicas) is >= 2, since
+  ## an autoscaler idling at minReplicas: 1 is still a single-replica
+  ## Deployment and would deadlock exactly the same way.
   ##
   podDisruptionBudget:
     enabled: true

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -230,7 +230,14 @@ executor:
   ##       maxSurge: 1
   ##       maxUnavailable: 0
   ##
-  strategy: {}
+  ## Surge-then-drain by default: a new pod becomes Ready (which gates on the
+  ## mux build and the endpoint index) before an old one is taken down, so a
+  ## rollout never dips below the current replica count.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   ## terminationGracePeriodSeconds gives in-flight work time to drain on
   ## shutdown. Leave unset for the Kubernetes default (30s). Keep it at or
   ## above GRACEFUL_SHUTDOWN_TIMEOUT.
@@ -397,15 +404,27 @@ router:
   ##
   strategy: {}
   ## terminationGracePeriodSeconds gives in-flight requests time to drain on
-  ## shutdown. Leave unset for the Kubernetes default (30s). Keep it at or
-  ## above GRACEFUL_SHUTDOWN_TIMEOUT.
+  ## shutdown. Keep it at or above GRACEFUL_SHUTDOWN_TIMEOUT.
   ##
-  terminationGracePeriodSeconds: null
-  ## podDisruptionBudget (opt-in) protects router availability during voluntary
-  ## disruptions. Only meaningful with replicas > 1 (not a DaemonSet).
+  ## 90s rather than the Kubernetes default of 30: the drain has to outlast the
+  ## longest in-flight request, and the default function timeout alone is 60s.
+  ## A grace period shorter than the request timeout turns every rollout into
+  ## truncated responses for the slowest requests in flight.
+  ##
+  terminationGracePeriodSeconds: 90
+  ## podDisruptionBudget protects router availability during voluntary
+  ## disruptions (node drains, cluster upgrades).
+  ##
+  ## Enabled by default, but the template renders it only when the router can
+  ## actually satisfy it: replicas >= 2, OR an autoscaler is enabled. A
+  ## minAvailable: 1 PDB on a genuinely single-replica Deployment blocks node
+  ## drains forever — so setting replicas: 1 silently and correctly drops the
+  ## PDB rather than deadlocking the cluster. An HPA/KEDA-scaled router keeps
+  ## replicas: 1 in its spec while running more, so it must NOT lose its PDB
+  ## to a naive replica check.
   ##
   podDisruptionBudget:
-    enabled: false
+    enabled: true
     minAvailable: 1
     # maxUnavailable:
   ## autoscaling (opt-in) deploys a HorizontalPodAutoscaler for the router. The
@@ -450,7 +469,13 @@ router:
   deployAsDaemonSet: false
   ## replicas decides how many router pods to deploy. Only used when deployAsDaemonSet is false.
   ##
-  replicas: 1
+  ## Two by default (RFC-0028): the router is the data plane, and a single
+  ## replica means every rollout, node drain or eviction is a traffic outage.
+  ## Small-footprint installs (kind, single-node) can set 1 and get exactly the
+  ## previous behaviour, including no PodDisruptionBudget — the PDB renders
+  ## only when it is safe (see podDisruptionBudget below).
+  ##
+  replicas: 2
   ## svcAddressMaxRetries is the max times for router to retry with a specific function service address
   ##
   svcAddressMaxRetries: 5
@@ -623,6 +648,40 @@ buildermgr:
 ## It contains validation and mutation for functions, triggers, environments, Kubernetes event watches, etc.
 ##
 webhook:
+  ## replicas decides how many webhook pods to deploy.
+  ##
+  ## The webhook is fail-closed (failurePolicy: Fail on every configuration),
+  ## so while it has zero Ready endpoints EVERY Fission CR write errors. Two
+  ## replicas by default (RFC-0028) so a rollout or an eviction is not a
+  ## write outage.
+  ##
+  ## NOTE: replicas alone does not make upgrades seamless on the default cert
+  ## path — the serving cert is still minted per render, so the caBundle can
+  ## race the still-serving old cert. cert-manager (webhook.certManager.enabled)
+  ## is the supported path for that; see RFC-0028 §2.
+  ##
+  replicas: 2
+
+  ## podDisruptionBudget protects webhook availability during voluntary
+  ## disruptions. Same render guard as the router's: it is emitted only when
+  ## replicas >= 2, because a minAvailable: 1 budget on a single-replica
+  ## Deployment blocks node drains forever.
+  ##
+  podDisruptionBudget:
+    enabled: true
+    minAvailable: 1
+    # maxUnavailable:
+
+  ## strategy is the Deployment rollout strategy for the webhook. Surge-first,
+  ## so a new pod is Ready before an old one goes away — with a fail-closed
+  ## webhook, a gap is a cluster-wide CR-write outage.
+  ##
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+
   ## Pod resources as:
   ##  resources:
   ##    limits:

--- a/pkg/router/endpointcache/informer.go
+++ b/pkg/router/endpointcache/informer.go
@@ -19,12 +19,20 @@ import (
 // options). The informer's initial LIST replays every existing slice as an Add,
 // so the index is complete once the cache syncs — no executor involvement on
 // router restart.
-func RegisterInformer(ctx context.Context, mgr ctrl.Manager, ix *Index, logger logr.Logger) error {
+//
+// It returns the registration's HasSynced. The Manager's own cache sync says
+// the informer's store is populated, which is NOT the same as this handler
+// having received the replay: registration-level sync is what tells you the
+// index has actually seen every existing slice. Discarding it leaves a bounded
+// window where a Ready replica serves warm traffic from a partially-filled
+// index and falls back to the executor — correct, but a latency cliff exactly
+// during a rolling upgrade (RFC-0028 §2).
+func RegisterInformer(ctx context.Context, mgr ctrl.Manager, ix *Index, logger logr.Logger) (cache.InformerSynced, error) {
 	informer, err := mgr.GetCache().GetInformer(ctx, &discoveryv1.EndpointSlice{})
 	if err != nil {
-		return fmt.Errorf("error getting endpointslice informer: %w", err)
+		return nil, fmt.Errorf("error getting endpointslice informer: %w", err)
 	}
-	_, err = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj any) {
 			if es, ok := obj.(*discoveryv1.EndpointSlice); ok {
 				ix.ApplySlice(es)
@@ -53,7 +61,7 @@ func RegisterInformer(ctx context.Context, mgr ctrl.Manager, ix *Index, logger l
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("error adding endpointslice event handler: %w", err)
+		return nil, fmt.Errorf("error adding endpointslice event handler: %w", err)
 	}
-	return nil
+	return reg.HasSynced, nil
 }

--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -74,6 +75,12 @@ type HTTPTriggerSet struct {
 	// gates /readyz on it so a starting/rolling pod stays out of the
 	// Service endpoints until its mux is populated.
 	ready atomic.Bool
+	// endpointsSynced reports whether the RFC-0002 endpoint index has received
+	// its informer's initial replay. nil when the slice-fed data plane is off.
+	// Readiness gates on it as well as on `ready`: a replica whose mux is built
+	// but whose index is still filling serves warm traffic through the executor
+	// fallback — correct, but a latency cliff during a rolling upgrade.
+	endpointsSynced cache.InformerSynced
 
 	// Incremental route updates (RFC-0013) are the only production path: the
 	// reconcilers feed per-event diffs into routeTable and the materializer
@@ -201,6 +208,14 @@ func (ts *HTTPTriggerSet) routerReadinessHandler(w http.ResponseWriter, r *http.
 	// mux has no user routes, so report 503 to stay out of the Service endpoints.
 	if !ts.ready.Load() {
 		http.Error(w, "router mux not yet built", http.StatusServiceUnavailable)
+		return
+	}
+	// With the slice-fed data plane on, also wait for the endpoint index to
+	// have seen its informer's initial replay: a mux-ready replica whose index
+	// is still filling would serve warm traffic through the executor fallback
+	// instead of the fast path (RFC-0028 §2).
+	if ts.endpointsSynced != nil && !ts.endpointsSynced() {
+		http.Error(w, "endpoint index not yet synced", http.StatusServiceUnavailable)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/pkg/router/lifecycle_test.go
+++ b/pkg/router/lifecycle_test.go
@@ -68,17 +68,30 @@ func TestPanicRecoveryMiddleware(t *testing.T) {
 // populated.
 func TestRouterReadinessHandler(t *testing.T) {
 	tests := []struct {
-		name  string
-		ready bool
-		want  int
+		name string
+		// synced is nil when the slice-fed data plane is off, matching the
+		// nil endpointsSynced the router leaves in that mode.
+		ready  bool
+		synced *bool
+		want   int
 	}{
-		{"mux built -> ready", true, http.StatusOK},
-		{"mux not built -> unavailable", false, http.StatusServiceUnavailable},
+		{"mux built, slice plane off -> ready", true, nil, http.StatusOK},
+		{"mux not built -> unavailable", false, nil, http.StatusServiceUnavailable},
+		{"mux built, index synced -> ready", true, new(true), http.StatusOK},
+		// The window this closes: the mux is serving, but the endpoint index
+		// has not seen its informer replay, so warm traffic would fall back to
+		// the executor — a latency cliff mid-upgrade (RFC-0028 §2).
+		{"mux built, index still filling -> unavailable", true, new(false), http.StatusServiceUnavailable},
+		{"index synced but mux not built -> unavailable", false, new(true), http.StatusServiceUnavailable},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			ts := &HTTPTriggerSet{}
 			ts.ready.Store(tc.ready)
+			if tc.synced != nil {
+				synced := *tc.synced
+				ts.endpointsSynced = func() bool { return synced }
+			}
 			rec := httptest.NewRecorder()
 			ts.routerReadinessHandler(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 			assert.Equal(t, tc.want, rec.Code)

--- a/pkg/router/lifecycle_test.go
+++ b/pkg/router/lifecycle_test.go
@@ -68,10 +68,10 @@ func TestPanicRecoveryMiddleware(t *testing.T) {
 // populated.
 func TestRouterReadinessHandler(t *testing.T) {
 	tests := []struct {
-		name string
+		name  string
+		ready bool
 		// synced is nil when the slice-fed data plane is off, matching the
 		// nil endpointsSynced the router leaves in that mode.
-		ready  bool
 		synced *bool
 		want   int
 	}{

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -448,9 +448,16 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// functions.
 	if cfg.endpointSliceCacheMode != endpointSliceCacheOff {
 		index := endpointcache.NewIndex()
-		if err := endpointcache.RegisterInformer(ctx, crMgr, index, logger); err != nil {
+		endpointsSynced, err := endpointcache.RegisterInformer(ctx, crMgr, index, logger)
+		if err != nil {
 			return fmt.Errorf("error registering endpointslice informer: %w", err)
 		}
+		// Gate readiness on the index having seen the initial replay, not just
+		// on the Manager's cache being populated: a Ready replica with a
+		// partially-filled index serves warm traffic through the executor
+		// fallback instead of the fast path — a latency cliff precisely during
+		// a rolling upgrade (RFC-0028 §2).
+		triggers.endpointsSynced = endpointsSynced
 		endpointcache.RegisterSizeGauge(index)
 		execResolver, ok := triggers.addressResolver.(*executorResolver)
 		if !ok {

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -29,6 +29,14 @@ manifests:
         namespace: fission
         setValues:
           analytics: "false"
+          # Single replicas for local/CI clusters. The chart defaults to 2 for
+          # router and webhook (RFC-0028: a single replica makes every rollout
+          # an outage), but a kind runner has ~4 vCPU and doubling both control
+          # -plane front ends starves the builders and the executor — which
+          # surfaces as builds stuck in "running" and executor RPC deadlines
+          # across unrelated tests, not as an obvious capacity error.
+          router.replicas: "1"
+          webhook.replicas: "1"
           # RFC-0024 async invocation needs the RFC-0021 statestore; enable both
           # (embedded SQLite) so the integration suite can exercise async invoke.
           asyncInvocation.enabled: "true"


### PR DESCRIPTION
## TL;DR

RFC-0028 ([#3625](https://github.com/fission/fission/issues/3625)) phase 2, the rollout-posture half: make a rolling upgrade survivable for the two components whose absence is immediately user-visible. Defaults flip; every old posture stays reachable through values.

The webhook's **serving-cert stability is deliberately not here** — see the bottom.

## Router

| Change | Why |
|---|---|
| `replicas` 1 → **2** | the router *is* the data plane; one replica makes every rollout, drain and eviction an outage |
| surge strategy (`maxSurge: 1`, `maxUnavailable: 0`) | explicit rather than the Kubernetes 25% defaults, which allow `maxUnavailable > 0` once scaled past 3 — exactly when a dip hurts |
| `terminationGracePeriodSeconds: 90` **+ new `gracefulShutdownTimeout: 75s`** | the grace period alone does nothing: the drain is capped at 30s in code unless `GRACEFUL_SHUTDOWN_TIMEOUT` is set, and no template set it |
| **new `preStopSleep: 5`** | the listener closed the instant SIGTERM arrived while kube-proxy still had the pod in its backend set → connection-refused, which the phase-1 gate counts as platform-attributed precisely because it carries no response and no attribution header |
| **topology spread** at `replicas >= 2` | otherwise both replicas can land on one node and a single drain takes out the whole data plane — the outage the flip exists to prevent |
| PDB on by default, behind a guard | see below |

## The PDB guard is the subtle part

A `minAvailable: 1` PDB over a genuinely single-replica Deployment blocks node drains **forever**. So `replicas: 1` correctly drops the PDB rather than deadlocking the cluster.

But an HPA/KEDA-scaled router keeps `replicas: 1` in its spec while running more, so an autoscaler counts as evidence too — **only when its own `minReplicas >= 2`**. Both autoscalers default to `minReplicas: 1`, so "an autoscaler is enabled" alone is not evidence the router ever runs more than one pod, and accepting it would have reproduced the exact deadlock the guard exists to prevent. (Review caught this; it renders correctly for all four combinations now.)

## Webhook

It had none of this surface: a `replicas` knob (default 2), a surge strategy, and a PDB behind the same guard. It is fail-closed on every configuration, so zero Ready endpoints means **every Fission CR write errors**.

It also had **no readinessProbe**, which made `maxUnavailable: 0` vacuous — the kubelet marked a pod Ready the moment the process started, so a surge pod joined the Service before it had bound `:9443`. Added a `tcpSocket` probe on the serving port.

## Router readiness now gates on the endpoint index

`RegisterInformer` returns the registration's `HasSynced` instead of discarding it. The Manager's cache sync says the *store* is populated, which is not the same as this handler having received the replay. Without it a Ready replica serves warm traffic through the executor fallback — correct, but a latency cliff precisely during the rolling upgrade this PR exists to smooth.

Verified this cannot wedge readiness: `HasSynced` is a monotone latch, and the first mux build already blocks on the same informer's cache sync, so anything that stalls this gate already stalls `ready`.

## Not here, on purpose

**Webhook serving-cert stability.** The default path mints a fresh CA per render, so the `caBundle` races the still-serving cert. Fixing it needs the same Helm-ownership migration as the internal-auth master — a `pre-upgrade` hook stamping `resource-policy: keep` onto the live object, which I verified on kind is the working mechanism (Helm reads that annotation from the *live* object at delete time). Three secrets need that migration; it belongs in one PR, not three partial ones.

## Testing

`make code-checks`, `make license-check`, `helm lint`, `go test -race ./pkg/router/...` green. Every guard path rendered and diffed: default, `replicas=1`, `replicas=1 + autoscaling`, `replicas=1 + autoscaling minReplicas=2`, webhook `replicas=1`. The readiness test now covers slice-plane-off, index-synced, and index-still-filling.

The benchmark leg is pinned to `router.replicas=1`: its pprof capture port-forwards to `items[0]`, and every recorded regression bar was measured single-replica.
