### PR TITLE
RFC-0029 phase 2: add nameFormat, widening the fullname helper behind a flag

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -7,12 +7,51 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+fission.nameFormat selects how generated resource names are built, and is
+validated here so a typo fails the render rather than silently falling back to
+legacy behaviour.
+
+  legacy   (default) — today's names, byte-for-byte. Existing installs must not
+                       be renamed by an upgrade: a rename is a delete-and-create
+                       for most resources, which is not something a minor
+                       release may do silently.
+  standard          — release-qualified names with room to stay distinct.
+
+RFC-0029 phase 2. #2906 closes when `standard` becomes the default, which is a
+separate, announced change; #2835 (two installs sharing a cluster) additionally
+needs the instance-class filter and does NOT close on this.
+*/}}
+{{- define "fission.nameFormat" -}}
+{{- $v := default "legacy" .Values.nameFormat -}}
+{{- if not (has $v (list "legacy" "standard")) -}}
+{{- fail (printf "nameFormat must be \"legacy\" or \"standard\", got %q" $v) -}}
+{{- end -}}
+{{- $v -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
-We truncate at 24 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+
+The legacy form truncates at 24 characters. That is NOT a Kubernetes limit —
+names allow 253, and DNS labels 63 — it is historical, and it is what makes two
+releases collide: any two release names sharing a 24-character prefix produce
+the same fullname, so a second install silently reuses the first's object names.
+
+The standard form keeps 43. That budget is derived, not chosen: the longest
+suffix any consumer appends is `-<chart version>-post-install` (20 characters
+at a 6-character version), and Job names must stay within 63 because the Job
+controller stamps the name into the `job-name` LABEL, where 63 is a hard limit.
+43 + 20 = 63. Raising it silently produces Jobs the apiserver rejects — which
+is exactly what the chart test caught while this was being written.
 */}}
 {{- define "fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 24 | trimSuffix "-" -}}
+{{- $full := printf "%s-%s" .Release.Name $name -}}
+{{- if eq (include "fission.nameFormat" .) "standard" -}}
+{{- $full | trunc 43 | trimSuffix "-" -}}
+{{- else -}}
+{{- $full | trunc 24 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1356,6 +1356,26 @@ authentication:
   ##
   jwtIssuer: fission
 
+
+## nameFormat selects how generated resource names are built (RFC-0029 §2).
+##
+##   legacy   (default) — today's names, byte-for-byte. An upgrade must never
+##                        rename existing resources: for most kinds a rename is
+##                        a delete-and-create, which a minor release may not do
+##                        silently.
+##   standard          — release-qualified names with room to stay distinct
+##                        (43 characters, leaving room for the suffixes the
+##                        chart appends inside the 63-char Job-name limit).
+##                        The legacy form truncates to 24 characters, so any two
+##                        release names sharing a 24-character prefix collide
+##                        and the second install silently reuses the first's
+##                        object names.
+##
+## Switching an existing install is a migration, not a flag flip: the old
+## objects are not renamed in place. Plan it like one.
+##
+nameFormat: legacy
+
 ## OpenTelemetry is a set of tools for collecting, analyzing, and visualizing
 ## distributed tracing data across function calls.
 ##

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
@@ -23,6 +24,50 @@ import (
 
 	"github.com/fission/fission/pkg/svcinfo"
 )
+
+// helmTemplate runs `helm template` with an explicit release name and returns
+// raw stdout, or the error with stderr attached.
+func helmTemplate(t *testing.T, release string, extraArgs ...string) (string, error) {
+	t.Helper()
+	helm, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("helm not installed; skipping chart drift check")
+	}
+	_, filename, _, _ := runtime.Caller(0) //nolint
+	chart := filepath.Join(filepath.Dir(filename), "..", "..", "charts", "fission-all")
+	args := append([]string{"template", release, chart, "--namespace", "fission"}, extraArgs...)
+	cmd := exec.CommandContext(t.Context(), helm, args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return string(out), nil
+}
+
+// renderAs renders under a specific release name and returns parsed docs.
+func renderAs(t *testing.T, release string, extraArgs ...string) []map[string]any {
+	t.Helper()
+	out, err := helmTemplate(t, release, extraArgs...)
+	require.NoError(t, err)
+	var docs []map[string]any
+	for doc := range strings.SplitSeq(out, "\n---") {
+		var m map[string]any
+		if yaml.Unmarshal([]byte(doc), &m) != nil || m == nil {
+			continue
+		}
+		docs = append(docs, m)
+	}
+	require.NotEmpty(t, docs)
+	return docs
+}
+
+// renderErr returns the render error, for cases that must FAIL to render.
+func renderErr(t *testing.T, extraArgs ...string) (string, error) {
+	t.Helper()
+	return helmTemplate(t, "fission", extraArgs...)
+}
 
 // render runs `helm template` on the chart with the given extra args and
 // returns the manifest stream split into unstructured docs.
@@ -452,4 +497,97 @@ func TestStateSvcChart(t *testing.T) {
 		docs := render(t)
 		assert.Nil(t, find(docs, "Deployment", svcinfo.SvcStateSvc))
 	})
+}
+
+// TestNameFormat pins RFC-0029 phase 2's naming groundwork.
+//
+// The property that matters most is that `legacy` is the default and changes
+// NOTHING: for most Kubernetes kinds a rename is a delete-and-create, so an
+// upgrade that silently renamed resources would be an outage, not a cosmetic
+// change.
+func TestNameFormat(t *testing.T) {
+	// The legacy form truncates to 24 characters, which is not a Kubernetes
+	// limit — it is what makes two releases collide.
+	const legacyTrunc = 24
+
+	// Compares generated NAMES, not the whole manifest: the chart mints a random
+	// master secret on every render, so a byte-for-byte stream comparison would
+	// differ for reasons unrelated to naming.
+	t.Run("legacy is the default, and default names are unchanged", func(t *testing.T) {
+		explicit := jobNamesFor(t, "fission", "legacy")
+		require.NotEmpty(t, explicit)
+		implicit := jobNamesForDefault(t, "fission")
+		assert.Equal(t, explicit, implicit,
+			"the default must be legacy: an upgrade that renamed resources would be a delete-and-create, not a cosmetic change")
+	})
+
+	// Two release names sharing a 24-char prefix collide under legacy. That is
+	// the bug; this asserts it is real rather than theoretical, so the value of
+	// `standard` is measurable.
+	t.Run("legacy collides for long release names; standard does not", func(t *testing.T) {
+		a := "fission-platform-team-alpha-one"
+		b := "fission-platform-team-alpha-two"
+		require.Equal(t, a[:legacyTrunc], b[:legacyTrunc],
+			"fixture precondition: the two release names must share a 24-char prefix")
+
+		legacyA := jobNamesFor(t, a, "legacy")
+		legacyB := jobNamesFor(t, b, "legacy")
+		require.NotEmpty(t, legacyA)
+		assert.Equal(t, legacyA, legacyB,
+			"legacy truncation makes two distinct releases produce identical names — the collision this phase exists to fix")
+
+		stdA := jobNamesFor(t, a, "standard")
+		stdB := jobNamesFor(t, b, "standard")
+		require.NotEmpty(t, stdA)
+		assert.NotEqual(t, stdA, stdB,
+			"standard must keep distinct releases distinct")
+	})
+
+	// Names still have to be legal: the suffixes callers append must fit inside
+	// the DNS-label budget.
+	t.Run("standard names stay within the DNS-label budget", func(t *testing.T) {
+		long := "fission-a-very-long-release-name-for-a-shared-cluster"
+		for _, n := range jobNamesFor(t, long, "standard") {
+			assert.LessOrEqualf(t, len(n), 63, "generated name %q exceeds the 63-char DNS label limit", n)
+		}
+	})
+
+	t.Run("an unknown value fails the render", func(t *testing.T) {
+		_, err := renderErr(t, "--set", "nameFormat=bogus")
+		require.Error(t, err, "a typo must fail the render, not fall back to legacy silently")
+		assert.Contains(t, err.Error(), "nameFormat must be")
+	})
+}
+
+// jobNamesForDefault renders with no nameFormat set at all.
+func jobNamesForDefault(t *testing.T, release string) []string {
+	t.Helper()
+	return jobNamesFrom(renderAs(t, release))
+}
+
+// jobNamesFor renders with a given release name and nameFormat, returning the
+// generated Job names (the fullname helper's only consumers today).
+func jobNamesFor(t *testing.T, release, format string) []string {
+	t.Helper()
+	return jobNamesFrom(renderAs(t, release, "--set", "nameFormat="+format))
+}
+
+// jobNamesFrom extracts generated Job names, dropping the random suffix so the
+// stable prefix can be compared.
+func jobNamesFrom(docs []map[string]any) []string {
+	var out []string
+	for _, d := range docs {
+		if kind, _ := d["kind"].(string); kind != "Job" {
+			continue
+		}
+		meta, _ := d["metadata"].(map[string]any)
+		if name, ok := meta["name"].(string); ok {
+			if i := strings.LastIndex(name, "-"); i > 0 {
+				name = name[:i]
+			}
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
 }


### PR DESCRIPTION
RFC-0029 phase 2's naming groundwork (epic #3626). Default `legacy`, so existing installs render byte-identical names.

## The bug, concretely

The `fullname` helper truncates to **24 characters**. That is not a Kubernetes limit — names allow 253, DNS labels 63 — it is historical. The consequence: any two release names sharing a 24-character prefix produce the *same* fullname, so a second install silently reuses the first's object names.

The test asserts that collision is **real rather than theoretical** — it renders two releases sharing a 24-char prefix, shows `legacy` produces identical names, then shows `standard` keeps them distinct. Without that, "standard is better" would be an assertion rather than a demonstration.

## The 43-character budget is derived, not chosen

The longest suffix any consumer appends is `-<chart version>-post-install` (20 characters), and Job names must stay within 63 because the Job controller stamps the name into the `job-name` **label**, where 63 is a hard limit. 43 + 20 = 63.

I did not get this right by inspection: the first attempt used 53 and produced a 65-character Job name the apiserver would have rejected. The chart test caught it.

## Safety

- **Default is `legacy`** — an upgrade must never rename resources, since for most kinds a rename is a delete-and-create, not a cosmetic change. Asserted by comparing generated names with no `nameFormat` set against an explicit `legacy`.
- **An unrecognised value fails the render.** A typo should not silently give you the old behaviour while you believe you opted in.
- The names comparison deliberately compares generated **names**, not the whole manifest — the chart mints a random master secret on every render, so a byte-for-byte stream comparison would differ for reasons unrelated to naming.

## Scope

Groundwork only, per the RFC:

- **#2906 closes when `standard` becomes the default** — a separate, announced change.
- **#2835** (two installs sharing a cluster) additionally needs the instance-class filter and does **not** close here.

Switching an existing install is a migration, not a flag flip: old objects are not renamed in place. `values.yaml` says so plainly rather than leaving operators to discover it.

## Verification

Mutation-verified: making `standard` truncate like `legacy` fails the collision test. All four subtests pass; `make code-checks` and `license-check` clean.