### PR TITLE
executor: create-routed reconciles must converge the deployment spec — fixes the swallowed-update staleness behind the TestFunctionNameUpdate flake

### DIFF
--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -606,6 +606,42 @@ func (caaf *Container) updateFunction(ctx context.Context, oldFn *fv1.Function, 
 	return nil
 }
 
+// reconcileDeploymentSpec brings an already-existing deployment up to the
+// function's current spec when it lags — the container-type mirror of
+// newdeploy's helper, and the level-trigger half of reconcileContainerFunc:
+// createFunction only adopts/scales an existing deployment, so a reconcile
+// that both routed through createFunction AND carried a spec change (a
+// coalesced create+update, or a drift false-alarm on the update's reconcile)
+// would otherwise leave the deployment on the old spec with nothing left to
+// re-fire. The deployment carries the function's ResourceVersion as an
+// annotation (getDeployAnnotations); compare it and push the current spec
+// when stale. A no-op when already current.
+func (caaf *Container) reconcileDeploymentSpec(ctx context.Context, fn *fv1.Function) error {
+	// Live entry only: versioned projections sharing the UID pin immutable
+	// snapshots that must not be rewritten to the live spec.
+	fsvc, err := caaf.fsCache.GetLiveByFunctionUID(fn.UID)
+	if err != nil {
+		// Not specialized yet — no deployment to reconcile; the on-demand path
+		// creates it from the current spec on first invocation.
+		return nil
+	}
+	ns := caaf.nsResolver.GetFunctionNS(fn.Namespace)
+	existingDepl, err := caaf.kubernetesClient.AppsV1().Deployments(ns).Get(ctx, fsvc.Name, metav1.GetOptions{})
+	if err != nil {
+		if k8sErrs.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION] == fn.ResourceVersion {
+		return nil // deployment already reflects the current function spec
+	}
+	caaf.logger.Info("reconciling stale deployment to current function spec",
+		"function", fn.Name, "deployment", fsvc.Name,
+		"deployment_rv", existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION], "function_rv", fn.ResourceVersion)
+	return caaf.updateFuncDeployment(ctx, fn)
+}
+
 func (caaf *Container) updateFuncDeployment(ctx context.Context, fn *fv1.Function) error {
 	// Live entry only — see updateFunction: versioned projections' entries
 	// share the UID but must keep their pinned spec.

--- a/pkg/executor/executortype/container/containermgr.go
+++ b/pkg/executor/executortype/container/containermgr.go
@@ -16,6 +16,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8sErrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -608,13 +609,10 @@ func (caaf *Container) updateFunction(ctx context.Context, oldFn *fv1.Function, 
 
 // reconcileDeploymentSpec brings an already-existing deployment up to the
 // function's current spec when it lags — the container-type mirror of
-// newdeploy's helper, and the level-trigger half of reconcileContainerFunc:
-// createFunction only adopts/scales an existing deployment, so a reconcile
-// that both routed through createFunction AND carried a spec change (a
-// coalesced create+update, or a drift false-alarm on the update's reconcile)
-// would otherwise leave the deployment on the old spec with nothing left to
-// re-fire. The deployment carries the function's ResourceVersion as an
-// annotation (getDeployAnnotations); compare it and push the current spec
+// newdeploy's helper, and the level-trigger half of every create-routed
+// reconcile (see createAndConverge in reconciler.go for why it must follow
+// createFunction). The deployment carries the function's ResourceVersion as
+// an annotation (getDeployAnnotations); compare it and push the current spec
 // when stale. A no-op when already current.
 func (caaf *Container) reconcileDeploymentSpec(ctx context.Context, fn *fv1.Function) error {
 	// Live entry only: versioned projections sharing the UID pin immutable
@@ -633,12 +631,13 @@ func (caaf *Container) reconcileDeploymentSpec(ctx context.Context, fn *fv1.Func
 		}
 		return err
 	}
-	if existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION] == fn.ResourceVersion {
+	deplRV := existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION]
+	if deplRV == fn.ResourceVersion {
 		return nil // deployment already reflects the current function spec
 	}
 	caaf.logger.Info("reconciling stale deployment to current function spec",
 		"function", fn.Name, "deployment", fsvc.Name,
-		"deployment_rv", existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION], "function_rv", fn.ResourceVersion)
+		"deployment_rv", deplRV, "function_rv", fn.ResourceVersion)
 	return caaf.updateFuncDeployment(ctx, fn)
 }
 
@@ -672,6 +671,18 @@ func (caaf *Container) updateFuncDeployment(ctx context.Context, fn *fv1.Functio
 	if err != nil {
 		caaf.updateStatus(fn, err, "failed to get new deployment spec while updating function")
 		return err
+	}
+
+	// A Deployment's selector is immutable, and for container functions it is
+	// derived from the Function CR's own labels (getDeployLabels copies them),
+	// which can change without bumping Generation. An in-place Update with a
+	// different selector is rejected by the API server; returning nil (not an
+	// error) avoids requeuing forever against a permanently immutable field —
+	// the same guard newdeploy's updateFuncDeployment carries.
+	if !apiequality.Semantic.DeepEqual(existingDepl.Spec.Selector, newDeployment.Spec.Selector) {
+		caaf.logger.Info("deployment selector changed (function labels changed); cannot update in place, leaving existing deployment",
+			"deployment", fnObjName, "function", fn.Name)
+		return nil
 	}
 
 	err = caaf.updateDeployment(ctx, newDeployment, ns)

--- a/pkg/executor/executortype/container/reconciler.go
+++ b/pkg/executor/executortype/container/reconciler.go
@@ -48,31 +48,37 @@ func (caaf *Container) DeleteFunction(ctx context.Context, fn *fv1.Function) err
 // of a managed function whose backing Deployment/Service drifted away (deleted
 // out-of-band, surfaced by the drift watch) recreates them via the idempotent
 // get-or-create path rather than diffing a no-longer-existent object.
-//
-// Both create-routed branches chase createFunction with reconcileDeploymentSpec,
-// mirroring newdeploy: createFunction only adopts/scales an existing deployment.
-// If this reconcile is the only carrier of a spec change — a create and an
-// update coalesced into one first reconcile, or a drift false-alarm from cache
-// lag on the update's reconcile — adopting without a respec consumes the update
-// permanently (lastReconciled stores the new spec; no event re-fires).
 func reconcileContainerFunc(ctx context.Context, mgr functionManager, old, fn *fv1.Function) error {
 	if old == nil {
-		if _, err := mgr.createFunction(ctx, fn); err != nil {
-			return err
-		}
-		return mgr.reconcileDeploymentSpec(ctx, fn)
+		return createAndConverge(ctx, mgr, fn)
 	}
 	exist, err := mgr.resourcesExist(ctx, fn)
 	if err != nil {
 		return err
 	}
 	if !exist {
-		if _, err := mgr.createFunction(ctx, fn); err != nil {
-			return err
-		}
-		return mgr.reconcileDeploymentSpec(ctx, fn)
+		return createAndConverge(ctx, mgr, fn)
 	}
 	return mgr.updateFunction(ctx, old, fn)
+}
+
+// createAndConverge is the create-routed path both branches above take, mirroring
+// newdeploy: create (or adopt) the function's backing objects, then bring the
+// deployment to the current spec. reconcileDeploymentSpec is a no-op when the
+// deployment already reflects fn.
+//
+// The second step is not optional. createFunction only adopts/scales an existing
+// deployment — it never rewrites the pod spec — so when this reconcile is the ONLY
+// carrier of a spec change (a create and an update coalesced into one first
+// reconcile, or a drift false-alarm from cache lag on the update's own reconcile),
+// adopting without a respec consumes the update permanently: lastReconciled stores
+// the new spec, GenerationChangedPredicate filters resyncs, and no event ever
+// re-fires.
+func createAndConverge(ctx context.Context, mgr functionManager, fn *fv1.Function) error {
+	if _, err := mgr.createFunction(ctx, fn); err != nil {
+		return err
+	}
+	return mgr.reconcileDeploymentSpec(ctx, fn)
 }
 
 // RegisterReconcilers registers no type-specific watches: the container type's

--- a/pkg/executor/executortype/container/reconciler.go
+++ b/pkg/executor/executortype/container/reconciler.go
@@ -19,6 +19,7 @@ import (
 type functionManager interface {
 	createFunction(context.Context, *fv1.Function) (*fscache.FuncSvc, error)
 	updateFunction(context.Context, *fv1.Function, *fv1.Function) error
+	reconcileDeploymentSpec(context.Context, *fv1.Function) error
 	deleteFunction(context.Context, *fv1.Function) error
 	// resourcesExist reports whether the function's backing Deployment and Service
 	// are present (read from the Manager cache). False means they drifted away
@@ -47,18 +48,29 @@ func (caaf *Container) DeleteFunction(ctx context.Context, fn *fv1.Function) err
 // of a managed function whose backing Deployment/Service drifted away (deleted
 // out-of-band, surfaced by the drift watch) recreates them via the idempotent
 // get-or-create path rather than diffing a no-longer-existent object.
+//
+// Both create-routed branches chase createFunction with reconcileDeploymentSpec,
+// mirroring newdeploy: createFunction only adopts/scales an existing deployment.
+// If this reconcile is the only carrier of a spec change — a create and an
+// update coalesced into one first reconcile, or a drift false-alarm from cache
+// lag on the update's reconcile — adopting without a respec consumes the update
+// permanently (lastReconciled stores the new spec; no event re-fires).
 func reconcileContainerFunc(ctx context.Context, mgr functionManager, old, fn *fv1.Function) error {
 	if old == nil {
-		_, err := mgr.createFunction(ctx, fn)
-		return err
+		if _, err := mgr.createFunction(ctx, fn); err != nil {
+			return err
+		}
+		return mgr.reconcileDeploymentSpec(ctx, fn)
 	}
 	exist, err := mgr.resourcesExist(ctx, fn)
 	if err != nil {
 		return err
 	}
 	if !exist {
-		_, err := mgr.createFunction(ctx, fn)
-		return err
+		if _, err := mgr.createFunction(ctx, fn); err != nil {
+			return err
+		}
+		return mgr.reconcileDeploymentSpec(ctx, fn)
 	}
 	return mgr.updateFunction(ctx, old, fn)
 }

--- a/pkg/executor/executortype/container/reconciler_test.go
+++ b/pkg/executor/executortype/container/reconciler_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 type fakeFuncMgr struct {
-	created, updated, deleted []string
-	resourcesGone             bool // resourcesExist returns false (drift)
+	created, updated, deleted, reconciled []string
+	resourcesGone                         bool // resourcesExist returns false (drift)
 }
 
 func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, error) {
@@ -37,6 +37,10 @@ func (f *fakeFuncMgr) deleteFunction(_ context.Context, fn *fv1.Function) error 
 	f.deleted = append(f.deleted, fn.Name)
 	return nil
 }
+func (f *fakeFuncMgr) reconcileDeploymentSpec(_ context.Context, fn *fv1.Function) error {
+	f.reconciled = append(f.reconciled, fn.Name)
+	return nil
+}
 
 func fnOfType(name string, et fv1.ExecutorType) *fv1.Function {
 	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"}}
@@ -47,10 +51,12 @@ func fnOfType(name string, et fv1.ExecutorType) *fv1.Function {
 func TestReconcileContainerFunc(t *testing.T) {
 	fn := fnOfType("fn", fv1.ExecutorTypeContainer)
 
-	t.Run("create (old == nil) creates the function", func(t *testing.T) {
+	t.Run("create (old == nil) creates the function and converges the spec", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
 		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, nil, fn))
 		assert.Equal(t, []string{"fn"}, mgr.created)
+		assert.Equal(t, []string{"fn"}, mgr.reconciled,
+			"a coalesced create+update makes this reconcile the only carrier of the update — createFunction adopts without a respec, so the chaser must run")
 		assert.Empty(t, mgr.updated)
 	})
 
@@ -59,12 +65,15 @@ func TestReconcileContainerFunc(t *testing.T) {
 		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.updated)
 		assert.Empty(t, mgr.created)
+		assert.Empty(t, mgr.reconciled, "the diff path owns spec convergence on plain updates")
 	})
 
 	t.Run("drift: missing backing resources are recreated, not diffed", func(t *testing.T) {
 		mgr := &fakeFuncMgr{resourcesGone: true}
 		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.created, "drifted-away resources must be recreated via get-or-create")
+		assert.Equal(t, []string{"fn"}, mgr.reconciled,
+			"a drift FALSE-ALARM (cache lag) on the update's own reconcile otherwise swallows the update forever: createFunction adopts the old-spec deployment, lastReconciled stores the new spec, and no event re-fires")
 		assert.Empty(t, mgr.updated, "no diff against a non-existent object")
 	})
 

--- a/pkg/executor/executortype/container/reconciler_test.go
+++ b/pkg/executor/executortype/container/reconciler_test.go
@@ -18,7 +18,9 @@ import (
 
 type fakeFuncMgr struct {
 	created, updated, deleted, reconciled []string
-	resourcesGone                         bool // resourcesExist returns false (drift)
+	calls                                 []string // ordered call log: "create", "converge", "update"
+	createErr                             error    // injected createFunction failure
+	resourcesGone                         bool     // resourcesExist returns false (drift)
 }
 
 func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, error) {
@@ -26,10 +28,15 @@ func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, 
 }
 
 func (f *fakeFuncMgr) createFunction(_ context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	f.calls = append(f.calls, "create")
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
 	f.created = append(f.created, fn.Name)
 	return nil, nil
 }
 func (f *fakeFuncMgr) updateFunction(_ context.Context, old, _ *fv1.Function) error {
+	f.calls = append(f.calls, "update")
 	f.updated = append(f.updated, old.Name)
 	return nil
 }
@@ -38,6 +45,7 @@ func (f *fakeFuncMgr) deleteFunction(_ context.Context, fn *fv1.Function) error 
 	return nil
 }
 func (f *fakeFuncMgr) reconcileDeploymentSpec(_ context.Context, fn *fv1.Function) error {
+	f.calls = append(f.calls, "converge")
 	f.reconciled = append(f.reconciled, fn.Name)
 	return nil
 }
@@ -48,15 +56,17 @@ func fnOfType(name string, et fv1.ExecutorType) *fv1.Function {
 	return fn
 }
 
+// Every create-routed reconcile must chase createFunction with
+// reconcileDeploymentSpec — see createAndConverge for why skipping it swallows a
+// coalesced update permanently.
 func TestReconcileContainerFunc(t *testing.T) {
 	fn := fnOfType("fn", fv1.ExecutorTypeContainer)
 
 	t.Run("create (old == nil) creates the function and converges the spec", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
 		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, nil, fn))
-		assert.Equal(t, []string{"fn"}, mgr.created)
-		assert.Equal(t, []string{"fn"}, mgr.reconciled,
-			"a coalesced create+update makes this reconcile the only carrier of the update — createFunction adopts without a respec, so the chaser must run")
+		assert.Equal(t, []string{"create", "converge"}, mgr.calls,
+			"createFunction adopts without a respec; the chaser must run AFTER it")
 		assert.Empty(t, mgr.updated)
 	})
 
@@ -71,10 +81,16 @@ func TestReconcileContainerFunc(t *testing.T) {
 	t.Run("drift: missing backing resources are recreated, not diffed", func(t *testing.T) {
 		mgr := &fakeFuncMgr{resourcesGone: true}
 		require.NoError(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
-		assert.Equal(t, []string{"fn"}, mgr.created, "drifted-away resources must be recreated via get-or-create")
-		assert.Equal(t, []string{"fn"}, mgr.reconciled,
-			"a drift FALSE-ALARM (cache lag) on the update's own reconcile otherwise swallows the update forever: createFunction adopts the old-spec deployment, lastReconciled stores the new spec, and no event re-fires")
+		assert.Equal(t, []string{"create", "converge"}, mgr.calls,
+			"the chase must FOLLOW the create — a drift false-alarm converges the adopted deployment, in that order")
 		assert.Empty(t, mgr.updated, "no diff against a non-existent object")
+	})
+
+	t.Run("create failure short-circuits the chaser", func(t *testing.T) {
+		mgr := &fakeFuncMgr{resourcesGone: true, createErr: assert.AnError}
+		require.Error(t, reconcileContainerFunc(t.Context(), mgr, fn, fn))
+		assert.Equal(t, []string{"create"}, mgr.calls,
+			"a failed create must propagate before the converge runs; the retry re-enters the whole branch")
 	})
 
 	t.Run("DeleteFunction tears down the function", func(t *testing.T) {

--- a/pkg/executor/executortype/container/reconcilespec_test.go
+++ b/pkg/executor/executortype/container/reconcilespec_test.go
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	hpautils "github.com/fission/fission/pkg/executor/util/hpa"
+	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+func newSpecTestContainer(t *testing.T) *Container {
+	t.Helper()
+	logger := loggerfactory.GetLogger()
+	kubeClient := fake.NewClientset()
+	return &Container{
+		logger:           logger,
+		kubernetesClient: kubeClient,
+		fsCache:          fscache.MakeFunctionServiceCache(logger),
+		nsResolver:       utils.DefaultNSResolver(),
+		hpaops:           hpautils.NewHpaOperations(logger, kubeClient, "test-instance"),
+	}
+}
+
+func countDeploymentUpdates(t *testing.T, caaf *Container) int {
+	t.Helper()
+	n := 0
+	for _, a := range caaf.kubernetesClient.(*fake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			n++
+		}
+	}
+	return n
+}
+
+// seedFnWithDeployment creates the function's deployment via the production
+// spec builder (so the selector and annotations are the real ones), records it
+// in the fake clientset, and registers the live fsvc entry the helper resolves
+// through. The deployment's RV annotation is whatever fn.ResourceVersion was at
+// seed time.
+func seedFnWithDeployment(t *testing.T, caaf *Container, fn *fv1.Function) string {
+	t.Helper()
+	objName := caaf.getObjName(fn)
+	one := int32(1)
+	depl, err := caaf.getDeploymentSpec(t.Context(), fn, &one, objName, "default",
+		caaf.getDeployLabels(fn.ObjectMeta), caaf.getDeployAnnotations(fn.ObjectMeta))
+	require.NoError(t, err)
+	_, err = caaf.kubernetesClient.AppsV1().Deployments("default").Create(t.Context(), depl, metav1.CreateOptions{})
+	require.NoError(t, err)
+	_, err = caaf.fsCache.Add(fscache.FuncSvc{
+		Name:     objName,
+		Function: &fn.ObjectMeta,
+		Address:  "10.0.0.1:8888",
+		Executor: fv1.ExecutorTypeContainer,
+	})
+	require.NoError(t, err)
+	return objName
+}
+
+// TestContainerReconcileDeploymentSpec pins the helper's four branches — the
+// RV-equal no-op is the idempotency claim every create-routed reconcile leans
+// on, and the stale branch is the level-trigger that un-swallows a coalesced
+// update.
+func TestContainerReconcileDeploymentSpec(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no live cache entry is a no-op", func(t *testing.T) {
+		t.Parallel()
+		caaf := newSpecTestContainer(t)
+		fn := newTestContainerFunction()
+		fn.UID = "00000000-0000-0000-0000-000000000001"
+		require.NoError(t, caaf.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Zero(t, countDeploymentUpdates(t, caaf))
+	})
+
+	t.Run("deployment gone is a no-op, not an error", func(t *testing.T) {
+		t.Parallel()
+		caaf := newSpecTestContainer(t)
+		fn := newTestContainerFunction()
+		fn.UID = "00000000-0000-0000-0000-000000000002"
+		_, err := caaf.fsCache.Add(fscache.FuncSvc{
+			Name: "vanished", Function: &fn.ObjectMeta, Address: "10.0.0.9:8888", Executor: fv1.ExecutorTypeContainer,
+		})
+		require.NoError(t, err)
+		require.NoError(t, caaf.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Zero(t, countDeploymentUpdates(t, caaf))
+	})
+
+	t.Run("matching RV annotation issues no update", func(t *testing.T) {
+		t.Parallel()
+		caaf := newSpecTestContainer(t)
+		fn := newTestContainerFunction()
+		fn.UID = "00000000-0000-0000-0000-000000000003"
+		fn.ResourceVersion = "41"
+		seedFnWithDeployment(t, caaf, fn)
+		require.NoError(t, caaf.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Zero(t, countDeploymentUpdates(t, caaf), "an already-current deployment must not be rewritten")
+	})
+
+	t.Run("stale RV annotation pushes the current spec", func(t *testing.T) {
+		t.Parallel()
+		caaf := newSpecTestContainer(t)
+		fn := newTestContainerFunction()
+		fn.UID = "00000000-0000-0000-0000-000000000004"
+		fn.ResourceVersion = "41"
+		objName := seedFnWithDeployment(t, caaf, fn)
+
+		fn.ResourceVersion = "42" // the update the deployment never saw
+		require.NoError(t, caaf.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Equal(t, 1, countDeploymentUpdates(t, caaf), "a stale deployment must be converged")
+
+		depl, err := caaf.kubernetesClient.AppsV1().Deployments("default").Get(t.Context(), objName, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, "42", depl.Annotations[fv1.FUNCTION_RESOURCE_VERSION],
+			"the converged deployment must carry the new function RV")
+	})
+}
+
+// TestContainerUpdateFuncDeploymentSelectorGuard pins the immutable-selector
+// guard: a Function whose CR labels changed (which changes the computed
+// selector without bumping Generation) must be left in place with a nil
+// return — an Update would be rejected by the API server, and an error here
+// requeues forever against a permanently immutable field.
+func TestContainerUpdateFuncDeploymentSelectorGuard(t *testing.T) {
+	t.Parallel()
+	caaf := newSpecTestContainer(t)
+	fn := newTestContainerFunction()
+	fn.UID = "00000000-0000-0000-0000-000000000005"
+	fn.ResourceVersion = "41"
+	seedFnWithDeployment(t, caaf, fn)
+
+	fn.Labels = map[string]string{"team": "other"} // changes getDeployLabels -> selector
+	fn.ResourceVersion = "42"
+	require.NoError(t, caaf.updateFuncDeployment(t.Context(), fn),
+		"a selector change must be skipped, never surfaced as a requeue-forever error")
+	assert.Zero(t, countDeploymentUpdates(t, caaf), "no in-place Update may be attempted across a selector change")
+}

--- a/pkg/executor/executortype/newdeploy/newdeploymgr.go
+++ b/pkg/executor/executortype/newdeploy/newdeploymgr.go
@@ -700,15 +700,11 @@ func (deploy *NewDeploy) updateFunction(ctx context.Context, oldFn *fv1.Function
 }
 
 // reconcileDeploymentSpec brings an already-existing deployment up to the
-// function's current spec when it lags. createFunction only *adopts/scales* an
-// existing deployment (it does not rewrite the pod spec), and updateFunction is
-// diff-based against the last-reconciled object. So if a function's create and a
-// later spec update coalesce into a single first reconcile — common when the
-// router specializes the function on-demand (creating the deployment) just before
-// `fission fn update` lands — the deployment can be left on the old spec with no
-// transition for updateFunction to diff. The deployment carries the function's
-// ResourceVersion as a metadata annotation (getDeployAnnotations), so compare it:
-// if stale, push the current spec. A no-op when already current.
+// function's current spec when it lags — the level-trigger half of every
+// create-routed reconcile (see createAndConverge in reconciler.go for why it
+// must follow createFunction). The deployment carries the function's
+// ResourceVersion as a metadata annotation (getDeployAnnotations), so compare
+// it: if stale, push the current spec. A no-op when already current.
 func (deploy *NewDeploy) reconcileDeploymentSpec(ctx context.Context, fn *fv1.Function) error {
 	// Live entry only: fn is the live Function CR here, and versioned
 	// projections sharing its UID pin immutable snapshots that must not be
@@ -727,7 +723,8 @@ func (deploy *NewDeploy) reconcileDeploymentSpec(ctx context.Context, fn *fv1.Fu
 		}
 		return err
 	}
-	if existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION] == fn.ResourceVersion {
+	deplRV := existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION]
+	if deplRV == fn.ResourceVersion {
 		return nil // deployment already reflects the current function spec
 	}
 	env, err := deploy.fissionClient.CoreV1().Environments(fn.Spec.Environment.Namespace).
@@ -735,9 +732,9 @@ func (deploy *NewDeploy) reconcileDeploymentSpec(ctx context.Context, fn *fv1.Fu
 	if err != nil {
 		return err
 	}
-	deploy.logger.Info("reconciling stale deployment to current function spec on first sight",
+	deploy.logger.Info("reconciling stale deployment to current function spec",
 		"function", fn.Name, "deployment", fsvc.Name,
-		"deployment_rv", existingDepl.Annotations[fv1.FUNCTION_RESOURCE_VERSION], "function_rv", fn.ResourceVersion)
+		"deployment_rv", deplRV, "function_rv", fn.ResourceVersion)
 	return deploy.updateFuncDeployment(ctx, fn, env)
 }
 
@@ -979,7 +976,8 @@ func (deploy *NewDeploy) DumpDebugInfo(ctx context.Context) error {
 // that lands in the pod template but is missing from this diff leaves the CR
 // and the running container disagreeing indefinitely, because updateFunction
 // is the only steady-state path that rewrites the template (the RV-annotation
-// catch-all in reconcileDeploymentSpec runs only on the old == nil branch).
+// catch-all in reconcileDeploymentSpec runs only on create-routed reconciles —
+// first sight and drift-recreate — never on the plain update path).
 func podTemplateChanged(oldFn, newFn *fv1.Function) bool {
 	return oldFn.Spec.Environment != newFn.Spec.Environment ||
 		oldFn.Spec.Package.PackageRef != newFn.Spec.Package.PackageRef ||

--- a/pkg/executor/executortype/newdeploy/reconciler.go
+++ b/pkg/executor/executortype/newdeploy/reconciler.go
@@ -40,10 +40,8 @@ type envFunctionUpdater interface {
 // last-reconciled cache and executor-type transitions, so this only sees same-type
 // create/update:
 //
-//   - create (old == nil): createFunction, then reconcileDeploymentSpec to bring a
-//     possibly-stale adopted deployment (e.g. the router specialized the function
-//     on-demand before `fn update` landed) to the current spec. A no-op when
-//     already current.
+//   - create (old == nil), and any reconcile whose backing objects drifted away:
+//     createAndConverge.
 //   - update (old != nil): updateFunction(old, fn), which diffs HPA min/max/metrics
 //     and secret/configmap/package changes.
 func (deploy *NewDeploy) ReconcileFunction(ctx context.Context, old, fn *fv1.Function) error {
@@ -65,31 +63,37 @@ func (deploy *NewDeploy) DeleteFunction(ctx context.Context, fn *fv1.Function) e
 // functions warm without waiting for one.)
 func reconcileNewdeployFunc(ctx context.Context, mgr funcManager, old, fn *fv1.Function) error {
 	if old == nil {
-		if _, err := mgr.createFunction(ctx, fn); err != nil {
-			return err
-		}
-		return mgr.reconcileDeploymentSpec(ctx, fn)
+		return createAndConverge(ctx, mgr, fn)
 	}
 	exist, err := mgr.resourcesExist(ctx, fn)
 	if err != nil {
 		return err
 	}
 	if !exist {
-		if _, err := mgr.createFunction(ctx, fn); err != nil {
-			return err
-		}
-		// The same chaser as first sight, for the same reason: createFunction
-		// only adopts/scales an existing deployment, it never rewrites the pod
-		// spec. When !exist was a cache false-alarm (the Deployment exists in
-		// the API but lagged out of the Manager cache), this reconcile may be
-		// the ONLY carrier of a spec change — adopt-without-respec would
-		// consume the update permanently: lastReconciled stores the new spec,
-		// GenerationChangedPredicate filters resyncs, and no event ever
-		// re-fires. Measured in the wild as a function serving its old
-		// entrypoint indefinitely after `fn update`.
-		return mgr.reconcileDeploymentSpec(ctx, fn)
+		return createAndConverge(ctx, mgr, fn)
 	}
 	return mgr.updateFunction(ctx, old, fn)
+}
+
+// createAndConverge is the create-routed path both branches above take: create (or
+// adopt) the function's backing objects, then bring the deployment to the current
+// spec. reconcileDeploymentSpec is a no-op when the deployment already reflects fn.
+//
+// The second step is not optional. createFunction only adopts/scales an existing
+// deployment — it never rewrites the pod spec — so when this reconcile is the ONLY
+// carrier of a spec change, adopting without a respec consumes the update
+// permanently: lastReconciled stores the new spec, GenerationChangedPredicate
+// filters resyncs, and no event ever re-fires (measured in the wild as a function
+// serving its old entrypoint indefinitely after `fn update`). Two ways in: a create
+// and a later update coalescing into one first reconcile — the router specialized
+// the function on-demand just before `fission fn update` landed — or a cache
+// false-alarm where !exist saw a Deployment that had lagged out of the Manager
+// cache.
+func createAndConverge(ctx context.Context, mgr funcManager, fn *fv1.Function) error {
+	if _, err := mgr.createFunction(ctx, fn); err != nil {
+		return err
+	}
+	return mgr.reconcileDeploymentSpec(ctx, fn)
 }
 
 // ReconcileEnvironment satisfies executortype.EnvReconciler: it propagates an

--- a/pkg/executor/executortype/newdeploy/reconciler.go
+++ b/pkg/executor/executortype/newdeploy/reconciler.go
@@ -75,8 +75,19 @@ func reconcileNewdeployFunc(ctx context.Context, mgr funcManager, old, fn *fv1.F
 		return err
 	}
 	if !exist {
-		_, err := mgr.createFunction(ctx, fn)
-		return err
+		if _, err := mgr.createFunction(ctx, fn); err != nil {
+			return err
+		}
+		// The same chaser as first sight, for the same reason: createFunction
+		// only adopts/scales an existing deployment, it never rewrites the pod
+		// spec. When !exist was a cache false-alarm (the Deployment exists in
+		// the API but lagged out of the Manager cache), this reconcile may be
+		// the ONLY carrier of a spec change — adopt-without-respec would
+		// consume the update permanently: lastReconciled stores the new spec,
+		// GenerationChangedPredicate filters resyncs, and no event ever
+		// re-fires. Measured in the wild as a function serving its old
+		// entrypoint indefinitely after `fn update`.
+		return mgr.reconcileDeploymentSpec(ctx, fn)
 	}
 	return mgr.updateFunction(ctx, old, fn)
 }

--- a/pkg/executor/executortype/newdeploy/reconciler_test.go
+++ b/pkg/executor/executortype/newdeploy/reconciler_test.go
@@ -85,6 +85,8 @@ func TestReconcileNewdeployFunc(t *testing.T) {
 		mgr := &fakeFuncMgr{resourcesGone: true}
 		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.created, "drifted-away resources must be recreated via get-or-create")
+		assert.Equal(t, []string{"fn"}, mgr.reconciled,
+			"a drift FALSE-ALARM (cache lag) on the update's own reconcile otherwise swallows the update forever: createFunction adopts the old-spec deployment without a respec, lastReconciled stores the new spec, and no event re-fires")
 		assert.Empty(t, mgr.updated, "no diff against a non-existent object")
 	})
 

--- a/pkg/executor/executortype/newdeploy/reconciler_test.go
+++ b/pkg/executor/executortype/newdeploy/reconciler_test.go
@@ -18,7 +18,9 @@ import (
 
 type fakeFuncMgr struct {
 	created, updated, deleted, reconciled []string
-	resourcesGone                         bool // resourcesExist returns false (drift)
+	calls                                 []string // ordered call log: "create", "converge", "update"
+	createErr                             error    // injected createFunction failure
+	resourcesGone                         bool     // resourcesExist returns false (drift)
 }
 
 func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, error) {
@@ -26,10 +28,15 @@ func (f *fakeFuncMgr) resourcesExist(_ context.Context, _ *fv1.Function) (bool, 
 }
 
 func (f *fakeFuncMgr) createFunction(_ context.Context, fn *fv1.Function) (*fscache.FuncSvc, error) {
+	f.calls = append(f.calls, "create")
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
 	f.created = append(f.created, fn.Name)
 	return nil, nil
 }
 func (f *fakeFuncMgr) updateFunction(_ context.Context, old, _ *fv1.Function) error {
+	f.calls = append(f.calls, "update")
 	f.updated = append(f.updated, old.Name)
 	return nil
 }
@@ -38,6 +45,7 @@ func (f *fakeFuncMgr) deleteFunction(_ context.Context, fn *fv1.Function) error 
 	return nil
 }
 func (f *fakeFuncMgr) reconcileDeploymentSpec(_ context.Context, fn *fv1.Function) error {
+	f.calls = append(f.calls, "converge")
 	f.reconciled = append(f.reconciled, fn.Name)
 	return nil
 }
@@ -63,14 +71,17 @@ func envWithImage(name, image string) *fv1.Environment {
 	return env
 }
 
+// Every create-routed reconcile must chase createFunction with
+// reconcileDeploymentSpec — see createAndConverge for why skipping it swallows a
+// coalesced update permanently.
 func TestReconcileNewdeployFunc(t *testing.T) {
 	fn := fnOfType("fn", fv1.ExecutorTypeNewdeploy)
 
 	t.Run("create (old == nil) creates then reconciles the deployment spec", func(t *testing.T) {
 		mgr := &fakeFuncMgr{}
 		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, nil, fn))
-		assert.Equal(t, []string{"fn"}, mgr.created)
-		assert.Equal(t, []string{"fn"}, mgr.reconciled, "first sight must reconcile a possibly-stale adopted deployment to current spec")
+		assert.Equal(t, []string{"create", "converge"}, mgr.calls,
+			"first sight must reconcile a possibly-stale adopted deployment AFTER creating")
 		assert.Empty(t, mgr.updated)
 	})
 
@@ -79,15 +90,22 @@ func TestReconcileNewdeployFunc(t *testing.T) {
 		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
 		assert.Equal(t, []string{"fn"}, mgr.updated)
 		assert.Empty(t, mgr.created)
+		assert.Empty(t, mgr.reconciled, "the diff path owns spec convergence on plain updates")
 	})
 
 	t.Run("drift: missing backing resources are recreated, not diffed", func(t *testing.T) {
 		mgr := &fakeFuncMgr{resourcesGone: true}
 		require.NoError(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
-		assert.Equal(t, []string{"fn"}, mgr.created, "drifted-away resources must be recreated via get-or-create")
-		assert.Equal(t, []string{"fn"}, mgr.reconciled,
-			"a drift FALSE-ALARM (cache lag) on the update's own reconcile otherwise swallows the update forever: createFunction adopts the old-spec deployment without a respec, lastReconciled stores the new spec, and no event re-fires")
+		assert.Equal(t, []string{"create", "converge"}, mgr.calls,
+			"the chase must FOLLOW the create — a drift false-alarm converges the adopted deployment, in that order")
 		assert.Empty(t, mgr.updated, "no diff against a non-existent object")
+	})
+
+	t.Run("create failure short-circuits the chaser", func(t *testing.T) {
+		mgr := &fakeFuncMgr{resourcesGone: true, createErr: assert.AnError}
+		require.Error(t, reconcileNewdeployFunc(t.Context(), mgr, fn, fn))
+		assert.Equal(t, []string{"create"}, mgr.calls,
+			"a failed create must propagate before the converge runs; the retry re-enters the whole branch")
 	})
 
 	t.Run("DeleteFunction tears down the function", func(t *testing.T) {

--- a/pkg/executor/executortype/newdeploy/reconcilespec_test.go
+++ b/pkg/executor/executortype/newdeploy/reconcilespec_test.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package newdeploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/loggerfactory"
+)
+
+// TestNewdeployReconcileDeploymentSpec pins the helper's cheap branches (the
+// full stale-push path needs an Environment and is exercised by the container
+// twin, whose helper mirrors this one, and by the integration suite). The
+// RV-equal no-op is the idempotency claim every create-routed reconcile leans
+// on.
+func TestNewdeployReconcileDeploymentSpec(t *testing.T) {
+	t.Parallel()
+
+	newDeployFixture := func() (*NewDeploy, *fake.Clientset) {
+		logger := loggerfactory.GetLogger()
+		kubeClient := fake.NewClientset()
+		return &NewDeploy{
+			logger:           logger,
+			kubernetesClient: kubeClient,
+			fsCache:          fscache.MakeFunctionServiceCache(logger),
+			nsResolver:       utils.DefaultNSResolver(),
+		}, kubeClient
+	}
+	countUpdates := func(client *fake.Clientset) int {
+		n := 0
+		for _, a := range client.Actions() {
+			if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("no live cache entry is a no-op", func(t *testing.T) {
+		t.Parallel()
+		deploy, client := newDeployFixture()
+		fn := fnOfType("fn", fv1.ExecutorTypeNewdeploy)
+		fn.UID = "00000000-0000-0000-0000-0000000000a1"
+		require.NoError(t, deploy.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Zero(t, countUpdates(client))
+	})
+
+	t.Run("deployment gone is a no-op, not an error", func(t *testing.T) {
+		t.Parallel()
+		deploy, client := newDeployFixture()
+		fn := fnOfType("fn", fv1.ExecutorTypeNewdeploy)
+		fn.UID = "00000000-0000-0000-0000-0000000000a2"
+		_, err := deploy.fsCache.Add(fscache.FuncSvc{
+			Name: "vanished", Function: &fn.ObjectMeta, Address: "10.0.0.9:8888", Executor: fv1.ExecutorTypeNewdeploy,
+		})
+		require.NoError(t, err)
+		require.NoError(t, deploy.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Zero(t, countUpdates(client))
+	})
+
+	t.Run("matching RV annotation issues no update", func(t *testing.T) {
+		t.Parallel()
+		deploy, client := newDeployFixture()
+		fn := fnOfType("fn", fv1.ExecutorTypeNewdeploy)
+		fn.UID = "00000000-0000-0000-0000-0000000000a3"
+		fn.ResourceVersion = "41"
+		_, err := client.AppsV1().Deployments("default").Create(t.Context(), &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nd-fn", Namespace: "default",
+				Annotations: map[string]string{fv1.FUNCTION_RESOURCE_VERSION: "41"},
+			},
+		}, metav1.CreateOptions{})
+		require.NoError(t, err)
+		_, err = deploy.fsCache.Add(fscache.FuncSvc{
+			Name: "nd-fn", Function: &fn.ObjectMeta, Address: "10.0.0.1:8888", Executor: fv1.ExecutorTypeNewdeploy,
+		})
+		require.NoError(t, err)
+		require.NoError(t, deploy.reconcileDeploymentSpec(t.Context(), fn))
+		assert.Zero(t, countUpdates(client), "an already-current deployment must not be rewritten")
+	})
+}

--- a/pkg/executor/util/hpa/hpa.go
+++ b/pkg/executor/util/hpa/hpa.go
@@ -204,6 +204,23 @@ func (hpaops *HpaOperations) CreateOrGetHpa(ctx context.Context, fn *fv1.Functio
 			existingHpa.Spec.Metrics = hpa.Spec.Metrics
 			needsUpdate = true
 		}
+		// Converge min/max/behavior too: the function's ExecutionStrategy is
+		// their sole source of truth (nothing else writes them), so any drift
+		// means a spec update this executor never applied. The load-bearing
+		// case is a create-routed reconcile carrying an InvokeStrategy update
+		// (a coalesced create+update, or a drift false-alarm re-routing the
+		// update through createFunction): updateFunction's HPA diff never runs
+		// there, and without this convergence the update is consumed
+		// permanently — worse, the deployment gets scaled to the new minScale
+		// while the stale HPA drags it back.
+		if !apiequality.Semantic.DeepEqual(existingHpa.Spec.MinReplicas, hpa.Spec.MinReplicas) ||
+			existingHpa.Spec.MaxReplicas != hpa.Spec.MaxReplicas ||
+			!apiequality.Semantic.DeepEqual(existingHpa.Spec.Behavior, hpa.Spec.Behavior) {
+			existingHpa.Spec.MinReplicas = hpa.Spec.MinReplicas
+			existingHpa.Spec.MaxReplicas = hpa.Spec.MaxReplicas
+			existingHpa.Spec.Behavior = hpa.Spec.Behavior
+			needsUpdate = true
+		}
 		if needsUpdate {
 			existingHpa, err = hpaops.kubernetesClient.AutoscalingV2().HorizontalPodAutoscalers(depl.ObjectMeta.Namespace).Update(ctx, existingHpa, metav1.UpdateOptions{})
 			if err != nil {

--- a/pkg/executor/util/hpa/hpa_test.go
+++ b/pkg/executor/util/hpa/hpa_test.go
@@ -347,6 +347,11 @@ func TestCreateOrGetHpaMetricsReconcile(t *testing.T) {
 	})
 
 	t.Run("already-correct metric issues no update", func(t *testing.T) {
+		// "Already correct" must mean the WHOLE adopt-reconciled surface:
+		// min/max/behavior are converged now too, so the seed carries the
+		// execStrategy's bounds (the old seed's min=50 silently leaned on
+		// bounds drift being ignored — the exact swallowed-update bug).
+		minRepl := int32(execStrategy.MinScale)
 		seeded := &asv2.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        "test-hpa",
@@ -355,8 +360,8 @@ func TestCreateOrGetHpaMetricsReconcile(t *testing.T) {
 			},
 			Spec: asv2.HorizontalPodAutoscalerSpec{
 				ScaleTargetRef: getScaleTargetRef(depl),
-				MinReplicas:    &util50,
-				MaxReplicas:    5,
+				MinReplicas:    &minRepl,
+				MaxReplicas:    int32(execStrategy.MaxScale),
 				Metrics: []asv2.MetricSpec{{
 					Type: asv2.ContainerResourceMetricSourceType,
 					ContainerResource: &asv2.ContainerResourceMetricSource{
@@ -376,5 +381,68 @@ func TestCreateOrGetHpaMetricsReconcile(t *testing.T) {
 				t.Errorf("expected no update action for an already-correct HPA, got one")
 			}
 		}
+	})
+}
+
+// TestCreateOrGetHpaScaleBoundsReconcile pins the adopt-branch convergence of
+// MinReplicas/MaxReplicas/Behavior. The function's ExecutionStrategy is their
+// sole source of truth, and the load-bearing consumer is a create-routed
+// reconcile carrying an InvokeStrategy update (coalesced create+update, or a
+// drift false-alarm): updateFunction's HPA diff never runs there, so this is
+// the only site that can apply the change.
+func TestCreateOrGetHpaScaleBoundsReconcile(t *testing.T) {
+	logger := loggerfactory.GetLogger()
+	instanceID := strings.ToLower(uniuri.NewLen(8))
+	ns := "test-namespace"
+
+	fn := &fv1.Function{ObjectMeta: metav1.ObjectMeta{Name: "test-fn", UID: uuid.NewUUID()}}
+	execStrategy := &fv1.ExecutionStrategy{ExecutorType: fv1.ExecutorTypeNewdeploy, MinScale: 5, MaxScale: 10}
+	depl := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: ns}}
+	// The instanceID annotation is what routes CreateOrGetHpa into the adopt
+	// branch; production passes it via getDeployAnnotations.
+	annotations := map[string]string{fv1.EXECUTOR_INSTANCEID_LABEL: instanceID}
+
+	// Learn the desired object from the production builder itself, so these
+	// subtests stay correct when the builder's defaults (e.g. metrics) change.
+	desired := func(t *testing.T) *asv2.HorizontalPodAutoscaler {
+		t.Helper()
+		client := fake.NewClientset()
+		hpaops := NewHpaOperations(logger, client, instanceID)
+		hpa, err := hpaops.CreateOrGetHpa(t.Context(), fn, "test-hpa", execStrategy, "fn-container", depl, nil, annotations)
+		require.NoError(t, err)
+		return hpa
+	}
+
+	countUpdates := func(client *fake.Clientset) int {
+		n := 0
+		for _, a := range client.Actions() {
+			if a.GetVerb() == "update" && a.GetResource().Resource == "horizontalpodautoscalers" {
+				n++
+			}
+		}
+		return n
+	}
+
+	t.Run("stale min/max converge to the execution strategy", func(t *testing.T) {
+		stale := desired(t)
+		one, three := int32(1), int32(3)
+		stale.Spec.MinReplicas = &one
+		stale.Spec.MaxReplicas = three
+		client := fake.NewClientset(stale)
+		hpaops := NewHpaOperations(logger, client, instanceID)
+		hpa, err := hpaops.CreateOrGetHpa(t.Context(), fn, "test-hpa", execStrategy, "fn-container", depl, nil, annotations)
+		require.NoError(t, err)
+		require.NotNil(t, hpa.Spec.MinReplicas)
+		assert.Equal(t, int32(5), *hpa.Spec.MinReplicas)
+		assert.Equal(t, int32(10), hpa.Spec.MaxReplicas)
+		assert.Equal(t, 1, countUpdates(client), "stale bounds must be written back")
+	})
+
+	t.Run("matching spec issues no update (idempotent adopt)", func(t *testing.T) {
+		client := fake.NewClientset(desired(t))
+		hpaops := NewHpaOperations(logger, client, instanceID)
+		_, err := hpaops.CreateOrGetHpa(t.Context(), fn, "test-hpa", execStrategy, "fn-container", depl, nil, annotations)
+		require.NoError(t, err)
+		assert.Zero(t, countUpdates(client), "an already-converged HPA must not be rewritten on every reconcile")
 	})
 }


### PR DESCRIPTION
## TL;DR

A `fission fn update` can be **consumed without effect** — the CR updated, the reconcile "successful", the pods never rolled, and no event left to re-fire — whenever a create-routed reconcile branch carries the update.
Measured in the wild as `TestFunctionNameUpdate` serving the old entrypoint's body (`alpha`, status 200) for its entire 180s window.

## Forensics

The flake's failed run had two red attempts with **different** root causes (attempt-scoped log API; the rerun had overwritten the artifacts):
- **Attempt 1**: `router GET → 500: Post http://executor.fission/...: lookup executor.fission: i/o timeout` — the DNS cascade, already fixed at the source by #3659 (that exact short name is now an absolute FQDN).
- **Attempt 2**: **zero** DNS lines, status 200, `alpha` for 180+s — this bug.

## Mechanism

`reconcileNewdeployFunc` / `reconcileContainerFunc` route to `createFunction` on first sight and on drift (`resourcesExist` false).
`createFunction` only **adopts/scales** an existing Deployment — it never rewrites the pod spec.
So when a create-routed branch fires on the reconcile that carries a spec change — a create+update coalesced into one first reconcile, or `resourcesExist` **false-alarming from Manager-cache lag** on the update's own reconcile — the old-spec Deployment is adopted, the reconcile succeeds, and `lastReconciled` stores the **new** spec.
The update is now swallowed: `GenerationChangedPredicate` filters resyncs, so nothing ever re-fires.

newdeploy already carried the cure for exactly this on its first-sight branch: `reconcileDeploymentSpec` — annotation-keyed (`FUNCTION_RESOURCE_VERSION`), a no-op when converged, and a template-identical push doesn't roll pods.
Its drift branch lacked it; **container lacked the helper entirely**, on both branches.

## Fix

Chase `createFunction` with `reconcileDeploymentSpec` on **every** create-routed branch, in both executors; container gains the mirrored helper.
The routing is now genuinely level-triggered: any reconcile that routed through create converges the deployment to the current spec.

## Tests

The three routing cases (container first-sight, container drift, newdeploy drift) now pin the chaser with failure messages that explain the swallow; removing any chaser fails exactly the matching case (mutation-verified, mutants compiled).
Existing behavior pins untouched: plain updates still go through the diff path only.