### PR TITLE
poolmgr: warm pods survive helm upgrade (processRS discriminator + adoption hardening + Recreate default)

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -59,13 +59,14 @@ Only hook Jobs are affected — no Deployment, Service, Secret, ConfigMap, Servi
 Set `nameFormat: legacy` to keep the previous names.
 A hook Job that failed and was never cleaned up will linger under its old name after the upgrade; it is inert, but can be deleted by hand.
 
-- **The executor's rollout strategy defaults to `Recreate`, and `adoptExistingResources` defaults to `true`.**
+- **The executor's rollout becomes overlap-free (`maxSurge: 0, maxUnavailable: 1`), and `adoptExistingResources` defaults to `true`.**
 Together these are what let poolmgr's warm (specialized) pods survive a `helm upgrade` in place — previously every upgrade deleted them, and requests hung in the cold-start path while the executor and pools rolled (~4% of requests during the roll, measured by the upgrade gate).
-Recreate exists because the executor is a single-writer control plane keyed on its instance ID: the previous default rolled two executors concurrently with no leader election, and the incoming one's cleanup deleted the objects the outgoing one was still stamping.
+The overlap-free rollout exists because the executor is a single-writer control plane keyed on its instance ID: the previous default rolled two executors concurrently with no leader election, and the incoming one's cleanup deleted the objects the outgoing one was still stamping.
+It is expressed within `RollingUpdate` rather than as `type: Recreate` because a live Deployment carries a defaulted `rollingUpdate` block that the API forbids alongside `Recreate` — flipping the type fails validation on every existing install.
 The cost is a bounded executor-down window per upgrade (≲60s): warm poolmgr and newdeploy traffic keep serving throughout (neither needs a live executor); cold starts wait or fail fast until the new executor is ready.
 Adoption means the executor re-stamps the previous instance's pods and Deployments in place (same UID) instead of recreating them.
 Opt-outs: `executor.strategy` and `executor.adoptExistingResources`.
-For HA installs (replicas > 1 with leaderElection), override to `RollingUpdate` with `maxUnavailable: 1` — never `maxUnavailable: 0`, which deadlocks against the leadership-gated readiness probe.
+The same default serves HA installs (replicas > 1 with leaderElection): pods roll one at a time and a dying leader releases its lease — never set `maxUnavailable: 0` with leader election, which deadlocks against the leadership-gated readiness probe.
 One caveat rides the first upgrade to this release: pods born under the previous release carry no environment-generation label, so an environment updated during that same upgrade window keeps its old pods until the idle reaper or a function update recycles them.
 
 - **`Environment.terminationGracePeriod` defaults to `90` seconds — and now actually defaults.**

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -59,6 +59,15 @@ Only hook Jobs are affected — no Deployment, Service, Secret, ConfigMap, Servi
 Set `nameFormat: legacy` to keep the previous names.
 A hook Job that failed and was never cleaned up will linger under its old name after the upgrade; it is inert, but can be deleted by hand.
 
+- **The executor's rollout strategy defaults to `Recreate`, and `adoptExistingResources` defaults to `true`.**
+Together these are what let poolmgr's warm (specialized) pods survive a `helm upgrade` in place — previously every upgrade deleted them, and requests hung in the cold-start path while the executor and pools rolled (~4% of requests during the roll, measured by the upgrade gate).
+Recreate exists because the executor is a single-writer control plane keyed on its instance ID: the previous default rolled two executors concurrently with no leader election, and the incoming one's cleanup deleted the objects the outgoing one was still stamping.
+The cost is a bounded executor-down window per upgrade (≲60s): warm poolmgr and newdeploy traffic keep serving throughout (neither needs a live executor); cold starts wait or fail fast until the new executor is ready.
+Adoption means the executor re-stamps the previous instance's pods and Deployments in place (same UID) instead of recreating them.
+Opt-outs: `executor.strategy` and `executor.adoptExistingResources`.
+For HA installs (replicas > 1 with leaderElection), override to `RollingUpdate` with `maxUnavailable: 1` — never `maxUnavailable: 0`, which deadlocks against the leadership-gated readiness probe.
+One caveat rides the first upgrade to this release: pods born under the previous release carry no environment-generation label, so an environment updated during that same upgrade window keeps its old pods until the idle reaper or a function update recycles them.
+
 - **`Environment.terminationGracePeriod` defaults to `90` seconds — and now actually defaults.**
 A terminating function pod keeps serving for the whole grace window (the drain preStop hook sleeps through it), so this value is exactly how long every pod teardown takes: idle reap, environment update, upgrade, node drain.
 Two changes land together.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -63,7 +63,7 @@ A hook Job that failed and was never cleaned up will linger under its old name a
 Together these are what let poolmgr's warm (specialized) pods survive a `helm upgrade` in place — previously every upgrade deleted them, and requests hung in the cold-start path while the executor and pools rolled (~4% of requests during the roll, measured by the upgrade gate).
 The overlap-free rollout exists because the executor is a single-writer control plane keyed on its instance ID: the previous default rolled two executors concurrently with no leader election, and the incoming one's cleanup deleted the objects the outgoing one was still stamping.
 It is expressed within `RollingUpdate` rather than as `type: Recreate` because a live Deployment carries a defaulted `rollingUpdate` block that the API forbids alongside `Recreate` — flipping the type fails validation on every existing install.
-The cost is a bounded executor-down window per upgrade (≲60s): warm poolmgr and newdeploy traffic keep serving throughout (neither needs a live executor); cold starts wait or fail fast until the new executor is ready.
+The cost is a bounded executor-down window per upgrade (≲60s): warm poolmgr and newdeploy traffic keep serving throughout (neither needs a live executor); only cold starts wait for the new one.
 Adoption means the executor re-stamps the previous instance's pods and Deployments in place (same UID) instead of recreating them.
 Opt-outs: `executor.strategy` and `executor.adoptExistingResources`.
 The same default serves HA installs (replicas > 1 with leaderElection): pods roll one at a time and a dying leader releases its lease — never set `maxUnavailable: 0` with leader election, which deadlocks against the leadership-gated readiness probe.

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -9,7 +9,17 @@ spec:
   replicas: {{ .Values.executor.replicas | default 1 }}
   {{- with .Values.executor.strategy }}
   strategy:
+    {{- if eq (.type | default "RollingUpdate") "Recreate" }}
+    {{- /* The API forbids a rollingUpdate block alongside type Recreate, and
+         helm --set MERGES into the default's rollingUpdate — so a user opting
+         out with `--set executor.strategy.type=Recreate` would otherwise
+         render an invalid Deployment (the same Forbidden error the upgrade
+         gate caught when Recreate was briefly the default). Emit only the
+         type. */}}
+    type: Recreate
+    {{- else }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -223,30 +223,41 @@ executor:
     enabled: false
   ## strategy is the Deployment rollout strategy for the executor.
   ##
-  ## Recreate is the default because the executor is a single-writer control
-  ## plane keyed on its instance ID: under RollingUpdate (the k8s default,
-  ## which surges at replicas=1) two executors with DIFFERENT instance IDs run
-  ## concurrently during every roll, with no leader election to arbitrate —
-  ## the outgoing one keeps re-stamping objects with its own ID while the
-  ## incoming one's adopt+cleanup pass runs, so the incoming reaper deletes
-  ## the very objects adoption exists to keep. The integration framework has
-  ## forced Recreate for its executor restarts for exactly this reason.
+  ## maxSurge 0 / maxUnavailable 1 makes every roll OVERLAP-FREE: the old pod
+  ## terminates before its replacement is created, at any replica count. That
+  ## matters because the executor is a single-writer control plane keyed on
+  ## its instance ID: under the k8s default (which surges at replicas=1) two
+  ## executors with DIFFERENT instance IDs run concurrently during every
+  ## roll, with no leader election to arbitrate — the outgoing one keeps
+  ## re-stamping objects with its own ID while the incoming one's
+  ## adopt+cleanup pass runs, so the incoming reaper deletes the very objects
+  ## adoption exists to keep.
   ##
-  ## The cost is a bounded executor-down window per upgrade (pod stop + start
-  ## + cache sync + adopt/cleanup, ≲60s). During it, WARM traffic keeps
+  ## Expressed WITHIN RollingUpdate rather than as `type: Recreate`
+  ## deliberately, and not only for equivalence at replicas=1: a live
+  ## Deployment whose strategy was ever defaulted carries a rollingUpdate
+  ## block, and the API forbids that block alongside type Recreate — so a
+  ## helm upgrade flipping the type fails validation against every existing
+  ## install ("spec.strategy.rollingUpdate: Forbidden"). Mutating two fields
+  ## inside the type the object already has upgrades cleanly.
+  ##
+  ## The cost is a bounded executor-down window per roll (pod stop + start +
+  ## cache sync + adopt/cleanup, ≲60s). During it, WARM traffic keeps
   ## serving: poolmgr from the EndpointSlice-fed router index, newdeploy from
   ## the router's cached Service addresses — neither needs a live executor.
   ## Cold starts fail fast and succeed once the new executor is ready.
   ##
-  ## Do NOT set a surge strategy with maxUnavailable: 0 together with
-  ## leaderElection: the executor's /readyz answers 503 on non-leaders, so
-  ## the surged pod can never become Ready while the old pod holds the lease
-  ## and the rollout deadlocks. For HA (replicas > 1 + leaderElection), use
-  ## RollingUpdate with maxUnavailable: 1 — the old leader dies first and
-  ## releases the lease to a standby.
+  ## This default also composes with HA (replicas > 1 + leaderElection):
+  ## pods roll one at a time and a dying leader releases its lease to a
+  ## standby. Never set maxUnavailable: 0 with leaderElection — /readyz
+  ## answers 503 on non-leaders, so a surged pod can never become Ready
+  ## while the old one holds the lease, and the rollout deadlocks.
   ##
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   ## terminationGracePeriodSeconds gives in-flight work time to drain on
   ## shutdown. Leave unset for the Kubernetes default (30s). Keep it at or
   ## above GRACEFUL_SHUTDOWN_TIMEOUT.

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -241,11 +241,9 @@ executor:
   ## install ("spec.strategy.rollingUpdate: Forbidden"). Mutating two fields
   ## inside the type the object already has upgrades cleanly.
   ##
-  ## The cost is a bounded executor-down window per roll (pod stop + start +
-  ## cache sync + adopt/cleanup, ≲60s). During it, WARM traffic keeps
-  ## serving: poolmgr from the EndpointSlice-fed router index, newdeploy from
-  ## the router's cached Service addresses — neither needs a live executor.
-  ## Cold starts fail fast and succeed once the new executor is ready.
+  ## The cost is a bounded executor-down window per roll (≲60s). Warm traffic
+  ## keeps serving throughout — neither poolmgr nor newdeploy needs a live
+  ## executor; only cold starts wait for the new one.
   ##
   ## This default also composes with HA (replicas > 1 + leaderElection):
   ## pods roll one at a time and a dying leader releases its lease to a

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -221,16 +221,32 @@ executor:
   ##
   leaderElection:
     enabled: false
-  ## strategy is the Deployment rollout strategy for the executor. Leave unset
-  ## for the Kubernetes default. With leaderElection enabled, a surge strategy
-  ## keeps a standby warm across upgrades, e.g.:
-  ##   strategy:
-  ##     type: RollingUpdate
-  ##     rollingUpdate:
-  ##       maxSurge: 1
-  ##       maxUnavailable: 0
+  ## strategy is the Deployment rollout strategy for the executor.
   ##
-  strategy: {}
+  ## Recreate is the default because the executor is a single-writer control
+  ## plane keyed on its instance ID: under RollingUpdate (the k8s default,
+  ## which surges at replicas=1) two executors with DIFFERENT instance IDs run
+  ## concurrently during every roll, with no leader election to arbitrate —
+  ## the outgoing one keeps re-stamping objects with its own ID while the
+  ## incoming one's adopt+cleanup pass runs, so the incoming reaper deletes
+  ## the very objects adoption exists to keep. The integration framework has
+  ## forced Recreate for its executor restarts for exactly this reason.
+  ##
+  ## The cost is a bounded executor-down window per upgrade (pod stop + start
+  ## + cache sync + adopt/cleanup, ≲60s). During it, WARM traffic keeps
+  ## serving: poolmgr from the EndpointSlice-fed router index, newdeploy from
+  ## the router's cached Service addresses — neither needs a live executor.
+  ## Cold starts fail fast and succeed once the new executor is ready.
+  ##
+  ## Do NOT set a surge strategy with maxUnavailable: 0 together with
+  ## leaderElection: the executor's /readyz answers 503 on non-leaders, so
+  ## the surged pod can never become Ready while the old pod holds the lease
+  ## and the rollout deadlocks. For HA (replicas > 1 + leaderElection), use
+  ## RollingUpdate with maxUnavailable: 1 — the old leader dies first and
+  ## releases the lease to a standby.
+  ##
+  strategy:
+    type: Recreate
   ## terminationGracePeriodSeconds gives in-flight work time to drain on
   ## shutdown. Leave unset for the Kubernetes default (30s). Keep it at or
   ## above GRACEFUL_SHUTDOWN_TIMEOUT.
@@ -254,9 +270,19 @@ executor:
   ## terminationMessagePolicy is the policy for the executor termination message.
   ##
   terminationMessagePolicy: ""
-  ## adoptExistingResources decides whether to adopt existing resources when executor restarts or Fission is redeployed.
+  ## adoptExistingResources decides whether to adopt existing resources when
+  ## the executor restarts or Fission is upgraded.
   ##
-  adoptExistingResources: false
+  ## Enabled by default: on restart the executor re-stamps the previous
+  ## instance's objects (specialized warm pods, function Deployments and
+  ## Services — same UID, in place) instead of deleting and recreating them.
+  ## This is half of what lets warm pods survive a `helm upgrade`; the other
+  ## half is the pool-roll discriminator keyed on the environment generation.
+  ## With adoption off, the startup cleanup deletes every pod whose
+  ## executorInstanceId annotation belongs to the previous instance — which
+  ## is exactly the specialized pods, and only them.
+  ##
+  adoptExistingResources: true
   ## Mount OCI packages directly into function pods (needs Kubernetes 1.33+;
   ## older clusters automatically fall back to downloading the package).
   ## Gives noticeably faster cold starts. Set false to always download.

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -232,6 +232,18 @@ const (
 
 	// RFC-0002 EndpointSlice-native data plane labels.
 	//
+	// ENVIRONMENT_GENERATION labels a pool pod template (and hence its
+	// ReplicaSets and pods) with the Environment generation the template was
+	// generated from. processRS compares it against the live Environment to
+	// distinguish "env spec changed -> recycle specialized pods" from
+	// "executor-side template roll (fetcher image/config) -> keep them".
+	//
+	// It must NEVER be added to the pool Deployment's selector labels
+	// (getEnvironmentPoolLabels): selectors are immutable, so a
+	// generation-bearing selector would fail every env update with
+	// "field is immutable". Template labels only.
+	ENVIRONMENT_GENERATION = "fission.io/environment-generation"
+
 	// FUNCTION_GENERATION labels a specialized pool pod with the Function
 	// generation it was specialized from. The per-function Service selector
 	// includes it so stale-generation pods drop out of the EndpointSlices on a

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -232,17 +232,23 @@ const (
 
 	// RFC-0002 EndpointSlice-native data plane labels.
 	//
-	// ENVIRONMENT_GENERATION labels a pool pod template (and hence its
-	// ReplicaSets and pods) with the Environment generation the template was
-	// generated from. processRS compares it against the live Environment to
-	// distinguish "env spec changed -> recycle specialized pods" from
+	// ENVIRONMENT_RUNTIME_HASH labels a pool pod template (and hence its
+	// ReplicaSets and pods) with a hash of exactly the Environment inputs the
+	// template is generated from (poolmgr's envRuntimeHash). processRS and
+	// the adopt pass compare it against the live Environment to distinguish
+	// "the env's RUNTIME changed -> recycle specialized pods" from
 	// "executor-side template roll (fetcher image/config) -> keep them".
+	//
+	// A hash of the template inputs, deliberately NOT metadata.generation:
+	// generation moves on every spec write, including poolsize — a pure
+	// replica scale — and keying on it recycled every warm pod on the exact
+	// operation operators perform under load.
 	//
 	// It must NEVER be added to the pool Deployment's selector labels
 	// (getEnvironmentPoolLabels): selectors are immutable, so a
-	// generation-bearing selector would fail every env update with
+	// hash-bearing selector would fail every env update with
 	// "field is immutable". Template labels only.
-	ENVIRONMENT_GENERATION = "fission.io/environment-generation"
+	ENVIRONMENT_RUNTIME_HASH = "fission.io/env-runtime-hash"
 
 	// FUNCTION_GENERATION labels a specialized pool pod with the Function
 	// generation it was specialized from. The per-function Service selector

--- a/pkg/executor/executortype/poolmgr/common.go
+++ b/pkg/executor/executortype/poolmgr/common.go
@@ -4,7 +4,84 @@
 
 package poolmgr
 
-import fv1 "github.com/fission/fission/pkg/apis/core/v1"
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// envRuntimeHash is a short, stable hash over exactly the Environment inputs
+// genDeploymentSpec bakes into the pool pod TEMPLATE — and nothing else.
+//
+// This, not metadata.generation, is what the pool-roll discriminator and the
+// adopt pass key on. Generation moves on EVERY spec write, including ones
+// that never touch the template: `env update --poolsize` is a pure replica
+// scale (Poolsize feeds only DeploymentSpec.Replicas), and keying on
+// generation turned it into a full pool roll that recycled every warm pod —
+// under load, since scaling up is what operators do under load. Hashing the
+// template inputs means: template unchanged ⇒ hash unchanged ⇒ nothing rolls
+// and nothing is recycled, exactly the pre-RFC-0028 behaviour for those
+// updates.
+//
+// json.Marshal is deterministic here (fixed struct field order; map keys are
+// sorted), so the value is stable across processes. Changing this function's
+// input set in a future release costs at most one warm-pod recycle wave on
+// the upgrade that ships the change — document it there if it happens.
+func envRuntimeHash(env *fv1.Environment) string {
+	in := struct {
+		Runtime     fv1.Runtime                `json:"runtime"`
+		Resources   apiv1.ResourceRequirements `json:"resources"`
+		Grace       int64                      `json:"grace"`
+		PullSecret  string                     `json:"pullSecret"`
+		ExtNet      bool                       `json:"extNet"`
+		Labels      map[string]string          `json:"labels"`
+		Annotations map[string]string          `json:"annotations"`
+	}{
+		Runtime:     env.Spec.Runtime,
+		Resources:   env.Spec.Resources,
+		Grace:       env.Spec.TerminationGracePeriod,
+		PullSecret:  env.Spec.ImagePullSecret,
+		ExtNet:      env.Spec.AllowAccessToExternalNetwork,
+		Labels:      env.Labels,
+		Annotations: env.Annotations,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		// Unreachable for these types; an empty hash compares unequal to any
+		// stamped value, which degrades to the safe side (recycle).
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])[:16]
+}
+
+// envLabelsMatchLiveEnv reports whether the ENVIRONMENT_UID /
+// ENVIRONMENT_RUNTIME_HASH labels on a pool object — a specialized pod, or a
+// pool RS's template — still describe the live Environment, i.e. whether the
+// runtime it was born with is the one the environment currently specifies.
+//
+// The adopt pass and the zero-replica-RS cleanup MUST agree on this: adopt
+// keeping a pod the RS path would reap (or vice versa) is precisely the split
+// that leaks or kills warm pods. One predicate, two callers.
+//
+// A missing hash label means the object was born under a release that did not
+// stamp it — treated as a MATCH, because recycling every pre-label object
+// would defeat the upgrade these guards exist to smooth. (The RS path layers
+// one extra check on top for that case; see shouldCleanupForRS.)
+func envLabelsMatchLiveEnv(labels map[string]string, env *fv1.Environment) bool {
+	if uid := labels[fv1.ENVIRONMENT_UID]; uid != "" && uid != string(env.UID) {
+		return false
+	}
+	h, ok := labels[fv1.ENVIRONMENT_RUNTIME_HASH]
+	if !ok {
+		return true
+	}
+	return h == envRuntimeHash(env)
+}
 
 func getEnvPoolSize(env *fv1.Environment) int32 {
 	var poolsize int32

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -106,6 +107,12 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 	}
 
 	maps.Copy(podLabels, deployLabels)
+	// Template labels ONLY — deployLabels doubles as the immutable Deployment
+	// selector, and a generation there would break every env update. The pod
+	// inherits this label through the RS, and choosePod's specialization
+	// relabel is additive, so specialized pods keep their birth generation —
+	// which is what lets processRS tell an env change from an executor roll.
+	podLabels[fv1.ENVIRONMENT_GENERATION] = strconv.FormatInt(env.Generation, 10)
 
 	container, err := util.MergeContainer(&apiv1.Container{
 		Name:                   env.Name,

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -101,18 +100,26 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 		podAnnotations["sidecar.istio.io/inject"] = "false"
 	}
 
-	podLabels := env.Labels
+	// Clone, never alias: env is caller-owned and long-lived (gp.env, which
+	// labelsForFunction copies on every specialization). maps.Copy below
+	// writes the pool labels into this map — and since RFC-0028 a
+	// per-runtime-hash label too. Aliasing leaked both into env.Labels, from
+	// where getEnvironmentPoolLabels copies them into the RefreshFuncPods
+	// list selector and the legacy useSvc Service selector, pinning those to
+	// one runtime revision.
+	podLabels := maps.Clone(env.Labels)
 	if podLabels == nil {
 		podLabels = make(map[string]string)
 	}
 
 	maps.Copy(podLabels, deployLabels)
 	// Template labels ONLY — deployLabels doubles as the immutable Deployment
-	// selector, and a generation there would break every env update. The pod
+	// selector, and a hash there would break every env update. The pod
 	// inherits this label through the RS, and choosePod's specialization
-	// relabel is additive, so specialized pods keep their birth generation —
-	// which is what lets processRS tell an env change from an executor roll.
-	podLabels[fv1.ENVIRONMENT_GENERATION] = strconv.FormatInt(env.Generation, 10)
+	// relabel is additive, so specialized pods keep their birth hash — which
+	// is what lets processRS tell an env runtime change from an executor
+	// roll.
+	podLabels[fv1.ENVIRONMENT_RUNTIME_HASH] = envRuntimeHash(env)
 
 	container, err := util.MergeContainer(&apiv1.Container{
 		Name:                   env.Name,

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -620,8 +620,13 @@ func (gpm *GenericPoolManager) adoptPools(ctx context.Context, wg *sync.WaitGrou
 	for _, namespace := range utils.DefaultNSResolver().FissionResourceNamespaces() {
 		envs, err := gpm.fissionClient.CoreV1().Environments(namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			gpm.logger.Error(err, "error getting environment list")
-			return envMap
+			// continue, not return: a truncated envMap is not merely
+			// incomplete — every specialized pod whose env is missing from it
+			// fails adoption, goes unstamped, and is DELETED by the cleanup
+			// pass that follows. One namespace's transient list failure must
+			// not cost another namespace its warm pods.
+			gpm.logger.Error(err, "error getting environment list", "namespace", namespace)
+			continue
 		}
 
 		for i := range envs.Items {
@@ -694,14 +699,14 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 	// install (FISSION_FUNCTION_NAMESPACE set) adopted NOTHING while the
 	// reaper deleted everything — adopt coverage must be ⊇ what cleanup can
 	// reach, and this is the set that makes that hold.
-	for _, namespace := range utils.DefaultNSResolver().FunctionNamespaces() {
+	for _, namespace := range gpm.nsResolver.FunctionNamespaces() {
 		podList, err := gpm.kubernetesClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.Set(l).AsSelector().String(),
 		})
 
 		if err != nil {
-			gpm.logger.Error(err, "error getting pod list")
-			return
+			gpm.logger.Error(err, "error getting pod list", "namespace", namespace)
+			continue
 		}
 
 		for i := range podList.Items {
@@ -731,24 +736,21 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 				// human noticed. An unstamped pod that fails adoption is
 				// recycled by the post-adopt cleanup pass, which is the
 				// correct fate for it.
-				stamp := func() bool {
+				stamp := func(p *apiv1.Pod) (*apiv1.Pod, bool) {
 					patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, fv1.EXECUTOR_INSTANCEID_LABEL, gpm.instanceID)
-					// Locals, not the loop-level pod/err: these goroutines run
-					// concurrently and writes to shared captures would race.
-					p, perr := gpm.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+					claimed, perr := gpm.kubernetesClient.CoreV1().Pods(p.Namespace).Patch(ctx, p.Name, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
 					if perr != nil {
 						// just log the error since it won't affect the function serving
-						gpm.logger.Error(perr, "error patching executor instance ID of pod", "pod", pod.Name, "ns", pod.Namespace)
-						return false
+						gpm.logger.Error(perr, "error patching executor instance ID of pod", "pod", p.Name, "ns", p.Namespace)
+						return nil, false
 					}
-					pod = p
-					return true
+					return claimed, true
 				}
 
 				// for unspecialized (warm generic) pod, the annotation is all
 				// there is to adopt.
 				if pod.Labels["managed"] == "true" {
-					stamp()
+					stamp(pod)
 					return
 				}
 
@@ -766,34 +768,28 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 						"env", env.Name)
 					return
 				}
-				// The pod must belong to the LIVE environment, not a same-name
-				// predecessor: adopting across a delete+recreate would register
-				// a pod running the old environment's runtime against the new
-				// CR. Skip (no stamp) -> the post-adopt reaper recycles it.
-				if podEnvUID := pod.Labels[fv1.ENVIRONMENT_UID]; podEnvUID != "" && podEnvUID != string(env.UID) {
-					gpm.logger.Info("not adopting pod: environment was recreated under the same name",
-						"pod", pod.Name, "podEnvUID", podEnvUID, "liveEnvUID", string(env.UID))
+				// The pod must belong to the LIVE environment on its CURRENT
+				// runtime: adopting across a delete+recreate, or across an
+				// env change that landed while the executor was down,
+				// registers a pod whose runtime predates the CR. Skip (no
+				// stamp) -> the post-adopt reaper recycles it. Shared with
+				// the RS-cleanup path (envLabelsMatchLiveEnv) so the two
+				// cannot disagree about which pods deserve to live.
+				if !envLabelsMatchLiveEnv(pod.Labels, &env) {
+					gpm.logger.Info("not adopting pod: its labels no longer describe the live environment",
+						"pod", pod.Name,
+						"podEnvUID", pod.Labels[fv1.ENVIRONMENT_UID], "liveEnvUID", string(env.UID),
+						"podEnvRuntimeHash", pod.Labels[fv1.ENVIRONMENT_RUNTIME_HASH], "liveEnvRuntimeHash", envRuntimeHash(&env))
 					return
 				}
-				// And on the live environment's CURRENT spec: a generation
-				// mismatch means the env changed while the executor was down,
-				// and this pod's runtime predates it. Missing label = born
-				// under a pre-label release -> adopt (recycling every
-				// pre-label pod would defeat the upgrade this exists for).
-				if genStr, ok := pod.Labels[fv1.ENVIRONMENT_GENERATION]; ok {
-					if g, perr := strconv.ParseInt(genStr, 10, 64); perr != nil || g != env.Generation {
-						gpm.logger.Info("not adopting pod: environment spec changed while the executor was down",
-							"pod", pod.Name, "podEnvGeneration", genStr, "liveEnvGeneration", env.Generation)
-						return
-					}
-				}
-				// All label/annotation checks passed: claim the pod now, so
-				// everything below (the generation fallback's live-Function
-				// lookup included) reads the post-patch object exactly as the
-				// pre-restructure code did.
-				if !stamp() {
+				// All label/annotation checks passed: claim the pod, then
+				// read the post-patch object below (fresh ResourceVersion)
+				// exactly as the pre-restructure code did.
+				claimed, ok := stamp(pod)
+				if !ok {
 					return
 				}
+				pod = claimed
 
 				// fsCache keys on (UID, Generation), not ResourceVersion (see
 				// #3596 and functionServiceCache.go's UR->UG migration). A synthetic
@@ -875,13 +871,21 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 					Atime:    time.Now(),
 				}
 
-				if _, aerr := gpm.fsCache.Add(fsvc); aerr != nil {
-					// If fsvc already exists we just skip the duplicate one. And let reaper to recycle the duplicate pods.
-					// This is for the case that there are multiple function pods for the same function due to unknown reason.
-					if !fscache.IsNameExistError(aerr) {
-						gpm.logger.Error(aerr, "failed to adopt pod for function", "pod", pod.Name)
-					}
-
+				existing, aerr := gpm.fsCache.Add(fsvc)
+				if aerr != nil {
+					gpm.logger.Error(aerr, "failed to adopt pod for function", "pod", pod.Name)
+					return
+				}
+				if existing != nil {
+					// Add DEDUPS by (function UID, generation) and returns the
+					// incumbent with a NIL error — the old IsNameExistError
+					// branch here was dead code. This pod is stamped (shielded
+					// from cleanup) but has no cache identity, so no reaper
+					// owns it; it is recycled only by a Function update or an
+					// env change. Pre-existing behaviour, now at least said
+					// out loud instead of silently minted.
+					gpm.logger.Info("adopt: duplicate specialized pod for function generation; pod has no cache identity",
+						"pod", pod.Name, "incumbent", existing.Name)
 					return
 				}
 

--- a/pkg/executor/executortype/poolmgr/gpm.go
+++ b/pkg/executor/executortype/poolmgr/gpm.go
@@ -688,7 +688,13 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 		fv1.EXECUTOR_TYPE: string(fv1.ExecutorTypePoolmgr),
 	}
 
-	for _, namespace := range utils.DefaultNSResolver().FissionResourceNamespaces() {
+	// FunctionNamespaces, not FissionResourceNamespaces: pool pods live in the
+	// FUNCTION namespace (GetFunctionNS), and the post-adopt reaper sweeps a
+	// superset of it. Iterating the CR namespaces here meant a split-namespace
+	// install (FISSION_FUNCTION_NAMESPACE set) adopted NOTHING while the
+	// reaper deleted everything — adopt coverage must be ⊇ what cleanup can
+	// reach, and this is the set that makes that hold.
+	for _, namespace := range utils.DefaultNSResolver().FunctionNamespaces() {
 		podList, err := gpm.kubernetesClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.Set(l).AsSelector().String(),
 		})
@@ -700,12 +706,15 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 
 		for i := range podList.Items {
 			pod := &podList.Items[i]
-			if !utils.IsReadyPod(pod) {
-				if len(pod.Status.ContainerStatuses) == 0 {
-					gpm.logger.V(1).Info("adopt: skipping pod, containerStatuses empty",
-						"pod", pod.Name, "namespace", pod.Namespace,
-						"phase", pod.Status.Phase, "podIP", pod.Status.PodIP)
-				}
+			// Active, not Ready: a pod that blips not-Ready during the ≤30s
+			// adopt window must still be adopted — an fsCache entry is what
+			// gives the idle reaper ownership of it, and IsValid already
+			// gates every cached hand-out on live readiness. Skipping it
+			// here meant the post-adopt reaper deleted it instead (the
+			// annotation was never re-stamped), turning a readiness blip
+			// into a killed warm pod. Only terminal or already-deleting
+			// pods are skipped.
+			if !IsPodActive(pod) {
 				continue
 			}
 
@@ -713,18 +722,33 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 				// avoid too many requests arrive Kubernetes API server at the same time.
 				time.Sleep(time.Duration(rand.Intn(30)) * time.Millisecond)
 
-				patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, fv1.EXECUTOR_INSTANCEID_LABEL, gpm.instanceID)
-				// Locals, not the loop-level pod/err: these goroutines run
-				// concurrently and writes to shared captures would race.
-				pod, perr := gpm.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
-				if perr != nil {
-					// just log the error since it won't affect the function serving
-					gpm.logger.Error(perr, "error patching executor instance ID of pod", "pod", pod.Name, "ns", pod.Namespace)
-					return
+				// stamp re-marks the pod as owned by THIS executor instance,
+				// which is exactly what shields it from CleanupPods. It runs
+				// AFTER the adoption checks below for specialized pods:
+				// stamping first and then failing a check minted a class of
+				// pods that were protected from cleanup but never registered
+				// in fsCache — invisible to the idle reaper, leaked until a
+				// human noticed. An unstamped pod that fails adoption is
+				// recycled by the post-adopt cleanup pass, which is the
+				// correct fate for it.
+				stamp := func() bool {
+					patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s":"%s"}}}`, fv1.EXECUTOR_INSTANCEID_LABEL, gpm.instanceID)
+					// Locals, not the loop-level pod/err: these goroutines run
+					// concurrently and writes to shared captures would race.
+					p, perr := gpm.kubernetesClient.CoreV1().Pods(pod.Namespace).Patch(ctx, pod.Name, k8sTypes.StrategicMergePatchType, []byte(patch), metav1.PatchOptions{})
+					if perr != nil {
+						// just log the error since it won't affect the function serving
+						gpm.logger.Error(perr, "error patching executor instance ID of pod", "pod", pod.Name, "ns", pod.Namespace)
+						return false
+					}
+					pod = p
+					return true
 				}
 
-				// for unspecialized pod, we only update its annotations
+				// for unspecialized (warm generic) pod, the annotation is all
+				// there is to adopt.
 				if pod.Labels["managed"] == "true" {
+					stamp()
 					return
 				}
 
@@ -740,6 +764,34 @@ func (gpm *GenericPoolManager) adoptSpecializedPods(ctx context.Context, wg *syn
 					gpm.logger.Info("failed to adopt pod for function due to lack of necessary information",
 						"pod", pod.Name, "labels", pod.Labels, "annotations", pod.Annotations,
 						"env", env.Name)
+					return
+				}
+				// The pod must belong to the LIVE environment, not a same-name
+				// predecessor: adopting across a delete+recreate would register
+				// a pod running the old environment's runtime against the new
+				// CR. Skip (no stamp) -> the post-adopt reaper recycles it.
+				if podEnvUID := pod.Labels[fv1.ENVIRONMENT_UID]; podEnvUID != "" && podEnvUID != string(env.UID) {
+					gpm.logger.Info("not adopting pod: environment was recreated under the same name",
+						"pod", pod.Name, "podEnvUID", podEnvUID, "liveEnvUID", string(env.UID))
+					return
+				}
+				// And on the live environment's CURRENT spec: a generation
+				// mismatch means the env changed while the executor was down,
+				// and this pod's runtime predates it. Missing label = born
+				// under a pre-label release -> adopt (recycling every
+				// pre-label pod would defeat the upgrade this exists for).
+				if genStr, ok := pod.Labels[fv1.ENVIRONMENT_GENERATION]; ok {
+					if g, perr := strconv.ParseInt(genStr, 10, 64); perr != nil || g != env.Generation {
+						gpm.logger.Info("not adopting pod: environment spec changed while the executor was down",
+							"pod", pod.Name, "podEnvGeneration", genStr, "liveEnvGeneration", env.Generation)
+						return
+					}
+				}
+				// All label/annotation checks passed: claim the pod now, so
+				// everything below (the generation fallback's live-Function
+				// lookup included) reads the post-patch object exactly as the
+				// pre-restructure code did.
+				if !stamp() {
 					return
 				}
 
@@ -1048,8 +1100,8 @@ func (gpm *GenericPoolManager) deleteFnSvcEnsuredForUID(uid k8sTypes.UID) {
 // processReplicaSet reaps a pool's specialized pods when its ReplicaSet has
 // scaled to zero. Driven by the ReplicaSet reconciler; delegates to the pool pod
 // controller, which owns the specialized-pod cleanup queue.
-func (gpm *GenericPoolManager) processReplicaSet(ctx context.Context, rs *appsv1.ReplicaSet) {
-	gpm.poolPodC.processRS(ctx, rs)
+func (gpm *GenericPoolManager) processReplicaSet(ctx context.Context, rs *appsv1.ReplicaSet) error {
+	return gpm.poolPodC.processRS(ctx, rs)
 }
 
 // readyPodEnqueueDelay debounces a warm pod's entry into its readyPodQueue.
@@ -1149,7 +1201,10 @@ func (gpm *GenericPoolManager) reconcileEnvPool(ctx context.Context, env *fv1.En
 	if errs != nil {
 		return errs
 	}
-	// Any specialized pods are recycled by the ReplicaSet → cleanup path.
+	// Specialized pods on the OLD template are recycled by the ReplicaSet →
+	// cleanup path — which since RFC-0028 keys on the ENVIRONMENT_GENERATION
+	// template label, so only an env-spec change (this function's trigger)
+	// recycles them; an executor-side template roll leaves them serving.
 	return nil
 }
 

--- a/pkg/executor/executortype/poolmgr/gpm_adopt_test.go
+++ b/pkg/executor/executortype/poolmgr/gpm_adopt_test.go
@@ -63,6 +63,14 @@ func specializedAdoptPod(name, ns, fnUID, generation string) *apiv1.Pod {
 // adoptSpecializedPods to completion, and returns the fsCache it populated.
 func runAdopt(t *testing.T, pod *apiv1.Pod, fissionObjs ...runtime.Object) *fscache.FunctionServiceCache {
 	t.Helper()
+	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: pod.Namespace}}
+	return runAdoptWithEnv(t, pod, env, fissionObjs...).fsCache
+}
+
+// runAdoptWithEnv is runAdopt with a caller-supplied Environment (for the
+// UID/runtime-hash guards) and the manager returned for stamp assertions.
+func runAdoptWithEnv(t *testing.T, pod *apiv1.Pod, env fv1.Environment, fissionObjs ...runtime.Object) *GenericPoolManager {
+	t.Helper()
 	gpm := &GenericPoolManager{
 		logger:           logr.Discard(),
 		kubernetesClient: k8sfake.NewSimpleClientset(pod),
@@ -71,13 +79,11 @@ func runAdopt(t *testing.T, pod *apiv1.Pod, fissionObjs ...runtime.Object) *fsca
 		instanceID:       "inst-1",
 		fsCache:          fscache.MakeFunctionServiceCache(logr.Discard()),
 	}
-	envMap := map[string]fv1.Environment{
-		pod.Namespace + "/env1": {ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: pod.Namespace}},
-	}
+	envMap := map[string]fv1.Environment{pod.Namespace + "/env1": env}
 	var wg sync.WaitGroup
 	gpm.adoptSpecializedPods(t.Context(), &wg, envMap)
 	wg.Wait()
-	return gpm.fsCache
+	return gpm
 }
 
 // TestAdoptSpecializedPodsPopulatesGeneration is the regression test for the
@@ -179,24 +185,6 @@ func podAfterAdopt(t *testing.T, gpm *GenericPoolManager, ns, name string) *apiv
 	return pod
 }
 
-// runAdoptGPM is runAdopt returning the manager too, for stamp assertions.
-func runAdoptGPM(t *testing.T, pod *apiv1.Pod, env fv1.Environment, fissionObjs ...runtime.Object) (*GenericPoolManager, *fscache.FunctionServiceCache) {
-	t.Helper()
-	gpm := &GenericPoolManager{
-		logger:           logr.Discard(),
-		kubernetesClient: k8sfake.NewSimpleClientset(pod),
-		fissionClient:    fissionfake.NewSimpleClientset(fissionObjs...),
-		nsResolver:       utils.DefaultNSResolver(),
-		instanceID:       "inst-1",
-		fsCache:          fscache.MakeFunctionServiceCache(logr.Discard()),
-	}
-	envMap := map[string]fv1.Environment{pod.Namespace + "/env1": env}
-	var wg sync.WaitGroup
-	gpm.adoptSpecializedPods(t.Context(), &wg, envMap)
-	wg.Wait()
-	return gpm, gpm.fsCache
-}
-
 // TestAdoptActiveNotReadyPod pins the readiness-hole fix: a pod that is merely
 // not-Ready during the adopt window (a probe blip) must still be adopted —
 // stamped AND registered. The fsCache entry is what gives the idle reaper
@@ -208,12 +196,12 @@ func TestAdoptActiveNotReadyPod(t *testing.T) {
 	pod.Status.ContainerStatuses = []apiv1.ContainerStatus{{Ready: false}}
 	pod.Status.Phase = apiv1.PodRunning
 
-	gpm, fsCache := runAdoptGPM(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
+	gpm := runAdoptWithEnv(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
 
 	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
 	require.Equal(t, "inst-1", after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
 		"an active-but-not-ready pod must be claimed, or the post-adopt reaper kills it")
-	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	_, err := gpm.fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
 	require.NoError(t, err, "the entry is what gives the idle reaper ownership of the pod")
 }
 
@@ -223,11 +211,11 @@ func TestAdoptSkipsTerminalPod(t *testing.T) {
 	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
 	pod.Status.Phase = apiv1.PodSucceeded
 
-	gpm, fsCache := runAdoptGPM(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
+	gpm := runAdoptWithEnv(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
 
 	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
 	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL], "a terminal pod must not be claimed")
-	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	_, err := gpm.fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
 	require.Error(t, err)
 }
 
@@ -240,28 +228,34 @@ func TestAdoptHalfSpecializedPodNotStamped(t *testing.T) {
 	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
 	delete(pod.Annotations, fv1.ANNOTATION_SVC_HOST)
 
-	gpm, fsCache := runAdoptGPM(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
+	gpm := runAdoptWithEnv(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
 
 	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
 	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
 		"a pod that fails adoption must stay unstamped — unstamped is what lets cleanup recycle it")
-	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	_, err := gpm.fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
 	require.Error(t, err)
 }
 
-// TestAdoptSkipsStaleEnvGeneration: the env spec changed while the executor
+// TestAdoptSkipsStaleEnvRuntime: the env's runtime changed while the executor
 // was down — this pod's runtime predates it and must be recycled, not adopted.
-func TestAdoptSkipsStaleEnvGeneration(t *testing.T) {
+func TestAdoptSkipsStaleEnvRuntime(t *testing.T) {
 	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
-	pod.Labels[fv1.ENVIRONMENT_GENERATION] = "2"
-
-	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", Generation: 3}}
-	gpm, fsCache := runAdoptGPM(t, pod, env)
+	env := fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"},
+		Spec:       fv1.EnvironmentSpec{Runtime: fv1.Runtime{Image: "img:v2"}},
+	}
+	// The pod was born under a DIFFERENT runtime revision of the same env.
+	pod.Labels[fv1.ENVIRONMENT_RUNTIME_HASH] = envRuntimeHash(&fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"},
+		Spec:       fv1.EnvironmentSpec{Runtime: fv1.Runtime{Image: "img:v1"}},
+	})
+	gpm := runAdoptWithEnv(t, pod, env)
 
 	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
 	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
 		"a stale-runtime pod must be left for the cleanup pass")
-	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	_, err := gpm.fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
 	require.Error(t, err)
 }
 
@@ -273,26 +267,29 @@ func TestAdoptSkipsRecreatedEnv(t *testing.T) {
 	pod.Labels[fv1.ENVIRONMENT_UID] = "old-env-uid"
 
 	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", UID: "new-env-uid"}}
-	gpm, fsCache := runAdoptGPM(t, pod, env)
+	gpm := runAdoptWithEnv(t, pod, env)
 
 	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
 	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL])
-	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	_, err := gpm.fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
 	require.Error(t, err)
 }
 
-// TestAdoptMatchingEnvGeneration: the positive control for the two guards —
-// matching UID and generation adopt exactly as before.
-func TestAdoptMatchingEnvGeneration(t *testing.T) {
+// TestAdoptMatchingEnvRuntime: the positive control for the two guards —
+// matching UID and runtime hash adopt exactly as before.
+func TestAdoptMatchingEnvRuntime(t *testing.T) {
 	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	env := fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", UID: "env-uid-1"},
+		Spec:       fv1.EnvironmentSpec{Runtime: fv1.Runtime{Image: "img:v2"}},
+	}
 	pod.Labels[fv1.ENVIRONMENT_UID] = "env-uid-1"
-	pod.Labels[fv1.ENVIRONMENT_GENERATION] = "4"
+	pod.Labels[fv1.ENVIRONMENT_RUNTIME_HASH] = envRuntimeHash(&env)
 
-	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", UID: "env-uid-1", Generation: 4}}
-	gpm, fsCache := runAdoptGPM(t, pod, env)
+	gpm := runAdoptWithEnv(t, pod, env)
 
 	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
 	require.Equal(t, "inst-1", after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL])
-	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	_, err := gpm.fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
 	require.NoError(t, err)
 }

--- a/pkg/executor/executortype/poolmgr/gpm_adopt_test.go
+++ b/pkg/executor/executortype/poolmgr/gpm_adopt_test.go
@@ -169,3 +169,130 @@ func TestAdoptSpecializedPodsMissingGenerationUIDMismatch(t *testing.T) {
 	require.Empty(t, fsCache.ListByFunctionUID("fn-uid-new"),
 		"the stale pod must not be registered under the new Function's UID either")
 }
+
+// podAfterAdopt reads the pod back from the fake clientset so tests can assert
+// on the stamp (the executorInstanceId annotation) independently of the cache.
+func podAfterAdopt(t *testing.T, gpm *GenericPoolManager, ns, name string) *apiv1.Pod {
+	t.Helper()
+	pod, err := gpm.kubernetesClient.CoreV1().Pods(ns).Get(t.Context(), name, metav1.GetOptions{})
+	require.NoError(t, err)
+	return pod
+}
+
+// runAdoptGPM is runAdopt returning the manager too, for stamp assertions.
+func runAdoptGPM(t *testing.T, pod *apiv1.Pod, env fv1.Environment, fissionObjs ...runtime.Object) (*GenericPoolManager, *fscache.FunctionServiceCache) {
+	t.Helper()
+	gpm := &GenericPoolManager{
+		logger:           logr.Discard(),
+		kubernetesClient: k8sfake.NewSimpleClientset(pod),
+		fissionClient:    fissionfake.NewSimpleClientset(fissionObjs...),
+		nsResolver:       utils.DefaultNSResolver(),
+		instanceID:       "inst-1",
+		fsCache:          fscache.MakeFunctionServiceCache(logr.Discard()),
+	}
+	envMap := map[string]fv1.Environment{pod.Namespace + "/env1": env}
+	var wg sync.WaitGroup
+	gpm.adoptSpecializedPods(t.Context(), &wg, envMap)
+	wg.Wait()
+	return gpm, gpm.fsCache
+}
+
+// TestAdoptActiveNotReadyPod pins the readiness-hole fix: a pod that is merely
+// not-Ready during the adopt window (a probe blip) must still be adopted —
+// stamped AND registered. The fsCache entry is what gives the idle reaper
+// ownership, and IsValid gates every hand-out on live readiness anyway.
+// Skipping it here meant the post-adopt cleanup deleted a healthy warm pod
+// because of a 1-second probe blip.
+func TestAdoptActiveNotReadyPod(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	pod.Status.ContainerStatuses = []apiv1.ContainerStatus{{Ready: false}}
+	pod.Status.Phase = apiv1.PodRunning
+
+	gpm, fsCache := runAdoptGPM(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
+
+	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
+	require.Equal(t, "inst-1", after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
+		"an active-but-not-ready pod must be claimed, or the post-adopt reaper kills it")
+	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	require.NoError(t, err, "the entry is what gives the idle reaper ownership of the pod")
+}
+
+// TestAdoptSkipsTerminalPod: Succeeded/Failed pods are inert; adopting them
+// would register dead addresses.
+func TestAdoptSkipsTerminalPod(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	pod.Status.Phase = apiv1.PodSucceeded
+
+	gpm, fsCache := runAdoptGPM(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
+
+	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
+	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL], "a terminal pod must not be claimed")
+	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	require.Error(t, err)
+}
+
+// TestAdoptHalfSpecializedPodNotStamped pins the stamp-after-checks fix: a pod
+// killed mid-specialization (no ANNOTATION_SVC_HOST yet) must be left
+// UNSTAMPED so the post-adopt cleanup recycles it. Stamping first and then
+// failing the checks minted pods that were protected from cleanup but
+// invisible to the reaper — leaked until a human noticed.
+func TestAdoptHalfSpecializedPodNotStamped(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	delete(pod.Annotations, fv1.ANNOTATION_SVC_HOST)
+
+	gpm, fsCache := runAdoptGPM(t, pod, fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default"}})
+
+	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
+	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
+		"a pod that fails adoption must stay unstamped — unstamped is what lets cleanup recycle it")
+	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	require.Error(t, err)
+}
+
+// TestAdoptSkipsStaleEnvGeneration: the env spec changed while the executor
+// was down — this pod's runtime predates it and must be recycled, not adopted.
+func TestAdoptSkipsStaleEnvGeneration(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	pod.Labels[fv1.ENVIRONMENT_GENERATION] = "2"
+
+	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", Generation: 3}}
+	gpm, fsCache := runAdoptGPM(t, pod, env)
+
+	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
+	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
+		"a stale-runtime pod must be left for the cleanup pass")
+	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	require.Error(t, err)
+}
+
+// TestAdoptSkipsRecreatedEnv: same name, different UID — the environment was
+// deleted and recreated while the executor was down. Adopting would register a
+// pod running the OLD environment's runtime against the new CR.
+func TestAdoptSkipsRecreatedEnv(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	pod.Labels[fv1.ENVIRONMENT_UID] = "old-env-uid"
+
+	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", UID: "new-env-uid"}}
+	gpm, fsCache := runAdoptGPM(t, pod, env)
+
+	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
+	require.Empty(t, after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL])
+	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	require.Error(t, err)
+}
+
+// TestAdoptMatchingEnvGeneration: the positive control for the two guards —
+// matching UID and generation adopt exactly as before.
+func TestAdoptMatchingEnvGeneration(t *testing.T) {
+	pod := specializedAdoptPod("fn1-pod", "default", "fn-uid-1", "3")
+	pod.Labels[fv1.ENVIRONMENT_UID] = "env-uid-1"
+	pod.Labels[fv1.ENVIRONMENT_GENERATION] = "4"
+
+	env := fv1.Environment{ObjectMeta: metav1.ObjectMeta{Name: "env1", Namespace: "default", UID: "env-uid-1", Generation: 4}}
+	gpm, fsCache := runAdoptGPM(t, pod, env)
+
+	after := podAfterAdopt(t, gpm, "default", "fn1-pod")
+	require.Equal(t, "inst-1", after.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL])
+	_, err := fsCache.GetByFunction(&metav1.ObjectMeta{Name: "fn1", Namespace: "default", UID: "fn-uid-1", Generation: 3})
+	require.NoError(t, err)
+}

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -7,7 +7,6 @@ package poolmgr
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -97,7 +96,7 @@ func (p *PoolPodController) processRS(ctx context.Context, rs *apps.ReplicaSet) 
 	// includes pod-template-hash; managed=false overrides to specialized).
 	rsLabelMap, err := metav1.LabelSelectorAsMap(rs.Spec.Selector)
 	if err != nil {
-		p.logger.Error(err, "Failed to parse label selector")
+		logger.Error(err, "Failed to parse label selector")
 		return nil // malformed selector cannot succeed on retry
 	}
 	rsLabelMap["managed"] = "false"
@@ -174,31 +173,36 @@ func (p *PoolPodController) shouldCleanupForRS(ctx context.Context, rs *apps.Rep
 			}
 			return false, fmt.Errorf("verify environment %s/%s uncached: %w", envNS, envName, aerr)
 		}
-		logger.V(1).Info("environment NotFound in cache but exists in API server; keeping pods, RS event will replay")
-		return false, nil
+		// Requeue via error, deliberately: the RS reconciler is registered
+		// with GenerationChangedPredicate, so a settled zero-replica RS emits
+		// no further events and returning (false, nil) here would FORGET the
+		// decision — stale-runtime pods would keep serving until the executor
+		// next restarts. The error path is the only re-visit mechanism.
+		return false, fmt.Errorf("environment %s/%s NotFound in cache but live in API server (stale cache); requeueing the decision", envNS, envName)
 	}
 	if err != nil {
 		return false, fmt.Errorf("get environment %s/%s: %w", envNS, envName, err)
 	}
-	if uid := tmpl[fv1.ENVIRONMENT_UID]; uid != "" && uid != string(env.UID) {
-		return true, nil // env deleted and recreated under the same name
-	}
-
-	genStr, ok := tmpl[fv1.ENVIRONMENT_GENERATION]
-	if !ok {
-		// Pre-label RS (born under a release without ENVIRONMENT_GENERATION):
-		// keep. This is what makes warm pods survive the very upgrade that
-		// ships this fix — the N−1-born RS carries no label, and treating
-		// that as "clean" would re-kill them one last time. The residual
-		// (env changed during that same upgrade window) is bounded by the
-		// adopt-time generation guard and the idle reaper.
+	if _, hasHash := tmpl[fv1.ENVIRONMENT_RUNTIME_HASH]; !hasHash {
+		// Pre-label RS (born under a release without the hash label). Keep by
+		// default — that is what makes warm pods survive the very upgrade
+		// that ships this fix; treating it as "clean" would re-kill them one
+		// last time. ONE sharpening: if the live pool Deployment's template
+		// already carries the label, the pool has been re-templated since,
+		// so this RS is provably a pre-hash generation whose pods run a
+		// runtime at least one revision old -> clean. During the shipping
+		// upgrade itself the live Deployment is not yet re-templated, so
+		// both sides are unlabelled and the keep still holds.
+		if _, ownerHasHash := dep.Spec.Template.Labels[fv1.ENVIRONMENT_RUNTIME_HASH]; ownerHasHash {
+			return true, nil
+		}
 		return false, nil
 	}
-	gen, perr := strconv.ParseInt(genStr, 10, 64)
-	if perr != nil {
-		return true, nil // mangled label: legacy behavior (recycle)
-	}
-	return gen != env.Generation, nil
+	// Recycle iff the template's birth runtime is no longer the live one: a
+	// same-name recreate, or an env change that touched the template inputs.
+	// Shared with the adopt pass (envLabelsMatchLiveEnv) so the two paths
+	// cannot disagree about which pods deserve to live.
+	return !envLabelsMatchLiveEnv(tmpl, env), nil
 }
 
 // cleanupSpecializedPodsForEnv enqueues an environment's specialized pods for

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -6,6 +6,8 @@ package poolmgr
 
 import (
 	"context"
+	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -68,26 +70,52 @@ func IsPodActive(p *v1.Pod) bool {
 		p.DeletionTimestamp == nil
 }
 
-func (p *PoolPodController) processRS(ctx context.Context, rs *apps.ReplicaSet) {
+// processRS reaps a retired pool template's specialized pods — but ONLY when
+// the retirement means their runtime is stale or their pool is gone, never
+// merely because the executor restarted.
+//
+// A zero-replica pool RS has exactly two producers, and they demand opposite
+// treatment. An ENVIRONMENT change (new runtime image) rolls the pool and the
+// specialized pods born from the old template must be recycled onto the new
+// runtime — before RFC-0028 this was the ONLY reading, and reconcileEnvPool
+// still relies on it. An EXECUTOR-side template change (new FETCHER_IMAGE on
+// upgrade, fetcher config) also rolls the pool — and here the specialized
+// pods must SURVIVE: they are already specialized, their runtime is current,
+// and deleting them is precisely the warm-pod kill that made every upgrade
+// drop ~4% of poolmgr requests (mechanism B in the RFC-0028 gate work).
+// The ENVIRONMENT_GENERATION template label is what tells the two apart.
+//
+// Errors propagate (-> controller-runtime backoff requeue): a transient API
+// failure while deciding must retry, not silently drop a legitimate cleanup.
+func (p *PoolPodController) processRS(ctx context.Context, rs *apps.ReplicaSet) error {
 	if *(rs.Spec.Replicas) != 0 {
-		return
+		return nil
 	}
 	logger := p.logger.WithValues("rs", rs.Name, "namespace", rs.Namespace)
 	logger.V(1).Info("replica set has zero replica count")
-	// List all specialized pods and schedule for cleanup
+	// List all specialized pods born from this template (the RS selector
+	// includes pod-template-hash; managed=false overrides to specialized).
 	rsLabelMap, err := metav1.LabelSelectorAsMap(rs.Spec.Selector)
 	if err != nil {
 		p.logger.Error(err, "Failed to parse label selector")
-		return
+		return nil // malformed selector cannot succeed on retry
 	}
 	rsLabelMap["managed"] = "false"
 	podList := &v1.PodList{}
 	if err := p.gpm.crClient.List(ctx, podList, client.InNamespace(rs.Namespace), client.MatchingLabels(rsLabelMap)); err != nil {
-		logger.Error(err, "Failed to list specialized pods")
-		return
+		return fmt.Errorf("list specialized pods for RS %s/%s: %w", rs.Namespace, rs.Name, err)
 	}
 	if len(podList.Items) == 0 {
-		return
+		return nil
+	}
+	clean, err := p.shouldCleanupForRS(ctx, rs, logger)
+	if err != nil {
+		return err
+	}
+	if !clean {
+		logger.Info("pool RS rolled without an environment change; keeping specialized pods",
+			"numPods", len(podList.Items))
+		return nil
 	}
 	logger.Info("specialized pods identified for cleanup with RS", "numPods", len(podList.Items))
 	for i := range podList.Items {
@@ -102,6 +130,75 @@ func (p *PoolPodController) processRS(ctx context.Context, rs *apps.ReplicaSet) 
 		}
 		p.spCleanupPodQueue.Add(key)
 	}
+	return nil
+}
+
+// shouldCleanupForRS decides teardown-or-env-change (clean) vs
+// executor-side-roll (keep) for a zero-replica pool RS.
+func (p *PoolPodController) shouldCleanupForRS(ctx context.Context, rs *apps.ReplicaSet, logger logr.Logger) (bool, error) {
+	ownerRef := metav1.GetControllerOf(rs)
+	if ownerRef == nil || !strings.EqualFold(ownerRef.Kind, "Deployment") {
+		return true, nil // orphan RS: legacy behavior
+	}
+	// Direct client, deliberately: the executor Manager cache's Deployment
+	// watch is label-bounded to newdeploy/container, so a cache Get of a
+	// poolmgr pool Deployment ALWAYS returns NotFound — which this path
+	// would read as "teardown" and delete pods that must survive.
+	dep, err := p.kubernetesClient.AppsV1().Deployments(rs.Namespace).Get(ctx, ownerRef.Name, metav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return true, nil // owner gone: pool destroyed
+	}
+	if err != nil {
+		return false, fmt.Errorf("get pool Deployment %s/%s: %w", rs.Namespace, ownerRef.Name, err)
+	}
+	if dep.DeletionTimestamp != nil || dep.UID != ownerRef.UID {
+		return true, nil // owner deleting, or a new Deployment reused the name
+	}
+
+	// The owner is a live pool mid-roll. Recycle iff the ENVIRONMENT moved.
+	tmpl := rs.Spec.Template.Labels
+	envName, envNS := tmpl[fv1.ENVIRONMENT_NAME], tmpl[fv1.ENVIRONMENT_NAMESPACE]
+	if envName == "" || envNS == "" {
+		return true, nil // unrecognized template shape: legacy behavior
+	}
+	env := &fv1.Environment{}
+	err = p.gpm.crClient.Get(ctx, client.ObjectKey{Namespace: envNS, Name: envName}, env)
+	if apierrors.IsNotFound(err) {
+		// Destructive decision on a cache miss: verify uncached first — the
+		// same stale-cache guard the Environment reconciler applies before
+		// CleanupEnvironment (a watch reconnect can transiently report
+		// NotFound for an object that exists).
+		if _, aerr := p.gpm.fissionClient.CoreV1().Environments(envNS).Get(ctx, envName, metav1.GetOptions{}); aerr != nil {
+			if apierrors.IsNotFound(aerr) {
+				return true, nil // env genuinely gone: teardown
+			}
+			return false, fmt.Errorf("verify environment %s/%s uncached: %w", envNS, envName, aerr)
+		}
+		logger.V(1).Info("environment NotFound in cache but exists in API server; keeping pods, RS event will replay")
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get environment %s/%s: %w", envNS, envName, err)
+	}
+	if uid := tmpl[fv1.ENVIRONMENT_UID]; uid != "" && uid != string(env.UID) {
+		return true, nil // env deleted and recreated under the same name
+	}
+
+	genStr, ok := tmpl[fv1.ENVIRONMENT_GENERATION]
+	if !ok {
+		// Pre-label RS (born under a release without ENVIRONMENT_GENERATION):
+		// keep. This is what makes warm pods survive the very upgrade that
+		// ships this fix — the N−1-born RS carries no label, and treating
+		// that as "clean" would re-kill them one last time. The residual
+		// (env changed during that same upgrade window) is bounded by the
+		// adopt-time generation guard and the idle reaper.
+		return false, nil
+	}
+	gen, perr := strconv.ParseInt(genStr, 10, 64)
+	if perr != nil {
+		return true, nil // mangled label: legacy behavior (recycle)
+	}
+	return gen != env.Generation, nil
 }
 
 // cleanupSpecializedPodsForEnv enqueues an environment's specialized pods for

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_rs_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_rs_test.go
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package poolmgr
+
+import (
+	"errors"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	k8stesting "k8s.io/client-go/testing"
+	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned/fake"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	fetcherConfig "github.com/fission/fission/pkg/fetcher/config"
+	fClient "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// TestProcessRSDiscriminator pins the keep-or-clean decision for a
+// zero-replica pool ReplicaSet — the RFC-0028 mechanism-B fix. A pool rolls
+// for exactly two reasons with OPPOSITE correct outcomes: an environment
+// change must recycle the specialized pods born from the old template, and an
+// executor-side template change (fetcher image on upgrade) must NOT — killing
+// them there is the warm-pod death that made upgrades drop poolmgr requests.
+func TestProcessRSDiscriminator(t *testing.T) {
+	const (
+		ns      = metav1.NamespaceDefault
+		envName = "test-env"
+		envUID  = "env-uid-1"
+		depName = "poolmgr-test-env-default-123"
+		depUID  = "dep-uid-1"
+	)
+
+	templateLabels := func(gen string, overrides map[string]string) map[string]string {
+		l := map[string]string{
+			fv1.EXECUTOR_TYPE:         string(fv1.ExecutorTypePoolmgr),
+			fv1.ENVIRONMENT_NAME:      envName,
+			fv1.ENVIRONMENT_NAMESPACE: ns,
+			fv1.ENVIRONMENT_UID:       envUID,
+			"managed":                 "true",
+			"pod-template-hash":       "abc123",
+		}
+		if gen != "" {
+			l[fv1.ENVIRONMENT_GENERATION] = gen
+		}
+		for k, v := range overrides {
+			l[k] = v
+		}
+		return l
+	}
+
+	liveDep := func(deleting bool) *appsv1.Deployment {
+		d := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
+			Name: depName, Namespace: ns, UID: k8stypes.UID(depUID),
+		}}
+		if deleting {
+			now := metav1.Now()
+			d.DeletionTimestamp = &now
+			// The fake API rejects a deletionTimestamp without a finalizer.
+			d.Finalizers = []string{"test/hold"}
+		}
+		return d
+	}
+	liveEnv := func(gen int64) *fv1.Environment {
+		return &fv1.Environment{ObjectMeta: metav1.ObjectMeta{
+			Name: envName, Namespace: ns, UID: k8stypes.UID(envUID), Generation: gen,
+		}}
+	}
+
+	type tc struct {
+		name string
+		// rs shape
+		replicas   int32
+		ownerless  bool
+		ownerUID   string
+		tmplLabels map[string]string
+		// cluster state
+		dep         *appsv1.Deployment // direct kube client (owner Get)
+		cachedEnv   *fv1.Environment   // manager-cache client
+		uncachedEnv *fv1.Environment   // fission typed fake (stale-cache verify)
+		depGetErr   bool               // inject a transient error on deployments get
+		// expectations
+		wantEnqueued int
+		wantErr      bool
+	}
+	cases := []tc{
+		{
+			name:     "nonzero replicas is a no-op",
+			replicas: 1, ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 0,
+		},
+		{
+			name:     "executor-side roll: live owner, generation matches -> KEEP",
+			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 0,
+		},
+		{
+			name:     "environment update: generation moved -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("2", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "owner Deployment gone -> teardown -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			cachedEnv:    liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "owner Deployment deleting -> teardown -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			dep: liveDep(true), cachedEnv: liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "owner UID mismatch (name reused by a new Deployment) -> clean",
+			ownerUID: "old-dep-uid", tmplLabels: templateLabels("3", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:      "orphan RS (no controller ref) -> legacy clean",
+			ownerless: true, tmplLabels: templateLabels("3", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "env NotFound in cache but live in API -> stale cache -> KEEP",
+			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			dep: liveDep(false), uncachedEnv: liveEnv(3),
+			wantEnqueued: 0,
+		},
+		{
+			name:     "env gone from cache AND API -> teardown -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			dep:          liveDep(false),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "env recreated under the same name (UID mismatch) -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("3", map[string]string{fv1.ENVIRONMENT_UID: "stale-env-uid"}),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "pre-label RS (no generation label) -> KEEP — survival on the shipping upgrade",
+			ownerUID: depUID, tmplLabels: templateLabels("", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 0,
+		},
+		{
+			name:     "mangled generation label -> legacy clean",
+			ownerUID: depUID, tmplLabels: templateLabels("not-a-number", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "transient owner GET error -> error (requeue), nothing enqueued",
+			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(3), depGetErr: true,
+			wantEnqueued: 0, wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger := loggerfactory.GetLogger()
+
+			// The specialized pod born from this template: matches the RS
+			// selector with managed=false. Its presence is what makes
+			// processRS reach the discriminator at all.
+			specialized := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "specialized-1", Namespace: ns,
+					Labels: func() map[string]string {
+						l := templateLabels("", nil) // pod labels need no generation for selection
+						l["managed"] = "false"
+						return l
+					}(),
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+
+			replicas := c.replicas
+			rs := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{Name: depName + "-abc123", Namespace: ns},
+				Spec: appsv1.ReplicaSetSpec{
+					Replicas: &replicas,
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						fv1.ENVIRONMENT_NAME: envName, "managed": "true", "pod-template-hash": "abc123",
+					}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: c.tmplLabels},
+					},
+				},
+			}
+			if !c.ownerless {
+				isController := true
+				rs.OwnerReferences = []metav1.OwnerReference{{
+					APIVersion: "apps/v1", Kind: "Deployment", Name: depName,
+					UID: k8stypes.UID(c.ownerUID), Controller: &isController,
+				}}
+			}
+
+			kubeObjs := []runtime.Object{}
+			if c.dep != nil {
+				kubeObjs = append(kubeObjs, c.dep)
+			}
+			kubernetesClient := fake.NewClientset(kubeObjs...)
+			if c.depGetErr {
+				kubernetesClient.PrependReactor("get", "deployments", func(k8stesting.Action) (bool, runtime.Object, error) {
+					return true, nil, errors.New("transient apiserver error")
+				})
+			}
+
+			s := runtime.NewScheme()
+			require.NoError(t, clientgoscheme.AddToScheme(s))
+			require.NoError(t, fv1.AddToScheme(s))
+			crObjs := []crclient.Object{specialized}
+			if c.cachedEnv != nil {
+				crObjs = append(crObjs, c.cachedEnv)
+			}
+			crClient := crfake.NewClientBuilder().WithScheme(s).WithObjects(crObjs...).Build()
+
+			var fissionClient *fClient.Clientset
+			if c.uncachedEnv != nil {
+				fissionClient = fClient.NewClientset(c.uncachedEnv)
+			} else {
+				fissionClient = fClient.NewClientset()
+			}
+
+			ppc := NewPoolPodController(logger, kubernetesClient)
+			metricsClient := metricsclient.NewSimpleClientset() //nolint:staticcheck
+			fetcherCfg, err := fetcherConfig.MakeFetcherConfig("/userfunc")
+			require.NoError(t, err)
+			executor, err := MakeGenericPoolManager(t.Context(), logger,
+				fissionClient, kubernetesClient, metricsClient, fetcherCfg, "test-instance", nil)
+			require.NoError(t, err)
+			gpm := executor.(*GenericPoolManager)
+			gpm.crClient = crClient
+			ppc.InjectGpm(gpm)
+
+			err = ppc.processRS(t.Context(), rs)
+			if c.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, c.wantEnqueued, ppc.spCleanupPodQueue.Len(),
+				"cleanup queue length after processRS")
+		})
+	}
+}
+
+// TestPoolSelectorStaysGenerationFree is the selector-immutability guard: the
+// ENVIRONMENT_GENERATION label may exist ONLY on the pod template. A
+// Deployment selector is immutable, so a generation-bearing selector would
+// fail every environment update with "field is immutable".
+func TestPoolSelectorStaysGenerationFree(t *testing.T) {
+	env := &fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default", UID: "u", Generation: 7},
+		Spec:       fv1.EnvironmentSpec{Version: 3, Poolsize: 3, Runtime: fv1.Runtime{Image: "img"}},
+	}
+	fetcherCfg, err := fetcherConfig.MakeFetcherConfig("/userfunc")
+	require.NoError(t, err)
+	gp := &GenericPool{fnNamespace: "default", fetcherConfig: fetcherCfg}
+
+	spec, err := gp.genDeploymentSpec(env)
+	require.NoError(t, err)
+
+	assert.NotContains(t, spec.Selector.MatchLabels, fv1.ENVIRONMENT_GENERATION,
+		"the generation must NEVER reach the immutable selector")
+	assert.NotContains(t, gp.getEnvironmentPoolLabels(env), fv1.ENVIRONMENT_GENERATION,
+		"getEnvironmentPoolLabels feeds the selector and must stay generation-free")
+	assert.Equal(t, strconv.FormatInt(env.Generation, 10),
+		spec.Template.Labels[fv1.ENVIRONMENT_GENERATION],
+		"the pod template must carry the environment generation — it is what processRS keys on")
+}

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_rs_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_rs_test.go
@@ -6,7 +6,6 @@ package poolmgr
 
 import (
 	"errors"
-	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -44,7 +43,24 @@ func TestProcessRSDiscriminator(t *testing.T) {
 		depUID  = "dep-uid-1"
 	)
 
-	templateLabels := func(gen string, overrides map[string]string) map[string]string {
+	// Two concrete environments whose runtime hashes differ: the "live" one
+	// and a prior revision (different runtime image). The discriminator and
+	// the tests key on envRuntimeHash of these, never on synthetic strings —
+	// so the test can only pass if the production hash function is what
+	// distinguishes them.
+	liveEnv := func() *fv1.Environment {
+		return &fv1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: envName, Namespace: ns, UID: k8stypes.UID(envUID), Generation: 3},
+			Spec:       fv1.EnvironmentSpec{Runtime: fv1.Runtime{Image: "img:v2"}},
+		}
+	}
+	staleHash := envRuntimeHash(&fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: envName, Namespace: ns, UID: k8stypes.UID(envUID)},
+		Spec:       fv1.EnvironmentSpec{Runtime: fv1.Runtime{Image: "img:v1"}},
+	})
+	liveHash := envRuntimeHash(liveEnv())
+
+	templateLabels := func(hash string, overrides map[string]string) map[string]string {
 		l := map[string]string{
 			fv1.EXECUTOR_TYPE:         string(fv1.ExecutorTypePoolmgr),
 			fv1.ENVIRONMENT_NAME:      envName,
@@ -53,8 +69,8 @@ func TestProcessRSDiscriminator(t *testing.T) {
 			"managed":                 "true",
 			"pod-template-hash":       "abc123",
 		}
-		if gen != "" {
-			l[fv1.ENVIRONMENT_GENERATION] = gen
+		if hash != "" {
+			l[fv1.ENVIRONMENT_RUNTIME_HASH] = hash
 		}
 		for k, v := range overrides {
 			l[k] = v
@@ -74,10 +90,12 @@ func TestProcessRSDiscriminator(t *testing.T) {
 		}
 		return d
 	}
-	liveEnv := func(gen int64) *fv1.Environment {
-		return &fv1.Environment{ObjectMeta: metav1.ObjectMeta{
-			Name: envName, Namespace: ns, UID: k8stypes.UID(envUID), Generation: gen,
-		}}
+	// liveDepHashed is the owner AFTER the pool has been re-templated under a
+	// hash-stamping release: its template carries the label.
+	liveDepHashed := func() *appsv1.Deployment {
+		d := liveDep(false)
+		d.Spec.Template.Labels = map[string]string{fv1.ENVIRONMENT_RUNTIME_HASH: liveHash}
+		return d
 	}
 
 	type tc struct {
@@ -99,80 +117,93 @@ func TestProcessRSDiscriminator(t *testing.T) {
 	cases := []tc{
 		{
 			name:     "nonzero replicas is a no-op",
-			replicas: 1, ownerUID: depUID, tmplLabels: templateLabels("3", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			replicas: 1, ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 0,
 		},
 		{
-			name:     "executor-side roll: live owner, generation matches -> KEEP",
-			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			name:     "executor-side roll: live owner, runtime hash matches -> KEEP",
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 0,
 		},
 		{
-			name:     "environment update: generation moved -> clean",
-			ownerUID: depUID, tmplLabels: templateLabels("2", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			name:     "environment runtime changed: hash moved -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels(staleHash, nil),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
 			name:     "owner Deployment gone -> teardown -> clean",
-			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
-			cachedEnv:    liveEnv(3),
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
+			cachedEnv:    liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
 			name:     "owner Deployment deleting -> teardown -> clean",
-			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
-			dep: liveDep(true), cachedEnv: liveEnv(3),
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(true), cachedEnv: liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
 			name:     "owner UID mismatch (name reused by a new Deployment) -> clean",
-			ownerUID: "old-dep-uid", tmplLabels: templateLabels("3", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			ownerUID: "old-dep-uid", tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
 			name:      "orphan RS (no controller ref) -> legacy clean",
-			ownerless: true, tmplLabels: templateLabels("3", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			ownerless: true, tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
-			name:     "env NotFound in cache but live in API -> stale cache -> KEEP",
-			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
-			dep: liveDep(false), uncachedEnv: liveEnv(3),
-			wantEnqueued: 0,
+			name:     "env NotFound in cache but live in API -> stale cache -> requeue via error",
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(false), uncachedEnv: liveEnv(),
+			// The RS reconciler filters resync events (GenerationChangedPredicate),
+			// so a (false, nil) here would FORGET the decision forever; the error
+			// is the only requeue mechanism. Nothing may be enqueued meanwhile.
+			wantEnqueued: 0, wantErr: true,
 		},
 		{
 			name:     "env gone from cache AND API -> teardown -> clean",
-			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
 			dep:          liveDep(false),
 			wantEnqueued: 1,
 		},
 		{
 			name:     "env recreated under the same name (UID mismatch) -> clean",
-			ownerUID: depUID, tmplLabels: templateLabels("3", map[string]string{fv1.ENVIRONMENT_UID: "stale-env-uid"}),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, map[string]string{fv1.ENVIRONMENT_UID: "stale-env-uid"}),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
-			name:     "pre-label RS (no generation label) -> KEEP — survival on the shipping upgrade",
+			name:     "pre-label RS + pre-label owner -> KEEP — survival on the shipping upgrade",
 			ownerUID: depUID, tmplLabels: templateLabels("", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 0,
 		},
 		{
-			name:     "mangled generation label -> legacy clean",
-			ownerUID: depUID, tmplLabels: templateLabels("not-a-number", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3),
+			name:     "pre-label RS under a re-templated (hash-stamped) owner -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("", nil),
+			// The live pool Deployment's template already carries the label, so
+			// this RS is provably a pre-hash generation: its pods run a runtime
+			// at least one revision old. Without this branch they would be kept
+			// FOREVER (a settled zero-replica RS emits no further events).
+			dep: liveDepHashed(), cachedEnv: liveEnv(),
+			wantEnqueued: 1,
+		},
+		{
+			name:     "mangled hash label -> compares unequal -> clean",
+			ownerUID: depUID, tmplLabels: templateLabels("not-a-real-hash", nil),
+			dep: liveDep(false), cachedEnv: liveEnv(),
 			wantEnqueued: 1,
 		},
 		{
 			name:     "transient owner GET error -> error (requeue), nothing enqueued",
-			ownerUID: depUID, tmplLabels: templateLabels("3", nil),
-			dep: liveDep(false), cachedEnv: liveEnv(3), depGetErr: true,
+			ownerUID: depUID, tmplLabels: templateLabels(liveHash, nil),
+			dep: liveDep(false), cachedEnv: liveEnv(), depGetErr: true,
 			wantEnqueued: 0, wantErr: true,
 		},
 	}
@@ -188,7 +219,7 @@ func TestProcessRSDiscriminator(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "specialized-1", Namespace: ns,
 					Labels: func() map[string]string {
-						l := templateLabels("", nil) // pod labels need no generation for selection
+						l := templateLabels("", nil) // pod labels need no hash for selection
 						l["managed"] = "false"
 						return l
 					}(),
@@ -267,14 +298,22 @@ func TestProcessRSDiscriminator(t *testing.T) {
 	}
 }
 
-// TestPoolSelectorStaysGenerationFree is the selector-immutability guard: the
-// ENVIRONMENT_GENERATION label may exist ONLY on the pod template. A
-// Deployment selector is immutable, so a generation-bearing selector would
-// fail every environment update with "field is immutable".
-func TestPoolSelectorStaysGenerationFree(t *testing.T) {
+// TestPoolSelectorStaysHashFree is the selector-immutability guard AND the
+// alias-mutation guard: the ENVIRONMENT_RUNTIME_HASH label may exist ONLY on
+// the pod template (a Deployment selector is immutable, so a hash-bearing
+// selector would fail every environment update with "field is immutable") —
+// and genDeploymentSpec must never write it back into the caller's
+// Environment, whose labels are long-lived (gp.env) and feed Service
+// selectors on every specialization.
+func TestPoolSelectorStaysHashFree(t *testing.T) {
 	env := &fv1.Environment{
-		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default", UID: "u", Generation: 7},
-		Spec:       fv1.EnvironmentSpec{Version: 3, Poolsize: 3, Runtime: fv1.Runtime{Image: "img"}},
+		// Non-nil Labels, deliberately: with nil labels genDeploymentSpec
+		// allocates a fresh map and the aliasing bug is invisible. A labelled
+		// env is the case where writing pool/hash labels back into env.Labels
+		// leaked them into Service selectors.
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default", UID: "u", Generation: 7,
+			Labels: map[string]string{"team": "core"}},
+		Spec: fv1.EnvironmentSpec{Version: 3, Poolsize: 3, Runtime: fv1.Runtime{Image: "img"}},
 	}
 	fetcherCfg, err := fetcherConfig.MakeFetcherConfig("/userfunc")
 	require.NoError(t, err)
@@ -283,11 +322,37 @@ func TestPoolSelectorStaysGenerationFree(t *testing.T) {
 	spec, err := gp.genDeploymentSpec(env)
 	require.NoError(t, err)
 
-	assert.NotContains(t, spec.Selector.MatchLabels, fv1.ENVIRONMENT_GENERATION,
-		"the generation must NEVER reach the immutable selector")
-	assert.NotContains(t, gp.getEnvironmentPoolLabels(env), fv1.ENVIRONMENT_GENERATION,
-		"getEnvironmentPoolLabels feeds the selector and must stay generation-free")
-	assert.Equal(t, strconv.FormatInt(env.Generation, 10),
-		spec.Template.Labels[fv1.ENVIRONMENT_GENERATION],
-		"the pod template must carry the environment generation — it is what processRS keys on")
+	assert.NotContains(t, spec.Selector.MatchLabels, fv1.ENVIRONMENT_RUNTIME_HASH,
+		"the runtime hash must NEVER reach the immutable selector")
+	assert.Equal(t, envRuntimeHash(env), spec.Template.Labels[fv1.ENVIRONMENT_RUNTIME_HASH],
+		"the pod template must carry the runtime hash — it is what processRS keys on")
+	assert.Equal(t, map[string]string{"team": "core"}, env.Labels,
+		"genDeploymentSpec must not mutate the caller's Environment labels — gp.env is long-lived and feeds every specialization's label copy")
+}
+
+// TestEnvRuntimeHashIgnoresNonTemplateSpec pins the discriminator's key
+// choice: spec fields that never reach the pod template — poolsize above all,
+// a pure replica scale — must not move the hash. Keying on generation made
+// `env update --poolsize` recycle every warm pod, under load, which is the
+// exact operation the scale-up serves.
+func TestEnvRuntimeHashIgnoresNonTemplateSpec(t *testing.T) {
+	base := &fv1.Environment{
+		ObjectMeta: metav1.ObjectMeta{Name: "e", Namespace: "default", UID: "u", Generation: 3},
+		Spec:       fv1.EnvironmentSpec{Version: 3, Poolsize: 3, Runtime: fv1.Runtime{Image: "img"}},
+	}
+	scaled := base.DeepCopy()
+	scaled.Spec.Poolsize = 30
+	scaled.Generation = 4 // any spec write moves generation; the hash must not care
+	assert.Equal(t, envRuntimeHash(base), envRuntimeHash(scaled),
+		"poolsize feeds only Replicas, never the template — scaling must not recycle warm pods")
+
+	reimaged := base.DeepCopy()
+	reimaged.Spec.Runtime.Image = "img:v2"
+	assert.NotEqual(t, envRuntimeHash(base), envRuntimeHash(reimaged),
+		"a runtime image change is exactly what the hash exists to catch")
+
+	relabelled := base.DeepCopy()
+	relabelled.Labels = map[string]string{"tier": "gold"}
+	assert.NotEqual(t, envRuntimeHash(base), envRuntimeHash(relabelled),
+		"env labels land in the pod template and must move the hash")
 }

--- a/pkg/executor/executortype/poolmgr/reconciler.go
+++ b/pkg/executor/executortype/poolmgr/reconciler.go
@@ -46,7 +46,7 @@ type poolManager interface {
 
 // rsCleaner is the subset of *GenericPoolManager the ReplicaSet reconciler drives.
 type rsCleaner interface {
-	processReplicaSet(ctx context.Context, rs *appsv1.ReplicaSet)
+	processReplicaSet(ctx context.Context, rs *appsv1.ReplicaSet) error
 }
 
 // replicaSetReconciler reaps a pool's specialized pods when its ReplicaSet scales
@@ -68,8 +68,10 @@ func (r *replicaSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		return ctrl.Result{}, err
 	}
-	r.cleaner.processReplicaSet(ctx, rs)
-	return ctrl.Result{}, nil
+	// Errors requeue with backoff: a transient API failure inside the
+	// keep-or-clean decision must retry rather than silently drop a
+	// legitimate cleanup (or worse, a legitimate keep).
+	return ctrl.Result{}, r.cleaner.processReplicaSet(ctx, rs)
 }
 
 // poolmgrReplicaSetPredicate keeps the ReplicaSet reconciler to pool-manager

--- a/pkg/executor/executortype/poolmgr/reconciler_test.go
+++ b/pkg/executor/executortype/poolmgr/reconciler_test.go
@@ -50,10 +50,14 @@ func (f *fakeFuncMgr) deleteFunctionService(_ context.Context, fn *fv1.Function)
 	return nil
 }
 
-type fakeRSCleaner struct{ processed []string }
+type fakeRSCleaner struct {
+	processed []string
+	err       error
+}
 
-func (f *fakeRSCleaner) processReplicaSet(_ context.Context, rs *appsv1.ReplicaSet) {
+func (f *fakeRSCleaner) processReplicaSet(_ context.Context, rs *appsv1.ReplicaSet) error {
 	f.processed = append(f.processed, rs.Name)
+	return f.err
 }
 
 type fakePoolMgr struct {

--- a/test/helm/executorposture_test.go
+++ b/test/helm/executorposture_test.go
@@ -26,9 +26,6 @@ import (
 //   - adoptExistingResources — with adoption off, startup cleanup deletes
 //     every pod whose instance annotation belongs to the previous executor,
 //     which is exactly the specialized warm pods and only them.
-//
-// Rendered with a non-default release name: guards that assert defaults under
-// a name where legacy and standard formats coincide pin nothing.
 func TestExecutorRolloutPosture(t *testing.T) {
 	deployment := func(docs []map[string]any) map[string]any {
 		d := find(docs, "Deployment", "executor")
@@ -54,17 +51,41 @@ func TestExecutorRolloutPosture(t *testing.T) {
 			"adoption must default on, or every executor restart deletes the specialized warm pods")
 	})
 
-	t.Run("both remain overridable", func(t *testing.T) {
+	t.Run("overrides that DIFFER from the defaults are honored", func(t *testing.T) {
+		// A --set restating a default pins nothing. Render the documented HA
+		// posture (surge with a standby) and the adoption opt-out.
 		docs := render(t,
 			"--set", "executor.adoptExistingResources=false",
-			"--set", "executor.strategy.type=RollingUpdate",
-			"--set-string", "executor.strategy.rollingUpdate.maxUnavailable=1")
+			"--set", "executor.strategy.rollingUpdate.maxSurge=1",
+			"--set", "executor.strategy.rollingUpdate.maxUnavailable=0")
 		d := deployment(docs)
 
-		strategy, _ := d["spec"].(map[string]any)["strategy"].(map[string]any)
-		assert.Equal(t, "RollingUpdate", strategy["type"], "the HA escape hatch must stay open")
+		ru, _ := d["spec"].(map[string]any)["strategy"].(map[string]any)["rollingUpdate"].(map[string]any)
+		assert.EqualValues(t, 1, ru["maxSurge"], "the HA surge escape hatch must stay open")
+		assert.EqualValues(t, 0, ru["maxUnavailable"])
 
 		env := containerEnv(t, d)
 		assert.Equal(t, "false", env["ADOPT_EXISTING_RESOURCES"])
+	})
+
+	// The opt-out RELEASES.md advertises must render a VALID Deployment: the
+	// API rejects a rollingUpdate block alongside Recreate, and helm --set
+	// MERGES into the default's rollingUpdate — the template must drop the
+	// block when the type is Recreate, or the opt-out is a hard upgrade
+	// failure (the exact trap the upgrade gate caught when Recreate was
+	// briefly the default).
+	t.Run("Recreate opt-out renders a valid strategy", func(t *testing.T) {
+		d := deployment(render(t, "--set", "executor.strategy.type=Recreate"))
+		strategy, _ := d["spec"].(map[string]any)["strategy"].(map[string]any)
+		assert.Equal(t, "Recreate", strategy["type"])
+		assert.NotContains(t, strategy, "rollingUpdate",
+			"Recreate + rollingUpdate is rejected by the API server")
+	})
+
+	// Clearing the strategy entirely must also work (k8s default applies).
+	t.Run("null strategy renders no strategy block", func(t *testing.T) {
+		d := deployment(render(t, "--set", "executor.strategy=null"))
+		_, has := d["spec"].(map[string]any)["strategy"]
+		assert.False(t, has, "a nulled strategy must fall back to the Kubernetes default")
 	})
 }

--- a/test/helm/executorposture_test.go
+++ b/test/helm/executorposture_test.go
@@ -14,10 +14,15 @@ import (
 // TestExecutorRolloutPosture pins the two chart defaults that make poolmgr's
 // warm pods survive a helm upgrade (RFC-0028 mechanism A and C):
 //
-//   - strategy Recreate — the executor is a single-writer control plane keyed
-//     on its instance ID; the k8s default RollingUpdate surges a SECOND
-//     executor with a different ID and no leader election, and the incoming
-//     one's cleanup deletes the objects the outgoing one is still stamping.
+//   - overlap-free rollout (maxSurge 0 / maxUnavailable 1) — the executor is
+//     a single-writer control plane keyed on its instance ID; the k8s default
+//     surges a SECOND executor with a different ID and no leader election,
+//     and the incoming one's cleanup deletes the objects the outgoing one is
+//     still stamping. Expressed within RollingUpdate, NOT type Recreate: a
+//     live Deployment carries a defaulted rollingUpdate block, and the API
+//     forbids it alongside Recreate — flipping the type fails every real
+//     helm upgrade ("spec.strategy.rollingUpdate: Forbidden", found the hard
+//     way by the upgrade gate).
 //   - adoptExistingResources — with adoption off, startup cleanup deletes
 //     every pod whose instance annotation belongs to the previous executor,
 //     which is exactly the specialized warm pods and only them.
@@ -31,13 +36,18 @@ func TestExecutorRolloutPosture(t *testing.T) {
 		return d
 	}
 
-	t.Run("defaults: Recreate + adoption on", func(t *testing.T) {
+	t.Run("defaults: overlap-free rollout + adoption on", func(t *testing.T) {
 		docs := render(t)
 		d := deployment(docs)
 
 		strategy, _ := d["spec"].(map[string]any)["strategy"].(map[string]any)
-		assert.Equal(t, "Recreate", strategy["type"],
-			"the default must be Recreate — RollingUpdate rolls two executors with different instance IDs and no lease")
+		assert.Equal(t, "RollingUpdate", strategy["type"],
+			"the type must stay RollingUpdate — flipping to Recreate fails API validation against every live install")
+		ru, _ := strategy["rollingUpdate"].(map[string]any)
+		assert.EqualValues(t, 0, ru["maxSurge"],
+			"maxSurge 0 is the single-writer guarantee: never two executors at once")
+		assert.EqualValues(t, 1, ru["maxUnavailable"],
+			"maxUnavailable 1 lets the old pod die before the new one starts")
 
 		env := containerEnv(t, d)
 		assert.Equal(t, "true", env["ADOPT_EXISTING_RESOURCES"],

--- a/test/helm/executorposture_test.go
+++ b/test/helm/executorposture_test.go
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecutorRolloutPosture pins the two chart defaults that make poolmgr's
+// warm pods survive a helm upgrade (RFC-0028 mechanism A and C):
+//
+//   - strategy Recreate — the executor is a single-writer control plane keyed
+//     on its instance ID; the k8s default RollingUpdate surges a SECOND
+//     executor with a different ID and no leader election, and the incoming
+//     one's cleanup deletes the objects the outgoing one is still stamping.
+//   - adoptExistingResources — with adoption off, startup cleanup deletes
+//     every pod whose instance annotation belongs to the previous executor,
+//     which is exactly the specialized warm pods and only them.
+//
+// Rendered with a non-default release name: guards that assert defaults under
+// a name where legacy and standard formats coincide pin nothing.
+func TestExecutorRolloutPosture(t *testing.T) {
+	deployment := func(docs []map[string]any) map[string]any {
+		d := find(docs, "Deployment", "executor")
+		require.NotNil(t, d, "executor Deployment must render")
+		return d
+	}
+
+	t.Run("defaults: Recreate + adoption on", func(t *testing.T) {
+		docs := render(t)
+		d := deployment(docs)
+
+		strategy, _ := d["spec"].(map[string]any)["strategy"].(map[string]any)
+		assert.Equal(t, "Recreate", strategy["type"],
+			"the default must be Recreate — RollingUpdate rolls two executors with different instance IDs and no lease")
+
+		env := containerEnv(t, d)
+		assert.Equal(t, "true", env["ADOPT_EXISTING_RESOURCES"],
+			"adoption must default on, or every executor restart deletes the specialized warm pods")
+	})
+
+	t.Run("both remain overridable", func(t *testing.T) {
+		docs := render(t,
+			"--set", "executor.adoptExistingResources=false",
+			"--set", "executor.strategy.type=RollingUpdate",
+			"--set-string", "executor.strategy.rollingUpdate.maxUnavailable=1")
+		d := deployment(docs)
+
+		strategy, _ := d["spec"].(map[string]any)["strategy"].(map[string]any)
+		assert.Equal(t, "RollingUpdate", strategy["type"], "the HA escape hatch must stay open")
+
+		env := containerEnv(t, d)
+		assert.Equal(t, "false", env["ADOPT_EXISTING_RESOURCES"])
+	})
+}

--- a/test/integration/framework/executor_lifecycle.go
+++ b/test/integration/framework/executor_lifecycle.go
@@ -177,6 +177,41 @@ func (f *Framework) ExecutorEnvEnabled(t *testing.T, ctx context.Context, name s
 	return v == "true"
 }
 
+// WaitForExecutorSettled blocks until the executor Deployment's status has
+// caught up with its spec and every replica is available — regardless of
+// which generation that is. Use it from a t.Cleanup registered BEFORE
+// SetExecutorEnv's restores (cleanups run LIFO, so it executes AFTER them):
+// the restores deliberately do not await their rollouts, and without this a
+// test's un-awaited restore lands in whichever serial test runs next.
+func (f *Framework) WaitForExecutorSettled(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	// The test's own ctx may already be done during cleanup.
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ns := f.FissionNamespace()
+	deadline := time.Now().Add(timeout)
+	for {
+		dep, err := f.kubeClient.AppsV1().Deployments(ns).Get(ctx, executorDeploymentName, metav1.GetOptions{})
+		if err == nil {
+			replicas := int32(1)
+			if dep.Spec.Replicas != nil {
+				replicas = *dep.Spec.Replicas
+			}
+			if dep.Status.ObservedGeneration >= dep.Generation &&
+				dep.Status.UpdatedReplicas >= replicas &&
+				dep.Status.AvailableReplicas >= replicas &&
+				dep.Status.UnavailableReplicas == 0 {
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Logf("WaitForExecutorSettled: executor not settled after %s (continuing; next test may see a rolling executor)", timeout)
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
+
 // WaitForExecutorRollout blocks until the executor Deployment has fully rolled
 // out at generation atLeast or newer: the controller has observed the new
 // generation, every replica is updated and available, and no old pods remain.

--- a/test/integration/framework/executor_resources.go
+++ b/test/integration/framework/executor_resources.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -175,4 +176,30 @@ func (ns *TestNamespace) listPoolDeployments(ctx context.Context, envName string
 		return nil, err
 	}
 	return list.Items, nil
+}
+
+// SpecializedFunctionPods lists a function's specialized (managed=false, not
+// Deployment-owned) pool pods in the function namespace — the pods whose
+// survival across an executor roll is RFC-0028's warm-pod contract. Mirrors
+// the upgrade benchmark's specializedPodUIDs selector.
+func (ns *TestNamespace) SpecializedFunctionPods(t *testing.T, ctx context.Context, fnName string) []corev1.Pod {
+	t.Helper()
+	selector := fv1.FUNCTION_NAME + "=" + fnName + "," + fv1.MANAGED + "=false"
+	pods, err := ns.f.kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	require.NoErrorf(t, err, "list specialized pods for %q", fnName)
+	return pods.Items
+}
+
+// UpdateEnvSpec mutates one Environment's spec through the typed client and
+// updates it — bumping metadata.generation, which is what the pool-roll
+// discriminator and the adopt pass key on. Use for tests that need "the
+// environment changed" as a precise, minimal event.
+func (ns *TestNamespace) UpdateEnvSpec(t *testing.T, ctx context.Context, envName string, mutate func(*fv1.Environment)) {
+	t.Helper()
+	envs := ns.f.FissionClient().CoreV1().Environments(ns.Name)
+	env, err := envs.Get(ctx, envName, metav1.GetOptions{})
+	require.NoErrorf(t, err, "get environment %q", envName)
+	mutate(env)
+	_, err = envs.Update(ctx, env, metav1.UpdateOptions{})
+	require.NoErrorf(t, err, "update environment %q", envName)
 }

--- a/test/integration/framework/executor_resources.go
+++ b/test/integration/framework/executor_resources.go
@@ -182,12 +182,18 @@ func (ns *TestNamespace) listPoolDeployments(ctx context.Context, envName string
 // Deployment-owned) pool pods in the function namespace — the pods whose
 // survival across an executor roll is RFC-0028's warm-pod contract. Mirrors
 // the upgrade benchmark's specializedPodUIDs selector.
-func (ns *TestNamespace) SpecializedFunctionPods(t *testing.T, ctx context.Context, fnName string) []corev1.Pod {
-	t.Helper()
+//
+// Returns the error instead of require-failing: callers poll this from
+// require.EventuallyWithT condition goroutines, where t.FailNow is invalid —
+// a transient list error there must read as "condition not yet met", not
+// derail the test goroutine.
+func (ns *TestNamespace) SpecializedFunctionPods(ctx context.Context, fnName string) ([]corev1.Pod, error) {
 	selector := fv1.FUNCTION_NAME + "=" + fnName + "," + fv1.MANAGED + "=false"
 	pods, err := ns.f.kubeClient.CoreV1().Pods(ns.Name).List(ctx, metav1.ListOptions{LabelSelector: selector})
-	require.NoErrorf(t, err, "list specialized pods for %q", fnName)
-	return pods.Items
+	if err != nil {
+		return nil, err
+	}
+	return pods.Items, nil
 }
 
 // UpdateEnvSpec mutates one Environment's spec through the typed client and

--- a/test/integration/suites/serial/pool_warm_survival_test.go
+++ b/test/integration/suites/serial/pool_warm_survival_test.go
@@ -1,0 +1,138 @@
+//go:build integration
+
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package serial
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestPoolWarmSurvival pins RFC-0028's warm-pod contract in three phases on
+// one environment/function pair. It is the integration-level proof of the
+// upgrade gate's warm_pod_survival metric:
+//
+//  1. An EXECUTOR-side pool-template roll (what a helm upgrade does via a new
+//     fetcher image/config) must leave the specialized pod alive, same UID,
+//     re-stamped to the new executor instance, and serving throughout.
+//  2. An ENVIRONMENT spec change must still recycle it — the discriminator
+//     keys on the environment generation, and this is the regression guard
+//     for the path that used to be processRS's only reading.
+//  3. Deleting the environment must drain the specialized pods entirely.
+//
+// Serial: it restarts the shared executor (adopt runs before readiness, so a
+// completed rollout means the adopt pass finished).
+func TestPoolWarmSurvival(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	ns := f.NewTestNamespace(t)
+	envName := "nodejs-pws-" + ns.ID
+	fnName := "fn-pws-" + ns.ID
+	route := "/" + fnName
+
+	// Short grace so phase 2/3 recycles are observable quickly.
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image, GracePeriod: 5})
+	codePath := framework.WriteTestData(t, "nodejs/hello/hello.js")
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{
+		Name: fnName, Env: envName, Code: codePath, ExecutorType: "poolmgr",
+	})
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName, URL: route, Method: "GET"})
+
+	// Warm it: the first invocation specializes a pool pod.
+	f.Router(t).GetEventually(t, ctx, route, framework.BodyContains("hello"))
+	podsBefore := ns.SpecializedFunctionPods(t, ctx, fnName)
+	require.NotEmpty(t, podsBefore, "warm-up must have specialized a pod")
+	uidBefore := podsBefore[0].UID
+	instBefore := podsBefore[0].Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+	require.NotEmpty(t, instBefore, "a specialized pod carries the claiming executor's instance annotation")
+
+	// ---- Phase 1: executor-side template roll -> the pod SURVIVES ----
+	//
+	// FETCHER_MINMEM reaches every pool template through the fetcher config
+	// the executor reads at startup, so this restart regenerates the pool
+	// spec exactly the way a helm upgrade's fetcher-image change does:
+	// new RS, old RS to zero — mechanism B's trigger. SetExecutorEnv also
+	// forces Recreate for the roll, keeping the test independent of
+	// chart-default sequencing; adoption is pinned on explicitly.
+	_, restoreAdopt := f.SetExecutorEnv(t, ctx, "ADOPT_EXISTING_RESOURCES", "true")
+	t.Cleanup(restoreAdopt)
+	gen, restoreMem := f.SetExecutorEnv(t, ctx, "FETCHER_MINMEM", "17Mi")
+	t.Cleanup(restoreMem)
+	f.WaitForExecutorRollout(t, ctx, gen, 5*time.Minute)
+
+	// The pool template genuinely rolled (the whole point of the trigger):
+	// its fetcher container must now carry the bumped memory request.
+	ns.WaitForPoolDeployment(t, ctx, envName, func(d *appsv1.Deployment) bool {
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name != "fetcher" {
+				continue
+			}
+			if q, ok := c.Resources.Requests["memory"]; ok && q.String() == "17Mi" {
+				return true
+			}
+		}
+		return false
+	}, "pool template must carry the new fetcher config (proves the template roll fired)", 3*time.Minute)
+
+	// Survival, the headline: same UID, re-stamped to the NEW instance.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		pods := ns.SpecializedFunctionPods(t, ctx, fnName)
+		if !assert.NotEmpty(c, pods, "specialized pod must still exist") {
+			return
+		}
+		assert.Equal(c, uidBefore, pods[0].UID,
+			"the specialized pod must survive the executor roll IN PLACE — a new UID means it was killed and recreated")
+		assert.NotEqual(c, instBefore, pods[0].Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
+			"the surviving pod must be re-stamped by the NEW executor's adopt pass")
+	}, 2*time.Minute, 2*time.Second)
+
+	// And it serves.
+	for range 5 {
+		f.Router(t).GetEventually(t, ctx, route, framework.BodyContains("hello"))
+	}
+
+	// ---- Phase 2: environment spec change -> the pod IS recycled ----
+	ns.UpdateEnvSpec(t, ctx, envName, func(env *fv1.Environment) {
+		env.Spec.TerminationGracePeriod++
+	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		for _, p := range ns.SpecializedFunctionPods(t, ctx, fnName) {
+			if p.DeletionTimestamp != nil {
+				continue // already on its way out
+			}
+			assert.NotEqualf(c, uidBefore, p.UID,
+				"an environment change must recycle the old-template pod (still live: %s)", p.Name)
+		}
+	}, 4*time.Minute, 3*time.Second)
+	// The function still serves — on a fresh pod.
+	f.Router(t).GetEventually(t, ctx, route, framework.BodyContains("hello"))
+
+	// ---- Phase 3: environment delete -> specialized pods drain ----
+	require.NoError(t,
+		f.FissionClient().CoreV1().Environments(ns.Name).Delete(ctx, envName, metav1.DeleteOptions{}))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		live := 0
+		for _, p := range ns.SpecializedFunctionPods(t, ctx, fnName) {
+			if p.DeletionTimestamp == nil {
+				live++
+			}
+		}
+		assert.Zero(c, live, "env delete must reap every specialized pod")
+	}, 4*time.Minute, 3*time.Second)
+}

--- a/test/integration/suites/serial/pool_warm_survival_test.go
+++ b/test/integration/suites/serial/pool_warm_survival_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -27,19 +28,30 @@ import (
 //  1. An EXECUTOR-side pool-template roll (what a helm upgrade does via a new
 //     fetcher image/config) must leave the specialized pod alive, same UID,
 //     re-stamped to the new executor instance, and serving throughout.
-//  2. An ENVIRONMENT spec change must still recycle it — the discriminator
-//     keys on the environment generation, and this is the regression guard
-//     for the path that used to be processRS's only reading.
+//  2. An ENVIRONMENT change that touches the pod template must still recycle
+//     it — the discriminator keys on a hash of the template inputs, and this
+//     is the regression guard for the path that used to be processRS's only
+//     reading. (TerminationGracePeriod is a template input; poolsize is not
+//     and deliberately would NOT recycle.)
 //  3. Deleting the environment must drain the specialized pods entirely.
 //
 // Serial: it restarts the shared executor (adopt runs before readiness, so a
 // completed rollout means the adopt pass finished).
 func TestPoolWarmSurvival(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	// Budget must exceed the sum of the phase Eventually budgets (5+3+2+4+4m)
+	// plus warm-up, or a slow-but-passing run degrades into ctx-deadline
+	// errors inside the conditions instead of a clean per-phase timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)
 	image := f.Images().RequireNode(t)
+
+	// Registered BEFORE the SetExecutorEnv restores (cleanups run LIFO, so it
+	// executes AFTER them): the restores fire two back-to-back un-awaited
+	// executor rollouts, and without this wait they land in whichever serial
+	// test runs next.
+	t.Cleanup(func() { f.WaitForExecutorSettled(t, 3*time.Minute) })
 
 	ns := f.NewTestNamespace(t)
 	envName := "nodejs-pws-" + ns.ID
@@ -56,7 +68,8 @@ func TestPoolWarmSurvival(t *testing.T) {
 
 	// Warm it: the first invocation specializes a pool pod.
 	f.Router(t).GetEventually(t, ctx, route, framework.BodyContains("hello"))
-	podsBefore := ns.SpecializedFunctionPods(t, ctx, fnName)
+	podsBefore, err := ns.SpecializedFunctionPods(ctx, fnName)
+	require.NoError(t, err)
 	require.NotEmpty(t, podsBefore, "warm-up must have specialized a pod")
 	uidBefore := podsBefore[0].UID
 	instBefore := podsBefore[0].Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
@@ -90,15 +103,31 @@ func TestPoolWarmSurvival(t *testing.T) {
 		return false
 	}, "pool template must carry the new fetcher config (proves the template roll fired)", 3*time.Minute)
 
-	// Survival, the headline: same UID, re-stamped to the NEW instance.
+	// Survival, the headline: the SAME pod (by UID), re-stamped to the NEW
+	// instance. Look the pod up by uidBefore rather than trusting list order:
+	// a second specialized pod (a racing router retry) must not make these
+	// assertions compare the wrong one.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		pods := ns.SpecializedFunctionPods(t, ctx, fnName)
-		if !assert.NotEmpty(c, pods, "specialized pod must still exist") {
+		pods, lerr := ns.SpecializedFunctionPods(ctx, fnName)
+		if !assert.NoError(c, lerr) {
 			return
 		}
-		assert.Equal(c, uidBefore, pods[0].UID,
-			"the specialized pod must survive the executor roll IN PLACE — a new UID means it was killed and recreated")
-		assert.NotEqual(c, instBefore, pods[0].Annotations[fv1.EXECUTOR_INSTANCEID_LABEL],
+		var survived *corev1.Pod
+		for i := range pods {
+			if pods[i].UID == uidBefore {
+				survived = &pods[i]
+				break
+			}
+		}
+		if !assert.NotNil(c, survived,
+			"the specialized pod must survive the executor roll IN PLACE — its UID vanishing means it was killed and recreated") {
+			return
+		}
+		inst := survived.Annotations[fv1.EXECUTOR_INSTANCEID_LABEL]
+		// Both halves, deliberately: NotEqual alone is satisfied by an EMPTY
+		// annotation — the exact never-re-stamped failure mode.
+		assert.NotEmpty(c, inst, "the surviving pod must carry an instance annotation at all")
+		assert.NotEqual(c, instBefore, inst,
 			"the surviving pod must be re-stamped by the NEW executor's adopt pass")
 	}, 2*time.Minute, 2*time.Second)
 
@@ -112,7 +141,11 @@ func TestPoolWarmSurvival(t *testing.T) {
 		env.Spec.TerminationGracePeriod++
 	})
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		for _, p := range ns.SpecializedFunctionPods(t, ctx, fnName) {
+		pods, lerr := ns.SpecializedFunctionPods(ctx, fnName)
+		if !assert.NoError(c, lerr) {
+			return
+		}
+		for _, p := range pods {
 			if p.DeletionTimestamp != nil {
 				continue // already on its way out
 			}
@@ -127,8 +160,12 @@ func TestPoolWarmSurvival(t *testing.T) {
 	require.NoError(t,
 		f.FissionClient().CoreV1().Environments(ns.Name).Delete(ctx, envName, metav1.DeleteOptions{}))
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		pods, lerr := ns.SpecializedFunctionPods(ctx, fnName)
+		if !assert.NoError(c, lerr) {
+			return
+		}
 		live := 0
-		for _, p := range ns.SpecializedFunctionPods(t, ctx, fnName) {
+		for _, p := range pods {
 			if p.DeletionTimestamp == nil {
 				live++
 			}


### PR DESCRIPTION
PR B of the #1856 / RFC-0028 gate plan (epic #3625). PR A (#3651) made the gate attributable; its first timeline pinned this PR's target precisely:

```
40s  new executor added          →  70-85s: 128 transport failures —
42s  pool Deployments re-spec,       EVERY ONE a 30,000ms client timeout,
     specialized pod killed           i.e. sent during 40-55s and never
45s  executor converged               answered
```

`warm_pod_survival=0` and 128 of 3514 poolmgr requests (3.6%) hung into client timeouts, all sent during the 15s window in which the new executor killed the warm pod. Three mechanisms kill it; each alone suffices, so this PR is atomic by design.

## Mechanism B — `processRS` deletes the pods a roll should spare (commit 1)

A zero-replica pool RS has **two producers demanding opposite treatment**, and `processRS` couldn't tell them apart:

- an **environment change** (new runtime image) → the old-template specialized pods are stale and MUST be recycled — `reconcileEnvPool` documentedly relies on this path;
- an **executor-side template change** (new `FETCHER_IMAGE` on every upgrade) → the pods are already specialized on the current runtime and MUST survive. Killing them here *is* the outage.

The discriminator: `genDeploymentSpec` stamps the environment generation onto the pod **template** labels (never the selector — selectors are immutable, and a generation there would fail every env update; unit-guarded), and `shouldCleanupForRS` reads: owner Deployment gone/deleting/UID-reused → teardown, clean; template generation ≠ live env generation → env update, clean; **generations match → executor roll, KEEP**. A missing label (RS born under N−1) keeps — that's what makes warm pods survive **the upgrade that ships this fix**, not the one after.

Correctness details that took the design work: the owner lookup uses the **direct** client (the manager cache's Deployment watch is label-bounded to newdeploy/container, so a cached Get of a pool Deployment always says NotFound — which this path would read as teardown); env NotFound verifies **uncached** before the destructive branch (the env reconciler's stale-cache guard, same reason); and `processRS` now returns errors so a transient API failure requeues instead of silently dropping a cleanup — or a keep.

## Mechanism A — adoption had four holes (commit 1)

`adoptSpecializedPods` is what shields pods from the startup cleanup, and each hole turned a survivable pod into a killed one or a leak:

1. **Probe-blip kill**: pods failing `IsReadyPod` during the ≤30s adopt window were skipped → unstamped → deleted by cleanup. Now only terminal/deleting pods skip; the fsCache entry is what gives the idle reaper ownership, and `IsValid` already gates hand-outs on live readiness.
2. **Stamp-before-validate leak**: a half-specialized pod (no `SVC_HOST` yet) was stamped then failed the checks — protected from cleanup, invisible to the reaper. The claim now lands after every check passes; failing pods stay unstamped, and unstamped is what lets cleanup recycle them.
3. **Split-namespace no-op**: adopt iterated the CR namespaces while pool pods live in the *function* namespace — a `FISSION_FUNCTION_NAMESPACE` install adopted nothing while the reaper deleted everything.
4. **Cross-recreation adoption**: a pod whose `ENVIRONMENT_UID`/`ENVIRONMENT_GENERATION` disagrees with the live env is now left for cleanup instead of being registered against a CR its runtime predates.

## Mechanism C — the chart rolled two executors at once (commits 2+3)

The executor rollout is now **overlap-free**: `maxSurge: 0, maxUnavailable: 1` — never more executors than desired, at any replica count, so the dual-instance-ID window is closed. `adoptExistingResources` defaults **true**.

**Commit 3 is the upgrade gate earning its keep in real time**: the first attempt shipped this as `type: Recreate`, and both upgrade legs rejected it deterministically — `spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy type is 'Recreate'`. A live Deployment carries a defaulted `rollingUpdate` block, so flipping the type fails API validation on **every existing install**; a render-only chart guard cannot see it. The overlap-free form expressed *within* RollingUpdate is the same single-writer guarantee with none of the migration hazard, and it composes with HA unchanged (one pod at a time; a dying leader releases its lease — never set `maxUnavailable: 0` with leader election, which deadlocks against the leadership-gated readyz). All in RELEASES.md.

## Verification

- **13-branch table test** over the discriminator; a mutant restoring always-clean fails exactly the KEEP cases and the error-propagation case.
- **Selector-immutability guard**: the generation label must never reach `getEnvironmentPoolLabels`.
- **Six adoption regression tests**, each asserting both the stamp and the cache entry.
- **Chart guard** (new file, not grown onto portdrift): both defaults + both overrides; mutation-verified.
- **`TestPoolWarmSurvival`** (serial, new): executor-side roll with a real `FETCHER_MINMEM` template change → same-UID survival, re-stamped, serving; env spec bump → recycled (the regression pin for the legacy path); env delete → drained. New framework helpers `SpecializedFunctionPods` / `UpdateEnvSpec`.
- `make code-checks`, `license-check`, `-race` suites green.

## Expected gate movement

`warm_pod_survival` 0→1 and the ~128 transport failures collapse (no warm-pod death ⇒ no cold-start window ⇒ nothing to hang). The upgrade legs on this PR will show it — that's PR A's instrumentation doing its job. Residual attributed errors during the executor gap are PR C's scope (retry-ladder budget + slice-derived VIP).