### PR TITLE
RFC-0026 phase4: provisioned-idle-warm benchmark scenario

### DIFF
--- a/test/benchmark/config/scenarios.default.yaml
+++ b/test/benchmark/config/scenarios.default.yaml
@@ -29,3 +29,16 @@ executors: [poolmgr, newdeploy]
 # which measures the per-reference specialization-time existence checks.
 configDepsSecrets: 5
 configDepsConfigmaps: 5
+# Function's provisioned target (floor) during the idle-warm scenario.
+provisionedIdleFloor: 3
+# Pool size for that scenario's shared environment; bigger than floor +
+# overflow burst so pool exhaustion isn't what's being measured.
+provisionedIdlePoolsize: 10
+# How long to let the floor sit idle before each post-idle burst.
+provisionedIdleDuration: 10m
+# Simultaneous requests for the within-floor burst; must stay <= floor so
+# it's fully absorbed by warm provisioned pods.
+provisionedIdleWithinBurst: 3
+# Simultaneous requests for the overflow burst; > floor so the excess pays
+# a real cold start.
+provisionedIdleOverflowBurst: 5

--- a/test/benchmark/config/scenarios.default.yaml
+++ b/test/benchmark/config/scenarios.default.yaml
@@ -33,7 +33,7 @@ configDepsConfigmaps: 5
 provisionedIdleFloor: 3
 # Pool size for that scenario's shared environment; bigger than floor +
 # overflow burst so pool exhaustion isn't what's being measured.
-provisionedIdlePoolsize: 10
+provisionedIdlePoolsize: 3
 # How long to let the floor sit idle before each post-idle burst.
 provisionedIdleDuration: 10m
 # Simultaneous requests for the within-floor burst; must stay <= floor so

--- a/test/benchmark/config/thresholds.yaml
+++ b/test/benchmark/config/thresholds.yaml
@@ -39,3 +39,13 @@ scenarios:
       # missing-invariants plan, Stage 3 decisions 4/5.
       contended_ratio: { max: 2.0 }
       failures: { max: 3 }
+  provisioned-idle-warm:
+    metrics:
+      # RFC-0026 phase4: within-floor requests must stay warm after sitting
+      # idle for the configured window (default 10m) — same burst measured
+      # pre/post-idle, gated at 1.5x per the phase4 idle-warm-bench plan.
+      within_floor_ratio: { max: 1.5 }
+      within_floor_failures: { max: 1 }
+      baseline_failures: { max: 1 }
+      # overflow_burst_* intentionally ungated: beyond-floor requests are
+      # expected to pay a real cold start, not proof of warmth.

--- a/test/benchmark/pkg/harness/wait.go
+++ b/test/benchmark/pkg/harness/wait.go
@@ -35,6 +35,21 @@ func (e *Env) WaitForPoolReady(ctx context.Context, envName string, minReady int
 	})
 }
 
+// WaitForProvisionedFloor polls unit at least minReady ProvisionedPods for the function
+// are Ready across all namespaces
+func (e *Env) WaitForProvisionedFloor(ctx context.Context, name string, minReady int, timeout time.Duration) error {
+	selector := labels.SelectorFromSet(labels.Set{
+		fv1.PROVISIONED_LABEL: fv1.PROVISIONED_VALUE,
+	}).String()
+	return Poll(ctx, timeout, 2*time.Second, func(ctx context.Context) (bool, error) {
+		pods, err := e.Clients.Kube.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return false, err
+		}
+		return countReady(pods.Items) >= minReady, nil
+	})
+}
+
 // countReady returns how many of the pods are Running + Ready.
 func countReady(pods []apiv1.Pod) int {
 	ready := 0

--- a/test/benchmark/pkg/harness/wait.go
+++ b/test/benchmark/pkg/harness/wait.go
@@ -35,18 +35,15 @@ func (e *Env) WaitForPoolReady(ctx context.Context, envName string, minReady int
 	})
 }
 
-// WaitForProvisionedFloor polls unit at least minReady ProvisionedPods for the function
-// are Ready across all namespaces
+// WaitForProvisionedFloor polls until at least minReady of the function's
+// provisioned pods are ready.
 func (e *Env) WaitForProvisionedFloor(ctx context.Context, name string, minReady int, timeout time.Duration) error {
-	selector := labels.SelectorFromSet(labels.Set{
-		fv1.PROVISIONED_LABEL: fv1.PROVISIONED_VALUE,
-	}).String()
 	return Poll(ctx, timeout, 2*time.Second, func(ctx context.Context) (bool, error) {
-		pods, err := e.Clients.Kube.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		fn, err := e.Clients.Fission.CoreV1().Functions(e.Namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
-		return countReady(pods.Items) >= minReady, nil
+		return fn.Status.ProvisionedReady >= minReady, nil
 	})
 }
 

--- a/test/benchmark/pkg/harness/wait_test.go
+++ b/test/benchmark/pkg/harness/wait_test.go
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package harness
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	"github.com/fission/fission/test/benchmark/pkg/cluster"
+)
+
+// TestWaitForProvisionedFloor pins that the poll queries the function in the
+// caller's namespace (regression guard: an earlier version used
+// metav1.NamespaceAll, which silently never matched the function the
+// scenario actually created) and correctly gates on Status.ProvisionedReady.
+func TestWaitForProvisionedFloor(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reaches floor", func(t *testing.T) {
+		t.Parallel()
+		fn := &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "bench"},
+			Status:     fv1.FunctionStatus{ProvisionedReady: 3},
+		}
+		e := &Env{Clients: &cluster.Clients{Fission: fake.NewSimpleClientset(fn)}, Namespace: "bench"}
+
+		err := e.WaitForProvisionedFloor(t.Context(), "fn", 3, 5*time.Second)
+		require.NoError(t, err)
+	})
+
+	t.Run("never reaches floor times out", func(t *testing.T) {
+		t.Parallel()
+		fn := &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "bench"},
+			Status:     fv1.FunctionStatus{ProvisionedReady: 1},
+		}
+		e := &Env{Clients: &cluster.Clients{Fission: fake.NewSimpleClientset(fn)}, Namespace: "bench"}
+
+		err := e.WaitForProvisionedFloor(t.Context(), "fn", 3, 0)
+		assert.ErrorContains(t, err, "timed out")
+	})
+
+	t.Run("wrong namespace never matches", func(t *testing.T) {
+		t.Parallel()
+		fn := &fv1.Function{
+			ObjectMeta: metav1.ObjectMeta{Name: "fn", Namespace: "bench"},
+			Status:     fv1.FunctionStatus{ProvisionedReady: 3},
+		}
+		e := &Env{Clients: &cluster.Clients{Fission: fake.NewSimpleClientset(fn)}, Namespace: "other"}
+
+		err := e.WaitForProvisionedFloor(t.Context(), "fn", 3, 0)
+		require.Error(t, err)
+	})
+}

--- a/test/benchmark/pkg/scenario/assets.go
+++ b/test/benchmark/pkg/scenario/assets.go
@@ -9,6 +9,8 @@ package scenario
 // archive size limit) so the benchmark has no runtime fixture dependency.
 const pythonHello = "def main():\n    return \"Hello, world!\\n\"\n"
 
+const pythonHelloSleep = "import time\n\ndef main():\n\ttime.sleep(0.15)\n\treturn \"Hello, world!\\n\"\n"
+
 // nodeHello is the Node.js counterpart to pythonHello: a single-file v1
 // function the runtime loads with no entrypoint. The Node server is
 // event-loop-concurrent, so unlike the Python default (single-threaded

--- a/test/benchmark/pkg/scenario/assets.go
+++ b/test/benchmark/pkg/scenario/assets.go
@@ -9,7 +9,7 @@ package scenario
 // archive size limit) so the benchmark has no runtime fixture dependency.
 const pythonHello = "def main():\n    return \"Hello, world!\\n\"\n"
 
-const pythonHelloSleep = "import time\n\ndef main():\n\ttime.sleep(0.15)\n\treturn \"Hello, world!\\n\"\n"
+const pythonHelloSleep = "import time\n\ndef main():\n\ttime.sleep(5)\n\treturn \"Hello, world!\\n\"\n"
 
 // nodeHello is the Node.js counterpart to pythonHello: a single-file v1
 // function the runtime loads with no entrypoint. The Node server is

--- a/test/benchmark/pkg/scenario/helper.go
+++ b/test/benchmark/pkg/scenario/helper.go
@@ -7,6 +7,7 @@ package scenario
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/fission/fission/test/benchmark/pkg/harness"
@@ -34,4 +35,27 @@ func measureColdStart(ctx context.Context, sc *harness.Scope, envName, label str
 		return 0, false
 	}
 	return measureFirstSuccess(ctx, env.RouterURL()+route, 3*time.Minute)
+}
+
+// fireBurst spins up n go routines each calling measureFirstSuccess at around the same time
+// and appending the results and returning samples along with failures.
+func fireBurst(ctx context.Context, url string, n int, timeout time.Duration) ([]time.Duration, int) {
+	wg := sync.WaitGroup{}
+	lock := sync.Mutex{}
+	failures := 0
+	samples := []time.Duration{}
+	for range n {
+		wg.Go(func() {
+			dur, ok := measureFirstSuccess(ctx, url, timeout)
+			lock.Lock()
+			if !ok {
+				failures++
+			} else {
+				samples = append(samples, dur)
+			}
+			lock.Unlock()
+		})
+	}
+	wg.Wait()
+	return samples, failures
 }

--- a/test/benchmark/pkg/scenario/provisionedidle.go
+++ b/test/benchmark/pkg/scenario/provisionedidle.go
@@ -65,7 +65,7 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 	}
 	// Sub-scope lives for the whole scenario, not just one phase: the function
 	// and route below must survive both idle windows and all three bursts.
-	iter := sc.SubScope("provisionedBenchmark")
+	iter := sc.SubScope("pb")
 	defer iter.CleanupDetached(ctx, time.Minute)
 	fnName := iter.Name("fn")
 	if err := iter.CreateCodeFunction(ctx, harness.FunctionOptions{
@@ -75,6 +75,11 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 		Entrypoint:             "main",
 		ExecutorType:           fv1.ExecutorTypePoolmgr,
 		ProvisionedConcurrency: p.floor,
+		// pythonHelloSleep sleeps for a fixed duration (see assets.go) to force
+		// real concurrent pod occupancy during a burst; must stay comfortably
+		// under FunctionTimeout or the router kills the request as a timeout
+		// before the sleep completes.
+		FunctionTimeout: 90,
 	}); err != nil {
 		return res, err
 	}
@@ -87,9 +92,13 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 		return res, err
 	}
 
-	if err := env.WaitForRoutable(ctx, route, time.Minute); err != nil {
-		return res, err
-	}
+	// No separate WaitForRoutable warm-up: WaitForProvisionedFloor above already
+	// confirms the pods are specialized, and pythonHelloSleep's fixed per-call
+	// sleep (see assets.go) means every invocation — not just the first — takes
+	// as long as the sleep, so WaitForRoutable's hardcoded 30s per-request
+	// client timeout can never succeed here regardless of its outer budget.
+	// fireBurst's own measureFirstSuccess already tolerates the remaining
+	// route-propagation gap (discards 404s, 3-minute per-request timeout).
 	baselineSamples, failures := fireBurst(ctx, env.RouterURL()+route, p.withinBurst, 3*time.Minute)
 	if len(baselineSamples) == 0 {
 		err := fmt.Errorf("zero baseline samples were returned, pointless continuing")

--- a/test/benchmark/pkg/scenario/provisionedidle.go
+++ b/test/benchmark/pkg/scenario/provisionedidle.go
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package scenario
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/benchmark/pkg/harness"
+	"github.com/fission/fission/test/benchmark/pkg/report"
+)
+
+type provisionedIdle struct {
+	floor         int
+	poolsize      int
+	withinBurst   int
+	overflowBurst int
+	idleDuration  time.Duration
+}
+
+func (p *provisionedIdle) Name() string   { return "provisioned-idle-warm" }
+func (p *provisionedIdle) Tags() []string { return []string{"latency", "coldstart", "provisioned"} }
+
+func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.ScenarioResult, error) {
+	var res report.ScenarioResult
+	res.SetMeta("poolsize", strconv.Itoa(p.poolsize))
+	res.SetMeta("floor", strconv.Itoa(p.floor))
+	res.SetMeta("withinBurst", strconv.Itoa(p.withinBurst))
+	res.SetMeta("overflowBurst", strconv.Itoa(p.overflowBurst))
+	res.SetMeta("idleDuration", p.idleDuration.String())
+	env := sc.Env()
+	image := env.Images.Python
+	if image == "" {
+		return res, skip("PYTHON_RUNTIME_IMAGE unset")
+	}
+	envName := sc.Name("burst-env")
+	// Version 3, not the 1 every other scenario in this package uses: poolmgr's
+	// getEnvPoolSize (pkg/executor/executortype/poolmgr/common.go) hardcodes a
+	// pool of 3 for any env with Version < 3, ignoring Spec.Poolsize entirely.
+	// Every other scenario's requested poolsize happens to already be 3, so
+	// this never surfaced; this scenario is the first to need a real custom
+	// pool size, which requires Version 3 to be honoured. The function itself
+	// (pythonHello) is unchanged — v1's plain `def main():` signature is valid
+	// at every environment version, confirmed against fission.io/docs.
+	if err := sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: image, Version: 3, Poolsize: p.poolsize}); err != nil {
+		return res, err
+	}
+	// Start from a fully warm pool so the measurement is specialization +
+	// refill, not initial pool creation.
+	if err := env.WaitForPoolReady(ctx, envName, p.poolsize, 3*time.Minute); err != nil {
+		return res, fmt.Errorf("pool warm-up: %w", err)
+	}
+	iter := sc.SubScope("baseline")
+	defer iter.CleanupDetached(ctx, time.Minute)
+	fnName := "provisionedIdleBenchmarkFn"
+	if err := iter.CreateCodeFunction(ctx, harness.FunctionOptions{
+		Name:                   fnName,
+		Env:                    envName,
+		Code:                   []byte(pythonHelloSleep),
+		Entrypoint:             "main",
+		ExecutorType:           fv1.ExecutorTypePoolmgr,
+		ProvisionedConcurrency: p.floor,
+	}); err != nil {
+		return res, err
+	}
+
+	route := "/" + fnName
+	if err := iter.CreateRoute(ctx, harness.RouteOptions{Function: fnName, URL: route}); err != nil {
+		return res, nil
+	}
+	env.WaitForProvisionedFloor(ctx, fnName, p.floor, 3*time.Minute)
+	env.WaitForRoutable(ctx, route, time.Minute)
+	baselineSamples, failures := fireBurst(ctx, env.RouterURL()+route, p.withinBurst, 3*time.Minute)
+	baselineP99 := percentile(baselineSamples, 99)
+	baselineP50 := percentile(baselineSamples, 50)
+	res.Add("baseline_p99", "ms", report.Lower, float64(baselineP99))
+	res.Add("baseline_p50", "ms", report.Lower, float64(baselineP50))
+	res.Add("baseline_failures", "count", report.Higher, float64(failures))
+
+	// idle
+	select {
+	case <-time.After(p.idleDuration):
+
+	case <-ctx.Done():
+		return res, ctx.Err()
+	}
+
+	withinFloorBurst, failures := fireBurst(ctx, env.RouterURL()+route, p.withinBurst, 3*time.Minute)
+	withinFloorP50 := percentile(withinFloorBurst, 50)
+	withinFloorP99 := percentile(withinFloorBurst, 99)
+	res.Add("within_floor_p99", "ms", report.Lower, float64(withinFloorP99))
+	res.Add("within_floor_p50", "ms", report.Lower, float64(withinFloorP50))
+	res.Add("within_floor_failures", "count", report.Higher, float64(failures))
+	res.Add("within_floor_sample", "count", report.Higher, float64(len(withinFloorBurst)))
+	res.Add("within_floor_ratio", "x", report.Lower, float64(withinFloorP99)/float64(baselineP99))
+	// idle
+	select {
+	case <-time.After(p.idleDuration):
+
+	case <-ctx.Done():
+		return res, ctx.Err()
+	}
+	overflowBurst, failures := fireBurst(ctx, env.RouterURL()+route, p.overflowBurst, 3*time.Minute)
+	overFlowBurstP50 := percentile(overflowBurst, 50)
+	overFlowBurstP99 := percentile(overflowBurst, 99)
+	res.Add("overflow_burst_p99", "ms", report.Lower, float64(overFlowBurstP99))
+	res.Add("overflow_burst_p50", "ms", report.Lower, float64(overFlowBurstP50))
+	res.Add("overflow_burst_failures", "count", report.Higher, float64(failures))
+	res.Add("overflow_burst_sample", "count", report.Higher, float64(len(overflowBurst)))
+	res.Add("overflow_burst_ratio", "x", report.Lower, float64(overFlowBurstP99)/float64(baselineP99))
+	return res, nil
+}

--- a/test/benchmark/pkg/scenario/provisionedidle.go
+++ b/test/benchmark/pkg/scenario/provisionedidle.go
@@ -15,12 +15,20 @@ import (
 	"github.com/fission/fission/test/benchmark/pkg/report"
 )
 
+// provisionedIdle proves that RFC-0026 provisioned-concurrency "floor" pods
+// stay genuinely warm after sitting idle, and that only requests beyond the
+// floor pay a cold start. It measures one burst of withinBurst requests
+// (baseline), lets the floor sit idle for idleDuration, then fires the same
+// burst again (within_floor_*) plus a larger overflowBurst burst
+// (overflow_burst_*). within_floor_ratio (post-idle vs baseline, same burst
+// size) is the gated signal — overflow_burst_ratio is reported but
+// intentionally ungated since exceeding the floor is expected to cold-start.
 type provisionedIdle struct {
-	floor         int
-	poolsize      int
-	withinBurst   int
-	overflowBurst int
-	idleDuration  time.Duration
+	floor         int           // provisioned target (the "floor") for the benchmark function
+	poolsize      int           // shared environment pool size; must absorb floor + overflowBurst
+	withinBurst   int           // concurrent requests for the baseline/within-floor bursts; must be <= floor
+	overflowBurst int           // concurrent requests for the post-idle overflow burst; > floor by design
+	idleDuration  time.Duration // how long the floor sits idle before each post-idle burst
 }
 
 func (p *provisionedIdle) Name() string   { return "provisioned-idle-warm" }
@@ -45,7 +53,7 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 	// Every other scenario's requested poolsize happens to already be 3, so
 	// this never surfaced; this scenario is the first to need a real custom
 	// pool size, which requires Version 3 to be honoured. The function itself
-	// (pythonHello) is unchanged — v1's plain `def main():` signature is valid
+	// (pythonHelloSleep) is unchanged — v1's plain `def main():` signature is valid
 	// at every environment version, confirmed against fission.io/docs.
 	if err := sc.CreateEnv(ctx, harness.EnvOptions{Name: envName, Image: image, Version: 3, Poolsize: p.poolsize}); err != nil {
 		return res, err
@@ -55,9 +63,11 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 	if err := env.WaitForPoolReady(ctx, envName, p.poolsize, 3*time.Minute); err != nil {
 		return res, fmt.Errorf("pool warm-up: %w", err)
 	}
-	iter := sc.SubScope("baseline")
+	// Sub-scope lives for the whole scenario, not just one phase: the function
+	// and route below must survive both idle windows and all three bursts.
+	iter := sc.SubScope("provisionedBenchmark")
 	defer iter.CleanupDetached(ctx, time.Minute)
-	fnName := "provisionedIdleBenchmarkFn"
+	fnName := iter.Name("fn")
 	if err := iter.CreateCodeFunction(ctx, harness.FunctionOptions{
 		Name:                   fnName,
 		Env:                    envName,
@@ -71,18 +81,29 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 
 	route := "/" + fnName
 	if err := iter.CreateRoute(ctx, harness.RouteOptions{Function: fnName, URL: route}); err != nil {
-		return res, nil
+		return res, err
 	}
-	env.WaitForProvisionedFloor(ctx, fnName, p.floor, 3*time.Minute)
-	env.WaitForRoutable(ctx, route, time.Minute)
+	if err := env.WaitForProvisionedFloor(ctx, fnName, p.floor, 3*time.Minute); err != nil {
+		return res, err
+	}
+
+	if err := env.WaitForRoutable(ctx, route, time.Minute); err != nil {
+		return res, err
+	}
 	baselineSamples, failures := fireBurst(ctx, env.RouterURL()+route, p.withinBurst, 3*time.Minute)
+	if len(baselineSamples) == 0 {
+		err := fmt.Errorf("zero baseline samples were returned, pointless continuing")
+		return res, err
+	}
 	baselineP99 := percentile(baselineSamples, 99)
 	baselineP50 := percentile(baselineSamples, 50)
-	res.Add("baseline_p99", "ms", report.Lower, float64(baselineP99))
-	res.Add("baseline_p50", "ms", report.Lower, float64(baselineP50))
-	res.Add("baseline_failures", "count", report.Higher, float64(failures))
+	res.Add("baseline_p99", "ms", report.Lower, float64(millis(baselineP99)))
+	res.Add("baseline_p50", "ms", report.Lower, float64(millis(baselineP50)))
+	res.Add("baseline_failures", "count", report.Lower, float64(failures))
 
-	// idle
+	// Single idle window feeds both post-idle bursts below (within-floor, then
+	// overflow) — no re-sleeping between them, so overflow measures recovery
+	// from the same idle period the within-floor gate is judged against.
 	select {
 	case <-time.After(p.idleDuration):
 
@@ -91,26 +112,31 @@ func (p *provisionedIdle) Run(ctx context.Context, sc *harness.Scope) (report.Sc
 	}
 
 	withinFloorBurst, failures := fireBurst(ctx, env.RouterURL()+route, p.withinBurst, 3*time.Minute)
+	if len(withinFloorBurst) == 0 {
+		err := fmt.Errorf("zero within floor samples were returned, pointless continuing")
+		return res, err
+	}
 	withinFloorP50 := percentile(withinFloorBurst, 50)
 	withinFloorP99 := percentile(withinFloorBurst, 99)
-	res.Add("within_floor_p99", "ms", report.Lower, float64(withinFloorP99))
-	res.Add("within_floor_p50", "ms", report.Lower, float64(withinFloorP50))
-	res.Add("within_floor_failures", "count", report.Higher, float64(failures))
+	res.Add("within_floor_p99", "ms", report.Lower, float64(millis(withinFloorP99)))
+	res.Add("within_floor_p50", "ms", report.Lower, float64(millis(withinFloorP50)))
+	res.Add("within_floor_failures", "count", report.Lower, float64(failures))
 	res.Add("within_floor_sample", "count", report.Higher, float64(len(withinFloorBurst)))
+	// Ratio of raw time.Duration (ns) values, not the millis()-converted ones
+	// above — the ns/ms unit cancels in the division either way, so this is
+	// equivalent, just computed before conversion.
 	res.Add("within_floor_ratio", "x", report.Lower, float64(withinFloorP99)/float64(baselineP99))
-	// idle
-	select {
-	case <-time.After(p.idleDuration):
 
-	case <-ctx.Done():
-		return res, ctx.Err()
-	}
 	overflowBurst, failures := fireBurst(ctx, env.RouterURL()+route, p.overflowBurst, 3*time.Minute)
+	if len(overflowBurst) == 0 {
+		err := fmt.Errorf("zero overflow burst samples were returned, pointless continuing")
+		return res, err
+	}
 	overFlowBurstP50 := percentile(overflowBurst, 50)
 	overFlowBurstP99 := percentile(overflowBurst, 99)
-	res.Add("overflow_burst_p99", "ms", report.Lower, float64(overFlowBurstP99))
-	res.Add("overflow_burst_p50", "ms", report.Lower, float64(overFlowBurstP50))
-	res.Add("overflow_burst_failures", "count", report.Higher, float64(failures))
+	res.Add("overflow_burst_p99", "ms", report.Lower, float64(millis(overFlowBurstP99)))
+	res.Add("overflow_burst_p50", "ms", report.Lower, float64(millis(overFlowBurstP50)))
+	res.Add("overflow_burst_failures", "count", report.Lower, float64(failures))
 	res.Add("overflow_burst_sample", "count", report.Higher, float64(len(overflowBurst)))
 	res.Add("overflow_burst_ratio", "x", report.Lower, float64(overFlowBurstP99)/float64(baselineP99))
 	return res, nil

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -85,9 +85,9 @@ type Params struct {
 	// scenarios fire; sized above Poolsize so the burst forces pool exhaustion
 	// and refill rather than being absorbed by warm pods.
 	BurstSize                    int                `json:"burstSize"`
-	ProvisionedWarmTarget        int                `json:"provisionedWarmTarget"`     // A's target during the burst
-	ProvisionedWarmPoolsize      int                `json:"provisionedWarmPoolsize"`   // pool size for the shared env
-	ProvisionedWarmIterations    int                `json:"provisionedWarmIterations"` // B cold-start samples per phase
+	ProvisionedWarmTarget        int                `json:"provisionedWarmTarget"`        // A's target during the burst
+	ProvisionedWarmPoolsize      int                `json:"provisionedWarmPoolsize"`      // pool size for the shared env
+	ProvisionedWarmIterations    int                `json:"provisionedWarmIterations"`    // B cold-start samples per phase
 	ProvisionedIdleFloor         int                `json:"provisionedIdleFloor"`         // provisioned target (the "floor") to keep warm
 	ProvisionedIdlePoolsize      int                `json:"provisionedIdlePoolsize"`      // pool size for the shared env; must absorb floor + overflow burst
 	ProvisionedIdleDuration      Duration           `json:"provisionedIdleDuration"`      // how long the floor sits idle before each post-idle burst
@@ -124,7 +124,7 @@ func DefaultParams() Params {
 		ProvisionedWarmPoolsize:      30,
 		ProvisionedWarmIterations:    10,
 		ProvisionedIdleFloor:         3,
-		ProvisionedIdlePoolsize:      10,
+		ProvisionedIdlePoolsize:      3,
 		ProvisionedIdleDuration:      Duration(10 * time.Minute),
 		ProvisionedIdleWithinBurst:   3,
 		ProvisionedIdleOverflowBurst: 5,

--- a/test/benchmark/pkg/scenario/scenario.go
+++ b/test/benchmark/pkg/scenario/scenario.go
@@ -84,17 +84,22 @@ type Params struct {
 	// BurstSize is the number of simultaneous first-requests the cold-burst
 	// scenarios fire; sized above Poolsize so the burst forces pool exhaustion
 	// and refill rather than being absorbed by warm pods.
-	BurstSize                 int                `json:"burstSize"`
-	ProvisionedWarmTarget     int                `json:"provisionedWarmTarget"`     // A's target during the burst
-	ProvisionedWarmPoolsize   int                `json:"provisionedWarmPoolsize"`   // pool size for the shared env
-	ProvisionedWarmIterations int                `json:"provisionedWarmIterations"` // B cold-start samples per phase
-	WarmDuration              Duration           `json:"warmDuration"`
-	WarmWarmup                Duration           `json:"warmWarmup"`
-	WarmConcurrency           int                `json:"warmConcurrency"`
-	ConcurrencyLevels         []int              `json:"concurrencyLevels"`
-	RPSLevels                 []int              `json:"rpsLevels"`
-	PayloadSizes              []int              `json:"payloadSizes"` // bytes
-	Executors                 []fv1.ExecutorType `json:"executors"`
+	BurstSize                    int                `json:"burstSize"`
+	ProvisionedWarmTarget        int                `json:"provisionedWarmTarget"`     // A's target during the burst
+	ProvisionedWarmPoolsize      int                `json:"provisionedWarmPoolsize"`   // pool size for the shared env
+	ProvisionedWarmIterations    int                `json:"provisionedWarmIterations"` // B cold-start samples per phase
+	ProvisionedIdleFloor         int                `json:"provisionedIdleFloor"`         // provisioned target (the "floor") to keep warm
+	ProvisionedIdlePoolsize      int                `json:"provisionedIdlePoolsize"`      // pool size for the shared env; must absorb floor + overflow burst
+	ProvisionedIdleDuration      Duration           `json:"provisionedIdleDuration"`      // how long the floor sits idle before each post-idle burst
+	ProvisionedIdleWithinBurst   int                `json:"provisionedIdleWithinBurst"`   // concurrent requests that must stay <= floor
+	ProvisionedIdleOverflowBurst int                `json:"provisionedIdleOverflowBurst"` // concurrent requests that must exceed floor
+	WarmDuration                 Duration           `json:"warmDuration"`
+	WarmWarmup                   Duration           `json:"warmWarmup"`
+	WarmConcurrency              int                `json:"warmConcurrency"`
+	ConcurrencyLevels            []int              `json:"concurrencyLevels"`
+	RPSLevels                    []int              `json:"rpsLevels"`
+	PayloadSizes                 []int              `json:"payloadSizes"` // bytes
+	Executors                    []fv1.ExecutorType `json:"executors"`
 
 	// Number of Secrets/ConfigMaps the cold-start-poolmgr-configdeps scenario's
 	// function references, sizing the per-reference specialization-time lookups.
@@ -111,27 +116,32 @@ type Params struct {
 // DefaultParams returns the standard full-run parameters.
 func DefaultParams() Params {
 	return Params{
-		Poolsize:                  3,
-		ColdIterations:            20,
-		Repetitions:               1,
-		BurstSize:                 10,
-		ProvisionedWarmTarget:     20,
-		ProvisionedWarmPoolsize:   30,
-		ProvisionedWarmIterations: 10,
-		WarmDuration:              Duration(60 * time.Second),
-		WarmWarmup:                Duration(10 * time.Second),
-		WarmConcurrency:           50,
-		ConcurrencyLevels:         []int{10, 50, 100, 250, 500},
-		RPSLevels:                 []int{100, 250, 500, 1000},
-		PayloadSizes:              []int{1 << 10, 10 << 10, 100 << 10, 1 << 20},
-		Executors:                 []fv1.ExecutorType{fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy},
-		ConfigDepsSecrets:         5,
-		ConfigDepsConfigMaps:      5,
-		AutoscaleMaxScale:         5,
-		AutoscaleObserve:          Duration(3 * time.Minute),
-		IndexScaleCount:           1000,
-		RouteChurnCount:           500,
-		BuildTimeout:              Duration(5 * time.Minute),
+		Poolsize:                     3,
+		ColdIterations:               20,
+		Repetitions:                  1,
+		BurstSize:                    10,
+		ProvisionedWarmTarget:        20,
+		ProvisionedWarmPoolsize:      30,
+		ProvisionedWarmIterations:    10,
+		ProvisionedIdleFloor:         3,
+		ProvisionedIdlePoolsize:      10,
+		ProvisionedIdleDuration:      Duration(10 * time.Minute),
+		ProvisionedIdleWithinBurst:   3,
+		ProvisionedIdleOverflowBurst: 5,
+		WarmDuration:                 Duration(60 * time.Second),
+		WarmWarmup:                   Duration(10 * time.Second),
+		WarmConcurrency:              50,
+		ConcurrencyLevels:            []int{10, 50, 100, 250, 500},
+		RPSLevels:                    []int{100, 250, 500, 1000},
+		PayloadSizes:                 []int{1 << 10, 10 << 10, 100 << 10, 1 << 20},
+		Executors:                    []fv1.ExecutorType{fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy},
+		ConfigDepsSecrets:            5,
+		ConfigDepsConfigMaps:         5,
+		AutoscaleMaxScale:            5,
+		AutoscaleObserve:             Duration(3 * time.Minute),
+		IndexScaleCount:              1000,
+		RouteChurnCount:              500,
+		BuildTimeout:                 Duration(5 * time.Minute),
 	}
 }
 
@@ -154,6 +164,21 @@ func (p Params) normalize() Params {
 	}
 	if p.ProvisionedWarmPoolsize == 0 {
 		p.ProvisionedWarmPoolsize = d.ProvisionedWarmPoolsize
+	}
+	if p.ProvisionedIdleFloor == 0 {
+		p.ProvisionedIdleFloor = d.ProvisionedIdleFloor
+	}
+	if p.ProvisionedIdlePoolsize == 0 {
+		p.ProvisionedIdlePoolsize = d.ProvisionedIdlePoolsize
+	}
+	if p.ProvisionedIdleDuration == 0 {
+		p.ProvisionedIdleDuration = d.ProvisionedIdleDuration
+	}
+	if p.ProvisionedIdleWithinBurst == 0 {
+		p.ProvisionedIdleWithinBurst = d.ProvisionedIdleWithinBurst
+	}
+	if p.ProvisionedIdleOverflowBurst == 0 {
+		p.ProvisionedIdleOverflowBurst = d.ProvisionedIdleOverflowBurst
 	}
 	if p.ProvisionedWarmIterations == 0 {
 		p.ProvisionedWarmIterations = d.ProvisionedWarmIterations
@@ -226,6 +251,7 @@ func BuildAll(p Params) []Scenario {
 	out = append(out, &asyncInvoke{duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
 	out = append(out, &eventingTopic{duration: p.WarmDuration.D(), warmup: p.WarmWarmup.D(), concurrency: p.WarmConcurrency, poolsize: p.Poolsize})
 	out = append(out, &provisionedWarm{burstTarget: p.ProvisionedWarmTarget, poolsize: p.ProvisionedWarmPoolsize, iterations: p.ProvisionedWarmIterations})
+	out = append(out, &provisionedIdle{floor: p.ProvisionedIdleFloor, poolsize: p.ProvisionedIdlePoolsize, withinBurst: p.ProvisionedIdleWithinBurst, overflowBurst: p.ProvisionedIdleOverflowBurst, idleDuration: p.ProvisionedIdleDuration.D()})
 	return out
 }
 

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -137,3 +137,15 @@ func TestWarmPathPerExecutor(t *testing.T) {
 		}
 	}
 }
+
+// TestProvisionedIdleScenarioRegistered pins that the RFC-0026 phase4
+// idle-warm guardrail (provisioned floor pods must stay warm after sitting
+// idle) is built and is deliberately OFF the smoke subset — the default 10m
+// idle window is far too slow for the per-PR smoke run.
+func TestProvisionedIdleScenarioRegistered(t *testing.T) {
+	t.Parallel()
+	all := BuildAll(DefaultParams())
+	assert.Contains(t, Names(all), "provisioned-idle-warm")
+	assert.NotContains(t, Names(Select(all, nil, []string{"smoke"})), "provisioned-idle-warm",
+		"provisioned-idle-warm must stay out of the fast per-PR smoke subset")
+}

--- a/test/benchmark/pkg/scenario/scenario_test.go
+++ b/test/benchmark/pkg/scenario/scenario_test.go
@@ -141,11 +141,29 @@ func TestWarmPathPerExecutor(t *testing.T) {
 // TestProvisionedIdleScenarioRegistered pins that the RFC-0026 phase4
 // idle-warm guardrail (provisioned floor pods must stay warm after sitting
 // idle) is built and is deliberately OFF the smoke subset — the default 10m
-// idle window is far too slow for the per-PR smoke run.
+// idle window is far too slow for the per-PR smoke run. It also checks that
+// custom Params reach the built scenario's fields, guarding the BuildAll
+// wiring line specifically.
 func TestProvisionedIdleScenarioRegistered(t *testing.T) {
 	t.Parallel()
 	all := BuildAll(DefaultParams())
 	assert.Contains(t, Names(all), "provisioned-idle-warm")
 	assert.NotContains(t, Names(Select(all, nil, []string{"smoke"})), "provisioned-idle-warm",
 		"provisioned-idle-warm must stay out of the fast per-PR smoke subset")
+
+	built := Select(BuildAll(Params{
+		ProvisionedIdleFloor:         2,
+		ProvisionedIdlePoolsize:      4,
+		ProvisionedIdleDuration:      Duration(30 * time.Second),
+		ProvisionedIdleWithinBurst:   2,
+		ProvisionedIdleOverflowBurst: 6,
+	}), []string{"provisioned-idle-warm"}, nil)
+	require.Len(t, built, 1)
+	pi, ok := built[0].(*provisionedIdle)
+	require.True(t, ok)
+	assert.Equal(t, 2, pi.floor)
+	assert.Equal(t, 4, pi.poolsize)
+	assert.Equal(t, 30*time.Second, pi.idleDuration)
+	assert.Equal(t, 2, pi.withinBurst)
+	assert.Equal(t, 6, pi.overflowBurst)
 }

--- a/test/integration/suites/common/provisioned_concurrency_test.go
+++ b/test/integration/suites/common/provisioned_concurrency_test.go
@@ -268,7 +268,7 @@ func TestProvisionedScheduledWindowCloseReapsPods(t *testing.T) {
 		ExecutorType:           "poolmgr",
 		ProvisionedConcurrency: 1,
 		ProvisionedSchedules: []string{
-			"name=w1;start=0 */4 * * * *;duration=60s;target=3",
+			"name=w1;start=0 */4 * * * *;duration=15s;target=3",
 		},
 		IdleTimeout: 20,
 		FnTimeout:   5,

--- a/test/integration/suites/common/provisioned_concurrency_test.go
+++ b/test/integration/suites/common/provisioned_concurrency_test.go
@@ -268,7 +268,7 @@ func TestProvisionedScheduledWindowCloseReapsPods(t *testing.T) {
 		ExecutorType:           "poolmgr",
 		ProvisionedConcurrency: 1,
 		ProvisionedSchedules: []string{
-			"name=w1;start=0 */4 * * * *;duration=15s;target=3",
+			"name=w1;start=0 */4 * * * *;duration=60s;target=3",
 		},
 		IdleTimeout: 20,
 		FnTimeout:   5,


### PR DESCRIPTION
## Summary
- Adds a new benchmark scenario (`provisioned-idle-warm`) proving RFC-0026 provisioned-concurrency "floor" pods stay genuinely warm after sitting idle, while requests beyond the floor correctly pay a real cold start.
- Measures a baseline burst, lets the floor idle, then re-measures the same burst (`within_floor_*`, gated at 1.5x vs baseline) plus a larger overflow burst beyond the floor (`overflow_burst_*`, reported but intentionally ungated).
- Wires the scenario into `Params`/`BuildAll`, adds its default config and threshold gate, and registers a `TestProvisionedIdleScenarioRegistered` pin (excluded from the `smoke` tag subset) that also asserts custom `Params` reach the built scenario's fields.
- Small fixes elsewhere: `harness.WaitForProvisionedFloor` now polls `Function.Status.ProvisionedReady` directly (previously a mis-scoped, cross-namespace pod-label list), with new fake-clientset unit tests (`pkg/harness/wait_test.go`) covering the reaches-floor, times-out, and wrong-namespace-never-matches cases — the last one is a direct regression guard for the namespace bug.

## Test plan
- [x] `go build ./...` / `go vet ./...` / `go test ./...` clean in both the root module and `test/benchmark`
- [x] `TestProvisionedIdleScenarioRegistered` and `TestWaitForProvisionedFloor` pass
- [x] Ran against a local kind cluster via `fission-benchmark run --scenarios provisioned-idle-warm`; confirmed floor pods stay warm across idle (`within_floor_ratio` ≈ 1.0) and the overflow burst correctly fans out to distinct pods beyond the floor (verified via `kubectl get pods -w`)
- [x] Full 10-minute (default `provisionedIdleDuration`) run against kind: `within_floor_ratio` 1.000x, `overflow_burst_ratio` 1.006x, all thresholds passed
- [x] "Prove the gate can actually fail" step: temporarily added a 5s artificial delay to only the within-floor samples, confirmed `report --thresholds` flagged `within_floor_ratio = 1.997 exceeds max 1.500` and exited non-zero, then reverted (clean diff confirmed against the committed scenario file)