### PR TITLE
fix(router): re-scope EndpointSlice cache for runtime-onboarded tenants (#3647)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,8 +81,3 @@ kind-132.yaml
 # whole source tree to the builder, which runs mvn itself — a locally-built
 # target/ is both redundant and easy to commit by accident.
 test/integration/testdata/**/target/
-/.agents/
-/.continue/
-/.devin/
-/.windsurf/
-/skills-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ kind-132.yaml
 # whole source tree to the builder, which runs mvn itself — a locally-built
 # target/ is both redundant and easy to commit by accident.
 test/integration/testdata/**/target/
+/.agents/
+/.continue/
+/.devin/
+/.windsurf/
+/skills-lock.json

--- a/charts/fission-all/templates/tenant-controller/_tenant-workload-roles.tpl
+++ b/charts/fission-all/templates/tenant-controller/_tenant-workload-roles.tpl
@@ -32,4 +32,9 @@ tests (a drift would fail tenant onboarding / the admission-policy test).
   rules: fissionFunction.builderRules
 - name: fission-fetcher-websocket-tenant-workload
   rules: fissionFunction.fetcherWebsocketRules
+# router-dataplane: read Fission-managed EndpointSlices + Services in tenant
+# namespaces (RFC-0002 warm path). The dynamic twin of the static per-namespace
+# Role in router/role-dataplane.yaml; pkg/tenant/provision.go binds this by name.
+- name: fission-router-dataplane-tenant
+  rules: router-dataplane-kuberules
 {{- end -}}

--- a/charts/fission-all/templates/tenant-controller/admission-policy.yaml
+++ b/charts/fission-all/templates/tenant-controller/admission-policy.yaml
@@ -12,8 +12,8 @@
 # them to an attacker-controlled ServiceAccount, granting that SA the namespace's
 # secret/configmap read. This policy rejects ANY RoleBinding that references a
 # tenant-workload ClusterRole unless every subject is one of the fixed Fission
-# fetcher/builder/executor/buildermgr ServiceAccounts — so the grant can only ever
-# reach Fission's own pods, never an arbitrary SA.
+# fetcher/builder/executor/buildermgr/router ServiceAccounts — so the grant can
+# only ever reach Fission's own pods, never an arbitrary SA.
 #
 # It is a cluster-wide ValidatingAdmissionPolicy (GA in k8s 1.30; the chart's floor
 # is 1.32) keyed on the binding's roleRef, so it applies to the binding SHAPE, not
@@ -49,12 +49,12 @@ spec:
     - expression: >
         !has(object.subjects) || object.subjects.all(s,
           s.kind == 'ServiceAccount' && s.name in [
-            'fission-fetcher', 'fission-builder', 'fission-executor', 'fission-buildermgr'
+            'fission-fetcher', 'fission-builder', 'fission-executor', 'fission-buildermgr', 'fission-router'
           ])
       reason: Forbidden
       message: >
         a RoleBinding to a Fission tenant-workload ClusterRole may only bind the
-        fixed fission fetcher/builder/executor/buildermgr ServiceAccounts
+        fixed fission fetcher/builder/executor/buildermgr/router ServiceAccounts
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingAdmissionPolicyBinding

--- a/charts/fission-all/templates/tenant-controller/rbac.yaml
+++ b/charts/fission-all/templates/tenant-controller/rbac.yaml
@@ -62,7 +62,8 @@ rules:
   - deletecollection
 # Bind ONLY the fixed-name tenant-workload ClusterRoles into tenant namespaces (via
 # the RoleBindings the controller provisions): the executor/buildermgr workload
-# roles AND the fetcher/builder/fetcher-websocket function-pod read roles.
+# roles, the fetcher/builder/fetcher-websocket function-pod read roles, AND the
+# router-dataplane EndpointSlice + Service read role.
 # resourceNames-scoped: the controller cannot bind any other ClusterRole, so it
 # cannot escalate itself to arbitrary cluster permissions.
 - apiGroups:

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -369,8 +369,11 @@ const (
 	// Control-plane ServiceAccounts (in the install/release namespace) that need
 	// workload RBAC in each tenant namespace under dynamic tenancy. The tenant
 	// controller binds them to the *TenantWorkloadClusterRole below per namespace.
+	// FissionRouterSA is the router's data-plane SA, bound to
+	// RouterDataplaneTenantClusterRole for EndpointSlice + Service reads.
 	FissionExecutorSA   = "fission-executor"
 	FissionBuildermgrSA = "fission-buildermgr"
+	FissionRouterSA     = "fission-router"
 
 	// The *TenantWorkloadClusterRole names are the fixed-name ClusterRoles
 	// (chart-rendered only in dynamic mode) holding the per-namespace rules a
@@ -379,13 +382,15 @@ const (
 	// install-independent (dynamic tenancy is one Fission install per cluster,
 	// since it watches cluster-wide). Executor/buildermgr carry workload-management
 	// rules; fetcher/builder/fetcher-websocket carry the function-pod sidecar read
-	// rules — all single-sourced from the chart's shared partials so the static
-	// and dynamic paths cannot drift.
+	// rules; router-dataplane carries the EndpointSlice + Service read grant for
+	// the RFC-0002 warm path — all single-sourced from the chart's shared partials
+	// so the static and dynamic paths cannot drift.
 	ExecutorTenantWorkloadClusterRole         = "fission-executor-tenant-workload"
 	BuildermgrTenantWorkloadClusterRole       = "fission-buildermgr-tenant-workload"
 	FetcherTenantWorkloadClusterRole          = "fission-fetcher-tenant-workload"
 	BuilderTenantWorkloadClusterRole          = "fission-builder-tenant-workload"
 	FetcherWebsocketTenantWorkloadClusterRole = "fission-fetcher-websocket-tenant-workload"
+	RouterDataplaneTenantClusterRole          = "fission-router-dataplane-tenant"
 )
 
 const (

--- a/pkg/router/dynamic_endpoint_cache_test.go
+++ b/pkg/router/dynamic_endpoint_cache_test.go
@@ -24,8 +24,7 @@ import (
 // whose SAR reactor consults the allowedNS map. A namespace present with value
 // true → SAR Allowed=true; absent or false → Allowed=false. The map is shared
 // so tests can flip a namespace's RBAC state between calls (the re-onboard
-// scenario). Returns the cache, the resolver (so tests can onboard/offboard),
-// and the clientset (so tests can mutate allowedNS via the reactor closure).
+// scenario). Returns the cache and the resolver (so tests can onboard/offboard).
 func newDynamicCacheTest(t *testing.T, allowedNS map[string]bool) (*dynamicEndpointCache, *utils.NamespaceResolver) {
 	t.Helper()
 	kubeClient := fake.NewSimpleClientset()

--- a/pkg/router/dynamic_endpoint_cache_test.go
+++ b/pkg/router/dynamic_endpoint_cache_test.go
@@ -5,6 +5,7 @@
 package router
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -166,9 +167,6 @@ func TestDynamicCacheReOnboardAfterRBACLands(t *testing.T) {
 // event fires to re-run the check.
 func TestDynamicCacheSARErrorReportsPending(t *testing.T) {
 	t.Parallel()
-	// SAR reactor that always errors — the retry loop in sliceWatchSAR
-	// exhausts 3 attempts (~4s), then sliceWatchAllowedForNamespace returns
-	// (true, error).
 	kubeClient := fake.NewSimpleClientset()
 	kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		return true, nil, assert.AnError
@@ -184,7 +182,10 @@ func TestDynamicCacheSARErrorReportsPending(t *testing.T) {
 	}
 	resolver.SetTenants(map[string]string{"team-a": "team-a"})
 
-	pending := dyn.syncInformers(t.Context())
+	errCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	pending := dyn.syncInformers(errCtx)
 
 	assert.True(t, pending, "SAR error must report pending so reconciler requeues")
 	_, cached := dyn.rbacChecked.Load("team-a")

--- a/pkg/router/dynamic_endpoint_cache_test.go
+++ b/pkg/router/dynamic_endpoint_cache_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -212,29 +214,103 @@ func TestDynamicCacheReOnboardAfterRBACLands(t *testing.T) {
 // is still set true. Without pending, a genuinely-unauthorized namespace whose
 // SAR consistently errors keeps an unsyncable informer forever — no FissionTenant
 // event fires to re-run the check.
+//
+// The test drives a genuine API error (assert.AnError from the reactor), NOT a
+// cancelled context. A cancelled context makes sliceWatchSAR return ctx.Err()
+// (context.Canceled), which syncInformers now distinguishes from a real API
+// failure and skips — so the cancellation path can no longer stand in for a
+// flake. Runs under testing/synctest so the 2 × 2s SAR retry delays elapse
+// instantly under virtual time instead of sleeping 4s real.
 func TestDynamicCacheSARErrorReportsPending(t *testing.T) {
 	t.Parallel()
-	kubeClient := fake.NewSimpleClientset()
-	kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		return true, nil, assert.AnError
+	synctest.Test(t, func(t *testing.T) {
+		kubeClient := fake.NewSimpleClientset()
+		kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, assert.AnError
+		})
+		resolver := &utils.NamespaceResolver{}
+		nsi := endpointcache.NewNamespaceInformers(kubeClient, endpointcache.NewIndex(), logr.Discard())
+		dyn := &dynamicEndpointCache{
+			kubeClient:  kubeClient,
+			resolver:    resolver,
+			nsInformers: nsi,
+			logger:      logr.Discard(),
+		}
+		resolver.SetTenants(map[string]string{"team-a": "team-a"})
+
+		// syncInformers blocks on the SAR retry delays (time.After inside
+		// sliceWatchSAR). Under synctest those are fake timers, so run the
+		// call in a goroutine and advance virtual time to fire them.
+		var pending bool
+		done := make(chan struct{})
+		go func() {
+			pending = dyn.syncInformers(t.Context())
+			close(done)
+		}()
+		synctest.Wait()
+		<-done
+
+		assert.True(t, pending, "SAR error must report pending so reconciler requeues")
+		_, cached := dyn.rbacChecked.Load("team-a")
+		assert.False(t, cached, "namespace with SAR error must not be cached")
+
+		// Drain informer goroutines before the bubble closes.
+		go func() { nsi.Close() }()
+		synctest.Wait()
 	})
-	resolver := &utils.NamespaceResolver{}
-	nsi := endpointcache.NewNamespaceInformers(kubeClient, endpointcache.NewIndex(), logr.Discard())
-	t.Cleanup(nsi.Close)
-	dyn := &dynamicEndpointCache{
-		kubeClient:  kubeClient,
-		resolver:    resolver,
-		nsInformers: nsi,
-		logger:      logr.Discard(),
+}
+
+// TestDynamicCacheCancellationNotCountedAsSARError verifies that a cancelled
+// context (router shutting down) does NOT bump sarErrors or log at Error for
+// every namespace. sliceWatchSAR returns ctx.Err() (context.Canceled or
+// context.DeadlineExceeded), which syncInformers distinguishes from a genuine
+// API failure and skips. Without this guard a shutdown would count every
+// namespace as an SAR flake.
+func TestDynamicCacheCancellationNotCountedAsSARError(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		ctx  func(t *testing.T) context.Context
+	}{
+		{"canceled", func(t *testing.T) context.Context {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			return ctx
+		}},
+		{"deadline exceeded", func(t *testing.T) context.Context {
+			ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+			t.Cleanup(cancel)
+			return ctx
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			kubeClient := fake.NewSimpleClientset()
+			kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				return true, nil, assert.AnError
+			})
+			resolver := &utils.NamespaceResolver{}
+			nsi := endpointcache.NewNamespaceInformers(kubeClient, endpointcache.NewIndex(), logr.Discard())
+			t.Cleanup(nsi.Close)
+			dyn := &dynamicEndpointCache{
+				kubeClient:  kubeClient,
+				resolver:    resolver,
+				nsInformers: nsi,
+				logger:      logr.Discard(),
+			}
+			resolver.SetTenants(map[string]string{"team-a": "team-a"})
+
+			// sliceWatchSAR returns ctx.Err() immediately on the first
+			// attempt (the cancelled context short-circuits the retry loop),
+			// so syncInformers returns without the retry delay.
+			pending := dyn.syncInformers(tc.ctx(t))
+
+			assert.False(t, pending, "cancelled context must not report pending")
+			_, counted := dyn.sarErrors["team-a"]
+			assert.False(t, counted, "cancelled context must not bump sarErrors")
+			_, cached := dyn.rbacChecked.Load("team-a")
+			assert.False(t, cached, "cancelled context must not cache the namespace")
+		})
 	}
-	resolver.SetTenants(map[string]string{"team-a": "team-a"})
-
-	errCtx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	pending := dyn.syncInformers(errCtx)
-
-	assert.True(t, pending, "SAR error must report pending so reconciler requeues")
-	_, cached := dyn.rbacChecked.Load("team-a")
-	assert.False(t, cached, "namespace with SAR error must not be cached")
 }

--- a/pkg/router/dynamic_endpoint_cache_test.go
+++ b/pkg/router/dynamic_endpoint_cache_test.go
@@ -7,6 +7,7 @@ package router
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-logr/logr"
@@ -16,10 +17,60 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/fission/fission/pkg/router/endpointcache"
 	"github.com/fission/fission/pkg/utils"
 )
+
+// addOnlyManager lets setupDynamicEndpointCache register its startup runnable
+// without starting a full controller-runtime manager. No other Manager method
+// is used while setupDynamicEndpointCache is being called.
+type addOnlyManager struct {
+	ctrl.Manager
+}
+
+func (*addOnlyManager) Add(manager.Runnable) error {
+	return nil
+}
+
+// TestSetupDynamicEndpointCacheReusesPreflightRBAC verifies that namespaces
+// approved by the startup preflight are reused by the initial dynamic-cache
+// sync instead of issuing the same SelfSubjectAccessReviews again.
+func TestSetupDynamicEndpointCacheReusesPreflightRBAC(t *testing.T) {
+	kubeClient := fake.NewSimpleClientset()
+	var sarCalls atomic.Int32
+	kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		sarCalls.Add(1)
+		sar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Spec:   sar.Spec,
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: true},
+		}, nil
+	})
+
+	precheckedNamespaces := sliceWatchNamespaces()
+	require.NotEmpty(t, precheckedNamespaces)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	_, hooks, err := setupDynamicEndpointCache(
+		ctx,
+		kubeClient,
+		endpointcache.NewIndex(),
+		&addOnlyManager{},
+		nil,
+		logr.Discard(),
+		precheckedNamespaces,
+	)
+	require.NoError(t, err)
+	require.Len(t, hooks, 1)
+
+	pending := hooks[0]()
+	assert.False(t, pending)
+	assert.Zero(t, sarCalls.Load(), "preflight-approved namespaces must not repeat SARs during dynamic-cache setup")
+}
 
 // newDynamicCacheTest builds a dynamicEndpointCache backed by a fake clientset
 // whose SAR reactor consults the allowedNS map. A namespace present with value

--- a/pkg/router/dynamic_endpoint_cache_test.go
+++ b/pkg/router/dynamic_endpoint_cache_test.go
@@ -6,7 +6,6 @@ package router
 
 import (
 	"context"
-	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -80,12 +79,9 @@ func TestSetupDynamicEndpointCacheReusesPreflightRBAC(t *testing.T) {
 func newDynamicCacheTest(t *testing.T, allowedNS map[string]bool) (*dynamicEndpointCache, *utils.NamespaceResolver) {
 	t.Helper()
 	kubeClient := fake.NewSimpleClientset()
-	var mu sync.Mutex
 	kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
 		sar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
 		ns := sar.Spec.ResourceAttributes.Namespace
-		mu.Lock()
-		defer mu.Unlock()
 		return true, &authorizationv1.SelfSubjectAccessReview{
 			Spec:   sar.Spec,
 			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: allowedNS[ns]},

--- a/pkg/router/dynamic_endpoint_cache_test.go
+++ b/pkg/router/dynamic_endpoint_cache_test.go
@@ -1,0 +1,193 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/fission/fission/pkg/router/endpointcache"
+	"github.com/fission/fission/pkg/utils"
+)
+
+// newDynamicCacheTest builds a dynamicEndpointCache backed by a fake clientset
+// whose SAR reactor consults the allowedNS map. A namespace present with value
+// true → SAR Allowed=true; absent or false → Allowed=false. The map is shared
+// so tests can flip a namespace's RBAC state between calls (the re-onboard
+// scenario). Returns the cache, the resolver (so tests can onboard/offboard),
+// and the clientset (so tests can mutate allowedNS via the reactor closure).
+func newDynamicCacheTest(t *testing.T, allowedNS map[string]bool) (*dynamicEndpointCache, *utils.NamespaceResolver) {
+	t.Helper()
+	kubeClient := fake.NewSimpleClientset()
+	var mu sync.Mutex
+	kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		sar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		ns := sar.Spec.ResourceAttributes.Namespace
+		mu.Lock()
+		defer mu.Unlock()
+		return true, &authorizationv1.SelfSubjectAccessReview{
+			Spec:   sar.Spec,
+			Status: authorizationv1.SubjectAccessReviewStatus{Allowed: allowedNS[ns]},
+		}, nil
+	})
+	resolver := &utils.NamespaceResolver{}
+	nsi := endpointcache.NewNamespaceInformers(kubeClient, endpointcache.NewIndex(), logr.Discard())
+	t.Cleanup(nsi.Close)
+	dynCache := &dynamicEndpointCache{
+		kubeClient:  kubeClient,
+		resolver:    resolver,
+		nsInformers: nsi,
+		logger:      logr.Discard(),
+	}
+	return dynCache, resolver
+}
+
+// TestDynamicCacheAllowedCachesAndIncludes verifies the happy path: a namespace
+// that passes SAR is cached in rbacChecked, included in the informer set, and
+// does not report pending.
+func TestDynamicCacheAllowedCachesAndIncludes(t *testing.T) {
+	t.Parallel()
+	allowedNS := map[string]bool{"team-a": true}
+	dyn, resolver := newDynamicCacheTest(t, allowedNS)
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+
+	pending := dyn.syncInformers(t.Context())
+	assert.False(t, pending, "allowed namespace must not report pending")
+	_, cached := dyn.rbacChecked.Load("team-a")
+	assert.True(t, cached, "allowed namespace must be cached in rbacChecked")
+}
+
+// TestDynamicCacheDeniedExcludesAndReportsPending verifies the #3647 exclusion:
+// a namespace whose SAR returns Allowed=false is EXCLUDED from the informer set
+// (not cached) and reports pending=true so the reconciler requeues.
+func TestDynamicCacheDeniedExcludesAndReportsPending(t *testing.T) {
+	t.Parallel()
+	allowedNS := map[string]bool{"team-a": false}
+	dyn, resolver := newDynamicCacheTest(t, allowedNS)
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+
+	pending := dyn.syncInformers(t.Context())
+	assert.True(t, pending, "denied namespace must report pending")
+	_, cached := dyn.rbacChecked.Load("team-a")
+	assert.False(t, cached, "denied namespace must not be cached")
+}
+
+// TestDynamicCachePrunesOnOffboard verifies fix #1: when a namespace leaves the
+// live set (offboard), its cached SAR pass is pruned from rbacChecked. Without
+// pruning, the stale entry would make a re-onboard skip the SAR.
+func TestDynamicCachePrunesOnOffboard(t *testing.T) {
+	t.Parallel()
+	allowedNS := map[string]bool{"team-a": true}
+	dyn, resolver := newDynamicCacheTest(t, allowedNS)
+
+	// Onboard team-a → SAR passes → cached.
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+	dyn.syncInformers(t.Context())
+	_, cached := dyn.rbacChecked.Load("team-a")
+	require.True(t, cached, "team-a must be cached after onboarding")
+
+	// Offboard team-a → cache must be pruned.
+	resolver.SetTenants(map[string]string{})
+	dyn.syncInformers(t.Context())
+	_, cached = dyn.rbacChecked.Load("team-a")
+	assert.False(t, cached, "team-a must be pruned from rbacChecked after offboard")
+}
+
+// TestDynamicCacheReOnboardReRunsSAR is the core regression test for fix #1:
+// onboard → offboard → re-onboard with SAR now DENIED. Without the cache-prune,
+// the stale rbacChecked entry would make syncInformers skip the SAR, include the
+// namespace, and return pending=false — starting an informer whose LIST stays
+// forbidden, wedging /readyz fleet-wide. With the prune, the SAR re-runs and
+// the namespace is correctly excluded + pending.
+func TestDynamicCacheReOnboardReRunsSAR(t *testing.T) {
+	t.Parallel()
+	allowedNS := map[string]bool{"team-a": true}
+	dyn, resolver := newDynamicCacheTest(t, allowedNS)
+
+	// Onboard team-a → SAR passes → cached.
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+	dyn.syncInformers(t.Context())
+	_, cached := dyn.rbacChecked.Load("team-a")
+	require.True(t, cached, "team-a must be cached after first onboarding")
+
+	// Offboard team-a → cache pruned.
+	resolver.SetTenants(map[string]string{})
+	dyn.syncInformers(t.Context())
+	_, cached = dyn.rbacChecked.Load("team-a")
+	require.False(t, cached, "team-a must be pruned after offboard")
+
+	// Re-onboard team-a, but now SAR denies (RoleBinding not yet recreated).
+	allowedNS["team-a"] = false
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+	pending := dyn.syncInformers(t.Context())
+
+	assert.True(t, pending, "re-onboarded namespace with denied SAR must report pending")
+	_, cached = dyn.rbacChecked.Load("team-a")
+	assert.False(t, cached, "re-onboarded namespace with denied SAR must not be cached")
+}
+
+// TestDynamicCacheReOnboardAfterRBACLands verifies the full lifecycle: onboard
+// denied → requeue (pending) → RBAC lands → re-onboard allowed → cached. This
+// is the normal onboarding race (tenant controller hasn't created the binding
+// yet) resolving correctly.
+func TestDynamicCacheReOnboardAfterRBACLands(t *testing.T) {
+	t.Parallel()
+	allowedNS := map[string]bool{"team-a": false}
+	dyn, resolver := newDynamicCacheTest(t, allowedNS)
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+
+	// First sync: SAR denied → pending, not cached.
+	pending := dyn.syncInformers(t.Context())
+	require.True(t, pending, "denied on first check")
+	_, cached := dyn.rbacChecked.Load("team-a")
+	require.False(t, cached, "not cached when denied")
+
+	// RBAC lands: SAR now allowed.
+	allowedNS["team-a"] = true
+	pending = dyn.syncInformers(t.Context())
+	assert.False(t, pending, "no longer pending once SAR passes")
+	_, cached = dyn.rbacChecked.Load("team-a")
+	assert.True(t, cached, "cached once SAR passes")
+}
+
+// TestDynamicCacheSARErrorReportsPending verifies fix #2: when the SAR itself
+// errors (apiserver flake), the namespace is optimistically included but pending
+// is still set true. Without pending, a genuinely-unauthorized namespace whose
+// SAR consistently errors keeps an unsyncable informer forever — no FissionTenant
+// event fires to re-run the check.
+func TestDynamicCacheSARErrorReportsPending(t *testing.T) {
+	t.Parallel()
+	// SAR reactor that always errors — the retry loop in sliceWatchSAR
+	// exhausts 3 attempts (~4s), then sliceWatchAllowedForNamespace returns
+	// (true, error).
+	kubeClient := fake.NewSimpleClientset()
+	kubeClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, assert.AnError
+	})
+	resolver := &utils.NamespaceResolver{}
+	nsi := endpointcache.NewNamespaceInformers(kubeClient, endpointcache.NewIndex(), logr.Discard())
+	t.Cleanup(nsi.Close)
+	dyn := &dynamicEndpointCache{
+		kubeClient:  kubeClient,
+		resolver:    resolver,
+		nsInformers: nsi,
+		logger:      logr.Discard(),
+	}
+	resolver.SetTenants(map[string]string{"team-a": "team-a"})
+
+	pending := dyn.syncInformers(t.Context())
+
+	assert.True(t, pending, "SAR error must report pending so reconciler requeues")
+	_, cached := dyn.rbacChecked.Load("team-a")
+	assert.False(t, cached, "namespace with SAR error must not be cached")
+}

--- a/pkg/router/endpointcache/handlers.go
+++ b/pkg/router/endpointcache/handlers.go
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package endpointcache
+
+import (
+	"github.com/go-logr/logr"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	"k8s.io/client-go/tools/cache"
+)
+
+// endpointSliceHandlers returns the Add/Update/Delete handlers that feed the
+// Index from EndpointSlice informer events. Shared by the manager-cache
+// informer (informer.go) and the per-namespace informers (nsinformers.go) so
+// the event-handling logic — including tombstone unwrapping — cannot drift
+// between the two paths.
+func endpointSliceHandlers(ix *Index, logger logr.Logger) cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj any) {
+			if es, ok := obj.(*discoveryv1.EndpointSlice); ok {
+				ix.ApplySlice(es)
+			}
+		},
+		UpdateFunc: func(_, newObj any) {
+			if es, ok := newObj.(*discoveryv1.EndpointSlice); ok {
+				ix.ApplySlice(es)
+			}
+		},
+		DeleteFunc: func(obj any) {
+			es, ok := obj.(*discoveryv1.EndpointSlice)
+			if !ok {
+				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+				if !ok {
+					logger.V(1).Info("unexpected object type in endpointslice delete event")
+					return
+				}
+				es, ok = tombstone.Obj.(*discoveryv1.EndpointSlice)
+				if !ok {
+					logger.V(1).Info("unexpected tombstone object type in endpointslice delete event")
+					return
+				}
+			}
+			ix.DeleteSlice(es)
+		},
+	}
+}

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -12,6 +12,7 @@ package endpointcache
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -330,25 +331,38 @@ func (ix *Index) DeleteSlice(es *discoveryv1.EndpointSlice) {
 	}
 }
 
-// RemoveNamespace drops every function entry whose namespace matches, used when
-// a tenant is offboarded and its informer is stopped (nsinformers.go Sync).
-// Without this the index would hold stale pod IPs for a namespace the router
-// can no longer watch — routing requests to dead pods. Iterates all shards
-// since functions hash by FnKey (namespace+name+version), not by namespace alone.
+// RemoveNamespace drops every slice whose object namespace matches, used when a
+// tenant is offboarded and its informer is stopped (nsinformers.go Sync).
+// FnKey.Namespace comes from the slice's functionNamespace label and may differ
+// from the namespace containing the slice, so cleanup must inspect the stored
+// slice keys. Function entries are rebuilt or removed after matching slices are
+// deleted.
 func (ix *Index) RemoveNamespace(ns string) {
 	for i := range ix.shards {
 		s := &ix.shards[i]
 		s.mu.Lock()
 		for key, e := range s.m {
-			if key.Namespace != ns {
+			e.mu.Lock()
+			removed := false
+			for sliceKey := range e.slices {
+				sliceNamespace, _, ok := strings.Cut(sliceKey, "/")
+				if ok && sliceNamespace == ns {
+					delete(e.slices, sliceKey)
+					removed = true
+				}
+			}
+			if !removed {
+				e.mu.Unlock()
 				continue
 			}
-			e.mu.Lock()
 			e.quarantined.Store(nil)
 			e.strikes = nil
+			e.rebuildLocked()
+			if len(e.slices) == 0 {
+				delete(s.m, key)
+				ix.size.Add(-1)
+			}
 			e.mu.Unlock()
-			delete(s.m, key)
-			ix.size.Add(-1)
 		}
 		s.mu.Unlock()
 	}

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -337,6 +337,21 @@ func (ix *Index) DeleteSlice(es *discoveryv1.EndpointSlice) {
 // from the namespace containing the slice, so cleanup must inspect the stored
 // slice keys. Function entries are rebuilt or removed after matching slices are
 // deleted.
+//
+// Two side effects worth noting, neither a bug:
+//
+//  1. A partially-removed entry (slices in multiple namespaces, only the
+//     offboarded one matched) has its quarantined set and strike map cleared
+//     for the surviving addresses. The old code never touched surviving
+//     entries. This is consistent with the "any slice event lifts quarantines"
+//     rule applied by ApplySlice/DeleteSlice, but it is a new side effect for
+//     offboard.
+//
+//  2. The shard lock is held for the full sweep with one entry lock taken per
+//     inhabited entry, so on a large index offboard briefly stalls concurrent
+//     Lookup/Admit. Acceptable because offboard is rare (a tenant removal), but
+//     a caller doing bulk offboard on a hot router should expect a short
+//     admission pause proportional to the shard size.
 func (ix *Index) RemoveNamespace(ns string) {
 	for i := range ix.shards {
 		s := &ix.shards[i]

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -330,6 +330,30 @@ func (ix *Index) DeleteSlice(es *discoveryv1.EndpointSlice) {
 	}
 }
 
+// RemoveNamespace drops every function entry whose namespace matches, used when
+// a tenant is offboarded and its informer is stopped (nsinformers.go Sync).
+// Without this the index would hold stale pod IPs for a namespace the router
+// can no longer watch — routing requests to dead pods. Iterates all shards
+// since functions hash by FnKey (namespace+name+version), not by namespace alone.
+func (ix *Index) RemoveNamespace(ns string) {
+	for i := range ix.shards {
+		s := &ix.shards[i]
+		s.mu.Lock()
+		for key, e := range s.m {
+			if key.Namespace != ns {
+				continue
+			}
+			e.mu.Lock()
+			e.quarantined.Store(nil)
+			e.strikes = nil
+			e.mu.Unlock()
+			delete(s.m, key)
+			ix.size.Add(-1)
+		}
+		s.mu.Unlock()
+	}
+}
+
 // rebuildLocked re-merges the per-slice endpoint lists into the copy-on-write
 // snapshot, attaching each pod's shared in-flight counter (created on first
 // sight, pruned when the pod leaves every slice). Caller holds e.mu.

--- a/pkg/router/endpointcache/index_test.go
+++ b/pkg/router/endpointcache/index_test.go
@@ -471,3 +471,34 @@ func TestReportDialTimeoutIgnoredWhileQuarantined(t *testing.T) {
 		assert.False(t, ix.ReportDialTimeout("default", "fn-a", "", "10.0.0.1:8888"))
 	}
 }
+
+func TestRemoveNamespace(t *testing.T) {
+	t.Parallel()
+	ix := NewIndex()
+
+	// Populate functions across three namespaces.
+	ix.ApplySlice(slice("s1", "fn-a", "ns-1", 8888, "10.0.0.1"))
+	ix.ApplySlice(slice("s2", "fn-b", "ns-1", 8888, "10.0.0.2"))
+	ix.ApplySlice(slice("s3", "fn-c", "ns-2", 8888, "10.0.0.3"))
+	ix.ApplySlice(slice("s4", "fn-d", "ns-3", 8888, "10.0.0.4"))
+	assert.Equal(t, 4, ix.Size())
+
+	// Remove ns-1 only; ns-2 and ns-3 must survive.
+	ix.RemoveNamespace("ns-1")
+	assert.Empty(t, ix.Lookup("ns-1", "fn-a", ""), "ns-1 fn-a must be gone")
+	assert.Empty(t, ix.Lookup("ns-1", "fn-b", ""), "ns-1 fn-b must be gone")
+	assert.ElementsMatch(t, []string{"10.0.0.3:8888"}, addrs(ix.Lookup("ns-2", "fn-c", "")))
+	assert.ElementsMatch(t, []string{"10.0.0.4:8888"}, addrs(ix.Lookup("ns-3", "fn-d", "")))
+	assert.Equal(t, 2, ix.Size(), "only ns-2 and ns-3 functions remain")
+
+	// Removing a namespace that was never populated is a no-op.
+	ix.RemoveNamespace("never-existed")
+	assert.Equal(t, 2, ix.Size())
+
+	// Remove the rest.
+	ix.RemoveNamespace("ns-2")
+	ix.RemoveNamespace("ns-3")
+	assert.Equal(t, 0, ix.Size())
+	assert.Empty(t, ix.Lookup("ns-2", "fn-c", ""))
+	assert.Empty(t, ix.Lookup("ns-3", "fn-d", ""))
+}

--- a/pkg/router/endpointcache/index_test.go
+++ b/pkg/router/endpointcache/index_test.go
@@ -25,7 +25,7 @@ func slice(name, fnName, fnNamespace string, port int32, addrs ...string) *disco
 	es := &discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: "fn-ns",
+			Namespace: fnNamespace,
 			Labels: map[string]string{
 				fv1.FUNCTION_NAME:      fnName,
 				fv1.FUNCTION_NAMESPACE: fnNamespace,
@@ -474,31 +474,63 @@ func TestReportDialTimeoutIgnoredWhileQuarantined(t *testing.T) {
 
 func TestRemoveNamespace(t *testing.T) {
 	t.Parallel()
-	ix := NewIndex()
 
-	// Populate functions across three namespaces.
-	ix.ApplySlice(slice("s1", "fn-a", "ns-1", 8888, "10.0.0.1"))
-	ix.ApplySlice(slice("s2", "fn-b", "ns-1", 8888, "10.0.0.2"))
-	ix.ApplySlice(slice("s3", "fn-c", "ns-2", 8888, "10.0.0.3"))
-	ix.ApplySlice(slice("s4", "fn-d", "ns-3", 8888, "10.0.0.4"))
-	assert.Equal(t, 4, ix.Size())
+	t.Run("matching function and slice namespaces", func(t *testing.T) {
+		ix := NewIndex()
+		// Populate functions across three namespaces.
+		ix.ApplySlice(slice("s1", "fn-a", "ns-1", 8888, "10.0.0.1"))
+		ix.ApplySlice(slice("s2", "fn-b", "ns-1", 8888, "10.0.0.2"))
+		ix.ApplySlice(slice("s3", "fn-c", "ns-2", 8888, "10.0.0.3"))
+		ix.ApplySlice(slice("s4", "fn-d", "ns-3", 8888, "10.0.0.4"))
+		assert.Equal(t, 4, ix.Size())
 
-	// Remove ns-1 only; ns-2 and ns-3 must survive.
-	ix.RemoveNamespace("ns-1")
-	assert.Empty(t, ix.Lookup("ns-1", "fn-a", ""), "ns-1 fn-a must be gone")
-	assert.Empty(t, ix.Lookup("ns-1", "fn-b", ""), "ns-1 fn-b must be gone")
-	assert.ElementsMatch(t, []string{"10.0.0.3:8888"}, addrs(ix.Lookup("ns-2", "fn-c", "")))
-	assert.ElementsMatch(t, []string{"10.0.0.4:8888"}, addrs(ix.Lookup("ns-3", "fn-d", "")))
-	assert.Equal(t, 2, ix.Size(), "only ns-2 and ns-3 functions remain")
+		// Remove ns-1 only; ns-2 and ns-3 must survive.
+		ix.RemoveNamespace("ns-1")
+		assert.Empty(t, ix.Lookup("ns-1", "fn-a", ""), "ns-1 fn-a must be gone")
+		assert.Empty(t, ix.Lookup("ns-1", "fn-b", ""), "ns-1 fn-b must be gone")
+		assert.ElementsMatch(t, []string{"10.0.0.3:8888"}, addrs(ix.Lookup("ns-2", "fn-c", "")))
+		assert.ElementsMatch(t, []string{"10.0.0.4:8888"}, addrs(ix.Lookup("ns-3", "fn-d", "")))
+		assert.Equal(t, 2, ix.Size(), "only ns-2 and ns-3 functions remain")
 
-	// Removing a namespace that was never populated is a no-op.
-	ix.RemoveNamespace("never-existed")
-	assert.Equal(t, 2, ix.Size())
+		// Removing a namespace that was never populated is a no-op.
+		ix.RemoveNamespace("never-existed")
+		assert.Equal(t, 2, ix.Size())
 
-	// Remove the rest.
-	ix.RemoveNamespace("ns-2")
-	ix.RemoveNamespace("ns-3")
-	assert.Equal(t, 0, ix.Size())
-	assert.Empty(t, ix.Lookup("ns-2", "fn-c", ""))
-	assert.Empty(t, ix.Lookup("ns-3", "fn-d", ""))
+		// Remove the rest.
+		ix.RemoveNamespace("ns-2")
+		ix.RemoveNamespace("ns-3")
+		assert.Equal(t, 0, ix.Size())
+		assert.Empty(t, ix.Lookup("ns-2", "fn-c", ""))
+		assert.Empty(t, ix.Lookup("ns-3", "fn-d", ""))
+	})
+
+	t.Run("different function and slice namespaces", func(t *testing.T) {
+		ix := NewIndex()
+		sl := slice("s5", "hello", "default", 8888, "10.0.0.5")
+		sl.Namespace = "workloads"
+		ix.ApplySlice(sl)
+		assert.Equal(t, 1, ix.Size())
+		assert.ElementsMatch(t, []string{"10.0.0.5:8888"}, addrs(ix.Lookup("default", "hello", "")))
+		ix.RemoveNamespace("workloads")
+		assert.Empty(t, ix.Lookup("default", "hello", ""))
+		assert.Equal(t, 0, ix.Size())
+	})
+
+	t.Run("preserves slices from other namespaces", func(t *testing.T) {
+		ix := NewIndex()
+		first := slice("s6", "hello", "default", 8888, "10.0.0.6")
+		first.Namespace = "workloads-a"
+		second := slice("s7", "hello", "default", 8888, "10.0.0.7")
+		second.Namespace = "workloads-b"
+		ix.ApplySlice(first)
+		ix.ApplySlice(second)
+
+		ix.RemoveNamespace("workloads-a")
+		assert.ElementsMatch(t, []string{"10.0.0.7:8888"}, addrs(ix.Lookup("default", "hello", "")))
+		assert.Equal(t, 1, ix.Size())
+
+		ix.RemoveNamespace("workloads-b")
+		assert.Empty(t, ix.Lookup("default", "hello", ""))
+		assert.Equal(t, 0, ix.Size())
+	})
 }

--- a/pkg/router/endpointcache/informer.go
+++ b/pkg/router/endpointcache/informer.go
@@ -32,34 +32,7 @@ func RegisterInformer(ctx context.Context, mgr ctrl.Manager, ix *Index, logger l
 	if err != nil {
 		return nil, fmt.Errorf("error getting endpointslice informer: %w", err)
 	}
-	reg, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj any) {
-			if es, ok := obj.(*discoveryv1.EndpointSlice); ok {
-				ix.ApplySlice(es)
-			}
-		},
-		UpdateFunc: func(_, newObj any) {
-			if es, ok := newObj.(*discoveryv1.EndpointSlice); ok {
-				ix.ApplySlice(es)
-			}
-		},
-		DeleteFunc: func(obj any) {
-			es, ok := obj.(*discoveryv1.EndpointSlice)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					logger.V(1).Info("unexpected object type in endpointslice delete event")
-					return
-				}
-				es, ok = tombstone.Obj.(*discoveryv1.EndpointSlice)
-				if !ok {
-					logger.V(1).Info("unexpected tombstone object type in endpointslice delete event")
-					return
-				}
-			}
-			ix.DeleteSlice(es)
-		},
-	})
+	reg, err := informer.AddEventHandler(endpointSliceHandlers(ix, logger))
 	if err != nil {
 		return nil, fmt.Errorf("error adding endpointslice event handler: %w", err)
 	}

--- a/pkg/router/endpointcache/metrics.go
+++ b/pkg/router/endpointcache/metrics.go
@@ -72,19 +72,7 @@ var (
 		"fission_router_endpointcache_mode",
 		"Always 1; labels carry the requested and effective EndpointSlice cache modes (off|on) and whether endpoint LB is enabled.",
 	)
-	// informersGauge reports the number of running per-namespace EndpointSlice
-	// informers. Dynamic-mode tests assert it returns to 0 after offboard as a
-	// deterministic leak guard (exact, vs. goroutine-count delta ±10).
-	informersGauge = metrics.Int64Gauge(
-		"fission_router_endpointcache_informers",
-		"Number of running per-namespace EndpointSlice informers.",
-	)
 )
-
-// RecordInformersCount sets the running-informer count gauge.
-func RecordInformersCount(n int64) {
-	informersGauge.Record(context.Background(), n)
-}
 
 // RecordHit counts one index-admitted request.
 func RecordHit() { hits.Add(context.Background(), 1) }
@@ -119,8 +107,10 @@ func RegisterModeInfo(requested, effective string, endpointLB bool) {
 }
 
 var (
-	sizeIndex     atomic.Pointer[Index]
-	sizeGaugeOnce sync.Once
+	sizeIndex          atomic.Pointer[Index]
+	sizeGaugeOnce      sync.Once
+	informersManager   atomic.Pointer[NamespaceInformers]
+	informersGaugeOnce sync.Once
 )
 
 // RegisterSizeGauge publishes an observable gauge reporting the number of
@@ -138,6 +128,25 @@ func RegisterSizeGauge(ix *Index) {
 			func(_ context.Context, o metric.Int64Observer) error {
 				if ix := sizeIndex.Load(); ix != nil {
 					o.Observe(int64(ix.Size()))
+				}
+				return nil
+			},
+		)
+	})
+}
+
+// RegisterInformersGauge publishes an observable gauge reporting the number of
+// running per-namespace informers. It registers the callback exactly once and
+// points later registrations at the newest NamespaceInformers instance.
+func RegisterInformersGauge(nsi *NamespaceInformers) {
+	informersManager.Store(nsi)
+	informersGaugeOnce.Do(func() {
+		metrics.Int64ObservableGauge(
+			"fission_router_endpointcache_informers",
+			"Number of running per-namespace EndpointSlice informers.",
+			func(_ context.Context, o metric.Int64Observer) error {
+				if nsi := informersManager.Load(); nsi != nil {
+					o.Observe(nsi.informerCount.Load())
 				}
 				return nil
 			},

--- a/pkg/router/endpointcache/metrics.go
+++ b/pkg/router/endpointcache/metrics.go
@@ -72,7 +72,19 @@ var (
 		"fission_router_endpointcache_mode",
 		"Always 1; labels carry the requested and effective EndpointSlice cache modes (off|on) and whether endpoint LB is enabled.",
 	)
+	// informersGauge reports the number of running per-namespace EndpointSlice
+	// informers. Dynamic-mode tests assert it returns to 0 after offboard as a
+	// deterministic leak guard (exact, vs. goroutine-count delta ±10).
+	informersGauge = metrics.Int64Gauge(
+		"fission_router_endpointcache_informers",
+		"Number of running per-namespace EndpointSlice informers.",
+	)
 )
+
+// RecordInformersCount sets the running-informer count gauge.
+func RecordInformersCount(n int64) {
+	informersGauge.Record(context.Background(), n)
+}
 
 // RecordHit counts one index-admitted request.
 func RecordHit() { hits.Add(context.Background(), 1) }

--- a/pkg/router/endpointcache/nsinformers.go
+++ b/pkg/router/endpointcache/nsinformers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/go-logr/logr"
 
@@ -38,11 +39,13 @@ type nsInformer struct {
 // Close stops every running informer and waits for their goroutines to exit;
 // tests must call it (typically via t.Cleanup) to avoid leaking goroutines.
 type NamespaceInformers struct {
-	kubeClient kubernetes.Interface
-	index      *Index
-	logger     logr.Logger
-	mu         sync.Mutex
-	informers  map[string]*nsInformer
+	kubeClient    kubernetes.Interface
+	index         *Index
+	logger        logr.Logger
+	mu            sync.Mutex
+	informers     map[string]*nsInformer
+	closed        bool         // set by Close; Sync returns immediately when true
+	informerCount atomic.Int64 // running per-namespace informer count; exposed as metric
 }
 
 // NewNamespaceInformers creates an empty informer manager. The caller owns
@@ -69,6 +72,9 @@ func NewNamespaceInformers(kubeClient kubernetes.Interface, index *Index, logger
 func (n *NamespaceInformers) Sync(namespaces []string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.closed {
+		return
+	}
 	// Build a set of desired namespaces.
 	desired := make(map[string]struct{}, len(namespaces))
 	for _, ns := range namespaces {
@@ -84,6 +90,8 @@ func (n *NamespaceInformers) Sync(namespaces []string) {
 			<-ni.done
 			n.index.RemoveNamespace(ns)
 			delete(n.informers, ns)
+			n.informerCount.Add(-1)
+			RecordInformersCount(n.informerCount.Load())
 			n.logger.Info("stopped endpointslice informer for namespace", "namespace", ns)
 		}
 	}
@@ -100,6 +108,8 @@ func (n *NamespaceInformers) Sync(namespaces []string) {
 			continue
 		}
 		n.informers[ns] = &nsInformer{informer: informer, cancel: cancel, done: done}
+		n.informerCount.Add(1)
+		RecordInformersCount(n.informerCount.Load())
 		n.logger.Info("started endpointslice informer for namespace", "namespace", ns)
 	}
 }
@@ -177,6 +187,7 @@ func (n *NamespaceInformers) WaitForCacheSync(ctx context.Context) bool {
 // context is cancelled; tests should register it via t.Cleanup.
 func (n *NamespaceInformers) Close() {
 	n.mu.Lock()
+	n.closed = true
 	stopped := n.informers
 	n.informers = make(map[string]*nsInformer)
 	n.mu.Unlock()
@@ -184,4 +195,6 @@ func (n *NamespaceInformers) Close() {
 		ni.cancel()
 		<-ni.done
 	}
+	n.informerCount.Store(0)
+	RecordInformersCount(0)
 }

--- a/pkg/router/endpointcache/nsinformers.go
+++ b/pkg/router/endpointcache/nsinformers.go
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package endpointcache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+)
+
+// nsInformer pairs one namespace's EndpointSlice informer with the cancel
+// function that stops it and a done channel closed only after the informer's
+// goroutines have fully drained (factory.Start + factory.Shutdown). Stored in
+// NamespaceInformers.informers, keyed by namespace. Waiting on done before
+// sweeping the index is the teardown fence (PRD §11.1): it guarantees no queued
+// or in-flight ApplySlice can repopulate a namespace after offboard.
+type nsInformer struct {
+	informer cache.SharedIndexInformer
+	cancel   context.CancelFunc
+	done     chan struct{}
+}
+
+// NamespaceInformers manages one EndpointSlice informer per tenant namespace.
+// Unlike the controller-runtime Manager's cache (scoped once at startup),
+// this can start/stop informers as tenants are onboarded/offboarded at runtime.
+// Close stops every running informer and waits for their goroutines to exit;
+// tests must call it (typically via t.Cleanup) to avoid leaking goroutines.
+type NamespaceInformers struct {
+	kubeClient kubernetes.Interface
+	index      *Index
+	logger     logr.Logger
+	mu         sync.Mutex
+	informers  map[string]*nsInformer
+}
+
+// NewNamespaceInformers creates an empty informer manager. The caller owns
+// the lifecycle: call Close when done (production ties it to the router's
+// context; tests register it via t.Cleanup).
+func NewNamespaceInformers(kubeClient kubernetes.Interface, index *Index, logger logr.Logger) *NamespaceInformers {
+	return &NamespaceInformers{
+		kubeClient: kubeClient,
+		index:      index,
+		logger:     logger,
+		informers:  make(map[string]*nsInformer),
+	}
+}
+
+// Sync reconciles the running informer set to match namespaces:
+// starts informers for new namespaces, stops informers for removed namespaces.
+// The whole transition is serialized under n.mu: cancel → wait for the
+// informer's goroutines to drain (factory.Shutdown via the done channel) →
+// sweep the index. Holding the lock across the wait prevents a concurrent
+// Sync from installing a replacement informer whose fresh entries the earlier
+// call would then delete (offboard/re-onboard overlap). The drain never takes
+// n.mu (handlers only touch the Index's own locks), so this cannot deadlock —
+// other callers just wait a moment.
+func (n *NamespaceInformers) Sync(namespaces []string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	// Build a set of desired namespaces.
+	desired := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		desired[ns] = struct{}{}
+	}
+	// Stop informers for namespaces no longer in the desired set. Waiting for
+	// the drain BEFORE sweeping is the teardown fence (PRD §11.1): no queued
+	// ApplySlice from the dying informer can repopulate the namespace after
+	// RemoveNamespace, resurrecting stale endpoints during offboard.
+	for ns, ni := range n.informers {
+		if _, ok := desired[ns]; !ok {
+			ni.cancel()
+			<-ni.done
+			n.index.RemoveNamespace(ns)
+			delete(n.informers, ns)
+			n.logger.Info("stopped endpointslice informer for namespace", "namespace", ns)
+		}
+	}
+	// Start informers for new namespaces.
+	for ns := range desired {
+		if _, ok := n.informers[ns]; ok {
+			continue // already running
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		informer, done, err := n.start(ctx, ns)
+		if err != nil {
+			cancel()
+			n.logger.Error(err, "failed to start endpointslice informer", "namespace", ns)
+			continue
+		}
+		n.informers[ns] = &nsInformer{informer: informer, cancel: cancel, done: done}
+		n.logger.Info("started endpointslice informer for namespace", "namespace", ns)
+	}
+}
+
+// start builds and runs a single-namespace EndpointSlice informer that feeds
+// slice add/update/delete events into the shared Index. The informer runs in a
+// background goroutine via factory.Start; cancelling ctx stops it. Returns the
+// informer (for HasSynced queries) and a done channel closed when the factory
+// goroutine has fully exited.
+func (n *NamespaceInformers) start(ctx context.Context, ns string) (cache.SharedIndexInformer, chan struct{}, error) {
+	// Label filter: only Fission-managed slices (same selector as routerCacheOptions).
+	labelSelector := labels.SelectorFromSet(labels.Set{
+		fv1.MANAGED_BY_LABEL: fv1.MANAGED_BY_VALUE,
+	}).String()
+	factory := informers.NewSharedInformerFactoryWithOptions(
+		n.kubeClient,
+		0, // no resync — the index is the source of truth
+		informers.WithNamespace(ns),
+		informers.WithTweakListOptions(func(opts *metav1.ListOptions) {
+			opts.LabelSelector = labelSelector
+		}))
+	informer := factory.Discovery().V1().EndpointSlices().Informer()
+
+	// Shared handlers (same as the manager-cache informer path).
+	_, err := informer.AddEventHandler(endpointSliceHandlers(n.index, n.logger))
+	if err != nil {
+		return nil, nil, fmt.Errorf("error adding endpointslice event handler: %w", err)
+	}
+	// Run the factory in the background; cancelling ctx stops it. Start is
+	// non-blocking (it only launches informer goroutines), so done must wait on
+	// Shutdown, which blocks until every informer's Run has returned — and the
+	// informer's processor drains all queued handler notifications before Run
+	// returns. Closing done after Shutdown is therefore a real teardown fence:
+	// once done fires, no handler for this namespace can ever run again.
+	done := make(chan struct{})
+	go func() {
+		factory.Start(ctx.Done())
+		factory.Shutdown()
+		close(done)
+	}()
+	return informer, done, nil
+}
+
+// HasSynced reports whether all running informers have completed their initial
+// list. Satisfies cache.InformerSynced (func() bool) so the router can gate
+// readiness on the index being populated, same as the manager-cache path.
+// Returns true when no informers are running (vacuously synced).
+func (n *NamespaceInformers) HasSynced() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	for _, ni := range n.informers {
+		if !ni.informer.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+// WaitForCacheSync blocks until all running informers have completed their
+// initial list or ctx is cancelled. Returns true if all synced, false on
+// timeout/cancel. This is the deterministic synchronization point for tests
+// (replacing polling) and for the router's readiness gate.
+func (n *NamespaceInformers) WaitForCacheSync(ctx context.Context) bool {
+	n.mu.Lock()
+	informers := make([]cache.InformerSynced, 0, len(n.informers))
+	for _, ni := range n.informers {
+		informers = append(informers, ni.informer.HasSynced)
+	}
+	n.mu.Unlock()
+	return cache.WaitForCacheSync(ctx.Done(), informers...)
+}
+
+// Close stops every running informer and waits for their goroutines to exit.
+// Safe to call multiple times. Production should call it when the router's
+// context is cancelled; tests should register it via t.Cleanup.
+func (n *NamespaceInformers) Close() {
+	n.mu.Lock()
+	stopped := n.informers
+	n.informers = make(map[string]*nsInformer)
+	n.mu.Unlock()
+	for _, ni := range stopped {
+		ni.cancel()
+		<-ni.done
+	}
+}

--- a/pkg/router/endpointcache/nsinformers.go
+++ b/pkg/router/endpointcache/nsinformers.go
@@ -47,17 +47,18 @@ type NamespaceInformers struct {
 
 // NewNamespaceInformers creates an empty informer manager. The caller owns
 // the lifecycle: call Close when done (production ties it to the router's
-// context; tests register it via t.Cleanup). It also registers this manager as
-// the current informer-count metric source.
+// context; tests register it via t.Cleanup). RegisterInformersGauge is NOT
+// called here — the constructor stays deterministic (no process-global side
+// effect, per the CLAUDE.md library-constructor guidance). The production
+// call site (setupDynamicEndpointCache) registers the gauge after setup
+// has succeeded.
 func NewNamespaceInformers(kubeClient kubernetes.Interface, index *Index, logger logr.Logger) *NamespaceInformers {
-	nsi := &NamespaceInformers{
+	return &NamespaceInformers{
 		kubeClient: kubeClient,
 		index:      index,
 		logger:     logger,
 		informers:  make(map[string]*nsInformer),
 	}
-	RegisterInformersGauge(nsi)
-	return nsi
 }
 
 // Sync reconciles the running informer set to match namespaces:

--- a/pkg/router/endpointcache/nsinformers.go
+++ b/pkg/router/endpointcache/nsinformers.go
@@ -47,14 +47,17 @@ type NamespaceInformers struct {
 
 // NewNamespaceInformers creates an empty informer manager. The caller owns
 // the lifecycle: call Close when done (production ties it to the router's
-// context; tests register it via t.Cleanup).
+// context; tests register it via t.Cleanup). It also registers this manager as
+// the current informer-count metric source.
 func NewNamespaceInformers(kubeClient kubernetes.Interface, index *Index, logger logr.Logger) *NamespaceInformers {
-	return &NamespaceInformers{
+	nsi := &NamespaceInformers{
 		kubeClient: kubeClient,
 		index:      index,
 		logger:     logger,
 		informers:  make(map[string]*nsInformer),
 	}
+	RegisterInformersGauge(nsi)
+	return nsi
 }
 
 // Sync reconciles the running informer set to match namespaces:
@@ -83,7 +86,6 @@ func (n *NamespaceInformers) Sync(namespaces []string) {
 			n.index.RemoveNamespace(ns)
 			delete(n.informers, ns)
 			n.informerCount.Add(-1)
-			RecordInformersCount(n.informerCount.Load())
 			n.logger.Info("stopped endpointslice informer for namespace", "namespace", ns)
 		}
 	}
@@ -101,7 +103,6 @@ func (n *NamespaceInformers) Sync(namespaces []string) {
 		}
 		n.informers[ns] = &nsInformer{informer: informer, cancel: cancel, done: done}
 		n.informerCount.Add(1)
-		RecordInformersCount(n.informerCount.Load())
 		n.logger.Info("started endpointslice informer for namespace", "namespace", ns)
 	}
 }
@@ -162,8 +163,8 @@ func (n *NamespaceInformers) HasSynced() bool {
 
 // WaitForCacheSync blocks until all running informers have completed their
 // initial list or ctx is cancelled. Returns true if all synced, false on
-// timeout/cancel. This is the deterministic synchronization point for tests
-// (replacing polling) and for the router's readiness gate.
+// timeout/cancel. Tests use it as a deterministic synchronization point;
+// production readiness polls HasSynced instead.
 func (n *NamespaceInformers) WaitForCacheSync(ctx context.Context) bool {
 	n.mu.Lock()
 	informers := make([]cache.InformerSynced, 0, len(n.informers))
@@ -188,5 +189,4 @@ func (n *NamespaceInformers) Close() {
 		<-ni.done
 	}
 	n.informerCount.Store(0)
-	RecordInformersCount(0)
 }

--- a/pkg/router/endpointcache/nsinformers.go
+++ b/pkg/router/endpointcache/nsinformers.go
@@ -9,13 +9,15 @@ import (
 	"fmt"
 	"sync"
 
-	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/go-logr/logr"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
 // nsInformer pairs one namespace's EndpointSlice informer with the cancel

--- a/pkg/router/endpointcache/nsinformers.go
+++ b/pkg/router/endpointcache/nsinformers.go
@@ -22,11 +22,8 @@ import (
 )
 
 // nsInformer pairs one namespace's EndpointSlice informer with the cancel
-// function that stops it and a done channel closed only after the informer's
-// goroutines have fully drained (factory.Start + factory.Shutdown). Stored in
-// NamespaceInformers.informers, keyed by namespace. Waiting on done before
-// sweeping the index is the teardown fence (PRD §11.1): it guarantees no queued
-// or in-flight ApplySlice can repopulate a namespace after offboard.
+// function that stops it and a done channel closed after the informer's
+// goroutines have drained. See start for the teardown-fence contract.
 type nsInformer struct {
 	informer cache.SharedIndexInformer
 	cancel   context.CancelFunc
@@ -62,13 +59,10 @@ func NewNamespaceInformers(kubeClient kubernetes.Interface, index *Index, logger
 
 // Sync reconciles the running informer set to match namespaces:
 // starts informers for new namespaces, stops informers for removed namespaces.
-// The whole transition is serialized under n.mu: cancel → wait for the
-// informer's goroutines to drain (factory.Shutdown via the done channel) →
-// sweep the index. Holding the lock across the wait prevents a concurrent
-// Sync from installing a replacement informer whose fresh entries the earlier
-// call would then delete (offboard/re-onboard overlap). The drain never takes
-// n.mu (handlers only touch the Index's own locks), so this cannot deadlock —
-// other callers just wait a moment.
+// Serialized under n.mu: cancel → wait for drain (see start's done channel) →
+// sweep the index. Holding the lock across the wait prevents offboard/re-onboard
+// overlap. The drain never takes n.mu (handlers only touch the Index's own
+// locks), so this cannot deadlock.
 func (n *NamespaceInformers) Sync(namespaces []string) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
@@ -80,10 +74,8 @@ func (n *NamespaceInformers) Sync(namespaces []string) {
 	for _, ns := range namespaces {
 		desired[ns] = struct{}{}
 	}
-	// Stop informers for namespaces no longer in the desired set. Waiting for
-	// the drain BEFORE sweeping is the teardown fence (PRD §11.1): no queued
-	// ApplySlice from the dying informer can repopulate the namespace after
-	// RemoveNamespace, resurrecting stale endpoints during offboard.
+	// Stop informers for namespaces no longer in the desired set.
+	// <-ni.done is the teardown fence (see start).
 	for ns, ni := range n.informers {
 		if _, ok := desired[ns]; !ok {
 			ni.cancel()

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -15,6 +15,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
@@ -297,4 +298,59 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	// Double-check after a short settle: no delayed event should appear.
 	time.Sleep(100 * time.Millisecond)
 	assert.Equal(t, 0, index.Size(), "index must stay empty after settle — no late resurrection")
+}
+
+// TestEndpointSliceHandlersUpdateAndDelete verifies the extracted UpdateFunc
+// and DeleteFunc handlers in handlers.go. The initial LIST replay exercises
+// AddFunc through the informer; this test exercises the Update and Delete paths
+// directly — including the tombstone unwrap in DeleteFunc — by calling the
+// handler functions, which is simpler and more reliable than relying on the
+// fake clientset's watch MODIFIED/DELETED event delivery.
+func TestEndpointSliceHandlersUpdateAndDelete(t *testing.T) {
+	t.Parallel()
+
+	index := NewIndex()
+	handlers := endpointSliceHandlers(index, logr.Discard())
+
+	s1 := makeSlice("s1", "ns-a", "fn-a", "10.0.0.1")
+
+	// Add: same path as the informer's initial LIST replay.
+	handlers.AddFunc(s1)
+	assert.Equal(t, 1, index.Size())
+	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+
+	// Update: UpdateFunc must call ApplySlice with the new endpoints.
+	updated := makeSlice("s1", "ns-a", "fn-a", "10.0.0.2", "10.0.0.3")
+	handlers.UpdateFunc(s1, updated)
+	assert.Equal(t, 1, index.Size(), "update must not change function count")
+	assert.ElementsMatch(t, []string{"10.0.0.2:8888", "10.0.0.3:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+
+	// Delete: DeleteFunc must call DeleteSlice, removing the entry.
+	handlers.DeleteFunc(updated)
+	assert.Equal(t, 0, index.Size(), "delete must remove the function entry")
+	assert.Empty(t, index.Lookup("ns-a", "fn-a", ""))
+
+	// Tombstone unwrap: when the informer's store loses the object, the
+	// reflector wraps it in a DeletedFinalStateUnknown. DeleteFunc must
+	// unwrap the tombstone and call DeleteSlice on the real object.
+	handlers.AddFunc(s1)
+	assert.Equal(t, 1, index.Size())
+	handlers.DeleteFunc(cache.DeletedFinalStateUnknown{Key: "ns-a/s1", Obj: s1})
+	assert.Equal(t, 0, index.Size(), "tombstone delete must also remove the entry")
+}
+
+// TestNamespaceInformersHasSyncedNonEmpty verifies HasSynced returns true when
+// a running informer has completed its initial LIST — the non-vacuous case
+// that TestNamespaceInformersHasSyncedEmpty doesn't cover.
+func TestNamespaceInformersHasSyncedNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	assert.True(t, nsi.HasSynced(), "HasSynced must be true after informer completes initial LIST")
 }

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -176,10 +176,25 @@ func TestNamespaceInformersCloseStopsAll(t *testing.T) {
 func TestNamespaceInformersSyncAfterCloseIsNoop(t *testing.T) {
 	t.Parallel()
 
+	releaseList := make(chan struct{})
+
 	kubeClient := fake.NewSimpleClientset(
 		makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"),
 		makeSlice("s2", "ns-b", "fn-b", "10.0.0.2"),
 	)
+
+	kubeClient.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		ns := action.GetNamespace()
+		switch ns {
+		case "ns-a":
+			return false, nil, nil
+		case "ns-b":
+			<-releaseList
+			return false, nil, nil
+		}
+		return false, nil, nil
+	})
+
 	index := NewIndex()
 	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
 
@@ -188,7 +203,14 @@ func TestNamespaceInformersSyncAfterCloseIsNoop(t *testing.T) {
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	waitForIndexSize(t, index, 1)
 
+	releaseFunc := sync.OnceFunc(func() {
+		close(releaseList)
+	})
+
 	// Close: stops ns-a informer, sets closed=true.
+	t.Cleanup(nsi.Close)
+	t.Cleanup(releaseFunc)
+
 	nsi.Close()
 
 	// Sync with ns-b: must be a no-op because closed=true.

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -239,3 +239,62 @@ func TestNamespaceInformersConcurrentSync(t *testing.T) {
 	waitForIndexSize(t, index, 1)
 	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
 }
+
+// TestNamespaceInformersFencePreventsResurrection verifies the teardown fence:
+// a slice event queued before offboard but processed during the informer drain
+// must be swept by RemoveNamespace. Without the fence (no <-ni.done wait), the
+// late ApplySlice resurrects the entry after RemoveNamespace — the index ends
+// up non-empty after offboard. With the fence, Sync blocks until the processor
+// drains, then sweeps, so the index is guaranteed empty.
+//
+// A continuous-churn goroutine fires Tracker().Add in a tight loop while the
+// main goroutine calls Sync. Tracker().Add fans out to the informer's watcher
+// natively, so events are constantly in flight. When cancel fires, some events
+// are already queued in the processor — the fence drains them before sweeping.
+// Without the fence, RemoveNamespace runs first and a late ApplySlice
+// resurrects the entry.
+func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	// Start informer for ns-a.
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	waitForIndexSize(t, index, 1)
+
+	// Continuous churn: fire Tracker().Add in a tight loop so events are
+	// constantly queued in the processor. When Sync cancels the informer,
+	// some events are already in-flight.
+	stop := make(chan struct{})
+	var churnDone sync.WaitGroup
+	churnDone.Add(1)
+	go func() {
+		defer churnDone.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s := makeSlice("s-churn", "ns-a", "fn-a", "10.0.0.2")
+			kubeClient.Tracker().Add(s)
+		}
+	}()
+	// Brief window so at least a few events are in the processor queue.
+	time.Sleep(20 * time.Millisecond)
+
+	// Offboard: Sync blocks until the informer drains, then sweeps.
+	nsi.Sync([]string{})
+	close(stop)
+	churnDone.Wait()
+
+	// Index must be empty — the fence prevented resurrection.
+	assert.Equal(t, 0, index.Size(), "fence must prevent late ApplySlice from resurrecting entries after offboard")
+	// Double-check after a short settle: no delayed event should appear.
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, 0, index.Size(), "index must stay empty after settle — no late resurrection")
+}

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -142,6 +142,41 @@ func TestNamespaceInformersCloseStopsAll(t *testing.T) {
 	assert.Equal(t, 1, index.Size(), "Close must not sweep the index")
 }
 
+// TestNamespaceInformersSyncAfterCloseIsNoop verifies the closed guard: after
+// Close, a racing Sync must not repopulate informers. Without the guard, Close
+// drains the map outside the lock, a racing Sync repopulates it, and those new
+// informers — parented on context.Background() — are unreachable by any cancel
+// and leak until process exit. With the guard, Sync returns immediately and the
+// informer map stays empty.
+func TestNamespaceInformersSyncAfterCloseIsNoop(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(
+		makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"),
+		makeSlice("s2", "ns-b", "fn-b", "10.0.0.2"),
+	)
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+
+	// Start an informer for ns-a.
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	waitForIndexSize(t, index, 1)
+
+	// Close: stops ns-a informer, sets closed=true.
+	nsi.Close()
+
+	// Sync with ns-b: must be a no-op because closed=true.
+	// Without the guard, this would start an informer for ns-b.
+	nsi.Sync([]string{"ns-b"})
+
+	// ns-b's slice must NOT be in the index — Sync was a no-op.
+	assert.Equal(t, 1, index.Size(), "Sync after Close must not start informers")
+	assert.NotEmpty(t, index.Lookup("ns-a", "fn-a", ""), "ns-a entries survive Close")
+	assert.Empty(t, index.Lookup("ns-b", "fn-b", ""), "ns-b must not appear — Sync was a no-op")
+	assert.True(t, nsi.HasSynced(), "HasSynced vacuously true after Close (zero informers)")
+}
+
 // TestNamespaceInformersOffboardReonboard exercises the PRD §11.1 lifecycle:
 // onboard → offboard → re-onboard the same namespace. After the fence, a
 // re-onboarded informer must deliver fresh entries, and a final offboard must

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -5,6 +5,7 @@
 package endpointcache
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -14,7 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
@@ -248,12 +251,11 @@ func TestNamespaceInformersConcurrentSync(t *testing.T) {
 // up non-empty after offboard. With the fence, Sync blocks until the processor
 // drains, then sweeps, so the index is guaranteed empty.
 //
-// A continuous-churn goroutine fires Tracker().Add in a tight loop while the
-// main goroutine calls Sync. Tracker().Add fans out to the informer's watcher
-// natively, so events are constantly in flight. When cancel fires, some events
-// are already queued in the processor — the fence drains them before sweeping.
-// Without the fence, RemoveNamespace runs first and a late ApplySlice
-// resurrects the entry.
+// A churn goroutine fires Tracker().Add with unique names in a tight loop.
+// A started channel signals when the first event is queued; the main goroutine
+// then calls Sync. Tracker().Add fans out to the informer's watcher natively,
+// so events are constantly in flight. When cancel fires, some events are
+// already queued in the processor — the fence drains them before sweeping.
 func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	t.Parallel()
 
@@ -267,10 +269,11 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	waitForIndexSize(t, index, 1)
 
-	// Continuous churn: fire Tracker().Add in a tight loop so events are
-	// constantly queued in the processor. When Sync cancels the informer,
-	// some events are already in-flight.
+	// Churn goroutine: fire Tracker().Add with unique names so every call
+	// succeeds (no AlreadyExists). Signal after first event is queued so the
+	// main goroutine doesn't call Sync before any events are in flight.
 	stop := make(chan struct{})
+	started := make(chan struct{})
 	var churnDone sync.WaitGroup
 	churnDone.Add(1)
 	go func() {
@@ -281,12 +284,19 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 				return
 			default:
 			}
-			s := makeSlice("s-churn", "ns-a", "fn-a", "10.0.0.2")
-			_ = kubeClient.Tracker().Add(s)
+			s := makeSlice(fmt.Sprintf("s-churn-%d", i), "ns-a", "fn-a", "10.0.0.2")
+			if err := kubeClient.Tracker().Add(s); err != nil {
+				continue // AlreadyExists from a concurrent Add, retry
+			}
+			if i == 0 {
+				close(started)
+			}
+			// Pace the churn so the fake watcher's channel (default 100)
+			// doesn't overflow before the informer drains events.
+			time.Sleep(time.Microsecond)
 		}
 	}()
-	// Brief window so at least a few events are in the processor queue.
-	time.Sleep(20 * time.Millisecond)
+	<-started
 
 	// Offboard: Sync blocks until the informer drains, then sweeps.
 	nsi.Sync([]string{})
@@ -295,9 +305,6 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 
 	// Index must be empty — the fence prevented resurrection.
 	assert.Equal(t, 0, index.Size(), "fence must prevent late ApplySlice from resurrecting entries after offboard")
-	// Double-check after a short settle: no delayed event should appear.
-	time.Sleep(100 * time.Millisecond)
-	assert.Equal(t, 0, index.Size(), "index must stay empty after settle — no late resurrection")
 }
 
 // TestEndpointSliceHandlersUpdateAndDelete verifies the extracted UpdateFunc
@@ -339,18 +346,32 @@ func TestEndpointSliceHandlersUpdateAndDelete(t *testing.T) {
 	assert.Equal(t, 0, index.Size(), "tombstone delete must also remove the entry")
 }
 
-// TestNamespaceInformersHasSyncedNonEmpty verifies HasSynced returns true when
-// a running informer has completed its initial LIST — the non-vacuous case
-// that TestNamespaceInformersHasSyncedEmpty doesn't cover.
+// TestNamespaceInformersHasSyncedNonEmpty verifies the HasSynced state
+// machine: false while an informer is running but hasn't completed its
+// initial LIST, true after it syncs. Uses a list reactor that blocks the
+// initial LIST until released, so the test can observe the false state
+// deterministically.
 func TestNamespaceInformersHasSyncedNonEmpty(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	// Block the initial LIST so HasSynced stays false until we release it.
+	releaseList := make(chan struct{})
+	kubeClient.PrependReactor("list", "endpointslices", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		<-releaseList
+		return false, nil, nil // fall through to default reactor
+	})
+
 	index := NewIndex()
 	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
 	t.Cleanup(nsi.Close)
 
+	// Start the informer — LIST is blocked, so HasSynced must be false.
 	nsi.Sync([]string{"ns-a"})
+	assert.False(t, nsi.HasSynced(), "HasSynced must be false while initial LIST is blocked")
+
+	// Release the LIST; the informer syncs.
+	close(releaseList)
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	assert.True(t, nsi.HasSynced(), "HasSynced must be true after informer completes initial LIST")
 }

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -245,9 +245,12 @@ func TestNamespaceInformersConcurrentSync(t *testing.T) {
 
 // TestNamespaceInformersFencePreventsResurrection verifies the teardown fence
 // deterministically: Sync must block on <-ni.done before RemoveNamespace sweeps
-// the index. Uses an nsInformer with a done channel the test controls directly
-// (same-package access) — no sleeps, no fake-watch timing, no scheduler
-// dependence.
+// the index, and a slice applied while fenced must be swept too (no resurrection).
+//
+// Synchronization: the injected cancel closes entered when Sync calls it,
+// proving the goroutine has reached the fence. After <-entered the goroutine is
+// guaranteed to block on <-ni.done (the next statement), so asserting syncDone
+// is still open is deterministic — no sleeps, no scheduler dependence.
 func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	t.Parallel()
 
@@ -256,12 +259,14 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
 	t.Cleanup(nsi.Close)
 
-	// Inject an informer with a done channel we control directly.
+	// Inject an informer with a done channel we control and a cancel that
+	// signals when Sync calls it (proving the goroutine reached the fence).
 	done := make(chan struct{})
+	entered := make(chan struct{})
 	nsi.mu.Lock()
 	nsi.informers["ns-a"] = &nsInformer{
 		informer: nil, // not needed — Sync only uses cancel and done
-		cancel:   func() {},
+		cancel:   func() { close(entered) },
 		done:     done,
 	}
 	nsi.informerCount.Store(1)
@@ -271,28 +276,37 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	index.ApplySlice(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
 	require.Equal(t, 1, index.Size())
 
-	// Call Sync in a goroutine — it must block on <-ni.done.
+	// Call Sync in a goroutine.
 	syncDone := make(chan struct{})
 	go func() {
 		nsi.Sync([]string{})
 		close(syncDone)
 	}()
 
-	// Sync must NOT have completed — it's blocked on <-ni.done.
+	// Wait for the goroutine to call cancel — after this it will block on
+	// <-ni.done (the next statement). Without the fence, RemoveNamespace
+	// would run immediately and syncDone would close.
+	<-entered
+
+	// The fence must hold: syncDone is still open, index is not swept.
 	select {
 	case <-syncDone:
 		t.Fatal("Sync completed without waiting for done channel — fence missing")
 	default:
 	}
-
-	// Index still has the entry — RemoveNamespace hasn't run yet.
 	assert.Equal(t, 1, index.Size(), "index must not be swept until done fires")
+
+	// Apply a late slice while fenced — simulates an event that would
+	// resurrect without the fence. The fence holds, so this entry is
+	// swept along with the original when done fires.
+	index.ApplySlice(makeSlice("s2", "ns-a", "fn-a", "10.0.0.2"))
 
 	// Close done — Sync can now drain and sweep.
 	close(done)
 	<-syncDone
 
-	// Index must be empty — the fence waited for the drain, then swept.
+	// Index must be empty — the fence waited for the drain, then swept
+	// everything including the late entry.
 	assert.Equal(t, 0, index.Size(), "index must be empty after fence drain + sweep")
 }
 

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -15,6 +15,7 @@ import (
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -121,6 +122,27 @@ func waitForIndexSize(t *testing.T, index *Index, n int) {
 	require.Eventuallyf(t, func() bool {
 		return index.Size() == n
 	}, 10*time.Second, 10*time.Millisecond, "index size never converged to %d", n)
+}
+
+// blockingStopWatch lets a test hold a real informer inside watcher shutdown.
+// Stop reports that shutdown began, then waits until the test releases it.
+type blockingStopWatch struct {
+	result      chan watch.Event
+	stopStarted chan struct{}
+	releaseStop <-chan struct{}
+	stopOnce    sync.Once
+}
+
+func (w *blockingStopWatch) Stop() {
+	w.stopOnce.Do(func() {
+		close(w.stopStarted)
+		<-w.releaseStop
+		close(w.result)
+	})
+}
+
+func (w *blockingStopWatch) ResultChan() <-chan watch.Event {
+	return w.result
 }
 
 // TestNamespaceInformersCloseStopsAll verifies that Close stops every running
@@ -243,71 +265,86 @@ func TestNamespaceInformersConcurrentSync(t *testing.T) {
 	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
 }
 
-// TestNamespaceInformersFencePreventsResurrection verifies the teardown fence
-// deterministically: Sync must block on <-ni.done before RemoveNamespace sweeps
-// the index, and a slice applied while fenced must be swept too (no resurrection).
-//
-// Synchronization: the injected cancel closes entered when Sync calls it,
-// proving the goroutine has reached the fence. After <-entered the goroutine is
-// guaranteed to block on <-ni.done (the next statement), so asserting syncDone
-// is still open is deterministic — no sleeps, no scheduler dependence.
+// TestNamespaceInformersFencePreventsResurrection verifies that the real done
+// channel does not fire until the real informer has fully shut down. Moving
+// close(done) before factory.Shutdown would let Sync sweep the namespace and
+// return while the watcher can still deliver a late event and resurrect it.
 func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	t.Parallel()
 
-	kubeClient := fake.NewSimpleClientset()
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	watchStarted := make(chan struct{})
+	stopStarted := make(chan struct{})
+	releaseStop := make(chan struct{})
+	blockingWatch := &blockingStopWatch{
+		result:      make(chan watch.Event),
+		stopStarted: stopStarted,
+		releaseStop: releaseStop,
+	}
+	var watchStartOnce sync.Once
+	kubeClient.PrependWatchReactor("endpointslices", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		watchStartOnce.Do(func() { close(watchStarted) })
+		return true, blockingWatch, nil
+	})
+
 	index := NewIndex()
 	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
 	t.Cleanup(nsi.Close)
+	release := sync.OnceFunc(func() { close(releaseStop) })
+	t.Cleanup(release)
 
-	// Inject an informer with a done channel we control and a cancel that
-	// signals when Sync calls it (proving the goroutine reached the fence).
-	done := make(chan struct{})
-	entered := make(chan struct{})
-	nsi.mu.Lock()
-	nsi.informers["ns-a"] = &nsInformer{
-		informer: nil, // not needed — Sync only uses cancel and done
-		cancel:   func() { close(entered) },
-		done:     done,
-	}
-	nsi.informerCount.Store(1)
-	nsi.mu.Unlock()
+	// Start the real informer and wait until its initial list has populated
+	// the index and its watch connection is active.
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	waitForIndexSize(t, index, 1)
+	require.Eventually(t, func() bool {
+		select {
+		case <-watchStarted:
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond, "informer watch never started")
 
-	// Populate the index for ns-a so the sweep has something to remove.
-	index.ApplySlice(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
-	require.Equal(t, 1, index.Size())
-
-	// Call Sync in a goroutine.
+	// Offboard in the background. Cancelling the informer reaches the real
+	// watch's Stop method, which remains blocked until release is called.
 	syncDone := make(chan struct{})
 	go func() {
 		nsi.Sync([]string{})
 		close(syncDone)
 	}()
 
-	// Wait for the goroutine to call cancel — after this it will block on
-	// <-ni.done (the next statement). Without the fence, RemoveNamespace
-	// would run immediately and syncDone would close.
-	<-entered
+	require.Eventually(t, func() bool {
+		select {
+		case <-stopStarted:
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond, "watcher shutdown never started")
 
-	// The fence must hold: syncDone is still open, index is not swept.
+	// Since the real watcher has not finished stopping, Sync must still be
+	// waiting and the namespace must not have been swept yet.
 	select {
 	case <-syncDone:
-		t.Fatal("Sync completed without waiting for done channel — fence missing")
+		t.Fatal("Sync completed before the watcher fully stopped")
 	default:
 	}
-	assert.Equal(t, 1, index.Size(), "index must not be swept until done fires")
+	assert.Equal(t, 1, index.Size(), "index must not be swept while the watcher is still stopping")
 
-	// Apply a late slice while fenced — simulates an event that would
-	// resurrect without the fence. The fence holds, so this entry is
-	// swept along with the original when done fires.
-	index.ApplySlice(makeSlice("s2", "ns-a", "fn-a", "10.0.0.2"))
+	// Let watcher shutdown finish. Only then may Sync sweep and return.
+	release()
+	require.Eventually(t, func() bool {
+		select {
+		case <-syncDone:
+			return true
+		default:
+			return false
+		}
+	}, 10*time.Second, 10*time.Millisecond, "Sync did not finish after watcher shutdown")
 
-	// Close done — Sync can now drain and sweep.
-	close(done)
-	<-syncDone
-
-	// Index must be empty — the fence waited for the drain, then swept
-	// everything including the late entry.
-	assert.Equal(t, 0, index.Size(), "index must be empty after fence drain + sweep")
+	assert.Equal(t, 0, index.Size(), "index must be empty after watcher shutdown and sweep")
 }
 
 // TestNamespaceInformersCreateUpdateDeleteThroughInformer exercises

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -5,7 +5,6 @@
 package endpointcache
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -244,19 +243,66 @@ func TestNamespaceInformersConcurrentSync(t *testing.T) {
 	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
 }
 
-// TestNamespaceInformersFencePreventsResurrection verifies the teardown fence:
-// a slice event queued before offboard but processed during the informer drain
-// must be swept by RemoveNamespace. Without the fence (no <-ni.done wait), the
-// late ApplySlice resurrects the entry after RemoveNamespace — the index ends
-// up non-empty after offboard. With the fence, Sync blocks until the processor
-// drains, then sweeps, so the index is guaranteed empty.
-//
-// A churn goroutine fires Tracker().Add with unique names in a tight loop.
-// A started channel signals when the first event is queued; the main goroutine
-// then calls Sync. Tracker().Add fans out to the informer's watcher natively,
-// so events are constantly in flight. When cancel fires, some events are
-// already queued in the processor — the fence drains them before sweeping.
+// TestNamespaceInformersFencePreventsResurrection verifies the teardown fence
+// deterministically: Sync must block on <-ni.done before RemoveNamespace sweeps
+// the index. Uses an nsInformer with a done channel the test controls directly
+// (same-package access) — no sleeps, no fake-watch timing, no scheduler
+// dependence.
 func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset()
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	// Inject an informer with a done channel we control directly.
+	done := make(chan struct{})
+	nsi.mu.Lock()
+	nsi.informers["ns-a"] = &nsInformer{
+		informer: nil, // not needed — Sync only uses cancel and done
+		cancel:   func() {},
+		done:     done,
+	}
+	nsi.informerCount.Store(1)
+	nsi.mu.Unlock()
+
+	// Populate the index for ns-a so the sweep has something to remove.
+	index.ApplySlice(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	require.Equal(t, 1, index.Size())
+
+	// Call Sync in a goroutine — it must block on <-ni.done.
+	syncDone := make(chan struct{})
+	go func() {
+		nsi.Sync([]string{})
+		close(syncDone)
+	}()
+
+	// Sync must NOT have completed — it's blocked on <-ni.done.
+	select {
+	case <-syncDone:
+		t.Fatal("Sync completed without waiting for done channel — fence missing")
+	default:
+	}
+
+	// Index still has the entry — RemoveNamespace hasn't run yet.
+	assert.Equal(t, 1, index.Size(), "index must not be swept until done fires")
+
+	// Close done — Sync can now drain and sweep.
+	close(done)
+	<-syncDone
+
+	// Index must be empty — the fence waited for the drain, then swept.
+	assert.Equal(t, 0, index.Size(), "index must be empty after fence drain + sweep")
+}
+
+// TestNamespaceInformersCreateUpdateDeleteThroughInformer exercises
+// Create→Update→Delete through the fake client's informer/watch path —
+// the full event lifecycle the shared handlers in handlers.go must handle.
+// The initial LIST replay exercises AddFunc; this test additionally exercises
+// UpdateFunc (via REST Update) and DeleteFunc (via REST Delete), asserting
+// the index converges after each step.
+func TestNamespaceInformersCreateUpdateDeleteThroughInformer(t *testing.T) {
 	t.Parallel()
 
 	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
@@ -264,55 +310,35 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
 	t.Cleanup(nsi.Close)
 
-	// Start informer for ns-a.
+	// Create: initial LIST replay through the informer (AddFunc).
 	nsi.Sync([]string{"ns-a"})
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	waitForIndexSize(t, index, 1)
+	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
 
-	// Churn goroutine: fire Tracker().Add with unique names so every call
-	// succeeds (no AlreadyExists). Signal after first event is queued so the
-	// main goroutine doesn't call Sync before any events are in flight.
-	stop := make(chan struct{})
-	started := make(chan struct{})
-	var churnDone sync.WaitGroup
-	churnDone.Add(1)
-	go func() {
-		defer churnDone.Done()
-		for i := 0; ; i++ {
-			select {
-			case <-stop:
-				return
-			default:
-			}
-			s := makeSlice(fmt.Sprintf("s-churn-%d", i), "ns-a", "fn-a", "10.0.0.2")
-			if err := kubeClient.Tracker().Add(s); err != nil {
-				continue // AlreadyExists from a concurrent Add, retry
-			}
-			if i == 0 {
-				close(started)
-			}
-			// Pace the churn so the fake watcher's channel (default 100)
-			// doesn't overflow before the informer drains events.
-			time.Sleep(time.Microsecond)
-		}
-	}()
-	<-started
+	// Update: REST Update triggers MODIFIED → UpdateFunc → ApplySlice.
+	updated := makeSlice("s1", "ns-a", "fn-a", "10.0.0.2", "10.0.0.3")
+	_, err := kubeClient.DiscoveryV1().EndpointSlices("ns-a").Update(t.Context(), updated, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	// Wait for the endpoints to reflect the update (size stays 1 — same function).
+	require.Eventually(t, func() bool {
+		got := addrs(index.Lookup("ns-a", "fn-a", ""))
+		return len(got) == 2
+	}, 10*time.Second, 10*time.Millisecond, "endpoints must converge after update")
+	assert.ElementsMatch(t, []string{"10.0.0.2:8888", "10.0.0.3:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
 
-	// Offboard: Sync blocks until the informer drains, then sweeps.
-	nsi.Sync([]string{})
-	close(stop)
-	churnDone.Wait()
-
-	// Index must be empty — the fence prevented resurrection.
-	assert.Equal(t, 0, index.Size(), "fence must prevent late ApplySlice from resurrecting entries after offboard")
+	// Delete: REST Delete triggers DELETED → DeleteFunc → DeleteSlice.
+	err = kubeClient.DiscoveryV1().EndpointSlices("ns-a").Delete(t.Context(), "s1", metav1.DeleteOptions{})
+	require.NoError(t, err)
+	require.Eventually(t, func() bool { return index.Size() == 0 }, 10*time.Second, 10*time.Millisecond,
+		"delete must remove the function entry from the index")
+	assert.Empty(t, index.Lookup("ns-a", "fn-a", ""))
 }
 
 // TestEndpointSliceHandlersUpdateAndDelete verifies the extracted UpdateFunc
-// and DeleteFunc handlers in handlers.go. The initial LIST replay exercises
-// AddFunc through the informer; this test exercises the Update and Delete paths
-// directly — including the tombstone unwrap in DeleteFunc — by calling the
-// handler functions, which is simpler and more reliable than relying on the
-// fake clientset's watch MODIFIED/DELETED event delivery.
+// and DeleteFunc handlers in handlers.go — including the tombstone unwrap —
+// by calling the handler functions directly. Covers the unit-level logic that
+// the informer-level test above exercises end-to-end.
 func TestEndpointSliceHandlersUpdateAndDelete(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package endpointcache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// makeSlice builds a Fission-managed EndpointSlice in the given namespace.
+func makeSlice(name, ns, fnName string, addrs ...string) *discoveryv1.EndpointSlice {
+	port := int32(8888)
+	ready := true
+	es := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels: map[string]string{
+				fv1.FUNCTION_NAME:      fnName,
+				fv1.FUNCTION_NAMESPACE: ns,
+				fv1.MANAGED_BY_LABEL:   fv1.MANAGED_BY_VALUE,
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{{Port: &port}},
+	}
+	for _, a := range addrs {
+		es.Endpoints = append(es.Endpoints, discoveryv1.Endpoint{
+			Addresses:  []string{a},
+			Conditions: discoveryv1.EndpointConditions{Ready: &ready},
+		})
+	}
+	return es
+}
+
+// TestNamespaceInformersSyncStartsAndStops verifies that Sync starts informers
+// for new namespaces and stops them for removed ones, feeding the Index from
+// the fake client's pre-populated EndpointSlices. Uses WaitForCacheSync as the
+// deterministic sync point (no polling). Close is registered via t.Cleanup so
+// informer goroutines don't outlive the test.
+func TestNamespaceInformersSyncStartsAndStops(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(
+		makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"),
+		makeSlice("s2", "ns-b", "fn-b", "10.0.0.2"),
+	)
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	// Start informers for both namespaces.
+	nsi.Sync([]string{"ns-a", "ns-b"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()), "both informers should sync")
+	waitForIndexSize(t, index, 2)
+
+	// Both functions must be in the index — proves the informers fed it.
+	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+	assert.ElementsMatch(t, []string{"10.0.0.2:8888"}, addrs(index.Lookup("ns-b", "fn-b", "")))
+
+	// Stop ns-b's informer; its entries must be swept from the index.
+	// Sync waits for the informer goroutine to exit before sweeping, so the
+	// index state is deterministic after Sync returns.
+	nsi.Sync([]string{"ns-a"})
+	assert.Empty(t, index.Lookup("ns-b", "fn-b", ""), "ns-b entries must be removed after stop")
+	assert.NotEmpty(t, index.Lookup("ns-a", "fn-a", ""), "ns-a must survive")
+	assert.Equal(t, 1, index.Size(), "only ns-a remains after ns-b offboard")
+}
+
+// TestNamespaceInformersSyncIdempotent verifies that calling Sync with the
+// same namespace set twice does not double-feed the index. Asserted through
+// the exported Index.Size() (observable behavior), not by inspecting private
+// informer map state.
+func TestNamespaceInformersSyncIdempotent(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()), "informer should sync")
+	waitForIndexSize(t, index, 1)
+
+	nsi.Sync([]string{"ns-a"}) // same set, no-op
+	assert.Equal(t, 1, index.Size(), "second Sync with same set must not double-feed")
+	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+}
+
+// TestNamespaceInformersHasSyncedEmpty verifies HasSynced returns true when
+// no informers are running (vacuously true — nothing to sync).
+func TestNamespaceInformersHasSyncedEmpty(t *testing.T) {
+	t.Parallel()
+	nsi := NewNamespaceInformers(fake.NewSimpleClientset(), NewIndex(), logr.Discard())
+	t.Cleanup(nsi.Close)
+	assert.True(t, nsi.HasSynced(), "empty informer set is vacuously synced")
+}
+
+// waitForIndexSize waits for the index to reach size n. WaitForCacheSync only
+// guarantees the reflector's initial LIST is stored; the Add notifications
+// still travel through the informer's async processor before ApplySlice runs,
+// so index state is genuinely eventual-convergence after a sync (bounded here
+// — never a bare sleep).
+func waitForIndexSize(t *testing.T, index *Index, n int) {
+	t.Helper()
+	require.Eventuallyf(t, func() bool {
+		return index.Size() == n
+	}, 10*time.Second, 10*time.Millisecond, "index size never converged to %d", n)
+}
+
+// TestNamespaceInformersCloseStopsAll verifies that Close stops every running
+// informer goroutine and sweeps nothing (Close is lifecycle-only; index
+// sweeping is Sync's job). After Close, the index is still queryable but no
+// new events arrive.
+func TestNamespaceInformersCloseStopsAll(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()), "informer should sync")
+	waitForIndexSize(t, index, 1)
+
+	// Close must return (not hang) — proves the done channel fires.
+	nsi.Close()
+
+	// Index state survives Close (Close doesn't sweep).
+	assert.Equal(t, 1, index.Size(), "Close must not sweep the index")
+}
+
+// TestNamespaceInformersOffboardReonboard exercises the PRD §11.1 lifecycle:
+// onboard → offboard → re-onboard the same namespace. After the fence, a
+// re-onboarded informer must deliver fresh entries, and a final offboard must
+// leave the index empty — no stale resurrection, no overlap.
+func TestNamespaceInformersOffboardReonboard(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	waitForIndexSize(t, index, 1)
+
+	// Offboard: Sync blocks until the informer drains, so the sweep is final.
+	nsi.Sync([]string{})
+	assert.Equal(t, 0, index.Size(), "offboard must sweep all entries")
+
+	// Re-onboard: a fresh informer replays the slice.
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	waitForIndexSize(t, index, 1)
+	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+
+	// Final offboard leaves nothing behind.
+	nsi.Sync([]string{})
+	assert.Equal(t, 0, index.Size())
+}
+
+// TestNamespaceInformersConcurrentSync hammers Sync from multiple goroutines
+// with alternating desired sets (offboard/re-onboard overlap). Under -race
+// this exercises the serialization: the final Sync must leave exactly the
+// desired entries, never a stale or duplicated set.
+func TestNamespaceInformersConcurrentSync(t *testing.T) {
+	t.Parallel()
+
+	kubeClient := fake.NewSimpleClientset(makeSlice("s1", "ns-a", "fn-a", "10.0.0.1"))
+	index := NewIndex()
+	nsi := NewNamespaceInformers(kubeClient, index, logr.Discard())
+	t.Cleanup(nsi.Close)
+
+	const workers = 4
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Go(func() {
+			for range 10 {
+				nsi.Sync([]string{"ns-a"})
+				nsi.Sync([]string{})
+			}
+		})
+	}
+	wg.Wait()
+
+	// Converge on ns-a: the fence guarantees the surviving informer is the
+	// only writer, and its replay yields exactly one entry.
+	nsi.Sync([]string{"ns-a"})
+	require.True(t, nsi.WaitForCacheSync(t.Context()))
+	waitForIndexSize(t, index, 1)
+	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+}

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -70,8 +70,8 @@ func TestNamespaceInformersSyncStartsAndStops(t *testing.T) {
 	waitForIndexSize(t, index, 2)
 
 	// Both functions must be in the index — proves the informers fed it.
-	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
-	assert.ElementsMatch(t, []string{"10.0.0.2:8888"}, addrs(index.Lookup("ns-b", "fn-b", "")))
+	waitForEndpoints(t, index, "ns-a", "fn-a", "10.0.0.1:8888")
+	waitForEndpoints(t, index, "ns-b", "fn-b", "10.0.0.2:8888")
 
 	// Stop ns-b's informer; its entries must be swept from the index.
 	// Sync waits for the informer goroutine to exit before sweeping, so the
@@ -117,11 +117,27 @@ func TestNamespaceInformersHasSyncedEmpty(t *testing.T) {
 // still travel through the informer's async processor before ApplySlice runs,
 // so index state is genuinely eventual-convergence after a sync (bounded here
 // — never a bare sleep).
+//
+// Size() alone is NOT a sufficient sync point for asserting on endpoints:
+// ApplySlice creates the entry and bumps ix.size under the SHARD lock, releases
+// it, and only then fills e.slices and rebuilds under the ENTRY lock. A poller
+// can therefore observe the entry while Lookup still returns nothing. Use
+// waitForEndpoints whenever the next assertion is about addresses.
 func waitForIndexSize(t *testing.T, index *Index, n int) {
 	t.Helper()
 	require.Eventuallyf(t, func() bool {
 		return index.Size() == n
 	}, 10*time.Second, 10*time.Millisecond, "index size never converged to %d", n)
+}
+
+// waitForEndpoints waits until the function's endpoint set matches want. It
+// polls the very thing being asserted, so unlike waitForIndexSize it cannot
+// observe the half-applied entry described above.
+func waitForEndpoints(t *testing.T, index *Index, ns, fn string, want ...string) {
+	t.Helper()
+	require.EventuallyWithTf(t, func(c *assert.CollectT) {
+		assert.ElementsMatch(c, want, addrs(index.Lookup(ns, fn, "")))
+	}, 10*time.Second, 10*time.Millisecond, "endpoints for %s/%s never converged to %v", ns, fn, want)
 }
 
 // blockingStopWatch lets a test hold a real informer inside watcher shutdown.
@@ -248,7 +264,7 @@ func TestNamespaceInformersOffboardReonboard(t *testing.T) {
 	nsi.Sync([]string{"ns-a"})
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	waitForIndexSize(t, index, 1)
-	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+	waitForEndpoints(t, index, "ns-a", "fn-a", "10.0.0.1:8888")
 
 	// Final offboard leaves nothing behind.
 	nsi.Sync([]string{})
@@ -284,7 +300,7 @@ func TestNamespaceInformersConcurrentSync(t *testing.T) {
 	nsi.Sync([]string{"ns-a"})
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	waitForIndexSize(t, index, 1)
-	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+	waitForEndpoints(t, index, "ns-a", "fn-a", "10.0.0.1:8888")
 }
 
 // TestNamespaceInformersFencePreventsResurrection verifies that the real done
@@ -387,18 +403,14 @@ func TestNamespaceInformersCreateUpdateDeleteThroughInformer(t *testing.T) {
 	nsi.Sync([]string{"ns-a"})
 	require.True(t, nsi.WaitForCacheSync(t.Context()))
 	waitForIndexSize(t, index, 1)
-	assert.ElementsMatch(t, []string{"10.0.0.1:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+	waitForEndpoints(t, index, "ns-a", "fn-a", "10.0.0.1:8888")
 
 	// Update: REST Update triggers MODIFIED → UpdateFunc → ApplySlice.
 	updated := makeSlice("s1", "ns-a", "fn-a", "10.0.0.2", "10.0.0.3")
 	_, err := kubeClient.DiscoveryV1().EndpointSlices("ns-a").Update(t.Context(), updated, metav1.UpdateOptions{})
 	require.NoError(t, err)
-	// Wait for the endpoints to reflect the update (size stays 1 — same function).
-	require.Eventually(t, func() bool {
-		got := addrs(index.Lookup("ns-a", "fn-a", ""))
-		return len(got) == 2
-	}, 10*time.Second, 10*time.Millisecond, "endpoints must converge after update")
-	assert.ElementsMatch(t, []string{"10.0.0.2:8888", "10.0.0.3:8888"}, addrs(index.Lookup("ns-a", "fn-a", "")))
+	// Size stays 1 — same function; only the endpoint set changes.
+	waitForEndpoints(t, index, "ns-a", "fn-a", "10.0.0.2:8888", "10.0.0.3:8888")
 
 	// Delete: REST Delete triggers DELETED → DeleteFunc → DeleteSlice.
 	err = kubeClient.DiscoveryV1().EndpointSlices("ns-a").Delete(t.Context(), "s1", metav1.DeleteOptions{})

--- a/pkg/router/endpointcache/nsinformers_test.go
+++ b/pkg/router/endpointcache/nsinformers_test.go
@@ -282,7 +282,7 @@ func TestNamespaceInformersFencePreventsResurrection(t *testing.T) {
 			default:
 			}
 			s := makeSlice("s-churn", "ns-a", "fn-a", "10.0.0.2")
-			kubeClient.Tracker().Add(s)
+			_ = kubeClient.Tracker().Add(s)
 		}
 	}()
 	// Brief window so at least a few events are in the processor queue.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -569,7 +569,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// AddResolverSync further down. A hook returns pending=true to make the
 	// reconciler requeue (no FissionTenant event fires when the missing piece
 	// is a RoleBinding provisioned asynchronously by the tenant controller).
-	var resolverSyncHooks []func(map[string]string) (pending bool)
+	var resolverSyncHooks []func() (pending bool)
 
 	if cfg.endpointSliceCacheMode != endpointSliceCacheOff {
 		index := endpointcache.NewIndex()
@@ -634,7 +634,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 				return fmt.Errorf("error registering tenant seed runnable: %w", err)
 			}
 			endpointsSynced = nsInformers.HasSynced
-			resolverSyncHooks = append(resolverSyncHooks, func(_ map[string]string) (pending bool) {
+			resolverSyncHooks = append(resolverSyncHooks, func() (pending bool) {
 				return dynCache.syncInformers(ctx)
 			})
 			// Stop all informers when the router's context is cancelled.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -134,12 +134,15 @@ func routerCacheOptions(mode endpointSliceCacheMode) crcache.Options {
 // symptom is a reflector error log. The chart renders the required Role +
 // RoleBinding (router/role-dataplane.yaml) whenever
 // router.endpointSliceCache.mode != off; bespoke-RBAC installs must mirror it.
+// On success it returns the exact namespace scopes that passed the review so
+// dynamic mode can seed its RBAC cache without repeating the same checks during
+// informer setup.
 //
 // Callers degrade to mode=off on error rather than exiting: the slice cache is
 // a warm-path optimization with a full legacy fallback, and crash-looping the
 // data plane over a missing optimization grant (e.g. a GitOps prune dropping
 // the Role) would turn it into an outage.
-func checkSliceWatchRBAC(ctx context.Context, kubeClient kubernetes.Interface) error {
+func checkSliceWatchRBAC(ctx context.Context, kubeClient kubernetes.Interface) ([]string, error) {
 	// Cluster mode watches EndpointSlices cluster-wide, so a single cluster-scoped
 	// review (empty Namespace) is the right preflight; other modes check each
 	// function namespace the informer scopes to.
@@ -149,10 +152,10 @@ func checkSliceWatchRBAC(ctx context.Context, kubeClient kubernetes.Interface) e
 	}
 	for _, ns := range watchNamespaces {
 		if err := checkSliceWatchRBACForNamespace(ctx, kubeClient, ns); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return watchNamespaces, nil
 }
 
 // checkSliceWatchRBACForNamespace verifies list+watch on EndpointSlices in one
@@ -336,7 +339,10 @@ func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool)
 //
 // The returned InformerSynced gates router readiness: it is true only after
 // every running informer has completed its initial LIST. The internal informer
-// manager is closed when ctx is cancelled.
+// manager is closed when ctx is cancelled. Successful startup preflight results
+// seed rbacChecked so the initial informer sync does not repeat the same
+// permission checks. Existing pruning removes those results when a namespace is
+// offboarded, so re-onboarding still performs fresh checks.
 func setupDynamicEndpointCache(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
@@ -344,6 +350,7 @@ func setupDynamicEndpointCache(
 	crMgr ctrl.Manager,
 	resolverSyncHooks []func() (pending bool),
 	logger logr.Logger,
+	precheckedSliceNamespaces []string,
 ) (cache.InformerSynced, []func() (pending bool), error) {
 	nsInformers := endpointcache.NewNamespaceInformers(kubeClient, index, logger.WithName("endpointcache"))
 	resolver := utils.DefaultNSResolver()
@@ -352,6 +359,10 @@ func setupDynamicEndpointCache(
 		resolver:    resolver,
 		nsInformers: nsInformers,
 		logger:      logger,
+	}
+	// Reuse successful startup preflight results during initial informer sync.
+	for _, ns := range precheckedSliceNamespaces {
+		dynCache.rbacChecked.Store(ns, struct{}{})
 	}
 	// Stop all informers when the router's context is cancelled.
 	go func() {
@@ -574,12 +585,14 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		"idleConnTimeout", transportIdleConnTimeout)
 
 	requestedMode := cfg.endpointSliceCacheMode
+	var precheckedSliceNamespaces []string
 	if cfg.endpointSliceCacheMode != endpointSliceCacheOff {
-		if rerr := checkSliceWatchRBAC(ctx, kubeClient); rerr != nil {
-			logger.Error(rerr, "disabling the EndpointSlice cache (degrading to the executor-RPC data plane)",
-				"requested_mode", cfg.endpointSliceCacheMode)
+		nsList, rerr := checkSliceWatchRBAC(ctx, kubeClient)
+		if rerr != nil {
+			logger.Error(rerr, "disabling the EndpointSlice cache (degrading to the executor-RPC data plane)", "requested_mode", cfg.endpointSliceCacheMode)
 			cfg.endpointSliceCacheMode = endpointSliceCacheOff
 		}
+		precheckedSliceNamespaces = nsList
 	}
 	// Registered unconditionally so the requested-vs-effective mode is
 	// alertable: an absent series cannot distinguish "mode=off install" from
@@ -663,7 +676,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 			// added later — this replaces it entirely in dynamic mode. The
 			// resolver-sync hook calls Sync on every FissionTenant change, so
 			// no restart is needed to admit a new tenant's warm path.
-			endpointsSynced, resolverSyncHooks, err = setupDynamicEndpointCache(ctx, kubeClient, index, crMgr, resolverSyncHooks, logger)
+			endpointsSynced, resolverSyncHooks, err = setupDynamicEndpointCache(ctx, kubeClient, index, crMgr, resolverSyncHooks, logger, precheckedSliceNamespaces)
 			if err != nil {
 				return err
 			}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -227,6 +227,8 @@ func sliceWatchSAR(ctx context.Context, kubeClient kubernetes.Interface, ns, ver
 	return res, err
 }
 
+const maxOptimisticSARErrors = 3
+
 // dynamicEndpointCache manages per-namespace EndpointSlice informers in dynamic
 // tenancy mode. It re-scopes the informer set as tenants are onboarded/offboarded,
 // gating each namespace on a SelfSubjectAccessReview so a namespace whose
@@ -245,6 +247,7 @@ type dynamicEndpointCache struct {
 	nsInformers *endpointcache.NamespaceInformers
 	rbacChecked sync.Map
 	logger      logr.Logger
+	sarErrors   map[string]int
 	mu          sync.Mutex // serializes syncInformers; prevents TOCTOU on namespace set
 }
 
@@ -257,6 +260,9 @@ type dynamicEndpointCache struct {
 func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	if d.sarErrors == nil {
+		d.sarErrors = make(map[string]int)
+	}
 	// Re-read inside the lock: the namespace set may have changed since the
 	// caller was invoked (startup seed vs. post-cache-sync re-seed vs. hook).
 	// Reading after the lock makes last-writer-wins converge — no namespace
@@ -278,6 +284,13 @@ func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool)
 		}
 		return true
 	})
+	// Drop stale error counts for namespaces that left the live set.
+	for ns := range d.sarErrors {
+		if _, ok := live[ns]; !ok {
+			delete(d.sarErrors, ns)
+		}
+	}
+
 	allowed := make([]string, 0, len(namespaces))
 	for _, ns := range namespaces {
 		if _, ok := d.rbacChecked.Load(ns); ok {
@@ -286,20 +299,24 @@ func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool)
 		}
 		ok, err := sliceWatchAllowedForNamespace(ctx, d.kubeClient, ns)
 		if err != nil {
-			// Transient SAR failure — optimistic include; the
-			// reflector's own retry absorbs apiserver flakes.
-			// Still mark pending: if the namespace genuinely lacks
-			// RBAC the informer can never sync, and no FissionTenant
-			// event will fire to re-run this check.
-			d.logger.Error(err, "endpointslice RBAC check failed transiently; keeping informer", "namespace", ns)
-			allowed = append(allowed, ns)
+			// we check for SAR errors optimistically; if the namespace
+			// continues to fail we exclude it from the informer set
+			d.sarErrors[ns]++
 			pending = true
+			if d.sarErrors[ns] <= maxOptimisticSARErrors {
+				d.logger.Info("endpointslice RBAC check failed transiently; keeping informer", "namespace", ns)
+				allowed = append(allowed, ns)
+				continue
+			}
+			d.logger.Error(err, "endpointslice RBAC check continues to fail; excluding namespace", "namespace", ns, "consecutive_errors", d.sarErrors[ns])
 			continue
 		}
+		delete(d.sarErrors, ns)
 		if !ok {
 			d.logger.Info("endpointslice RBAC not yet granted for tenant namespace; "+
 				"the tenant controller provisions fission-router-dataplane at onboarding — "+
-				"namespace excluded from the warm path until it lands", "namespace", ns)
+				"namespace excluded from the warm path until it lands", "namespace", ns,
+			)
 			pending = true
 			continue
 		}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -310,6 +310,66 @@ func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool)
 	return pending
 }
 
+// setupDynamicEndpointCache wires the dynamic-mode EndpointSlice data plane:
+// creates the per-namespace informer manager, seeds the informer set from the
+// env config immediately (so HasSynced isn't vacuously true with zero informers),
+// and registers a post-cache-sync RunnableFunc that re-seeds from the LIVE
+// FissionTenant set. The resolver-sync hook calls Sync on every FissionTenant
+// change, so no restart is needed to admit a new tenant's warm path.
+//
+// The returned InformerSynced gates router readiness: it is true only after
+// every running informer has completed its initial LIST. The caller must not
+// call Close — the returned nsInformers is closed by the ctx-cancel goroutine
+// registered here.
+func setupDynamicEndpointCache(
+	ctx context.Context,
+	kubeClient kubernetes.Interface,
+	index *endpointcache.Index,
+	crMgr ctrl.Manager,
+	resolverSyncHooks []func() (pending bool),
+	logger logr.Logger,
+) (cache.InformerSynced, []func() (pending bool), error) {
+	nsInformers := endpointcache.NewNamespaceInformers(kubeClient, index, logger.WithName("endpointcache"))
+	resolver := utils.DefaultNSResolver()
+	dynCache := &dynamicEndpointCache{
+		kubeClient:  kubeClient,
+		resolver:    resolver,
+		nsInformers: nsInformers,
+		logger:      logger,
+	}
+	// Seed with the env seed immediately so HasSynced isn't vacuously
+	// true with zero informers. The RunnableFunc below re-seeds from
+	// the LIVE FissionTenant set after the Manager cache syncs (the
+	// direct client list fails before the cache starts).
+	dynCache.syncInformers(ctx)
+	// After the Manager cache syncs, re-seed the resolver from existing
+	// FissionTenant CRs and re-sync the informers to cover tenants that
+	// existed before startup. This closes the gap between the env-seed
+	// and the live tenant set (the resolver-sync reconciler hasn't run
+	// yet — it's registered below and fires on its first Reconcile).
+	// Log-and-continue on error: the reconciler retries on the next
+	// FissionTenant event, so a transient cache miss isn't fatal.
+	if err := crMgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		if err := tenant.SyncResolverFromTenants(ctx, crMgr.GetClient(), resolver); err != nil {
+			logger.Error(err, "error seeding resolver from existing tenants — reconciler will retry")
+			return nil
+		}
+		dynCache.syncInformers(ctx)
+		return nil
+	})); err != nil {
+		return nil, nil, fmt.Errorf("error registering tenant seed runnable: %w", err)
+	}
+	resolverSyncHooks = append(resolverSyncHooks, func() (pending bool) {
+		return dynCache.syncInformers(ctx)
+	})
+	// Stop all informers when the router's context is cancelled.
+	go func() {
+		<-ctx.Done()
+		nsInformers.Close()
+	}()
+	return nsInformers.HasSynced, resolverSyncHooks, nil
+}
+
 // runnableFunc adapts a function to a controller-runtime manager.Runnable.
 type runnableFunc func(context.Context) error
 
@@ -586,45 +646,10 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 			// added later — this replaces it entirely in dynamic mode. The
 			// resolver-sync hook calls Sync on every FissionTenant change, so
 			// no restart is needed to admit a new tenant's warm path.
-			nsInformers := endpointcache.NewNamespaceInformers(kubeClient, index, logger.WithName("endpointcache"))
-			resolver := utils.DefaultNSResolver()
-			dynCache := &dynamicEndpointCache{
-				kubeClient:  kubeClient,
-				resolver:    resolver,
-				nsInformers: nsInformers,
-				logger:      logger,
+			endpointsSynced, resolverSyncHooks, err = setupDynamicEndpointCache(ctx, kubeClient, index, crMgr, resolverSyncHooks, logger)
+			if err != nil {
+				return err
 			}
-			// Seed with the env seed immediately so HasSynced isn't vacuously
-			// true with zero informers. The RunnableFunc below re-seeds from
-			// the LIVE FissionTenant set after the Manager cache syncs (the
-			// direct client list fails before the cache starts).
-			dynCache.syncInformers(ctx)
-			// After the Manager cache syncs, re-seed the resolver from existing
-			// FissionTenant CRs and re-sync the informers to cover tenants that
-			// existed before startup. This closes the gap between the env-seed
-			// and the live tenant set (the resolver-sync reconciler hasn't run
-			// yet — it's registered below and fires on its first Reconcile).
-			// Log-and-continue on error: the reconciler retries on the next
-			// FissionTenant event, so a transient cache miss isn't fatal.
-			if err := crMgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
-				if err := tenant.SyncResolverFromTenants(ctx, crMgr.GetClient(), resolver); err != nil {
-					logger.Error(err, "error seeding resolver from existing tenants — reconciler will retry")
-					return nil
-				}
-				dynCache.syncInformers(ctx)
-				return nil
-			})); err != nil {
-				return fmt.Errorf("error registering tenant seed runnable: %w", err)
-			}
-			endpointsSynced = nsInformers.HasSynced
-			resolverSyncHooks = append(resolverSyncHooks, func() (pending bool) {
-				return dynCache.syncInformers(ctx)
-			})
-			// Stop all informers when the router's context is cancelled.
-			go func() {
-				<-ctx.Done()
-				nsInformers.Close()
-			}()
 		} else {
 			// Static + cluster modes: the manager-cache informer (scoped at
 			// startup) covers all watched namespaces — no runtime re-scoping

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -36,6 +36,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -50,9 +51,11 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	crcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
@@ -145,47 +148,83 @@ func checkSliceWatchRBAC(ctx context.Context, kubeClient kubernetes.Interface) e
 		watchNamespaces = []string{""}
 	}
 	for _, ns := range watchNamespaces {
-		for _, verb := range []string{"list", "watch"} {
-			sar := &authorizationv1.SelfSubjectAccessReview{
-				Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-					ResourceAttributes: &authorizationv1.ResourceAttributes{
-						Namespace: ns,
-						Verb:      verb,
-						Group:     "discovery.k8s.io",
-						Resource:  "endpointslices",
-					},
-				},
-			}
-			// Retry the review itself: a transient apiserver error during boot
-			// must not degrade the data plane for the router's whole lifetime.
-			// Only an explicit Allowed=false (genuinely missing RBAC) or a
-			// persistent API failure degrades.
-			var res *authorizationv1.SelfSubjectAccessReview
-			var err error
-			for attempt := range 3 {
-				if attempt > 0 {
-					select {
-					case <-ctx.Done():
-						return ctx.Err()
-					case <-time.After(2 * time.Second):
-					}
-				}
-				res, err = kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
-				if err == nil {
-					break
-				}
-			}
-			if err != nil {
-				return fmt.Errorf("error checking endpointslice RBAC in namespace %q: %w", ns, err)
-			}
-			if !res.Status.Allowed {
-				return fmt.Errorf("router is not allowed to %s endpointslices in namespace %q "+
-					"(reason: %s); the Helm chart renders the required router-dataplane Role for "+
-					"router.endpointSliceCache.mode != off — grant the RBAC to enable the EndpointSlice data plane", verb, ns, res.Status.Reason)
-			}
+		if err := checkSliceWatchRBACForNamespace(ctx, kubeClient, ns); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+// checkSliceWatchRBACForNamespace verifies list+watch on EndpointSlices in one
+// namespace via SelfSubjectAccessReview, returning an actionable error. Used by
+// the startup preflight.
+func checkSliceWatchRBACForNamespace(ctx context.Context, kubeClient kubernetes.Interface, ns string) error {
+	for _, verb := range []string{"list", "watch"} {
+		res, err := sliceWatchSAR(ctx, kubeClient, ns, verb)
+		if err != nil {
+			return fmt.Errorf("error checking endpointslice RBAC in namespace %q: %w", ns, err)
+		}
+		if !res.Status.Allowed {
+			return fmt.Errorf("router is not allowed to %s endpointslices in namespace %q "+
+				"(reason: %s); the Helm chart renders the required router-dataplane Role for "+
+				"router.endpointSliceCache.mode != off — grant the RBAC to enable the EndpointSlice data plane", verb, ns, res.Status.Reason)
+		}
+	}
+	return nil
+}
+
+// sliceWatchAllowedForNamespace reports whether the router may list+watch
+// EndpointSlices in one namespace. The dynamic-tenancy resolver-sync hook uses
+// it to EXCLUDE explicitly-denied namespaces from the informer set: a namespace
+// onboarded at runtime gets its fission-router-dataplane RoleBinding from the
+// tenant controller, which races the informer start (issue #3647), and an
+// orphaned FissionTenant (namespace deleted) can never pass — either way the
+// informer must not wedge readiness on a LIST that only fails. A transient
+// apiserver error is reported as allowed (optimistic: the informer's own
+// reflector retry handles flakes) so a wobble never tears down working watches.
+func sliceWatchAllowedForNamespace(ctx context.Context, kubeClient kubernetes.Interface, ns string) (bool, error) {
+	for _, verb := range []string{"list", "watch"} {
+		res, err := sliceWatchSAR(ctx, kubeClient, ns, verb)
+		if err != nil {
+			return true, fmt.Errorf("error checking endpointslice RBAC in namespace %q: %w", ns, err)
+		}
+		if !res.Status.Allowed {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// sliceWatchSAR issues one SelfSubjectAccessReview for verb+endpointslices in
+// ns, retrying transient apiserver errors (a boot-time flake must not degrade
+// the data plane for the router's whole lifetime).
+func sliceWatchSAR(ctx context.Context, kubeClient kubernetes.Interface, ns, verb string) (*authorizationv1.SelfSubjectAccessReview, error) {
+	sar := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: ns,
+				Verb:      verb,
+				Group:     "discovery.k8s.io",
+				Resource:  "endpointslices",
+			},
+		},
+	}
+	var res *authorizationv1.SelfSubjectAccessReview
+	var err error
+	for attempt := range 3 {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(2 * time.Second):
+			}
+		}
+		res, err = kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
+		if err == nil {
+			break
+		}
+	}
+	return res, err
 }
 
 // runnableFunc adapts a function to a controller-runtime manager.Runnable.
@@ -441,16 +480,118 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// shape changes.
 	triggers.initIncrementalRoutes()
 
-	// EndpointSlice-fed endpoint index (RFC-0002). Every router replica watches
-	// independently (no leader election — that is the point: warm-path state is
-	// replica-local). The fallback resolver serves the warm path from the
-	// index and uses the executor for cold starts, capacity, and strict-mode
-	// functions.
+	// resolverSyncHooks collects hooks for the tenant resolver-sync reconciler.
+	// The EndpointSlice block below may append one so per-namespace informers
+	// re-scope when tenants are onboarded/offboarded at runtime. Passed to
+	// AddResolverSync further down. A hook returns pending=true to make the
+	// reconciler requeue (no FissionTenant event fires when the missing piece
+	// is a RoleBinding provisioned asynchronously by the tenant controller).
+	var resolverSyncHooks []func(map[string]string) (pending bool)
+
 	if cfg.endpointSliceCacheMode != endpointSliceCacheOff {
 		index := endpointcache.NewIndex()
-		endpointsSynced, err := endpointcache.RegisterInformer(ctx, crMgr, index, logger)
-		if err != nil {
-			return fmt.Errorf("error registering endpointslice informer: %w", err)
+		endpointcache.RegisterSizeGauge(index)
+		executorResolver, ok := triggers.addressResolver.(*executorResolver)
+		if !ok {
+			return fmt.Errorf("unexpected address resolver type %T", triggers.addressResolver)
+		}
+		var endpointsSynced cache.InformerSynced
+		if utils.DynamicNamespacesEnabled() {
+			// Dynamic tenancy: per-namespace informers that re-scope at runtime
+			// as tenants are onboarded/offboarded. The manager-cache informer is
+			// frozen at startup, so it cannot see EndpointSlices in namespaces
+			// added later — this replaces it entirely in dynamic mode. The
+			// resolver-sync hook calls Sync on every FissionTenant change, so
+			// no restart is needed to admit a new tenant's warm path.
+			nsInformers := endpointcache.NewNamespaceInformers(kubeClient, index, logger.WithName("endpointcache"))
+			resolver := utils.DefaultNSResolver()
+			// rbacChecked caches namespaces whose EndpointSlice RBAC has passed
+			// the SelfSubjectAccessReview. A namespace onboarded at runtime gets
+			// its fission-router-dataplane RoleBinding from the tenant controller,
+			// which races the informer start (issue #3647), and an orphaned
+			// FissionTenant (namespace deleted) can never pass — so explicitly-
+			// denied namespaces are EXCLUDED from the informer set (their functions
+			// fall back to the executor RPC, same as the legacy data plane) and
+			// re-checked on every reconcile until the binding lands. Exclusion is
+			// what keeps one bad namespace from wedging /readyz for every tenant.
+			var rbacChecked sync.Map
+			// syncInformers re-scopes the informer set to the resolver's live
+			// namespaces, filtered by EndpointSlice RBAC. Shared by the startup
+			// seed, the post-cache-sync re-seed, and the resolver-sync hook so
+			// all three apply the same exclusion semantics. Returns pending=true
+			// when any namespace is still waiting on its RBAC — the reconciler
+			// requeues until every namespace passes (no tenant event fires for
+			// a RoleBinding the tenant controller creates asynchronously).
+			syncInformers := func() (pending bool) {
+				namespaces := resolver.FunctionNamespaces()
+				allowed := make([]string, 0, len(namespaces))
+				for _, ns := range namespaces {
+					if _, ok := rbacChecked.Load(ns); ok {
+						allowed = append(allowed, ns)
+						continue
+					}
+					ok, err := sliceWatchAllowedForNamespace(ctx, kubeClient, ns)
+					if err != nil {
+						// Transient SAR failure — optimistic include; the
+						// reflector's own retry absorbs apiserver flakes.
+						logger.Error(err, "endpointslice RBAC check failed transiently; keeping informer", "namespace", ns)
+						allowed = append(allowed, ns)
+						continue
+					}
+					if !ok {
+						logger.Info("endpointslice RBAC not yet granted for tenant namespace; "+
+							"the tenant controller provisions fission-router-dataplane at onboarding — "+
+							"namespace excluded from the warm path until it lands", "namespace", ns)
+						pending = true
+						continue
+					}
+					rbacChecked.Store(ns, struct{}{})
+					allowed = append(allowed, ns)
+				}
+				nsInformers.Sync(allowed)
+				return pending
+			}
+			// Seed with the env seed immediately so HasSynced isn't vacuously
+			// true with zero informers. The RunnableFunc below re-seeds from
+			// the LIVE FissionTenant set after the Manager cache syncs (the
+			// direct client list fails before the cache starts).
+			syncInformers()
+			// After the Manager cache syncs, re-seed the resolver from existing
+			// FissionTenant CRs and re-sync the informers to cover tenants that
+			// existed before startup. This closes the gap between the env-seed
+			// and the live tenant set (the resolver-sync reconciler hasn't run
+			// yet — it's registered below and fires on its first Reconcile).
+			// Log-and-continue on error: the reconciler retries on the next
+			// FissionTenant event, so a transient cache miss isn't fatal.
+			if err := crMgr.Add(manager.RunnableFunc(func(ctx context.Context) error {
+				if err := tenant.SyncResolverFromTenants(ctx, crMgr.GetClient(), resolver); err != nil {
+					logger.Error(err, "error seeding resolver from existing tenants — reconciler will retry")
+					return nil
+				}
+				syncInformers()
+				return nil
+			})); err != nil {
+				return fmt.Errorf("error registering tenant seed runnable: %w", err)
+			}
+			endpointsSynced = nsInformers.HasSynced
+			resolverSyncHooks = append(resolverSyncHooks, func(_ map[string]string) (pending bool) {
+				return syncInformers()
+			})
+			// Stop all informers when the router's context is cancelled.
+			go func() {
+				<-ctx.Done()
+				nsInformers.Close()
+			}()
+		} else {
+			// Static + cluster modes: the manager-cache informer (scoped at
+			// startup) covers all watched namespaces — no runtime re-scoping
+			// needed. Cluster mode watches cluster-wide; static mode watches
+			// the env-seeded set, both fixed for the process lifetime.
+			var err error
+			endpointsSynced, err = endpointcache.RegisterInformer(ctx, crMgr, index, logger)
+			if err != nil {
+				return fmt.Errorf("error registering endpointslice informer: %w", err)
+			}
 		}
 		// Gate readiness on the index having seen the initial replay, not just
 		// on the Manager's cache being populated: a Ready replica with a
@@ -458,24 +599,20 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		// fallback instead of the fast path — a latency cliff precisely during
 		// a rolling upgrade (RFC-0028 §2).
 		triggers.endpointsSynced = endpointsSynced
-		endpointcache.RegisterSizeGauge(index)
-		execResolver, ok := triggers.addressResolver.(*executorResolver)
-		if !ok {
-			return fmt.Errorf("unexpected address resolver type %T", triggers.addressResolver)
-		}
 		switch cfg.endpointSliceCacheMode {
 		case endpointSliceCacheOn:
 			// The client interface carries EnsureCapacity since phase 4; an
 			// OLD executor (predating /v2/ensureCapacity) still degrades at
 			// runtime via the 404 → legacy-RPC fallback in the resolver.
-			triggers.addressResolver = newFallbackResolver(logger, index, execResolver, executor, cfg.endpointSliceEndpointLB)
+			triggers.addressResolver = newFallbackResolver(logger, index, executorResolver, executor, cfg.endpointSliceEndpointLB)
 		default:
 			// Unreachable: loadRouterConfig validates the mode. The guard
 			// keeps a future refactor from silently paying for the informer
 			// while leaving the legacy resolver wired.
 			return fmt.Errorf("unhandled endpointslice cache mode %q", cfg.endpointSliceCacheMode)
 		}
-		logger.Info("endpointslice cache enabled", "mode", cfg.endpointSliceCacheMode, "endpoint_lb", cfg.endpointSliceEndpointLB)
+		logger.Info("endpointslice cache enabled", "mode", cfg.endpointSliceCacheMode, "endpoint_lb", cfg.endpointSliceEndpointLB,
+			"dynamic", utils.DynamicNamespacesEnabled())
 	}
 
 	// Build the route providers. The ingress provider is always registered (it
@@ -523,7 +660,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// reads this resolver) and its HTTPTriggers start routing without a restart.
 	// The router's cache is already cluster-wide in this mode (FissionCacheOptions).
 	// AddResolverSync is a no-op when dynamic tenancy is off.
-	if err := tenant.AddResolverSync(crMgr); err != nil {
+	if err := tenant.AddResolverSync(crMgr, resolverSyncHooks...); err != nil {
 		return fmt.Errorf("error registering tenant resolver-sync: %w", err)
 	}
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -594,23 +594,6 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 				nsInformers: nsInformers,
 				logger:      logger,
 			}
-			// Seed with the env seed immediately so HasSynced isn't vacuously namespaces whose EndpointSlice RBAC has passed
-			// the SelfSubjectAccessReview. A namespace onboarded at runtime gets
-			// its fission-router-dataplane RoleBinding from the tenant controller,
-			// which races the informer start (issue #3647), and an orphaned
-			// FissionTenant (namespace deleted) can never pass — so explicitly-
-			// denied namespaces are EXCLUDED from the informer set (their functions
-			// fall back to the executor RPC, same as the legacy data plane) and
-			// re-checked on every reconcile until the binding lands. Exclusion is
-			// what keeps one bad namespace from wedging /readyz for every tenant.
-			dynCache.syncInformers(ctx)
-			// After the Manager cache syncs
-			// namespaces, filtered by EndpointSlice RBAC. Shared by the startup
-			// seed, the post-cache-sync re-seed, and the resolver-sync hook so
-			// all three apply the same exclusion semantics. Returns pending=true
-			// when any namespace is still waiting on its RBAC — the reconciler
-			// requeues until every namespace passes (no tenant event fires for
-			// a RoleBinding the tenant controller creates asynchronously).
 			// Seed with the env seed immediately so HasSynced isn't vacuously
 			// true with zero informers. The RunnableFunc below re-seeds from
 			// the LIVE FissionTenant set after the Manager cache syncs (the

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -227,6 +227,89 @@ func sliceWatchSAR(ctx context.Context, kubeClient kubernetes.Interface, ns, ver
 	return res, err
 }
 
+// dynamicEndpointCache manages per-namespace EndpointSlice informers in dynamic
+// tenancy mode. It re-scopes the informer set as tenants are onboarded/offboarded,
+// gating each namespace on a SelfSubjectAccessReview so a namespace whose
+// fission-router-dataplane RoleBinding hasn't landed yet is EXCLUDED rather than
+// wedging /readyz with a forbidden LIST (issue #3647).
+//
+// rbacChecked caches namespaces that have passed the SAR. It is pruned on every
+// sync for namespaces that have left the live set: offboarding deletes the
+// tenant's RoleBinding, so a later re-onboard MUST re-run the SAR rather than
+// trust a stale pass — otherwise the informer starts before the binding is
+// recreated, its LIST stays forbidden, HasSynced never latches, and /readyz
+// returns 503 fleet-wide (no leader election — every replica wedges).
+type dynamicEndpointCache struct {
+	kubeClient  kubernetes.Interface
+	resolver    *utils.NamespaceResolver
+	nsInformers *endpointcache.NamespaceInformers
+	rbacChecked sync.Map
+	logger      logr.Logger
+	mu          sync.Mutex // serializes syncInformers; prevents TOCTOU on namespace set
+}
+
+// syncInformers re-scopes the informer set to the resolver's live namespaces,
+// filtered by EndpointSlice RBAC. Shared by the startup seed, the post-cache-sync
+// re-seed, and the resolver-sync hook so all three apply the same exclusion
+// semantics. Returns pending=true when any namespace is still waiting on its
+// RBAC — the reconciler requeues until every namespace passes (no tenant event
+// fires for a RoleBinding the tenant controller creates asynchronously).
+func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	// Re-read inside the lock: the namespace set may have changed since the
+	// caller was invoked (startup seed vs. post-cache-sync re-seed vs. hook).
+	// Reading after the lock makes last-writer-wins converge — no namespace
+	// onboarded during a slow SAR check is silently dropped.
+	namespaces := d.resolver.FunctionNamespaces()
+	live := make(map[string]struct{}, len(namespaces))
+	for _, ns := range namespaces {
+		live[ns] = struct{}{}
+	}
+	// Drop cached passes for namespaces that have left the set:
+	// offboarding deletes the tenant's fission-router-dataplane
+	// RoleBinding, so a later re-onboard MUST re-run the SAR rather
+	// than start an informer whose LIST stays forbidden until the
+	// tenant controller recreates the binding — an informer that
+	// never syncs holds HasSynced (and so /readyz) false fleet-wide.
+	d.rbacChecked.Range(func(k, _ any) bool {
+		if _, ok := live[k.(string)]; !ok {
+			d.rbacChecked.Delete(k)
+		}
+		return true
+	})
+	allowed := make([]string, 0, len(namespaces))
+	for _, ns := range namespaces {
+		if _, ok := d.rbacChecked.Load(ns); ok {
+			allowed = append(allowed, ns)
+			continue
+		}
+		ok, err := sliceWatchAllowedForNamespace(ctx, d.kubeClient, ns)
+		if err != nil {
+			// Transient SAR failure — optimistic include; the
+			// reflector's own retry absorbs apiserver flakes.
+			// Still mark pending: if the namespace genuinely lacks
+			// RBAC the informer can never sync, and no FissionTenant
+			// event will fire to re-run this check.
+			d.logger.Error(err, "endpointslice RBAC check failed transiently; keeping informer", "namespace", ns)
+			allowed = append(allowed, ns)
+			pending = true
+			continue
+		}
+		if !ok {
+			d.logger.Info("endpointslice RBAC not yet granted for tenant namespace; "+
+				"the tenant controller provisions fission-router-dataplane at onboarding — "+
+				"namespace excluded from the warm path until it lands", "namespace", ns)
+			pending = true
+			continue
+		}
+		d.rbacChecked.Store(ns, struct{}{})
+		allowed = append(allowed, ns)
+	}
+	d.nsInformers.Sync(allowed)
+	return pending
+}
+
 // runnableFunc adapts a function to a controller-runtime manager.Runnable.
 type runnableFunc func(context.Context) error
 
@@ -505,7 +588,13 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 			// no restart is needed to admit a new tenant's warm path.
 			nsInformers := endpointcache.NewNamespaceInformers(kubeClient, index, logger.WithName("endpointcache"))
 			resolver := utils.DefaultNSResolver()
-			// rbacChecked caches namespaces whose EndpointSlice RBAC has passed
+			dynCache := &dynamicEndpointCache{
+				kubeClient:  kubeClient,
+				resolver:    resolver,
+				nsInformers: nsInformers,
+				logger:      logger,
+			}
+			// Seed with the env seed immediately so HasSynced isn't vacuously namespaces whose EndpointSlice RBAC has passed
 			// the SelfSubjectAccessReview. A namespace onboarded at runtime gets
 			// its fission-router-dataplane RoleBinding from the tenant controller,
 			// which races the informer start (issue #3647), and an orphaned
@@ -514,48 +603,19 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 			// fall back to the executor RPC, same as the legacy data plane) and
 			// re-checked on every reconcile until the binding lands. Exclusion is
 			// what keeps one bad namespace from wedging /readyz for every tenant.
-			var rbacChecked sync.Map
-			// syncInformers re-scopes the informer set to the resolver's live
+			dynCache.syncInformers(ctx)
+			// After the Manager cache syncs
 			// namespaces, filtered by EndpointSlice RBAC. Shared by the startup
 			// seed, the post-cache-sync re-seed, and the resolver-sync hook so
 			// all three apply the same exclusion semantics. Returns pending=true
 			// when any namespace is still waiting on its RBAC — the reconciler
 			// requeues until every namespace passes (no tenant event fires for
 			// a RoleBinding the tenant controller creates asynchronously).
-			syncInformers := func() (pending bool) {
-				namespaces := resolver.FunctionNamespaces()
-				allowed := make([]string, 0, len(namespaces))
-				for _, ns := range namespaces {
-					if _, ok := rbacChecked.Load(ns); ok {
-						allowed = append(allowed, ns)
-						continue
-					}
-					ok, err := sliceWatchAllowedForNamespace(ctx, kubeClient, ns)
-					if err != nil {
-						// Transient SAR failure — optimistic include; the
-						// reflector's own retry absorbs apiserver flakes.
-						logger.Error(err, "endpointslice RBAC check failed transiently; keeping informer", "namespace", ns)
-						allowed = append(allowed, ns)
-						continue
-					}
-					if !ok {
-						logger.Info("endpointslice RBAC not yet granted for tenant namespace; "+
-							"the tenant controller provisions fission-router-dataplane at onboarding — "+
-							"namespace excluded from the warm path until it lands", "namespace", ns)
-						pending = true
-						continue
-					}
-					rbacChecked.Store(ns, struct{}{})
-					allowed = append(allowed, ns)
-				}
-				nsInformers.Sync(allowed)
-				return pending
-			}
 			// Seed with the env seed immediately so HasSynced isn't vacuously
 			// true with zero informers. The RunnableFunc below re-seeds from
 			// the LIVE FissionTenant set after the Manager cache syncs (the
 			// direct client list fails before the cache starts).
-			syncInformers()
+			dynCache.syncInformers(ctx)
 			// After the Manager cache syncs, re-seed the resolver from existing
 			// FissionTenant CRs and re-sync the informers to cover tenants that
 			// existed before startup. This closes the gap between the env-seed
@@ -568,14 +628,14 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 					logger.Error(err, "error seeding resolver from existing tenants — reconciler will retry")
 					return nil
 				}
-				syncInformers()
+				dynCache.syncInformers(ctx)
 				return nil
 			})); err != nil {
 				return fmt.Errorf("error registering tenant seed runnable: %w", err)
 			}
 			endpointsSynced = nsInformers.HasSynced
 			resolverSyncHooks = append(resolverSyncHooks, func(_ map[string]string) (pending bool) {
-				return syncInformers()
+				return dynCache.syncInformers(ctx)
 			})
 			// Stop all informers when the router's context is cancelled.
 			go func() {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -335,9 +335,8 @@ func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool)
 // change, so no restart is needed to admit a new tenant's warm path.
 //
 // The returned InformerSynced gates router readiness: it is true only after
-// every running informer has completed its initial LIST. The caller must not
-// call Close — the returned nsInformers is closed by the ctx-cancel goroutine
-// registered here.
+// every running informer has completed its initial LIST. The internal informer
+// manager is closed when ctx is cancelled.
 func setupDynamicEndpointCache(
 	ctx context.Context,
 	kubeClient kubernetes.Interface,
@@ -354,6 +353,11 @@ func setupDynamicEndpointCache(
 		nsInformers: nsInformers,
 		logger:      logger,
 	}
+	// Stop all informers when the router's context is cancelled.
+	go func() {
+		<-ctx.Done()
+		nsInformers.Close()
+	}()
 	// Seed with the env seed immediately so HasSynced isn't vacuously
 	// true with zero informers. The RunnableFunc below re-seeds from
 	// the LIVE FissionTenant set after the Manager cache syncs (the
@@ -379,11 +383,6 @@ func setupDynamicEndpointCache(
 	resolverSyncHooks = append(resolverSyncHooks, func() (pending bool) {
 		return dynCache.syncInformers(ctx)
 	})
-	// Stop all informers when the router's context is cancelled.
-	go func() {
-		<-ctx.Done()
-		nsInformers.Close()
-	}()
 	return nsInformers.HasSynced, resolverSyncHooks, nil
 }
 
@@ -426,7 +425,8 @@ func router(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, httpTr
 }
 
 func serve(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, opts Options,
-	httpTriggerSet *HTTPTriggerSet) error {
+	httpTriggerSet *HTTPTriggerSet,
+) error {
 	publicMR, internalMR, err := router(ctx, logger, mgr, httpTriggerSet)
 	if err != nil {
 		return fmt.Errorf("error making router: %w", err)

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -185,6 +185,9 @@ func checkSliceWatchRBACForNamespace(ctx context.Context, kubeClient kubernetes.
 // informer must not wedge readiness on a LIST that only fails. A transient
 // apiserver error is reported as allowed (optimistic: the informer's own
 // reflector retry handles flakes) so a wobble never tears down working watches.
+// The caller (syncInformers) caps this optimism at maxOptimisticSARErrors
+// consecutive failures per namespace, after which it excludes the namespace
+// regardless of the optimistic allow returned here.
 func sliceWatchAllowedForNamespace(ctx context.Context, kubeClient kubernetes.Interface, ns string) (bool, error) {
 	for _, verb := range []string{"list", "watch"} {
 		res, err := sliceWatchSAR(ctx, kubeClient, ns, verb)
@@ -197,6 +200,12 @@ func sliceWatchAllowedForNamespace(ctx context.Context, kubeClient kubernetes.In
 	}
 	return true, nil
 }
+
+// sarRetryDelay is the delay between SAR retry attempts in sliceWatchSAR. A
+// boot-time apiserver flake must not degrade the data plane for the router's
+// whole lifetime, so the SAR is attempted up to 3 times total, waiting this
+// delay between attempts, before surfacing the error to the caller.
+const sarRetryDelay = 2 * time.Second
 
 // sliceWatchSAR issues one SelfSubjectAccessReview for verb+endpointslices in
 // ns, retrying transient apiserver errors (a boot-time flake must not degrade
@@ -219,7 +228,7 @@ func sliceWatchSAR(ctx context.Context, kubeClient kubernetes.Interface, ns, ver
 			select {
 			case <-ctx.Done():
 				return nil, ctx.Err()
-			case <-time.After(2 * time.Second):
+			case <-time.After(sarRetryDelay):
 			}
 		}
 		res, err = kubeClient.AuthorizationV1().SelfSubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
@@ -230,6 +239,14 @@ func sliceWatchSAR(ctx context.Context, kubeClient kubernetes.Interface, ns, ver
 	return res, err
 }
 
+// maxOptimisticSARErrors is the number of consecutive transient SAR failures
+// (apiserver flakes, throttling) a namespace is tolerated for before being
+// excluded from the informer set. Up to and including this cap the namespace
+// stays admitted optimistically — the informer's own reflector retry handles
+// transient LIST failures — so a brief wobble never tears down a working
+// watch. Exceeding the cap excludes the namespace: a persistently-failing
+// check must not wedge /readyz on a LIST that only fails. The counter resets
+// on the next successful SAR or when the namespace leaves the live set.
 const maxOptimisticSARErrors = 3
 
 // dynamicEndpointCache manages per-namespace EndpointSlice informers in dynamic
@@ -302,8 +319,22 @@ func (d *dynamicEndpointCache) syncInformers(ctx context.Context) (pending bool)
 		}
 		ok, err := sliceWatchAllowedForNamespace(ctx, d.kubeClient, ns)
 		if err != nil {
-			// we check for SAR errors optimistically; if the namespace
-			// continues to fail we exclude it from the informer set
+			// A cancelled context (router shutting down) surfaces as a SAR
+			// error here because sliceWatchSAR returns ctx.Err(). Don't treat
+			// that as an apiserver flake: skip the error accounting and log
+			// so a shutdown doesn't bump sarErrors and log at Error for every
+			// namespace. Both Canceled and DeadlineExceeded are context
+			// errors, not genuine API failures. errors.Is rather than
+			// ctx.Err()!=nil so a real API failure arriving on a cancelled
+			// context (e.g. a test reactor returning assert.AnError) is
+			// still counted.
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return pending
+			}
+			// A transient SAR failure is handled optimistically for up to
+			// maxOptimisticSARErrors consecutive attempts; after that the
+			// namespace is excluded so a persistently-failing check does not
+			// wedge readiness on a LIST that only fails.
 			d.sarErrors[ns]++
 			pending = true
 			if d.sarErrors[ns] <= maxOptimisticSARErrors {
@@ -394,6 +425,11 @@ func setupDynamicEndpointCache(
 	resolverSyncHooks = append(resolverSyncHooks, func() (pending bool) {
 		return dynCache.syncInformers(ctx)
 	})
+	// Register the informer-count gauge only after setup has succeeded
+	// (crMgr.Add above can fail). Registered here, not inside
+	// NewNamespaceInformers, so the constructor stays deterministic per
+	// the CLAUDE.md library-constructor guidance.
+	endpointcache.RegisterInformersGauge(nsInformers)
 	return nsInformers.HasSynced, resolverSyncHooks, nil
 }
 

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package router
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/router/endpointcache"
+	"github.com/fission/fission/pkg/utils"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+func TestDynamicCachePersistentSARErrorsEventuallyExcludeAndRecover(t *testing.T) {
+	type testStep struct {
+		name                 string
+		sarError             bool
+		wantPending          bool
+		wantErrorEntry       bool
+		wantIndexSize        int
+		wantErrorCount       int
+		wantPermissionCached bool
+	}
+	steps := []testStep{
+		{
+			name:                 "first permission-check error",
+			sarError:             true,
+			wantPending:          true,
+			wantErrorEntry:       true,
+			wantIndexSize:        1,
+			wantErrorCount:       1,
+			wantPermissionCached: false,
+		},
+		{
+			name:                 "second permission-check error",
+			sarError:             true,
+			wantPending:          true,
+			wantErrorEntry:       true,
+			wantIndexSize:        1,
+			wantErrorCount:       2,
+			wantPermissionCached: false,
+		},
+		{
+			name:                 "third permission-check error",
+			sarError:             true,
+			wantPending:          true,
+			wantErrorEntry:       true,
+			wantIndexSize:        1,
+			wantErrorCount:       3,
+			wantPermissionCached: false,
+		},
+		{
+			name:                 "fourth permission-check error",
+			sarError:             true,
+			wantPending:          true,
+			wantErrorEntry:       true,
+			wantIndexSize:        0,
+			wantErrorCount:       4,
+			wantPermissionCached: false,
+		},
+		{
+			name:                 "fifth permission-check error",
+			sarError:             true,
+			wantPending:          true,
+			wantErrorEntry:       true,
+			wantIndexSize:        0,
+			wantErrorCount:       5,
+			wantPermissionCached: false,
+		},
+		{
+			name:                 "sixth permission-check allowed",
+			sarError:             false,
+			wantPending:          false,
+			wantErrorEntry:       false,
+			wantIndexSize:        1,
+			wantErrorCount:       0,
+			wantPermissionCached: true,
+		},
+	}
+	port := int32(8888)
+	ready := true
+	fakeEndpointSlice := &discoveryv1.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testendpoint",
+			Namespace: "team-a",
+			Labels: map[string]string{
+				fv1.FUNCTION_NAMESPACE: "team-a",
+				fv1.MANAGED_BY_LABEL:   fv1.MANAGED_BY_VALUE,
+				fv1.FUNCTION_NAME:      "fn-a",
+			},
+		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{
+				Addresses: []string{"10.0.0.1"},
+				Conditions: discoveryv1.EndpointConditions{
+					Ready: &ready,
+				},
+			},
+		},
+		Ports: []discoveryv1.EndpointPort{
+			{
+				Port: &port,
+			},
+		},
+	}
+
+	fakeClient := fake.NewClientset(fakeEndpointSlice)
+
+	permissionCheck := atomic.Bool{}
+	permissionCheck.Store(true)
+	fakeClient.PrependReactor(
+		"create",
+		"selfsubjectaccessreviews",
+		func(action k8stesting.Action) (bool, runtime.Object, error) {
+			sar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+			if permissionCheck.Load() {
+				return true, nil, assert.AnError
+			}
+			return true, &authorizationv1.SelfSubjectAccessReview{
+				Spec: sar.Spec,
+				Status: authorizationv1.SubjectAccessReviewStatus{
+					Allowed: true,
+				},
+			}, nil
+		},
+	)
+
+	index := endpointcache.NewIndex()
+	nsManager := endpointcache.NewNamespaceInformers(
+		fakeClient,
+		index,
+		logr.Discard(),
+	)
+	t.Cleanup(nsManager.Close)
+
+	nsResolver := &utils.NamespaceResolver{}
+	dynCache := &dynamicEndpointCache{
+		kubeClient:  fakeClient,
+		resolver:    nsResolver,
+		nsInformers: nsManager,
+		logger:      logr.Discard(),
+	}
+	nsResolver.AddTenant("team-a")
+
+	errCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	for _, step := range steps {
+		t.Run(step.name, func(t *testing.T) {
+			ctx := t.Context()
+			if step.sarError {
+				ctx = errCtx
+			}
+			permissionCheck.Store(step.sarError)
+			got := dynCache.syncInformers(ctx)
+			assert.Equal(t, step.wantPending, got)
+			if step.wantIndexSize > 0 {
+				require.True(t, nsManager.WaitForCacheSync(t.Context()))
+			}
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, step.wantIndexSize, index.Size())
+			}, 1*time.Second, 100*time.Millisecond,
+			)
+			count, ok := dynCache.sarErrors["team-a"]
+			assert.Equal(t, step.wantErrorEntry, ok)
+			if step.wantErrorEntry {
+				assert.Equal(t, step.wantErrorCount, count)
+			}
+			_, ok = dynCache.rbacChecked.Load("team-a")
+			assert.Equal(t, step.wantPermissionCached, ok)
+		})
+	}
+
+}

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -5,14 +5,12 @@
 package router
 
 import (
-	"context"
 	"sync/atomic"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	authorizationv1 "k8s.io/api/authorization/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +24,12 @@ import (
 )
 
 func TestDynamicCachePersistentSARErrorsEventuallyExcludeAndRecover(t *testing.T) {
+	// Runs under testing/synctest so the 2 × 2s SAR retry delays per step
+	// elapse instantly under virtual time. The test drives a genuine API
+	// error (assert.AnError from the reactor), NOT a cancelled context —
+	// syncInformers now distinguishes context.Canceled from a real API
+	// failure and skips the former, so the cancellation path can no longer
+	// stand in for a flake.
 	type testStep struct {
 		name                 string
 		sarError             bool
@@ -119,72 +123,84 @@ func TestDynamicCachePersistentSARErrorsEventuallyExcludeAndRecover(t *testing.T
 		},
 	}
 
-	fakeClient := fake.NewClientset(fakeEndpointSlice)
+	synctest.Test(t, func(t *testing.T) {
+		fakeClient := fake.NewClientset(fakeEndpointSlice)
 
-	permissionCheck := atomic.Bool{}
-	permissionCheck.Store(true)
-	fakeClient.PrependReactor(
-		"create",
-		"selfsubjectaccessreviews",
-		func(action k8stesting.Action) (bool, runtime.Object, error) {
-			sar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
-			if permissionCheck.Load() {
-				return true, nil, assert.AnError
-			}
-			return true, &authorizationv1.SelfSubjectAccessReview{
-				Spec: sar.Spec,
-				Status: authorizationv1.SubjectAccessReviewStatus{
-					Allowed: true,
-				},
-			}, nil
-		},
-	)
+		permissionCheck := atomic.Bool{}
+		permissionCheck.Store(true)
+		fakeClient.PrependReactor(
+			"create",
+			"selfsubjectaccessreviews",
+			func(action k8stesting.Action) (bool, runtime.Object, error) {
+				sar := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+				if permissionCheck.Load() {
+					return true, nil, assert.AnError
+				}
+				return true, &authorizationv1.SelfSubjectAccessReview{
+					Spec: sar.Spec,
+					Status: authorizationv1.SubjectAccessReviewStatus{
+						Allowed: true,
+					},
+				}, nil
+			},
+		)
 
-	index := endpointcache.NewIndex()
-	nsManager := endpointcache.NewNamespaceInformers(
-		fakeClient,
-		index,
-		logr.Discard(),
-	)
-	t.Cleanup(nsManager.Close)
+		index := endpointcache.NewIndex()
+		nsManager := endpointcache.NewNamespaceInformers(
+			fakeClient,
+			index,
+			logr.Discard(),
+		)
 
-	nsResolver := &utils.NamespaceResolver{}
-	dynCache := &dynamicEndpointCache{
-		kubeClient:  fakeClient,
-		resolver:    nsResolver,
-		nsInformers: nsManager,
-		logger:      logr.Discard(),
-	}
-	nsResolver.AddTenant("team-a")
+		nsResolver := &utils.NamespaceResolver{}
+		dynCache := &dynamicEndpointCache{
+			kubeClient:  fakeClient,
+			resolver:    nsResolver,
+			nsInformers: nsManager,
+			logger:      logr.Discard(),
+		}
+		nsResolver.AddTenant("team-a")
 
-	errCtx, cancel := context.WithCancel(t.Context())
-	cancel()
-
-	for _, step := range steps {
-		t.Run(step.name, func(t *testing.T) {
-			ctx := t.Context()
-			if step.sarError {
-				ctx = errCtx
-			}
+		for _, step := range steps {
 			permissionCheck.Store(step.sarError)
-			got := dynCache.syncInformers(ctx)
-			assert.Equal(t, step.wantPending, got)
-			if step.wantIndexSize > 0 {
-				require.True(t, nsManager.WaitForCacheSync(t.Context()))
-			}
 
-			require.EventuallyWithT(t, func(c *assert.CollectT) {
-				assert.Equal(c, step.wantIndexSize, index.Size())
-			}, 1*time.Second, 100*time.Millisecond,
-			)
+			// syncInformers blocks on SAR retry delays (time.After inside
+			// sliceWatchSAR) and on informer start/stop (nsInformers.Sync
+			// waits on <-ni.done). Under synctest those are fake timers,
+			// so run in a goroutine and advance virtual time.
+			var got bool
+			done := make(chan struct{})
+			go func() {
+				got = dynCache.syncInformers(t.Context())
+				close(done)
+			}()
+			synctest.Wait()
+			<-done
+
+			// The informer's internal goroutines (reflector + processor) use
+			// sync.Mutex/sync.Cond which are NOT durably blocking, so a single
+			// Wait may return before the handler has processed the initial LIST.
+			// Wait again so the processor goroutine gets scheduled and drains
+			// its queue.
+			synctest.Wait()
+
+			assert.Equal(t, step.wantPending, got, step.name)
+			// After synctest.Wait the informer goroutines have completed
+			// their initial LIST (synchronous against the fake clientset)
+			// and processed all queued handler calls, so the index size
+			// is settled — no EventuallyWithT polling needed.
+			assert.Equal(t, step.wantIndexSize, index.Size(), step.name)
 			count, ok := dynCache.sarErrors["team-a"]
-			assert.Equal(t, step.wantErrorEntry, ok)
+			assert.Equal(t, step.wantErrorEntry, ok, step.name)
 			if step.wantErrorEntry {
-				assert.Equal(t, step.wantErrorCount, count)
+				assert.Equal(t, step.wantErrorCount, count, step.name)
 			}
 			_, ok = dynCache.rbacChecked.Load("team-a")
-			assert.Equal(t, step.wantPermissionCached, ok)
-		})
-	}
+			assert.Equal(t, step.wantPermissionCached, ok, step.name)
+		}
 
+		// Drain informer goroutines before the bubble closes.
+		go func() { nsManager.Close() }()
+		synctest.Wait()
+	})
 }

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -10,9 +10,6 @@ import (
 	"testing"
 	"time"
 
-	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/router/endpointcache"
-	"github.com/fission/fission/pkg/utils"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +19,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	k8stesting "k8s.io/client-go/testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/router/endpointcache"
+	"github.com/fission/fission/pkg/utils"
 )
 
 func TestDynamicCachePersistentSARErrorsEventuallyExcludeAndRecover(t *testing.T) {

--- a/pkg/tenant/provision.go
+++ b/pkg/tenant/provision.go
@@ -124,16 +124,20 @@ func namespaceRBACObjects(ns, releaseNamespace string, owner metav1.OwnerReferen
 		clusterRoleBinding(fetcherWebsocketRoleName, fv1.FissionFetcherSA, ns, fv1.FetcherWebsocketTenantWorkloadClusterRole),
 	}
 
-	// Bind the executor and buildermgr (release-namespace SAs) to their workload
-	// ClusterRoles so they can create/manage workloads in this tenant namespace —
-	// the dynamic equivalent of the chart's per-namespace executor/buildermgr
-	// kubernetes Roles. Skipped when the release namespace is unknown (the subject
-	// would be unresolvable), in which case the executor/buildermgr fall back to
-	// any statically-rendered Role for this namespace.
+	// Bind the executor, buildermgr, and router (release-namespace SAs) to their
+	// workload ClusterRoles so they can create/manage workloads (executor,
+	// buildermgr) or read EndpointSlices + Services (router) in this tenant
+	// namespace — the dynamic equivalent of the chart's per-namespace kubernetes
+	// Roles. Skipped when the release namespace is unknown (the subject would be
+	// unresolvable), in which case the executor/buildermgr fall back to any
+	// statically-rendered Role for this namespace. The router has no static
+	// fallback in dynamic mode; its warm path is inert until a tenant is
+	// onboarded with a known release namespace.
 	if releaseNamespace != "" {
 		objs = append(objs,
 			clusterRoleBinding("fission-executor-workload", fv1.FissionExecutorSA, releaseNamespace, fv1.ExecutorTenantWorkloadClusterRole),
 			clusterRoleBinding("fission-buildermgr-workload", fv1.FissionBuildermgrSA, releaseNamespace, fv1.BuildermgrTenantWorkloadClusterRole),
+			clusterRoleBinding("fission-router-dataplane", fv1.FissionRouterSA, releaseNamespace, fv1.RouterDataplaneTenantClusterRole),
 		)
 	}
 	return objs

--- a/pkg/tenant/provision_test.go
+++ b/pkg/tenant/provision_test.go
@@ -94,6 +94,28 @@ func TestEnsureNamespaceRBACBindsWorkloadClusterRoles(t *testing.T) {
 	}
 }
 
+// TestEnsureNamespaceRBACBindsRouterDataplane pins that the router's
+// dataplane ClusterRole is bound in each tenant namespace, so the router can
+// read EndpointSlices + Services for the warm path (#3647). The binding is
+// scoped to the namespace (RoleBinding) and the subject points at the release
+// namespace (where the router SA lives).
+func TestEnsureNamespaceRBACBindsRouterDataplane(t *testing.T) {
+	c := newFakeClient(t)
+	ctx := t.Context()
+	require.NoError(t, EnsureNamespaceRBAC(ctx, c, "team-a", "fission", metav1.OwnerReference{}))
+
+	rb := &rbacv1.RoleBinding{}
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "fission-router-dataplane"}, rb),
+		"router dataplane RoleBinding must exist in tenant namespace")
+	assert.Equal(t, "ClusterRole", rb.RoleRef.Kind, "must bind a ClusterRole")
+	assert.Equal(t, fv1.RouterDataplaneTenantClusterRole, rb.RoleRef.Name,
+		"must reference the router dataplane ClusterRole")
+	require.Len(t, rb.Subjects, 1)
+	assert.Equal(t, fv1.FissionRouterSA, rb.Subjects[0].Name, "subject must be the router SA")
+	assert.Equal(t, "fission", rb.Subjects[0].Namespace, "subject SA lives in the release namespace")
+	assert.Equal(t, managedByValue, rb.Labels[managedByLabelKey], "must be labelled for cleanup")
+}
+
 // TestEnsureNamespaceRBACSkipsWorkloadBindingsWithoutReleaseNS guards the
 // fallback: with no release namespace known, the workload bindings are skipped
 // (an unresolvable subject would be useless), leaving the fetcher/builder RBAC.
@@ -105,6 +127,8 @@ func TestEnsureNamespaceRBACSkipsWorkloadBindingsWithoutReleaseNS(t *testing.T) 
 	rb := &rbacv1.RoleBinding{}
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "fission-executor-workload"}, rb)),
 		"workload binding must be skipped when the release namespace is unknown")
+	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "fission-router-dataplane"}, &rbacv1.RoleBinding{})),
+		"router dataplane binding must be skipped when the release namespace is unknown")
 	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, &rbacv1.RoleBinding{}),
 		"the fetcher function-access binding is still provisioned without a release namespace")
 }
@@ -132,6 +156,8 @@ func TestDeleteNamespaceRBACRemovesManaged(t *testing.T) {
 	rb := &rbacv1.RoleBinding{}
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fetcherRoleName}, rb)), "fetcher RoleBinding must be deleted")
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: builderRoleName}, rb)), "builder RoleBinding must be deleted")
+	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: "fission-router-dataplane"}, &rbacv1.RoleBinding{})),
+		"router dataplane RoleBinding must be deleted")
 	keys := &corev1.Secret{}
 	assert.True(t, apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: "team-a", Name: fv1.TenantAuthKeysSecret}, keys)),
 		"derived-key Secret must be deleted by name on teardown")

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -6,6 +6,7 @@ package tenant
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -17,16 +18,27 @@ import (
 	"github.com/fission/fission/pkg/utils"
 )
 
-// hookRetryDelay is the fixed poll interval used when a hook reports pending
+// hookRetryDelay is the FIRST poll interval used when a hook reports pending
 // work (e.g. the router waiting on a tenant's fission-router-dataplane
 // RoleBinding, which the tenant controller provisions asynchronously — no
-// FissionTenant event fires when it lands). A fixed interval is used instead
-// of Result.Requeue because Requeue drives the workqueue rate limiter, whose
-// exponential backoff caps at ~1000s and would leave a namespace unadmitted
-// for ~16 minutes after the binding finally lands. Requeue is also deprecated
-// in controller-runtime v0.24.x; when it is removed, Requeue:true silently
-// becomes a no-op and the wedge returns with no compile error.
-const hookRetryDelay = 2 * time.Second
+// FissionTenant event fires when it lands). An explicit interval is used
+// instead of Result.Requeue because Requeue drives the workqueue rate limiter,
+// whose exponential backoff caps at ~1000s and would leave a namespace
+// unadmitted for ~16 minutes after the binding finally lands. Requeue is also
+// deprecated in controller-runtime v0.24.x; when it is removed, Requeue:true
+// silently becomes a no-op and the wedge returns with no compile error.
+//
+// The interval doubles on each consecutive pending reconcile up to
+// hookRetryMaxDelay, then holds. That keeps the common case — RBAC landing a
+// second or two after the event — converging in ~2s, while a namespace that
+// can never pass (an orphaned FissionTenant whose namespace was deleted) settles
+// into a cheap 30s poll instead of re-checking every 2s forever. At a flat 2s
+// such a tenant costs ~43k reconciles, SelfSubjectAccessReviews and log lines
+// per replica per day; capped at 30s that drops to ~2.9k.
+const (
+	hookRetryDelay    = 2 * time.Second
+	hookRetryMaxDelay = 30 * time.Second
+)
 
 // SyncResolverFromTenants sets the resolver's live tenant set to the env seed
 // plus every FissionTenant's namespace. It is shared by the tenant controller
@@ -64,6 +76,11 @@ type ResolverSyncReconciler struct {
 	// hooks are called after every successful SetTenants. See AddResolverSync
 	// for the hook/pending contract.
 	hooks []func() (pending bool)
+	// pendingRounds counts consecutive reconciles whose hooks reported pending
+	// work; it drives the escalating poll interval and resets as soon as one
+	// reconcile comes back clean. Atomic because the manager may run this
+	// reconciler with more than one worker.
+	pendingRounds atomic.Int64
 }
 
 func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
@@ -77,9 +94,24 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 		}
 	}
 	if pending {
-		return ctrl.Result{RequeueAfter: hookRetryDelay}, nil
+		return ctrl.Result{RequeueAfter: r.nextRetryDelay()}, nil
 	}
+	r.pendingRounds.Store(0)
 	return ctrl.Result{}, nil
+}
+
+// nextRetryDelay returns the poll interval for the next pending retry: it
+// doubles from hookRetryDelay on each consecutive pending reconcile and is
+// clamped at hookRetryMaxDelay (2s, 4s, 8s, 16s, 30s, 30s, …). The shift is
+// bounded before it is applied so the doubling can never overflow.
+func (r *ResolverSyncReconciler) nextRetryDelay() time.Duration {
+	const maxShift = 4 // hookRetryDelay<<4 == 32s, already past the cap
+	shift := r.pendingRounds.Add(1) - 1
+	if shift > maxShift {
+		shift = maxShift
+	}
+	delay := hookRetryDelay << shift
+	return min(delay, hookRetryMaxDelay)
 }
 
 // AddResolverSync registers the resolver-sync reconciler on mgr, watching
@@ -95,8 +127,9 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 // hooks are called after every successful SetTenants. The router passes one to
 // re-scope its per-namespace EndpointSlice informers (#3647); executor/buildermgr
 // pass none. A hook returns pending=true when it has unfinished work (e.g. RBAC
-// not yet landed); the reconciler then requeues after hookRetryDelay. Variadic so
-// existing callers (AddResolverSync(mgr)) compile unchanged.
+// not yet landed); the reconciler then requeues after an interval that starts at
+// hookRetryDelay and doubles up to hookRetryMaxDelay while work stays pending.
+// Variadic so existing callers (AddResolverSync(mgr)) compile unchanged.
 func AddResolverSync(mgr ctrl.Manager, hooks ...func() (pending bool)) error {
 	if !utils.CrdWatchClusterWide() {
 		return nil

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -50,13 +50,8 @@ func SyncResolverFromTenants(ctx context.Context, c client.Client, resolver *uti
 type ResolverSyncReconciler struct {
 	client   client.Client
 	resolver *utils.NamespaceResolver
-	// hooks are called after every successful SetTenants. The router uses one
-	// to re-scope its per-namespace EndpointSlice informers when tenants change
-	// at runtime (#3647); other callers (executor, buildermgr) pass none. A hook
-	// returns pending=true when it has unfinished work (e.g. a namespace whose
-	// EndpointSlice RBAC has not landed yet): the reconciler then requeues after
-	// a short delay, because no FissionTenant event will fire when the missing
-	// piece is a RoleBinding the tenant controller creates asynchronously.
+	// hooks are called after every successful SetTenants. See AddResolverSync
+	// for the hook/pending contract.
 	hooks []func() (pending bool)
 }
 

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -6,7 +6,6 @@ package tenant
 
 import (
 	"context"
-	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -55,11 +54,6 @@ type ResolverSyncReconciler struct {
 	hooks []func() (pending bool)
 }
 
-// hookRetryDelay is how soon the reconciler re-runs when a hook reports
-// pending work. Short: the common case is RBAC landing a second or two after
-// the FissionTenant event that triggered the reconcile.
-const hookRetryDelay = 2 * time.Second
-
 func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	if err := SyncResolverFromTenants(ctx, r.client, r.resolver); err != nil {
 		return ctrl.Result{}, err
@@ -71,7 +65,7 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 		}
 	}
 	if pending {
-		return ctrl.Result{RequeueAfter: hookRetryDelay}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 	return ctrl.Result{}, nil
 }

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -6,6 +6,7 @@ package tenant
 
 import (
 	"context"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -15,6 +16,17 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/utils"
 )
+
+// hookRetryDelay is the fixed poll interval used when a hook reports pending
+// work (e.g. the router waiting on a tenant's fission-router-dataplane
+// RoleBinding, which the tenant controller provisions asynchronously — no
+// FissionTenant event fires when it lands). A fixed interval is used instead
+// of Result.Requeue because Requeue drives the workqueue rate limiter, whose
+// exponential backoff caps at ~1000s and would leave a namespace unadmitted
+// for ~16 minutes after the binding finally lands. Requeue is also deprecated
+// in controller-runtime v0.24.x; when it is removed, Requeue:true silently
+// becomes a no-op and the wedge returns with no compile error.
+const hookRetryDelay = 2 * time.Second
 
 // SyncResolverFromTenants sets the resolver's live tenant set to the env seed
 // plus every FissionTenant's namespace. It is shared by the tenant controller
@@ -65,7 +77,7 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 		}
 	}
 	if pending {
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{RequeueAfter: hookRetryDelay}, nil
 	}
 	return ctrl.Result{}, nil
 }

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -50,15 +50,14 @@ func SyncResolverFromTenants(ctx context.Context, c client.Client, resolver *uti
 type ResolverSyncReconciler struct {
 	client   client.Client
 	resolver *utils.NamespaceResolver
-	// hooks are called (with the live FissionResourceNamespaces set) after every
-	// successful SetTenants. The router uses one to re-scope its per-namespace
-	// EndpointSlice informers when tenants change at runtime (#3647); other
-	// callers (executor, buildermgr) pass none. A hook returns pending=true when
-	// it has unfinished work (e.g. a namespace whose EndpointSlice RBAC has not
-	// landed yet): the reconciler then requeues after a short delay, because no
-	// FissionTenant event will fire when the missing piece is a RoleBinding the
-	// tenant controller creates asynchronously.
-	hooks []func(map[string]string) (pending bool)
+	// hooks are called after every successful SetTenants. The router uses one
+	// to re-scope its per-namespace EndpointSlice informers when tenants change
+	// at runtime (#3647); other callers (executor, buildermgr) pass none. A hook
+	// returns pending=true when it has unfinished work (e.g. a namespace whose
+	// EndpointSlice RBAC has not landed yet): the reconciler then requeues after
+	// a short delay, because no FissionTenant event will fire when the missing
+	// piece is a RoleBinding the tenant controller creates asynchronously.
+	hooks []func() (pending bool)
 }
 
 // hookRetryDelay is how soon the reconciler re-runs when a hook reports
@@ -72,7 +71,7 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 	}
 	pending := false
 	for _, h := range r.hooks {
-		if h(r.resolver.FissionResourceNamespaces()) {
+		if h() {
 			pending = true
 		}
 	}
@@ -92,13 +91,12 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 // no extra cache wiring; the component's ClusterRole must grant fissiontenants
 // get/list/watch (charts/.../tenant-controller/dynamic-cluster-roles.yaml).
 //
-// hooks are called (with the live FissionResourceNamespaces set) after every
-// successful SetTenants. The router passes one to re-scope its per-namespace
-// EndpointSlice informers (#3647); executor/buildermgr pass none. A hook
-// returns pending=true when it has unfinished work (e.g. RBAC not yet landed);
-// the reconciler then requeues after hookRetryDelay. Variadic so existing
-// callers (AddResolverSync(mgr)) compile unchanged.
-func AddResolverSync(mgr ctrl.Manager, hooks ...func(map[string]string) (pending bool)) error {
+// hooks are called after every successful SetTenants. The router passes one to
+// re-scope its per-namespace EndpointSlice informers (#3647); executor/buildermgr
+// pass none. A hook returns pending=true when it has unfinished work (e.g. RBAC
+// not yet landed); the reconciler then requeues after hookRetryDelay. Variadic so
+// existing callers (AddResolverSync(mgr)) compile unchanged.
+func AddResolverSync(mgr ctrl.Manager, hooks ...func() (pending bool)) error {
 	if !utils.CrdWatchClusterWide() {
 		return nil
 	}

--- a/pkg/tenant/resolversync.go
+++ b/pkg/tenant/resolversync.go
@@ -6,6 +6,7 @@ package tenant
 
 import (
 	"context"
+	"time"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -49,11 +50,34 @@ func SyncResolverFromTenants(ctx context.Context, c client.Client, resolver *uti
 type ResolverSyncReconciler struct {
 	client   client.Client
 	resolver *utils.NamespaceResolver
+	// hooks are called (with the live FissionResourceNamespaces set) after every
+	// successful SetTenants. The router uses one to re-scope its per-namespace
+	// EndpointSlice informers when tenants change at runtime (#3647); other
+	// callers (executor, buildermgr) pass none. A hook returns pending=true when
+	// it has unfinished work (e.g. a namespace whose EndpointSlice RBAC has not
+	// landed yet): the reconciler then requeues after a short delay, because no
+	// FissionTenant event will fire when the missing piece is a RoleBinding the
+	// tenant controller creates asynchronously.
+	hooks []func(map[string]string) (pending bool)
 }
+
+// hookRetryDelay is how soon the reconciler re-runs when a hook reports
+// pending work. Short: the common case is RBAC landing a second or two after
+// the FissionTenant event that triggered the reconcile.
+const hookRetryDelay = 2 * time.Second
 
 func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
 	if err := SyncResolverFromTenants(ctx, r.client, r.resolver); err != nil {
 		return ctrl.Result{}, err
+	}
+	pending := false
+	for _, h := range r.hooks {
+		if h(r.resolver.FissionResourceNamespaces()) {
+			pending = true
+		}
+	}
+	if pending {
+		return ctrl.Result{RequeueAfter: hookRetryDelay}, nil
 	}
 	return ctrl.Result{}, nil
 }
@@ -67,11 +91,18 @@ func (r *ResolverSyncReconciler) Reconcile(ctx context.Context, _ ctrl.Request) 
 // is cluster-wide in these modes, so the cluster-scoped FissionTenant watch needs
 // no extra cache wiring; the component's ClusterRole must grant fissiontenants
 // get/list/watch (charts/.../tenant-controller/dynamic-cluster-roles.yaml).
-func AddResolverSync(mgr ctrl.Manager) error {
+//
+// hooks are called (with the live FissionResourceNamespaces set) after every
+// successful SetTenants. The router passes one to re-scope its per-namespace
+// EndpointSlice informers (#3647); executor/buildermgr pass none. A hook
+// returns pending=true when it has unfinished work (e.g. RBAC not yet landed);
+// the reconciler then requeues after hookRetryDelay. Variadic so existing
+// callers (AddResolverSync(mgr)) compile unchanged.
+func AddResolverSync(mgr ctrl.Manager, hooks ...func(map[string]string) (pending bool)) error {
 	if !utils.CrdWatchClusterWide() {
 		return nil
 	}
-	r := &ResolverSyncReconciler{client: mgr.GetClient(), resolver: utils.DefaultNSResolver()}
+	r := &ResolverSyncReconciler{client: mgr.GetClient(), resolver: utils.DefaultNSResolver(), hooks: hooks}
 	return builder.ControllerManagedBy(mgr).
 		For(&fv1.FissionTenant{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Named("fission-resolver-sync").

--- a/pkg/tenant/resolversync_test.go
+++ b/pkg/tenant/resolversync_test.go
@@ -6,6 +6,7 @@ package tenant
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -67,10 +68,10 @@ func TestResolverSyncReconcilerHooks(t *testing.T) {
 }
 
 // TestResolverSyncReconcilerPendingRequeues verifies that a hook reporting
-// pending work triggers a fixed-interval requeue (hookRetryDelay). This retries
-// quickly while avoiding the workqueue rate limiter's exponential backoff,
-// which would leave a namespace unadmitted for ~16 minutes when the missing
-// RoleBinding finally lands.
+// pending work triggers an explicit-interval requeue starting at
+// hookRetryDelay. This retries quickly while avoiding the workqueue rate
+// limiter's exponential backoff, which would leave a namespace unadmitted for
+// ~16 minutes when the missing RoleBinding finally lands.
 func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 	c := newFakeClient(t, tenant("team-a", "team-a"))
 	resolver := &utils.NamespaceResolver{}
@@ -84,7 +85,43 @@ func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 
 	res, err := r.Reconcile(t.Context(), ctrl.Request{})
 	require.NoError(t, err)
-	assert.Equal(t, hookRetryDelay, res.RequeueAfter, "pending hook must requeue after the fixed poll interval")
+	assert.Equal(t, hookRetryDelay, res.RequeueAfter, "first pending reconcile must requeue after the base poll interval")
+}
+
+// TestResolverSyncReconcilerPendingBackoff verifies the escalating poll
+// interval: consecutive pending reconciles double the delay up to
+// hookRetryMaxDelay and hold there, so a namespace that can never pass (an
+// orphaned FissionTenant) settles into a cheap poll instead of re-checking
+// every 2s forever. A clean reconcile resets it, so the next onboarding race
+// still converges at the base interval.
+func TestResolverSyncReconcilerPendingBackoff(t *testing.T) {
+	c := newFakeClient(t, tenant("team-a", "team-a"))
+	pending := true
+	r := &ResolverSyncReconciler{
+		client:   c,
+		resolver: &utils.NamespaceResolver{},
+		hooks: []func() bool{
+			func() bool { return pending },
+		},
+	}
+
+	for _, want := range []time.Duration{2 * time.Second, 4 * time.Second, 8 * time.Second, 16 * time.Second, hookRetryMaxDelay, hookRetryMaxDelay} {
+		res, err := r.Reconcile(t.Context(), ctrl.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, want, res.RequeueAfter, "escalating poll interval")
+	}
+
+	// A clean reconcile clears the counter...
+	pending = false
+	res, err := r.Reconcile(t.Context(), ctrl.Request{})
+	require.NoError(t, err)
+	require.Zero(t, res.RequeueAfter, "no requeue once hooks report no pending work")
+
+	// ...so the next pending round starts over at the base interval.
+	pending = true
+	res, err = r.Reconcile(t.Context(), ctrl.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, hookRetryDelay, res.RequeueAfter, "backoff must reset after a clean reconcile")
 }
 
 // TestResolverSyncReconcilerNoHooks verifies that a reconciler with no hooks

--- a/pkg/tenant/resolversync_test.go
+++ b/pkg/tenant/resolversync_test.go
@@ -40,3 +40,65 @@ func TestResolverSyncReconciler(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, resolver.IsTenant("team-a"))
 }
+
+// TestResolverSyncReconcilerHooks verifies that hooks are called after
+// SetTenants, receiving the live namespace set. This is the mechanism the
+// router uses to re-scope its per-namespace EndpointSlice informers when
+// tenants change at runtime (#3647).
+func TestResolverSyncReconcilerHooks(t *testing.T) {
+	c := newFakeClient(t, tenant("team-a", "team-a"), tenant("team-b", "team-b"))
+	resolver := &utils.NamespaceResolver{}
+
+	var called int
+	var got map[string]string
+	r := &ResolverSyncReconciler{
+		client:   c,
+		resolver: resolver,
+		hooks: []func(map[string]string) bool{
+			func(set map[string]string) bool {
+				called++
+				got = set
+				return false
+			},
+		},
+	}
+
+	res, err := r.Reconcile(t.Context(), ctrl.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, 1, called, "hook must be called once per Reconcile")
+	assert.Contains(t, got, "team-a", "hook must receive the live namespace set")
+	assert.Contains(t, got, "team-b", "hook must receive the live namespace set")
+	assert.Zero(t, res.RequeueAfter, "no requeue when no hook reports pending")
+}
+
+// TestResolverSyncReconcilerPendingRequeues verifies that a hook reporting
+// pending work makes the reconciler requeue after hookRetryDelay — the
+// mechanism that re-checks RBAC after the tenant controller provisions it
+// asynchronously (#3647: no FissionTenant event fires for that).
+func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
+	c := newFakeClient(t, tenant("team-a", "team-a"))
+	resolver := &utils.NamespaceResolver{}
+	r := &ResolverSyncReconciler{
+		client:   c,
+		resolver: resolver,
+		hooks: []func(map[string]string) bool{
+			func(set map[string]string) bool { return true },
+		},
+	}
+
+	res, err := r.Reconcile(t.Context(), ctrl.Request{})
+	require.NoError(t, err)
+	assert.Equal(t, hookRetryDelay, res.RequeueAfter, "pending hook must trigger a requeue")
+}
+
+// TestResolverSyncReconcilerNoHooks verifies that a reconciler with no hooks
+// (the default for executor/buildermgr) still works — backward compatibility.
+func TestResolverSyncReconcilerNoHooks(t *testing.T) {
+	c := newFakeClient(t, tenant("team-a", "team-a"))
+	resolver := &utils.NamespaceResolver{}
+	r := &ResolverSyncReconciler{client: c, resolver: resolver}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{})
+	require.NoError(t, err)
+	assert.True(t, resolver.IsTenant("team-a"))
+}

--- a/pkg/tenant/resolversync_test.go
+++ b/pkg/tenant/resolversync_test.go
@@ -42,22 +42,19 @@ func TestResolverSyncReconciler(t *testing.T) {
 }
 
 // TestResolverSyncReconcilerHooks verifies that hooks are called after
-// SetTenants, receiving the live namespace set. This is the mechanism the
-// router uses to re-scope its per-namespace EndpointSlice informers when
-// tenants change at runtime (#3647).
+// SetTenants. This is the mechanism the router uses to re-scope its
+// per-namespace EndpointSlice informers when tenants change at runtime (#3647).
 func TestResolverSyncReconcilerHooks(t *testing.T) {
 	c := newFakeClient(t, tenant("team-a", "team-a"), tenant("team-b", "team-b"))
 	resolver := &utils.NamespaceResolver{}
 
 	var called int
-	var got map[string]string
 	r := &ResolverSyncReconciler{
 		client:   c,
 		resolver: resolver,
-		hooks: []func(map[string]string) bool{
-			func(set map[string]string) bool {
+		hooks: []func() bool{
+			func() bool {
 				called++
-				got = set
 				return false
 			},
 		},
@@ -66,8 +63,6 @@ func TestResolverSyncReconcilerHooks(t *testing.T) {
 	res, err := r.Reconcile(t.Context(), ctrl.Request{})
 	require.NoError(t, err)
 	assert.Equal(t, 1, called, "hook must be called once per Reconcile")
-	assert.Contains(t, got, "team-a", "hook must receive the live namespace set")
-	assert.Contains(t, got, "team-b", "hook must receive the live namespace set")
 	assert.Zero(t, res.RequeueAfter, "no requeue when no hook reports pending")
 }
 
@@ -81,8 +76,8 @@ func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 	r := &ResolverSyncReconciler{
 		client:   c,
 		resolver: resolver,
-		hooks: []func(map[string]string) bool{
-			func(set map[string]string) bool { return true },
+		hooks: []func() bool{
+			func() bool { return true },
 		},
 	}
 

--- a/pkg/tenant/resolversync_test.go
+++ b/pkg/tenant/resolversync_test.go
@@ -82,7 +82,7 @@ func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 
 	res, err := r.Reconcile(t.Context(), ctrl.Request{})
 	require.NoError(t, err)
-	assert.True(t, res.Requeue, "pending hook must trigger a rate-limited requeue")
+	assert.True(t, res.Requeue, "pending hook must trigger a rate-limited requeue") //nolint:staticcheck // intentional rate-limiter coverage
 	assert.Zero(t, res.RequeueAfter, "pending hook must not bypass rate limiting with a fixed delay")
 }
 

--- a/pkg/tenant/resolversync_test.go
+++ b/pkg/tenant/resolversync_test.go
@@ -67,9 +67,8 @@ func TestResolverSyncReconcilerHooks(t *testing.T) {
 }
 
 // TestResolverSyncReconcilerPendingRequeues verifies that a hook reporting
-// pending work makes the reconciler requeue after hookRetryDelay — the
-// mechanism that re-checks RBAC after the tenant controller provisions it
-// asynchronously (#3647: no FissionTenant event fires for that).
+// pending work uses the controller's rate-limited requeue. This retries quickly
+// at first while avoiding a fixed two-second retry loop when RBAC never lands.
 func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 	c := newFakeClient(t, tenant("team-a", "team-a"))
 	resolver := &utils.NamespaceResolver{}
@@ -83,7 +82,8 @@ func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 
 	res, err := r.Reconcile(t.Context(), ctrl.Request{})
 	require.NoError(t, err)
-	assert.Equal(t, hookRetryDelay, res.RequeueAfter, "pending hook must trigger a requeue")
+	assert.True(t, res.Requeue, "pending hook must trigger a rate-limited requeue")
+	assert.Zero(t, res.RequeueAfter, "pending hook must not bypass rate limiting with a fixed delay")
 }
 
 // TestResolverSyncReconcilerNoHooks verifies that a reconciler with no hooks

--- a/pkg/tenant/resolversync_test.go
+++ b/pkg/tenant/resolversync_test.go
@@ -67,8 +67,10 @@ func TestResolverSyncReconcilerHooks(t *testing.T) {
 }
 
 // TestResolverSyncReconcilerPendingRequeues verifies that a hook reporting
-// pending work uses the controller's rate-limited requeue. This retries quickly
-// at first while avoiding a fixed two-second retry loop when RBAC never lands.
+// pending work triggers a fixed-interval requeue (hookRetryDelay). This retries
+// quickly while avoiding the workqueue rate limiter's exponential backoff,
+// which would leave a namespace unadmitted for ~16 minutes when the missing
+// RoleBinding finally lands.
 func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 	c := newFakeClient(t, tenant("team-a", "team-a"))
 	resolver := &utils.NamespaceResolver{}
@@ -82,8 +84,7 @@ func TestResolverSyncReconcilerPendingRequeues(t *testing.T) {
 
 	res, err := r.Reconcile(t.Context(), ctrl.Request{})
 	require.NoError(t, err)
-	assert.True(t, res.Requeue, "pending hook must trigger a rate-limited requeue") //nolint:staticcheck // intentional rate-limiter coverage
-	assert.Zero(t, res.RequeueAfter, "pending hook must not bypass rate limiting with a fixed delay")
+	assert.Equal(t, hookRetryDelay, res.RequeueAfter, "pending hook must requeue after the fixed poll interval")
 }
 
 // TestResolverSyncReconcilerNoHooks verifies that a reconciler with no hooks

--- a/test/integration/framework/endpointslice.go
+++ b/test/integration/framework/endpointslice.go
@@ -126,6 +126,37 @@ func (f *Framework) RouterEndpointSliceMode(t *testing.T, ctx context.Context) s
 	return "off"
 }
 
+// RouterEndpointSliceCacheActive reports whether every running router replica
+// is actually using the EndpointSlice cache. This reads the effective runtime
+// mode, so it detects a configured-on router that fell back to off after an
+// RBAC preflight failure.
+func (f *Framework) RouterEndpointSliceCacheActive(t *testing.T, ctx context.Context) bool {
+	t.Helper()
+	pods, err := f.kubeClient.CoreV1().Pods(f.FissionNamespace()).List(ctx, metav1.ListOptions{
+		LabelSelector: "svc=router",
+	})
+	require.NoError(t, err, "list router pods")
+	running := 0
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil || pod.Status.Phase != apiv1.PodRunning {
+			continue
+		}
+		running++
+		raw, err := f.kubeClient.CoreV1().Pods(f.FissionNamespace()).
+			ProxyGet("http", pod.Name, "8080", "/metrics", nil).DoRaw(ctx)
+		require.NoErrorf(t, err, "scrape metrics from router pod %s", pod.Name)
+		active, err := MetricHasLabels(raw, "fission_router_endpointcache_mode", map[string]string{
+			"effective": "on",
+		})
+		require.NoErrorf(t, err, "parse metrics from router pod %s", pod.Name)
+		if !active {
+			return false
+		}
+	}
+	require.NotZero(t, running, "no running router pod found")
+	return true
+}
+
 // ExecutorFunctionServicesEnabled reports the executor's
 // ENABLE_FUNCTION_SERVICES gate.
 func (f *Framework) ExecutorFunctionServicesEnabled(t *testing.T, ctx context.Context) bool {

--- a/test/integration/framework/metrics.go
+++ b/test/integration/framework/metrics.go
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"bufio"
+	"bytes"
+	"strconv"
+	"strings"
+)
+
+// SumMetricLines sums every Prometheus exposition line for name, labeled or
+// not (both "foo 3" and `foo{a="b"} 3` match), skipping comment lines.
+// Returns 0 if the metric is absent.
+//
+// Promoted from the three local copies (parseGaugeValue in dynamic_tenant_test,
+// sumMetricLines in alias_routing_test, parseMetric in memory_soak_test) so
+// tests share one correct implementation — sum-all semantics handle labeled
+// metrics correctly, unlike the first-match variants that silently under-report.
+func SumMetricLines(raw []byte, name string) float64 {
+	var total float64
+	sc := bufio.NewScanner(bytes.NewReader(raw))
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		rest, ok := strings.CutPrefix(line, name)
+		if !ok {
+			continue
+		}
+		if len(rest) == 0 || (rest[0] != ' ' && rest[0] != '{') {
+			continue // matched a longer metric name sharing this prefix
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			continue
+		}
+		total += v
+	}
+	return total
+}

--- a/test/integration/framework/metrics.go
+++ b/test/integration/framework/metrics.go
@@ -9,6 +9,9 @@ import (
 	"bytes"
 	"strconv"
 	"strings"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 // SumMetricLines sums every Prometheus exposition line for name, labeled or
@@ -45,4 +48,35 @@ func SumMetricLines(raw []byte, name string) float64 {
 		total += v
 	}
 	return total
+}
+
+// MetricHasLabels reports whether the Prometheus exposition contains a sample
+// for name with every requested label. Extra labels on the sample are allowed.
+func MetricHasLabels(raw []byte, name string, want map[string]string) (bool, error) {
+	parser := expfmt.NewTextParser(model.UTF8Validation)
+	families, err := parser.TextToMetricFamilies(bytes.NewReader(raw))
+	if err != nil {
+		return false, err
+	}
+	family := families[name]
+	if family == nil {
+		return false, nil
+	}
+	for _, metric := range family.GetMetric() {
+		labels := make(map[string]string, len(metric.GetLabel()))
+		for _, label := range metric.GetLabel() {
+			labels[label.GetName()] = label.GetValue()
+		}
+		matched := true
+		for label, value := range want {
+			if labels[label] != value {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true, nil
+		}
+	}
+	return false, nil
 }

--- a/test/integration/framework/metrics_test.go
+++ b/test/integration/framework/metrics_test.go
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package framework
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetricHasLabels(t *testing.T) {
+	t.Parallel()
+	raw := []byte(`# HELP fission_router_endpointcache_mode Always 1.
+# TYPE fission_router_endpointcache_mode gauge
+fission_router_endpointcache_mode{effective="off",requested="on"} 1
+fission_router_endpointcache_mode{effective="on",requested="on",replica="second"} 1
+`)
+	tests := []struct {
+		name string
+		want map[string]string
+		has  bool
+	}{
+		{name: "finds exact sample", want: map[string]string{"effective": "on", "requested": "on"}, has: true},
+		{name: "allows extra labels", want: map[string]string{"replica": "second"}, has: true},
+		{name: "rejects different value", want: map[string]string{"effective": "missing"}, has: false},
+		{name: "rejects missing label", want: map[string]string{"namespace": "default"}, has: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := MetricHasLabels(raw, "fission_router_endpointcache_mode", tt.want)
+			require.NoError(t, err)
+			assert.Equal(t, tt.has, got)
+		})
+	}
+}
+
+func TestMetricHasLabelsRejectsMalformedInput(t *testing.T) {
+	t.Parallel()
+	_, err := MetricHasLabels([]byte("not valid prometheus text\n"), "metric", nil)
+	require.Error(t, err)
+}

--- a/test/integration/suites/common/alias_routing_test.go
+++ b/test/integration/suites/common/alias_routing_test.go
@@ -324,9 +324,7 @@ func servedPodNameEventually(t *testing.T, ctx context.Context, f *framework.Fra
 // instruments with at least one recorded point) but omits
 // resync_drift/version_fallback entirely until something increments them.
 // So "absent from the scrape" and "zero" are the same observable state for
-// these two counters, and scrapeCounterSum returns 0 rather than failing
-// when no line matches, instead of requiring a match the way
-// memory_soak_test.go's parseMetric does for an always-present gauge.
+// these two counters, and scrapeCounterSum returns 0 when no line matches.
 func scrapeCounterSum(t *testing.T, ctx context.Context, f *framework.Framework, svc, metricName string) float64 {
 	t.Helper()
 	pods, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).List(ctx, metav1.ListOptions{LabelSelector: "svc=" + svc})

--- a/test/integration/suites/common/alias_routing_test.go
+++ b/test/integration/suites/common/alias_routing_test.go
@@ -17,8 +17,6 @@
 package common_test
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -338,42 +336,7 @@ func scrapeCounterSum(t *testing.T, ctx context.Context, f *framework.Framework,
 	for _, p := range pods.Items {
 		raw, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).ProxyGet("http", p.Name, "8080", "/metrics", nil).DoRaw(ctx)
 		require.NoErrorf(t, err, "scraping /metrics from %s pod %s", svc, p.Name)
-		total += sumMetricLines(raw, metricName)
-	}
-	return total
-}
-
-// sumMetricLines sums every Prometheus exposition line for `name`, labeled
-// or not (both "foo 3" and `foo{a="b"} 3` match), skipping comment lines.
-// Unlike memory_soak_test.go's parseMetric, which returns the first match
-// for a metric callers know by construction is unlabeled, this sums every
-// label combination -- needed here because callers only know these two
-// counters are unlabeled by reading their registration site, not by
-// contract.
-func sumMetricLines(raw []byte, name string) float64 {
-	var total float64
-	sc := bufio.NewScanner(bytes.NewReader(raw))
-	for sc.Scan() {
-		line := sc.Text()
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		rest, ok := strings.CutPrefix(line, name)
-		if !ok {
-			continue
-		}
-		if len(rest) == 0 || (rest[0] != ' ' && rest[0] != '{') {
-			continue // matched a longer metric name sharing this prefix
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
-		if err != nil {
-			continue
-		}
-		total += v
+		total += framework.SumMetricLines(raw, metricName)
 	}
 	return total
 }

--- a/test/integration/suites/common/memory_soak_test.go
+++ b/test/integration/suites/common/memory_soak_test.go
@@ -7,12 +7,8 @@
 package common_test
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -114,29 +110,7 @@ func readResidentMemory(t *testing.T, ctx context.Context, f *framework.Framewor
 		ProxyGet("http", podName, "8080", "/metrics", nil).DoRaw(ctx)
 	require.NoErrorf(t, err, "scraping /metrics from %s pod %s", svc, podName)
 
-	val, ok := parseMetric(raw, "process_resident_memory_bytes")
-	require.Truef(t, ok, "process_resident_memory_bytes not found in %s metrics", svc)
+	val := framework.SumMetricLines(raw, "process_resident_memory_bytes")
+	require.NotZerof(t, val, "process_resident_memory_bytes not found in %s metrics", svc)
 	return val
-}
-
-// parseMetric returns the value of an unlabelled prometheus metric line.
-func parseMetric(raw []byte, name string) (float64, bool) {
-	sc := bufio.NewScanner(bytes.NewReader(raw))
-	prefix := name + " "
-	for sc.Scan() {
-		line := sc.Text()
-		if !strings.HasPrefix(line, prefix) {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		v, err := strconv.ParseFloat(fields[1], 64)
-		if err != nil {
-			continue
-		}
-		return v, true
-	}
-	return 0, false
 }

--- a/test/integration/suites/common/tenant_admission_policy_test.go
+++ b/test/integration/suites/common/tenant_admission_policy_test.go
@@ -61,4 +61,14 @@ func TestTenantWorkloadBindingAdmissionPolicy(t *testing.T) {
 	t.Cleanup(func() {
 		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(context.Background(), good, metav1.DeleteOptions{})
 	})
+
+	// Binding to the fixed fission-router SA is also allowed (#3653: the router
+	// SA was added to the ValidatingAdmissionPolicy allowlist for per-tenant
+	// dataplane RoleBindings).
+	goodRouter := "vap-good-router-" + framework.RandomID()
+	_, err = f.KubeClient().RbacV1().RoleBindings(ns).Create(ctx, rb(goodRouter, fv1.FissionRouterSA), metav1.CreateOptions{})
+	require.NoError(t, err, "binding to the fixed fission-router SA must be allowed")
+	t.Cleanup(func() {
+		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(context.Background(), goodRouter, metav1.DeleteOptions{})
+	})
 }

--- a/test/integration/suites/common/tenant_admission_policy_test.go
+++ b/test/integration/suites/common/tenant_admission_policy_test.go
@@ -29,7 +29,7 @@ import (
 func TestTenantWorkloadBindingAdmissionPolicy(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)
@@ -59,7 +59,9 @@ func TestTenantWorkloadBindingAdmissionPolicy(t *testing.T) {
 	_, err = f.KubeClient().RbacV1().RoleBindings(ns).Create(ctx, rb(good, fv1.FissionFetcherSA), metav1.CreateOptions{})
 	require.NoError(t, err, "binding to the fixed fission-fetcher SA must be allowed")
 	t.Cleanup(func() {
-		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(context.Background(), good, metav1.DeleteOptions{})
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cleanupCancel()
+		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(cleanupCtx, good, metav1.DeleteOptions{})
 	})
 
 	// Binding to the fixed fission-router SA is also allowed (#3653: the router
@@ -69,6 +71,8 @@ func TestTenantWorkloadBindingAdmissionPolicy(t *testing.T) {
 	_, err = f.KubeClient().RbacV1().RoleBindings(ns).Create(ctx, rb(goodRouter, fv1.FissionRouterSA), metav1.CreateOptions{})
 	require.NoError(t, err, "binding to the fixed fission-router SA must be allowed")
 	t.Cleanup(func() {
-		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(context.Background(), goodRouter, metav1.DeleteOptions{})
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.WithoutCancel(t.Context()), 30*time.Second)
+		defer cleanupCancel()
+		_ = f.KubeClient().RbacV1().RoleBindings(ns).Delete(cleanupCtx, goodRouter, metav1.DeleteOptions{})
 	})
 }

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -240,8 +240,7 @@ func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterCli
 
 // scrapeRouterMetric scrapes a single Prometheus metric from the router pods
 // (via pod proxy, no port-forward needed) and returns its sum across replicas.
-// Works for gauges and counters whose callers know are unlabeled (first
-// matching sample per pod — correct when there is exactly one).
+// Sums all matching samples per pod via framework.SumMetricLines.
 func scrapeRouterMetric(t require.TestingT, ctx context.Context, f *framework.Framework, metricName string) float64 {
 	pods, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).List(ctx, metav1.ListOptions{LabelSelector: "svc=router"})
 	require.NoErrorf(t, err, "listing router pods")

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -42,12 +42,21 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	if !f.DynamicNamespacesEnabled(t, ctx) {
 		t.Skip("tenancy.mode is not dynamic; this leg runs a different tenancy model")
 	}
+	if f.RouterEndpointSliceMode(t, ctx) != "on" {
+		t.Skip("router.endpointSliceCache.mode is not 'on'; dynamic warm-path assertions require it")
+	}
+	if !f.ExecutorFunctionServicesEnabled(t, ctx) {
+		t.Skip("executor.functionServices.enabled is off; poolmgr functions have no EndpointSlices")
+	}
 	pyImage := f.Images().RequirePython(t)
 
 	// Let any rollout from a prior serial test (e.g. the adopt test's un-waited
 	// executor restore) settle, then snapshot the control plane so we can prove
 	// onboarding restarts nothing — the headline promise of dynamic tenancy.
 	f.WaitForControlPlaneStable(t, ctx, 3*time.Minute)
+	if !f.RouterEndpointSliceCacheActive(t, ctx) {
+		t.Skip("router EndpointSlice cache fell back to off; dynamic warm-path assertions cannot run")
+	}
 	before := f.ControlPlanePodUIDs(t, ctx)
 
 	// A namespace that did not exist at install time: the dynamic path's reason
@@ -134,8 +143,9 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	require.Equalf(t, "fission-router-dataplane-tenant", rbac.RoleRef.Name,
 		"RoleBinding should reference the fission-router-dataplane-tenant ClusterRole")
 
-	// The first invocation was a cold start (executor RPC); a warm hit proves the
-	// per-namespace informer fed the tenant's EndpointSlices into the index.
+	// The first invocation was a cold start (executor RPC). This serial test makes
+	// no other function requests, so a warm hit observed while invoking this route
+	// shows the per-namespace informer fed the EndpointSlices into the index.
 	hitsBefore := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
 	assertWarmPathHit(t, ctx, r, f, routeURL, hitsBefore, "warm path never served tenant %q's function", tenantNS)
 
@@ -190,8 +200,8 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	// First invocation cold-starts; verify the re-onboarded namespace serves.
 	r.GetEventually(t, ctx, route2URL, framework.BodyContains("hello"))
 
-	// Second invocation must hit the warm path — proves the new informer fed
-	// the re-onboarded tenant's EndpointSlices into the index.
+	// A warm hit observed while invoking the second route shows the new informer
+	// fed the re-onboarded tenant's EndpointSlices into the index.
 	hitsBefore2 := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
 	assertWarmPathHit(t, ctx, r, f, route2URL, hitsBefore2, "warm path never served re-onboarded tenant %q's function", tenantNS)
 
@@ -220,8 +230,10 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 
 // assertWarmPathHit polls until invoking routeURL increments the router's
 // fission_router_endpointcache_hits_total beyond hitsBefore — i.e. the warm
-// path (slice-fed index, no executor RPC) served a request. The invocation is
-// INSIDE the poll: after a cold start the executor patches the pod's served
+// path (slice-fed index, no executor RPC) served a request. The counter is
+// process-wide rather than tenant-labeled; this serial test makes no competing
+// function requests, so the increase is attributable to the route invoked
+// inside the poll. After a cold start the executor patches the pod's served
 // label and the EndpointSlice controller mirrors it (both async, seconds of
 // lag), so scraping without invoking can never move the counter.
 func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterClient, f *framework.Framework, routeURL string, hitsBefore float64, msg string, args ...any) {
@@ -234,7 +246,7 @@ func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterCli
 		assert.Contains(c, strings.ToLower(body), "hello")
 		hitsAfter := scrapeRouterMetric(c, ctx, f, "fission_router_endpointcache_hits_total")
 		assert.Greaterf(c, hitsAfter, hitsBefore,
-			"endpointcache_hits_total must increase on a warm invocation — proves the warm path served the tenant's function")
+			"endpointcache_hits_total must increase while the route is invoked — shows the router warm path was active")
 	}, 2*time.Minute, 5*time.Second, append([]any{msg}, args...)...)
 }
 

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -54,9 +54,13 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	// executor restore) settle, then snapshot the control plane so we can prove
 	// onboarding restarts nothing — the headline promise of dynamic tenancy.
 	f.WaitForControlPlaneStable(t, ctx, 3*time.Minute)
-	if !f.RouterEndpointSliceCacheActive(t, ctx) {
-		t.Skip("router EndpointSlice cache fell back to off; dynamic warm-path assertions cannot run")
-	}
+	// The requested mode is "on" (gated above), so a false result here means
+	// the router degraded to off after an RBAC preflight failure — the exact
+	// defect this PR guards against. Assert rather than skip: a chart regression
+	// that drops the router-dataplane Role must fail the suite, not green-skip it.
+	require.Truef(t, f.RouterEndpointSliceCacheActive(t, ctx),
+		"router EndpointSlice cache fell back to off after RBAC preflight failure; "+
+			"expected effective=on on every running router pod (the requested mode is on)")
 	before := f.ControlPlanePodUIDs(t, ctx)
 
 	// A namespace that did not exist at install time: the dynamic path's reason

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -88,9 +88,9 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	// 2. Onboard. The controller provisions per-namespace RBAC, ServiceAccounts and
 	//    the derived-key Secret; the data-plane managers add the namespace to their
 	//    watched set AND re-enqueue the staged CRs — all without a restart.
-	//    Capture the router goroutine baseline first: the final offboard must
-	//    return to it (Tier-B informer teardown leak guard, testing-plan §4.2).
-	goroutinesBefore := scrapeRouterMetric(t, ctx, f, "go_goroutines")
+	//    Capture the router's informer count baseline: the final offboard must
+	//    return to it (deterministic leak guard — exact, vs. goroutine delta ±10).
+	informersBefore := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_informers")
 	ns.EnableTenant(t, ctx)
 	f.WaitForTenantReady(t, ctx, tenantNS)
 
@@ -198,11 +198,10 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	hitsBefore2 := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
 	assertWarmPathHit(t, ctx, r, f, route2URL, hitsBefore2, "warm path never served re-onboarded tenant %q's function", tenantNS)
 
-	// 7. Final offboard + goroutine-delta leak guard (testing-plan §4.2): the
-	//    per-namespace informer must die with the tenant. A leaked informer
-	//    would pin several goroutines (reflector + processor listeners) per
-	//    namespace forever, so the router's goroutine count must return to the
-	//    pre-onboard baseline once the tenant is offboarded.
+	// 7. Final offboard + informer-count leak guard (testing-plan §4.2): the
+	//    per-namespace informer must die with the tenant. The informer count
+	//    gauge is exact (0 = no leak, >0 = leak), replacing the ±10 goroutine
+	//    delta which couldn't detect a single leaked informer (~5-7 goroutines).
 	require.NoError(t, fc.HTTPTriggers(tenantNS).Delete(ctx, "route-"+fnName2, metav1.DeleteOptions{}))
 	require.NoError(t, fc.Functions(tenantNS).Delete(ctx, fnName2, metav1.DeleteOptions{}))
 	require.NoError(t, fc.Environments(tenantNS).Delete(ctx, envName2, metav1.DeleteOptions{}))
@@ -213,11 +212,11 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	ns.DisableTenant(t, ctx)
 	f.WaitForTenantOffboarded(t, ctx, tenantNS)
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		g := scrapeRouterMetric(t, ctx, f, "go_goroutines")
-		assert.LessOrEqualf(c, g, goroutinesBefore+10,
-			"router goroutines must return to the pre-onboard baseline after offboard (baseline=%.0f, current=%.0f) — a per-namespace informer leak pins goroutines forever",
-			goroutinesBefore, g)
-	}, 2*time.Minute, 5*time.Second, "router goroutines never returned to baseline — per-namespace informer leak suspected")
+		n := scrapeRouterMetric(c, ctx, f, "fission_router_endpointcache_informers")
+		assert.Equalf(c, informersBefore, n,
+			"informer count must return to the pre-onboard baseline after offboard (baseline=%.0f, current=%.0f) — a leaked informer pins goroutines forever",
+			informersBefore, n)
+	}, 2*time.Minute, 5*time.Second, "informer count never returned to baseline — per-namespace informer leak suspected")
 
 	// 8. The namespace itself is deleted by the NewTestNamespaceIn cleanup hook.
 }
@@ -236,7 +235,7 @@ func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterCli
 			return
 		}
 		assert.Contains(c, strings.ToLower(body), "hello")
-		hitsAfter := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
+		hitsAfter := scrapeRouterMetric(c, ctx, f, "fission_router_endpointcache_hits_total")
 		assert.Greaterf(c, hitsAfter, hitsBefore,
 			"endpointcache_hits_total must increase on a warm invocation — proves the warm path served the tenant's function")
 	}, 2*time.Minute, 5*time.Second, append([]any{msg}, args...)...)
@@ -245,8 +244,7 @@ func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterCli
 // scrapeRouterMetric scrapes a single Prometheus metric from the router pods
 // (via pod proxy, no port-forward needed) and returns its sum across replicas.
 // Works for both gauges and counters (sums the latest sample per pod).
-func scrapeRouterMetric(t *testing.T, ctx context.Context, f *framework.Framework, metricName string) float64 {
-	t.Helper()
+func scrapeRouterMetric(t require.TestingT, ctx context.Context, f *framework.Framework, metricName string) float64 {
 	pods, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).List(ctx, metav1.ListOptions{LabelSelector: "svc=router"})
 	require.NoErrorf(t, err, "listing router pods")
 	require.NotEmptyf(t, pods.Items, "no router pod found in namespace %s", f.FissionNamespace())

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -7,10 +7,7 @@
 package serial_test
 
 import (
-	"bufio"
-	"bytes"
 	"context"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -243,7 +240,8 @@ func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterCli
 
 // scrapeRouterMetric scrapes a single Prometheus metric from the router pods
 // (via pod proxy, no port-forward needed) and returns its sum across replicas.
-// Works for both gauges and counters (sums the latest sample per pod).
+// Works for gauges and counters whose callers know are unlabeled (first
+// matching sample per pod — correct when there is exactly one).
 func scrapeRouterMetric(t require.TestingT, ctx context.Context, f *framework.Framework, metricName string) float64 {
 	pods, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).List(ctx, metav1.ListOptions{LabelSelector: "svc=router"})
 	require.NoErrorf(t, err, "listing router pods")
@@ -252,36 +250,7 @@ func scrapeRouterMetric(t require.TestingT, ctx context.Context, f *framework.Fr
 	for _, p := range pods.Items {
 		raw, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).ProxyGet("http", p.Name, "8080", "/metrics", nil).DoRaw(ctx)
 		require.NoErrorf(t, err, "scraping /metrics from router pod %s", p.Name)
-		total += parseGaugeValue(raw, metricName)
+		total += framework.SumMetricLines(raw, metricName)
 	}
 	return total
-}
-
-// parseGaugeValue extracts the value of a Prometheus metric from a /metrics
-// scrape body. Returns 0 if the metric is absent (e.g. before any slice event).
-// Works for gauges and counters (returns the last sample's value).
-func parseGaugeValue(raw []byte, name string) float64 {
-	sc := bufio.NewScanner(bytes.NewReader(raw))
-	for sc.Scan() {
-		line := sc.Text()
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-		rest, ok := strings.CutPrefix(line, name)
-		if !ok {
-			continue
-		}
-		if len(rest) == 0 || (rest[0] != ' ' && rest[0] != '{') {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) < 2 {
-			continue
-		}
-		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
-		if err == nil {
-			return v
-		}
-	}
-	return 0
 }

--- a/test/integration/suites/serial/dynamic_tenant_test.go
+++ b/test/integration/suites/serial/dynamic_tenant_test.go
@@ -7,7 +7,10 @@
 package serial_test
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -85,6 +88,9 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	// 2. Onboard. The controller provisions per-namespace RBAC, ServiceAccounts and
 	//    the derived-key Secret; the data-plane managers add the namespace to their
 	//    watched set AND re-enqueue the staged CRs — all without a restart.
+	//    Capture the router goroutine baseline first: the final offboard must
+	//    return to it (Tier-B informer teardown leak guard, testing-plan §4.2).
+	goroutinesBefore := scrapeRouterMetric(t, ctx, f, "go_goroutines")
 	ns.EnableTenant(t, ctx)
 	f.WaitForTenantReady(t, ctx, tenantNS)
 
@@ -120,6 +126,22 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	// tenant's trigger on onboarding, with no restart.
 	r.GetEventually(t, ctx, routeURL, framework.BodyContains("hello"))
 
+	// 3b. The router's per-namespace EndpointSlice informer must have picked up
+	//     the new tenant (#3647): the RBAC grant exists AND the warm path served
+	//     a request — proving the informer fed the new tenant's EndpointSlices
+	//     into the index. Before the fix the informer was frozen at startup and
+	//     the router never saw the new tenant's EndpointSlices.
+	rbac, rerr := f.KubeClient().RbacV1().RoleBindings(tenantNS).Get(ctx, "fission-router-dataplane", metav1.GetOptions{})
+	require.NoErrorf(t, rerr, "router dataplane RoleBinding must exist in tenant namespace %q", tenantNS)
+	require.Equalf(t, "ClusterRole", rbac.RoleRef.Kind, "RoleBinding should reference a ClusterRole")
+	require.Equalf(t, "fission-router-dataplane-tenant", rbac.RoleRef.Name,
+		"RoleBinding should reference the fission-router-dataplane-tenant ClusterRole")
+
+	// The first invocation was a cold start (executor RPC); a warm hit proves the
+	// per-namespace informer fed the tenant's EndpointSlices into the index.
+	hitsBefore := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
+	assertWarmPathHit(t, ctx, r, f, routeURL, hitsBefore, "warm path never served tenant %q's function", tenantNS)
+
 	// 4. Onboarding + serving a fresh tenant must not have rolled any
 	//    control-plane pod (#3298: the whole point of the dynamic model).
 	f.AssertNoControlPlaneRestart(t, ctx, before)
@@ -148,5 +170,120 @@ func TestDynamicTenantLifecycle(t *testing.T) {
 	ns.DisableTenant(t, ctx)
 	f.WaitForTenantOffboarded(t, ctx, tenantNS)
 
-	// 6. The namespace itself is deleted by the NewTestNamespaceIn cleanup hook.
+	// 6. Re-onboard the SAME namespace (testing-plan §4.2: onboard→offboard→
+	//    re-onboard). This is the Tier-B teardown leak guard: the old informer's
+	//    goroutine must have exited during offboard, and the new informer must
+	//    start cleanly without overlapping the old one. A function created in
+	//    the re-onboarded namespace must be invocable through the warm path.
+	ns.EnableTenant(t, ctx)
+	f.WaitForTenantReady(t, ctx, tenantNS)
+
+	// Re-create env + function + trigger in the same namespace, using the
+	// same patterns as the initial stage (ns.ID for unique names).
+	envName2 := "python2-" + ns.ID
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName2, Image: pyImage, Poolsize: 1})
+
+	fnName2 := "hello2-" + ns.ID
+	codePath2 := framework.WriteTestData(t, "python/hello/hello.py")
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{Name: fnName2, Env: envName2, Code: codePath2})
+
+	route2URL := "/" + fnName2
+	ns.CreateRoute(t, ctx, framework.RouteOptions{Function: fnName2, URL: route2URL, Method: "GET"})
+
+	// First invocation cold-starts; verify the re-onboarded namespace serves.
+	r.GetEventually(t, ctx, route2URL, framework.BodyContains("hello"))
+
+	// Second invocation must hit the warm path — proves the new informer fed
+	// the re-onboarded tenant's EndpointSlices into the index.
+	hitsBefore2 := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
+	assertWarmPathHit(t, ctx, r, f, route2URL, hitsBefore2, "warm path never served re-onboarded tenant %q's function", tenantNS)
+
+	// 7. Final offboard + goroutine-delta leak guard (testing-plan §4.2): the
+	//    per-namespace informer must die with the tenant. A leaked informer
+	//    would pin several goroutines (reflector + processor listeners) per
+	//    namespace forever, so the router's goroutine count must return to the
+	//    pre-onboard baseline once the tenant is offboarded.
+	require.NoError(t, fc.HTTPTriggers(tenantNS).Delete(ctx, "route-"+fnName2, metav1.DeleteOptions{}))
+	require.NoError(t, fc.Functions(tenantNS).Delete(ctx, fnName2, metav1.DeleteOptions{}))
+	require.NoError(t, fc.Environments(tenantNS).Delete(ctx, envName2, metav1.DeleteOptions{}))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := fc.Functions(tenantNS).Get(ctx, fnName2, metav1.GetOptions{})
+		assert.Truef(c, apierrors.IsNotFound(err), "function %q should clear before offboarding (err=%v)", fnName2, err)
+	}, time.Minute, time.Second)
+	ns.DisableTenant(t, ctx)
+	f.WaitForTenantOffboarded(t, ctx, tenantNS)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		g := scrapeRouterMetric(t, ctx, f, "go_goroutines")
+		assert.LessOrEqualf(c, g, goroutinesBefore+10,
+			"router goroutines must return to the pre-onboard baseline after offboard (baseline=%.0f, current=%.0f) — a per-namespace informer leak pins goroutines forever",
+			goroutinesBefore, g)
+	}, 2*time.Minute, 5*time.Second, "router goroutines never returned to baseline — per-namespace informer leak suspected")
+
+	// 8. The namespace itself is deleted by the NewTestNamespaceIn cleanup hook.
+}
+
+// assertWarmPathHit polls until invoking routeURL increments the router's
+// fission_router_endpointcache_hits_total beyond hitsBefore — i.e. the warm
+// path (slice-fed index, no executor RPC) served a request. The invocation is
+// INSIDE the poll: after a cold start the executor patches the pod's served
+// label and the EndpointSlice controller mirrors it (both async, seconds of
+// lag), so scraping without invoking can never move the counter.
+func assertWarmPathHit(t *testing.T, ctx context.Context, r *framework.RouterClient, f *framework.Framework, routeURL string, hitsBefore float64, msg string, args ...any) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, body, err := r.Get(ctx, routeURL)
+		if !assert.NoError(c, err) {
+			return
+		}
+		assert.Contains(c, strings.ToLower(body), "hello")
+		hitsAfter := scrapeRouterMetric(t, ctx, f, "fission_router_endpointcache_hits_total")
+		assert.Greaterf(c, hitsAfter, hitsBefore,
+			"endpointcache_hits_total must increase on a warm invocation — proves the warm path served the tenant's function")
+	}, 2*time.Minute, 5*time.Second, append([]any{msg}, args...)...)
+}
+
+// scrapeRouterMetric scrapes a single Prometheus metric from the router pods
+// (via pod proxy, no port-forward needed) and returns its sum across replicas.
+// Works for both gauges and counters (sums the latest sample per pod).
+func scrapeRouterMetric(t *testing.T, ctx context.Context, f *framework.Framework, metricName string) float64 {
+	t.Helper()
+	pods, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).List(ctx, metav1.ListOptions{LabelSelector: "svc=router"})
+	require.NoErrorf(t, err, "listing router pods")
+	require.NotEmptyf(t, pods.Items, "no router pod found in namespace %s", f.FissionNamespace())
+	var total float64
+	for _, p := range pods.Items {
+		raw, err := f.KubeClient().CoreV1().Pods(f.FissionNamespace()).ProxyGet("http", p.Name, "8080", "/metrics", nil).DoRaw(ctx)
+		require.NoErrorf(t, err, "scraping /metrics from router pod %s", p.Name)
+		total += parseGaugeValue(raw, metricName)
+	}
+	return total
+}
+
+// parseGaugeValue extracts the value of a Prometheus metric from a /metrics
+// scrape body. Returns 0 if the metric is absent (e.g. before any slice event).
+// Works for gauges and counters (returns the last sample's value).
+func parseGaugeValue(raw []byte, name string) float64 {
+	sc := bufio.NewScanner(bytes.NewReader(raw))
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		rest, ok := strings.CutPrefix(line, name)
+		if !ok {
+			continue
+		}
+		if len(rest) == 0 || (rest[0] != ' ' && rest[0] != '{') {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		v, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err == nil {
+			return v
+		}
+	}
+	return 0
 }


### PR DESCRIPTION
Fixes https://github.com/fission/fission/issues/3647

## Problem

With `tenancy.mode=dynamic`, onboarding a tenant namespace at runtime worked for routing/invocation, but the router's RFC-0002 warm path never saw the new tenant's EndpointSlices:

1. **Informer scope gap** — the router's EndpointSlice informer was scoped once at startup (`routerCacheOptions`). A namespace onboarded later was never watched, so every request to its functions fell back to the executor RPC forever.
2. **RBAC gap** — the router's ServiceAccount had no RoleBinding in a runtime-onboarded namespace, so even a re-scoped informer would have gotten `forbidden` LISTs.

## Fix (3 parts)

### A. RBAC — grant the router SA per-tenant dataplane read
- New `fission-router-dataplane-tenant` ClusterRole (dynamic-mode chart partial, single-sourced from the same `router-dataplane-kuberules` the static Role uses — the two paths cannot drift).
- `fission-router` added to the ValidatingAdmissionPolicy SA allowlist.
- The tenant controller binds it per namespace at onboarding (`fission-router-dataplane` RoleBinding) and deletes it at offboard.

### B. Data plane — per-namespace informers that re-scope at runtime
- New `NamespaceInformers` (`pkg/router/endpointcache/nsinformers.go`): one client-go EndpointSlice informer per tenant namespace, started/stopped as tenants are onboarded/offboarded. In dynamic mode this **replaces** the manager-cache informer entirely (static/cluster modes keep the existing path).
- The tenant resolver-sync reconciler gained optional hooks; the router registers one that re-scopes the informer set on every FissionTenant change.
- **Teardown fence** (PRD §11.1): `Sync` cancels the informer, waits for its goroutines to fully drain (`factory.Start` is non-blocking — `factory.Shutdown` is the real fence), and only then sweeps the index. The whole transition is serialized under one lock, so an offboard/re-onboard overlap cannot (a) resurrect stale endpoints after the sweep or (b) wipe a replacement informer's fresh entries.
- The shared Add/Update/Delete handlers (including tombstone unwrapping) are extracted so the manager-cache path and per-namespace path cannot drift.

### C. Readiness — exclusion instead of wedging
- A namespace that fails the EndpointSlice `SelfSubjectAccessReview` is **excluded** from the informer set (its functions fall back to the executor RPC, byte-identical to the legacy path) and re-checked on every reconcile. This matters twice: the tenant controller's RoleBinding lands asynchronously after the FissionTenant event, and an orphaned FissionTenant (namespace deleted) can never pass — before this, either case would wedge `/readyz` for every tenant.
- Hooks report `pending` when any namespace is still waiting on RBAC; the reconciler requeues after 2s, since no FissionTenant event fires when the missing piece is an asynchronously-created RoleBinding.

## Reviewer guide

| Area | Files |
|---|---|
| RBAC (chart) | `charts/fission-all/templates/tenant-controller/_tenant-workload-roles.tpl`, `admission-policy.yaml`, `rbac.yaml` |
| RBAC (provisioning) | `pkg/tenant/provision.go`, `pkg/apis/core/v1/const.go` |
| Per-namespace informers | `pkg/router/endpointcache/nsinformers.go`, `handlers.go`, `index.go` (`RemoveNamespace`) |
| Re-scope wiring | `pkg/router/router.go`, `pkg/tenant/resolversync.go` |
| Tests | `nsinformers_test.go`, `index_test.go`, `resolversync_test.go`, `provision_test.go`, `test/integration/suites/serial/dynamic_tenant_test.go` |

Suggested order: `nsinformers.go` (the fence + lock) → `router.go` dynamic block (seed → RBAC filter → hook) → `resolversync.go` (pending-requeue) → `provision.go` + chart partials → tests.

## Manual verification (kind cluster, `SKAFFOLD_PROFILE=kind,dynamic-tenancy`)

### 1. Chart/RBAC render checks

```bash
# ClusterRole renders in dynamic mode with the same rules as the static dataplane Role
helm template fission charts/fission-all --set tenancy.mode=dynamic | grep -A10 'fission-router-dataplane-tenant'

# Router SA can read EndpointSlices + Services in a provisioned tenant namespace
kubectl auth can-i list endpointslices -n <tenant-ns> --as system:serviceaccount:fission:fission-router   # yes
kubectl auth can-i watch endpointslices -n <tenant-ns> --as system:serviceaccount:fission:fission-router   # yes
```

### 2. End-to-end onboard → warm path (fission CLI)

```bash
kubectl create ns manual-reonboard
fission tenant enable --namespace manual-reonboard
fission env create --name python-man --image ghcr.io/fission/python-env --poolsize 1 --namespace manual-reonboard
fission fn create --name hello-man --env python-man --code hello.py --namespace manual-reonboard
fission route create --name route-hello-man --url /hello-man --method GET --function hello-man --namespace manual-reonboard
```

Observed, step by step:

```bash
# Router logs: informer started for the new tenant — no restart of any control-plane pod
"started endpointslice informer for namespace"  namespace="manual-reonboard"

# RoleBinding provisioned by the tenant controller
kubectl get rolebindings -n manual-reonboard
# fission-router-dataplane   ClusterRole/fission-router-dataplane-tenant

# First invocations (cold start → executor RPC):
curl localhost:8888/hello-man   # Hello, world!
# metrics: fission_router_endpointcache_misses_total +1, hits unchanged

# Executor patched served=true onto the specialized pod; the EndpointSlice
# controller mirrored it seconds later:
kubectl get pod -n manual-reonboard <pod> -o jsonpath='{.metadata.labels.fission\.io/served}'   # true
kubectl get endpointslice -n manual-reonboard -o yaml | grep -A2 'endpoints:'                  # populated, ready: true

# Next invocation — warm path, no executor RPC:
curl localhost:8888/hello-man   # Hello, world!
# metrics: fission_router_endpointcache_hits_total incremented (4 -> 5)
```

### 3. Offboard → re-onboard the SAME namespace

```bash
# drain functions, then:
fission tenant disable --namespace manual-reonboard
# router logs: "stopped endpointslice informer for namespace" — after the drain fence
fission tenant enable --namespace manual-reonboard
# re-create env/fn/route, invoke twice: cold start, then warm hit again
# (hits_total incremented again; no stale endpoints from the first generation)
```

### 4. Orphaned-tenant readiness (regression found during manual testing)

A leftover FissionTenant whose namespace had been deleted wedged `/readyz` at 503 permanently (informer LIST `forbidden` forever). With the exclusion fix:

```bash
kubectl get fissiontenants   # orphan present, namespace gone
kubectl logs deploy/router | grep 'excluded from the warm path'
# "endpointslice RBAC not yet granted ... namespace excluded from the warm path until it lands"
kubectl get pods -l svc=router   # 1/1 Running — readiness no longer wedges
# (orphan then removed: kubectl patch fissiontenant <name> --type json \
#    -p '[{"op":"remove","path":"/metadata/finalizers"}]' && kubectl delete fissiontenant <name>)
```

## Automated test plan

- [x] `go test -race ./pkg/router/endpointcache ./pkg/tenant` — incl. new concurrent-Sync hammer (4 goroutines × 20 Syncs under `-race`), offboard→re-onboard lifecycle, hook pending-requeue
- [x] `TestDynamicTenantLifecycle` (serial integration, kind + dynamic-tenancy profile) — passes (~35s): onboard → warm-path hit → no control-plane restarts → offboard → **re-onboard same namespace** → warm-path hit → final offboard → `go_goroutines` returns to baseline (informer leak guard)
- [ ] CI legs (static + cluster modes) — unchanged paths, expected green

## Known follow-ups (not in scope)

- The tenant controller leaves an orphaned FissionTenant when a namespace is deleted without `tenant disable` (finalizer stuck) — the router now tolerates this (exclusion), but the controller should prune orphans.
