### PR TITLE
poolmgr: pre-label pool RS is KEEP unconditionally — restore warm-pod survival on the shipping upgrade

### DIFF
--- a/pkg/executor/executortype/poolmgr/poolpodcontroller.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller.go
@@ -184,18 +184,25 @@ func (p *PoolPodController) shouldCleanupForRS(ctx context.Context, rs *apps.Rep
 		return false, fmt.Errorf("get environment %s/%s: %w", envNS, envName, err)
 	}
 	if _, hasHash := tmpl[fv1.ENVIRONMENT_RUNTIME_HASH]; !hasHash {
-		// Pre-label RS (born under a release without the hash label). Keep by
-		// default — that is what makes warm pods survive the very upgrade
-		// that ships this fix; treating it as "clean" would re-kill them one
-		// last time. ONE sharpening: if the live pool Deployment's template
-		// already carries the label, the pool has been re-templated since,
-		// so this RS is provably a pre-hash generation whose pods run a
-		// runtime at least one revision old -> clean. During the shipping
-		// upgrade itself the live Deployment is not yet re-templated, so
-		// both sides are unlabelled and the keep still holds.
-		if _, ownerHasHash := dep.Spec.Template.Labels[fv1.ENVIRONMENT_RUNTIME_HASH]; ownerHasHash {
-			return true, nil
-		}
+		// Pre-label RS (born under a release without the hash label): KEEP,
+		// unconditionally — that is what makes warm pods survive the very
+		// upgrade that ships the labels.
+		//
+		// Do NOT sharpen this with "clean when the live Deployment's template
+		// already carries the label". That clause shipped once and killed the
+		// exact pods it was reviewed to protect: the executor's own
+		// hash-stamping update is what ROLLS the pool, so by the time the old
+		// RS reports zero replicas its owner ALWAYS carries the label — the
+		// "not yet re-templated" window does not exist (the upgrade gate
+		// measured warm_pod_survival 1 -> 0 on both legs). It would also
+		// re-fire on every later executor restart: zero-replica RSes are
+		// retained by the Deployment's revision history and replay through
+		// this reconciler on informer sync, condemning the survivors then.
+		//
+		// The cost of the plain keep is the documented one-release caveat
+		// (RELEASES.md): a pre-label pod whose environment changed while the
+		// executor was down is recycled by the idle reaper or the next
+		// function update rather than here.
 		return false, nil
 	}
 	// Recycle iff the template's birth runtime is no longer the live one: a

--- a/pkg/executor/executortype/poolmgr/poolpodcontroller_rs_test.go
+++ b/pkg/executor/executortype/poolmgr/poolpodcontroller_rs_test.go
@@ -185,14 +185,16 @@ func TestProcessRSDiscriminator(t *testing.T) {
 			wantEnqueued: 0,
 		},
 		{
-			name:     "pre-label RS under a re-templated (hash-stamped) owner -> clean",
+			name:     "pre-label RS under the hash-stamped owner that just rolled it -> KEEP (the shipping upgrade)",
 			ownerUID: depUID, tmplLabels: templateLabels("", nil),
-			// The live pool Deployment's template already carries the label, so
-			// this RS is provably a pre-hash generation: its pods run a runtime
-			// at least one revision old. Without this branch they would be kept
-			// FOREVER (a settled zero-replica RS emits no further events).
+			// This IS the shipping-upgrade shape, not a rare one: the new
+			// executor's hash-stamping update is what rolls the pool, so the
+			// old RS always reports zero replicas AFTER the owner carries the
+			// label. A "clean" here killed every N-1-born warm pod (the gate
+			// measured warm_pod_survival 1 -> 0) and would re-fire on each
+			// executor restart via the revision-history RSes.
 			dep: liveDepHashed(), cachedEnv: liveEnv(),
-			wantEnqueued: 1,
+			wantEnqueued: 0,
 		},
 		{
 			name:     "mangled hash label -> compares unequal -> clean",


### PR DESCRIPTION
## TL;DR

One clause deleted, one unit-table expectation corrected: a pool ReplicaSet born **before** the runtime-hash labels (i.e. under the currently published release) is now kept unconditionally by `shouldCleanupForRS`.
This restores `warm_pod_survival = 1`, which regressed to 0 in #3652's review-fix commit — masked until #3656 made the rest of the gate clean enough to see it.

## Evidence chain

1. #3656's gate run: all six error counters 0 on both legs, but `warm_pod_survival = 0` on both.
2. Main's own push run (`9da757b1`): also 0 — the regression is in merged main, not in #3656 (which is workflow-only).
3. The attribution timeline: all four old-RS pods (the specialized one included) went terminating at 44–48s, right at the pool roll; the 90s drain posture is the only reason no requests failed.
4. The executor log names the killer: `specialized pods identified for cleanup with RS` (numPods=1) on the N−1-born RS — the discriminator's clean branch.

## Root cause

The `ca238f66` review round added a sharpening: pre-label RS **under an owner Deployment whose template already carries the hash label** → provably stale generation → clean.
Its safety argument was that during the shipping upgrade the owner is "not yet re-templated".
That window does not exist: the new executor's own hash-stamping update is **what rolls the pool**, so the old RS reports zero replicas strictly *after* the owner carries the label.
The clause therefore fires on the exact upgrade it had to sit out — and would re-fire on every later executor restart, because zero-replica RSes are retained in the Deployment's revision history and replay through the reconciler on informer sync, condemning the survivors then.

The unit table covered this shape but pinned the wrong expected value (reviewer and verifier agreed with each other, not with the cluster).
The serial suite could not catch it: its pods are born from already-labelled templates; only a real published-release → HEAD upgrade produces pre-label pods, and only the gate runs that.

## The fix

Plain, unconditional KEEP for pre-label RSes under a live owner — the original #3652 design, which the gate measured surviving before the review round.
Cost: the already-documented one-release caveat (RELEASES.md) — a pre-label pod whose environment changed while unlabelled is recycled by the idle reaper or the next function update rather than by processRS.
The flipped table case is named for the shipping-upgrade sequence and fails if the clause ever returns (mutation-verified: re-adding the clause compiles and fails exactly that case).

## Expected on this PR's gate run

Both legs: every error counter 0 **and** `warm_pod_survival = 1` — the full published budget, for the first time simultaneously.