### PR TITLE
fix(spec): list cluster Packages once per apply, not twice

### DIFF
--- a/pkg/fission-cli/cmd/spec/apply.go
+++ b/pkg/fission-cli/cmd/spec/apply.go
@@ -355,13 +355,27 @@ func pluralize(num int, word string) string {
 	return word + "s"
 }
 
+// listClusterPackages returns every Package across all namespaces. A single
+// `spec apply` needs this list twice — to build the archive dedup map
+// (applyArchives) and to diff desired vs live packages (applyPackages) — so the
+// caller fetches it once and threads the same snapshot to both, halving the
+// apiserver load of an apply on large multi-tenant clusters where Packages carry
+// archive metadata and build logs in .status and are far from tiny.
+func listClusterPackages(ctx context.Context, fclient cmd.Client) ([]fv1.Package, error) {
+	l, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+	return l.Items, nil
+}
+
 // applyArchives figures out the set of archives that need to be uploaded, and uploads them.
 // Under dryRun the read-only work still runs — local archives are built/checksummed
 // and matched against archives already on the cluster — so the resolved Package
 // specs (and therefore the diff) are accurate for unchanged archives; only the
 // actual upload of a new/changed archive is skipped (such a Package legitimately
 // shows as a would-create/update).
-func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool) error {
+func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *FissionResources, dryRun bool, clusterPkgs []fv1.Package) error {
 	// archive:// URL -> archive map.
 	archiveFiles := make(map[string]fv1.Archive)
 
@@ -378,13 +392,11 @@ func applyArchives(input cli.Input, fclient cmd.Client, specDir string, fr *Fiss
 		archiveFiles[archiveUrl] = *ar
 	}
 
-	// get list of packages, make content-indexed map of available archives
+	// Make a content-indexed map of available archives from the cluster-wide
+	// Package snapshot the caller fetched once (see listClusterPackages) and
+	// shares with applyPackages, so a single apply lists Packages once.
 	availableArchives := make(map[string]string) // (sha256 -> url)
-	pkgs, err := fclient.FissionClientSet.CoreV1().Packages(metav1.NamespaceAll).List(input.Context(), metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	for _, pkg := range pkgs.Items {
+	for _, pkg := range clusterPkgs {
 		for _, ar := range []fv1.Archive{pkg.Spec.Source, pkg.Spec.Deployment} {
 			if ar.Type == fv1.ArchiveTypeUrl && len(ar.URL) > 0 {
 				availableArchives[ar.Checksum.Sum] = ar.URL
@@ -449,8 +461,24 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 
 	applyStatus := make(map[string]ResourceApplyStatus)
 
+	// Fetch every Package on the cluster once and share the snapshot with both
+	// consumers below: applyArchives builds its content-indexed (sha256 -> URL)
+	// archive dedup map from it, and applyPackages diffs the spec's desired
+	// packages against it. A single `spec apply` therefore lists Packages once
+	// instead of twice.
+	//
+	// The two consumers run at different points (applyArchives before archive
+	// uploads, applyPackages after), so sharing one snapshot assumes nothing
+	// relevant to the package set changes in between. That holds within an apply:
+	// the fission CLI is the only writer of Packages, and the archive uploads in
+	// between touch storage, not Package objects.
+	clusterPkgs, err := listClusterPackages(input.Context(), fclient)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// upload archives that need to be uploaded. Changes archive references in fr.Packages.
-	err := applyArchives(input, fclient, specDir, fr, dryRun)
+	err = applyArchives(input, fclient, specDir, fr, dryRun, clusterPkgs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -461,7 +489,7 @@ func applyResources(input cli.Input, fclient cmd.Client, specDir string, fr *Fis
 	}
 	applyStatus["environment"] = *ras
 
-	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun)
+	pkgMeta, ras, err := applyPackages(input.Context(), fclient, fr, delete, specAllowConflicts, dryRun, clusterPkgs)
 	if err != nil {
 		return nil, nil, fmt.Errorf("package apply failed: %w", err)
 	}
@@ -720,18 +748,17 @@ func waitForPackageBuild(ctx context.Context, fclient cmd.Client, pkg *fv1.Packa
 	}
 }
 
-func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
+func applyPackages(ctx context.Context, fclient cmd.Client, fr *FissionResources, delete bool, specAllowConflicts bool, dryRun bool, clusterPkgs []fv1.Package) (map[string]metav1.ObjectMeta, *ResourceApplyStatus, error) {
 	packages := func(ns string) typedv1.PackageInterface {
 		return fclient.FissionClientSet.CoreV1().Packages(ns)
 	}
 	return applyResourceType(ctx, fr, resourceOps[fv1.Package, *fv1.Package]{
 		items: func(fr *FissionResources) []fv1.Package { return fr.Packages },
+		// list returns the cluster-wide Package snapshot the caller already
+		// fetched (see listClusterPackages); applyArchives consumes the same
+		// slice, so one `spec apply` lists Packages once, not twice.
 		list: func(ctx context.Context) ([]fv1.Package, error) {
-			l, err := packages(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
-			if err != nil {
-				return nil, err
-			}
-			return l.Items, nil
+			return clusterPkgs, nil
 		},
 		meta: func(p *fv1.Package) *metav1.ObjectMeta { return &p.ObjectMeta },
 		// A package is up to date when its spec matches (or its env + non-empty

--- a/pkg/fission-cli/cmd/spec/apply_listonce_test.go
+++ b/pkg/fission-cli/cmd/spec/apply_listonce_test.go
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package spec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+// TestSpecApplyListsPackagesOnce pins the fix for the double cluster-wide
+// Package enumeration: applyArchives (archive dedup map) and applyPackages
+// (desired-vs-live diff) both need the full Package list, and before the fix
+// each issued its own List, so one `spec apply` listed Packages twice. The list
+// is now fetched once in applyResources and threaded to both, so a single apply
+// must issue exactly one Packages.List — asserted here via a fake-clientset
+// reactor counting the "list" verb on "packages".
+func TestSpecApplyListsPackagesOnce(t *testing.T) {
+	t.Parallel()
+
+	// A couple of cluster packages so both consumers have real data to walk.
+	existing := []runtime.Object{
+		&fv1.Package{ObjectMeta: metav1.ObjectMeta{Name: "pkg-a", Namespace: "default"}},
+		&fv1.Package{ObjectMeta: metav1.ObjectMeta{Name: "pkg-b", Namespace: "other"}},
+	}
+	//nolint:staticcheck // SMD schema not yet generated for NewClientset, see k8s#126850
+	fc := fissionfake.NewSimpleClientset(existing...)
+
+	var packageLists int
+	// PrependReactor runs before the default tracker; returning handled=false
+	// lets the real List proceed, so we only count without intercepting.
+	fc.PrependReactor("list", "packages", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		packageLists++
+		return false, nil, nil
+	})
+
+	fclient := cmd.Client{
+		FissionClientSet: fc,
+		KubernetesClient: k8sfake.NewSimpleClientset(),
+	}
+
+	// An empty spec with dry-run makes the apply read-only: it still runs the
+	// full list -> diff for every kind (so both package consumers execute) but
+	// performs no create/update/delete against the cluster.
+	input := fakeInput{ctx: t.Context()}
+	fr := &FissionResources{}
+
+	_, _, err := applyResources(input, fclient, "" /*specDir*/, fr,
+		false /*delete*/, false /*specAllowConflicts*/, true /*dryRun*/)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, packageLists,
+		"a single spec apply must list cluster Packages exactly once (was twice before the shared-snapshot fix)")
+}

--- a/pkg/fission-cli/cmd/spec/destroy.go
+++ b/pkg/fission-cli/cmd/spec/destroy.go
@@ -113,7 +113,11 @@ func forceDeleteResources(ctx context.Context, fclient cmd.Client, fr *FissionRe
 		return fmt.Errorf("function delete failed: %w", err)
 	}
 
-	_, _, err = applyPackages(ctx, fclient, fr, true, false, false)
+	clusterPkgs, err := listClusterPackages(ctx, fclient)
+	if err != nil {
+		return fmt.Errorf("list packages: %w", err)
+	}
+	_, _, err = applyPackages(ctx, fclient, fr, true, false, false, clusterPkgs)
 	if err != nil {
 		return fmt.Errorf("package delete failed: %w", err)
 	}


### PR DESCRIPTION
## What

`fission spec apply` enumerated every Package cluster-wide **twice** — `applyArchives` (to build the sha256→archive-URL dedup map) and `applyPackages` (to diff desired vs live) each issued their own `Packages.List(NamespaceAll)`.

This fetches the list **once** in `applyResources` (new `listClusterPackages` helper) and threads the same snapshot to both consumers. `destroy`'s `forceDeleteResources` fetches-and-passes it too. A comment pins the single-writer assumption that makes sharing one snapshot safe: within an apply the fission CLI is the only writer of Packages, and the archive uploads that happen between the two consumers touch storage, not Package objects.

## Why

Negligible on small installs; on large multi-tenant clusters (thousands of Packages that carry archive metadata and build logs in `.status`, so they are not tiny) it is two full cluster-wide `Package` listings of apiserver load and latency per apply. This halves it. `NamespaceAll` also only needs to be requested from one call site now.

## Testing

Added `TestSpecApplyListsPackagesOnce`, which drives a dry-run apply against a fake clientset with a reactor counting the `list` verb on `packages` and asserts it fires exactly once (it was twice before). Full `spec` package suite and `go vet` pass locally.

Fixes #3664