### PR TITLE
RFC-0028/0029 wave: auth-material provisioning, name inventory, spec-apply idempotency, CI flake fixes

### DIFF
--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -284,6 +284,11 @@ jobs:
           name: upgrade-results-${{ github.run_id }}-${{ matrix.kindversion }}-${{ matrix.upgradeFrom }}
           path: upgrade-results.json
           retention-days: 14
+          # A skipped leg (SKIP_LEG=1: fewer than three published appVersions,
+          # so there is no N-2 to skip-level from) never writes the file, and
+          # this step still runs under always(). Default `warn` would print a
+          # red herring on every such run; the leg is meant to skip cleanly.
+          if-no-files-found: ignore
 
       - name: Kind export logs
         if: ${{ always() }}

--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -63,6 +63,12 @@ jobs:
       matrix:
         kindversion: ["v1.32.11"]
         os: [ubuntu-24.04]
+        # RFC-0028 phase 5. "latest" is the N-1 -> N path RELEASES.md supports;
+        # "skip-level" is N-2 -> N, which the support window does NOT promise but
+        # real clusters attempt constantly, because upgrading is deferred until
+        # something forces it. Testing it is how we learn whether it works
+        # rather than finding out from an issue.
+        upgradeFrom: [latest, skip-level]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -110,12 +116,37 @@ jobs:
           # appVersion already carries the v prefix (hack/generate-helm-manifest.sh
           # stamps the git tag verbatim), e.g. "appVersion: v1.27.0".
           LATEST_TAG=$(helm show chart fission-charts/fission-all | awk '/^appVersion:/{print $2}')
-          echo "Installing latest published release $LATEST_TAG"
-          echo "LATEST_TAG=$LATEST_TAG" >> "$GITHUB_ENV"
+
+          # Distinct appVersions, newest first. A chart may publish several
+          # revisions per appVersion, so dedupe before counting back.
+          mapfile -t VERSIONS < <(helm search repo fission-charts/fission-all --versions -o json \
+            | python3 -c 'import sys,json;seen=[];[seen.append(r["app_version"]) for r in json.load(sys.stdin) if r.get("app_version") and r["app_version"] not in seen];print("\n".join(seen))')
+
+          case "${{ matrix.upgradeFrom }}" in
+            latest)
+              FROM_TAG="$LATEST_TAG"
+              ;;
+            skip-level)
+              # N-2. Outside the supported window on purpose: this leg exists to
+              # find out whether the skip works, not to assert a promise.
+              if [ "${#VERSIONS[@]}" -lt 3 ]; then
+                echo "fewer than three published appVersions (${VERSIONS[*]}); nothing to skip from"
+                echo "SKIP_LEG=1" >> "$GITHUB_ENV"
+                exit 0
+              fi
+              FROM_TAG="${VERSIONS[2]}"
+              ;;
+          esac
+
+          CHART_VER=$(helm search repo fission-charts/fission-all --versions -o json \
+            | python3 -c "import sys,json;print(next(r['version'] for r in json.load(sys.stdin) if r['app_version']=='$FROM_TAG'))")
+
+          echo "Installing $FROM_TAG (chart $CHART_VER) as the upgrade source [${{ matrix.upgradeFrom }}]"
+          echo "LATEST_TAG=$FROM_TAG" >> "$GITHUB_ENV"
           kubectl create ns ${{ env.FISSION_NAMESPACE }}
-          kubectl create -k "github.com/fission/fission/crds/v1?ref=$LATEST_TAG"
+          kubectl create -k "github.com/fission/fission/crds/v1?ref=$FROM_TAG"
           helm install --wait --timeout 10m --namespace ${{ env.FISSION_NAMESPACE }} fission \
-            fission-charts/fission-all --set routerServiceType=NodePort,analytics=false
+            fission-charts/fission-all --version "$CHART_VER" --set routerServiceType=NodePort,analytics=false
 
       # Record which Secrets the HEAD chart will ask the pre-upgrade hook to
       # adopt AND that the PUBLISHED release actually created. Both filters
@@ -125,6 +156,7 @@ jobs:
       # legitimately un-annotated afterwards. Deriving the list from the chart
       # rather than hardcoding it keeps this from drifting out of sync.
       - name: Record pre-upgrade secret inventory
+        if: ${{ env.SKIP_LEG != '1' }}
         run: |
           set -euo pipefail
           adopt=$(helm template fission "$GITHUB_WORKSPACE/charts/fission-all" \
@@ -147,6 +179,7 @@ jobs:
           cat "$GITHUB_WORKSPACE/pre-upgrade-secrets.txt"
 
       - name: Build HEAD images and load into kind
+        if: ${{ env.SKIP_LEG != '1' }}
         run: |
           make skaffold-prebuild
           # builder images come from Environment CRDs and the reporter is
@@ -160,6 +193,7 @@ jobs:
           helm dependency update charts/fission-all
 
       - name: Run upgrade-under-load
+        if: ${{ env.SKIP_LEG != '1' }}
         timeout-minutes: 30
         env:
           NODE_RUNTIME_IMAGE: ghcr.io/fission/node-env
@@ -179,7 +213,7 @@ jobs:
             --upgrade-cmd "$UPGRADE_CMD" \
             --router-url "http://$NODE_IP:${{ env.ROUTER_NODEPORT }}" \
             --namespace default --fission-namespace ${{ env.FISSION_NAMESPACE }} \
-            --fission-version "${{ env.LATEST_TAG }}->HEAD" \
+            --fission-version "${{ env.LATEST_TAG }}->HEAD (${{ matrix.upgradeFrom }})" \
             --git-sha "${{ github.sha }}" \
             --out "$GITHUB_WORKSPACE/upgrade-results.json"
           # The benchmark CLI's failure budget records scenario errors in the
@@ -201,6 +235,7 @@ jobs:
       # CreateContainerConfigError. Assert it here, on a real upgrade from
       # the last published release, which is the only place the hook runs.
       - name: Verify the pre-upgrade hook adopted the generated Secrets
+        if: ${{ env.SKIP_LEG != '1' }}
         run: |
           set -euo pipefail
           if [ ! -s "$GITHUB_WORKSPACE/pre-upgrade-secrets.txt" ]; then
@@ -221,6 +256,7 @@ jobs:
           exit $rc
 
       - name: Evaluate error budget (non-gating)
+        if: ${{ env.SKIP_LEG != '1' }}
         continue-on-error: true
         run: |
           jq '.scenarios[] | select(.name=="upgrade-under-load")' upgrade-results.json | tee upgrade-summary.json
@@ -245,7 +281,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: upgrade-results-${{ github.run_id }}-${{ matrix.kindversion }}
+          name: upgrade-results-${{ github.run_id }}-${{ matrix.kindversion }}-${{ matrix.upgradeFrom }}
           path: upgrade-results.json
           retention-days: 14
 
@@ -258,6 +294,6 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: kind-logs-${{ github.run_id }}-${{ matrix.kindversion }}
+          name: kind-logs-${{ github.run_id }}-${{ matrix.kindversion }}-${{ matrix.upgradeFrom }}
           path: kind-logs/*
           retention-days: 5

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,6 +34,9 @@ A release is tagged only when all of the following are green, mechanically and a
 
 - Within one minor, control-plane components tolerate mixed versions while a rolling upgrade is in flight: wire formats and RPC surfaces are additive-only within a minor.
 - Formal N/N−1 skew and rollback contracts (including `helm rollback` guarantees) are being specified in RFC-0028 and will be added here as they become tested guarantees rather than intentions.
+- **Skip-level upgrades (N−2 → N) are exercised in CI but not promised.**
+  Clusters routinely defer upgrading until something forces it, so the jump from an out-of-window line is the common real-world case; CI runs it on every change so we learn whether it works rather than hearing it from an issue.
+  The supported path remains one minor at a time.
 
 ## Deprecation policy
 

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -453,8 +453,21 @@ the pre-upgrade hook stamps helm.sh/resource-policy=keep onto, so that moving
 their generation out of the templating layer does not prune the live object on
 the next upgrade (RFC-0029 §3; mechanism verified on Helm v4.2.3).
 
-Only Secrets the chart itself may have created belong here — never one supplied
-via an existingSecret value, which the operator owns and Helm never manages.
+What belongs here is decided by ONE question: could Helm prune this object?
+Not "who owns it" — that reading is what the internalAuth entry below had to
+stop using, and the two entries genuinely differ:
+
+  - internal-auth-secret.yaml and webhook-server/cert.yaml carry NO
+    helm.sh/hook annotation, so they are ordinary release-manifest resources
+    and Helm prunes them the moment a template stops rendering them. They need
+    retention whether or not an existingSecret is set.
+  - router/secret.yaml IS a hook resource ("helm.sh/hook": pre-install,
+    pre-upgrade), so it lives outside Helm's deletion set and is never pruned.
+    Its existingSecret guard below is therefore correct and must stay.
+
+That asymmetry looks like an oversight and is not. Do not "fix" it by making
+the two branches match.
+
 Empty when nothing needs adopting, which makes the whole migration render away.
 */}}
 {{- define "fission.adoptSecretNames" -}}
@@ -471,14 +484,26 @@ ownership of it. The template stops rendering it, nothing stamps keep, and Helm
 prunes a Secret that is still in use — every control-plane pod wedges on next
 restart and function pods run unsigned.
 
-Stamping keep on a Secret Helm no longer manages is harmless, and so is naming
-one that does not exist (the hook logs "no live secret to adopt" and moves on),
-so the unconditional form is strictly safer. An operator-supplied Secret under a
-DIFFERENT name is never added: Helm never managed it, so it was never at risk.
+Naming a Secret that does not exist is free (the hook logs "no live secret to
+adopt" and moves on), and an operator-supplied Secret under a DIFFERENT name is
+still never added — Helm never managed it, so it was never at risk.
+
+The unconditional form does have a cost, and it is retention, not exposure: on
+a migration to `existingSecret: <another-name>`, the old chart-generated master
+is stamped keep in every namespace it was replicated into and then survives
+`helm uninstall`, where Helm would previously have pruned it. Live HMAC key
+material outliving the release is the lesser failure — the alternative deletes
+a master that is still in use — but it is why values.yaml carries the "NOTE ON
+SECRET RETENTION" block describing the manual per-namespace cleanup.
 */}}
 {{- if .Values.internalAuth.enabled -}}
 {{- $names = append $names "fission-internal-auth" -}}
 {{- end -}}
+{{- /*
+Guarded, unlike internalAuth above, and deliberately so: router/secret.yaml is
+a HOOK resource, so it is outside Helm's deletion set and cannot be pruned. See
+the header — the test is prunability, not ownership.
+*/}}
 {{- if and .Values.authentication.enabled (not .Values.authentication.existingSecret) -}}
 {{- $names = append $names "router" -}}
 {{- end -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -200,12 +200,6 @@ it). Disabled by default → behaviour is unchanged for single-replica installs.
 {{- end }}
 
 {{/*
-internalAuth.envs renders the two env entries that wire the HMAC shared
-secret into a Fission control-plane container. See the design at docs/internal-auth/00-design.md. The OLD
-secret is mounted with optional: true so rotation can drop it without
-forcing the chart to render an empty key.
-*/}}
-{{/*
 fission.internalAuthSecretName is the Secret holding the internal-auth HMAC
 master: the operator's pre-created one when internalAuth.existingSecret is set,
 otherwise the chart-generated "fission-internal-auth".
@@ -220,6 +214,32 @@ builder upload 401s with nothing naming the Secret as the cause.
 {{- default "fission-internal-auth" .Values.internalAuth.existingSecret -}}
 {{- end -}}
 
+{{/*
+fission.internalAuthGenerateInCluster is non-empty when the pre-upgrade hook,
+not the template, mints the master.
+
+Exactly one of them may provision it, and this is the ONLY place that decides
+which. Three templates gate on this answer — the Secret itself, the hook's
+GENERATE_AUTH_SECRET env, and the hook's RBAC — and open-coding the condition
+in each is how they drift apart. Both drift directions fail silently: both
+provisioning means two masters race and half the derived keys are wrong;
+neither means no master at all and every internal call is unsigned.
+
+The whitespace trimming is load-bearing. A stray newline would make the
+`include` non-empty, so the helper would read as true in every case.
+*/}}
+{{- define "fission.internalAuthGenerateInCluster" -}}
+{{- if and .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+internalAuth.envs renders the two env entries that wire the HMAC shared
+secret into a Fission control-plane container. See the design at docs/internal-auth/00-design.md. The OLD
+secret is mounted with optional: true so rotation can drop it without
+forcing the chart to render an empty key.
+*/}}
 {{- define "internalAuth.envs" }}
 {{- if .Values.internalAuth.enabled }}
 - name: FISSION_INTERNAL_AUTH_SECRET

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -155,19 +155,38 @@ secret into a Fission control-plane container. See the design at docs/internal-a
 secret is mounted with optional: true so rotation can drop it without
 forcing the chart to render an empty key.
 */}}
+{{/*
+fission.internalAuthSecretName is the Secret holding the internal-auth HMAC
+master: the operator's pre-created one when internalAuth.existingSecret is set,
+otherwise the chart-generated "fission-internal-auth".
+
+Every consumer must go through this. The Go side resolves the same name from
+FISSION_INTERNAL_AUTH_SECRET_NAME (fv1.InternalAuthSecretName), and a
+disagreement between the two does not fail loudly — the secretKeyRef is
+optional, so pods start with the env var absent and every archive fetch and
+builder upload 401s with nothing naming the Secret as the cause.
+*/}}
+{{- define "fission.internalAuthSecretName" -}}
+{{- default "fission-internal-auth" .Values.internalAuth.existingSecret -}}
+{{- end -}}
+
 {{- define "internalAuth.envs" }}
 {{- if .Values.internalAuth.enabled }}
 - name: FISSION_INTERNAL_AUTH_SECRET
   valueFrom:
     secretKeyRef:
-      name: fission-internal-auth
+      name: {{ include "fission.internalAuthSecretName" . }}
       key: secret
 - name: FISSION_INTERNAL_AUTH_SECRET_OLD
   valueFrom:
     secretKeyRef:
-      name: fission-internal-auth
+      name: {{ include "fission.internalAuthSecretName" . }}
       key: oldSecret
       optional: true
+# The Go side (fetcher pod-spec builder, storagesvc client) resolves the same
+# name from this env var; see fv1.InternalAuthSecretName.
+- name: FISSION_INTERNAL_AUTH_SECRET_NAME
+  value: {{ include "fission.internalAuthSecretName" . | quote }}
 {{- end }}
 {{- end }}
 
@@ -371,7 +390,7 @@ Empty when nothing needs adopting, which makes the whole migration render away.
 {{- define "fission.adoptSecretNames" -}}
 {{- $names := list -}}
 {{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) -}}
-{{- $names = append $names "fission-internal-auth" -}}
+{{- $names = append $names (include "fission.internalAuthSecretName" .) -}}
 {{- end -}}
 {{- if and .Values.authentication.enabled (not .Values.authentication.existingSecret) -}}
 {{- $names = append $names "router" -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -459,8 +459,25 @@ Empty when nothing needs adopting, which makes the whole migration render away.
 */}}
 {{- define "fission.adoptSecretNames" -}}
 {{- $names := list -}}
-{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) -}}
-{{- $names = append $names (include "fission.internalAuthSecretName" .) -}}
+{{- /*
+The CHART-GENERATED name, unconditionally — deliberately not the resolved one.
+
+Retention has to cover the object Helm previously managed, and setting
+existingSecret is exactly what removes that object from the rendered manifest.
+The obvious-looking `(not .Values.internalAuth.existingSecret)` guard here
+destroys the master in the most natural adoption there is: an operator with a
+chart-generated master who sets `existingSecret: fission-internal-auth` to take
+ownership of it. The template stops rendering it, nothing stamps keep, and Helm
+prunes a Secret that is still in use — every control-plane pod wedges on next
+restart and function pods run unsigned.
+
+Stamping keep on a Secret Helm no longer manages is harmless, and so is naming
+one that does not exist (the hook logs "no live secret to adopt" and moves on),
+so the unconditional form is strictly safer. An operator-supplied Secret under a
+DIFFERENT name is never added: Helm never managed it, so it was never at risk.
+*/}}
+{{- if .Values.internalAuth.enabled -}}
+{{- $names = append $names "fission-internal-auth" -}}
 {{- end -}}
 {{- if and .Values.authentication.enabled (not .Values.authentication.existingSecret) -}}
 {{- $names = append $names "router" -}}

--- a/charts/fission-all/templates/internal-auth-secret.yaml
+++ b/charts/fission-all/templates/internal-auth-secret.yaml
@@ -11,7 +11,10 @@ Secret before Helm computes its deletion set. Without that, Helm would prune
 the master it is no longer rendering and wedge every control-plane pod in
 CreateContainerConfigError.
 */ -}}
-{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) }}
+{{- /* autoGenerate hands generation to the pre-upgrade hook, so the template
+       must stop rendering the Secret — the retention hook keeps the live value
+       from being pruned when it does. */ -}}
+{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) (not (and .Values.internalAuth.autoGenerate (not .Values.internalAuth.secret))) }}
 {{- /*
 fission-internal-auth holds the shared HMAC secret used by Fission's
 internal application-layer auth (the design at docs/internal-auth/00-design.md).

--- a/charts/fission-all/templates/internal-auth-secret.yaml
+++ b/charts/fission-all/templates/internal-auth-secret.yaml
@@ -14,7 +14,7 @@ CreateContainerConfigError.
 {{- /* autoGenerate hands generation to the pre-upgrade hook, so the template
        must stop rendering the Secret — the retention hook keeps the live value
        from being pruned when it does. */ -}}
-{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) (not (and .Values.internalAuth.autoGenerate (not .Values.internalAuth.secret))) }}
+{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) (not (include "fission.internalAuthGenerateInCluster" .)) }}
 {{- /*
 fission-internal-auth holds the shared HMAC secret used by Fission's
 internal application-layer auth (the design at docs/internal-auth/00-design.md).

--- a/charts/fission-all/templates/internal-auth-secret.yaml
+++ b/charts/fission-all/templates/internal-auth-secret.yaml
@@ -1,4 +1,17 @@
-{{- if .Values.internalAuth.enabled }}
+{{- /*
+existingSecret hands the master to the operator: the chart renders NOTHING and
+every consumer reads the named Secret instead. This is the supported path for
+GitOps renderers, where `lookup` returns empty under `helm template` and the
+preservation below cannot work, so a generated value would be re-minted on
+every sync and break every pod signed with the previous one.
+
+Upgrading an existing install into this mode is safe ONLY because the
+pre-upgrade retention hook stamps helm.sh/resource-policy=keep on the live
+Secret before Helm computes its deletion set. Without that, Helm would prune
+the master it is no longer rendering and wedge every control-plane pod in
+CreateContainerConfigError.
+*/ -}}
+{{- if and .Values.internalAuth.enabled (not .Values.internalAuth.existingSecret) }}
 {{- /*
 fission-internal-auth holds the shared HMAC secret used by Fission's
 internal application-layer auth (the design at docs/internal-auth/00-design.md).
@@ -61,7 +74,7 @@ rotation window) and re-run helm upgrade.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: fission-internal-auth
+  name: {{ include "fission.internalAuthSecretName" $ }}
   namespace: {{ $ns }}
   labels:
     chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"

--- a/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
@@ -47,6 +47,12 @@ spec:
         - name: ADOPT_SECRET_NAMESPACES
           value: {{ include "fission.adoptSecretNamespaces" $ | quote }}
         {{- end }}
+{{- if and .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) }}
+        - name: GENERATE_AUTH_SECRET
+          value: {{ include "fission.internalAuthSecretName" . | quote }}
+        - name: GENERATE_AUTH_SECRET_NAMESPACES
+          value: {{ include "fission.adoptSecretNamespaces" . | quote }}
+{{- end }}
         {{- include "fission.podNamespaceEnv" . | nindent 8 }}
         - name: CRDS_MODE
           value: {{ include "fission.crdsMode" . | quote }}

--- a/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/pre-upgrade-job.yaml
@@ -6,6 +6,16 @@ schemas at all.
 {{- if and (eq (include "fission.crdsMode" .) "hook") (not .Values.preUpgradeChecks.enabled) }}
 {{- fail "crds.mode=hook delivers the CRDs through the pre-upgrade-checks Job, so preUpgradeChecks.enabled must be true (or set crds.mode=none)" }}
 {{- end }}
+{{- /*
+Same shape, same reason: internalAuth.autoGenerate moves master provisioning
+from the template into THIS Job, so the template renders no Secret. With the
+Job switched off, nothing provisions it at all and every control-plane pod
+wedges in CreateContainerConfigError on a required secretKeyRef — a whole
+install that comes up dead, from two values that each look reasonable alone.
+*/}}
+{{- if and (include "fission.internalAuthGenerateInCluster" .) (not .Values.preUpgradeChecks.enabled) }}
+{{- fail "internalAuth.autoGenerate provisions the master through the pre-upgrade-checks Job, so preUpgradeChecks.enabled must be true (or set internalAuth.secret / internalAuth.existingSecret instead)" }}
+{{- end }}
 {{- if .Values.preUpgradeChecks.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -47,7 +57,7 @@ spec:
         - name: ADOPT_SECRET_NAMESPACES
           value: {{ include "fission.adoptSecretNamespaces" $ | quote }}
         {{- end }}
-{{- if and .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) }}
+{{- if include "fission.internalAuthGenerateInCluster" . }}
         - name: GENERATE_AUTH_SECRET
           value: {{ include "fission.internalAuthSecretName" . | quote }}
         - name: GENERATE_AUTH_SECRET_NAMESPACES

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -82,7 +82,7 @@ the master is replicated into — under dynamic/cluster tenancy the release
 namespace alone, because tenant namespaces receive controller-owned derived keys
 and the master must never land there.
 */}}
-{{- if and .Values.preUpgradeChecks.enabled .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) }}
+{{- if and .Values.preUpgradeChecks.enabled (include "fission.internalAuthGenerateInCluster" .) }}
 {{- range $ns := splitList " " (include "fission.adoptSecretNamespaces" $) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -11,13 +11,22 @@ annotates chart-generated Secrets with helm.sh/resource-policy=keep before Helm
 computes its deletion set, so a template can stop rendering them without the
 live object being pruned.
 
-PATCH ONLY, fenced by resourceNames to exactly the Secrets the chart generates.
+PATCH ONLY, fenced by resourceNames to the exact Secret NAMES the chart uses.
 resourceNames does restrict get and patch (both name the object in the request
 path), and deliberately no `get`: the merge patch is idempotent, so the hook
 never needs to read, and these are the highest-value Secrets in the namespace —
 a grant that cannot read the HMAC master, the JWT signing key or the webhook TLS
 key is worth far more than one that can. No list (which would let this identity
 enumerate every Secret), no create, no delete.
+
+"NAMES the chart uses", not "Secrets the chart generates" — the distinction is
+real. fission.adoptSecretNames names the internal-auth Secret unconditionally,
+because retention has to cover whatever Helm could prune, so with
+`internalAuth.existingSecret: fission-internal-auth` this grants patch on an
+object the OPERATOR owns. That is intended: it is the only way to stop Helm
+deleting it. Note the grant is `patch`, which is full .data mutation even
+though the hook writes one annotation — accepted knowingly, and bounded by the
+ServiceAccount being torn down with the hook.
 
 Rendered once per namespace the master is replicated into, and only when the
 Job that uses it actually renders — a standing Secret grant bound to a
@@ -116,11 +125,29 @@ rules:
 # apply, deliberately — apply would take ownership of .data and rotate the
 # master, which is the one thing this hook must never do.
 #
-# So the residual grant is "create A Secret in this one namespace". It
-# cannot read, patch or delete any existing Secret, and create fails
-# AlreadyExists rather than overwriting the master. That is the floor RBAC
-# allows here, and it is bounded by the hook ServiceAccount being deleted
-# with the hook.
+# So the residual grant is "create A Secret in this namespace". It cannot
+# patch or delete an existing one, and create fails AlreadyExists rather than
+# overwriting the master.
+#
+# Do NOT read that as harmless, and note it is the floor plain RBAC reaches,
+# not the floor the cluster can enforce. Two things sharpen it:
+#
+#   - It composes with the fenced `get` above. On a fresh install an actor
+#     with execution in the hook pod can create <master-name> as a
+#     kubernetes.io/service-account-token Secret annotated for any
+#     ServiceAccount in the namespace, let the token controller populate it,
+#     then read the token back through that `get`. Neither verb is a
+#     token-read primitive alone; together they are.
+#   - Under static tenancy this Role renders into defaultNamespace and every
+#     additionalFissionNamespaces too, where user workloads and function-pod
+#     ServiceAccounts live — not just the release namespace.
+#
+# It is bounded by needing control of the hook ServiceAccount already, and by
+# that ServiceAccount being torn down with the hook. The real fix is a
+# ValidatingAdmissionPolicy pinning CREATE secrets by this SA to
+# name == <master> && type == Opaque — the chart already ships exactly that
+# pattern in validatingadmissionpolicy.yaml for the CRD grant. Tracked as
+# follow-up work; until it lands, this comment is the honest description.
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create"]

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -95,11 +95,35 @@ metadata:
     helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
     helm.sh/hook-weight: "-2"
 rules:
+# get IS name-scoped: a GET carries the name in the request path, so the
+# authorizer matches it against resourceNames and this read reaches the
+# master and nothing else.
 - apiGroups: [""]
   resources: ["secrets"]
-  verbs: ["get", "create"]
+  verbs: ["get"]
   resourceNames:
   - {{ include "fission.internalAuthSecretName" $ }}
+# create CANNOT be name-scoped, and pairing it with resourceNames does not
+# tighten the grant — it voids it. A POST carries the object name in the
+# BODY, not the path, so the authorizer sees an empty name, a
+# resourceNames-fenced rule never matches, and generation fails Forbidden.
+# The grant would be inert and the feature dead on arrival.
+#
+# This is the exact inverse of the CRD ClusterRole next door, which DOES
+# keep its resourceNames scope on create: server-side apply PATCHes a
+# named path, so the create authorization it additionally needs is
+# evaluated against that name. createIfAbsent uses a plain Create, not an
+# apply, deliberately — apply would take ownership of .data and rotate the
+# master, which is the one thing this hook must never do.
+#
+# So the residual grant is "create A Secret in this one namespace". It
+# cannot read, patch or delete any existing Secret, and create fails
+# AlreadyExists rather than overwriting the master. That is the floor RBAC
+# allows here, and it is bounded by the hook ServiceAccount being deleted
+# with the hook.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -64,3 +64,59 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 {{- end }}
 {{- end }}
+
+{{- /*
+Generation grant (see cmd/preupgradechecks/generateauth.go), SEPARATE from the
+adoption grant above on purpose.
+
+Adoption is patch-only and deliberately cannot read: a grant that cannot read
+the HMAC master, the JWT signing key or the webhook TLS key is worth far more
+than one that can. Generation genuinely needs `get` — it must tell "already
+provisioned" from "absent", and without that a re-run would mint a new master
+and rotate every derived key with no dual-accept window. Widening the adoption
+Role would have handed that read over all three Secrets; a separate Role fenced
+to the master ALONE confines it to the one object that needs it.
+
+Rendered only when the chart is actually generating, and only in the namespaces
+the master is replicated into — under dynamic/cluster tenancy the release
+namespace alone, because tenant namespaces receive controller-owned derived keys
+and the master must never land there.
+*/}}
+{{- if and .Values.preUpgradeChecks.enabled .Values.internalAuth.enabled .Values.internalAuth.autoGenerate (not .Values.internalAuth.existingSecret) (not .Values.internalAuth.secret) }}
+{{- range $ns := splitList " " (include "fission.adoptSecretNamespaces" $) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ $.Release.Name }}-preupgrade-authgen"
+  namespace: {{ $ns }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+    helm.sh/hook-weight: "-2"
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "create"]
+  resourceNames:
+  - {{ include "fission.internalAuthSecretName" $ }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ $.Release.Name }}-preupgrade-authgen"
+  namespace: {{ $ns }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,hook-failed,before-hook-creation
+    helm.sh/hook-weight: "-2"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ $.Release.Name }}-preupgrade-authgen"
+subjects:
+- kind: ServiceAccount
+  name: fission-preupgrade
+  namespace: {{ $.Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1608,4 +1608,27 @@ internalAuth:
   enabled: true
   # secret: "" — auto-generated on first install; preserved on upgrade.
   # oldSecret: "" — set during rotation; accepted by the verifier alongside `secret`.
+  ## existingSecret names a Secret you create yourself, holding key `secret`
+  ## (and optionally `oldSecret`). When set the chart renders NO master Secret
+  ## and every component reads yours instead.
+  ##
+  ## Recommended for GitOps renderers (Argo CD, Flux). Those run `helm
+  ## template`, where the chart's `lookup`-based preservation of a generated
+  ## value cannot work — so a generated master would be re-minted on every
+  ## sync, breaking every pod signed with the previous one.
+  ##
+  ## YOU MUST CREATE IT IN EVERY NAMESPACE FISSION RUNS PODS IN — the release
+  ## namespace plus defaultNamespace plus each additionalFissionNamespaces.
+  ## kubelet cannot resolve a cross-namespace secretKeyRef, so a single copy in
+  ## the release namespace leaves builder and function pods without the key:
+  ## the mount is optional, so those pods START and then 401 on every archive
+  ## fetch and builder upload. (Under dynamic/cluster tenancy only the release
+  ## namespace is needed; tenant namespaces get controller-owned derived keys.)
+  ##
+  ## Switching an existing install to this is safe: the pre-upgrade retention
+  ## hook stamps helm.sh/resource-policy=keep on the chart-generated Secret
+  ## before Helm computes its deletion set, so the value it stops rendering is
+  ## not pruned.
+  ##
+  existingSecret: ""
 

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1608,6 +1608,24 @@ internalAuth:
   enabled: true
   # secret: "" — auto-generated on first install; preserved on upgrade.
   # oldSecret: "" — set during rotation; accepted by the verifier alongside `secret`.
+  ## autoGenerate moves master generation OUT of the chart template and into
+  ## the pre-install/pre-upgrade hook, which creates it only if absent.
+  ##
+  ## Why: the template preserves a generated value across upgrades with
+  ## `lookup`, and `lookup` returns EMPTY under `helm template`. A GitOps
+  ## renderer therefore re-mints the master on every sync, breaking every pod
+  ## signed with the previous one. An in-cluster create-if-absent survives any
+  ## renderer. Prefer existingSecret if you would rather own the value.
+  ##
+  ## Default false, so existing installs are untouched.
+  ##
+  ## The hook writes the master into the same namespaces the template would
+  ## have: under static tenancy the release namespace plus defaultNamespace
+  ## plus each additionalFissionNamespaces; under dynamic/cluster tenancy the
+  ## release namespace ONLY, since tenant namespaces get controller-owned
+  ## derived keys and the master must never land there.
+  ##
+  autoGenerate: false
   ## existingSecret names a Secret you create yourself, holding key `secret`
   ## (and optionally `oldSecret`). When set the chart renders NO master Secret
   ## and every component reads yours instead.

--- a/cmd/preupgradechecks/generateauth.go
+++ b/cmd/preupgradechecks/generateauth.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// authSecretKey is the data key holding the HMAC master.
+	authSecretKey = "secret"
+	// authMasterBytes is the generated master's length before base64. 32 bytes
+	// matches what the chart's randAlphaNum 32 produced, and exceeds the
+	// minimum the signer enforces.
+	authMasterBytes = 32
+)
+
+// GenerateAuthSecret creates the internal-auth master where it is missing,
+// using ONE value across every namespace it writes.
+//
+// Why this exists (RFC-0029 §10): the chart generated the master in the
+// templating layer, preserved across upgrades by `lookup`. Under a GitOps
+// renderer `lookup` returns empty — Argo and Flux run `helm template` — so the
+// value was re-minted on every sync, breaking every pod signed with the
+// previous one. Generation has to be an idempotent in-cluster action instead.
+//
+// The namespace set is supplied by the caller, NOT derived here, and that is
+// deliberate: it is tenancy-dependent, and the chart already computes it in one
+// place (fission.adoptSecretNamespaces). Under STATIC tenancy the master is
+// replicated into the release namespace plus defaultNamespace plus each
+// additionalFissionNamespaces, because kubelet cannot resolve a cross-namespace
+// secretKeyRef. Under DYNAMIC or CLUSTER tenancy it goes to the release
+// namespace ONLY — tenant namespaces receive controller-owned derived keys and
+// the master must never land there, which is the whole isolation end state.
+// Duplicating that rule in Go would be a second source of truth for a
+// security-relevant decision.
+//
+// Idempotent by construction, which matters because this runs on every install
+// AND every upgrade: an existing master anywhere in the set is reused rather
+// than regenerated, and a namespace that already has it is left untouched. A
+// regenerated master would rotate every derived key with no dual-accept window.
+func GenerateAuthSecret(ctx context.Context, client kubernetes.Interface, logger logr.Logger, namespaces []string, secretName string) error {
+	if len(namespaces) == 0 || secretName == "" {
+		return nil
+	}
+
+	// Reuse an existing value if there is one. Reading the master is what the
+	// `get` grant on this single name is for: without it a second run could not
+	// tell "already provisioned" from "absent" and would mint a new master,
+	// which is strictly worse than the read.
+	master, found, err := existingMaster(ctx, client, namespaces, secretName)
+	if err != nil {
+		return err
+	}
+	if !found {
+		master, err = newMaster()
+		if err != nil {
+			return err
+		}
+		logger.Info("generating internal-auth master", "secret", secretName)
+	}
+
+	for _, ns := range namespaces {
+		if ns == "" {
+			continue
+		}
+		created, err := createIfAbsent(ctx, client, ns, secretName, master)
+		if err != nil {
+			return err
+		}
+		if created {
+			logger.Info("created internal-auth master", "secret", secretName, "namespace", ns)
+		}
+	}
+	return nil
+}
+
+// existingMaster returns the first master value already present in the set.
+// Namespaces are checked in order, so the release namespace (first) wins if
+// copies ever disagree.
+func existingMaster(ctx context.Context, client kubernetes.Interface, namespaces []string, secretName string) ([]byte, bool, error) {
+	for _, ns := range namespaces {
+		if ns == "" {
+			continue
+		}
+		s, err := client.CoreV1().Secrets(ns).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			if k8serrors.IsNotFound(err) {
+				continue
+			}
+			return nil, false, fmt.Errorf("read %s/%s: %w", ns, secretName, err)
+		}
+		if v, ok := s.Data[authSecretKey]; ok && len(v) > 0 {
+			return v, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func newMaster() ([]byte, error) {
+	raw := make([]byte, authMasterBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return nil, fmt.Errorf("generate internal-auth master: %w", err)
+	}
+	// base64 so the value is safe in an env var and in `kubectl get -o yaml`
+	// round-trips, matching the shape the chart produced.
+	out := make([]byte, base64.RawStdEncoding.EncodedLen(len(raw)))
+	base64.RawStdEncoding.Encode(out, raw)
+	return out, nil
+}
+
+// createIfAbsent creates the Secret and reports whether it did. An
+// AlreadyExists from a concurrent starter is success, not an error: two hook
+// Jobs racing must converge, not fail the install.
+func createIfAbsent(ctx context.Context, client kubernetes.Interface, namespace, name string, master []byte) (bool, error) {
+	_, err := client.CoreV1().Secrets(namespace).Create(ctx, &apiv1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				// Marks the object as Helm-managed so a later
+				// internalAuth.secret rotation can adopt it rather than
+				// failing on an unowned object.
+				"app.kubernetes.io/managed-by": "Helm",
+				"application":                  "fission-internal-auth",
+			},
+		},
+		Type: apiv1.SecretTypeOpaque,
+		Data: map[string][]byte{authSecretKey: master},
+	}, metav1.CreateOptions{})
+	switch {
+	case err == nil:
+		return true, nil
+	case k8serrors.IsAlreadyExists(err):
+		return false, nil
+	default:
+		return false, fmt.Errorf("create %s/%s: %w", namespace, name, err)
+	}
+}

--- a/cmd/preupgradechecks/generateauth.go
+++ b/cmd/preupgradechecks/generateauth.go
@@ -125,6 +125,16 @@ func writeMaster(ctx context.Context, client kubernetes.Interface, logger logr.L
 // existingMaster returns the first master value already present in the set.
 // Namespaces are checked in order, so the release namespace (first) wins if
 // copies ever disagree.
+//
+// A Secret that exists but carries no usable key is rejected HERE, before the
+// caller writes anything. That placement is the point: this scan holds `get` on
+// every namespace and runs entirely ahead of the first create, so refusing here
+// leaves the cluster untouched. Refusing later — at the create that trips over
+// it — would already have written a freshly minted master into the namespaces
+// ahead of it, and this identity has neither `patch` nor `delete` on the
+// master, so it could never take that back. The operator would then be holding
+// one namespace it must populate by hand and another the hook now insists is
+// authoritative, which is a worse place to stand than where they started.
 func existingMaster(ctx context.Context, client kubernetes.Interface, namespaces []string, secretName string) ([]byte, bool, error) {
 	for _, ns := range namespaces {
 		if ns == "" {
@@ -137,9 +147,13 @@ func existingMaster(ctx context.Context, client kubernetes.Interface, namespaces
 			}
 			return nil, false, fmt.Errorf("read %s/%s: %w", ns, secretName, err)
 		}
-		if v, ok := s.Data[authSecretKey]; ok && len(v) > 0 {
-			return v, true, nil
+		v, ok := s.Data[authSecretKey]
+		if !ok || len(v) == 0 {
+			return nil, false, fmt.Errorf("%s/%s exists but carries no %q value; "+
+				"populate the key, delete the Secret, or point internalAuth.existingSecret "+
+				"at the Secret you manage, then re-run", ns, secretName, authSecretKey)
 		}
+		return v, true, nil
 	}
 	return nil, false, nil
 }
@@ -195,11 +209,14 @@ func createIfAbsent(ctx context.Context, client kubernetes.Interface, namespace,
 		}
 		switch v := live.Data[authSecretKey]; {
 		case len(v) == 0:
-			// Unrecoverable here: this identity may create the Secret but not
-			// patch it, and overwriting a master is the one thing this hook
-			// must never do. Surface it instead of provisioning around it.
-			return false, false, fmt.Errorf("%s/%s exists but carries no %q value; "+
-				"delete it or populate the key, then re-run", namespace, name, authSecretKey)
+			// existingMaster already rejects a keyless Secret before any write,
+			// so reaching this means one appeared BETWEEN that scan and this
+			// create. Rare, and unlike the scan it cannot be atomic — earlier
+			// namespaces are already written. Still refuse: provisioning
+			// around it would leave this namespace keyless for good while the
+			// hook exits 0.
+			return false, false, fmt.Errorf("%s/%s was created without a %q value while this run was in flight; "+
+				"populate the key or delete the Secret, then re-run", namespace, name, authSecretKey)
 		case !bytes.Equal(v, master):
 			return false, false, nil
 		default:

--- a/cmd/preupgradechecks/generateauth.go
+++ b/cmd/preupgradechecks/generateauth.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"encoding/base64"
@@ -21,9 +22,15 @@ const (
 	// authSecretKey is the data key holding the HMAC master.
 	authSecretKey = "secret"
 	// authMasterBytes is the generated master's length before base64. 32 bytes
-	// matches what the chart's randAlphaNum 32 produced, and exceeds the
-	// minimum the signer enforces.
+	// matches what the chart's randAlphaNum 32 produced. Note the signer
+	// itself enforces no minimum — it only rejects a zero-length master
+	// (pkg/auth/hmac/keys.go) — so this length is the guarantee, not a floor
+	// something downstream would catch.
 	authMasterBytes = 32
+
+	// provisionAttempts bounds the adopt-the-winner retry; a third round means
+	// two runs each won a different namespace, which no value can reconcile.
+	provisionAttempts = 3
 )
 
 // GenerateAuthSecret creates the internal-auth master where it is missing,
@@ -55,35 +62,64 @@ func GenerateAuthSecret(ctx context.Context, client kubernetes.Interface, logger
 		return nil
 	}
 
-	// Reuse an existing value if there is one. Reading the master is what the
-	// `get` grant on this single name is for: without it a second run could not
-	// tell "already provisioned" from "absent" and would mint a new master,
-	// which is strictly worse than the read.
-	master, found, err := existingMaster(ctx, client, namespaces, secretName)
-	if err != nil {
-		return err
-	}
-	if !found {
-		master, err = newMaster()
+	// Retry, because a create that loses to a concurrent hook Job does not mean
+	// this run's master is the right one — it means someone else's is. Re-read
+	// and adopt the winner rather than carrying our own value into the
+	// remaining namespaces, which is how the set would diverge permanently.
+	for attempt := range provisionAttempts {
+		// Reuse an existing value if there is one. Reading the master is what
+		// the `get` grant on this single name is for: without it a second run
+		// could not tell "already provisioned" from "absent" and would mint a
+		// new master, which is strictly worse than the read.
+		master, found, err := existingMaster(ctx, client, namespaces, secretName)
 		if err != nil {
 			return err
 		}
-		logger.Info("generating internal-auth master", "secret", secretName)
-	}
+		if !found {
+			master, err = newMaster()
+			if err != nil {
+				return err
+			}
+			logger.Info("generating internal-auth master", "secret", secretName)
+		}
 
+		lost, err := writeMaster(ctx, client, logger, namespaces, secretName, master)
+		if err != nil {
+			return err
+		}
+		if !lost {
+			return nil
+		}
+		logger.Info("lost a create to a concurrent run; re-reading the winning master",
+			"secret", secretName, "attempt", attempt+1)
+	}
+	// Two runs each won a different namespace. There is no value that makes the
+	// set consistent, and guessing would leave half the derived keys wrong with
+	// no error anywhere, so stop and say so.
+	return fmt.Errorf("internal-auth master %q still disagrees across namespaces after %d attempts; "+
+		"delete the inconsistent copies and re-run", secretName, provisionAttempts)
+}
+
+// writeMaster provisions master into every namespace, reporting whether any
+// namespace already held a DIFFERENT one (in which case the caller must adopt
+// the winner and try again).
+func writeMaster(ctx context.Context, client kubernetes.Interface, logger logr.Logger, namespaces []string, secretName string, master []byte) (bool, error) {
 	for _, ns := range namespaces {
 		if ns == "" {
 			continue
 		}
-		created, err := createIfAbsent(ctx, client, ns, secretName, master)
+		created, agreed, err := createIfAbsent(ctx, client, ns, secretName, master)
 		if err != nil {
-			return err
+			return false, err
+		}
+		if !agreed {
+			return true, nil
 		}
 		if created {
 			logger.Info("created internal-auth master", "secret", secretName, "namespace", ns)
 		}
 	}
-	return nil
+	return false, nil
 }
 
 // existingMaster returns the first master value already present in the set.
@@ -115,23 +151,33 @@ func newMaster() ([]byte, error) {
 	}
 	// base64 so the value is safe in an env var and in `kubectl get -o yaml`
 	// round-trips, matching the shape the chart produced.
-	out := make([]byte, base64.RawStdEncoding.EncodedLen(len(raw)))
-	base64.RawStdEncoding.Encode(out, raw)
-	return out, nil
+	return []byte(base64.RawStdEncoding.EncodeToString(raw)), nil
 }
 
-// createIfAbsent creates the Secret and reports whether it did. An
-// AlreadyExists from a concurrent starter is success, not an error: two hook
-// Jobs racing must converge, not fail the install.
-func createIfAbsent(ctx context.Context, client kubernetes.Interface, namespace, name string, master []byte) (bool, error) {
-	_, err := client.CoreV1().Secrets(namespace).Create(ctx, &apiv1.Secret{
+// createIfAbsent creates the Secret, reporting whether it created one and
+// whether the live object agrees with master.
+//
+// An AlreadyExists is not success on its own. The Secret that beat us may hold
+// a different master (a concurrent hook Job that minted its own) or no usable
+// key at all (an aborted rotation, or an ExternalSecret placeholder that
+// existingMaster deliberately skipped). Returning "fine" for either is what
+// lets the namespaces diverge, and the symptom is 401s from pods signing with
+// a key the control plane does not verify — with nothing naming the cause.
+func createIfAbsent(ctx context.Context, client kubernetes.Interface, namespace, name string, master []byte) (created, agreed bool, err error) {
+	_, err = client.CoreV1().Secrets(namespace).Create(ctx, &apiv1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				// Marks the object as Helm-managed so a later
-				// internalAuth.secret rotation can adopt it rather than
-				// failing on an unowned object.
+				// NOT sufficient to make this Helm-adoptable, and deliberately
+				// not claiming to be. Helm's ownership check wants this label
+				// AND the meta.helm.sh/release-{name,namespace} annotations;
+				// the hook does not know the release, so it cannot set them.
+				// The label is here for selectors and parity with the chart's
+				// other objects only. Consequence: switching an autoGenerate
+				// install to a templated internalAuth.secret makes Helm refuse
+				// to adopt this Secret ("invalid ownership metadata") — see
+				// values.yaml, which documents deleting it first.
 				"app.kubernetes.io/managed-by": "Helm",
 				"application":                  "fission-internal-auth",
 			},
@@ -141,10 +187,25 @@ func createIfAbsent(ctx context.Context, client kubernetes.Interface, namespace,
 	}, metav1.CreateOptions{})
 	switch {
 	case err == nil:
-		return true, nil
+		return true, true, nil
 	case k8serrors.IsAlreadyExists(err):
-		return false, nil
+		live, getErr := client.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+		if getErr != nil {
+			return false, false, fmt.Errorf("read existing %s/%s: %w", namespace, name, getErr)
+		}
+		switch v := live.Data[authSecretKey]; {
+		case len(v) == 0:
+			// Unrecoverable here: this identity may create the Secret but not
+			// patch it, and overwriting a master is the one thing this hook
+			// must never do. Surface it instead of provisioning around it.
+			return false, false, fmt.Errorf("%s/%s exists but carries no %q value; "+
+				"delete it or populate the key, then re-run", namespace, name, authSecretKey)
+		case !bytes.Equal(v, master):
+			return false, false, nil
+		default:
+			return false, true, nil
+		}
 	default:
-		return false, fmt.Errorf("create %s/%s: %w", namespace, name, err)
+		return false, false, fmt.Errorf("create %s/%s: %w", namespace, name, err)
 	}
 }

--- a/cmd/preupgradechecks/generateauth_test.go
+++ b/cmd/preupgradechecks/generateauth_test.go
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+const testAuthSecret = "fission-internal-auth"
+
+func masterIn(t *testing.T, cs kubernetes.Interface, ns string) []byte {
+	t.Helper()
+	s, err := cs.CoreV1().Secrets(ns).Get(context.Background(), testAuthSecret, metav1.GetOptions{})
+	require.NoErrorf(t, err, "expected the master in %q", ns)
+	return s.Data[authSecretKey]
+}
+
+func TestGenerateAuthSecret(t *testing.T) {
+	t.Parallel()
+	logger := loggerfactory.GetLogger()
+
+	// STATIC tenancy: the master is replicated because kubelet cannot resolve a
+	// cross-namespace secretKeyRef, so builder and function pods in
+	// defaultNamespace need a local copy. Every copy must hold the SAME value —
+	// they are one HMAC master, not three.
+	t.Run("static tenancy: one value across every namespace", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		nss := []string{"fission", "default", "fission-fn"}
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nss, testAuthSecret))
+
+		want := masterIn(t, cs, "fission")
+		assert.NotEmpty(t, want)
+		for _, ns := range nss[1:] {
+			assert.Equalf(t, want, masterIn(t, cs, ns),
+				"every namespace must carry the same master; %q differs", ns)
+		}
+	})
+
+	// DYNAMIC/CLUSTER tenancy: the chart passes ONLY the release namespace,
+	// because tenant namespaces get controller-owned derived keys and the
+	// master must never land there. This asserts the hook writes exactly what
+	// it is given and invents no fan-out of its own.
+	t.Run("dynamic tenancy: the master reaches only the namespace it was given", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission"}, testAuthSecret))
+
+		assert.NotEmpty(t, masterIn(t, cs, "fission"))
+		for _, tenant := range []string{"default", "tenant-a"} {
+			_, err := cs.CoreV1().Secrets(tenant).Get(t.Context(), testAuthSecret, metav1.GetOptions{})
+			assert.Errorf(t, err, "the master must NOT appear in %q under dynamic tenancy", tenant)
+		}
+	})
+
+	// The hook runs on every install AND every upgrade. Regenerating would
+	// rotate every derived key with no dual-accept window, so a second run must
+	// change nothing.
+	t.Run("re-running preserves the existing master", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		nss := []string{"fission", "default"}
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nss, testAuthSecret))
+		first := masterIn(t, cs, "fission")
+
+		for range 3 {
+			require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nss, testAuthSecret))
+		}
+		assert.Equal(t, first, masterIn(t, cs, "fission"),
+			"re-running must not re-mint the master: that rotates every derived key with no dual-accept window")
+		assert.Equal(t, first, masterIn(t, cs, "default"))
+	})
+
+	// Upgrade path: an install predating this hook already has the master in
+	// the release namespace. Adding a namespace must copy THAT value, not a new
+	// one, or the new namespace's pods sign with a key nobody verifies.
+	t.Run("an existing master is reused when filling a new namespace", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte("already-provisioned-master-value")
+		cs := fake.NewClientset(&apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: "fission"},
+			Data:       map[string][]byte{authSecretKey: existing},
+		})
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission", "default"}, testAuthSecret))
+
+		assert.Equal(t, existing, masterIn(t, cs, "fission"), "the pre-existing master must be left alone")
+		assert.Equal(t, existing, masterIn(t, cs, "default"), "the new copy must carry the SAME value, not a fresh one")
+	})
+
+	// A copy that exists only outside the release namespace is still the
+	// install's master; ignoring it would mint a second one.
+	t.Run("a master found in a later namespace is reused", func(t *testing.T) {
+		t.Parallel()
+		existing := []byte("master-living-in-default")
+		cs := fake.NewClientset(&apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: "default"},
+			Data:       map[string][]byte{authSecretKey: existing},
+		})
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission", "default"}, testAuthSecret))
+		assert.Equal(t, existing, masterIn(t, cs, "fission"))
+	})
+
+	t.Run("no namespaces or no name is a no-op", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, nil, testAuthSecret))
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission"}, ""))
+		list, err := cs.CoreV1().Secrets(metav1.NamespaceAll).List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		assert.Empty(t, list.Items)
+	})
+
+	t.Run("the generated master is long enough to be a key", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger, []string{"fission"}, testAuthSecret))
+		assert.GreaterOrEqual(t, len(masterIn(t, cs, "fission")), 32,
+			"a short master would weaken every derived key")
+	})
+
+	t.Run("two runs on empty clusters do not produce the same master", func(t *testing.T) {
+		t.Parallel()
+		a, b := fake.NewClientset(), fake.NewClientset()
+		require.NoError(t, GenerateAuthSecret(t.Context(), a, logger, []string{"fission"}, testAuthSecret))
+		require.NoError(t, GenerateAuthSecret(t.Context(), b, logger, []string{"fission"}, testAuthSecret))
+		assert.NotEqual(t, masterIn(t, a, "fission"), masterIn(t, b, "fission"),
+			"the master must come from a CSPRNG, not a fixed or time-derived value")
+	})
+}

--- a/cmd/preupgradechecks/generateauth_test.go
+++ b/cmd/preupgradechecks/generateauth_test.go
@@ -219,6 +219,31 @@ func TestGenerateAuthSecretConvergence(t *testing.T) {
 	// so without this guard the run would provision every OTHER namespace and
 	// leave this one keyless — control-plane pods there stay wedged while the
 	// hook exits 0.
+	// Failing is not enough — it must fail having written NOTHING. The hook
+	// holds neither patch nor delete on the master, so a partial write is one
+	// it can never take back: the operator is left with a fresh master in one
+	// namespace and a keyless Secret in another, and the next run reports an
+	// irreconcilable split forever.
+	t.Run("a keyless Secret aborts before anything is written", func(t *testing.T) {
+		t.Parallel()
+		cs := fake.NewClientset()
+		_, err := cs.CoreV1().Secrets("default").Create(t.Context(), &apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: "default"},
+			Data:       map[string][]byte{},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		// "fission" is scanned FIRST and is absent, so the pre-fix ordering
+		// minted a master and created it here before ever reaching "default".
+		err = GenerateAuthSecret(t.Context(), cs, logger,
+			[]string{"fission", "default"}, testAuthSecret)
+		require.Error(t, err)
+
+		_, getErr := cs.CoreV1().Secrets("fission").Get(t.Context(), testAuthSecret, metav1.GetOptions{})
+		assert.True(t, k8serrors.IsNotFound(getErr),
+			"the run must abort before writing any namespace; found a master in %q that the hook can never remove", "fission")
+	})
+
 	t.Run("a keyless existing Secret fails loudly instead of being provisioned around", func(t *testing.T) {
 		t.Parallel()
 		for name, data := range map[string]map[string][]byte{

--- a/cmd/preupgradechecks/generateauth_test.go
+++ b/cmd/preupgradechecks/generateauth_test.go
@@ -5,15 +5,18 @@
 package main
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/fission/fission/pkg/utils/loggerfactory"
 )
@@ -22,7 +25,7 @@ const testAuthSecret = "fission-internal-auth"
 
 func masterIn(t *testing.T, cs kubernetes.Interface, ns string) []byte {
 	t.Helper()
-	s, err := cs.CoreV1().Secrets(ns).Get(context.Background(), testAuthSecret, metav1.GetOptions{})
+	s, err := cs.CoreV1().Secrets(ns).Get(t.Context(), testAuthSecret, metav1.GetOptions{})
 	require.NoErrorf(t, err, "expected the master in %q", ns)
 	return s.Data[authSecretKey]
 }
@@ -137,5 +140,100 @@ func TestGenerateAuthSecret(t *testing.T) {
 		require.NoError(t, GenerateAuthSecret(t.Context(), b, logger, []string{"fission"}, testAuthSecret))
 		assert.NotEqual(t, masterIn(t, a, "fission"), masterIn(t, b, "fission"),
 			"the master must come from a CSPRNG, not a fixed or time-derived value")
+	})
+}
+
+// TestGenerateAuthSecretConvergence pins what happens when this run is NOT the
+// one that created a copy. A create that loses is not evidence that our master
+// is right — it is evidence someone else's is. Carrying our own value into the
+// remaining namespaces is what makes the set diverge permanently, and the
+// symptom is pods signing with a key the control plane will not verify.
+func TestGenerateAuthSecretConvergence(t *testing.T) {
+	t.Parallel()
+	logger := loggerfactory.GetLogger()
+
+	seed := func(t *testing.T, ns string, data map[string][]byte) *fake.Clientset {
+		t.Helper()
+		cs := fake.NewClientset()
+		_, err := cs.CoreV1().Secrets(ns).Create(t.Context(), &apiv1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: ns},
+			Data:       data,
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		return cs
+	}
+
+	// The ordinary re-run: a master already exists, so every other namespace
+	// must receive THAT value, never a freshly minted one. A regenerated master
+	// rotates every derived key with no dual-accept window.
+	t.Run("adopts the existing master rather than minting a new one", func(t *testing.T) {
+		t.Parallel()
+		incumbent := []byte("incumbent-master-value")
+		cs := seed(t, "fission", map[string][]byte{authSecretKey: incumbent})
+
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger,
+			[]string{"fission", "default"}, testAuthSecret))
+
+		assert.Equal(t, incumbent, masterIn(t, cs, "fission"), "the incumbent must not be rotated")
+		assert.Equal(t, incumbent, masterIn(t, cs, "default"), "the replica must carry the incumbent value")
+	})
+
+	// The race this is really about: another run created the FIRST namespace's
+	// copy after we read it as absent. Adopting the winner is the only outcome
+	// that leaves one master; keeping ours would leave two.
+	t.Run("a create lost mid-run converges on the winner", func(t *testing.T) {
+		t.Parallel()
+		winner := []byte("winner-master-value")
+		cs := fake.NewClientset()
+
+		// Let the run see an empty cluster, then plant the winner so the first
+		// Create returns AlreadyExists — exactly the interleaving of two hook
+		// Jobs started together.
+		var planted bool
+		cs.PrependReactor("create", "secrets", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			if planted {
+				return false, nil, nil
+			}
+			planted = true
+			ns := action.GetNamespace()
+			// Add via the tracker, not the clientset: a nested client call
+			// from inside a reactor re-enters the reaction chain.
+			require.NoError(t, cs.Tracker().Add(&apiv1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: testAuthSecret, Namespace: ns},
+				Data:       map[string][]byte{authSecretKey: winner},
+			}))
+			return true, nil, k8serrors.NewAlreadyExists(
+				schema.GroupResource{Resource: "secrets"}, testAuthSecret)
+		})
+
+		require.NoError(t, GenerateAuthSecret(t.Context(), cs, logger,
+			[]string{"fission", "default"}, testAuthSecret))
+
+		assert.Equal(t, winner, masterIn(t, cs, "fission"))
+		assert.Equal(t, winner, masterIn(t, cs, "default"),
+			"the loser must adopt the winner's master, not carry its own into the rest of the set")
+	})
+
+	// A Secret that exists but carries no usable key (an aborted rotation, or
+	// an ExternalSecret placeholder not yet populated). existingMaster skips it,
+	// so without this guard the run would provision every OTHER namespace and
+	// leave this one keyless — control-plane pods there stay wedged while the
+	// hook exits 0.
+	t.Run("a keyless existing Secret fails loudly instead of being provisioned around", func(t *testing.T) {
+		t.Parallel()
+		for name, data := range map[string]map[string][]byte{
+			"missing key": {},
+			"empty value": {authSecretKey: {}},
+		} {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+				cs := seed(t, "default", data)
+				err := GenerateAuthSecret(t.Context(), cs, logger,
+					[]string{"fission", "default"}, testAuthSecret)
+				require.Error(t, err, "a keyless master must not be silently provisioned around")
+				assert.Contains(t, err.Error(), authSecretKey,
+					"the error must name the key an operator has to fix")
+			})
+		}
 	})
 }

--- a/cmd/preupgradechecks/main.go
+++ b/cmd/preupgradechecks/main.go
@@ -53,6 +53,27 @@ func main() {
 		}
 	}
 
+	// Generate the internal-auth master in-cluster when the chart asks for it
+	// (internalAuth.autoGenerate). Generating here rather than in the template
+	// is what makes the value survive a GitOps renderer: `lookup` returns empty
+	// under `helm template`, so a templated value is re-minted on every sync.
+	//
+	// GENERATE_AUTH_SECRET_NAMESPACES is computed by the chart, not derived
+	// here, because the set is tenancy-dependent — release namespace only under
+	// dynamic/cluster tenancy, plus the replicated namespaces under static.
+	// See GenerateAuthSecret.
+	if name := os.Getenv("GENERATE_AUTH_SECRET"); name != "" {
+		namespaces := adoptSecretNames(os.Getenv("GENERATE_AUTH_SECRET_NAMESPACES"))
+		if len(namespaces) == 0 {
+			logger.Error(nil, "GENERATE_AUTH_SECRET set but GENERATE_AUTH_SECRET_NAMESPACES is empty; refusing to guess which namespaces need the master")
+			os.Exit(1)
+		}
+		if err := GenerateAuthSecret(ctx, preupgradeClient.k8sClient, logger, namespaces, name); err != nil {
+			logger.Error(err, "failed to provision the internal-auth master; control-plane pods would start unsigned")
+			os.Exit(1)
+		}
+	}
+
 	if mode := os.Getenv("CRDS_MODE"); mode == crdsModeHook {
 		// Adoption of hand-applied CRDs needs --force-conflicts: they carry
 		// managedFields owned by kubectl-create as an Update operation.

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -30,11 +30,8 @@ const (
 	// supported path for GitOps renderers, where the chart's lookup-based
 	// preservation of a generated value cannot work.
 	//
-	// Read it through InternalAuthSecretName rather than using this constant
-	// directly. Two components resolve this name independently — the fetcher
-	// pod-spec builder and the storagesvc client — and if they disagree the
-	// failure is a 401 on every archive fetch and builder upload, with nothing
-	// pointing at the name as the cause.
+	// Read it through InternalAuthSecretName, not this constant directly — see
+	// that function's doc for why two components must agree on the name.
 	DefaultInternalAuthSecret = "fission-internal-auth"
 
 	// InternalAuthSecretNameEnv overrides DefaultInternalAuthSecret. The chart

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -24,6 +24,23 @@ const (
 )
 
 const (
+	// DefaultInternalAuthSecret is the chart's master-bearing Secret. It is the
+	// DEFAULT, not a fixed fact: an operator may point the chart at a
+	// pre-created Secret instead (internalAuth.existingSecret), which is the
+	// supported path for GitOps renderers, where the chart's lookup-based
+	// preservation of a generated value cannot work.
+	//
+	// Read it through InternalAuthSecretName rather than using this constant
+	// directly. Two components resolve this name independently — the fetcher
+	// pod-spec builder and the storagesvc client — and if they disagree the
+	// failure is a 401 on every archive fetch and builder upload, with nothing
+	// pointing at the name as the cause.
+	DefaultInternalAuthSecret = "fission-internal-auth"
+
+	// InternalAuthSecretNameEnv overrides DefaultInternalAuthSecret. The chart
+	// sets it on every component that resolves the master.
+	InternalAuthSecretNameEnv = "FISSION_INTERNAL_AUTH_SECRET_NAME"
+
 	// TenantAuthKeysSecret is the controller-owned Secret (one per tenant
 	// namespace) holding that namespace's derived HMAC keys. It is deliberately
 	// a DIFFERENT name from the chart's master-bearing "fission-internal-auth":

--- a/pkg/apis/core/v1/internalauth.go
+++ b/pkg/apis/core/v1/internalauth.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import "os"
+
+// InternalAuthSecretName is the name of the Secret holding the internal-auth
+// HMAC master for this install.
+//
+// It exists so the name is resolved in exactly ONE place. The fetcher pod-spec
+// builder and the storagesvc client both need it, and a disagreement between
+// them does not fail loudly: the fetcher's secretKeyRef is marked optional, so
+// the pod starts, the env var is simply absent, and every archive fetch and
+// builder upload 401s with nothing naming the Secret as the cause.
+//
+// The default is the chart-generated name. internalAuth.existingSecret points
+// an install at a pre-created Secret instead — the supported path for GitOps
+// renderers, where the chart cannot preserve a generated value across a
+// `helm template` sync.
+func InternalAuthSecretName() string {
+	if name := os.Getenv(InternalAuthSecretNameEnv); name != "" {
+		return name
+	}
+	return DefaultInternalAuthSecret
+}

--- a/pkg/apis/core/v1/internalauth_test.go
+++ b/pkg/apis/core/v1/internalauth_test.go
@@ -11,27 +11,18 @@ import (
 )
 
 // TestInternalAuthSecretName pins the resolution the fetcher pod-spec builder
-// and the storagesvc client both depend on.
-//
-// They must agree. A disagreement does not fail loudly: the fetcher's
-// secretKeyRef is optional, so the pod starts with the env var simply absent,
-// and every archive fetch and builder upload 401s with nothing naming the
-// Secret as the cause.
+// and the storagesvc client both depend on agreeing on — see
+// InternalAuthSecretName's doc for why a disagreement fails silently.
 func TestInternalAuthSecretName(t *testing.T) {
 	t.Run("defaults to the chart-generated name", func(t *testing.T) {
 		t.Setenv(InternalAuthSecretNameEnv, "")
-		assert.Equal(t, DefaultInternalAuthSecret, InternalAuthSecretName())
+		assert.Equal(t, DefaultInternalAuthSecret, InternalAuthSecretName(),
+			"an unset or blank override must fall back, not resolve to empty")
 	})
 
 	t.Run("an override wins", func(t *testing.T) {
 		t.Setenv(InternalAuthSecretNameEnv, "my-preexisting-secret")
 		assert.Equal(t, "my-preexisting-secret", InternalAuthSecretName(),
 			"internalAuth.existingSecret must reach every component that resolves the master")
-	})
-
-	t.Run("an empty override falls back rather than resolving to nothing", func(t *testing.T) {
-		t.Setenv(InternalAuthSecretNameEnv, "")
-		assert.NotEmpty(t, InternalAuthSecretName(),
-			"an unset or blank override must not yield an empty Secret name")
 	})
 }

--- a/pkg/apis/core/v1/internalauth_test.go
+++ b/pkg/apis/core/v1/internalauth_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestInternalAuthSecretName pins the resolution the fetcher pod-spec builder
+// and the storagesvc client both depend on.
+//
+// They must agree. A disagreement does not fail loudly: the fetcher's
+// secretKeyRef is optional, so the pod starts with the env var simply absent,
+// and every archive fetch and builder upload 401s with nothing naming the
+// Secret as the cause.
+func TestInternalAuthSecretName(t *testing.T) {
+	t.Run("defaults to the chart-generated name", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretNameEnv, "")
+		assert.Equal(t, DefaultInternalAuthSecret, InternalAuthSecretName())
+	})
+
+	t.Run("an override wins", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretNameEnv, "my-preexisting-secret")
+		assert.Equal(t, "my-preexisting-secret", InternalAuthSecretName(),
+			"internalAuth.existingSecret must reach every component that resolves the master")
+	})
+
+	t.Run("an empty override falls back rather than resolving to nothing", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretNameEnv, "")
+		assert.NotEmpty(t, InternalAuthSecretName(),
+			"an unset or blank override must not yield an empty Secret name")
+	})
+}

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 // The storage key stays optional even then: storagesvc dual-accepts a
 // master-derived signature, so an unprovisioned fetcher degrades gracefully.
 func internalAuthEnvVars(namespace string) []apiv1.EnvVar {
-	const chartSecret = "fission-internal-auth"
+	chartSecret := fv1.InternalAuthSecretName()
 	keysSecret := fv1.TenantAuthKeysSecret
 
 	// Require the fetcher key only where it is guaranteed to be provisioned (a

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -45,7 +45,7 @@ type Config struct {
 }
 
 // internalAuthEnvVars returns the env-var entries that mount the
-// HMAC-shared-secret values from the chart-installed Secret/fission-internal-auth
+// HMAC-shared-secret values from the internal-auth master Secret
 // onto the fetcher sidecar container. Every key is marked optional so a
 // pod still admits when the chart's internalAuth is disabled.
 //
@@ -70,7 +70,9 @@ type Config struct {
 // The storage key stays optional even then: storagesvc dual-accepts a
 // master-derived signature, so an unprovisioned fetcher degrades gracefully.
 func internalAuthEnvVars(namespace string) []apiv1.EnvVar {
-	chartSecret := fv1.InternalAuthSecretName()
+	// Not necessarily chart-generated: internalAuth.existingSecret points this
+	// at an operator-supplied Secret instead.
+	masterSecret := fv1.InternalAuthSecretName()
 	keysSecret := fv1.TenantAuthKeysSecret
 
 	// Require the fetcher key only where it is guaranteed to be provisioned (a
@@ -80,8 +82,8 @@ func internalAuthEnvVars(namespace string) []apiv1.EnvVar {
 	fetcherKeyRequired := utils.PerNamespaceKeyRequired(namespace)
 
 	return []apiv1.EnvVar{
-		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET", chartSecret, "secret", true),
-		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET_OLD", chartSecret, "oldSecret", true),
+		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET", masterSecret, "secret", true),
+		secretKeyEnv("FISSION_INTERNAL_AUTH_SECRET_OLD", masterSecret, "oldSecret", true),
 		secretKeyEnv("FISSION_FETCHER_KEY", keysSecret, fv1.TenantAuthFetcherKey, !fetcherKeyRequired),
 		secretKeyEnv("FISSION_FETCHER_KEY_OLD", keysSecret, "fetcherKeyOld", true),
 		secretKeyEnv("FISSION_STORAGE_KEY", keysSecret, fv1.TenantAuthStorageKey, true),

--- a/pkg/fission-cli/cmd/function/run_test.go
+++ b/pkg/fission-cli/cmd/function/run_test.go
@@ -421,6 +421,33 @@ func TestRunLocalPropagatesEnvAndPorts(t *testing.T) {
 	assert.Equal(t, 5005, f.lastSpec.Ports[1].Host)
 }
 
+// requireReSpecialize waits for an edit to path to trigger a re-specialize,
+// rewriting the file on every tick rather than once.
+//
+// serveAndWatch registers the fsnotify watch AFTER the initial specialize —
+// runLocal specializes inside launch(), then calls serveAndWatch, which is
+// where addWatchTree/watcher.Add happen. A caller that writes as soon as it
+// observes that first specialize can therefore land its write in the gap
+// before the watch exists, and inotify has no replay: the event is lost for
+// good and the reload never comes. Rewriting each tick closes the gap.
+//
+// The tick must stay above serveAndWatch's 250ms debounce. A faster rewrite
+// loop would keep restarting drainBurst's quiet period, so the burst would
+// never drain and no reload would fire at all.
+func requireReSpecialize(t *testing.T, f *fakeRuntime, path, content, msg string) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		if f.getSpecializePath() == "/v2/specialize" {
+			return true
+		}
+		// Errors are not asserted here: this runs on Eventually's goroutine,
+		// where FailNow is invalid. A failing write simply leaves the
+		// condition unsatisfied and fails with msg below.
+		_ = os.WriteFile(path, []byte(content), 0o644)
+		return false
+	}, 12*time.Second, 500*time.Millisecond, msg)
+}
+
 func TestRunLocalWatchReloadsOnChange(t *testing.T) {
 	f := &fakeRuntime{echo: "ok"}
 	code := writeTempCode(t, "v1")
@@ -443,9 +470,7 @@ func TestRunLocalWatchReloadsOnChange(t *testing.T) {
 	// Wait for the initial specialize, then edit the source and expect a re-specialize.
 	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond)
 	f.setSpecializePath("")
-	require.NoError(t, os.WriteFile(code, []byte("v2"), 0o644))
-	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond,
-		"editing the source should trigger a re-specialize")
+	requireReSpecialize(t, f, code, "v2", "editing the source should trigger a re-specialize")
 
 	cancel()
 	require.NoError(t, <-done)
@@ -505,9 +530,7 @@ func TestRunLocalWatchDirectoryReloadsOnChange(t *testing.T) {
 
 	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond)
 	f.setSpecializePath("")
-	require.NoError(t, os.WriteFile(main, []byte("v2"), 0o644))
-	require.Eventually(t, func() bool { return f.getSpecializePath() == "/v2/specialize" }, 3*time.Second, 10*time.Millisecond,
-		"editing a file inside the source dir should trigger a re-specialize")
+	requireReSpecialize(t, f, main, "v2", "editing a file inside the source dir should trigger a re-specialize")
 
 	cancel()
 	require.NoError(t, <-done)

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -517,22 +517,29 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 				f.Namespace, f.Name, f.Spec.Package.PackageRef.Namespace, f.Spec.Package.PackageRef.Name)
 		}
 
-		fnKey := k8sCache.MetaObjectToName(&metav1.ObjectMeta{Namespace: f.Namespace, Name: f.Name}).String()
-		switch stamp, isLive := liveStamps[fnKey]; {
-		case written[k]:
-			// This apply created or updated the package: propagate the new
-			// ResourceVersion so the change reaches running pods.
-			fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
-		case isLive:
-			// Package untouched and the function already exists: keep the
-			// stamp it has, so an unchanged reapply is a genuine no-op.
-			fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = stamp
-		default:
-			// A new function against a pre-existing package still needs a
-			// stamp, and the package's current ResourceVersion is the only
-			// one there is.
-			fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
+		// Default to the package's current ResourceVersion. That is right when
+		// this apply wrote the package (the change must reach running pods),
+		// and it is the only stamp available for a function that is new, or
+		// that this spec repoints at a different package.
+		rv := m.ResourceVersion
+
+		// The one case that must NOT take the current version: the package was
+		// untouched by this apply and the live function already references that
+		// same package. Re-stamping there would rewrite an unchanged function
+		// on every apply, minting spurious RFC-0025 versions.
+		//
+		// "Same package" is load-bearing. A spec that repoints a function from
+		// pkgA to an untouched pkgB must not inherit pkgA's stamp: the
+		// reference would name pkgB with pkgA's ResourceVersion, the next apply
+		// would preserve that same wrong value, and nothing converges —
+		// package restamping only fires when pkgB itself is written.
+		fnKey := k8sCache.MetaObjectToName(&f.ObjectMeta).String()
+		if live, isLive := liveStamps[fnKey]; !written[k] && isLive &&
+			live.Name == f.Spec.Package.PackageRef.Name &&
+			live.Namespace == f.Spec.Package.PackageRef.Namespace {
+			rv = live.ResourceVersion
 		}
+		fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = rv
 	}
 
 	_, ras, err = applyFunctions(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
@@ -831,15 +838,19 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 // field is a runtime stamp, not something a user writes. So "leave it alone"
 // cannot mean "leave it empty": an empty stamp differs from what is live and
 // would force the very update this is avoiding.
-func liveFunctionStamps(ctx context.Context, fclient cmd.Client) (map[string]string, error) {
+// The whole PackageRef is returned, not just the stamp: a stamp is only worth
+// preserving when the live function still points at the SAME package the spec
+// now names. Keying on the function alone would carry the old package's
+// ResourceVersion onto a repointed reference.
+func liveFunctionStamps(ctx context.Context, fclient cmd.Client) (map[string]fv1.PackageRef, error) {
 	list, err := fclient.FissionClientSet.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("list functions to preserve package stamps: %w", err)
 	}
-	out := make(map[string]string, len(list.Items))
+	out := make(map[string]fv1.PackageRef, len(list.Items))
 	for i := range list.Items {
 		fn := &list.Items[i]
-		out[k8sCache.MetaObjectToName(&fn.ObjectMeta).String()] = fn.Spec.Package.PackageRef.ResourceVersion
+		out[k8sCache.MetaObjectToName(&fn.ObjectMeta).String()] = fn.Spec.Package.PackageRef
 	}
 	return out, nil
 }

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -475,6 +475,30 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	// no-op/created packages, and the dryRunResourceVersion sentinel for packages
 	// that would be updated — so a would-be package update correctly cascades into
 	// a would-be update of the functions that reference it, matching a real apply.
+	// Packages this apply actually wrote. Copying a package's CURRENT
+	// ResourceVersion into every referencing function is only correct for
+	// these: a package's ResourceVersion also drifts on controller STATUS
+	// writes (buildermgr records a content hash), so stamping unconditionally
+	// re-stamps functions whose package nobody touched — which bumps their
+	// generation, recycles their pods and mints an RFC-0025 version. A GitOps
+	// controller reapplies on every sync, so that is continuous churn, not a
+	// one-off. See TestSpecApplyIsIdempotent.
+	written := make(map[string]bool, len(ras.Created)+len(ras.Updated))
+	for _, m := range ras.Created {
+		written[k8sCache.MetaObjectToName(m).String()] = true
+	}
+	for _, m := range ras.Updated {
+		written[k8sCache.MetaObjectToName(m).String()] = true
+	}
+
+	// Stamps the live functions already carry, so an untouched package leaves
+	// its referencing functions byte-identical instead of empty (which would
+	// itself read as a change and force an update).
+	liveStamps, err := liveFunctionStamps(input.Context(), fclient)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	for i, f := range fr.Functions {
 		if f.Spec.InvokeStrategy.ExecutionStrategy.ExecutorType == fv1.ExecutorTypeContainer {
 			continue
@@ -492,7 +516,23 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 			return nil, nil, fmt.Errorf("function %v/%v references package %v/%v, which doesn't exist in the specs",
 				f.Namespace, f.Name, f.Spec.Package.PackageRef.Namespace, f.Spec.Package.PackageRef.Name)
 		}
-		fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
+
+		fnKey := k8sCache.MetaObjectToName(&metav1.ObjectMeta{Namespace: f.Namespace, Name: f.Name}).String()
+		switch stamp, isLive := liveStamps[fnKey]; {
+		case written[k]:
+			// This apply created or updated the package: propagate the new
+			// ResourceVersion so the change reaches running pods.
+			fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
+		case isLive:
+			// Package untouched and the function already exists: keep the
+			// stamp it has, so an unchanged reapply is a genuine no-op.
+			fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = stamp
+		default:
+			// A new function against a pre-existing package still needs a
+			// stamp, and the package's current ResourceVersion is the only
+			// one there is.
+			fr.Functions[i].Spec.Package.PackageRef.ResourceVersion = m.ResourceVersion
+		}
 	}
 
 	_, ras, err = applyFunctions(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
@@ -782,6 +822,26 @@ func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources
 			return packages(ns).Delete(ctx, name, metav1.DeleteOptions{})
 		},
 	}, delete, specAllowConflicts, dryRun)
+}
+
+// liveFunctionStamps returns each existing function's current
+// PackageRef.ResourceVersion, keyed by namespace/name.
+//
+// Needed because a function in a spec FILE carries no ResourceVersion — that
+// field is a runtime stamp, not something a user writes. So "leave it alone"
+// cannot mean "leave it empty": an empty stamp differs from what is live and
+// would force the very update this is avoiding.
+func liveFunctionStamps(ctx context.Context, fclient cmd.Client) (map[string]string, error) {
+	list, err := fclient.FissionClientSet.CoreV1().Functions(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("list functions to preserve package stamps: %w", err)
+	}
+	out := make(map[string]string, len(list.Items))
+	for i := range list.Items {
+		fn := &list.Items[i]
+		out[k8sCache.MetaObjectToName(&fn.ObjectMeta).String()] = fn.Spec.Package.PackageRef.ResourceVersion
+	}
+	return out, nil
 }
 
 func applyFunctions(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -24,14 +24,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/storagesvc"
 )
-
-// internalAuthSecretName is the chart-installed Secret that holds the
-// shared HMAC key used for internal control-plane authentication. The
-// chart's name is fixed; see charts/fission-all/templates/internal-auth-secret.yaml.
-const internalAuthSecretName = "fission-internal-auth"
 
 // internalAuthSecretKey is the data key inside that Secret.
 const internalAuthSecretKey = "secret"
@@ -146,7 +142,7 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	if kubeClient == nil {
 		return nil, nil
 	}
-	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, internalAuthSecretName, metav1.GetOptions{})
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, fv1.InternalAuthSecretName(), metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -156,7 +152,7 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	value, ok := secret.Data[internalAuthSecretKey]
 	if !ok || len(value) == 0 {
 		return nil, fmt.Errorf("secret %s/%s exists but has no %q key with a non-empty value; either the chart's internalAuth materialisation has been overridden or the Secret was hand-authored",
-			namespace, internalAuthSecretName, internalAuthSecretKey)
+			namespace, fv1.InternalAuthSecretName(), internalAuthSecretKey)
 	}
 	return value, nil
 }

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -142,7 +142,8 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	if kubeClient == nil {
 		return nil, nil
 	}
-	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, fv1.InternalAuthSecretName(), metav1.GetOptions{})
+	secretName := fv1.InternalAuthSecretName()
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, nil
@@ -152,7 +153,7 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 	value, ok := secret.Data[internalAuthSecretKey]
 	if !ok || len(value) == 0 {
 		return nil, fmt.Errorf("secret %s/%s exists but has no %q key with a non-empty value; either the chart's internalAuth materialisation has been overridden or the Secret was hand-authored",
-			namespace, fv1.InternalAuthSecretName(), internalAuthSecretKey)
+			namespace, secretName, internalAuthSecretKey)
 	}
 	return value, nil
 }

--- a/pkg/workflow/engine_branch_test.go
+++ b/pkg/workflow/engine_branch_test.go
@@ -60,10 +60,13 @@ func TestEngineParallelJoin(t *testing.T) {
 	assert.Contains(t, out[0].(map[string]any)["fn"], "fn-x")
 	assert.Contains(t, out[1].(map[string]any)["fn"], "fn-y")
 
-	assertInvariants(t, h.log(t), 1)
-	assertRegionInvariants(t, h.log(t), 2)
-	assert.Equal(t, 1, h.calls["fn-x"])
-	assert.Equal(t, 1, h.calls["fn-y"])
+	log := h.log(t)
+	assertInvariants(t, log, 1)
+	assertRegionInvariants(t, log, 2)
+	assert.Equal(t, 1, attempts(log, "x"), "one attempt per branch state")
+	assert.Equal(t, 1, attempts(log, "y"), "one attempt per branch state")
+	assert.GreaterOrEqual(t, h.callCount("fn-x"), 1, "at-least-once execution")
+	assert.GreaterOrEqual(t, h.callCount("fn-y"), 1, "at-least-once execution")
 }
 
 func TestEngineParallelFailFast(t *testing.T) {

--- a/pkg/workflow/engine_test.go
+++ b/pkg/workflow/engine_test.go
@@ -148,6 +148,37 @@ func (h *harness) log(t *testing.T) []Event {
 	return out
 }
 
+// callCount reads the harness invocation counter under the lock. The
+// counter is written from the httptest handler goroutine, and a duplicate
+// delivery can still be in flight when the run reaches terminal, so an
+// unsynchronised read here is a real race, not a formality.
+func (h *harness) callCount(name string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.calls[name]
+}
+
+// attempts counts the attempts the LOG records for a state.
+//
+// Assert retry policy here rather than on the harness call counter. The
+// engine guarantees exactly one EvStepScheduled and one result per attempt
+// (W1/W2) — it does not guarantee exactly one HTTP delivery per attempt.
+// execute() sets X-Fission-Workflow-{Run,Attempt} precisely because
+// delivery is at-least-once and functions are expected to dedup on that
+// pair: a redelivered attempt re-runs the side effect, and its result then
+// loses the append guard, leaving the log correct and the call counter
+// high. Asserting an exact call count therefore tests a property the
+// design deliberately does not offer, and fails under CI contention.
+func attempts(log []Event, state string) int {
+	n := 0
+	for _, e := range log {
+		if e.Type == EvStepScheduled && e.State == state {
+			n++
+		}
+	}
+	return n
+}
+
 // assertInvariants re-verifies W1-W6 over the final log.
 func assertInvariants(t *testing.T, log []Event, maxAttempts int) {
 	t.Helper()
@@ -185,8 +216,12 @@ func TestEngineLinearPipeline(t *testing.T) {
 
 	assert.Equal(t, fv1.WorkflowRunSucceeded, s.Terminal)
 	assert.JSONEq(t, `{"fn":"fn-b","call":1}`, string(s.Output))
-	assertInvariants(t, h.log(t), 1)
-	assert.Equal(t, map[string]int{"fn-a": 1, "fn-b": 1}, h.calls)
+	log := h.log(t)
+	assertInvariants(t, log, 1)
+	assert.Equal(t, 1, attempts(log, "a"), "one attempt per state")
+	assert.Equal(t, 1, attempts(log, "b"), "one attempt per state")
+	assert.GreaterOrEqual(t, h.callCount("fn-a"), 1, "at-least-once execution")
+	assert.GreaterOrEqual(t, h.callCount("fn-b"), 1, "at-least-once execution")
 }
 
 func TestEngineRetryThenCatch(t *testing.T) {
@@ -208,9 +243,12 @@ func TestEngineRetryThenCatch(t *testing.T) {
 	s := h.drive(t, h.engine, 10*time.Second)
 
 	assert.Equal(t, fv1.WorkflowRunSucceeded, s.Terminal, "catch routed to b, which succeeded")
-	assertInvariants(t, h.log(t), 2)
-	assert.Equal(t, 2, h.calls["fn-a"], "retried to budget")
-	assert.Equal(t, 1, h.calls["fn-b"])
+	log := h.log(t)
+	assertInvariants(t, log, 2)
+	assert.Equal(t, 2, attempts(log, "a"), "retried to budget")
+	assert.Equal(t, 1, attempts(log, "b"), "the catch target runs once")
+	assert.GreaterOrEqual(t, h.callCount("fn-a"), 2, "at-least-once per attempt")
+	assert.GreaterOrEqual(t, h.callCount("fn-b"), 1, "at-least-once execution")
 }
 
 // TestEngineCatchResultPathKeepsDocument pins the catch resultPath contract:
@@ -265,8 +303,9 @@ func TestEnginePermanentErrorFailsRun(t *testing.T) {
 
 	assert.Equal(t, fv1.WorkflowRunFailed, s.Terminal)
 	assert.Equal(t, fv1.WorkflowErrPermanentError, s.ErrorType)
-	assert.Equal(t, 1, h.calls["fn-a"], "4xx never retries")
-	assertInvariants(t, h.log(t), 1)
+	log := h.log(t)
+	assert.Equal(t, 1, attempts(log, "a"), "4xx never retries")
+	assertInvariants(t, log, 1)
 }
 
 func TestEngineCancellation(t *testing.T) {
@@ -322,7 +361,7 @@ func TestEngineCrashPointResume(t *testing.T) {
 
 			assert.Equal(t, fv1.WorkflowRunSucceeded, s.Terminal)
 			assertInvariants(t, h.log(t), 2)
-			assert.GreaterOrEqual(t, h.calls["fn-a"], 1, "at-least-once execution")
+			assert.GreaterOrEqual(t, h.callCount("fn-a"), 1, "at-least-once execution")
 		})
 	}
 }

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -453,3 +453,118 @@ func TestStateSvcChart(t *testing.T) {
 		assert.Nil(t, find(docs, "Deployment", svcinfo.SvcStateSvc))
 	})
 }
+
+// TestInternalAuthExistingSecret pins RFC-0029's `internalAuth.existingSecret`
+// contract, whose failure mode is silent.
+//
+// Every consumer must resolve ONE name. The secretKeyRef is mounted optional so
+// rotation can drop a key without forcing an empty render — which also means a
+// pod whose reference points at a Secret that does not exist starts happily
+// with the env var absent, and then 401s on every archive fetch and builder
+// upload with nothing naming the Secret as the cause.
+//
+// The Go side resolves the same name from FISSION_INTERNAL_AUTH_SECRET_NAME
+// (fv1.InternalAuthSecretName), so the chart must set it to whatever it wired
+// into the secretKeyRefs.
+func TestInternalAuthExistingSecret(t *testing.T) {
+	const defaultName = "fission-internal-auth"
+
+	t.Run("default: the chart renders the master and points at it", func(t *testing.T) {
+		docs := render(t)
+		assert.Positive(t, countByKindName(docs, "Secret", defaultName),
+			"with no existingSecret the chart must generate the master itself")
+		for _, name := range internalAuthEnvNames(docs) {
+			assert.Equal(t, defaultName, name)
+		}
+	})
+
+	t.Run("existingSecret: the chart renders no master and points at theirs", func(t *testing.T) {
+		docs := render(t, "--set", "internalAuth.existingSecret=my-master")
+		assert.Zero(t, countByKindName(docs, "Secret", defaultName),
+			"the chart must not generate a master when the operator supplies one")
+		names := internalAuthEnvNames(docs)
+		require.NotEmpty(t, names, "no internal-auth secretKeyRef was rendered")
+		for _, name := range names {
+			assert.Equal(t, "my-master", name,
+				"every consumer must read the operator's Secret, not the chart's default")
+		}
+	})
+
+	// The env var is what the Go side reads. If it disagrees with the
+	// secretKeyRefs above, the two halves resolve different Secrets.
+	t.Run("the name env var matches the secretKeyRefs", func(t *testing.T) {
+		for _, tc := range []struct{ arg, want string }{
+			{"", defaultName},
+			{"my-master", "my-master"},
+		} {
+			var docs []map[string]any
+			if tc.arg == "" {
+				docs = render(t)
+			} else {
+				docs = render(t, "--set", "internalAuth.existingSecret="+tc.arg)
+			}
+			vals := envValues(docs, "FISSION_INTERNAL_AUTH_SECRET_NAME")
+			require.NotEmptyf(t, vals, "FISSION_INTERNAL_AUTH_SECRET_NAME must be set (existingSecret=%q)", tc.arg)
+			for _, v := range vals {
+				assert.Equal(t, tc.want, v)
+			}
+		}
+	})
+}
+
+// internalAuthEnvNames collects the Secret names every FISSION_INTERNAL_AUTH_SECRET
+// secretKeyRef points at, across every rendered pod template.
+func internalAuthEnvNames(docs []map[string]any) []string {
+	var out []string
+	forEachContainerEnv(docs, func(e map[string]any) {
+		name, _ := e["name"].(string)
+		if name != "FISSION_INTERNAL_AUTH_SECRET" {
+			return
+		}
+		vf, _ := e["valueFrom"].(map[string]any)
+		skr, _ := vf["secretKeyRef"].(map[string]any)
+		if n, ok := skr["name"].(string); ok {
+			out = append(out, n)
+		}
+	})
+	return out
+}
+
+// envValues collects the literal values of a named env var across every
+// rendered pod template.
+func envValues(docs []map[string]any, envName string) []string {
+	var out []string
+	forEachContainerEnv(docs, func(e map[string]any) {
+		if name, _ := e["name"].(string); name == envName {
+			if v, ok := e["value"].(string); ok {
+				out = append(out, v)
+			}
+		}
+	})
+	return out
+}
+
+// forEachContainerEnv walks every env entry of every container in every
+// rendered pod template.
+func forEachContainerEnv(docs []map[string]any, fn func(map[string]any)) {
+	for _, doc := range docs {
+		spec, _ := doc["spec"].(map[string]any)
+		tmpl, ok := spec["template"].(map[string]any)
+		if !ok {
+			continue
+		}
+		podSpec, _ := tmpl["spec"].(map[string]any)
+		for _, key := range []string{"containers", "initContainers"} {
+			cs, _ := podSpec[key].([]any)
+			for _, c := range cs {
+				cm, _ := c.(map[string]any)
+				envs, _ := cm["env"].([]any)
+				for _, e := range envs {
+					if em, ok := e.(map[string]any); ok {
+						fn(em)
+					}
+				}
+			}
+		}
+	}
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -571,3 +571,94 @@ func forEachContainerEnv(docs []map[string]any, fn func(map[string]any)) {
 		}
 	}
 }
+
+// TestInternalAuthAutoGenerate pins RFC-0029 §10's generation path, including
+// the tenancy rule that decides where the master may land.
+func TestInternalAuthAutoGenerate(t *testing.T) {
+	const master = "fission-internal-auth"
+
+	countMasterSecrets := func(docs []map[string]any) int {
+		n := 0
+		for _, d := range docs {
+			kind, _ := d["kind"].(string)
+			meta, _ := d["metadata"].(map[string]any)
+			name, _ := meta["name"].(string)
+			if kind == "Secret" && name == master {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("off by default: the template still renders the master", func(t *testing.T) {
+		docs := render(t)
+		assert.Positive(t, countMasterSecrets(docs),
+			"autoGenerate defaults off, so existing installs must be untouched")
+		assert.Zero(t, countByKindName(docs, "Role", "fission-preupgrade-authgen"),
+			"no generation means no read grant")
+	})
+
+	t.Run("on: the template stops rendering and the hook is wired", func(t *testing.T) {
+		docs := render(t, "--set", "internalAuth.autoGenerate=true")
+		assert.Zero(t, countMasterSecrets(docs),
+			"generation moves in-cluster, so the template must render no master — "+
+				"the retention hook is what stops Helm pruning the live one")
+		vals := envValues(docs, "GENERATE_AUTH_SECRET")
+		require.NotEmpty(t, vals, "the hook must be told which Secret to provision")
+		for _, v := range vals {
+			assert.Equal(t, master, v)
+		}
+	})
+
+	// The rule the whole design turns on: under dynamic/cluster tenancy the
+	// master must NOT reach tenant namespaces — they get controller-owned
+	// derived keys, and a master there would defeat the isolation end state.
+	t.Run("static tenancy fans out; dynamic does not", func(t *testing.T) {
+		static := render(t,
+			"--set", "internalAuth.autoGenerate=true",
+			"--set", "additionalFissionNamespaces={fission-fn}")
+		staticNS := envValues(static, "GENERATE_AUTH_SECRET_NAMESPACES")
+		require.NotEmpty(t, staticNS)
+		assert.Contains(t, staticNS[0], "fission-fn",
+			"static tenancy replicates the master: kubelet cannot resolve a cross-namespace secretKeyRef")
+
+		dynamic := render(t,
+			"--set", "internalAuth.autoGenerate=true",
+			"--set", "tenancy.mode=dynamic",
+			"--set", "additionalFissionNamespaces={fission-fn}")
+		dynNS := envValues(dynamic, "GENERATE_AUTH_SECRET_NAMESPACES")
+		require.NotEmpty(t, dynNS)
+		assert.NotContains(t, dynNS[0], "fission-fn",
+			"under dynamic tenancy the master must stay in the release namespace: "+
+				"tenant namespaces get controller-owned derived keys and must never hold the master")
+	})
+
+	// The read grant is the one concession this design makes; it must not widen
+	// beyond the single object that needs it.
+	t.Run("the generation grant is fenced to the master alone", func(t *testing.T) {
+		docs := render(t, "--set", "internalAuth.autoGenerate=true")
+		var checked int
+		for _, d := range docs {
+			kind, _ := d["kind"].(string)
+			meta, _ := d["metadata"].(map[string]any)
+			name, _ := meta["name"].(string)
+			if kind != "Role" || name != "fission-preupgrade-authgen" {
+				continue
+			}
+			checked++
+			rules, _ := d["rules"].([]any)
+			for _, r := range rules {
+				rule, _ := r.(map[string]any)
+				names, _ := rule["resourceNames"].([]any)
+				require.Len(t, names, 1, "the grant must name exactly one Secret")
+				assert.Equal(t, master, names[0])
+				verbs, _ := rule["verbs"].([]any)
+				for _, v := range verbs {
+					assert.NotEqual(t, "list", v, "list would let this identity enumerate every Secret")
+					assert.NotEqual(t, "delete", v)
+				}
+			}
+		}
+		require.Positive(t, checked, "no generation Role was rendered; the guard is inert")
+	})
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -689,7 +689,7 @@ func TestNameFormat(t *testing.T) {
 		leg := jobNamesFor(t, distinguishing, "legacy")
 		require.NotEqual(t, std, leg, "fixture precondition: the release name must distinguish the two formats")
 
-		implicit := jobNamesForDefault(t, distinguishing)
+		implicit := jobNamesFrom(renderAs(t, distinguishing))
 		assert.Equal(t, std, implicit, "the chart default must be standard")
 		assert.NotEqual(t, leg, implicit, "the chart default must no longer be legacy")
 	})
@@ -739,12 +739,6 @@ func TestNameFormat(t *testing.T) {
 		require.Error(t, err, "a typo must fail the render, not fall back to legacy silently")
 		assert.Contains(t, err.Error(), "nameFormat must be")
 	})
-}
-
-// jobNamesForDefault renders with no nameFormat set at all.
-func jobNamesForDefault(t *testing.T, release string) []string {
-	t.Helper()
-	return jobNamesFrom(renderAs(t, release))
 }
 
 // jobNamesFor renders with a given release name and nameFormat, returning the
@@ -897,22 +891,9 @@ func forEachContainerEnv(docs []map[string]any, fn func(map[string]any)) {
 func TestInternalAuthAutoGenerate(t *testing.T) {
 	const master = "fission-internal-auth"
 
-	countMasterSecrets := func(docs []map[string]any) int {
-		n := 0
-		for _, d := range docs {
-			kind, _ := d["kind"].(string)
-			meta, _ := d["metadata"].(map[string]any)
-			name, _ := meta["name"].(string)
-			if kind == "Secret" && name == master {
-				n++
-			}
-		}
-		return n
-	}
-
 	t.Run("off by default: the template still renders the master", func(t *testing.T) {
 		docs := render(t)
-		assert.Positive(t, countMasterSecrets(docs),
+		assert.Positive(t, countByKindName(docs, "Secret", master),
 			"autoGenerate defaults off, so existing installs must be untouched")
 		assert.Zero(t, countByKindName(docs, "Role", "fission-preupgrade-authgen"),
 			"no generation means no read grant")
@@ -920,7 +901,7 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 
 	t.Run("on: the template stops rendering and the hook is wired", func(t *testing.T) {
 		docs := render(t, "--set", "internalAuth.autoGenerate=true")
-		assert.Zero(t, countMasterSecrets(docs),
+		assert.Zero(t, countByKindName(docs, "Secret", master),
 			"generation moves in-cluster, so the template must render no master — "+
 				"the retention hook is what stops Helm pruning the live one")
 		vals := envValues(docs, "GENERATE_AUTH_SECRET")
@@ -951,6 +932,24 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 		assert.NotContains(t, dynNS[0], "fission-fn",
 			"under dynamic tenancy the master must stay in the release namespace: "+
 				"tenant namespaces get controller-owned derived keys and must never hold the master")
+	})
+
+	// autoGenerate moves provisioning into the hook Job, so the template stops
+	// rendering the Secret. If the Job is also switched off, NOTHING provisions
+	// the master and every control-plane pod wedges on a required secretKeyRef
+	// — a whole install that comes up dead from two values that each look
+	// reasonable alone. The chart must refuse to render, exactly as it already
+	// does for crds.mode=hook with the same Job disabled.
+	t.Run("autoGenerate without the hook Job refuses to render", func(t *testing.T) {
+		_, err := renderErr(t,
+			"--set", "internalAuth.autoGenerate=true",
+			"--set", "preUpgradeChecks.enabled=false",
+			// Otherwise the pre-existing crds.mode guard fires first and we
+			// would be asserting the wrong refusal.
+			"--set", "crds.mode=none")
+		require.Error(t, err, "autoGenerate with preUpgradeChecks disabled provisions no master at all")
+		assert.Contains(t, err.Error(), "preUpgradeChecks.enabled must be true",
+			"the failure must name the value the operator has to change")
 	})
 
 	// The read grant is the one concession this design makes; it must not widen

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -473,7 +473,13 @@ func podSelectorSvcLabels(doc map[string]any) []string {
 		rule, _ := r.(map[string]any)
 		froms, _ := rule["from"].([]any)
 		for _, f := range froms {
-			if sel, ok := f.(map[string]any)["podSelector"].(map[string]any); ok {
+			fm, ok := f.(map[string]any)
+			if !ok {
+				// A non-map `from` entry is malformed chart output; skip it so
+				// the caller reports a missing selector rather than panicking.
+				continue
+			}
+			if sel, ok := fm["podSelector"].(map[string]any); ok {
 				add(sel)
 			}
 		}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -473,7 +473,10 @@ func TestInternalAuthExistingSecret(t *testing.T) {
 		docs := render(t)
 		assert.Positive(t, countByKindName(docs, "Secret", defaultName),
 			"with no existingSecret the chart must generate the master itself")
-		for _, name := range internalAuthEnvNames(docs) {
+		names := internalAuthEnvNames(docs)
+		require.NotEmpty(t, names,
+			"no internal-auth secretKeyRef was rendered; the loop below would assert nothing")
+		for _, name := range names {
 			assert.Equal(t, defaultName, name)
 		}
 	})

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -453,3 +453,91 @@ func TestStateSvcChart(t *testing.T) {
 		assert.Nil(t, find(docs, "Deployment", svcinfo.SvcStateSvc))
 	})
 }
+
+// podSelectorSvcLabels collects every `svc:` value a NetworkPolicy references,
+// from both its own podSelector and every ingress `from` podSelector.
+func podSelectorSvcLabels(doc map[string]any) []string {
+	var out []string
+	add := func(sel map[string]any) {
+		ml, _ := sel["matchLabels"].(map[string]any)
+		if v, ok := ml["svc"].(string); ok && v != "" {
+			out = append(out, v)
+		}
+	}
+	spec, _ := doc["spec"].(map[string]any)
+	if sel, ok := spec["podSelector"].(map[string]any); ok {
+		add(sel)
+	}
+	ingress, _ := spec["ingress"].([]any)
+	for _, r := range ingress {
+		rule, _ := r.(map[string]any)
+		froms, _ := rule["from"].([]any)
+		for _, f := range froms {
+			if sel, ok := f.(map[string]any)["podSelector"].(map[string]any); ok {
+				add(sel)
+			}
+		}
+	}
+	return out
+}
+
+// TestNetworkPolicySvcLabelsResolveToRealWorkloads is the fixed-name inventory
+// guard for RFC-0029 phase 2 (naming / multi-instance).
+//
+// NetworkPolicies address workloads by a bare `svc:` pod label, which is a
+// STRING that no template or Go constant forces to agree with the pod labels
+// the Deployments actually carry. That makes a rename — exactly what phase 2
+// does — able to orphan an allowlist entry, and the failure is silent: traffic
+// is dropped, not rejected, and surfaces far away as `dial tcp <ip>:8889: i/o
+// timeout` in an unrelated test.
+//
+// Asserting every referenced label is carried by some rendered pod template
+// turns that into a build-time failure.
+func TestNetworkPolicySvcLabelsResolveToRealWorkloads(t *testing.T) {
+	// Every optional component is enabled on purpose. The allowlist legitimately
+	// names workloads that only render behind a flag, so a default render would
+	// report them as orphaned — the check is only meaningful when the workloads
+	// it references actually exist.
+	docs := render(t,
+		"--set", "networkPolicy.enabled=true",
+		"--set", "mcp.enabled=true", "--set", "mcp.allowInsecure=true",
+		"--set", "canaryDeployment.enabled=true",
+		"--set", "workflows.enabled=true",
+		// workflows depends on the statestore; the chart refuses to render
+		// otherwise (statestore/validate.yaml).
+		"--set", "statestore.enabled=true", "--set", "statestore.mode=embedded",
+		"--set", "functionState.enabled=true",
+	)
+
+	// Every `svc:` label carried by a rendered pod template.
+	known := map[string]bool{}
+	for _, doc := range docs {
+		spec, _ := doc["spec"].(map[string]any)
+		tmpl, ok := spec["template"].(map[string]any)
+		if !ok {
+			continue
+		}
+		meta, _ := tmpl["metadata"].(map[string]any)
+		labels, _ := meta["labels"].(map[string]any)
+		if v, ok := labels["svc"].(string); ok && v != "" {
+			known[v] = true
+		}
+	}
+	require.NotEmpty(t, known, "no pod template carried an svc label; the selector convention changed")
+
+	var checked int
+	for _, doc := range docs {
+		if kind, _ := doc["kind"].(string); kind != "NetworkPolicy" {
+			continue
+		}
+		meta, _ := doc["metadata"].(map[string]any)
+		npName, _ := meta["name"].(string)
+		for _, label := range podSelectorSvcLabels(doc) {
+			checked++
+			assert.Truef(t, known[label],
+				"NetworkPolicy %q references svc=%q, which no rendered pod template carries; "+
+					"the policy would silently drop that traffic", npName, label)
+		}
+	}
+	require.Positive(t, checked, "no NetworkPolicy svc selectors were checked; the guard is inert")
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -934,6 +934,31 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 				"tenant namespaces get controller-owned derived keys and must never hold the master")
 	})
 
+	// The retention set must cover the Secret Helm PREVIOUSLY managed, and
+	// setting existingSecret is precisely what drops that object from the
+	// rendered manifest. Scoping retention to "we are not using an existing
+	// secret" destroys the master in the most natural adoption there is:
+	// point existingSecret at the chart-generated Secret to take ownership of
+	// it, and Helm prunes a Secret that is still in use.
+	t.Run("retention still covers the master when existingSecret adopts it", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			args []string
+		}{
+			{"default", nil},
+			{"adopting the chart-generated secret", []string{"--set", "internalAuth.existingSecret=" + master}},
+			{"an operator-owned secret under another name", []string{"--set", "internalAuth.existingSecret=my-own"}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				vals := envValues(render(t, tc.args...), "ADOPT_SECRETS")
+				require.NotEmpty(t, vals, "the retention hook must render")
+				assert.Containsf(t, vals[0], master,
+					"the chart-generated master must stay in the retention set (%s), "+
+						"or Helm prunes it the moment the template stops rendering it", tc.name)
+			})
+		}
+	})
+
 	// autoGenerate moves provisioning into the hook Job, so the template stops
 	// rendering the Secret. If the Job is also switched off, NOTHING provisions
 	// the master and every control-plane pod wedges on a required secretKeyRef

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -680,9 +681,16 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 
 	// The read grant is the one concession this design makes; it must not widen
 	// beyond the single object that needs it.
+	//
+	// The split between the two rules is load-bearing, not cosmetic. RBAC
+	// matches resourceNames against the name in the REQUEST PATH, and a POST
+	// carries the object name in the body instead — so a create rule fenced by
+	// resourceNames matches nothing and the hook fails Forbidden. Fencing
+	// create looks safer and is actually inert, which is precisely the kind of
+	// mistake that survives review, so pin both halves.
 	t.Run("the generation grant is fenced to the master alone", func(t *testing.T) {
 		docs := render(t, "--set", "internalAuth.autoGenerate=true")
-		var checked int
+		var checked, sawGet, sawCreate int
 		for _, d := range docs {
 			kind, _ := d["kind"].(string)
 			meta, _ := d["metadata"].(map[string]any)
@@ -695,17 +703,41 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 			for _, r := range rules {
 				rule, _ := r.(map[string]any)
 				names, _ := rule["resourceNames"].([]any)
-				require.Len(t, names, 1, "the grant must name exactly one Secret")
-				assert.Equal(t, master, names[0])
 				verbs, _ := rule["verbs"].([]any)
 				for _, v := range verbs {
 					assert.NotEqual(t, "list", v, "list would let this identity enumerate every Secret")
 					assert.NotEqual(t, "delete", v)
 				}
+				switch {
+				case slices.Contains(verbsOf(verbs), "create"):
+					sawCreate++
+					assert.Empty(t, names,
+						"create must NOT carry resourceNames: the name is in the POST body, "+
+							"not the path, so a fenced rule never matches and generation fails Forbidden")
+					assert.Equal(t, []string{"create"}, verbsOf(verbs),
+						"the unfenced rule must carry create and nothing else — "+
+							"any read/write verb here would apply to every Secret in the namespace")
+				default:
+					sawGet++
+					require.Len(t, names, 1, "the read grant must name exactly one Secret")
+					assert.Equal(t, master, names[0])
+				}
 			}
 		}
 		require.Positive(t, checked, "no generation Role was rendered; the guard is inert")
+		assert.Positive(t, sawGet, "generation needs a name-scoped get to tell provisioned from absent")
+		assert.Positive(t, sawCreate, "generation needs a create it can actually use")
 	})
+}
+
+// verbsOf converts a decoded YAML verb list to strings.
+func verbsOf(verbs []any) []string {
+	out := make([]string, 0, len(verbs))
+	for _, v := range verbs {
+		s, _ := v.(string)
+		out = append(out, s)
+	}
+	return out
 }
 
 // TestNameFormat pins RFC-0029 phase 2's naming.

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -293,23 +293,45 @@ func TestWebhookEnvReaderRBACScopesByTenancy(t *testing.T) {
 	})
 }
 
-// npAllowsFromSvc reports whether any ingress rule's `from` allowlist admits the
-// given svc label via a podSelector.
-func npAllowsFromSvc(doc map[string]any, svcLabel string) bool {
+// selectorSvcLabel returns a podSelector's `svc:` matchLabel ("" when absent).
+func selectorSvcLabel(sel map[string]any) string {
+	ml, _ := sel["matchLabels"].(map[string]any)
+	s, _ := ml["svc"].(string)
+	return s
+}
+
+// ingressSvcLabels collects every `svc:` value a NetworkPolicy's ingress
+// allowlists ADMIT.
+//
+// Deliberately excludes spec.podSelector. That is the workload the policy
+// PROTECTS, not one it admits, and folding it in would make npAllowsFromSvc
+// report every policy as admitting its own target — the router policy targets
+// `svc: router`, so the async-allowlist guard below (which asserts the router
+// is NOT admitted by default) would go permanently true and stop guarding.
+func ingressSvcLabels(doc map[string]any) []string {
+	var out []string
 	spec, _ := doc["spec"].(map[string]any)
 	ingress, _ := spec["ingress"].([]any)
 	for _, r := range ingress {
 		rule, _ := r.(map[string]any)
 		froms, _ := rule["from"].([]any)
 		for _, f := range froms {
-			sel, _ := f.(map[string]any)["podSelector"].(map[string]any)
-			ml, _ := sel["matchLabels"].(map[string]any)
-			if ml["svc"] == svcLabel {
-				return true
+			// A non-map `from` entry is malformed chart output; skip it so the
+			// caller reports a missing selector rather than panicking.
+			fm, _ := f.(map[string]any)
+			sel, _ := fm["podSelector"].(map[string]any)
+			if v := selectorSvcLabel(sel); v != "" {
+				out = append(out, v)
 			}
 		}
 	}
-	return false
+	return out
+}
+
+// npAllowsFromSvc reports whether any ingress rule's `from` allowlist admits the
+// given svc label via a podSelector.
+func npAllowsFromSvc(doc map[string]any, svcLabel string) bool {
+	return slices.Contains(ingressSvcLabels(doc), svcLabel)
 }
 
 // TestWorkflowChart is the drift check for the RFC-0022 workflow head: port
@@ -500,6 +522,16 @@ func TestStateSvcChart(t *testing.T) {
 	})
 }
 
+// stringsOf converts a decoded YAML string list to []string.
+func stringsOf(vals []any) []string {
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		s, _ := v.(string)
+		out = append(out, s)
+	}
+	return out
+}
+
 // verbsFor returns the verbs a rendered Role/ClusterRole grants for a resource
 // in an API group, merged across every rule that mentions it.
 func verbsFor(doc map[string]any, apiGroup, resource string) map[string]bool {
@@ -508,66 +540,32 @@ func verbsFor(doc map[string]any, apiGroup, resource string) map[string]bool {
 	for _, r := range rules {
 		rule, _ := r.(map[string]any)
 		groups, _ := rule["apiGroups"].([]any)
-		hasGroup := false
-		for _, g := range groups {
-			if s, _ := g.(string); s == apiGroup {
-				hasGroup = true
-			}
-		}
-		if !hasGroup {
-			continue
-		}
 		resources, _ := rule["resources"].([]any)
-		hasResource := false
-		for _, res := range resources {
-			if s, _ := res.(string); s == resource {
-				hasResource = true
-			}
-		}
-		if !hasResource {
+		if !slices.Contains(stringsOf(groups), apiGroup) ||
+			!slices.Contains(stringsOf(resources), resource) {
 			continue
 		}
 		verbs, _ := rule["verbs"].([]any)
-		for _, v := range verbs {
-			if s, _ := v.(string); s != "" {
-				out[s] = true
+		for _, v := range stringsOf(verbs) {
+			if v != "" {
+				out[v] = true
 			}
 		}
 	}
 	return out
 }
 
-// podSelectorSvcLabels collects every `svc:` value a NetworkPolicy references,
-// from both its own podSelector and every ingress `from` podSelector.
+// podSelectorSvcLabels collects every `svc:` value a NetworkPolicy references —
+// the workload it TARGETS plus everything its ingress allowlists admit. Both
+// must name a workload that actually renders, which is what this feeds.
 func podSelectorSvcLabels(doc map[string]any) []string {
 	var out []string
-	add := func(sel map[string]any) {
-		ml, _ := sel["matchLabels"].(map[string]any)
-		if v, ok := ml["svc"].(string); ok && v != "" {
-			out = append(out, v)
-		}
-	}
 	spec, _ := doc["spec"].(map[string]any)
-	if sel, ok := spec["podSelector"].(map[string]any); ok {
-		add(sel)
+	sel, _ := spec["podSelector"].(map[string]any)
+	if v := selectorSvcLabel(sel); v != "" {
+		out = append(out, v)
 	}
-	ingress, _ := spec["ingress"].([]any)
-	for _, r := range ingress {
-		rule, _ := r.(map[string]any)
-		froms, _ := rule["from"].([]any)
-		for _, f := range froms {
-			fm, ok := f.(map[string]any)
-			if !ok {
-				// A non-map `from` entry is malformed chart output; skip it so
-				// the caller reports a missing selector rather than panicking.
-				continue
-			}
-			if sel, ok := fm["podSelector"].(map[string]any); ok {
-				add(sel)
-			}
-		}
-	}
-	return out
+	return append(out, ingressSvcLabels(doc)...)
 }
 
 // TestBuildermgrCanRollBuilderDeployments guards an RBAC gap that fails CLOSED
@@ -636,12 +634,7 @@ func TestNetworkPolicySvcLabelsResolveToRealWorkloads(t *testing.T) {
 
 	// Every `svc:` label carried by a rendered pod template.
 	known := map[string]bool{}
-	for _, doc := range docs {
-		spec, _ := doc["spec"].(map[string]any)
-		tmpl, ok := spec["template"].(map[string]any)
-		if !ok {
-			continue
-		}
+	for _, tmpl := range podTemplates(docs) {
 		meta, _ := tmpl["metadata"].(map[string]any)
 		labels, _ := meta["labels"].(map[string]any)
 		if v, ok := labels["svc"].(string); ok && v != "" {
@@ -810,18 +803,15 @@ func TestInternalAuthExistingSecret(t *testing.T) {
 	// The env var is what the Go side reads. If it disagrees with the
 	// secretKeyRefs above, the two halves resolve different Secrets.
 	t.Run("the name env var matches the secretKeyRefs", func(t *testing.T) {
-		for _, tc := range []struct{ arg, want string }{
-			{"", defaultName},
-			{"my-master", "my-master"},
+		for _, tc := range []struct {
+			args []string
+			want string
+		}{
+			{nil, defaultName},
+			{[]string{"--set", "internalAuth.existingSecret=my-master"}, "my-master"},
 		} {
-			var docs []map[string]any
-			if tc.arg == "" {
-				docs = render(t)
-			} else {
-				docs = render(t, "--set", "internalAuth.existingSecret="+tc.arg)
-			}
-			vals := envValues(docs, "FISSION_INTERNAL_AUTH_SECRET_NAME")
-			require.NotEmptyf(t, vals, "FISSION_INTERNAL_AUTH_SECRET_NAME must be set (existingSecret=%q)", tc.arg)
+			vals := envValues(render(t, tc.args...), "FISSION_INTERNAL_AUTH_SECRET_NAME")
+			require.NotEmptyf(t, vals, "FISSION_INTERNAL_AUTH_SECRET_NAME must be set (%v)", tc.args)
 			for _, v := range vals {
 				assert.Equal(t, tc.want, v)
 			}
@@ -861,15 +851,23 @@ func envValues(docs []map[string]any, envName string) []string {
 	return out
 }
 
+// podTemplates returns every rendered pod template (Deployments, Jobs, ...).
+// Docs without one are skipped, which is most of a render.
+func podTemplates(docs []map[string]any) []map[string]any {
+	var out []map[string]any
+	for _, doc := range docs {
+		spec, _ := doc["spec"].(map[string]any)
+		if tmpl, ok := spec["template"].(map[string]any); ok {
+			out = append(out, tmpl)
+		}
+	}
+	return out
+}
+
 // forEachContainerEnv walks every env entry of every container in every
 // rendered pod template.
 func forEachContainerEnv(docs []map[string]any, fn func(map[string]any)) {
-	for _, doc := range docs {
-		spec, _ := doc["spec"].(map[string]any)
-		tmpl, ok := spec["template"].(map[string]any)
-		if !ok {
-			continue
-		}
+	for _, tmpl := range podTemplates(docs) {
 		podSpec, _ := tmpl["spec"].(map[string]any)
 		for _, key := range []string{"containers", "initContainers"} {
 			cs, _ := podSpec[key].([]any)
@@ -1001,21 +999,21 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 			for _, r := range rules {
 				rule, _ := r.(map[string]any)
 				names, _ := rule["resourceNames"].([]any)
-				verbs, _ := rule["verbs"].([]any)
+				rawVerbs, _ := rule["verbs"].([]any)
+				verbs := stringsOf(rawVerbs)
 				for _, v := range verbs {
 					assert.NotEqual(t, "list", v, "list would let this identity enumerate every Secret")
 					assert.NotEqual(t, "delete", v)
 				}
-				switch {
-				case slices.Contains(verbsOf(verbs), "create"):
+				if slices.Contains(verbs, "create") {
 					sawCreate++
 					assert.Empty(t, names,
 						"create must NOT carry resourceNames: the name is in the POST body, "+
 							"not the path, so a fenced rule never matches and generation fails Forbidden")
-					assert.Equal(t, []string{"create"}, verbsOf(verbs),
+					assert.Equal(t, []string{"create"}, verbs,
 						"the unfenced rule must carry create and nothing else — "+
 							"any read/write verb here would apply to every Secret in the namespace")
-				default:
+				} else {
 					sawGet++
 					require.Len(t, names, 1, "the read grant must name exactly one Secret")
 					assert.Equal(t, master, names[0])
@@ -1026,14 +1024,4 @@ func TestInternalAuthAutoGenerate(t *testing.T) {
 		assert.Positive(t, sawGet, "generation needs a name-scoped get to tell provisioned from absent")
 		assert.Positive(t, sawCreate, "generation needs a create it can actually use")
 	})
-}
-
-// verbsOf converts a decoded YAML verb list to strings.
-func verbsOf(verbs []any) []string {
-	out := make([]string, 0, len(verbs))
-	for _, v := range verbs {
-		s, _ := v.(string)
-		out = append(out, s)
-	}
-	return out
 }

--- a/test/integration/suites/common/spec_idempotency_test.go
+++ b/test/integration/suites/common/spec_idempotency_test.go
@@ -37,29 +37,6 @@ import (
 // exercised.
 func TestSpecApplyIsIdempotent(t *testing.T) {
 	t.Parallel()
-	// SKIPPED: this documents a CONFIRMED bug, not a passing contract.
-	//
-	// Measured on CI (v1.34.8, 2026-08-01): reapplying a byte-identical spec
-	// directory moved the function's PackageRef.ResourceVersion 4785 -> 4789
-	// and its generation 1 -> 2. So every GitOps sync of an unchanged spec
-	// recycles pods and mints an RFC-0025 version.
-	//
-	// Root cause is in the apply engine, not the spec files. applyResourceType
-	// records a NO-OP package's CURRENT live metadata, and apply.go's
-	// cross-reference pass then copies that ResourceVersion into every
-	// referencing function. The package's ResourceVersion drifts on controller
-	// STATUS writes (buildermgr records a content hash), so the copy carries
-	// drift that has nothing to do with the spec. Same defect class as the
-	// `fn update` stamp fixed in #3635, in a second code path.
-	//
-	// The fix is not simply skipping the stamp: the function in the spec file
-	// carries no ResourceVersion, so leaving it empty also differs from live
-	// and still forces an update. The engine has to preserve the LIVE
-	// function's stamp when the referenced package was a no-op this apply.
-	//
-	// RFC-0029 §4 lists this as phase-4 work (#3296, #1491). Unskip with the
-	// fix.
-	t.Skip("known non-idempotency in the spec apply engine — see the comment above and RFC-0029 phase 4 (#3296, #1491)")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()

--- a/test/integration/suites/common/spec_idempotency_test.go
+++ b/test/integration/suites/common/spec_idempotency_test.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestSpecApplyIsIdempotent pins the first of RFC-0029's three `fission spec`
+// guarantees: reapplying unchanged specs is a no-op.
+//
+// The existing dry-run test proves the PREVIEW reports no creates. This asserts
+// the stronger and more useful property — that a real second apply writes
+// nothing observable. The distinction matters because the failure mode is not a
+// visible error: a spec apply that rewrites unchanged objects bumps the
+// Function's PackageRef, which recycles pods and mints an RFC-0025 version for
+// content nobody edited. A GitOps controller reapplies on every sync, so that
+// would be continuous churn rather than a one-off.
+//
+// Uses a --code (literal deploy) function so no builder or runtime image is
+// needed: nothing is built or specialized, only the spec reconcile is
+// exercised.
+func TestSpecApplyIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	ns := f.NewTestNamespace(t)
+	fc := f.FissionClient().CoreV1()
+
+	envName := "idem-env-" + ns.ID
+	fnName := "idem-fn-" + ns.ID
+
+	workdir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(workdir, "hello.js"),
+		[]byte("module.exports = async function(){ return {status:200, body:'hi'} }\n"), 0o644))
+
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "init")
+		ns.CLI(t, ctx, "env", "create", "--spec", "--name", envName, "--image", "fission/node-env")
+		ns.CLI(t, ctx, "fn", "create", "--spec", "--name", fnName, "--env", envName, "--code", "hello.js")
+
+		ns.CLI(t, ctx, "spec", "apply")
+		t.Cleanup(func() {
+			dctx, dcancel := context.WithTimeout(context.Background(), time.Minute)
+			defer dcancel()
+			ns.WithCWD(t, workdir, func() { _ = ns.CLI(t, dctx, "spec", "destroy") })
+		})
+	})
+
+	// Let the package settle: buildermgr records a content hash on first sight,
+	// and that status write must land BEFORE the baseline is taken or it would
+	// be mistaken for churn caused by the second apply.
+	fn, err := fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+	require.NoError(t, err)
+	pkgName := fn.Spec.Package.PackageRef.Name
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		pkg, err := fc.Packages(ns.Name).Get(ctx, pkgName, metav1.GetOptions{})
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.NotEmpty(c, pkg.Status.ContentHash)
+	}, 2*time.Minute, 2*time.Second)
+
+	before, err := fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+	require.NoError(t, err)
+	pkgBefore, err := fc.Packages(ns.Name).Get(ctx, pkgName, metav1.GetOptions{})
+	require.NoError(t, err)
+	versionsBefore := countFunctionVersions(t, ctx, f, ns.Name, fnName)
+
+	// Reapply the identical spec directory, twice — one repeat can coincide
+	// with a settling write, a pair cannot.
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "apply")
+		ns.CLI(t, ctx, "spec", "apply")
+	})
+
+	after, err := fc.Functions(ns.Name).Get(ctx, fnName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, before.Spec.Package.PackageRef.ResourceVersion, after.Spec.Package.PackageRef.ResourceVersion,
+		"reapplying an unchanged spec must not re-stamp the function: the stamp is what recycles pods")
+	assert.Equal(t, before.Generation, after.Generation,
+		"reapplying an unchanged spec must not bump the function's generation")
+
+	pkgAfter, err := fc.Packages(ns.Name).Get(ctx, pkgName, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, pkgBefore.Generation, pkgAfter.Generation,
+		"reapplying an unchanged spec must not rewrite the package spec")
+	assert.Equal(t, pkgBefore.Status.ContentHash, pkgAfter.Status.ContentHash,
+		"the delivered content did not change, so its recorded hash must not either")
+
+	assert.Equal(t, versionsBefore, countFunctionVersions(t, ctx, f, ns.Name, fnName),
+		"reapplying an unchanged spec must not mint an RFC-0025 version")
+}
+
+// countFunctionVersions returns how many FunctionVersions exist for fnName.
+func countFunctionVersions(t *testing.T, ctx context.Context, f *framework.Framework, namespace, fnName string) int {
+	t.Helper()
+	list, err := f.FissionClient().CoreV1().FunctionVersions(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fv1.VersionFunctionNameLabel + "=" + fnName,
+	})
+	require.NoError(t, err)
+	return len(list.Items)
+}

--- a/test/integration/suites/common/spec_idempotency_test.go
+++ b/test/integration/suites/common/spec_idempotency_test.go
@@ -37,6 +37,29 @@ import (
 // exercised.
 func TestSpecApplyIsIdempotent(t *testing.T) {
 	t.Parallel()
+	// SKIPPED: this documents a CONFIRMED bug, not a passing contract.
+	//
+	// Measured on CI (v1.34.8, 2026-08-01): reapplying a byte-identical spec
+	// directory moved the function's PackageRef.ResourceVersion 4785 -> 4789
+	// and its generation 1 -> 2. So every GitOps sync of an unchanged spec
+	// recycles pods and mints an RFC-0025 version.
+	//
+	// Root cause is in the apply engine, not the spec files. applyResourceType
+	// records a NO-OP package's CURRENT live metadata, and apply.go's
+	// cross-reference pass then copies that ResourceVersion into every
+	// referencing function. The package's ResourceVersion drifts on controller
+	// STATUS writes (buildermgr records a content hash), so the copy carries
+	// drift that has nothing to do with the spec. Same defect class as the
+	// `fn update` stamp fixed in #3635, in a second code path.
+	//
+	// The fix is not simply skipping the stamp: the function in the spec file
+	// carries no ResourceVersion, so leaving it empty also differs from live
+	// and still forces an update. The engine has to preserve the LIVE
+	// function's stamp when the referenced package was a no-op this apply.
+	//
+	// RFC-0029 §4 lists this as phase-4 work (#3296, #1491). Unskip with the
+	// fix.
+	t.Skip("known non-idempotency in the spec apply engine — see the comment above and RFC-0029 phase 4 (#3296, #1491)")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()

--- a/test/integration/suites/common/spec_idempotency_test.go
+++ b/test/integration/suites/common/spec_idempotency_test.go
@@ -84,7 +84,9 @@ func TestSpecApplyIsIdempotent(t *testing.T) {
 		t.Cleanup(func() {
 			dctx, dcancel := context.WithTimeout(context.Background(), time.Minute)
 			defer dcancel()
-			ns.WithCWD(t, workdir, func() { _ = ns.CLI(t, dctx, "spec", "destroy") })
+			// Best-effort: the test may have failed before anything was applied,
+			// and a destroy that finds nothing must not mask the real failure.
+			ns.WithCWD(t, workdir, func() { _, _ = ns.CLICaptureStdoutWithEnvBestEffort(t, dctx, nil, "spec", "destroy") })
 		})
 	})
 


### PR DESCRIPTION
Consolidates the outstanding RFC-0028/0029 work into one branch. Supersedes **#3639**, **#3640** and **#3648**, which are closed in favour of this — they were touching the same chart templates and the same `test/helm/portdrift_test.go`, so keeping them parallel meant re-resolving the same append/append conflicts on every rebase. That churn was the main source of review noise.

Every commit is preserved, so the individual pieces stay reviewable in isolation.

---

## 1. Auth material: provision the master in-cluster (RFC-0029 §10)

The chart previously minted the internal-auth master **in the template**, which makes it a function of render inputs rather than cluster state — a re-render with different inputs silently rotates it, and every derived key with it.

- `internalAuth.existingSecret` — point the install at a Secret you already manage. Resolution now happens in **one place** (`fission.internalAuthSecretName`); previously each consumer re-derived the name, which is the kind of duplication that drifts silently and then 401s at runtime.
- `internalAuth.autoGenerate` — a pre-upgrade hook (`cmd/preupgradechecks/generateauth.go`) generates the master in-cluster if absent. It `get`s first so a re-run reuses the existing master rather than rotating every derived key with no dual-accept window.
- The namespace set is supplied by the **chart**, never derived in Go. Under dynamic/cluster tenancy the master stays in the release namespace: tenant namespaces get controller-owned derived keys, and a master there would defeat the isolation end state.

### The RBAC bug this consolidation surfaced

The generation Role granted `["get","create"]` under a single `resourceNames` fence. **RBAC matches `resourceNames` against the name in the request path, and a POST carries the name in the body** — so the authorizer sees an empty name, the rule never matches, and generation fails Forbidden. The fence did not tighten the grant, it voided it: `autoGenerate` was dead on arrival for anyone who enabled it. CI never caught it because CI supplies `internalAuth.secret` directly and never exercises the path.

`get` keeps its fence; `create` drops it, because RBAC offers no way to keep it. This is the exact inverse of the CRD ClusterRole next door, which *does* keep `resourceNames` on `create` — server-side apply PATCHes a named path, so create is authorized against that name. Switching generation to apply would recover the fence and is deliberately not done: apply takes ownership of `.data` and would rotate the master, the one thing this hook must never do.

The chart guard asserted that *every* rule carried exactly one `resourceName` — it encoded the bug, so it could never have caught it. It now pins both halves separately and fails on the old fenced form.

## 2. Fixed-name inventory (RFC-0029 phase 2)

NetworkPolicies address workloads by a bare `svc:` pod label. A policy naming a label no workload carries does not error — it silently drops the traffic. `TestNetworkPolicySvcLabelsResolveToRealWorkloads` renders the chart and requires every `svc:` selector to resolve to a real workload.

Also `TestBuildermgrCanRollBuilderDeployments`: buildermgr rolls a drifted builder Deployment (#776), which needs `update` on `apps/deployments`. The Role granted only list/create/delete, so the feature would have shipped inert.

## 3. `spec apply` idempotency

A second `fission spec apply` of an unchanged spec rewrote Function package stamps, minting spurious RFC-0025 versions. The stamp is now driven by what this apply actually wrote (`ras.Created`/`ras.Updated`) against live stamps, so an untouched package keeps its existing reference. Covered by `test/integration/suites/common/spec_idempotency_test.go` — which previously existed as a `t.Skip` documenting the bug, and is now unskipped.

## 4. Two CI flakes that were reddening main

**`TestEngineLinearPipeline`** asserted exactly-once *delivery*. `execute()` sets `X-Fission-Workflow-{Run,Attempt}` precisely because delivery is **at-least-once**; what is exactly-once is the recorded outcome (W1/W2). A redelivered attempt re-runs the function and its append loses the result guard — log correct, call counter one high, which is exactly what CI showed (the run succeeded, output was the *first* call's response, all invariants passed). Exact assertions move onto the log via `attempts(log, state)`; the counter becomes a lower bound. The retry-budget and "4xx never retries" cases keep exact expectations, now against `attempts`, and still fail on a policy regression (mutation-verified).

**`TestRunLocalWatch*`** wrote the source file as soon as the first specialize was observed — but `runLocal` specializes inside `launch()` and only *then* calls `serveAndWatch`, where the fsnotify watch is registered. A write landing in that gap is lost for good, which is why the symptom was a full-timeout miss. Now rewrites on every tick, with the tick above the 250ms debounce so a faster loop cannot keep `drainBurst` from draining.

Plus `if-no-files-found: ignore` on the skip-level upgrade leg's artifact upload, so a designed skip does not annotate the run.

---

## Testing

`make code-checks` and `make license-check` exit 0. `go build ./...` clean. `./test/helm/...`, `./pkg/workflow/...`, `./pkg/fission-cli/cmd/function/...`, `./pkg/fission-cli/cmd/spec/...` all pass; workflow and watch suites additionally verified under `-race -count=20` / `-count=8`.

All new guards are mutation-verified: each was confirmed to fail on the defect it targets and pass on the fix.