### PR TITLE
RFC-0028 phase 3: roll drifted builders (#776) + skew reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,13 @@ output.sarif
 *.sarif
 /fission-bundle
 
+# Stray binaries from `go build ./cmd/<name>` with no -o: Go writes the binary
+# into the working directory, which is the repo root. Each is ~90MB.
+/preupgradechecks
+/fetcher
+/builder
+/reporter
+
 # Stray archive-download artifacts from e2e CLI test runs (UUID-named files
 # written to the test's working directory by `fission archive download`).
 test/e2e/cli/????????-????-????-????-????????????

--- a/charts/fission-all/templates/_fission-kubernetes-roles.tpl
+++ b/charts/fission-all/templates/_fission-kubernetes-roles.tpl
@@ -65,6 +65,11 @@ rules:
   verbs:
   - list
   - create
+  # update: the reconciler rolls a builder Deployment whose pod template has
+  # drifted from the chart (RFC-0028 phase 3, #776). Without this verb the
+  # drift is detected and the update is denied, so the builder silently keeps
+  # running the stale image — the exact symptom the feature removes.
+  - update
   - delete
 - apiGroups:
   - apiextensions.k8s.io

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -6,6 +6,8 @@ package buildermgr
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -34,6 +36,11 @@ const (
 	LABEL_ENV_RESOURCEVERSION = "envResourceVersion"
 	LABEL_DEPLOYMENT_OWNER    = "owner"
 	BUILDER_MGR               = "buildermgr"
+
+	// builderSpecHashAnnotation carries a hash of the builder pod template the
+	// reconciler last applied, so drift that does NOT bump the Environment's
+	// ResourceVersion is still detectable (RFC-0028 phase 3, issue #776).
+	builderSpecHashAnnotation = "fission.io/builder-spec-hash"
 )
 
 var (
@@ -187,10 +194,59 @@ func (r *EnvironmentReconciler) ensureBuilder(ctx context.Context, env *fv1.Envi
 			return fmt.Errorf("error creating builder deployment for environment %s in namespace %s: %w", env.Name, ns, err)
 		}
 	case 1:
-		// already present
+		if err := r.reconcileBuilderDeployment(ctx, env, ns, &deployList[0]); err != nil {
+			return fmt.Errorf("error reconciling builder deployment for environment %s in namespace %s: %w", env.Name, ns, err)
+		}
 	default:
 		return fmt.Errorf("found more than one builder deployment for environment %s in namespace %s", env.Name, ns)
 	}
+	return nil
+}
+
+// reconcileBuilderDeployment rolls an existing builder Deployment whose pod
+// template no longer matches what this reconciler would create.
+//
+// The Environment's ResourceVersion is NOT a sufficient trigger (issue #776).
+// Everything the builder pod is made of that comes from the chart rather than
+// the CR — the fetcher image, the builder image-pull policy, the pod-spec patch
+// — changes without the Environment being touched at all. The RV-keyed
+// name/selector stays identical, so the old code found a matching Deployment
+// and did nothing, and the builder kept running the previous image until
+// someone deleted the Deployment by hand. Deleting the POD does not help
+// either: the ReplicaSet just recreates it from the same stale template.
+//
+// The Deployment is updated in place rather than recreated: its name is
+// <env>-<rv>, which buildPackage resolves as a DNS hostname, so renaming or
+// recreating per-generation would break in-flight builds.
+func (r *EnvironmentReconciler) reconcileBuilderDeployment(ctx context.Context, env *fv1.Environment, ns string, live *appsv1.Deployment) error {
+	desired, err := r.genBuilderDeployment(env, ns)
+	if err != nil {
+		return err
+	}
+	want := desired.Annotations[builderSpecHashAnnotation]
+	if live.Annotations[builderSpecHashAnnotation] == want {
+		return nil
+	}
+
+	// Carry the live object's identity so this is an update, not a create, and
+	// so we do not clobber annotations set by anything else.
+	updated := live.DeepCopy()
+	updated.Spec = desired.Spec
+	updated.Labels = desired.Labels
+	if updated.Annotations == nil {
+		updated.Annotations = map[string]string{}
+	}
+	updated.Annotations[builderSpecHashAnnotation] = want
+
+	if _, err := r.kubernetesClient.AppsV1().Deployments(ns).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+	// An empty previous hash means the Deployment predates this annotation, so
+	// the first reconcile after upgrade rolls every builder exactly once — a
+	// one-time cost, not ongoing churn, because the hash matches from then on.
+	r.logger.Info("builder deployment spec drifted, rolling it",
+		"deployment", updated.Name, "namespace", ns,
+		"previous", live.Annotations[builderSpecHashAnnotation], "current", want)
 	return nil
 }
 
@@ -381,7 +437,11 @@ func builderAuthEnvVars(namespace string) []apiv1.EnvVar {
 	}
 }
 
-func (r *EnvironmentReconciler) createBuilderDeployment(ctx context.Context, env *fv1.Environment, ns string) (*appsv1.Deployment, error) {
+// genBuilderDeployment computes the DESIRED builder Deployment for an
+// Environment. Split out from the create path so the reconciler can compute the
+// same object on every pass and compare it against what is live — see
+// builderSpecHash and ensureBuilder.
+func (r *EnvironmentReconciler) genBuilderDeployment(env *fv1.Environment, ns string) (*appsv1.Deployment, error) {
 	name := fmt.Sprintf("%v-%v", env.Name, env.ResourceVersion)
 	sel := r.getLabels(env.Name, ns, env.ResourceVersion)
 	var replicas int32 = 1
@@ -532,12 +592,47 @@ func (r *EnvironmentReconciler) createBuilderDeployment(ctx context.Context, env
 		return nil, err
 	}
 
-	_, err = r.kubernetesClient.AppsV1().Deployments(ns).Create(ctx, deployment, metav1.CreateOptions{})
+	// Stamp a hash of the desired pod template so a later reconcile can tell
+	// "this Deployment is what we would create today" from "this Deployment is
+	// stale". Comparing the live PodSpec directly cannot work: the apiserver
+	// defaults dozens of fields on write, so a live-vs-desired comparison is
+	// never equal and would rewrite the Deployment on every pass forever.
+	// Hashing OUR desired object and comparing that to the value we ourselves
+	// stamped sidesteps defaulting entirely.
+	hash, err := builderSpecHash(&deployment.Spec.Template)
 	if err != nil {
 		return nil, err
 	}
+	if deployment.Annotations == nil {
+		deployment.Annotations = map[string]string{}
+	}
+	deployment.Annotations[builderSpecHashAnnotation] = hash
 
-	r.logger.Info("creating builder deployment", "deployment", name)
+	return deployment, nil
+}
 
+// builderSpecHash fingerprints the desired builder pod template. It is stamped
+// on the Deployment (never on the template itself, which would make the hash
+// cover its own value).
+func builderSpecHash(tmpl *apiv1.PodTemplateSpec) (string, error) {
+	b, err := json.Marshal(tmpl)
+	if err != nil {
+		return "", fmt.Errorf("error hashing builder pod template: %w", err)
+	}
+	sum := sha256.Sum256(b)
+	return fmt.Sprintf("sha256:%x", sum), nil
+}
+
+// createBuilderDeployment creates the builder Deployment for the current
+// Environment generation.
+func (r *EnvironmentReconciler) createBuilderDeployment(ctx context.Context, env *fv1.Environment, ns string) (*appsv1.Deployment, error) {
+	deployment, err := r.genBuilderDeployment(env, ns)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := r.kubernetesClient.AppsV1().Deployments(ns).Create(ctx, deployment, metav1.CreateOptions{}); err != nil {
+		return nil, err
+	}
+	r.logger.Info("creating builder deployment", "deployment", deployment.Name)
 	return deployment, nil
 }

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -10,7 +10,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
+	"strings"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -233,6 +235,11 @@ func (r *EnvironmentReconciler) reconcileBuilderDeployment(ctx context.Context, 
 	updated := live.DeepCopy()
 	updated.Spec = desired.Spec
 	updated.Labels = desired.Labels
+	// Selector is immutable on a Deployment: sending a different one makes the
+	// apiserver reject the whole update. It is derived from the same
+	// name/namespace/RV as the live object's, so it cannot legitimately differ
+	// — keep the live value rather than betting the update on that staying true.
+	updated.Spec.Selector = live.Spec.Selector
 	if updated.Annotations == nil {
 		updated.Annotations = map[string]string{}
 	}
@@ -614,13 +621,51 @@ func (r *EnvironmentReconciler) genBuilderDeployment(env *fv1.Environment, ns st
 // builderSpecHash fingerprints the desired builder pod template. It is stamped
 // on the Deployment (never on the template itself, which would make the hash
 // cover its own value).
+//
+// The template is CANONICALISED first, and that is not cosmetic. MergePodSpec
+// round-trips containers through a map[string]*Container and emits them in map
+// iteration order, which Go randomises per range — so two calls with identical
+// inputs produce slices in different orders, within a single process. Hashing
+// that directly gives a different answer nearly every call, and the reconciler
+// would see permanent drift and roll the builder on every reconcile forever:
+// the exact churn this feature exists to prevent, arriving from the other side.
+// Any environment setting Builder.PodSpec would hit it, since the merge runs
+// whether or not the patch names a container.
+//
+// Sorting by name is safe because container order carries no meaning here: the
+// entrypoint is chosen by name, and init containers are appended by the same
+// merge rather than ordered by the user.
 func builderSpecHash(tmpl *apiv1.PodTemplateSpec) (string, error) {
-	b, err := json.Marshal(tmpl)
+	canonical := tmpl.DeepCopy()
+	sortByName(canonical.Spec.Containers)
+	sortByName(canonical.Spec.InitContainers)
+	slices.SortFunc(canonical.Spec.Volumes, func(a, b apiv1.Volume) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+
+	b, err := json.Marshal(canonical)
 	if err != nil {
 		return "", fmt.Errorf("error hashing builder pod template: %w", err)
 	}
 	sum := sha256.Sum256(b)
 	return fmt.Sprintf("sha256:%x", sum), nil
+}
+
+// sortByName orders containers by name and, within each, its env vars and
+// volume mounts — every slice on the path that is assembled from a map or from
+// os.Environ(), whose order is not guaranteed stable across calls or restarts.
+func sortByName(containers []apiv1.Container) {
+	slices.SortFunc(containers, func(a, b apiv1.Container) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+	for i := range containers {
+		slices.SortFunc(containers[i].Env, func(a, b apiv1.EnvVar) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+		slices.SortFunc(containers[i].VolumeMounts, func(a, b apiv1.VolumeMount) int {
+			return strings.Compare(a.Name, b.Name)
+		})
+	}
 }
 
 // createBuilderDeployment creates the builder Deployment for the current

--- a/pkg/buildermgr/environment_reconciler_test.go
+++ b/pkg/buildermgr/environment_reconciler_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -325,4 +326,89 @@ func TestEnvironmentReconcilePrunesStaleGeneration(t *testing.T) {
 	assert.True(t, apierrors.IsNotFound(err), "stale-generation builder deployment must be pruned")
 	_, err = r.kubernetesClient.CoreV1().Services(ns).Get(t.Context(), env.Name+"-2", metav1.GetOptions{})
 	require.NoError(t, err, "current-generation builder service must exist")
+}
+
+// TestEnvironmentReconcileRollsDriftedBuilder is issue #776: builder drift that
+// does NOT bump the Environment's ResourceVersion must still roll the builder.
+//
+// Everything the builder pod is made of that comes from the chart rather than
+// the CR — the fetcher image, the builder image-pull policy, the pod-spec patch
+// — changes without the Environment being touched. The name and selector are
+// keyed on the RV, so they still match, and the reconciler used to find a
+// Deployment and do nothing. The builder then ran the previous image until
+// someone deleted the Deployment by hand; deleting the POD did nothing, because
+// the ReplicaSet recreated it from the same stale template.
+func TestEnvironmentReconcileRollsDriftedBuilder(t *testing.T) {
+	env := newTestBuilderEnv()
+	env.ResourceVersion = "7"
+	r := newTestEnvironmentReconciler(t, nil, env)
+	ns := r.nsResolver.GetBuilderNS(env.Namespace)
+
+	// First reconcile creates the builder at the current desired spec.
+	_, err := r.Reconcile(t.Context(), envReq(env))
+	require.NoError(t, err)
+
+	name := env.Name + "-7"
+	created, err := r.kubernetesClient.AppsV1().Deployments(ns).Get(t.Context(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	originalHash := created.Annotations[builderSpecHashAnnotation]
+	require.NotEmpty(t, originalHash, "the created builder must carry a spec hash to compare against later")
+
+	// Drift the live Deployment the way a chart-level change would: the pod
+	// template no longer matches what the reconciler would produce, while the
+	// Environment — and therefore the name, selector and RV label — is untouched.
+	drifted := created.DeepCopy()
+	drifted.Spec.Template.Spec.Containers[0].Image = "fission/python-builder:STALE"
+	drifted.Annotations[builderSpecHashAnnotation] = "sha256:stale"
+	_, err = r.kubernetesClient.AppsV1().Deployments(ns).Update(t.Context(), drifted, metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	_, err = r.Reconcile(t.Context(), envReq(env))
+	require.NoError(t, err)
+
+	got, err := r.kubernetesClient.AppsV1().Deployments(ns).Get(t.Context(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, env.Spec.Builder.Image, got.Spec.Template.Spec.Containers[0].Image,
+		"a drifted builder must be rolled back onto the desired image")
+	assert.Equal(t, originalHash, got.Annotations[builderSpecHashAnnotation],
+		"the spec hash must be re-stamped so the next reconcile is a no-op")
+	assert.Equal(t, name, got.Name,
+		"the Deployment must be updated in place: buildPackage resolves <env>-<rv> as a DNS hostname")
+}
+
+// TestEnvironmentReconcileDoesNotRollAnUndriftedBuilder is the other half, and
+// the direction whose failure mode is silent: a reconciler that rewrote the
+// Deployment every pass would roll every builder on every resync forever.
+// Comparing the apiserver's view of the PodSpec would do exactly that, since it
+// defaults fields we never set — hence hashing our own desired object instead.
+func TestEnvironmentReconcileDoesNotRollAnUndriftedBuilder(t *testing.T) {
+	env := newTestBuilderEnv()
+	env.ResourceVersion = "7"
+	r := newTestEnvironmentReconciler(t, nil, env)
+	ns := r.nsResolver.GetBuilderNS(env.Namespace)
+
+	_, err := r.Reconcile(t.Context(), envReq(env))
+	require.NoError(t, err)
+	_, err = r.kubernetesClient.AppsV1().Deployments(ns).Get(t.Context(), env.Name+"-7", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// Count Deployment writes with a reactor rather than comparing
+	// ResourceVersion: the fake clientset does not bump RV on Update, so an
+	// RV comparison passes even when the reconciler rewrites the object on
+	// every pass — the exact regression this test exists to catch.
+	var updates int
+	fakeCS, ok := r.kubernetesClient.(*k8sfake.Clientset)
+	require.True(t, ok, "test reconciler must use the fake clientset")
+	fakeCS.PrependReactor("update", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		return false, nil, nil
+	})
+
+	for range 3 {
+		_, err = r.Reconcile(t.Context(), envReq(env))
+		require.NoError(t, err)
+	}
+
+	assert.Zero(t, updates,
+		"repeated reconciles of an unchanged environment must not write the Deployment at all")
 }

--- a/pkg/buildermgr/environment_reconciler_test.go
+++ b/pkg/buildermgr/environment_reconciler_test.go
@@ -431,7 +431,6 @@ func TestEnvironmentReconcileDoesNotRollWhenPodSpecPatched(t *testing.T) {
 		NodeSelector: map[string]string{"disktype": "ssd"},
 	}
 	r := newTestEnvironmentReconciler(t, nil, env)
-	ns := r.nsResolver.GetBuilderNS(env.Namespace)
 
 	_, err := r.Reconcile(t.Context(), envReq(env))
 	require.NoError(t, err)
@@ -453,7 +452,6 @@ func TestEnvironmentReconcileDoesNotRollWhenPodSpecPatched(t *testing.T) {
 
 	assert.Zero(t, updates,
 		"a builder whose environment sets Builder.PodSpec must not be rolled by repeated reconciles")
-	_ = ns
 }
 
 // TestBuilderSpecHashIsStableAcrossCalls isolates the same invariant without a

--- a/pkg/buildermgr/environment_reconciler_test.go
+++ b/pkg/buildermgr/environment_reconciler_test.go
@@ -412,3 +412,70 @@ func TestEnvironmentReconcileDoesNotRollAnUndriftedBuilder(t *testing.T) {
 	assert.Zero(t, updates,
 		"repeated reconciles of an unchanged environment must not write the Deployment at all")
 }
+
+// TestEnvironmentReconcileDoesNotRollWhenPodSpecPatched is the case the drift
+// check exists for, and the one that breaks a naive hash.
+//
+// env.Spec.Builder.PodSpec routes the pod template through MergePodSpec, whose
+// mergeContainerList round-trips containers through a Go map and emits them in
+// map-iteration order — randomized per range, even inside one process. Hashing
+// that order directly yields a different hash on every call, so the reconciler
+// would "detect drift" forever and roll the builder on every single reconcile:
+// the exact churn this feature exists to prevent, arriving from the other side.
+func TestEnvironmentReconcileDoesNotRollWhenPodSpecPatched(t *testing.T) {
+	env := newTestBuilderEnv()
+	env.ResourceVersion = "7"
+	// Container-free on purpose: mergeContainerList runs regardless of whether
+	// the patch names any container, so an unrelated patch is enough.
+	env.Spec.Builder.PodSpec = &apiv1.PodSpec{
+		NodeSelector: map[string]string{"disktype": "ssd"},
+	}
+	r := newTestEnvironmentReconciler(t, nil, env)
+	ns := r.nsResolver.GetBuilderNS(env.Namespace)
+
+	_, err := r.Reconcile(t.Context(), envReq(env))
+	require.NoError(t, err)
+
+	var updates int
+	fakeCS, ok := r.kubernetesClient.(*k8sfake.Clientset)
+	require.True(t, ok)
+	fakeCS.PrependReactor("update", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+		updates++
+		return false, nil, nil
+	})
+
+	// Several passes: one map iteration can coincidentally match, a run of them
+	// will not.
+	for range 8 {
+		_, err = r.Reconcile(t.Context(), envReq(env))
+		require.NoError(t, err)
+	}
+
+	assert.Zero(t, updates,
+		"a builder whose environment sets Builder.PodSpec must not be rolled by repeated reconciles")
+	_ = ns
+}
+
+// TestBuilderSpecHashIsStableAcrossCalls isolates the same invariant without a
+// reconcile, so a failure points at the hash rather than at the controller.
+func TestBuilderSpecHashIsStableAcrossCalls(t *testing.T) {
+	env := newTestBuilderEnv()
+	env.ResourceVersion = "7"
+	env.Spec.Builder.PodSpec = &apiv1.PodSpec{
+		NodeSelector: map[string]string{"disktype": "ssd"},
+	}
+	r := newTestEnvironmentReconciler(t, nil, env)
+	ns := r.nsResolver.GetBuilderNS(env.Namespace)
+
+	first, err := r.genBuilderDeployment(env, ns)
+	require.NoError(t, err)
+	want := first.Annotations[builderSpecHashAnnotation]
+	require.NotEmpty(t, want)
+
+	for i := range 20 {
+		again, err := r.genBuilderDeployment(env, ns)
+		require.NoError(t, err)
+		require.Equalf(t, want, again.Annotations[builderSpecHashAnnotation],
+			"hash must not depend on map iteration order (differed on call %d)", i+2)
+	}
+}

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -117,11 +117,23 @@ func (hc *HealthChecker) CheckFissionVersion(ctx context.Context, input cli.Inpu
 	console.Verbose(2, "clientVersion: %s", clientVersion)
 	console.Verbose(2, "serverVersion: %s", serverVersion)
 
-	if clientVersion != serverVersion {
-		return fmt.Errorf("client version %s does not match with server version %s", clientVersion, serverVersion)
+	// Judged against the support window in RELEASES.md rather than by string
+	// equality. Exact equality failed on any patch difference — which the
+	// policy explicitly permits — and on the ordinary state of a staged
+	// rollout, where the CLI and the cluster are upgraded at different moments.
+	verdict, detail := CheckVersionSkew(clientVersion, serverVersion)
+	switch verdict {
+	case SkewSame:
+		return nil
+	case SkewSupported, SkewUnknown:
+		// Reported, not failed: both are states a healthy cluster is legitimately
+		// in, and turning them into an error is what made this check something
+		// users learned to ignore.
+		console.Warn(detail)
+		return nil
+	default:
+		return fmt.Errorf("unsupported version skew: %s", detail)
 	}
-
-	return nil
 }
 
 func NewCategory(id CategoryID, checkers []Checker, enabled bool) *Category {

--- a/pkg/healthcheck/skew.go
+++ b/pkg/healthcheck/skew.go
@@ -111,8 +111,8 @@ func CheckVersionSkew(clientVersion, serverVersion string) (SkewVerdict, string)
 		return SkewSame, ""
 	case skew <= SupportedMinorSkew:
 		return SkewSupported, fmt.Sprintf(
-			"client %s and server %s differ by one minor version; both are inside the supported window",
-			clientVersion, serverVersion)
+			"client %s and server %s differ by %d minor version(s); both are inside the supported window of %d",
+			clientVersion, serverVersion, skew, SupportedMinorSkew)
 	default:
 		return SkewUnsupported, fmt.Sprintf(
 			"client %s and server %s are %d minor versions apart; only %d is supported (see RELEASES.md). Upgrade the CLI or the cluster before relying on this client",

--- a/pkg/healthcheck/skew.go
+++ b/pkg/healthcheck/skew.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SupportedMinorSkew is how many minor releases the CLI may differ from the
+// control plane and still be supported.
+//
+// It is 1 because RELEASES.md promises fixes for the latest TWO minor lines:
+// with 1.N and 1.N-1 both supported, a CLI and a cluster on adjacent minors are
+// both in the window, and anything further apart is not. Changing the support
+// window means changing this constant, and vice versa — they are one policy.
+const SupportedMinorSkew = 1
+
+// SkewVerdict is the outcome of comparing a client and server version.
+type SkewVerdict int
+
+const (
+	// SkewSame — identical minor. Nothing to report.
+	SkewSame SkewVerdict = iota
+	// SkewSupported — different minor, still inside the support window. This
+	// is the normal state during a staged rollout and must NOT be an error.
+	SkewSupported
+	// SkewUnsupported — outside the window; behaviour is not guaranteed.
+	SkewUnsupported
+	// SkewUnknown — at least one version could not be parsed (a dev build, a
+	// source build, an unreachable control plane).
+	SkewUnknown
+)
+
+// semver is a parsed major.minor.patch, ignoring any pre-release or build
+// suffix and a leading "v".
+type semver struct {
+	major, minor, patch int
+}
+
+// parseSemver parses "v1.27.0", "1.27.0", "1.27.0-rc1" and "1.27" leniently.
+// It reports ok=false for anything it cannot read as major.minor, including the
+// empty string and dev builds, so callers can distinguish "no skew" from "no
+// idea" rather than silently treating an unparsable version as 0.0.0.
+func parseSemver(v string) (semver, bool) {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" {
+		return semver{}, false
+	}
+	// Drop pre-release / build metadata: 1.27.0-rc1+abc -> 1.27.0
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		return semver{}, false
+	}
+	out := semver{}
+	var err error
+	if out.major, err = strconv.Atoi(parts[0]); err != nil {
+		return semver{}, false
+	}
+	if out.minor, err = strconv.Atoi(parts[1]); err != nil {
+		return semver{}, false
+	}
+	if len(parts) > 2 {
+		// A non-numeric patch is tolerated: the skew rule only reads
+		// major.minor, so refusing the whole version over it would report
+		// "unknown" for versions we can in fact judge.
+		out.patch, _ = strconv.Atoi(parts[2])
+	}
+	return out, true
+}
+
+// CheckVersionSkew judges a client version against a server version under the
+// support window in RELEASES.md.
+//
+// A DIFFERING MINOR IS NOT AN ERROR. The previous check required exact string
+// equality, which fails during any staged rollout — the CLI is upgraded on a
+// laptop or in CI at a different moment from the cluster — and contradicts the
+// published policy of supporting two minor lines. It also failed on any patch
+// difference, which the policy explicitly permits.
+//
+// A differing MAJOR is always unsupported: nothing in the policy promises
+// compatibility across a major.
+func CheckVersionSkew(clientVersion, serverVersion string) (SkewVerdict, string) {
+	c, cok := parseSemver(clientVersion)
+	s, sok := parseSemver(serverVersion)
+	if !cok || !sok {
+		return SkewUnknown, fmt.Sprintf(
+			"cannot compare versions (client %q, server %q); this is expected for dev or source builds",
+			clientVersion, serverVersion)
+	}
+
+	if c.major != s.major {
+		return SkewUnsupported, fmt.Sprintf(
+			"client %s and server %s are on different major versions; compatibility is not supported across a major",
+			clientVersion, serverVersion)
+	}
+
+	skew := c.minor - s.minor
+	if skew < 0 {
+		skew = -skew
+	}
+	switch {
+	case skew == 0:
+		return SkewSame, ""
+	case skew <= SupportedMinorSkew:
+		return SkewSupported, fmt.Sprintf(
+			"client %s and server %s differ by one minor version; both are inside the supported window",
+			clientVersion, serverVersion)
+	default:
+		return SkewUnsupported, fmt.Sprintf(
+			"client %s and server %s are %d minor versions apart; only %d is supported (see RELEASES.md). Upgrade the CLI or the cluster before relying on this client",
+			clientVersion, serverVersion, skew, SupportedMinorSkew)
+	}
+}

--- a/pkg/healthcheck/skew_test.go
+++ b/pkg/healthcheck/skew_test.go
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCheckVersionSkew pins the support window from RELEASES.md: the latest two
+// minor lines are supported, so adjacent minors are fine and anything further
+// apart is not.
+//
+// The cases that matter most are the ones the previous exact-equality check got
+// wrong — a patch difference and a one-minor difference are both NORMAL, and
+// failing them is what made `fission check` noisy enough to ignore.
+func TestCheckVersionSkew(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name           string
+		client, server string
+		want           SkewVerdict
+	}{
+		{"identical", "1.27.0", "1.27.0", SkewSame},
+		{"identical with v prefix on one side", "v1.27.0", "1.27.0", SkewSame},
+		{"patch differs — explicitly permitted by the policy", "1.27.3", "1.27.0", SkewSame},
+		{"pre-release suffix is ignored", "1.27.0-rc1", "1.27.0", SkewSame},
+		{"build metadata is ignored", "1.27.0+abc123", "1.27.0", SkewSame},
+
+		{"client one minor ahead — staged rollout", "1.28.0", "1.27.0", SkewSupported},
+		{"client one minor behind — staged rollout", "1.26.0", "1.27.0", SkewSupported},
+
+		{"two minors apart is outside the window", "1.29.0", "1.27.0", SkewUnsupported},
+		{"two minors behind is outside the window", "1.25.0", "1.27.0", SkewUnsupported},
+		{"different major is never supported", "2.0.0", "1.27.0", SkewUnsupported},
+		{"different major, adjacent minor number", "2.27.0", "1.27.0", SkewUnsupported},
+
+		{"dev build client", "dev", "1.27.0", SkewUnknown},
+		{"empty server (control plane unreachable)", "1.27.0", "", SkewUnknown},
+		{"both unparsable", "", "", SkewUnknown},
+		{"major only is not enough to judge a minor skew", "1", "1.27.0", SkewUnknown},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, detail := CheckVersionSkew(tc.client, tc.server)
+			assert.Equal(t, tc.want, got)
+			if tc.want == SkewSame {
+				assert.Empty(t, detail, "an in-sync pair must produce no message to print")
+			} else {
+				assert.NotEmpty(t, detail, "every non-trivial verdict must explain itself to the user")
+			}
+		})
+	}
+}
+
+// TestCheckVersionSkewIsSymmetric pins that the rule judges DISTANCE, not
+// direction: a client one minor ahead of the cluster and one minor behind it
+// are equally supported. Only the message differs.
+func TestCheckVersionSkewIsSymmetric(t *testing.T) {
+	t.Parallel()
+	for _, pair := range [][2]string{
+		{"1.28.0", "1.27.0"},
+		{"1.29.0", "1.27.0"},
+		{"1.27.0", "1.27.0"},
+	} {
+		fwd, _ := CheckVersionSkew(pair[0], pair[1])
+		rev, _ := CheckVersionSkew(pair[1], pair[0])
+		assert.Equalf(t, fwd, rev, "verdict must not depend on which side is newer (%s vs %s)", pair[0], pair[1])
+	}
+}
+
+// TestSupportedMinorSkewMatchesPolicy guards the coupling between this constant
+// and RELEASES.md. Two supported minor lines means adjacent minors are in the
+// window and two-apart is not; if someone widens the support window without
+// touching the constant (or the reverse), one of these fails.
+func TestSupportedMinorSkewMatchesPolicy(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, 1, SupportedMinorSkew,
+		"RELEASES.md promises the latest TWO minor lines, which is a skew of exactly 1")
+
+	adjacent, _ := CheckVersionSkew("1.28.0", "1.27.0")
+	assert.Equal(t, SkewSupported, adjacent, "two supported lines must make adjacent minors supported")
+
+	twoApart, _ := CheckVersionSkew("1.29.0", "1.27.0")
+	assert.Equal(t, SkewUnsupported, twoApart, "two supported lines must make a two-minor gap unsupported")
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -453,3 +453,76 @@ func TestStateSvcChart(t *testing.T) {
 		assert.Nil(t, find(docs, "Deployment", svcinfo.SvcStateSvc))
 	})
 }
+
+// verbsFor returns the verbs a rendered Role/ClusterRole grants for a resource
+// in an API group, merged across every rule that mentions it.
+func verbsFor(doc map[string]any, apiGroup, resource string) map[string]bool {
+	out := map[string]bool{}
+	rules, _ := doc["rules"].([]any)
+	for _, r := range rules {
+		rule, _ := r.(map[string]any)
+		groups, _ := rule["apiGroups"].([]any)
+		hasGroup := false
+		for _, g := range groups {
+			if s, _ := g.(string); s == apiGroup {
+				hasGroup = true
+			}
+		}
+		if !hasGroup {
+			continue
+		}
+		resources, _ := rule["resources"].([]any)
+		hasResource := false
+		for _, res := range resources {
+			if s, _ := res.(string); s == resource {
+				hasResource = true
+			}
+		}
+		if !hasResource {
+			continue
+		}
+		verbs, _ := rule["verbs"].([]any)
+		for _, v := range verbs {
+			if s, _ := v.(string); s != "" {
+				out[s] = true
+			}
+		}
+	}
+	return out
+}
+
+// TestBuildermgrCanRollBuilderDeployments guards an RBAC gap that fails CLOSED
+// and silently: buildermgr rolls a builder Deployment whose pod template has
+// drifted from the chart (RFC-0028 phase 3, #776), which needs `update` on
+// deployments. The Role historically granted only list/create/delete.
+//
+// Nothing else would catch this. The reconciler's unit tests use a fake
+// clientset, which does not enforce RBAC, so they pass either way; in a real
+// cluster the drift is detected, the update is denied, and the builder keeps
+// running the stale image — the exact symptom the feature exists to remove.
+func TestBuildermgrCanRollBuilderDeployments(t *testing.T) {
+	docs := render(t)
+
+	var found bool
+	for _, doc := range docs {
+		kind, _ := doc["kind"].(string)
+		if kind != "Role" && kind != "ClusterRole" {
+			continue
+		}
+		meta, _ := doc["metadata"].(map[string]any)
+		name, _ := meta["name"].(string)
+		if !strings.Contains(name, "buildermgr") {
+			continue
+		}
+		verbs := verbsFor(doc, "apps", "deployments")
+		if len(verbs) == 0 {
+			continue
+		}
+		found = true
+		for _, want := range []string{"list", "create", "update", "delete"} {
+			assert.Truef(t, verbs[want],
+				"%s %q must grant %q on apps/deployments (have %v)", kind, name, want, verbs)
+		}
+	}
+	require.True(t, found, "no buildermgr Role/ClusterRole granting apps/deployments was rendered")
+}


### PR DESCRIPTION
Part of RFC-0028 phase 3 (epic #3625). Closes the half of #776 that the Environment ResourceVersion cannot cover.

## The bug

Most of what a builder pod is made of comes from the **chart**, not the Environment CR — the fetcher image, the builder image-pull policy, the pod-spec patch. None of those touch the Environment, so its ResourceVersion is unchanged, the RV-keyed name and selector still match, and `ensureBuilder` found a Deployment and did nothing. The builder kept running the previous image until someone deleted the Deployment by hand.

Deleting the *pod* did not help either: the ReplicaSet recreated it from the same stale template.

## The fix

The reconciler stamps a hash of the pod template it applied and compares it on every pass, updating in place when they differ and letting Kubernetes roll the pods. **In place, not recreated** — the Deployment is named `<env>-<rv>`, which `buildPackage` resolves as a DNS hostname, so renaming would break in-flight builds.

Deployments predating the annotation have an empty hash and so roll exactly once on the first reconcile after upgrade, then match.

### Why the hash is over a canonicalised template

`MergePodSpec` round-trips containers through a `map[string]*Container` and emits them in map-iteration order, which Go randomises per range — so two calls with identical inputs produce differently ordered slices *within one process*. Hashing that directly yields a different hash nearly every call, and the reconciler would detect drift on every pass and roll the builder forever: the exact churn this feature exists to prevent, inverted. Any environment setting `Builder.PodSpec` hits it.

The template is therefore sorted by name (containers, init containers, volumes, and each container's env vars and volume mounts) before marshalling. Sorting env vars also covers the fetcher sidecar's OTEL block, built from `os.Environ()`.

Hashing *our desired object* rather than diffing the live PodSpec is deliberate: the apiserver defaults dozens of fields on write, so a live-vs-desired comparison is never equal.

## RBAC

buildermgr's Role granted `list`/`create`/`delete` on `apps/deployments` — **not `update`**. Without it the drift is detected and the write denied, so the feature would have shipped inert in every install. The reconciler's unit tests use a fake clientset, which does not enforce RBAC, so nothing existing could have caught it; the guard therefore lives with the chart-vs-code drift tests.

## Skew reporting

`fission check` compared client and server versions as **strings**. That fails on any patch difference — which RELEASES.md explicitly permits — and during every staged rollout, since the CLI and cluster are upgraded at different moments. A check that goes red during normal operation is one users learn to ignore.

It now judges against the published window: two supported minor lines, so adjacent minors are supported and further apart is not; a differing major never is. Supported skew and unparsable versions (dev builds, unreachable control plane) **warn** rather than fail. `SupportedMinorSkew` is coupled to the policy by a test.

## Testing

Every change is mutation-verified — reverting it fails a specific named test:

| change | guarded by |
|---|---|
| drift detection | `TestEnvironmentReconcileRollsDriftedBuilder` |
| no churn when undrifted | `TestEnvironmentReconcileDoesNotRollAnUndriftedBuilder` (counts writes via reactor — the fake clientset does not bump ResourceVersion, so an RV comparison passes even when the code rewrites every pass) |
| hash stability | `TestBuilderSpecHashIsStableAcrossCalls`, `TestEnvironmentReconcileDoesNotRollWhenPodSpecPatched` |
| RBAC verb | `TestBuildermgrCanRollBuilderDeployments` |
| skew window | `TestCheckVersionSkew`, `TestSupportedMinorSkewMatchesPolicy` |

Code, security, and quality reviews run; the hash instability and the RBAC gap were both found by review, not by my tests.