### PR TITLE
test: fix two CI flakes blocking main (workflow delivery counts, run --watch registration race)

### DIFF
--- a/pkg/fission-cli/cmd/function/run_test.go
+++ b/pkg/fission-cli/cmd/function/run_test.go
@@ -421,6 +421,33 @@ func TestRunLocalPropagatesEnvAndPorts(t *testing.T) {
 	assert.Equal(t, 5005, f.lastSpec.Ports[1].Host)
 }
 
+// requireReSpecialize waits for an edit to path to trigger a re-specialize,
+// rewriting the file on every tick rather than once.
+//
+// serveAndWatch registers the fsnotify watch AFTER the initial specialize —
+// runLocal specializes inside launch(), then calls serveAndWatch, which is
+// where addWatchTree/watcher.Add happen. A caller that writes as soon as it
+// observes that first specialize can therefore land its write in the gap
+// before the watch exists, and inotify has no replay: the event is lost for
+// good and the reload never comes. Rewriting each tick closes the gap.
+//
+// The tick must stay above serveAndWatch's 250ms debounce. A faster rewrite
+// loop would keep restarting drainBurst's quiet period, so the burst would
+// never drain and no reload would fire at all.
+func requireReSpecialize(t *testing.T, f *fakeRuntime, path, content, msg string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		if f.getSpecializePath() == "/v2/specialize" {
+			return true
+		}
+		// Errors are not asserted here: this runs on Eventually's goroutine,
+		// where FailNow is invalid. A failing write simply leaves the
+		// condition unsatisfied and fails with msg below.
+		_ = os.WriteFile(path, []byte(content), 0o644)
+		return false
+	}, 12*time.Second, 500*time.Millisecond, msg)
+}
+
 func TestRunLocalWatchReloadsOnChange(t *testing.T) {
 	f := &fakeRuntime{echo: "ok"}
 	code := writeTempCode(t, "v1")
@@ -443,9 +470,7 @@ func TestRunLocalWatchReloadsOnChange(t *testing.T) {
 	// Wait for the initial specialize, then edit the source and expect a re-specialize.
 	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond)
 	f.setSpecializePath("")
-	require.NoError(t, os.WriteFile(code, []byte("v2"), 0o644))
-	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond,
-		"editing the source should trigger a re-specialize")
+	requireReSpecialize(t, f, code, "v2", "editing the source should trigger a re-specialize")
 
 	cancel()
 	require.NoError(t, <-done)
@@ -505,9 +530,7 @@ func TestRunLocalWatchDirectoryReloadsOnChange(t *testing.T) {
 
 	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond)
 	f.setSpecializePath("")
-	require.NoError(t, os.WriteFile(main, []byte("v2"), 0o644))
-	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond,
-		"editing a file inside the source dir should trigger a re-specialize")
+	requireReSpecialize(t, f, main, "v2", "editing a file inside the source dir should trigger a re-specialize")
 
 	cancel()
 	require.NoError(t, <-done)

--- a/pkg/workflow/engine_branch_test.go
+++ b/pkg/workflow/engine_branch_test.go
@@ -60,10 +60,13 @@ func TestEngineParallelJoin(t *testing.T) {
 	assert.Contains(t, out[0].(map[string]any)["fn"], "fn-x")
 	assert.Contains(t, out[1].(map[string]any)["fn"], "fn-y")
 
-	assertInvariants(t, h.log(t), 1)
-	assertRegionInvariants(t, h.log(t), 2)
-	assert.Equal(t, 1, h.calls["fn-x"])
-	assert.Equal(t, 1, h.calls["fn-y"])
+	log := h.log(t)
+	assertInvariants(t, log, 1)
+	assertRegionInvariants(t, log, 2)
+	assert.Equal(t, 1, attempts(log, "x"), "one attempt per branch state")
+	assert.Equal(t, 1, attempts(log, "y"), "one attempt per branch state")
+	assert.GreaterOrEqual(t, h.callCount("fn-x"), 1, "at-least-once execution")
+	assert.GreaterOrEqual(t, h.callCount("fn-y"), 1, "at-least-once execution")
 }
 
 func TestEngineParallelFailFast(t *testing.T) {

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -148,6 +148,37 @@ func (h *harness) log(t *testing.T) []Event {
 	return out
 }
 
+// callCount reads the harness invocation counter under the lock. The
+// counter is written from the httptest handler goroutine, and a duplicate
+// delivery can still be in flight when the run reaches terminal, so an
+// unsynchronised read here is a real race, not a formality.
+func (h *harness) callCount(name string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls[name]
+}
+
+// attempts counts the attempts the LOG records for a state.
+//
+// Assert retry policy here rather than on the harness call counter. The
+// engine guarantees exactly one EvStepScheduled and one result per attempt
+// (W1/W2) — it does not guarantee exactly one HTTP delivery per attempt.
+// execute() sets X-Fission-Workflow-{Run,Attempt} precisely because
+// delivery is at-least-once and functions are expected to dedup on that
+// pair: a redelivered attempt re-runs the side effect, and its result then
+// loses the append guard, leaving the log correct and the call counter
+// high. Asserting an exact call count therefore tests a property the
+// design deliberately does not offer, and fails under CI contention.
+func attempts(log []Event, state string) int {
+	n := 0
+	for _, e := range log {
+		if e.Type == EvStepScheduled && e.State == state {
+			n++
+		}
+	}
+	return n
+}
+
 // assertInvariants re-verifies W1-W6 over the final log.
 func assertInvariants(t *testing.T, log []Event, maxAttempts int) {
 	t.Helper()
@@ -185,8 +216,12 @@ func TestEngineLinearPipeline(t *testing.T) {
 
 	assert.Equal(t, fv1.WorkflowRunSucceeded, s.Terminal)
 	assert.JSONEq(t, `{"fn":"fn-b","call":1}`, string(s.Output))
-	assertInvariants(t, h.log(t), 1)
-	assert.Equal(t, map[string]int{"fn-a": 1, "fn-b": 1}, h.calls)
+	log := h.log(t)
+	assertInvariants(t, log, 1)
+	assert.Equal(t, 1, attempts(log, "a"), "one attempt per state")
+	assert.Equal(t, 1, attempts(log, "b"), "one attempt per state")
+	assert.GreaterOrEqual(t, h.callCount("fn-a"), 1, "at-least-once execution")
+	assert.GreaterOrEqual(t, h.callCount("fn-b"), 1, "at-least-once execution")
 }
 
 func TestEngineRetryThenCatch(t *testing.T) {
@@ -208,9 +243,12 @@ func TestEngineRetryThenCatch(t *testing.T) {
 	s := h.drive(t, h.engine, 10*time.Second)
 
 	assert.Equal(t, fv1.WorkflowRunSucceeded, s.Terminal, "catch routed to b, which succeeded")
-	assertInvariants(t, h.log(t), 2)
-	assert.Equal(t, 2, h.calls["fn-a"], "retried to budget")
-	assert.Equal(t, 1, h.calls["fn-b"])
+	log := h.log(t)
+	assertInvariants(t, log, 2)
+	assert.Equal(t, 2, attempts(log, "a"), "retried to budget")
+	assert.Equal(t, 1, attempts(log, "b"), "the catch target runs once")
+	assert.GreaterOrEqual(t, h.callCount("fn-a"), 2, "at-least-once per attempt")
+	assert.GreaterOrEqual(t, h.callCount("fn-b"), 1, "at-least-once execution")
 }
 
 // TestEngineCatchResultPathKeepsDocument pins the catch resultPath contract:
@@ -265,8 +303,9 @@ func TestEnginePermanentErrorFailsRun(t *testing.T) {
 
 	assert.Equal(t, fv1.WorkflowRunFailed, s.Terminal)
 	assert.Equal(t, fv1.WorkflowErrPermanentError, s.ErrorType)
-	assert.Equal(t, 1, h.calls["fn-a"], "4xx never retries")
-	assertInvariants(t, h.log(t), 1)
+	log := h.log(t)
+	assert.Equal(t, 1, attempts(log, "a"), "4xx never retries")
+	assertInvariants(t, log, 1)
 }
 
 func TestEngineCancellation(t *testing.T) {
@@ -322,7 +361,7 @@ func TestEngineCrashPointResume(t *testing.T) {
 
 			assert.Equal(t, fv1.WorkflowRunSucceeded, s.Terminal)
 			assertInvariants(t, h.log(t), 2)
-			assert.GreaterOrEqual(t, h.calls["fn-a"], 1, "at-least-once execution")
+			assert.GreaterOrEqual(t, h.callCount("fn-a"), 1, "at-least-once execution")
 		})
 	}
 }


### PR DESCRIPTION
Two unrelated unit-test flakes are turning `lint` red on main and on everything branched from it (#3639 hit the first, #3640 the second). Both are test bugs — neither product path is at fault — and each is fixed in its own commit.

---

## 1. `TestEngineLinearPipeline` — asserting a guarantee the engine does not make

```
engine_test.go:189:
    expected: map[string]int{"fn-a":1, "fn-b":1}
    actual  : map[string]int{"fn-a":1, "fn-b":2}
```

That line is the **only** failing assertion. The run is `Succeeded`, the recorded output is `{"fn":"fn-b","call":1}` — the *first* call's response — and `assertInvariants` passes: one `EvStepScheduled` and one result per attempt.

That combination is the engine working. `execute()` sets the idempotency headers deliberately:

```go
// Idempotency contract: functions dedup on (run, attempt).
req.Header.Set("X-Fission-Workflow-Run", iv.runUID)
req.Header.Set("X-Fission-Workflow-Attempt", strconv.Itoa(int(iv.attempt)))
```

Delivery is **at-least-once**. What is exactly-once is the *recorded outcome* (W1/W2), not the side effect. A redelivered attempt re-runs the function and its append then loses the result guard — leaving the log exactly right and the harness counter one high, which is precisely the observed state.

So the assertion tested a property the design deliberately does not offer, and could only fail under the contention that makes redelivery likely: CI, not a laptop. It does not reproduce locally in 100+ runs across `-race`, `-cpu=1`, and `-cpu=2`.

`engine_test.go:364` already had the right shape (`GreaterOrEqual(..., 1, "at-least-once execution")`) for the crash-and-resume case; four other sites did not.

**Fix.** Exact assertions move onto the log, where the guarantee lives, via a new `attempts(log, state)` helper counting recorded `EvStepScheduled` per state. The harness counter becomes a lower bound. The two sites where the exact number *is* the contract keep exact expectations, now against `attempts`:

- `TestEngineRetryThenCatch` — `attempts(log, "a") == 2`, "retried to budget"
- `TestEnginePermanentErrorFailsRun` — `attempts(log, "a") == 1`, "4xx never retries"

Both still fail if the retry policy regresses (mutation-verified: `2`→`3`, `1`→`9` both compile and fail, then pass on revert).

Also routes the counter through `callCount()` under the harness mutex. It is written from the httptest handler goroutine, and the very redelivery above can still be in flight at terminal — the unsynchronised map read was a real race.

---

## 2. `TestRunLocal*Watch*` — writing before the watcher exists

```
run_test.go:507: Condition never satisfied
  editing a file inside the source dir should trigger a re-specialize
```

Fails on the **second** wait only, for the full 3s: the initial specialize is observed, the edit that should re-specialize never lands.

The tests wait for the first specialize, then immediately write the source file. But `runLocal` specializes inside `launch()` and only *then* calls `serveAndWatch` — which is where `addWatchTree`/`watcher.Add` happen. Observing the first specialize does not mean the watch exists yet, and a write landing in that gap is lost for good: inotify has no replay. That is why the symptom is a full-timeout miss rather than a slow pass. On a laptop the gap is microseconds; on a loaded runner the goroutine can be descheduled straight across it.

**Fix.** Rewrite the file on every tick instead of once, via `requireReSpecialize`. The tick stays above `serveAndWatch`'s 250ms debounce — a faster loop would keep restarting `drainBurst`'s quiet period so no reload would ever fire, trading one flake for a worse one.

Both watch tests had the identical pattern; the single-file one had simply not lost the race yet, so both are converted. Mutation-verified that they still catch a broken watcher (`watchTriggers` stubbed to `false`: both fail; pass again on revert).

---

## Testing

`go test -race -count=20 ./pkg/workflow/` and `-count=8 -run TestRunLocalWatch ./pkg/fission-cli/cmd/function/` both clean. `make code-checks` and `make license-check` exit 0.