### PR TITLE
ci+dns: raise the kind pod cap to 250 and make hot-path service names absolute FQDNs

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -12,6 +12,9 @@ on:
       - go.mod
       - go.sum
       - .github/workflows/push_pr.yaml
+      # The integration job's cluster shape (node count, kubelet maxPods)
+      # lives here — capacity changes must produce a run as evidence.
+      - kind.yaml
   pull_request:
     branches:
       - main
@@ -22,6 +25,7 @@ on:
       - go.mod
       - go.sum
       - .github/workflows/push_pr.yaml
+      - kind.yaml
 
 env:
   HELM_VERSION: v4.2.2
@@ -514,6 +518,22 @@ jobs:
           # context fires first (clear failure) rather than the hard timeout.
           go test -tags=integration "${COVER_FLAGS[@]}" -p 1 -timeout=25m -v \
             ./test/integration/suites/serial/... "${COVER_ARGS[@]}"
+
+      # When the suite goes red from pod-capacity starvation, the per-test
+      # symptoms are misleading (builder timeouts, HPA that never scales,
+      # canary promotions that hang) and the cause — pods Pending on
+      # "Too many pods" — is buried in events that expire from etcd. Surface
+      # it loudly next to the failure so nobody root-causes the same
+      # starvation twice.
+      - name: Surface scheduling starvation (capacity check)
+        timeout-minutes: 2
+        if: ${{ failure() }}
+        run: |
+          echo "=== node pod capacity vs live pods ==="
+          kubectl get nodes -o custom-columns='NAME:.metadata.name,PODS-CAP:.status.capacity.pods,PODS-ALLOC:.status.allocatable.pods' || true
+          kubectl get pods -A --no-headers 2>/dev/null | wc -l | sed 's/^/total pods now: /' || true
+          echo "=== FailedScheduling events (capacity exhaustion reads 'Too many pods') ==="
+          kubectl get events -A --field-selector reason=FailedScheduling --sort-by=.lastTimestamp 2>/dev/null | tail -30 || true
 
       - name: Collect integration coverage
         # Only the instrumented leg produced coverage; collect there.

--- a/charts/fission-all/templates/buildermgr/deployment.yaml
+++ b/charts/fission-all/templates/buildermgr/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         env:
         {{- include "fission.podNamespaceEnv" . | nindent 8 }}
         {{- include "leaderElection.envs" (dict "enabled" (dig "leaderElection" "enabled" false (.Values.buildermgr | default dict))) | indent 8 }}
+        # Consumed by utils.ServiceFQDN when dialing per-environment builder
+        # services (absolute names, no search-path walk).
+        - name: CLUSTER_DOMAIN
+          value: {{ .Values.clusterDomain | quote }}
         - name: FETCHER_IMAGE
           value: {{ include "fetcherImage" . | quote }}
         {{- if .Values.packageRegistry.enabled }}

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -61,6 +61,10 @@ spec:
           value: "{{ .Values.pullPolicy }}"
         - name: ADOPT_EXISTING_RESOURCES
           value: {{ .Values.executor.adoptExistingResources | default false | quote }}
+        # Consumed by utils.ServiceFQDN when building newdeploy/container
+        # function-service addresses (absolute names, no search-path walk).
+        - name: CLUSTER_DOMAIN
+          value: {{ .Values.clusterDomain | quote }}
         - name: FINALIZER_ENABLED
           value: {{ .Values.finalizerEnabled | quote }}
         - name: POD_READY_TIMEOUT

--- a/charts/fission-all/templates/router/deployment.yaml
+++ b/charts/fission-all/templates/router/deployment.yaml
@@ -58,7 +58,10 @@ spec:
           - "--routerInternalPort"
           - {{ include "fission.routerInternalPort" . | quote }}
           - "--executorUrl"
-          - "http://executor.{{ .Release.Namespace }}"
+          # Absolute FQDN (trailing dot): the router calls this on every cold
+          # start, and the short name's resolv.conf search walk is the DNS
+          # load that melts down under parallel traffic.
+          - "http://executor.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}."
         env:
         {{- if .Values.authentication.enabled }}
         - name: AUTH_USERNAME

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -11,6 +11,17 @@ serviceType: ClusterIP
 ##
 routerServiceType: LoadBalancer
 
+## clusterDomain is the cluster's DNS suffix, used to build ABSOLUTE
+## (trailing-dot) in-cluster Service names on the request hot paths — the
+## router's executor URL and the executor/buildermgr-built function and
+## builder service addresses. Absolute names skip the pod resolv.conf
+## search-path walk (ndots:5), cutting per-resolution DNS queries ~4x;
+## the short forms' extra queries are what drop under parallel load
+## ("lookup <svc>.<ns>: i/o timeout" cascades). Change only if your
+## cluster uses a non-default DNS domain.
+##
+clusterDomain: cluster.local
+
 ## repository represents base repository for images used in the chart.
 ## Keep it empty for using existing local image
 ##

--- a/kind.yaml
+++ b/kind.yaml
@@ -1,6 +1,7 @@
 #######################################################################################
 # Kind Config for running a local cluster (More about Kind:https://kind.sigs.k8s.io/)
-# Creates a three node cluster for local development and testing
+# Creates a single-node cluster, used both for local development and by the
+# CI integration job (.github/workflows/push_pr.yaml).
 #
 #######################################################################################
 
@@ -15,6 +16,18 @@ nodes:
         kubeletExtraArgs:
           node-labels: "ingress-ready=true"
           authorization-mode: "AlwaysAllow"
+    # The kubelet default of 110 pods starves the CI integration suite: six
+    # parallel test packages spawn pool/builder/function pods that peak past
+    # the cap, and every pod over it sits Pending with a FailedScheduling
+    # "Too many pods" event while tests burn their timeouts (the recurring
+    # builder/HPA/canary red legs). One node with a higher cap beats extra
+    # nodes here: the 4-vCPU runner would pay per-node kubelet/etcd overhead
+    # and `kind load` copies every image to every node. The pods are small
+    # (warm pool + fetcher sidecars, mostly idle), so the binding constraint
+    # is the count, not CPU.
+    - |
+      kind: KubeletConfiguration
+      maxPods: 250
   extraPortMappings:
   - containerPort: 80
     hostPort: 80

--- a/pkg/buildermgr/common.go
+++ b/pkg/buildermgr/common.go
@@ -78,7 +78,10 @@ func buildPackage(ctx context.Context, logger logr.Logger, fissionClient version
 		return nil, e, ferror.MakeError(http.StatusInternalServerError, e)
 	}
 
-	svcName := fmt.Sprintf("%s-%s.%s", env.Name, env.ResourceVersion, envBuilderNamespace)
+	// Dial address only (never a Service object name — those cannot contain
+	// dots). Absolute FQDN so every build's fetcher/builder calls skip the
+	// resolv.conf search-path walk; see utils.ServiceFQDN.
+	svcName := utils.ServiceFQDN(fmt.Sprintf("%s-%s", env.Name, env.ResourceVersion), envBuilderNamespace)
 	srcPkgFilename := fmt.Sprintf("%s-%s", pkg.Name, strings.ToLower(uniuri.NewLen(6)))
 	// HMACSecretFromEnv returns nil when internalAuth is disabled; the
 	// fetcher / builder clients pass-through unsigned in that case,

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -401,7 +401,9 @@ func (caaf *Container) fnCreate(ctx context.Context, fn *fv1.Function) (*fscache
 		}
 		return nil, fmt.Errorf("error creating service %s: %w", objName, err)
 	}
-	svcAddress := fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
+	// Absolute FQDN — same rationale as the newdeploy site: keep the
+	// router's per-request dials off the resolv.conf search path.
+	svcAddress := utils.ServiceFQDN(svc.Name, svc.Namespace)
 
 	depl, err := caaf.createOrGetDeployment(ctx, fn, objName, deployLabels, deployAnnotations, ns)
 	if err != nil {

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -495,7 +495,10 @@ func (deploy *NewDeploy) fnCreate(ctx context.Context, fn *fv1.Function) (*fscac
 		}
 		return nil, fmt.Errorf("error creating service %s: %w", objName, err)
 	}
-	svcAddress := fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
+	// Absolute FQDN, deliberately: the router dials this on every proxied
+	// request whose connection isn't already warm, and the short name's
+	// search-path walk is what melts down in-cluster DNS under load.
+	svcAddress := utils.ServiceFQDN(svc.Name, svc.Namespace)
 
 	depl, err := deploy.createOrGetDeployment(ctx, fn, env, objName, deployLabels, deployAnnotations, ns)
 	if err != nil {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -43,6 +43,32 @@ const (
 // `:<alias>`/`:<version>` route into the not-yet-materialized hint.
 const HeaderRouteMiss = "X-Fission-Route-Miss"
 
+// ServiceFQDN returns the ABSOLUTE in-cluster DNS name for a Service:
+// "<name>.<namespace>.svc.<cluster-domain>." — trailing dot included.
+//
+// The short "<name>.<namespace>" form resolves only through the pod's
+// resolv.conf search path (ndots:5), so every resolution first walks the
+// search domains: up to three extra name attempts, each an A/AAAA query
+// pair, before the one that hits. Under parallel load those extra UDP round
+// trips through kube-proxy's DNAT are exactly the queries that get dropped
+// (the conntrack race behind "lookup <svc>.<ns>: i/o timeout" cascades that
+// fail dozens of in-flight requests at once). An absolute name is answered
+// in a single attempt and never touches the search path.
+//
+// The cluster domain comes from CLUSTER_DOMAIN (the chart sets it from
+// .Values.clusterDomain on the components that build these names); unset
+// falls back to the near-universal default "cluster.local".
+func ServiceFQDN(name, namespace string) string {
+	return serviceFQDN(name, namespace, os.Getenv("CLUSTER_DOMAIN"))
+}
+
+func serviceFQDN(name, namespace, domain string) string {
+	if domain == "" {
+		domain = "cluster.local"
+	}
+	return fmt.Sprintf("%s.%s.svc.%s.", name, namespace, domain)
+}
+
 func UrlForFunction(name, namespace string) string {
 	prefix := "/fission-function"
 	if namespace != metav1.NamespaceDefault {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -348,4 +349,19 @@ func TestRootFileChecksum_ConfinesToBase(t *testing.T) {
 	// A path escaping base is rejected.
 	_, err = RootFileChecksum(base, "../../etc/hostname")
 	assert.Error(t, err)
+}
+
+// TestServiceFQDN pins the absolute-name contract: in-cluster service dial
+// addresses must be fully qualified WITH the trailing dot, or Go's resolver
+// walks the pod's resolv.conf search path (ndots:5) and multiplies every
+// resolution into the extra A/AAAA queries that drop under parallel load.
+func TestServiceFQDN(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "fn-svc.default.svc.cluster.local.", ServiceFQDN("fn-svc", "default"),
+		"default cluster domain, absolute form, trailing dot")
+	assert.Equal(t, "b-123.fission-builder.svc.example.org.", serviceFQDN("b-123", "fission-builder", "example.org"),
+		"CLUSTER_DOMAIN override must reach the name")
+	assert.True(t, strings.HasSuffix(ServiceFQDN("a", "b"), "."),
+		"the trailing dot IS the fix: without it the name is still search-path relative")
 }

--- a/test/helm/clusterdomain_test.go
+++ b/test/helm/clusterdomain_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+package helm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClusterDomainAbsoluteNames guards the DNS-hot-path contract: the
+// in-cluster URLs the chart hands to the router, and the CLUSTER_DOMAIN env
+// the executor/buildermgr use to build service FQDNs in code, must render as
+// ABSOLUTE names (trailing dot / explicit domain). A regression back to the
+// short "<name>.<namespace>" form re-enables the resolv.conf search-path
+// walk whose extra queries drop under parallel load ("lookup <svc>: i/o
+// timeout" cascades).
+func TestClusterDomainAbsoluteNames(t *testing.T) {
+	t.Parallel()
+
+	containerOf := func(docs []map[string]any, kind, name string) map[string]any {
+		t.Helper()
+		for _, d := range docs {
+			if d["kind"] != kind {
+				continue
+			}
+			meta := d["metadata"].(map[string]any)
+			if meta["name"] != name {
+				continue
+			}
+			spec := d["spec"].(map[string]any)["template"].(map[string]any)["spec"].(map[string]any)
+			return spec["containers"].([]any)[0].(map[string]any)
+		}
+		t.Fatalf("%s %q not rendered", kind, name)
+		return nil
+	}
+
+	envValue := func(c map[string]any, key string) (string, bool) {
+		t.Helper()
+		for _, e := range c["env"].([]any) {
+			ev := e.(map[string]any)
+			if ev["name"] == key {
+				v, _ := ev["value"].(string)
+				return v, true
+			}
+		}
+		return "", false
+	}
+
+	t.Run("defaults render cluster.local absolutes", func(t *testing.T) {
+		t.Parallel()
+		docs := render(t)
+
+		router := containerOf(docs, "Deployment", "router")
+		joined := strings.Join(func() []string {
+			var out []string
+			for _, a := range router["args"].([]any) {
+				out = append(out, a.(string))
+			}
+			return out
+		}(), " ")
+		assert.Contains(t, joined, "http://executor.fission.svc.cluster.local.",
+			"the router's executor URL must be an absolute FQDN with the trailing dot")
+
+		for _, dep := range []string{"executor", "buildermgr"} {
+			v, ok := envValue(containerOf(docs, "Deployment", dep), "CLUSTER_DOMAIN")
+			require.Truef(t, ok, "%s must carry CLUSTER_DOMAIN for utils.ServiceFQDN", dep)
+			assert.Equal(t, "cluster.local", v, dep)
+		}
+	})
+
+	t.Run("clusterDomain override reaches every consumer", func(t *testing.T) {
+		t.Parallel()
+		docs := render(t, "--set", "clusterDomain=example.org")
+
+		router := containerOf(docs, "Deployment", "router")
+		var joined strings.Builder
+		for _, a := range router["args"].([]any) {
+			joined.WriteString(a.(string) + " ")
+		}
+		assert.Contains(t, joined.String(), "http://executor.fission.svc.example.org.",
+			"the override must reach the router's executor URL")
+
+		for _, dep := range []string{"executor", "buildermgr"} {
+			v, _ := envValue(containerOf(docs, "Deployment", dep), "CLUSTER_DOMAIN")
+			assert.Equalf(t, "example.org", v, "%s must receive the overridden domain", dep)
+		}
+	})
+}

--- a/test/helm/portdrift_test.go
+++ b/test/helm/portdrift_test.go
@@ -245,7 +245,13 @@ func TestChartPortsMatchSvcinfo(t *testing.T) {
 
 	t.Run("sibling-service URL args", func(t *testing.T) {
 		router := containerArgs(t, find(docs, "Deployment", svcinfo.SvcRouter))
-		assert.Equal(t, svcinfo.ExecutorURL("fission"), argAfter(router, "--executorUrl"))
+		// The chart renders the ABSOLUTE (trailing-dot) form of the svcinfo
+		// URL — same service, namespace, and implicit port, plus the
+		// .svc.<clusterDomain>. suffix that keeps the router's cold-start
+		// dials off the resolv.conf search path. In-process consumers (the
+		// e2e/portless framework) deliberately keep the short svcinfo form:
+		// they resolve by registry name, not DNS.
+		assert.Equal(t, svcinfo.ExecutorURL("fission")+".svc.cluster.local.", argAfter(router, "--executorUrl"))
 
 		buildermgr := containerArgs(t, find(docs, "Deployment", "buildermgr"))
 		assert.Equal(t, svcinfo.StorageSvcURL("fission"), argAfter(buildermgr, "--storageSvcUrl"))


### PR DESCRIPTION
## TL;DR

Two commits that only work together:

1. **Raise the kind node's pod cap 110 → 250** (`KubeletConfiguration` patch) + a failure-only step printing pod capacity and the FailedScheduling tail. This removes the recurring starvation reds (builder/HPA/canary legs dying at 180s on `Too many pods`).
2. **Make the control-plane's hot-path service names absolute FQDNs** (`utils.ServiceFQDN`, trailing dot) — because the cap raise exposed that the 110 limit was acting as an accidental backpressure valve for our own DNS load.

## The evidence trail

- With the cap raised, the two busy legs failed with a NEW signature: mass `lookup <svc>.<ns>: i/o timeout` in router/executor/buildermgr (~770 lines), while the new capacity step proved scheduling was healthy (cap 250, zero FailedScheduling, 43–49 pods) and CoreDNS logs were completely clean — queries dropped in the UDP/conntrack path *before* CoreDNS.
- A/B: main (cap 110) went green on all legs in the same window; the repeat run failed v1.34.8 again (2-of-2) — the all-legacy leg, i.e. the most DNS-dependent data plane.
- The volume is self-inflicted: every hot dial used the short `<name>.<namespace>` form, which ndots:5 expands through the search domains — up to three extra name attempts (each an A/AAAA pair) per resolution, multiplying DNS ~4×. The existing `single-request-reopen` hardening serializes pairs but cannot remove the amplification.

## The DNS fix (product, benefits every cluster)

`utils.ServiceFQDN(name, ns)` → `<name>.<ns>.svc.<domain>.` — the trailing dot makes the name absolute, so the resolver never walks the search path: one attempt per resolution. Applied to the three evidenced constructors:
- newdeploy function-service addresses (router dials per request) — `newdeploymgr.go`
- container function-service addresses — `containermgr.go`
- buildermgr's per-environment builder/fetcher dial address — `common.go`

and to the router's chart-side executor URL (dialed per cold start).
Domain from `CLUSTER_DOMAIN` env ← new chart value `clusterDomain` (default `cluster.local`), set on executor and buildermgr.

## Guards (all mutation-verified, mutants compiled)

- Unit: absolute form + trailing dot + domain override (dropping the dot fails it).
- Chart: rendered executor URL and both `CLUSTER_DOMAIN` plumbing points, under defaults and `clusterDomain=example.org` (restoring the short URL fails it).

## Acceptance on this PR's run

All three integration legs green with the cap at 250 — the DNS load that made the raised cap dangerous is gone at the source.