### PR TITLE
RFC-0029: default nameFormat to standard, closing #2906

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -46,6 +46,16 @@ The statestore schema follows **expand/contract**, and the reason is the skew ru
 
 These are enforced, not just documented: `pkg/statestore/sqlstore` fails the build on destructive DDL, on a version gap or reorder, and on any change to an already-pinned migration's statements.
 
+## Notable default changes
+
+Behaviour changes that arrive by a changed default, rather than by a new flag, are listed here so an upgrade holds no surprises.
+
+- **`nameFormat` defaults to `standard`.**
+The generated names of the chart's hook Jobs are now release-qualified instead of truncated to 24 characters, so two releases whose names share a 24-character prefix no longer collide.
+Only hook Jobs are affected — no Deployment, Service, Secret, ConfigMap, ServiceAccount, Role or CRD name derives from this.
+Set `nameFormat: legacy` to keep the previous names.
+A hook Job that failed and was never cleaned up will linger under its old name after the upgrade; it is inert, but can be deleted by hand.
+
 ## Deprecation policy
 
 - Flags, CRD fields, chart values, and CLI commands are deprecated with **notice in one full minor release before removal**.

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -11,18 +11,29 @@ fission.nameFormat selects how generated resource names are built, and is
 validated here so a typo fails the render rather than silently falling back to
 legacy behaviour.
 
-  legacy   (default) — today's names, byte-for-byte. Existing installs must not
-                       be renamed by an upgrade: a rename is a delete-and-create
-                       for most resources, which is not something a minor
-                       release may do silently.
-  standard          — release-qualified names with room to stay distinct.
+  standard (default) — release-qualified names with room to stay distinct.
+  legacy             — the pre-1.(N+1) names, kept as an escape hatch.
 
-RFC-0029 phase 2. #2906 closes when `standard` becomes the default, which is a
-separate, announced change; #2835 (two installs sharing a cluster) additionally
-needs the instance-class filter and does NOT close on this.
+RFC-0029 phase 2; `standard` became the default in 1.(N+1), closing #2906.
+
+Flipping the default is safe because `fullname` has exactly four consumers and
+all of them are hook JOBS — no Deployment, Service, Secret, ConfigMap,
+ServiceAccount, Role or CRD name is derived from it. Two of those Jobs already
+carry a `randNumeric 3` suffix, so their names change on every render anyway,
+and the analytics Jobs carry `hook-delete-policy: hook-succeeded`, so a
+successful run leaves nothing behind under the old name.
+
+The one residue: a hook Job that FAILED and was never cleaned up stays under
+its old name after the flip. It is inert — an orphaned completed/failed Job —
+but it will not be reaped by `before-hook-creation`, which matches on name.
+Delete it by hand if you see one.
+
+#2835 (two installs sharing a cluster) additionally needs the instance-class
+filter and does NOT close on this: every fixed-name resource (router, executor,
+the ClusterRoles) still collides.
 */}}
 {{- define "fission.nameFormat" -}}
-{{- $v := default "legacy" .Values.nameFormat -}}
+{{- $v := default "standard" .Values.nameFormat -}}
 {{- if not (has $v (list "legacy" "standard")) -}}
 {{- fail (printf "nameFormat must be \"legacy\" or \"standard\", got %q" $v) -}}
 {{- end -}}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1359,22 +1359,22 @@ authentication:
 
 ## nameFormat selects how generated resource names are built (RFC-0029 §2).
 ##
-##   legacy   (default) — today's names, byte-for-byte. An upgrade must never
-##                        rename existing resources: for most kinds a rename is
-##                        a delete-and-create, which a minor release may not do
-##                        silently.
-##   standard          — release-qualified names with room to stay distinct
-##                        (43 characters, leaving room for the suffixes the
-##                        chart appends inside the 63-char Job-name limit).
-##                        The legacy form truncates to 24 characters, so any two
-##                        release names sharing a 24-character prefix collide
-##                        and the second install silently reuses the first's
-##                        object names.
+##   standard (default) — release-qualified names with room to stay distinct.
+##   legacy             — the pre-1.(N+1) names, kept as an escape hatch if you
+##                        need an upgrade to change nothing at all.
 ##
-## Switching an existing install is a migration, not a flag flip: the old
-## objects are not renamed in place. Plan it like one.
+## standard keeps 43 characters, leaving room for the suffixes the chart
+## appends inside the 63-char Job-name limit. The legacy form truncated to 24,
+## so any two release names sharing a 24-character prefix collided and the
+## second install silently reused the first's object names.
 ##
-nameFormat: legacy
+## The flip is low-impact because `fullname` has exactly four consumers and all
+## are hook Jobs — no Deployment, Service, Secret or RBAC name derives from it.
+## Two already carry a random suffix, and the analytics Jobs delete themselves
+## on success. A hook Job that FAILED and was never cleaned up will linger under
+## its old name; it is inert, but delete it by hand if you see one.
+##
+nameFormat: standard
 
 ## OpenTelemetry is a set of tools for collecting, analyzing, and visualizing
 ## distributed tracing data across function calls.

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -510,15 +510,29 @@ func TestNameFormat(t *testing.T) {
 	// limit — it is what makes two releases collide.
 	const legacyTrunc = 24
 
-	// Compares generated NAMES, not the whole manifest: the chart mints a random
-	// master secret on every render, so a byte-for-byte stream comparison would
-	// differ for reasons unrelated to naming.
-	t.Run("legacy is the default, and default names are unchanged", func(t *testing.T) {
-		explicit := jobNamesFor(t, "fission", "legacy")
-		require.NotEmpty(t, explicit)
-		implicit := jobNamesForDefault(t, "fission")
-		assert.Equal(t, explicit, implicit,
-			"the default must be legacy: an upgrade that renamed resources would be a delete-and-create, not a cosmetic change")
+	// The release name matters: with a short one ("fission") both formats
+	// produce the SAME names, so a default-check using it passes whichever
+	// format is the default and pins nothing. Use one long enough to
+	// distinguish them.
+	const distinguishing = "fission-platform-team-alpha"
+
+	t.Run("standard is the default", func(t *testing.T) {
+		std := jobNamesFor(t, distinguishing, "standard")
+		leg := jobNamesFor(t, distinguishing, "legacy")
+		require.NotEqual(t, std, leg, "fixture precondition: the release name must distinguish the two formats")
+
+		implicit := jobNamesForDefault(t, distinguishing)
+		assert.Equal(t, std, implicit, "the chart default must be standard")
+		assert.NotEqual(t, leg, implicit, "the chart default must no longer be legacy")
+	})
+
+	t.Run("legacy remains available as an escape hatch", func(t *testing.T) {
+		leg := jobNamesFor(t, distinguishing, "legacy")
+		require.NotEmpty(t, leg)
+		for _, n := range leg {
+			assert.LessOrEqual(t, len(strings.SplitN(n, "-1.", 2)[0]), legacyTrunc,
+				"legacy must still truncate to 24, so an operator can pin the old names")
+		}
 	})
 
 	// Two release names sharing a 24-char prefix collide under legacy. That is


### PR DESCRIPTION
Flips the default introduced in #3645. Closes **#2906**.

## Why it is safe

`fullname` has exactly **four consumers, and all of them are hook Jobs**. No Deployment, Service, Secret, ConfigMap, ServiceAccount, Role or CRD name derives from it — verified against the chart, not assumed:

| Job | name today | cleanup |
|---|---|---|
| pre-upgrade-checks | includes `randNumeric 3` — **already changes every render** | hook |
| analytics post-install | stable | `hook-delete-policy: hook-succeeded` |
| analytics post-upgrade | stable | `hook-delete-policy: hook-succeeded` |
| analytics non-helm install | includes `randNumeric 3` | — |

Two already have non-deterministic names, and the analytics Jobs delete themselves on success. So under normal operation nothing survives under an old name.

## The one residue

A hook Job that **failed** and was never cleaned up stays under its old name after the upgrade. It is inert — a completed/failed Job object — but `before-hook-creation` matches on *name* and will not reap it, so it wants a manual delete. Documented in `values.yaml` and `RELEASES.md` rather than glossed over.

`legacy` remains available for anyone who needs an upgrade to change nothing at all.

## A test that was passing for the wrong reason

The default-check from #3645 used the release name `fission` — for which **both formats produce identical names**. It therefore passed whichever format was the default and pinned nothing at all.

It now uses a release name long enough to distinguish them, and is mutation-verified: reverting `values.yaml` to `legacy` fails it.

Worth recording for anyone changing this area: the **effective** default is the values file, not the helper's `default` fallback — that fallback is dead code while `values.yaml` sets the key explicitly, so mutating the helper proves nothing. I found this by mutating the helper first and watching the test pass.

## Scope

**#2835 does not close on this.** Two installs sharing a cluster still collide on every fixed-name resource — `router`, `executor`, the ClusterRoles — which needs the instance-class filter.

## Release notes

`RELEASES.md` gains a "Notable default changes" section, so a behaviour change arriving by changed default rather than by a new flag is discoverable before an upgrade rather than after.