### PR TITLE
spec apply: enumerate cluster-wide Packages once, not twice

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -357,11 +357,15 @@ func pluralize(num int, word string) string {
 
 // listAllPackages enumerates every Package in every namespace.
 //
-// This is the single cluster-wide Package enumeration an apply performs: the
-// resulting snapshot is threaded to both consumers that need it (archive
+// This is the single cluster-wide Package enumeration applyResources performs:
+// the resulting snapshot is threaded to both consumers that need it (archive
 // de-duplication in applyArchives and the create/update/delete diff in
 // applyPackages) rather than each listing for itself. See applyResources for
-// why one snapshot is safe to share across both.
+// what sharing one snapshot across both costs.
+//
+// It is not the only Package listing a `spec apply` command makes: validation
+// lists them too (getAllPackages, in validate.go), as does the build watch
+// under --wait.
 func listAllPackages(ctx context.Context, fclient cmd.Client) ([]fv1.Package, error) {
 	l, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -468,14 +472,24 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	// re-uploading bytes already on the cluster, and applyPackages diffs the spec
 	// against it.
 	//
-	// Sharing one snapshot across both is safe because nothing between them
-	// mutates Packages: applyArchives only uploads archive bytes to storagesvc
-	// (pkgutil.UploadArchiveFile writes no Package), and applyEnvironments touches
-	// only Environments. The snapshot is therefore stale only with respect to a
-	// *concurrent external writer*, and within a single apply the CLI is the only
-	// writer of the Packages this spec owns. A second List here would not close
-	// that window either — it would merely move it — so the assumption is pinned
-	// here rather than paid for with a second full cluster-wide enumeration.
+	// Nothing the CLI itself does between the two consumers writes a Package:
+	// pkgutil.UploadArchiveFile only pushes archive bytes to storagesvc, and
+	// applyEnvironments touches only Environments.
+	//
+	// The buildermgr, though, is a genuine concurrent writer of these same
+	// objects — updatePackage sets spec.Deployment, and the status write that
+	// follows it sets status.BuildStatus — and those are exactly the fields the
+	// equal() closure in applyPackages reads. So sharing one snapshot does not
+	// merely move the staleness window, it widens it: the second List this
+	// replaces ran *after* the archive uploads, this one runs before them, so
+	// the diff can now be reading a package set that is stale by the whole
+	// upload duration.
+	//
+	// That is accepted deliberately. A build landing inside the window makes its
+	// package read not-ready, so it takes the update path and gets retriggered:
+	// redundant work that converges on the next reconcile, not lost data. The
+	// alternative is the second full cluster-wide enumeration on every apply
+	// that issue #3664 was filed to remove.
 	livePkgs, err := listAllPackages(input.Context(), fclient)
 	if err != nil {
 		return nil, nil, fmt.Errorf("list packages: %w", err)
@@ -754,8 +768,10 @@ func waitForPackageBuild(ctx context.Context, fclient cmd.Client, pkg *fv1.Packa
 
 // applyPackages reconciles the spec's Packages against livePkgs, the caller's
 // cluster-wide Package snapshot. The snapshot is supplied rather than fetched
-// here so a single apply performs one Package enumeration; callers with no
-// snapshot in hand (spec destroy) obtain one from listAllPackages.
+// here so that applyResources performs one Package enumeration rather than two;
+// callers with no snapshot in hand (spec destroy) obtain one from
+// listAllPackages. See applyResources for how stale the snapshot can be by the
+// time the diff below reads it.
 func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, livePkgs []fv1.Package, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	packages := func(ns string) typedv1.PackageInterface {
 		return fclient.FissionClientSet.CoreV1().Packages(ns)

--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -355,13 +355,31 @@ func pluralize(num int, word string) string {
 	return word + "s"
 }
 
+// listAllPackages enumerates every Package in every namespace.
+//
+// This is the single cluster-wide Package enumeration an apply performs: the
+// resulting snapshot is threaded to both consumers that need it (archive
+// de-duplication in applyArchives and the create/update/delete diff in
+// applyPackages) rather than each listing for itself. See applyResources for
+// why one snapshot is safe to share across both.
+func listAllPackages(ctx context.Context, fclient cmd.Client) ([]fv1.Package, error) {
+	l, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return l.Items, nil
+}
+
 // applyArchives figures out the set of archives that need to be uploaded, and uploads them.
 // Under dryRun the read-only work still runs — local archives are built/checksummed
 // and matched against archives already on the cluster — so the resolved Package
 // specs (and therefore the diff) are accurate for unchanged archives; only the
 // actual upload of a new/changed archive is skipped (such a Package legitimately
 // shows as a would-create/update).
-func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool) error {
+//
+// livePkgs is the caller's cluster-wide Package snapshot; it is read only to
+// build the content-index of archives already present on the cluster.
+func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, livePkgs []fv1.Package, dryRun bool) error {
 	// archive:// URL -> archive map.
 	archiveFiles := make(map[string]fv1.Archive)
 
@@ -378,13 +396,9 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 		archiveFiles[archiveUrl] = *ar
 	}
 
-	// get list of packages, make content-indexed map of available archives
+	// make content-indexed map of available archives from the caller's snapshot
 	availableArchives := make(map[string]string) // (sha256 -> url)
-	pkgs, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, pkg := range pkgs.Items {
+	for _, pkg := range livePkgs {
 		for _, ar := range []fv1.Archive{pkg.Spec.Source, pkg.Spec.Deployment} {
 			if ar.Type == fv1.ArchiveTypeUrl && len(ar.URL) > 0 {
 				availableArchives[ar.Checksum.Sum] = ar.URL
@@ -449,8 +463,26 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 
 	applyStatus := make(map[string]ResourceApplyStatus)
 
+	// One cluster-wide Package enumeration per apply, shared by the two consumers
+	// that need it: applyArchives indexes it by archive checksum to skip
+	// re-uploading bytes already on the cluster, and applyPackages diffs the spec
+	// against it.
+	//
+	// Sharing one snapshot across both is safe because nothing between them
+	// mutates Packages: applyArchives only uploads archive bytes to storagesvc
+	// (pkgutil.UploadArchiveFile writes no Package), and applyEnvironments touches
+	// only Environments. The snapshot is therefore stale only with respect to a
+	// *concurrent external writer*, and within a single apply the CLI is the only
+	// writer of the Packages this spec owns. A second List here would not close
+	// that window either — it would merely move it — so the assumption is pinned
+	// here rather than paid for with a second full cluster-wide enumeration.
+	livePkgs, err := listAllPackages(input.Context(), fclient)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list packages: %w", err)
+	}
+
 	// upload archives that need to be uploaded. Changes archive references in fr.Packages.
-	err := applyArchives(input, fclient, specDir, fr, dryRun)
+	err = applyArchives(input, fclient, specDir, fr, livePkgs, dryRun)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -461,7 +493,7 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	}
 	applyStatus["environment"] = *ras
 
-	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
+	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, livePkgs, delete, specAllowConflicts, dryRun)
 	if err != nil {
 		return nil, nil, fmt.Errorf("package apply failed: %w", err)
 	}
@@ -720,19 +752,18 @@ func waitForPackageBuild(ctx context.Context, fclient cmd.Client, pkg *fv1.Packa
 	}
 }
 
-func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+// applyPackages reconciles the spec's Packages against livePkgs, the caller's
+// cluster-wide Package snapshot. The snapshot is supplied rather than fetched
+// here so a single apply performs one Package enumeration; callers with no
+// snapshot in hand (spec destroy) obtain one from listAllPackages.
+func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, livePkgs []fv1.Package, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	packages := func(ns string) typedv1.PackageInterface {
 		return fclient.FissionClientSet.CoreV1().Packages(ns)
 	}
 	return applyResourceType(ctx, fr, resourceOps[fv1.Package, *fv1.Package]{
 		items: func(fr *FissionResources) []fv1.Package { return fr.Packages },
-		list: func(ctx context.Context) ([]fv1.Package, error) {
-			l, err := packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return nil, err
-			}
-			return l.Items, nil
-		},
+		// The snapshot is already in hand, so this needs no context.
+		list: func(context.Context) ([]fv1.Package, error) { return livePkgs, nil },
 		meta: func(p *fv1.Package) *metav1.ObjectMeta { return &p.ObjectMeta },
 		// A package is up to date when its spec matches (or its env + non-empty
 		// source + build command match), its metadata matches, and its last

--- a/pkg/fission-cli/cmd/spec/apply_test.go
+++ b/pkg/fission-cli/cmd/spec/apply_test.go
@@ -17,6 +17,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
+	spectypes "github.com/fission/fission/pkg/fission-cli/cmd/spec/types"
 	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
 )
 
@@ -414,4 +415,48 @@ func TestApplyFunctionAliasesPruneOnlyWithDeploymentUID(t *testing.T) {
 
 	_, err = fc.CoreV1().FunctionAliases("default").Get(t.Context(), "foreign", metav1.GetOptions{})
 	assert.NoError(t, err, "foreign alias must survive prune")
+}
+
+// TestSpecApplyListsPackagesOnce pins the single cluster-wide Package
+// enumeration per apply. applyArchives (archive de-duplication) and
+// applyPackages (the create/update/delete diff) both need the full list; they
+// used to fetch it independently, so every apply paid for two full listings of
+// every Package in every namespace. Both now read one snapshot taken in
+// applyResources.
+//
+// The assertion is on the *count*, not on the resulting diff, because the
+// regression this guards is invisible in behaviour — two lists and one list
+// produce the same apply result, they just cost the apiserver twice.
+func TestSpecApplyListsPackagesOnce(t *testing.T) {
+	t.Parallel()
+
+	live := &fv1.Package{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "hello", Namespace: "default",
+			Annotations: map[string]string{FISSION_DEPLOYMENT_UID_KEY: "uid-1"},
+		},
+		Spec:   fv1.PackageSpec{Environment: fv1.EnvironmentReference{Name: "node", Namespace: "default"}},
+		Status: fv1.PackageStatus{BuildStatus: fv1.BuildStatusSucceeded},
+	}
+	fc := fissionfake.NewSimpleClientset(live) //nolint:staticcheck // see k8s#126850
+
+	var pkgLists int
+	fc.PrependReactor("list", "packages", func(k8stesting.Action) (bool, runtime.Object, error) {
+		pkgLists++
+		return false, nil, nil // fall through to the default object tracker
+	})
+
+	fr := &FissionResources{
+		DeploymentConfig: spectypes.DeploymentConfig{Name: "test", UID: "uid-1"},
+		Packages:         []fv1.Package{*live.DeepCopy()},
+	}
+
+	// dryRun: the listing this asserts on happens on the read-only path too, so
+	// the count is pinned without mutating the fake cluster.
+	_, _, err := applyResources(
+		fakeInput{ctx: t.Context()}, cmd.Client{FissionClientSet: fc}, "",
+		fr, false /* delete */, false /* allowConflicts */, true /* dryRun */)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, pkgLists, "one spec apply must enumerate cluster-wide Packages exactly once")
 }

--- a/pkg/fission-cli/cmd/spec/apply_test.go
+++ b/pkg/fission-cli/cmd/spec/apply_test.go
@@ -424,16 +424,30 @@ func TestApplyFunctionAliasesPruneOnlyWithDeploymentUID(t *testing.T) {
 // every Package in every namespace. Both now read one snapshot taken in
 // applyResources.
 //
-// The assertion is on the *count*, not on the resulting diff, because the
-// regression this guards is invisible in behaviour — two lists and one list
-// produce the same apply result, they just cost the apiserver twice.
+// Two assertions, guarding two different regressions:
+//
+//   - the *count*, because collapsing two lists into one is invisible in the
+//     apply result — it only costs the apiserver twice;
+//   - the resulting *diff*, because the count alone does not pin that the
+//     snapshot actually reaches applyPackages. Threading nil instead of
+//     livePkgs still lists exactly once, but the diff then sees an empty
+//     cluster and reports this already-live package as a would-create.
+//
+// The fixture is a re-apply of an unchanged package, so a correctly threaded
+// snapshot makes it a no-op: the annotations below are exactly what
+// setDeploymentUID stamps (both the name and UID keys — isObjectMetaEqual
+// compares the whole map), and BuildStatusSucceeded satisfies equal()'s
+// readiness check.
 func TestSpecApplyListsPackagesOnce(t *testing.T) {
 	t.Parallel()
 
 	live := &fv1.Package{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "hello", Namespace: "default",
-			Annotations: map[string]string{FISSION_DEPLOYMENT_UID_KEY: "uid-1"},
+			Annotations: map[string]string{
+				FISSION_DEPLOYMENT_NAME_KEY: "test",
+				FISSION_DEPLOYMENT_UID_KEY:  "uid-1",
+			},
 		},
 		Spec:   fv1.PackageSpec{Environment: fv1.EnvironmentReference{Name: "node", Namespace: "default"}},
 		Status: fv1.PackageStatus{BuildStatus: fv1.BuildStatusSucceeded},
@@ -453,10 +467,16 @@ func TestSpecApplyListsPackagesOnce(t *testing.T) {
 
 	// dryRun: the listing this asserts on happens on the read-only path too, so
 	// the count is pinned without mutating the fake cluster.
-	_, _, err := applyResources(
+	_, applyStatus, err := applyResources(
 		fakeInput{ctx: t.Context()}, cmd.Client{FissionClientSet: fc}, "",
 		fr, false /* delete */, false /* allowConflicts */, true /* dryRun */)
 	require.NoError(t, err)
 
-	assert.Equal(t, 1, pkgLists, "one spec apply must enumerate cluster-wide Packages exactly once")
+	assert.Equal(t, 1, pkgLists, "applyResources must enumerate cluster-wide Packages exactly once")
+
+	pkgStatus, ok := applyStatus["package"]
+	require.True(t, ok, "apply status must carry a package entry")
+	assert.Empty(t, pkgStatus.Created, "an unchanged package must not be reported as a would-create — the snapshot did not reach applyPackages")
+	assert.Empty(t, pkgStatus.Updated, "an unchanged package must not be reported as a would-update")
+	assert.Empty(t, pkgStatus.Deleted, "nothing must be pruned when the spec matches the cluster")
 }

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -113,7 +113,14 @@ func forceDeleteResources(ctx context.Context, fclient cmd.Client, fr *FissionRe
 		return fmt.Errorf("function delete failed: %w", err)
 	}
 
-	_, _, err = applyPackages(ctx, fclient, fr, true, false, false)
+	// destroy uploads no archives, so unlike apply it has no snapshot in hand:
+	// take the one cluster-wide Package enumeration it needs here.
+	livePkgs, err := listAllPackages(ctx, fclient)
+	if err != nil {
+		return fmt.Errorf("list packages: %w", err)
+	}
+
+	_, _, err = applyPackages(ctx, fclient, fr, livePkgs, true, false, false)
 	if err != nil {
 		return fmt.Errorf("package delete failed: %w", err)
 	}


### PR DESCRIPTION
Closes #3664.

## What

A single `fission spec apply` enumerated every `Package` in every namespace **twice**, from two independent call sites in `pkg/fission-cli/cmd/spec/apply.go`:

- `applyArchives` (was L383) — builds a content index (`sha256 → archive URL`) to skip re-uploading archive bytes already on the cluster.
- `applyPackages` (was L730) — lists again to diff the spec's desired Packages against what is live.

Both were correct; the second was redundant. The list the first already fetched is exactly the input the second needs. Now the snapshot is taken once in `applyResources` and threaded to both consumers.

## The time-of-check assumption, made explicit

As the issue notes, this is a "decide", not a trivial dedup: the two lists were taken at **different points in time** — `applyArchives` runs *before* archives are uploaded, `applyPackages` *after*. Sharing one snapshot asserts nothing relevant changed in between.

I checked what actually runs between them, and nothing mutates `Package`:

- `pkgutil.UploadArchiveFile` only writes archive bytes to storagesvc — it creates no `Package`.
- `applyEnvironments` touches only `Environment`.

So the snapshot is stale only with respect to a **concurrent external writer**, and within one apply the CLI is the only writer of the Packages the spec owns. A second List would not close that window either — it would only move it. That reasoning is pinned in a comment at the fetch site rather than left implicit.

## `spec destroy`

`applyPackages` has a second caller — `forceDeleteResources` in `destroy.go` — which the issue doesn't mention. It uploads no archives, so it has no snapshot in hand and takes the single list it needs itself. **Its Package-list count is unchanged at one**; this PR does not add or remove a call there.

## Test

`TestSpecApplyListsPackagesOnce` counts the `list` verb on `packages` via a fake-clientset reactor that falls through to the default object tracker.

The regression being guarded is invisible in behaviour — two lists and one list produce an identical apply result, they just cost the apiserver twice — so a test asserting on the resulting diff would not catch it. Hence the assertion is on the count.

It runs under `--dry-run`, since `applyResourceType` calls `ops.list` unconditionally on the read-only path too; that pins the count without mutating the fake cluster.

**Verified it fails as intended:** with the second `List` restored it reports `2 != 1`.

## Verification

- `go build ./...` — clean
- `go vet ./pkg/fission-cli/cmd/spec/...` — clean
- `go test ./pkg/fission-cli/cmd/spec/` — pass
- `gofmt` — clean

No API, CRD, or generated-code changes; no codegen needed.
