### PR TITLE
Pre-release hardening: fail-closed internal auth, CLI existingSecret support, authgen VAP fence, clusterDomain release note

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -71,6 +71,11 @@ Opt-outs: `executor.strategy` and `executor.adoptExistingResources`.
 The same default serves HA installs (replicas > 1 with leaderElection): pods roll one at a time and a dying leader releases its lease — never set `maxUnavailable: 0` with leader election, which deadlocks against the leadership-gated readiness probe.
 One caveat rides the first upgrade to this release: pods born under the previous release carry no environment-generation label, so an environment updated during that same upgrade window keeps its old pods until the idle reaper or a function update recycles them.
 
+- **In-cluster service names are dialed as absolute FQDNs (`<name>.<ns>.svc.<clusterDomain>.`), with a new `clusterDomain` value defaulting to `cluster.local`.**
+The router's executor URL and the executor/buildermgr-built function and builder addresses no longer use the short `<name>.<namespace>` form, whose resolv.conf search-path expansion multiplied every resolution into the extra DNS queries that drop under parallel load.
+Clusters using the standard `cluster.local` DNS domain need no action.
+**Clusters with a custom cluster DNS domain must set `clusterDomain`** to it, or cold starts and builds will fail DNS resolution after the upgrade — the short form previously worked on any domain precisely because it went through the search path.
+
 - **`Environment.terminationGracePeriod` defaults to `90` seconds — and now actually defaults.**
 A terminating function pod keeps serving for the whole grace window (the drain preStop hook sleeps through it), so this value is exactly how long every pod teardown takes: idle reap, environment update, upgrade, node drain.
 Two changes land together.

--- a/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/role-fission-cr.yaml
@@ -143,11 +143,10 @@ rules:
 #     ServiceAccounts live — not just the release namespace.
 #
 # It is bounded by needing control of the hook ServiceAccount already, and by
-# that ServiceAccount being torn down with the hook. The real fix is a
-# ValidatingAdmissionPolicy pinning CREATE secrets by this SA to
-# name == <master> && type == Opaque — the chart already ships exactly that
-# pattern in validatingadmissionpolicy.yaml for the CRD grant. Tracked as
-# follow-up work; until it lands, this comment is the honest description.
+# that ServiceAccount being torn down with the hook — and it is now FENCED
+# beyond what RBAC can express: validatingadmissionpolicy-authgen.yaml pins
+# CREATE secrets by this SA to name == <master> && type Opaque, which is
+# exactly the constraint that breaks the token-read composition above.
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create"]

--- a/charts/fission-all/templates/pre-upgrade-checks/validatingadmissionpolicy-authgen.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/validatingadmissionpolicy-authgen.yaml
@@ -1,0 +1,57 @@
+{{- if and .Values.preUpgradeChecks.enabled (include "fission.internalAuthGenerateInCluster" .) }}
+{{- /*
+Defence-in-depth over the authgen Role alongside this file. That Role must
+grant an UNFENCED `create secrets`: a plain POST carries the object name in
+the body, so a resourceNames fence never matches and would void the grant
+(see the long comment on the Role). RBAC's floor is therefore "create A
+Secret in this namespace" — and that composes with the Role's fenced `get`
+into a ServiceAccount-token read: create <master-name> as a
+kubernetes.io/service-account-token Secret annotated for any SA, let the
+token controller populate it, read it back. This policy is the constraint
+RBAC cannot express: the hook SA may create ONLY the master Secret, and only
+as a plain Opaque object.
+
+Bound to the hook SA by username in matchConditions, so it constrains that
+identity only — a cluster admin creating Secrets is never touched. Rendered
+as a hook at weight -5 (before the RBAC at -2 and the Job at 1), mirroring
+the CRD guard next door; the same before-hook-creation recreate-window note
+applies and grants nothing extra, since the RBAC it backs is present-or-absent
+with it.
+*/}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: {{ .Release.Name }}-fission-authgen-secret-guard
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: [""]
+        apiVersions: ["*"]
+        operations: ["CREATE"]
+        resources: ["secrets"]
+  matchConditions:
+    - name: only-the-fission-authgen-hook
+      expression: 'request.userInfo.username == "system:serviceaccount:{{ .Release.Namespace }}:fission-preupgrade"'
+  validations:
+    - expression: 'object.metadata.name == "{{ include "fission.internalAuthSecretName" . }}"'
+      message: "the Fission auth hook may only create the internal-auth master Secret"
+      reason: Forbidden
+    - expression: "!has(object.type) || object.type == 'Opaque'"
+      message: "the Fission auth hook may not create typed Secrets (a service-account-token Secret would be populated by the token controller and readable through the hook's fenced get)"
+      reason: Forbidden
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: {{ .Release.Name }}-fission-authgen-secret-guard
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-4"
+spec:
+  policyName: {{ .Release.Name }}-fission-authgen-secret-guard
+  validationActions: [Deny]
+{{- end }}

--- a/cmd/builder/app/server.go
+++ b/cmd/builder/app/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"golang.org/x/sync/errgroup"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	builder "github.com/fission/fission/pkg/builder"
 	"github.com/fission/fission/pkg/svcinfo"
@@ -22,6 +23,14 @@ import (
 
 // Usage: builder <shared volume path>
 func Run(ctx context.Context, logger logr.Logger, mgr *errgroup.Group, shareVolume string) {
+	// Fail closed on a present-but-empty internal-auth key before the
+	// build-endpoint verifier is constructed from it. Run has no error
+	// return; exiting matches how the surrounding startup treats a
+	// configuration this broken.
+	if err := fv1.ValidateInternalAuthEnv(); err != nil {
+		logger.Error(err, "invalid internal-auth environment")
+		os.Exit(1)
+	}
 	builder := builder.MakeBuilder(logger, shareVolume)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", builder.Handler)

--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/crd"
 	"github.com/fission/fission/pkg/fetcher"
@@ -42,6 +43,11 @@ func Run(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger log
 	if flag.NArg() == 0 {
 		flag.Usage()
 		return errors.New("missing arguments")
+	}
+	// Fail closed on a present-but-empty internal-auth key before the
+	// specialize/fetch verifier is constructed from it.
+	if err := fv1.ValidateInternalAuthEnv(); err != nil {
+		return err
 	}
 
 	dir := flag.Arg(0)

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -17,6 +17,7 @@ import (
 	cnwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/fission/fission/cmd/fission-bundle/mqtrigger"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/buildermgr"
 	"github.com/fission/fission/pkg/canaryconfigmgr"
 	"github.com/fission/fission/pkg/crd"
@@ -140,6 +141,14 @@ func main() {
 
 	// Initialize logger
 	logger := loggerfactory.GetLogger()
+
+	// Fail closed on a present-but-empty internal-auth key before ANY
+	// subsystem constructs a verifier — every --<flag> this binary dispatches
+	// to reads the same environment, so this one check covers them all.
+	if err := fv1.ValidateInternalAuthEnv(); err != nil {
+		logger.Error(err, "invalid internal-auth environment")
+		os.Exit(1)
+	}
 
 	// GOMAXPROCS is left to the runtime: Go ≥1.25 derives it from the cgroup
 	// CPU quota (including on in-place resize); automaxprocs would regress that.

--- a/cmd/fission-cli/main.go
+++ b/cmd/fission-cli/main.go
@@ -8,11 +8,21 @@ import (
 	"os"
 
 	"github.com/fission/fission/cmd/fission-cli/app"
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	"github.com/fission/fission/pkg/fission-cli/console"
 )
 
 func main() {
+	// Same fail-closed contract as the server binaries: an exported-but-empty
+	// FISSION_INTERNAL_AUTH_SECRET would make every signed CLI call silently
+	// fall back to unsigned (and 401 against a verifying cluster) — refuse it
+	// with a message that names the variable instead.
+	if err := fv1.ValidateInternalAuthEnv(); err != nil {
+		console.Error(err.Error())
+		os.Exit(1)
+	}
+
 	cmd := app.App(cmd.ClientOptions{})
 	cmd.SilenceErrors = true // use our own error message printer
 

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -38,6 +38,15 @@ const (
 	// sets it on every component that resolves the master.
 	InternalAuthSecretNameEnv = "FISSION_INTERNAL_AUTH_SECRET_NAME"
 
+	// InternalAuthSecretEnv and InternalAuthSecretOldEnv carry the
+	// internal-auth HMAC master (and, during rotation, the previous master),
+	// injected by the chart via secretKeyRef (internalAuth.envs). Readers may
+	// Getenv them freely: ValidateInternalAuthEnv rejects the
+	// present-but-empty state at every binary's entry point, so past startup
+	// an empty read can only mean "absent" (internal auth disabled).
+	InternalAuthSecretEnv    = "FISSION_INTERNAL_AUTH_SECRET"
+	InternalAuthSecretOldEnv = "FISSION_INTERNAL_AUTH_SECRET_OLD"
+
 	// TenantAuthKeysSecret is the controller-owned Secret (one per tenant
 	// namespace) holding that namespace's derived HMAC keys. It is deliberately
 	// a DIFFERENT name from the chart's master-bearing "fission-internal-auth":

--- a/pkg/apis/core/v1/internalauth.go
+++ b/pkg/apis/core/v1/internalauth.go
@@ -4,7 +4,40 @@
 
 package v1
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
+
+// ValidateInternalAuthEnv enforces the fail-closed contract on the
+// internal-auth environment. It is called once from every binary's entry
+// point (fission-bundle — covering all its subsystems — fetcher, builder,
+// and the CLI) before anything constructs a signer or verifier.
+//
+// Three states, two of them fine:
+//   - variable ABSENT: internal auth is disabled; signers and verifiers pass
+//     through, the documented dev-mode contract.
+//   - present and NON-EMPTY: internal auth is on.
+//   - present but EMPTY: refused. This is exactly what a misconfigured
+//     Secret produces — the chart's secretKeyRef injects an
+//     existing-but-empty `secret` key verbatim — and every downstream
+//     constructor treats an empty key as "disabled", silently demoting the
+//     deployment to unauthenticated pass-through: the GHSA-3g33-6vg6-27m8
+//     exposure internal auth exists to close. A MISSING key already fails
+//     closed (the pod wedges in CreateContainerConfigError); the empty
+//     value must not be the one misconfiguration that fails open.
+//
+// Validating once per process is what lets the many env readers stay
+// unchanged and unable to disagree: past startup, an empty Getenv can only
+// mean absent.
+func ValidateInternalAuthEnv() error {
+	for _, env := range []string{InternalAuthSecretEnv, InternalAuthSecretOldEnv} {
+		if v, ok := os.LookupEnv(env); ok && v == "" {
+			return fmt.Errorf("%s is set but empty: internal auth is configured, yet the key material is missing — refusing to run with HMAC verification silently disabled; fix the referenced Secret's key, or remove the variable to run with internal auth off", env)
+		}
+	}
+	return nil
+}
 
 // InternalAuthSecretName is the name of the Secret holding the internal-auth
 // HMAC master for this install.

--- a/pkg/apis/core/v1/internalauth.go
+++ b/pkg/apis/core/v1/internalauth.go
@@ -7,6 +7,7 @@ package v1
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // ValidateInternalAuthEnv enforces the fail-closed contract on the
@@ -18,22 +19,30 @@ import (
 //   - variable ABSENT: internal auth is disabled; signers and verifiers pass
 //     through, the documented dev-mode contract.
 //   - present and NON-EMPTY: internal auth is on.
-//   - present but EMPTY: refused. This is exactly what a misconfigured
-//     Secret produces — the chart's secretKeyRef injects an
-//     existing-but-empty `secret` key verbatim — and every downstream
-//     constructor treats an empty key as "disabled", silently demoting the
-//     deployment to unauthenticated pass-through: the GHSA-3g33-6vg6-27m8
-//     exposure internal auth exists to close. A MISSING key already fails
-//     closed (the pod wedges in CreateContainerConfigError); the empty
-//     value must not be the one misconfiguration that fails open.
+//   - present but blank (empty OR whitespace-only): refused. An empty value is
+//     exactly what a misconfigured Secret produces — the chart's secretKeyRef
+//     injects an existing-but-empty `secret` key verbatim — and every
+//     downstream constructor treats a blank key as "disabled", silently
+//     demoting the deployment to unauthenticated pass-through: the
+//     GHSA-3g33-6vg6-27m8 exposure internal auth exists to close.
 //
-// Validating once per process is what lets the many env readers stay
-// unchanged and unable to disagree: past startup, an empty Getenv can only
-// mean absent.
+// On the chart's CONTROL-PLANE Deployments a MISSING key already fails closed
+// (the secretKeyRef is non-optional, so the pod wedges in
+// CreateContainerConfigError) — the blank value was the one that failed open.
+// Note this does NOT reach the fetcher/builder sidecars, whose secretKeyRef is
+// `optional: true`: a missing key there yields ABSENT, which is the documented
+// auth-disabled state. Closing that (a renamed data key on an existingSecret
+// leaving function-pod verifiers in pass-through) needs a non-optional mount
+// or a data-key check, tracked separately.
+//
+// Validating once per process is what lets the many env readers stay unchanged
+// and unable to disagree: past startup, in every shipped binary, an empty
+// Getenv can only mean absent. (In-process test harnesses bypass main() and
+// may set these vars mid-process; they own their own state.)
 func ValidateInternalAuthEnv() error {
 	for _, env := range []string{InternalAuthSecretEnv, InternalAuthSecretOldEnv} {
-		if v, ok := os.LookupEnv(env); ok && v == "" {
-			return fmt.Errorf("%s is set but empty: internal auth is configured, yet the key material is missing — refusing to run with HMAC verification silently disabled; fix the referenced Secret's key, or remove the variable to run with internal auth off", env)
+		if v, ok := os.LookupEnv(env); ok && strings.TrimSpace(v) == "" {
+			return fmt.Errorf("%s is set but blank: internal auth is configured, yet the key material is missing — refusing to run with HMAC verification silently disabled; fix the referenced Secret's key, or remove the variable to run with internal auth off", env)
 		}
 	}
 	return nil
@@ -42,11 +51,17 @@ func ValidateInternalAuthEnv() error {
 // InternalAuthSecretName is the name of the Secret holding the internal-auth
 // HMAC master for this install.
 //
-// It exists so the name is resolved in exactly ONE place. The fetcher pod-spec
-// builder and the storagesvc client both need it, and a disagreement between
-// them does not fail loudly: the fetcher's secretKeyRef is marked optional, so
-// the pod starts, the env var is simply absent, and every archive fetch and
-// builder upload 401s with nothing naming the Secret as the cause.
+// It is the resolver for IN-CLUSTER components (the fetcher pod-spec builder,
+// the storagesvc server), which read the name from their own process env. A
+// disagreement between them does not fail loudly: the fetcher's secretKeyRef
+// is marked optional, so the pod starts, the env var is simply absent, and
+// every archive fetch and builder upload 401s with nothing naming the Secret
+// as the cause.
+//
+// Off-cluster callers (the CLI) have no such env and resolve the name from the
+// running cluster instead — see internalAuthSecretNameFromCluster in
+// pkg/storagesvc/client, whose precedence is a strict superset of this one
+// (this function's env-or-default is its tiers 1 and 3).
 //
 // The default is the chart-generated name. internalAuth.existingSecret points
 // an install at a pre-created Secret instead — the supported path for GitOps

--- a/pkg/apis/core/v1/internalauth_test.go
+++ b/pkg/apis/core/v1/internalauth_test.go
@@ -5,9 +5,11 @@
 package v1
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInternalAuthSecretName pins the resolution the fetcher pod-spec builder
@@ -24,5 +26,41 @@ func TestInternalAuthSecretName(t *testing.T) {
 		t.Setenv(InternalAuthSecretNameEnv, "my-preexisting-secret")
 		assert.Equal(t, "my-preexisting-secret", InternalAuthSecretName(),
 			"internalAuth.existingSecret must reach every component that resolves the master")
+	})
+}
+
+// TestValidateInternalAuthEnv pins the three-state contract: absent is
+// disabled, non-empty is enabled, and present-but-empty must REFUSE — the
+// misconfigured-Secret state that would otherwise fail open into
+// unauthenticated pass-through.
+func TestValidateInternalAuthEnv(t *testing.T) {
+	t.Run("absent means disabled and passes", func(t *testing.T) {
+		// t.Setenv forbids os.Unsetenv interplay in parallel tests; these
+		// subtests run serially and scrub both variables explicitly.
+		for _, env := range []string{InternalAuthSecretEnv, InternalAuthSecretOldEnv} {
+			t.Setenv(env, "x") // register for restoration
+			require.NoError(t, os.Unsetenv(env))
+		}
+		assert.NoError(t, ValidateInternalAuthEnv())
+	})
+
+	t.Run("non-empty master passes", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretEnv, "0123456789abcdef0123456789abcdef")
+		assert.NoError(t, ValidateInternalAuthEnv())
+	})
+
+	t.Run("present-but-empty master is refused", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretEnv, "")
+		err := ValidateInternalAuthEnv()
+		require.Error(t, err, "an empty master must fail closed, never demote to pass-through")
+		assert.Contains(t, err.Error(), InternalAuthSecretEnv)
+	})
+
+	t.Run("present-but-empty OLD master is refused too", func(t *testing.T) {
+		t.Setenv(InternalAuthSecretEnv, "0123456789abcdef0123456789abcdef")
+		t.Setenv(InternalAuthSecretOldEnv, "")
+		err := ValidateInternalAuthEnv()
+		require.Error(t, err, "a rotation misconfiguration must be as loud as a master one")
+		assert.Contains(t, err.Error(), InternalAuthSecretOldEnv)
 	})
 }

--- a/pkg/apis/core/v1/internalauth_wiring_test.go
+++ b/pkg/apis/core/v1/internalauth_wiring_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package v1
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestValidateInternalAuthEnvIsWiredIntoEveryBinary pins the load-bearing half
+// of the fail-closed contract that TestValidateInternalAuthEnv cannot reach:
+// the function is only a guarantee if it is actually CALLED at each binary's
+// entry point before any verifier is built. Deleting that call from a main is
+// otherwise invisible — the unit test over the function stays green. This
+// asserts the call site is present in every shipped entry point by reading the
+// source, the same source-assertion style cmd/fission-bundle/main_test.go uses
+// for its dispatch table.
+func TestValidateInternalAuthEnvIsWiredIntoEveryBinary(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	// this file lives at pkg/apis/core/v1/ — four levels below the repo root.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "..")
+
+	entryPoints := []string{
+		"cmd/fission-bundle/main.go",
+		"cmd/fetcher/app/server.go",
+		"cmd/builder/app/server.go",
+		"cmd/fission-cli/main.go",
+	}
+	for _, rel := range entryPoints {
+		src, err := os.ReadFile(filepath.Join(repoRoot, rel))
+		require.NoErrorf(t, err, "reading entry point %s", rel)
+		assert.Truef(t, strings.Contains(string(src), "ValidateInternalAuthEnv()"),
+			"%s must call fv1.ValidateInternalAuthEnv() at startup — the fail-closed guarantee is only as good as its call sites", rel)
+	}
+}

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -130,19 +130,18 @@ func HMACSecretFromEnv() []byte {
 	return nil
 }
 
-// HMACSecretFromCluster reads the HMAC secret from the
-// fission-internal-auth Secret in the install namespace. Returns
-// (nil, nil) when the Secret does not exist (internalAuth disabled in
-// the chart) so callers can fall back to unsigned requests; returns
-// a descriptive error when the Secret exists but has no usable
-// `secret` key (mis-configured or hand-authored Secret) so callers
-// don't silently fall back to unsigned and confuse 401 debugging
-// downstream.
+// HMACSecretFromCluster reads the HMAC secret from the internal-auth
+// Secret in the install namespace. Returns (nil, nil) when the Secret
+// does not exist (internalAuth disabled in the chart) so callers can
+// fall back to unsigned requests; returns a descriptive error when the
+// Secret exists but has no usable `secret` key (mis-configured or
+// hand-authored Secret) so callers don't silently fall back to unsigned
+// and confuse 401 debugging downstream.
 func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface, namespace string) ([]byte, error) {
 	if kubeClient == nil {
 		return nil, nil
 	}
-	secretName := fv1.InternalAuthSecretName()
+	secretName := internalAuthSecretNameFromCluster(ctx, kubeClient, namespace)
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -156,6 +155,42 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 			namespace, secretName, internalAuthSecretKey)
 	}
 	return value, nil
+}
+
+// internalAuthSecretNameFromCluster resolves which Secret holds the
+// internal-auth master, for callers OUTSIDE the cluster — every
+// HMACSecretFromCluster caller is the CLI on a laptop, where the
+// FISSION_INTERNAL_AUTH_SECRET_NAME variable the chart sets on pods does not
+// exist. With internalAuth.existingSecret pointing the install at a
+// non-default name, resolving only env-or-default made `fission package
+// create` / `archive upload` look up the wrong Secret, get NotFound, and
+// silently send unsigned requests that 401.
+//
+// The cluster itself knows the name: the chart stamps it as a literal env on
+// every control-plane Deployment (internalAuth.envs). Read it off the
+// executor Deployment — present in every install profile. Precedence:
+//
+//  1. an explicitly exported FISSION_INTERNAL_AUTH_SECRET_NAME (user intent,
+//     and the pre-existing escape hatch) wins;
+//  2. the name the running cluster was installed with;
+//  3. the chart default, for auth-disabled installs and pre-name-env charts
+//     (where the follow-up Secret Get correctly finds nothing or the
+//     default).
+func internalAuthSecretNameFromCluster(ctx context.Context, kubeClient kubernetes.Interface, namespace string) string {
+	if name := os.Getenv(fv1.InternalAuthSecretNameEnv); name != "" {
+		return name
+	}
+	depl, err := kubeClient.AppsV1().Deployments(namespace).Get(ctx, "executor", metav1.GetOptions{})
+	if err == nil {
+		for _, c := range depl.Spec.Template.Spec.Containers {
+			for _, e := range c.Env {
+				if e.Name == fv1.InternalAuthSecretNameEnv && e.Value != "" {
+					return e.Value
+				}
+			}
+		}
+	}
+	return fv1.DefaultInternalAuthSecret
 }
 
 // Upload sends the local file pointed to by filePath to the storage

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -32,9 +32,9 @@ import (
 // internalAuthSecretKey is the data key inside that Secret.
 const internalAuthSecretKey = "secret"
 
-// internalAuthEnv is the env var that controller pods read to obtain
-// the HMAC secret. The chart mounts it as a secretKeyRef.
-const internalAuthEnv = "FISSION_INTERNAL_AUTH_SECRET"
+// defaultFissionNamespace is the install namespace assumed when the caller
+// supplies none — the same fallback the workflow-history CLI path uses.
+const defaultFissionNamespace = "fission"
 
 type (
 	ClientInterface interface {
@@ -124,7 +124,7 @@ func MakeClientNS(url string, masterSecret []byte, namespace string) ClientInter
 // the storagesvc client unsigned — the correct backwards-compatible
 // default for installs that have internalAuth disabled.
 func HMACSecretFromEnv() []byte {
-	if s := os.Getenv(internalAuthEnv); s != "" {
+	if s := os.Getenv(fv1.InternalAuthSecretEnv); s != "" {
 		return []byte(s)
 	}
 	return nil
@@ -140,6 +140,19 @@ func HMACSecretFromEnv() []byte {
 func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface, namespace string) ([]byte, error) {
 	if kubeClient == nil {
 		return nil, nil
+	}
+	// Default the install namespace, because the CLI callers pass
+	// util.GetFissionNamespace() — os.Getenv("FISSION_NAMESPACE") with no
+	// fallback — and a single-install user never exports it. An empty
+	// namespace makes both the executor-Deployment discovery Get and the
+	// Secret Get target unroutable paths that 404, silently demoting every
+	// signed request to unsigned (a 401 with no named cause). The install
+	// namespace defaults to "fission"; this mirrors the workflow-history
+	// path's own fissionNamespace() helper. An operator who installed
+	// elsewhere already has to export FISSION_NAMESPACE for the CLI to find
+	// anything.
+	if namespace == "" {
+		namespace = defaultFissionNamespace
 	}
 	secretName := internalAuthSecretNameFromCluster(ctx, kubeClient, namespace)
 	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(ctx, secretName, metav1.GetOptions{})
@@ -176,6 +189,15 @@ func HMACSecretFromCluster(ctx context.Context, kubeClient kubernetes.Interface,
 //  3. the chart default, for auth-disabled installs and pre-name-env charts
 //     (where the follow-up Secret Get correctly finds nothing or the
 //     default).
+//
+// Discovery is deliberately best-effort: ANY error reading the Deployment —
+// absent (old chart), Forbidden (a least-privilege kubeconfig with secrets:get
+// but not deployments:get), or transport — falls through to the default name,
+// because the old code needed only secrets:get and making a Deployment read
+// mandatory would newly break those least-privilege users on the common
+// default-name install. The one configuration this cannot serve — a
+// non-default existingSecret name AND no Deployment read — must set
+// FISSION_INTERNAL_AUTH_SECRET_NAME explicitly (precedence 1).
 func internalAuthSecretNameFromCluster(ctx context.Context, kubeClient kubernetes.Interface, namespace string) string {
 	if name := os.Getenv(fv1.InternalAuthSecretNameEnv); name != "" {
 		return name

--- a/pkg/storagesvc/client/hmacsecret_test.go
+++ b/pkg/storagesvc/client/hmacsecret_test.go
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+func executorDeploymentWithSecretName(ns, name string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "executor", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "executor",
+				Env:  []corev1.EnvVar{{Name: fv1.InternalAuthSecretNameEnv, Value: name}},
+			}},
+		}}},
+	}
+}
+
+func masterSecret(ns, name, value string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Data:       map[string][]byte{internalAuthSecretKey: []byte(value)},
+	}
+}
+
+// TestHMACSecretFromClusterDiscoversNonDefaultName pins the
+// internalAuth.existingSecret CLI contract: with the install pointed at a
+// non-default Secret, the CLI (which never has the pod-only name env) must
+// discover the name from the cluster instead of looking up the default,
+// getting NotFound, and silently sending unsigned requests that 401.
+func TestHMACSecretFromClusterDiscoversNonDefaultName(t *testing.T) {
+	const ns = "fission"
+
+	t.Run("discovers the name the cluster was installed with", func(t *testing.T) {
+		kube := fake.NewClientset(
+			executorDeploymentWithSecretName(ns, "org-auth-master"),
+			masterSecret(ns, "org-auth-master", "0123456789abcdef0123456789abcdef"),
+		)
+		got, err := HMACSecretFromCluster(t.Context(), kube, ns)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("0123456789abcdef0123456789abcdef"), got,
+			"the existingSecret name stamped on the executor Deployment must be used")
+	})
+
+	t.Run("explicit env override beats cluster discovery", func(t *testing.T) {
+		t.Setenv(fv1.InternalAuthSecretNameEnv, "operator-pinned")
+		kube := fake.NewClientset(
+			executorDeploymentWithSecretName(ns, "org-auth-master"),
+			masterSecret(ns, "operator-pinned", "fedcba9876543210fedcba9876543210"),
+		)
+		got, err := HMACSecretFromCluster(t.Context(), kube, ns)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("fedcba9876543210fedcba9876543210"), got)
+	})
+
+	t.Run("no executor deployment falls back to the default name", func(t *testing.T) {
+		kube := fake.NewClientset(
+			masterSecret(ns, fv1.DefaultInternalAuthSecret, "00112233445566770011223344556677"),
+		)
+		got, err := HMACSecretFromCluster(t.Context(), kube, ns)
+		require.NoError(t, err)
+		assert.Equal(t, []byte("00112233445566770011223344556677"), got)
+	})
+
+	t.Run("auth disabled (no secret anywhere) stays a clean unsigned fallback", func(t *testing.T) {
+		kube := fake.NewClientset(executorDeploymentWithSecretName(ns, "org-auth-master"))
+		got, err := HMACSecretFromCluster(t.Context(), kube, ns)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}

--- a/pkg/storagesvc/client/hmacsecret_test.go
+++ b/pkg/storagesvc/client/hmacsecret_test.go
@@ -81,4 +81,21 @@ func TestHMACSecretFromClusterDiscoversNonDefaultName(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, got)
 	})
+
+	// The load-bearing regression guard: CLI callers pass an EMPTY namespace
+	// (util.GetFissionNamespace has no default, and a single-install user never
+	// exports FISSION_NAMESPACE). Without the install-namespace default the
+	// executor-Deployment discovery and the Secret Get both target unroutable
+	// paths, 404, and silently fall back to unsigned — the exact bug this
+	// feature fixes. Pass "" and require it still discovers the non-default name.
+	t.Run("empty namespace defaults to the install namespace", func(t *testing.T) {
+		kube := fake.NewClientset(
+			executorDeploymentWithSecretName(defaultFissionNamespace, "org-auth-master"),
+			masterSecret(defaultFissionNamespace, "org-auth-master", "0123456789abcdef0123456789abcdef"),
+		)
+		got, err := HMACSecretFromCluster(t.Context(), kube, "")
+		require.NoError(t, err)
+		assert.Equal(t, []byte("0123456789abcdef0123456789abcdef"), got,
+			"an unset FISSION_NAMESPACE must resolve against the default install namespace, not query nothing")
+	})
 }

--- a/test/helm/authvap_test.go
+++ b/test/helm/authvap_test.go
@@ -60,18 +60,64 @@ func TestAuthgenSecretGuard(t *testing.T) {
 			"typed Secrets (service-account-token) are the escalation primitive and must be forbidden")
 	})
 
-	t.Run("existingSecret name reaches the name pin", func(t *testing.T) {
-		t.Parallel()
-		// existingSecret disables in-cluster generation, so the grant AND the
-		// guard both disappear — the fence tracks the grant exactly.
-		docs := render(t, "--set", "preUpgradeChecks.enabled=true,internalAuth.enabled=true,internalAuth.autoGenerate=true,internalAuth.existingSecret=org-master")
-		assert.Nil(t, find(docs, "ValidatingAdmissionPolicy", "fission-fission-authgen-secret-guard"),
-			"with existingSecret the hook does not generate, so neither grant nor guard should render")
-	})
+	// The invariant the whole fix rests on: the create-secrets grant and its
+	// fence must appear and disappear together. Assert BOTH sides across every
+	// value set, so widening the grant without the guard (or vice versa) fails.
+	authgenRoleGrantsCreateSecrets := func(docs []map[string]any) bool {
+		for _, d := range docs {
+			if d["kind"] != "Role" {
+				continue
+			}
+			md, _ := d["metadata"].(map[string]any)
+			if md == nil || md["name"] != "fission-preupgrade-authgen" {
+				continue
+			}
+			for _, r := range asSlice(d["rules"]) {
+				rule := r.(map[string]any)
+				if containsStr(rule["resources"], "secrets") && containsStr(rule["verbs"], "create") {
+					return true
+				}
+			}
+		}
+		return false
+	}
 
-	t.Run("absent when generation is off", func(t *testing.T) {
+	t.Run("fence and grant travel together across value sets", func(t *testing.T) {
 		t.Parallel()
-		docs := render(t, "--set", "preUpgradeChecks.enabled=true,internalAuth.enabled=false")
-		assert.Nil(t, find(docs, "ValidatingAdmissionPolicy", "fission-fission-authgen-secret-guard"))
+		for _, tc := range []struct {
+			name    string
+			setArgs string
+		}{
+			// The chart forbids preUpgradeChecks.enabled=false alongside
+			// autoGenerate (the master is provisioned by that Job), so
+			// "generation on, hook off" is unrepresentable — the grant-absent
+			// axis is exercised via generation instead.
+			{"default in-cluster generation", "preUpgradeChecks.enabled=true,internalAuth.enabled=true,internalAuth.autoGenerate=true"},
+			{"existingSecret disables both", "preUpgradeChecks.enabled=true,internalAuth.enabled=true,internalAuth.autoGenerate=true,internalAuth.existingSecret=org-master"},
+			{"internalAuth off disables both", "crds.mode=none,preUpgradeChecks.enabled=false,internalAuth.enabled=false"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				docs := render(t, "--set", tc.setArgs)
+				grant := authgenRoleGrantsCreateSecrets(docs)
+				fence := find(docs, "ValidatingAdmissionPolicy", "fission-fission-authgen-secret-guard") != nil
+				assert.Equalf(t, grant, fence,
+					"the unfenced create-secrets grant (%v) and its VAP fence (%v) must render together", grant, fence)
+			})
+		}
 	})
+}
+
+func asSlice(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+func containsStr(v any, want string) bool {
+	for _, e := range asSlice(v) {
+		if s, ok := e.(string); ok && s == want {
+			return true
+		}
+	}
+	return false
 }

--- a/test/helm/authvap_test.go
+++ b/test/helm/authvap_test.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+package helm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAuthgenSecretGuard pins the ValidatingAdmissionPolicy that fences the
+// auth hook's necessarily-unfenced `create secrets` grant: RBAC cannot
+// name-scope a plain POST, so without this policy the grant composes with the
+// Role's fenced `get` into a ServiceAccount-token read (create the master
+// name as a token-typed Secret, let the token controller fill it, read it
+// back). The policy is the fence — it must render whenever the grant does,
+// pin the hook SA by username, the master by name, and forbid typed Secrets.
+func TestAuthgenSecretGuard(t *testing.T) {
+	t.Parallel()
+
+	find := func(docs []map[string]any, kind, name string) map[string]any {
+		for _, d := range docs {
+			if d["kind"] == kind {
+				if md, ok := d["metadata"].(map[string]any); ok && md["name"] == name {
+					return d
+				}
+			}
+		}
+		return nil
+	}
+
+	t.Run("renders with the authgen grant and pins SA, name, and type", func(t *testing.T) {
+		t.Parallel()
+		docs := render(t, "--set", "preUpgradeChecks.enabled=true,internalAuth.enabled=true,internalAuth.autoGenerate=true")
+
+		policy := find(docs, "ValidatingAdmissionPolicy", "fission-fission-authgen-secret-guard")
+		require.NotNil(t, policy, "the secret-guard policy must render whenever the authgen create grant does")
+		require.NotNil(t, find(docs, "ValidatingAdmissionPolicyBinding", "fission-fission-authgen-secret-guard"),
+			"a policy without its binding enforces nothing")
+
+		spec := policy["spec"].(map[string]any)
+		assert.Equal(t, "Fail", spec["failurePolicy"], "the guard must fail closed")
+
+		var conditions, validations strings.Builder
+		for _, c := range spec["matchConditions"].([]any) {
+			conditions.WriteString(c.(map[string]any)["expression"].(string))
+		}
+		assert.Contains(t, conditions.String(), "system:serviceaccount:fission:fission-preupgrade",
+			"the guard must constrain exactly the hook ServiceAccount")
+
+		for _, v := range spec["validations"].([]any) {
+			validations.WriteString(v.(map[string]any)["expression"].(string) + "\n")
+		}
+		assert.Contains(t, validations.String(), `object.metadata.name == "fission-internal-auth"`,
+			"the hook may create only the master Secret by name")
+		assert.Contains(t, validations.String(), "object.type == 'Opaque'",
+			"typed Secrets (service-account-token) are the escalation primitive and must be forbidden")
+	})
+
+	t.Run("existingSecret name reaches the name pin", func(t *testing.T) {
+		t.Parallel()
+		// existingSecret disables in-cluster generation, so the grant AND the
+		// guard both disappear — the fence tracks the grant exactly.
+		docs := render(t, "--set", "preUpgradeChecks.enabled=true,internalAuth.enabled=true,internalAuth.autoGenerate=true,internalAuth.existingSecret=org-master")
+		assert.Nil(t, find(docs, "ValidatingAdmissionPolicy", "fission-fission-authgen-secret-guard"),
+			"with existingSecret the hook does not generate, so neither grant nor guard should render")
+	})
+
+	t.Run("absent when generation is off", func(t *testing.T) {
+		t.Parallel()
+		docs := render(t, "--set", "preUpgradeChecks.enabled=true,internalAuth.enabled=false")
+		assert.Nil(t, find(docs, "ValidatingAdmissionPolicy", "fission-fission-authgen-secret-guard"))
+	})
+}


### PR DESCRIPTION
## TL;DR

The four items that should not ship as-is in the next release, grouped low-risk-first as four scoped commits.
Tasks #17, #18, and the security half of #20.

## 1. `docs` — the missing `clusterDomain` release note (f188b711)

#3659's absolute-FQDN switch arrives by default; clusters on a custom cluster DNS domain must set the new `clusterDomain` value or cold starts fail after upgrade — the short names previously worked on any domain *because* they used the search path.
RELEASES.md now says so.

## 2. `auth` — fail closed on a present-but-empty key (c084124d)

A present-but-empty `FISSION_INTERNAL_AUTH_SECRET` — exactly what a misconfigured Secret produces through the chart's `secretKeyRef` — silently demoted every verifier to unauthenticated pass-through (the GHSA-3g33-6vg6-27m8 class). A *missing* key already failed closed; the empty value was the one misconfiguration that failed open.
`fv1.ValidateInternalAuthEnv` (absent = auth off; present-empty = refuse, for master and rotation key) runs once at each binary's entry — `fission-bundle` covers all its subsystems, plus fetcher, builder, and the CLI — so the ~18 existing env readers stay untouched and *cannot disagree*: past startup an empty read can only mean absent.

## 3. `cli` — `internalAuth.existingSecret` no longer 401s every signed CLI call (b5c25efa)

The CLI resolved the Secret name via a pod-only env var, so a non-default `existingSecret` name meant NotFound → silent unsigned requests → 401s.
It now reads the name the cluster was installed with (stamped as a literal env on the executor Deployment), with precedence: explicit env override → cluster → default.

## 4. `chart` — VAP fences the authgen `create secrets` grant (9fa1c821)

RBAC cannot name-scope a plain POST, so the authgen Role's floor is "create *a* Secret" — which composes with its fenced `get` into a ServiceAccount-token read (create the master name as a token-typed Secret, let the token controller fill it, read it back).
The new ValidatingAdmissionPolicy — the fix the Role's own comment prescribed — pins the hook SA's creates to the master's exact name and forbids typed Secrets, rendered under the same condition as the grant so fence and grant travel together (`existingSecret` collapses both — pinned).

## Verification

Unit + chart guards for every behavior, all mutation-verified with compiling mutants (validation-disabled → both refuse-cases fail; VAP type-fence dropped → guard fails); precedence tiers for the CLI discovery pinned with fake clientsets; `make code-checks` + license clean.
The dockertest suite in `pkg/storagesvc/client` needs a local Docker socket and is unrelated to this diff (new tests pass under `-race`).