### PR TITLE
RFC-0029: support internalAuth.existingSecret for the auth master

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -155,19 +155,38 @@ secret into a Fission control-plane container. See the design at docs/internal-a
 secret is mounted with optional: true so rotation can drop it without
 forcing the chart to render an empty key.
 */}}
+{{/*
+fission.internalAuthSecretName is the Secret holding the internal-auth HMAC
+master: the operator's pre-created one when internalAuth.existingSecret is set,
+otherwise the chart-generated "fission-internal-auth".
+
+Every consumer must go through this. The Go side resolves the same name from
+FISSION_INTERNAL_AUTH_SECRET_NAME (fv1.InternalAuthSecretName), and a
+disagreement between the two does not fail loudly — the secretKeyRef is
+optional, so pods start with the env var absent and every archive fetch and
+builder upload 401s with nothing naming the Secret as the cause.
+*/}}
+{{- define "fission.internalAuthSecretName" -}}
+{{- default "fission-internal-auth" .Values.internalAuth.existingSecret -}}
+{{- end -}}
+
 {{- define "internalAuth.envs" }}
 {{- if .Values.internalAuth.enabled }}
 - name: FISSION_INTERNAL_AUTH_SECRET
   valueFrom:
     secretKeyRef:
-      name: fission-internal-auth
+      name: {{ include "fission.internalAuthSecretName" . }}
       key: secret
 - name: FISSION_INTERNAL_AUTH_SECRET_OLD
   valueFrom:
     secretKeyRef:
-      name: fission-internal-auth
+      name: {{ include "fission.internalAuthSecretName" . }}
       key: oldSecret
       optional: true
+# The Go side (fetcher pod-spec builder, storagesvc client) resolves the same
+# name from this env var; see fv1.InternalAuthSecretName.
+- name: FISSION_INTERNAL_AUTH_SECRET_NAME
+  value: {{ include "fission.internalAuthSecretName" . | quote }}
 {{- end }}
 {{- end }}
 
@@ -371,7 +390,7 @@ Empty when nothing needs adopting, which makes the whole migration render away.
 {{- define "fission.adoptSecretNames" -}}
 {{- $names := list -}}
 {{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) -}}
-{{- $names = append $names "fission-internal-auth" -}}
+{{- $names = append $names (include "fission.internalAuthSecretName" .) -}}
 {{- end -}}
 {{- if and .Values.authentication.enabled (not .Values.authentication.existingSecret) -}}
 {{- $names = append $names "router" -}}

--- a/charts/fission-all/templates/internal-auth-secret.yaml
+++ b/charts/fission-all/templates/internal-auth-secret.yaml
@@ -11,7 +11,10 @@ Secret before Helm computes its deletion set. Without that, Helm would prune
 the master it is no longer rendering and wedge every control-plane pod in
 CreateContainerConfigError.
 */ -}}
-{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) }}
+{{- /* autoGenerate hands generation to the pre-upgrade hook, so the template
+       must stop rendering the Secret — the retention hook keeps the live value
+       from being pruned when it does. */ -}}
+{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) (not (and .Values.internalAuth.autoGenerate (not .Values.internalAuth.secret))) }}
 {{- /*
 fission-internal-auth holds the shared HMAC secret used by Fission's
 internal application-layer auth (the design at docs/internal-auth/00-design.md).

--- a/charts/fission-all/templates/internal-auth-secret.yaml
+++ b/charts/fission-all/templates/internal-auth-secret.yaml
@@ -1,4 +1,17 @@
-{{- if .Values.internalAuth.enabled }}
+{{- /*
+existingSecret hands the master to the operator: the chart renders NOTHING and
+every consumer reads the named Secret instead. This is the supported path for
+GitOps renderers, where `lookup` returns empty under `helm template` and the
+preservation below cannot work, so a generated value would be re-minted on
+every sync and break every pod signed with the previous one.
+
+Upgrading an existing install into this mode is safe ONLY because the
+pre-upgrade retention hook stamps helm.sh/resource-policy=keep on the live
+Secret before Helm computes its deletion set. Without that, Helm would prune
+the master it is no longer rendering and wedge every control-plane pod in
+CreateContainerConfigError.
+*/ -}}
+{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) }}
 {{- /*
 fission-internal-auth holds the shared HMAC secret used by Fission's
 internal application-layer auth (the design at docs/internal-auth/00-design.md).
@@ -61,7 +74,7 @@ rotation window) and re-run helm upgrade.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: fission-internal-auth
+  name: {{ include "fission.internalAuthSecretName" $ }}
   namespace: {{ $ns }}
   labels:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"

--- a/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
@@ -47,6 +47,12 @@ spec:
         - name: ADOPT_SECRET_NAMESPACES
           value: {{ include "fission.adoptSecretNamespaces" $ | quote }}
         {{- end }}
+{{- if and .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) }}
+        - name: GENERATE_AUTH_SECRET
+          value: {{ include "fission.internalAuthSecretName" . | quote }}
+        - name: GENERATE_AUTH_SECRET_NAMESPACES
+          value: {{ include "fission.adoptSecretNamespaces" . | quote }}
+{{- end }}
         {{- include "fission.podNamespaceEnv" . | nindent 8 }}
         - name: CRDS_MODE
           value: {{ include "fission.crdsMode" . | quote }}

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -95,11 +95,35 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
     helm.sh/hook-weight: "-2"
 rules:
+# get IS name-scoped: a GET carries the name in the request path, so the
+# authorizer matches it against resourceNames and this read reaches the
+# master and nothing else.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "create"]
+  verbs: ["get"]
   resourceNames:
   - {{ include "fission.internalAuthSecretName" $ }}
+# create CANNOT be name-scoped, and pairing it with resourceNames does not
+# tighten the grant — it voids it. A POST carries the object name in the
+# BODY, not the path, so the authorizer sees an empty name, a
+# resourceNames-fenced rule never matches, and generation fails Forbidden.
+# The grant would be inert and the feature dead on arrival.
+#
+# This is the exact inverse of the CRD ClusterRole next door, which DOES
+# keep its resourceNames scope on create: server-side apply PATCHes a
+# named path, so the create authorization it additionally needs is
+# evaluated against that name. createIfAbsent uses a plain Create, not an
+# apply, deliberately — apply would take ownership of .data and rotate the
+# master, which is the one thing this hook must never do.
+#
+# So the residual grant is "create A Secret in this one namespace". It
+# cannot read, patch or delete any existing Secret, and create fails
+# AlreadyExists rather than overwriting the master. That is the floor RBAC
+# allows here, and it is bounded by the hook ServiceAccount being deleted
+# with the hook.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -64,3 +64,59 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}
+
+{{- /*
+Generation grant (see cmd/preupgradechecks/generateauth.go), SEPARATE from the
+adoption grant above on purpose.
+
+Adoption is patch-only and deliberately cannot read: a grant that cannot read
+the HMAC master, the JWT signing key or the webhook TLS key is worth far more
+than one that can. Generation genuinely needs `get` — it must tell "already
+provisioned" from "absent", and without that a re-run would mint a new master
+and rotate every derived key with no dual-accept window. Widening the adoption
+Role would have handed that read over all three Secrets; a separate Role fenced
+to the master ALONE confines it to the one object that needs it.
+
+Rendered only when the chart is actually generating, and only in the namespaces
+the master is replicated into — under dynamic/cluster tenancy the release
+namespace alone, because tenant namespaces receive controller-owned derived keys
+and the master must never land there.
+*/}}
+{{- if and .Values.preUpgradeChecks.enabled .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) }}
+{{- range $ns := splitList " " (include "fission.adoptSecretNamespaces" $) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ $.Release.Name }}-preupgrade-authgen"
+  namespace: {{ $ns }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+    helm.sh/hook-weight: "-2"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create"]
+  resourceNames:
+  - {{ include "fission.internalAuthSecretName" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $.Release.Name }}-preupgrade-authgen"
+  namespace: {{ $ns }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+    helm.sh/hook-weight: "-2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ $.Release.Name }}-preupgrade-authgen"
+subjects:
+- kind: ServiceAccount
+  name: fission-preupgrade
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1608,4 +1608,27 @@ internalAuth:
   enabled: true
   # secret: "" — auto-generated on first install; preserved on upgrade.
   # oldSecret: "" — set during rotation; accepted by the verifier alongside `secret`.
+  ## existingSecret names a Secret you create yourself, holding key `secret`
+  ## (and optionally `oldSecret`). When set the chart renders NO master Secret
+  ## and every component reads yours instead.
+  ##
+  ## Recommended for GitOps renderers (Argo CD, Flux). Those run `helm
+  ## template`, where the chart's `lookup`-based preservation of a generated
+  ## value cannot work — so a generated master would be re-minted on every
+  ## sync, breaking every pod signed with the previous one.
+  ##
+  ## YOU MUST CREATE IT IN EVERY NAMESPACE FISSION RUNS PODS IN — the release
+  ## namespace plus defaultNamespace plus each additionalFissionNamespaces.
+  ## kubelet cannot resolve a cross-namespace secretKeyRef, so a single copy in
+  ## the release namespace leaves builder and function pods without the key:
+  ## the mount is optional, so those pods START and then 401 on every archive
+  ## fetch and builder upload. (Under dynamic/cluster tenancy only the release
+  ## namespace is needed; tenant namespaces get controller-owned derived keys.)
+  ##
+  ## Switching an existing install to this is safe: the pre-upgrade retention
+  ## hook stamps helm.sh/resource-policy=keep on the chart-generated Secret
+  ## before Helm computes its deletion set, so the value it stops rendering is
+  ## not pruned.
+  ##
+  existingSecret: ""
 

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1608,6 +1608,24 @@ internalAuth:
   enabled: true
   # secret: "" — auto-generated on first install; preserved on upgrade.
   # oldSecret: "" — set during rotation; accepted by the verifier alongside `secret`.
+  ## autoGenerate moves master generation OUT of the chart template and into
+  ## the pre-install/pre-upgrade hook, which creates it only if absent.
+  ##
+  ## Why: the template preserves a generated value across upgrades with
+  ## `lookup`, and `lookup` returns EMPTY under `helm template`. A GitOps
+  ## renderer therefore re-mints the master on every sync, breaking every pod
+  ## signed with the previous one. An in-cluster create-if-absent survives any
+  ## renderer. Prefer existingSecret if you would rather own the value.
+  ##
+  ## Default false, so existing installs are untouched.
+  ##
+  ## The hook writes the master into the same namespaces the template would
+  ## have: under static tenancy the release namespace plus defaultNamespace
+  ## plus each additionalFissionNamespaces; under dynamic/cluster tenancy the
+  ## release namespace ONLY, since tenant namespaces get controller-owned
+  ## derived keys and the master must never land there.
+  ##
+  autoGenerate: false
   ## existingSecret names a Secret you create yourself, holding key `secret`
   ## (and optionally `oldSecret`). When set the chart renders NO master Secret
   ## and every component reads yours instead.

--- a/cmd/preupgradechecks/generateauth.go
+++ b/cmd/preupgradechecks/generateauth.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// authSecretKey is the data key holding the HMAC master.
+	authSecretKey = "secret"
+	// authMasterBytes is the generated master's length before base64. 32 bytes
+	// matches what the chart's randAlphaNum 32 produced, and exceeds the
+	// minimum the signer enforces.
+	authMasterBytes = 32
+)
+
+// GenerateAuthSecret creates the internal-auth master where it is missing,
+// using ONE value across every namespace it writes.
+//
+// Why this exists (RFC-0029 §10): the chart generated the master in the
+// templating layer, preserved across upgrades by `lookup`. Under a GitOps
+// renderer `lookup` returns empty — Argo and Flux run `helm template` — so the
+// value was re-minted on every sync, breaking every pod signed with the
+// previous one. Generation has to be an idempotent in-cluster action instead.
+//
+// The namespace set is supplied by the caller, NOT derived here, and that is
+// deliberate: it is tenancy-dependent, and the chart already computes it in one
+// place (fission.adoptSecretNamespaces). Under STATIC tenancy the master is
+// replicated into the release namespace plus defaultNamespace plus each
+// additionalFissionNamespaces, because kubelet cannot resolve a cross-namespace
+// secretKeyRef. Under DYNAMIC or CLUSTER tenancy it goes to the release
+// namespace ONLY — tenant namespaces receive controller-owned derived keys and
+// the master must never land there, which is the whole isolation end state.
+// Duplicating that rule in Go would be a second source of truth for a
+// security-relevant decision.
+//
+// Idempotent by construction, which matters because this runs on every install
+// AND every upgrade: an existing master anywhere in the set is reused rather
+// than regenerated, and a namespace that already has it is left untouched. A
+// regenerated master would rotate every derived key with no dual-accept window.
+func GenerateAuthSecret(ctx context.Context, client kubernetes.Interface, logger logr.Logger, namespaces []string, secretName string) error {
+	if len(namespaces) == 0 || secretName == "" {
+		return nil
+	}
+
+	// Reuse an existing value if there is one. Reading the master is what the
+	// `get` grant on this single name is for: without it a second run could not
+	// tell "already provisioned" from "absent" and would mint a new master,
+	// which is strictly worse than the read.
+	master, found, err := existingMaster(ctx, client, namespaces, secretName)
+	if err != nil {
+		return err
+	}
+	if !found {
+		master, err = newMaster()
+		if err != nil {
+			return err
+		}
+		logger.Info("generating internal-auth master", "secret", secretName)
+	}
+
+	for _, ns := range namespaces {
+		if ns == "" {
+			continue
+		}
+		created, err := createIfAbsent(ctx, client, ns, secretName, master)
+		if err != nil {
+			return err
+		}
+		if created {
+			logger.Info("created internal-auth master", "secret", secretName, "namespace", ns)
+		}
+	}
+	return nil
+}
+
+// existingMaster returns the first master value already present in the set.
+// Namespaces are checked in order, so the release namespace (first) wins if
+// copies ever disagree.
+func existingMaster(ctx context.Context, client kubernetes.Interface, namespaces []string, secretName string) ([]byte, bool, error) {
+	for _, ns := range namespaces {
+		if ns == "" {
+			continue
+		}
+		s, err := client.CoreV1().Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return nil, false, fmt.Errorf("read %s/%s: %w", ns, secretName, err)
+		}
+		if v, ok := s.Data[authSecretKey]; ok && len(v) > 0 {
+			return v, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func newMaster() ([]byte, error) {
+	raw := make([]byte, authMasterBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return nil, fmt.Errorf("generate internal-auth master: %w", err)
+	}
+	// base64 so the value is safe in an env var and in `kubectl get -o yaml`
+	// round-trips, matching the shape the chart produced.
+	out := make([]byte, base64.RawStdEncoding.EncodedLen(len(raw)))
+	base64.RawStdEncoding.Encode(out, raw)
+	return out, nil
+}
+
+// createIfAbsent creates the Secret and reports whether it did. An
+// AlreadyExists from a concurrent starter is success, not an error: two hook
+// Jobs racing must converge, not fail the install.
+func createIfAbsent(ctx context.Context, client kubernetes.Interface, namespace, name string, master []byte) (bool, error) {
+	_, err := client.CoreV1().Secrets(namespace).Create(ctx, &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				// Marks the object as Helm-managed so a later
+				// internalAuth.secret rotation can adopt it rather than
+				// failing on an unowned object.
+				"app.kubernetes.io/managed-by": "Helm",
+				"application":                  "fission-internal-auth",
+			},
+		},
+		Type: apiv1.SecretTypeOpaque,
+		Data: map[string][]byte{authSecretKey: master},
+	}, metav1.CreateOptions{})
+	switch {
+	case err == nil:
+		return true, nil
+	case k8serrors.IsAlreadyExists(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("create %s/%s: %w", namespace, name, err)
+	}
+}

--- a/cmd/preupgradechecks/generateauth_test.go
+++ b/cmd/preupgradechecks/generateauth_test.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+const testAuthSecret = "fission-internal-auth"
+
+func masterIn(t *testing.T, cs kubernetes.Interface, ns string) []byte {
+	t.Helper()
+	s, err := cs.CoreV1().Secrets(ns).Get(context.Background(), testAuthSecret, metav1.GetOptions{})
+	require.NoErrorf(t, err, "expected the master in %q", ns)
+	return s.Data[authSecretKey]
+}
+
+func TestGenerateAuthSecret(t *testing.T) {
+	t.Parallel()
+	logger := loggerfactory.GetLogger()
+
+	// STATIC tenancy: the master is replicated because kubelet cannot resolve a
+	// cross-namespace secretKeyRef, so builder and function pods in
+	// defaultNamespace need a local copy. Every copy must hold the SAME value —
+	// they are one HMAC master, not three.
+	t.Run("static tenancy: one value across every namespace", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		nss := []string{"fission", "default", "fission-fn"}
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nss, testAuthSecret))
+
+		want := masterIn(t, cs, "fission")
+		assert.NotEmpty(t, want)
+		for _, ns := range nss[1:] {
+			assert.Equalf(t, want, masterIn(t, cs, ns),
+				"every namespace must carry the same master; %q differs", ns)
+		}
+	})
+
+	// DYNAMIC/CLUSTER tenancy: the chart passes ONLY the release namespace,
+	// because tenant namespaces get controller-owned derived keys and the
+	// master must never land there. This asserts the hook writes exactly what
+	// it is given and invents no fan-out of its own.
+	t.Run("dynamic tenancy: the master reaches only the namespace it was given", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission"}, testAuthSecret))
+
+		assert.NotEmpty(t, masterIn(t, cs, "fission"))
+		for _, tenant := range []string{"default", "tenant-a"} {
+			_, err := cs.CoreV1().Secrets(tenant).Get(t.Context(), testAuthSecret, metav1.GetOptions{})
+			assert.Errorf(t, err, "the master must NOT appear in %q under dynamic tenancy", tenant)
+		}
+	})
+
+	// The hook runs on every install AND every upgrade. Regenerating would
+	// rotate every derived key with no dual-accept window, so a second run must
+	// change nothing.
+	t.Run("re-running preserves the existing master", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		nss := []string{"fission", "default"}
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nss, testAuthSecret))
+		first := masterIn(t, cs, "fission")
+
+		for range 3 {
+			require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nss, testAuthSecret))
+		}
+		assert.Equal(t, first, masterIn(t, cs, "fission"),
+			"re-running must not re-mint the master: that rotates every derived key with no dual-accept window")
+		assert.Equal(t, first, masterIn(t, cs, "default"))
+	})
+
+	// Upgrade path: an install predating this hook already has the master in
+	// the release namespace. Adding a namespace must copy THAT value, not a new
+	// one, or the new namespace's pods sign with a key nobody verifies.
+	t.Run("an existing master is reused when filling a new namespace", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte("already-provisioned-master-value")
+		cs := fake.NewClientset(&apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: "fission"},
+			Data:       map[string][]byte{authSecretKey: existing},
+		})
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission", "default"}, testAuthSecret))
+
+		assert.Equal(t, existing, masterIn(t, cs, "fission"), "the pre-existing master must be left alone")
+		assert.Equal(t, existing, masterIn(t, cs, "default"), "the new copy must carry the SAME value, not a fresh one")
+	})
+
+	// A copy that exists only outside the release namespace is still the
+	// install's master; ignoring it would mint a second one.
+	t.Run("a master found in a later namespace is reused", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte("master-living-in-default")
+		cs := fake.NewClientset(&apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: "default"},
+			Data:       map[string][]byte{authSecretKey: existing},
+		})
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission", "default"}, testAuthSecret))
+		assert.Equal(t, existing, masterIn(t, cs, "fission"))
+	})
+
+	t.Run("no namespaces or no name is a no-op", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nil, testAuthSecret))
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission"}, ""))
+		list, err := cs.CoreV1().Secrets(metav1.NamespaceAll).List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, list.Items)
+	})
+
+	t.Run("the generated master is long enough to be a key", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission"}, testAuthSecret))
+		assert.GreaterOrEqual(t, len(masterIn(t, cs, "fission")), 32,
+			"a short master would weaken every derived key")
+	})
+
+	t.Run("two runs on empty clusters do not produce the same master", func(t *testing.T) {
+		t.Parallel()
+		a, b := fake.NewClientset(), fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), a, logger, []string{"fission"}, testAuthSecret))
+		require.NoError(t, GenerateAuthSecret(t.Context(), b, logger, []string{"fission"}, testAuthSecret))
+		assert.NotEqual(t, masterIn(t, a, "fission"), masterIn(t, b, "fission"),
+			"the master must come from a CSPRNG, not a fixed or time-derived value")
+	})
+}

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -53,6 +53,27 @@ func main() {
 		}
 	}
 
+	// Generate the internal-auth master in-cluster when the chart asks for it
+	// (internalAuth.autoGenerate). Generating here rather than in the template
+	// is what makes the value survive a GitOps renderer: `lookup` returns empty
+	// under `helm template`, so a templated value is re-minted on every sync.
+	//
+	// GENERATE_AUTH_SECRET_NAMESPACES is computed by the chart, not derived
+	// here, because the set is tenancy-dependent — release namespace only under
+	// dynamic/cluster tenancy, plus the replicated namespaces under static.
+	// See GenerateAuthSecret.
+	if name := os.Getenv("GENERATE_AUTH_SECRET"); name != "" {
+		namespaces := adoptSecretNames(os.Getenv("GENERATE_AUTH_SECRET_NAMESPACES"))
+		if len(namespaces) == 0 {
+			logger.Error(nil, "GENERATE_AUTH_SECRET set but GENERATE_AUTH_SECRET_NAMESPACES is empty; refusing to guess which namespaces need the master")
+			os.Exit(1)
+		}
+		if err := GenerateAuthSecret(ctx, preupgradeClient.k8sClient, logger, namespaces, name); err != nil {
+			logger.Error(err, "failed to provision the internal-auth master; control-plane pods would start unsigned")
+			os.Exit(1)
+		}
+	}
+
 	if mode := os.Getenv("CRDS_MODE"); mode == crdsModeHook {
 		// Adoption of hand-applied CRDs needs --force-conflicts: they carry
 		// managedFields owned by kubectl-create as an Update operation.

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -24,6 +24,23 @@ const (
 )
 
 const (
+	// DefaultInternalAuthSecret is the chart's master-bearing Secret. It is the
+	// DEFAULT, not a fixed fact: an operator may point the chart at a
+	// pre-created Secret instead (internalAuth.existingSecret), which is the
+	// supported path for GitOps renderers, where the chart's lookup-based
+	// preservation of a generated value cannot work.
+	//
+	// Read it through InternalAuthSecretName rather than using this constant
+	// directly. Two components resolve this name independently — the fetcher
+	// pod-spec builder and the storagesvc client — and if they disagree the
+	// failure is a 401 on every archive fetch and builder upload, with nothing
+	// pointing at the name as the cause.
+	DefaultInternalAuthSecret = "fission-internal-auth"
+
+	// InternalAuthSecretNameEnv overrides DefaultInternalAuthSecret. The chart
+	// sets it on every component that resolves the master.
+	InternalAuthSecretNameEnv = "FISSION_INTERNAL_AUTH_SECRET_NAME"
+
 	// TenantAuthKeysSecret is the controller-owned Secret (one per tenant
 	// namespace) holding that namespace's derived HMAC keys. It is deliberately
 	// a DIFFERENT name from the chart's master-bearing "fission-internal-auth":

--- a/pkg/apis/core/v1/internalauth.go
+++ b/pkg/apis/core/v1/internalauth.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import "os"
+
+// InternalAuthSecretName is the name of the Secret holding the internal-auth
+// HMAC master for this install.
+//
+// It exists so the name is resolved in exactly ONE place. The fetcher pod-spec
+// builder and the storagesvc client both need it, and a disagreement between
+// them does not fail loudly: the fetcher's secretKeyRef is marked optional, so
+// the pod starts, the env var is simply absent, and every archive fetch and
+// builder upload 401s with nothing naming the Secret as the cause.
+//
+// The default is the chart-generated name. internalAuth.existingSecret points
+// an install at a pre-created Secret instead — the supported path for GitOps
+// renderers, where the chart cannot preserve a generated value across a
+// `helm template` sync.
+func InternalAuthSecretName() string {
+	if name := os.Getenv(InternalAuthSecretNameEnv); name != "" {
+		return name
+	}
+	return DefaultInternalAuthSecret
+}

--- a/pkg/apis/core/v1/internalauth_test.go
+++ b/pkg/apis/core/v1/internalauth_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInternalAuthSecretName pins the resolution the fetcher pod-spec builder
+// and the storagesvc client both depend on.
+//
+// They must agree. A disagreement does not fail loudly: the fetcher's
+// secretKeyRef is optional, so the pod starts with the env var simply absent,
+// and every archive fetch and builder upload 401s with nothing naming the
+// Secret as the cause.
+func TestInternalAuthSecretName(t *testing.T) {
+	t.Run("defaults to the chart-generated name", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretNameEnv, "")
+		assert.Equal(t, DefaultInternalAuthSecret, InternalAuthSecretName())
+	})
+
+	t.Run("an override wins", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretNameEnv, "my-preexisting-secret")
+		assert.Equal(t, "my-preexisting-secret", InternalAuthSecretName(),
+			"internalAuth.existingSecret must reach every component that resolves the master")
+	})
+
+	t.Run("an empty override falls back rather than resolving to nothing", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretNameEnv, "")
+		assert.NotEmpty(t, InternalAuthSecretName(),
+			"an unset or blank override must not yield an empty Secret name")
+	})
+}

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 // The storage key stays optional even then: storagesvc dual-accepts a
 // master-derived signature, so an unprovisioned fetcher degrades gracefully.
 func internalAuthEnvVars(namespace string) []apiv1.EnvVar {
-	const chartSecret = "fission-internal-auth"
+	chartSecret := fv1.InternalAuthSecretName()
 	keysSecret := fv1.TenantAuthKeysSecret
 
 	// Require the fetcher key only where it is guaranteed to be provisioned (a

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 // internalAuthEnvVars returns the env-var entries that mount the
-// HMAC-shared-secret values from the chart-installed Secret/fission-internal-auth
+// HMAC-shared-secret values from the internal-auth master Secret
 // onto the fetcher sidecar container. Every key is marked optional so a
 // pod still admits when the chart's internalAuth is disabled.
 //
@@ -70,7 +70,9 @@ type Config struct {
 // The storage key stays optional even then: storagesvc dual-accepts a
 // master-derived signature, so an unprovisioned fetcher degrades gracefully.
 func internalAuthEnvVars(namespace string) []apiv1.EnvVar {
-	chartSecret := fv1.InternalAuthSecretName()
+	// Not necessarily chart-generated: internalAuth.existingSecret points this
+	// at an operator-supplied Secret instead.
+	masterSecret := fv1.InternalAuthSecretName()
 	keysSecret := fv1.TenantAuthKeysSecret
 
 	// Require the fetcher key only where it is guaranteed to be provisioned (a
@@ -80,8 +82,8 @@ func internalAuthEnvVars(namespace string) []apiv1.EnvVar {
 	fetcherKeyRequired := utils.PerNamespaceKeyRequired(namespace)
 
 	return []apiv1.EnvVar{
-		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET", chartSecret, "secret", true),
-		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET_OLD", chartSecret, "oldSecret", true),
+		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET", masterSecret, "secret", true),
+		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET_OLD", masterSecret, "oldSecret", true),
 		secretKeyEnv("FISSION_FETCHER_KEY", keysSecret, fv1.TenantAuthFetcherKey, !fetcherKeyRequired),
 		secretKeyEnv("FISSION_FETCHER_KEY_OLD", keysSecret, "fetcherKeyOld", true),
 		secretKeyEnv("FISSION_STORAGE_KEY", keysSecret, fv1.TenantAuthStorageKey, true),

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -24,14 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/storagesvc"
 )
-
-// internalAuthSecretName is the chart-installed Secret that holds the
-// shared HMAC key used for internal control-plane authentication. The
-// chart's name is fixed; see charts/fission-all/templates/internal-auth-secret.yaml.
-const internalAuthSecretName = "fission-internal-auth"
 
 // internalAuthSecretKey is the data key inside that Secret.
 const internalAuthSecretKey = "secret"
@@ -146,7 +142,7 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	if kubeClient == nil {
 		return nil, nil
 	}
-	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, internalAuthSecretName, metav1.GetOptions{})
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, fv1.InternalAuthSecretName(), metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -156,7 +152,7 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	value, ok := secret.Data[internalAuthSecretKey]
 	if !ok || len(value) == 0 {
 		return nil, fmt.Errorf("secret %s/%s exists but has no %q key with a non-empty value; either the chart's internalAuth materialisation has been overridden or the Secret was hand-authored",
-			namespace, internalAuthSecretName, internalAuthSecretKey)
+			namespace, fv1.InternalAuthSecretName(), internalAuthSecretKey)
 	}
 	return value, nil
 }

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -142,7 +142,8 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	if kubeClient == nil {
 		return nil, nil
 	}
-	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, fv1.InternalAuthSecretName(), metav1.GetOptions{})
+	secretName := fv1.InternalAuthSecretName()
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -152,7 +153,7 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	value, ok := secret.Data[internalAuthSecretKey]
 	if !ok || len(value) == 0 {
 		return nil, fmt.Errorf("secret %s/%s exists but has no %q key with a non-empty value; either the chart's internalAuth materialisation has been overridden or the Secret was hand-authored",
-			namespace, fv1.InternalAuthSecretName(), internalAuthSecretKey)
+			namespace, secretName, internalAuthSecretKey)
 	}
 	return value, nil
 }

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -453,3 +453,118 @@ func TestStateSvcChart(t *testing.T) {
 		assert.Nil(t, find(docs, "Deployment", svcinfo.SvcStateSvc))
 	})
 }
+
+// TestInternalAuthExistingSecret pins RFC-0029's `internalAuth.existingSecret`
+// contract, whose failure mode is silent.
+//
+// Every consumer must resolve ONE name. The secretKeyRef is mounted optional so
+// rotation can drop a key without forcing an empty render — which also means a
+// pod whose reference points at a Secret that does not exist starts happily
+// with the env var absent, and then 401s on every archive fetch and builder
+// upload with nothing naming the Secret as the cause.
+//
+// The Go side resolves the same name from FISSION_INTERNAL_AUTH_SECRET_NAME
+// (fv1.InternalAuthSecretName), so the chart must set it to whatever it wired
+// into the secretKeyRefs.
+func TestInternalAuthExistingSecret(t *testing.T) {
+	const defaultName = "fission-internal-auth"
+
+	t.Run("default: the chart renders the master and points at it", func(t *testing.T) {
+		docs := render(t)
+		assert.Positive(t, countByKindName(docs, "Secret", defaultName),
+			"with no existingSecret the chart must generate the master itself")
+		for _, name := range internalAuthEnvNames(docs) {
+			assert.Equal(t, defaultName, name)
+		}
+	})
+
+	t.Run("existingSecret: the chart renders no master and points at theirs", func(t *testing.T) {
+		docs := render(t, "--set", "internalAuth.existingSecret=my-master")
+		assert.Zero(t, countByKindName(docs, "Secret", defaultName),
+			"the chart must not generate a master when the operator supplies one")
+		names := internalAuthEnvNames(docs)
+		require.NotEmpty(t, names, "no internal-auth secretKeyRef was rendered")
+		for _, name := range names {
+			assert.Equal(t, "my-master", name,
+				"every consumer must read the operator's Secret, not the chart's default")
+		}
+	})
+
+	// The env var is what the Go side reads. If it disagrees with the
+	// secretKeyRefs above, the two halves resolve different Secrets.
+	t.Run("the name env var matches the secretKeyRefs", func(t *testing.T) {
+		for _, tc := range []struct{ arg, want string }{
+			{"", defaultName},
+			{"my-master", "my-master"},
+		} {
+			var docs []map[string]any
+			if tc.arg == "" {
+				docs = render(t)
+			} else {
+				docs = render(t, "--set", "internalAuth.existingSecret="+tc.arg)
+			}
+			vals := envValues(docs, "FISSION_INTERNAL_AUTH_SECRET_NAME")
+			require.NotEmptyf(t, vals, "FISSION_INTERNAL_AUTH_SECRET_NAME must be set (existingSecret=%q)", tc.arg)
+			for _, v := range vals {
+				assert.Equal(t, tc.want, v)
+			}
+		}
+	})
+}
+
+// internalAuthEnvNames collects the Secret names every FISSION_INTERNAL_AUTH_SECRET
+// secretKeyRef points at, across every rendered pod template.
+func internalAuthEnvNames(docs []map[string]any) []string {
+	var out []string
+	forEachContainerEnv(docs, func(e map[string]any) {
+		name, _ := e["name"].(string)
+		if name != "FISSION_INTERNAL_AUTH_SECRET" {
+			return
+		}
+		vf, _ := e["valueFrom"].(map[string]any)
+		skr, _ := vf["secretKeyRef"].(map[string]any)
+		if n, ok := skr["name"].(string); ok {
+			out = append(out, n)
+		}
+	})
+	return out
+}
+
+// envValues collects the literal values of a named env var across every
+// rendered pod template.
+func envValues(docs []map[string]any, envName string) []string {
+	var out []string
+	forEachContainerEnv(docs, func(e map[string]any) {
+		if name, _ := e["name"].(string); name == envName {
+			if v, ok := e["value"].(string); ok {
+				out = append(out, v)
+			}
+		}
+	})
+	return out
+}
+
+// forEachContainerEnv walks every env entry of every container in every
+// rendered pod template.
+func forEachContainerEnv(docs []map[string]any, fn func(map[string]any)) {
+	for _, doc := range docs {
+		spec, _ := doc["spec"].(map[string]any)
+		tmpl, ok := spec["template"].(map[string]any)
+		if !ok {
+			continue
+		}
+		podSpec, _ := tmpl["spec"].(map[string]any)
+		for _, key := range []string{"containers", "initContainers"} {
+			cs, _ := podSpec[key].([]any)
+			for _, c := range cs {
+				cm, _ := c.(map[string]any)
+				envs, _ := cm["env"].([]any)
+				for _, e := range envs {
+					if em, ok := e.(map[string]any); ok {
+						fn(em)
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -571,3 +571,94 @@ func forEachContainerEnv(docs []map[string]any, fn func(map[string]any)) {
 		}
 	}
 }
+
+// TestInternalAuthAutoGenerate pins RFC-0029 §10's generation path, including
+// the tenancy rule that decides where the master may land.
+func TestInternalAuthAutoGenerate(t *testing.T) {
+	const master = "fission-internal-auth"
+
+	countMasterSecrets := func(docs []map[string]any) int {
+		n := 0
+		for _, d := range docs {
+			kind, _ := d["kind"].(string)
+			meta, _ := d["metadata"].(map[string]any)
+			name, _ := meta["name"].(string)
+			if kind == "Secret" && name == master {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("off by default: the template still renders the master", func(t *testing.T) {
+		docs := render(t)
+		assert.Positive(t, countMasterSecrets(docs),
+			"autoGenerate defaults off, so existing installs must be untouched")
+		assert.Zero(t, countByKindName(docs, "Role", "fission-preupgrade-authgen"),
+			"no generation means no read grant")
+	})
+
+	t.Run("on: the template stops rendering and the hook is wired", func(t *testing.T) {
+		docs := render(t, "--set", "internalAuth.autoGenerate=true")
+		assert.Zero(t, countMasterSecrets(docs),
+			"generation moves in-cluster, so the template must render no master — "+
+				"the retention hook is what stops Helm pruning the live one")
+		vals := envValues(docs, "GENERATE_AUTH_SECRET")
+		require.NotEmpty(t, vals, "the hook must be told which Secret to provision")
+		for _, v := range vals {
+			assert.Equal(t, master, v)
+		}
+	})
+
+	// The rule the whole design turns on: under dynamic/cluster tenancy the
+	// master must NOT reach tenant namespaces — they get controller-owned
+	// derived keys, and a master there would defeat the isolation end state.
+	t.Run("static tenancy fans out; dynamic does not", func(t *testing.T) {
+		static := render(t,
+			"--set", "internalAuth.autoGenerate=true",
+			"--set", "additionalFissionNamespaces={fission-fn}")
+		staticNS := envValues(static, "GENERATE_AUTH_SECRET_NAMESPACES")
+		require.NotEmpty(t, staticNS)
+		assert.Contains(t, staticNS[0], "fission-fn",
+			"static tenancy replicates the master: kubelet cannot resolve a cross-namespace secretKeyRef")
+
+		dynamic := render(t,
+			"--set", "internalAuth.autoGenerate=true",
+			"--set", "tenancy.mode=dynamic",
+			"--set", "additionalFissionNamespaces={fission-fn}")
+		dynNS := envValues(dynamic, "GENERATE_AUTH_SECRET_NAMESPACES")
+		require.NotEmpty(t, dynNS)
+		assert.NotContains(t, dynNS[0], "fission-fn",
+			"under dynamic tenancy the master must stay in the release namespace: "+
+				"tenant namespaces get controller-owned derived keys and must never hold the master")
+	})
+
+	// The read grant is the one concession this design makes; it must not widen
+	// beyond the single object that needs it.
+	t.Run("the generation grant is fenced to the master alone", func(t *testing.T) {
+		docs := render(t, "--set", "internalAuth.autoGenerate=true")
+		var checked int
+		for _, d := range docs {
+			kind, _ := d["kind"].(string)
+			meta, _ := d["metadata"].(map[string]any)
+			name, _ := meta["name"].(string)
+			if kind != "Role" || name != "fission-preupgrade-authgen" {
+				continue
+			}
+			checked++
+			rules, _ := d["rules"].([]any)
+			for _, r := range rules {
+				rule, _ := r.(map[string]any)
+				names, _ := rule["resourceNames"].([]any)
+				require.Len(t, names, 1, "the grant must name exactly one Secret")
+				assert.Equal(t, master, names[0])
+				verbs, _ := rule["verbs"].([]any)
+				for _, v := range verbs {
+					assert.NotEqual(t, "list", v, "list would let this identity enumerate every Secret")
+					assert.NotEqual(t, "delete", v)
+				}
+			}
+		}
+		require.Positive(t, checked, "no generation Role was rendered; the guard is inert")
+	})
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -473,7 +473,10 @@ func TestInternalAuthExistingSecret(t *testing.T) {
 		docs := render(t)
 		assert.Positive(t, countByKindName(docs, "Secret", defaultName),
 			"with no existingSecret the chart must generate the master itself")
-		for _, name := range internalAuthEnvNames(docs) {
+		names := internalAuthEnvNames(docs)
+		require.NotEmpty(t, names,
+			"no internal-auth secretKeyRef was rendered; the loop below would assert nothing")
+		for _, name := range names {
 			assert.Equal(t, defaultName, name)
 		}
 	})

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -680,9 +681,16 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 
 	// The read grant is the one concession this design makes; it must not widen
 	// beyond the single object that needs it.
+	//
+	// The split between the two rules is load-bearing, not cosmetic. RBAC
+	// matches resourceNames against the name in the REQUEST PATH, and a POST
+	// carries the object name in the body instead — so a create rule fenced by
+	// resourceNames matches nothing and the hook fails Forbidden. Fencing
+	// create looks safer and is actually inert, which is precisely the kind of
+	// mistake that survives review, so pin both halves.
 	t.Run("the generation grant is fenced to the master alone", func(t *testing.T) {
 		docs := render(t, "--set", "internalAuth.autoGenerate=true")
-		var checked int
+		var checked, sawGet, sawCreate int
 		for _, d := range docs {
 			kind, _ := d["kind"].(string)
 			meta, _ := d["metadata"].(map[string]any)
@@ -695,17 +703,41 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 			for _, r := range rules {
 				rule, _ := r.(map[string]any)
 				names, _ := rule["resourceNames"].([]any)
-				require.Len(t, names, 1, "the grant must name exactly one Secret")
-				assert.Equal(t, master, names[0])
 				verbs, _ := rule["verbs"].([]any)
 				for _, v := range verbs {
 					assert.NotEqual(t, "list", v, "list would let this identity enumerate every Secret")
 					assert.NotEqual(t, "delete", v)
 				}
+				switch {
+				case slices.Contains(verbsOf(verbs), "create"):
+					sawCreate++
+					assert.Empty(t, names,
+						"create must NOT carry resourceNames: the name is in the POST body, "+
+							"not the path, so a fenced rule never matches and generation fails Forbidden")
+					assert.Equal(t, []string{"create"}, verbsOf(verbs),
+						"the unfenced rule must carry create and nothing else — "+
+							"any read/write verb here would apply to every Secret in the namespace")
+				default:
+					sawGet++
+					require.Len(t, names, 1, "the read grant must name exactly one Secret")
+					assert.Equal(t, master, names[0])
+				}
 			}
 		}
 		require.Positive(t, checked, "no generation Role was rendered; the guard is inert")
+		assert.Positive(t, sawGet, "generation needs a name-scoped get to tell provisioned from absent")
+		assert.Positive(t, sawCreate, "generation needs a create it can actually use")
 	})
+}
+
+// verbsOf converts a decoded YAML verb list to strings.
+func verbsOf(verbs []any) []string {
+	out := make([]string, 0, len(verbs))
+	for _, v := range verbs {
+		s, _ := v.(string)
+		out = append(out, s)
+	}
+	return out
 }
 
 // TestNameFormat pins RFC-0029 phase 2's naming.


### PR DESCRIPTION
Part of RFC-0029 (epic #3626). Delivers the G3 assertion that the internal-auth HMAC master can be **supplied** rather than generated. Two commits: a prerequisite refactor, then the feature.

Depends on #3636 (merged) — see "Why this is safe now" below.

## Why it matters

Argo CD and Flux run `helm template`. There, the chart's `lookup`-based preservation of a generated master returns empty — so the master is **re-minted on every sync**, and every pod signed with the previous one breaks. Letting the operator supply the Secret is the fix, and RFC-0029 asserts it; nothing delivered it until now.

## What changes

`internalAuth.existingSecret` makes the chart render **no** master Secret, and every consumer read the operator's instead. Default behaviour is unchanged: with the value unset the chart generates and wires `fission-internal-auth` exactly as before.

## Why this is safe now, and wasn't before

Switching an existing install into this mode means the chart stops rendering a Secret Helm owns. Helm deletes resources that disappear from a release, so without protection it would **prune the master** and wedge every control-plane pod in `CreateContainerConfigError` (`internalAuth.envs` mounts it with a required `secretKeyRef`).

That is exactly how an earlier attempt at this failed and was reverted. #3636's `pre-upgrade` hook stamps `helm.sh/resource-policy: keep` on the live Secret before Helm computes its deletion set, which is what makes this a one-release migration rather than a breaking change.

## The silent failure this guards

Two independent halves resolve the Secret name — the chart's `secretKeyRef`s and the Go side (fetcher pod-spec builder, storagesvc client). **A disagreement between them does not fail loudly.** The `secretKeyRef` is mounted `optional: true` so rotation can drop a key without forcing an empty render; that also means a reference to a Secret which does not exist starts the pod happily with the env var simply absent — and then every archive fetch and builder upload 401s, with nothing naming the Secret as the cause.

So:

- **commit 1** collapses the two hardcoded `"fission-internal-auth"` constants into `fv1.InternalAuthSecretName()`, overridable by `FISSION_INTERNAL_AUTH_SECRET_NAME`. No behaviour change on its own — the default is the same name.
- **commit 2** has the chart set that env var to whatever it wired into the `secretKeyRef`s, and `TestInternalAuthExistingSecret` asserts the two agree in both modes. Hardcoding either one fails it (verified).

## Operational requirement, documented in values.yaml

The Secret must exist in **every namespace Fission runs pods in** — the release namespace plus `defaultNamespace` plus each `additionalFissionNamespaces` — because kubelet cannot resolve a cross-namespace `secretKeyRef`. A single copy in the release namespace leaves builder and function pods silently unauthenticated, for the reason above. (Under dynamic/cluster tenancy only the release namespace is needed; tenant namespaces get controller-owned derived keys.)

## Deliberately out of scope

Generation stays in the template. Moving it into an idempotent hook Job is the rest of RFC-0029 §10 and needs the per-namespace fan-out, its RBAC decision, Helm-ownership labels on the generated Secret, and `oldSecret` on the generated path. That is the riskier half and deserves its own change.

## Verification

`helm template` in both modes, `helm lint`, chart tests, `make code-checks`, `make license-check`. Rendered output checked directly: default renders the master and points 12 `secretKeyRef`s at it; `existingSecret=my-master` renders **zero** chart masters and points all 12 at `my-master`.