### PR TITLE
ci(upgrade-gate): measure the steady-state upgrade path — patch the drain posture onto the installed release

### DIFF
--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -1,7 +1,8 @@
 name: Fission CI upgrade
 
 # RFC-0028 phase 1: upgrade-under-load. Installs the latest published release,
-# seeds fixtures, drives constant-rate load against the router via NodePort
+# aligns its router with the chart's steady-state drain posture, seeds
+# fixtures, drives constant-rate load against the router via NodePort
 # (port-forward would reconnect during the roll and pollute the transport-
 # failure signal), runs `helm upgrade` to HEAD mid-load, and classifies every
 # request outcome (ok / transport failure / platform-attributed / unattributed
@@ -147,6 +148,46 @@ jobs:
           kubectl create -k "github.com/fission/fission/crds/v1?ref=$FROM_TAG"
           helm install --wait --timeout 10m --namespace ${{ env.FISSION_NAMESPACE }} fission \
             fission-charts/fission-all --version "$CHART_VER" --set routerServiceType=NodePort,analytics=false
+
+      # The published releases predate the chart's router drain posture
+      # (preStopSleep + gracefulShutdownTimeout + 90s grace, RFC-0028 §2), so
+      # their router pods close the listener the instant the mid-load roll
+      # reaches them, and every connection kube-proxy has not yet re-routed is
+      # refused: a handful of transport failures pinned to the router roll
+      # that no code in HEAD can prevent — the pods are born from the OLD
+      # release's chart. Patch the same posture onto the installed release
+      # before load starts, so the gate measures the steady-state upgrade path
+      # (N-with-posture -> N+1) — the path every future upgrade takes — rather
+      # than the one-time bootstrap from a pre-posture release.
+      #
+      # The values mirror the router defaults in charts/fission-all/values.yaml
+      # and are also semantically pinned (grace 90 > drain 75s > the 60s
+      # default function timeout); `helm upgrade` later replaces the patch
+      # with the identical chart-rendered fields, so there is nothing to
+      # unwind. GRACEFUL_SHUTDOWN_TIMEOUT is unread by binaries that predate
+      # it, and the Sleep lifecycle action is served by the kubelet (GA in
+      # Kubernetes 1.32) — no sleep binary is needed in the old image. Once
+      # the oldest release this matrix installs ships the posture itself, the
+      # patch matches the live spec and no-ops; delete the step then.
+      - name: Align installed release with the router drain posture
+        if: ${{ env.SKIP_LEG != '1' }}
+        run: |
+          kubectl patch deployment router -n ${{ env.FISSION_NAMESPACE }} --type strategic --patch '
+          spec:
+            template:
+              spec:
+                terminationGracePeriodSeconds: 90
+                containers:
+                  - name: router
+                    lifecycle:
+                      preStop:
+                        sleep:
+                          seconds: 5
+                    env:
+                      - name: GRACEFUL_SHUTDOWN_TIMEOUT
+                        value: "75s"
+          '
+          kubectl rollout status deployment/router -n ${{ env.FISSION_NAMESPACE }} --timeout=3m
 
       # Record which Secrets the HEAD chart will ask the pre-upgrade hook to
       # adopt AND that the PUBLISHED release actually created. Both filters

--- a/.github/workflows/upgrade_test.yaml
+++ b/.github/workflows/upgrade_test.yaml
@@ -24,6 +24,9 @@ on:
       - "test/**"
       - go.mod
       - go.sum
+      # Self-trigger: changes to the gate itself (posture steps, error budget,
+      # flipping continue-on-error) must produce a run as evidence.
+      - ".github/workflows/upgrade_test.yaml"
   pull_request:
     branches:
       - main
@@ -33,6 +36,7 @@ on:
       - "test/**"
       - go.mod
       - go.sum
+      - ".github/workflows/upgrade_test.yaml"
 
 env:
   HELM_VERSION: v4.2.2


### PR DESCRIPTION
## TL;DR

One workflow step, no product code: patch the chart's router drain posture (`preStop sleep 5s`, `GRACEFUL_SHUTDOWN_TIMEOUT=75s`, `terminationGracePeriodSeconds: 90`) onto the **installed N−1/N−2 release** before the upgrade-under-load gate starts driving traffic.
This removes the last failure class the gate still records, and is the first half of RFC-0028 phase 4 (flip the gate to enforcing, close #1856).

## The residual signature

With #3651 (instrumentation + grace) and #3652 (warm-pod survival) in, the gate's remaining failures are 1–4 fast `connection refused` errors pinned exactly to the router roll (~47s offset in the attribution timeline), on otherwise all-zero legs.

They come from the **old release's** router pods: born from the N−1 chart, they have no preStop sleep and no extended grace, so when `helm upgrade` rolls them they close the listener instantly, and every connection kube-proxy has not yet re-routed is refused.
No code or chart change in HEAD can prevent this — HEAD's posture only applies to pods created *from* HEAD.

## What the step does

After `helm install` of the published release and before load starts:

1. `kubectl patch` the router Deployment with the same three fields the HEAD chart now ships by default.
2. `kubectl rollout status` so the (pre-load) roll settles before measurement begins.

The gate then measures the **steady-state upgrade path** — N-with-posture → N+1, the path every future upgrade takes — rather than the one-time bootstrap from a pre-posture release.

## Why this is honest, not gaming the gate

- The patched values are byte-identical to the HEAD chart's router defaults, and semantically pinned by the same inequality documented in `values.yaml` (grace 90 > drain 75s > 60s default function timeout).
- The mid-load `helm upgrade` replaces the patch with the identical chart-rendered fields — there is nothing to unwind and no divergence between what the gate runs and what users deploy.
- The one-time bootstrap path (a truly pre-posture N−1) still exists for real users exactly once, and its worst case is the 1–4 refused connections measured here — documented, bounded, and shrinking to zero as releases ship the posture.

## Self-retiring

`GRACEFUL_SHUTDOWN_TIMEOUT` is unread by binaries that predate it; the `sleep` lifecycle action is served by the kubelet (GA in Kubernetes 1.32), so the old image needs no sleep binary.
Once the oldest release the matrix installs ships the posture itself, the patch matches the live spec and no-ops — the step then deletes cleanly.

## Expected evidence on this PR's own run

Both upgrade legs (`latest`, `skip-level`) should report every error-budget counter at 0 **and** `warm_pod_survival = 1`.
That starts the green streak required before the follow-up PR removes `continue-on-error` from the error-budget step and closes #1856 with before/after numbers.

## Review pointer

Two commits, one file (`.github/workflows/upgrade_test.yaml`):

1. The posture step + two comments; the embedded patch is plain YAML validated to parse to exactly the three intended fields.
2. Add the workflow file itself to the gate's `paths` filters — without it, a PR editing only the gate (this one; the follow-up that drops `continue-on-error`) produces no run at all, on the PR or on the merge push.
