### PR TITLE
perf(spec): reuse cluster-wide package snapshot

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -361,7 +361,7 @@ func pluralize(num int, word string) string {
 // specs (and therefore the diff) are accurate for unchanged archives; only the
 // actual upload of a new/changed archive is skipped (such a Package legitimately
 // shows as a would-create/update).
-func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool) error {
+func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool) (*fv1.PackageList, error) {
 	// archive:// URL -> archive map.
 	archiveFiles := make(map[string]fv1.Archive)
 
@@ -372,7 +372,7 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 	for _, aus := range fr.ArchiveUploadSpecs {
 		ar, err := localArchiveFromSpec(input.Context(), specDir, &aus)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		archiveUrl := fmt.Sprintf("%v%v", ARCHIVE_URL_PREFIX, aus.Name)
 		archiveFiles[archiveUrl] = *ar
@@ -382,7 +382,7 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 	availableArchives := make(map[string]string) // (sha256 -> url)
 	pkgs, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
 	if err != nil {
-		return err
+		return nil, err
 	}
 	for _, pkg := range pkgs.Items {
 		for _, ar := range []fv1.Archive{pkg.Spec.Source, pkg.Spec.Deployment} {
@@ -419,7 +419,7 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 			// tracked follow-up that needs per-package-namespace upload handling.
 			uploadedAr, err := pkgutil.UploadArchiveFile(input.Context(), fclient, ar.URL, "")
 			if err != nil {
-				return err
+				return nil, err
 			}
 			archiveFiles[name] = *uploadedAr
 		}
@@ -431,7 +431,7 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 			if strings.HasPrefix(ar.URL, ARCHIVE_URL_PREFIX) {
 				availableAr, ok := archiveFiles[ar.URL]
 				if !ok {
-					return fmt.Errorf("unknown archive name %v", strings.TrimPrefix(ar.URL, ARCHIVE_URL_PREFIX))
+					return nil, fmt.Errorf("unknown archive name %v", strings.TrimPrefix(ar.URL, ARCHIVE_URL_PREFIX))
 				}
 				ar.Type = availableAr.Type
 				ar.Literal = availableAr.Literal
@@ -440,7 +440,7 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 			}
 		}
 	}
-	return nil
+	return pkgs, nil
 }
 
 // applyResources applies the given set of fission resources. When dryRun is set
@@ -450,7 +450,7 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	applyStatus := make(map[string]ResourceApplyStatus)
 
 	// upload archives that need to be uploaded. Changes archive references in fr.Packages.
-	err := applyArchives(input, fclient, specDir, fr, dryRun)
+	packageSnapshot, err := applyArchives(input, fclient, specDir, fr, dryRun)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -461,7 +461,7 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	}
 	applyStatus["environment"] = *ras
 
-	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
+	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun, packageSnapshot)
 	if err != nil {
 		return nil, nil, fmt.Errorf("package apply failed: %w", err)
 	}
@@ -720,13 +720,20 @@ func waitForPackageBuild(ctx context.Context, fclient cmd.Client, pkg *fv1.Packa
 	}
 }
 
-func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool, packageSnapshot *fv1.PackageList) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	packages := func(ns string) typedv1.PackageInterface {
 		return fclient.FissionClientSet.CoreV1().Packages(ns)
 	}
 	return applyResourceType(ctx, fr, resourceOps[fv1.Package, *fv1.Package]{
 		items: func(fr *FissionResources) []fv1.Package { return fr.Packages },
 		list: func(ctx context.Context) ([]fv1.Package, error) {
+			if packageSnapshot != nil {
+				// The apply flow already listed Packages before uploading archives.
+				// Reusing that snapshot avoids a second cluster-wide List; apply is
+				// the only writer in this interval, so the reconciliation sees the
+				// same package set that archive de-duplication inspected.
+				return packageSnapshot.Items, nil
+			}
 			l, err := packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 			if err != nil {
 				return nil, err

--- a/pkg/fission-cli/cmd/spec/apply_test.go
+++ b/pkg/fission-cli/cmd/spec/apply_test.go
@@ -262,6 +262,42 @@ func TestPackageRetriggerDecision(t *testing.T) {
 	}
 }
 
+// TestApplyPackagesUsesArchivePackageSnapshot verifies that the apply path can
+// reuse the cluster-wide Package list collected while resolving archives. A
+// second List would reintroduce the API load that issue #3664 is intended to
+// remove.
+func TestApplyPackagesUsesArchivePackageSnapshot(t *testing.T) {
+	t.Parallel()
+
+	existing := fv1.Package{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "deploypkg",
+			Namespace:   "default",
+			Annotations: map[string]string{FISSION_DEPLOYMENT_UID_KEY: testDeployUID},
+		},
+		Spec: fv1.PackageSpec{
+			Deployment: fv1.Archive{URL: "http://storagesvc/deploy.zip"},
+		},
+		Status: fv1.PackageStatus{BuildStatus: fv1.BuildStatusNone},
+	}
+
+	fc := fissionfake.NewSimpleClientset() //nolint:staticcheck // see k8s#126850
+	fc.PrependReactor("list", "packages", func(k8stesting.Action) (bool, runtime.Object, error) {
+		t.Fatal("applyPackages must use the archive package snapshot instead of listing again")
+		return false, nil, nil
+	})
+
+	fr := &FissionResources{
+		Packages: []fv1.Package{existing},
+	}
+	fr.DeploymentConfig.UID = testDeployUID
+	fr.DeploymentConfig.Name = "test-deploy"
+	_, ras, err := applyPackages(t.Context(), cmd.Client{FissionClientSet: fc}, fr, false, false, false, &fv1.PackageList{Items: []fv1.Package{existing}})
+	require.NoError(t, err)
+	assert.Empty(t, ras.Created)
+	assert.Empty(t, ras.Updated)
+}
+
 // aliasFR builds a minimal FissionResources carrying the given aliases,
 // stamped with the test deployment UID (mirrors frWith in resourcetype_test.go).
 func aliasFR(aliases ...fv1.FunctionAlias) *FissionResources {

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -113,7 +113,7 @@ func forceDeleteResources(ctx context.Context, fclient cmd.Client, fr *FissionRe
 		return fmt.Errorf("function delete failed: %w", err)
 	}
 
-	_, _, err = applyPackages(ctx, fclient, fr, true, false, false)
+	_, _, err = applyPackages(ctx, fclient, fr, true, false, false, nil)
 	if err != nil {
 		return fmt.Errorf("package delete failed: %w", err)
 	}


### PR DESCRIPTION
## Summary

`fission spec apply` currently lists every cluster-wide Package twice: once while de-duplicating archive uploads and again during package reconciliation. This reuses the first Package snapshot for reconciliation, so one apply performs one cluster-wide Package list while keeping the two consumers' existing roles explicit.

## Changes

- return the Package snapshot collected by `applyArchives`;
- pass it through the normal apply path into `applyPackages`;
- keep direct package deletion callers on the existing live-list path;
- add a regression test that fails if the snapshot-aware package path issues another list.

The snapshot is taken before archive uploads. The apply CLI is the only spec writer in this interval, so archive de-duplication and reconciliation can share the same package set. Controller status updates do not change the package specs being reconciled.

Closes #3664.

## Validation

- `go test ./pkg/fission-cli/cmd/spec -run 'TestApplyPackagesUsesArchivePackageSnapshot|TestPackageEqual|TestPackageRetriggerDecision' -count=1`
- `go test ./pkg/fission-cli/cmd/spec -count=1`
- `git diff --check`
