### PR TITLE
RFC-0029 phase 5: Terraform/Pulumi examples (+ .gitignore was eating example trees)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,10 @@ test/e2e/cli/????????-????-????-????-????????????
 # Added by code-review-graph
 .code-review-graph/
 notes
-examples
+# Anchored to the repo root. Unanchored, this pattern matched EVERY directory
+# named "examples" at any depth, which silently swallowed committed example
+# trees — RFC-0029's examples/gitops/ and docs/examples/ among them.
+/examples
 .nvim.json
 .github/code-review-graph.instruction.md
 .claude/skills

--- a/docs/examples/terraform/README.md
+++ b/docs/examples/terraform/README.md
@@ -1,0 +1,82 @@
+<!--
+SPDX-FileCopyrightText: The Fission Authors
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Fission with Terraform
+
+Manage Fission resources as Terraform-managed Kubernetes objects, using the Kubernetes provider's generic `kubernetes_manifest` against Fission's CRDs.
+
+This is one of several declarative renderers, not a separate management system.
+The same objects apply identically with `kubectl apply`, Argo CD, or Flux — the CRDs are the interface, and the CLI is a convenience over them rather than the source of truth.
+
+## Why there is no Fission Terraform provider
+
+A hand-maintained provider drifts from the CRDs: every new field needs a second implementation, and the two disagree exactly when it matters.
+`kubernetes_manifest` reads the cluster's own OpenAPI schema, so it is always current by construction.
+
+A *generated* provider is a reasonable future step, but only against evidence.
+The criteria, so it is a decision rather than a preference:
+
+- users repeatedly hit `kubernetes_manifest`'s requirement that the CRD exist at plan time, in a way documentation does not resolve;
+- plan-time diffs on Fission objects prove misleading often enough to cause real incidents;
+- or type-safety complaints on these examples arrive from more than a handful of installs.
+
+None of those is currently evidenced.
+If one becomes so, the provider is generated from the published schemas — never hand-written.
+
+## Prerequisites
+
+The CRDs must exist **before** `terraform plan`, because `kubernetes_manifest` validates against the live schema at plan time.
+Install Fission first (the chart installs CRDs by default — see `crds.mode`), then apply this.
+
+This is the one genuine sharp edge of the `kubernetes_manifest` approach, and it is worth knowing up front rather than discovering it in a broken pipeline.
+
+## Usage
+
+```bash
+terraform init
+terraform apply \
+  -var 'function_image=ghcr.io/example/hello-fn:v1' \
+  -var 'function_image_digest=sha256:...'
+```
+
+## Pin images by digest
+
+`function_image_digest` is required, and deliberately so.
+
+A tag is mutable.
+Re-running Terraform with an unchanged tag whose image has been rebuilt produces **no diff**, so nothing converges and the cluster quietly runs different code from the one Git describes.
+A digest changes exactly when the bytes change, which is exactly when a rollout should happen.
+
+The intended loop:
+
+1. CI builds and pushes the function image.
+2. CI commits the new digest into your Terraform variables.
+3. Terraform applies it; Fission converges on the content change.
+
+No CLI runs anywhere in that loop.
+
+## Everything shares one namespace
+
+Fission requires a Function's Package, Secrets and ConfigMaps to live in the Function's own namespace.
+Cross-namespace references are rejected at admission, and kubelet cannot resolve a cross-namespace `secretKeyRef` in any case.
+`var.namespace` therefore applies to every object here.
+
+## Field-name gotcha
+
+`InvokeStrategy` and `ExecutionStrategy` are capitalised exactly that way in the CRD — they are not camelCase like their neighbours.
+
+A lowercase spelling is **silently dropped as an unknown field**, leaving the function on executor defaults instead of failing.
+If a function ignores your `MinScale`/`MaxScale`, check the capitalisation first.
+
+## Pulumi
+
+Pulumi users generate typed CRD classes from the same schemas with [`crd2pulumi`](https://github.com/pulumi/crd2pulumi):
+
+```bash
+crd2pulumi --nodejsPath ./fission-types crds/v1/*.yaml
+```
+
+That yields real types over the identical objects, so the modelling above carries across unchanged — only the syntax differs.

--- a/docs/examples/terraform/main.tf
+++ b/docs/examples/terraform/main.tf
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: The Fission Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Fission via Terraform, using the Kubernetes provider's generic
+# `kubernetes_manifest` resource against Fission's CRDs (RFC-0029 §5).
+#
+# There is deliberately no Fission Terraform provider. A hand-maintained one
+# drifts from the CRDs; a generated one is worth building only if the friction
+# below proves real in practice. See README.md for the criteria.
+#
+# The declarative path is additive: everything here can equally be applied with
+# `kubectl apply`, Argo, or Flux. Terraform is one renderer among several, not a
+# separate management system.
+
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.30"
+    }
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig
+}
+
+locals {
+  # One place to change the namespace for every object below. Fission requires
+  # a Function's Package, Secrets and ConfigMaps to live in the function's own
+  # namespace — kubelet cannot resolve a cross-namespace secretKeyRef, and the
+  # webhook rejects cross-namespace references outright.
+  namespace = var.namespace
+}
+
+# ---------------------------------------------------------------------------
+# Environment — the language runtime a function executes in.
+# ---------------------------------------------------------------------------
+resource "kubernetes_manifest" "environment" {
+  manifest = {
+    apiVersion = "fission.io/v1"
+    kind       = "Environment"
+    metadata = {
+      name      = var.environment_name
+      namespace = local.namespace
+    }
+    spec = {
+      # version 2 is the current environment interface; version 1 predates
+      # builders and is not accepted for anything in these examples.
+      version = 2
+      runtime = {
+        image = var.runtime_image
+      }
+      poolsize = var.poolsize
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Package — the code. Pinned by DIGEST, which is what makes this declarative.
+# ---------------------------------------------------------------------------
+#
+# A tag is mutable: re-running Terraform with an unchanged tag whose image has
+# been rebuilt produces no diff, so nothing converges and the cluster silently
+# runs different code from the one Git describes. A digest changes when the
+# bytes change, which is exactly when a rollout should happen.
+#
+# The intended loop: CI builds and pushes the image, then commits the new
+# digest here. Terraform (or Argo/Flux) applies it, and Fission converges on
+# the content change — no CLI involved.
+resource "kubernetes_manifest" "package" {
+  manifest = {
+    apiVersion = "fission.io/v1"
+    kind       = "Package"
+    metadata = {
+      name      = var.function_name
+      namespace = local.namespace
+    }
+    spec = {
+      environment = {
+        name      = var.environment_name
+        namespace = local.namespace
+      }
+      deployment = {
+        type = "oci"
+        oci = {
+          image  = var.function_image
+          digest = var.function_image_digest
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.environment]
+}
+
+# ---------------------------------------------------------------------------
+# Function
+# ---------------------------------------------------------------------------
+resource "kubernetes_manifest" "function" {
+  manifest = {
+    apiVersion = "fission.io/v1"
+    kind       = "Function"
+    metadata = {
+      name      = var.function_name
+      namespace = local.namespace
+    }
+    spec = {
+      environment = {
+        name      = var.environment_name
+        namespace = local.namespace
+      }
+      package = {
+        functionName = var.entrypoint
+        packageref = {
+          name      = var.function_name
+          namespace = local.namespace
+        }
+      }
+      # NOTE the capitalisation: these two keys are `InvokeStrategy` and
+      # `ExecutionStrategy`, not camelCase. They are serialised that way in the
+      # CRD, and a lowercase spelling is silently dropped as an unknown field —
+      # leaving the function on executor defaults rather than failing.
+      InvokeStrategy = {
+        StrategyType = "execution"
+        ExecutionStrategy = {
+          ExecutorType = var.executor_type
+          MinScale     = var.min_scale
+          MaxScale     = var.max_scale
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.package]
+}
+
+# ---------------------------------------------------------------------------
+# HTTPTrigger — the route.
+# ---------------------------------------------------------------------------
+resource "kubernetes_manifest" "http_trigger" {
+  manifest = {
+    apiVersion = "fission.io/v1"
+    kind       = "HTTPTrigger"
+    metadata = {
+      name      = "${var.function_name}-route"
+      namespace = local.namespace
+    }
+    spec = {
+      prefix  = var.route_prefix
+      methods = var.route_methods
+      functionref = {
+        type            = "name"
+        name            = var.function_name
+        functionweights = {}
+      }
+    }
+  }
+
+  depends_on = [kubernetes_manifest.function]
+}

--- a/docs/examples/terraform/variables.tf
+++ b/docs/examples/terraform/variables.tf
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: The Fission Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+variable "kubeconfig" {
+  description = "Path to the kubeconfig for the target cluster."
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "namespace" {
+  description = "Namespace for the Environment, Package, Function and HTTPTrigger. They must share one: Fission rejects cross-namespace references."
+  type        = string
+  default     = "default"
+}
+
+variable "environment_name" {
+  type    = string
+  default = "nodejs"
+}
+
+variable "runtime_image" {
+  description = "Environment runtime image."
+  type        = string
+  default     = "ghcr.io/fission/node-env-22"
+}
+
+variable "poolsize" {
+  description = "Warm pool size for the poolmgr executor. Ignored by newdeploy and container."
+  type        = number
+  default     = 3
+}
+
+variable "function_name" {
+  type    = string
+  default = "hello"
+}
+
+variable "entrypoint" {
+  description = "Environment-specific entrypoint, e.g. \"hello.main\" for python or \"\" to accept the runtime default."
+  type        = string
+  default     = ""
+}
+
+variable "function_image" {
+  description = "OCI image holding the function's deployment archive."
+  type        = string
+  default     = "ghcr.io/example/hello-fn:v1"
+}
+
+variable "function_image_digest" {
+  description = <<-EOT
+    Digest of function_image, e.g. "sha256:abc...". Pinning by digest is what
+    makes this declarative: a tag is mutable, so a rebuilt image behind an
+    unchanged tag produces no Terraform diff and the cluster silently diverges
+    from Git. Have CI commit this value when it pushes the image.
+  EOT
+  type        = string
+}
+
+variable "executor_type" {
+  description = "poolmgr (warm pool), newdeploy (per-function Deployment), or container (your own image)."
+  type        = string
+  default     = "poolmgr"
+
+  validation {
+    condition     = contains(["poolmgr", "newdeploy", "container"], var.executor_type)
+    error_message = "executor_type must be poolmgr, newdeploy or container."
+  }
+}
+
+variable "min_scale" {
+  type    = number
+  default = 1
+}
+
+variable "max_scale" {
+  type    = number
+  default = 3
+}
+
+variable "route_prefix" {
+  type    = string
+  default = "/hello"
+}
+
+variable "route_methods" {
+  type    = list(string)
+  default = ["GET"]
+}


### PR DESCRIPTION
Part of RFC-0029 phase 5 (epic #3626). Closes the IaC gap — **#1907**, open since 2021 with no surface at all. Docs and examples only; no code paths touched.

## First: a `.gitignore` bug worth knowing about

The entry `examples` was **unanchored**, so it matched every directory named `examples` *at any depth*.

That silently swallowed committed example trees. RFC-0029's own documented path — `examples/gitops/` — could never have existed, and `docs/examples/` was ignored too. I only found it because `git add` refused the new directory.

Anchored to `/examples`, which preserves what the tooling wanted (a root-level scratch dir) without eating the repo's documentation. Worth a look in case `notes` deserves the same treatment.

## Approach: `kubernetes_manifest`, not a Fission provider

A hand-maintained provider drifts from the CRDs — every new field needs a second implementation, and the two disagree exactly when it matters. `kubernetes_manifest` reads the cluster's own OpenAPI schema, so it is current by construction.

A **generated** provider stays on the table. The README states the criteria, so it stays a decision rather than a preference:

- repeated, documentation-resistant friction from the plan-time CRD requirement;
- plan diffs misleading often enough to cause real incidents;
- type-safety complaints from more than a handful of installs.

None is currently evidenced. If one becomes so, generate it from the published schemas — never hand-write it.

## What the examples teach

Each of these fails **quietly**, which is why they are called out rather than left implicit:

**Pin by digest.** `function_image_digest` is required. A tag is mutable, so a rebuilt image behind an unchanged tag produces *no Terraform diff* — nothing converges, and the cluster runs different code from the one Git describes. The intended loop: CI pushes the image, CI commits the digest, Terraform applies, Fission converges on the content change. No CLI anywhere.

**`InvokeStrategy` / `ExecutionStrategy` are capitalised exactly that way.** A camelCase spelling is dropped as an unknown field, so `MinScale`/`MaxScale` are ignored rather than rejected — which reads as a Fission bug when it is a typo.

**One namespace for everything.** Cross-namespace references are rejected at admission, and kubelet cannot resolve a cross-namespace `secretKeyRef` regardless.

## Honest about the sharp edge

`kubernetes_manifest` validates against the live schema at **plan** time, so the CRDs must exist before `terraform plan`. That is the genuine friction of this approach, stated up front rather than left to surface in a broken pipeline.

## Pulumi

Covered by generating typed CRD classes from the same schemas with `crd2pulumi` — the modelling carries across unchanged, only the syntax differs.

## Verification

Field shapes read out of the generated CRD schemas rather than memory (`required` and property names from `crds/v1/*.yaml`) — which is how the `InvokeStrategy` capitalisation got documented. Every declared variable is used and every used variable declared; brace structure balanced. Terraform is not installed on my machine, so `terraform validate` should run in review.