### PR TITLE
support: capture KEDA ScaledObjects and TriggerAuthentications in the dump

### DIFF
--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -98,6 +98,11 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"fission-crd-mqtriggers":    resources.NewCrdDumper(opts.Client(), resources.CrdMessageQueueTrigger),
 		"fission-crd-timetriggers":  resources.NewCrdDumper(opts.Client(), resources.CrdTimeTrigger),
 		"fission-crd-canaryconfigs": resources.NewCrdDumper(opts.Client(), resources.CrdCanaryConfig),
+
+		// KEDA objects created by the mqt-keda scaler for MessageQueueTriggers.
+		// Skipped quietly when KEDA is not installed.
+		"fission-keda-scaledobjects":          resources.NewKedaDumper(opts.Client(), resources.KedaScaledObject),
+		"fission-keda-triggerauthentications": resources.NewKedaDumper(opts.Client(), resources.KedaTriggerAuthentication),
 	}
 
 	dumpName := fmt.Sprintf("%v_%v", DUMP_ARCHIVE_PREFIX, time.Now().Unix())

--- a/pkg/fission-cli/cmd/support/resources/keda.go
+++ b/pkg/fission-cli/cmd/support/resources/keda.go
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	kedaClient "github.com/kedacore/keda/v2/pkg/generated/clientset/versioned"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/console"
+)
+
+const (
+	KedaScaledObject          = "ScaledObject"
+	KedaTriggerAuthentication = "TriggerAuthentication"
+)
+
+// mqtKind mirrors mqtrigger.MqtKind, the Kind the mqt-keda scaler stamps into
+// the OwnerReferences of every KEDA object it creates. Duplicated rather than
+// imported because pkg/mqtrigger would pull the controller-runtime scaler
+// machinery into the CLI binary.
+const mqtKind = "MessageQueueTrigger"
+
+// KedaDumper dumps the KEDA objects that fission's mqt-keda scaler manager
+// creates for MessageQueueTriggers (see pkg/mqtrigger/scalermanager.go).
+//
+// Only objects owned by a MessageQueueTrigger are dumped. KEDA is a
+// cluster-wide component that other workloads use too, and a support bundle
+// should carry fission's own resources, not an unrelated team's ScaledObjects.
+// The scaler sets no labels on what it creates, so ownership is the only
+// selector available — which is why this cannot reuse the label-selector-based
+// KubernetesObjectDumper.
+type KedaDumper struct {
+	client   kedaClient.Interface
+	kedaType string
+	// clientErr defers a client-construction failure to Dump, so one
+	// unavailable client cannot abort the whole support bundle.
+	clientErr error
+}
+
+func NewKedaDumper(client cmd.Client, kedaType string) Resource {
+	kc, err := kedaClient.NewForConfig(client.RestConfig)
+	return KedaDumper{client: kc, kedaType: kedaType, clientErr: err}
+}
+
+// ownedByMessageQueueTrigger reports whether obj was created by fission's
+// mqt-keda scaler for a MessageQueueTrigger.
+func ownedByMessageQueueTrigger(meta metav1.ObjectMeta) bool {
+	for _, ref := range meta.OwnerReferences {
+		if ref.Kind == mqtKind {
+			return true
+		}
+	}
+	return false
+}
+
+// kedaAbsent reports whether err means the KEDA CRDs are not installed, as
+// opposed to a real failure. A cluster with no KEDA is the normal case for
+// anyone not using mqt of type keda, so it is reported as a verbose note
+// rather than a warning that would look like a problem in every bundle.
+func kedaAbsent(err error) bool {
+	return apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err)
+}
+
+func (res KedaDumper) Dump(ctx context.Context, dumpDir string) {
+	if res.clientErr != nil {
+		console.Warn(fmt.Sprintf("Error creating keda client for %v: %v", res.kedaType, res.clientErr))
+		return
+	}
+
+	switch res.kedaType {
+	case KedaScaledObject:
+		items, err := res.client.KedaV1alpha1().ScaledObjects(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if kedaAbsent(err) {
+				console.Verbose(2, "KEDA ScaledObjects not available in this cluster, skipping")
+				return
+			}
+			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.kedaType, err))
+			return
+		}
+
+		for _, item := range items.Items {
+			if !ownedByMessageQueueTrigger(item.ObjectMeta) {
+				continue
+			}
+			f := getFileName(dumpDir, item.ObjectMeta)
+			writeToFile(f, item)
+		}
+
+	case KedaTriggerAuthentication:
+		items, err := res.client.KedaV1alpha1().TriggerAuthentications(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			if kedaAbsent(err) {
+				console.Verbose(2, "KEDA TriggerAuthentications not available in this cluster, skipping")
+				return
+			}
+			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.kedaType, err))
+			return
+		}
+
+		for _, item := range items.Items {
+			if !ownedByMessageQueueTrigger(item.ObjectMeta) {
+				continue
+			}
+			cleaned := triggerAuthClean(&item)
+			f := getFileName(dumpDir, cleaned.ObjectMeta)
+			writeToFile(f, cleaned)
+		}
+
+	default:
+		console.Warn(fmt.Sprintf("Unknown keda type: %v", res.kedaType))
+	}
+}
+
+// triggerAuthClean masks the one field of a TriggerAuthentication that holds a
+// credential inline rather than by reference: the HashiCorp Vault token. Every
+// other auth source in the spec (secretTargetRef, configMapTargetRef, env,
+// azureKeyVault's clientSecret.valueFrom) names a Secret or ConfigMap instead
+// of carrying its value, so those are safe to dump as-is.
+//
+// Fission's own scaler only ever sets secretTargetRef, but a support bundle is
+// sent to a third party, and nothing stops an operator editing the object the
+// scaler created. Masks with "-" to show the field was set, matching pkgClean.
+func triggerAuthClean(ta *kedav1alpha1.TriggerAuthentication) *kedav1alpha1.TriggerAuthentication {
+	if ta.Spec.HashiCorpVault == nil || ta.Spec.HashiCorpVault.Credential == nil ||
+		ta.Spec.HashiCorpVault.Credential.Token == "" {
+		return ta
+	}
+	// Copy before masking: the token lives behind a pointer shared with the
+	// List result, so mutating in place would edit the caller's object too.
+	out := ta.DeepCopy()
+	out.Spec.HashiCorpVault.Credential.Token = "-"
+	return out
+}

--- a/pkg/fission-cli/cmd/support/resources/keda_test.go
+++ b/pkg/fission-cli/cmd/support/resources/keda_test.go
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
+	kedafake "github.com/kedacore/keda/v2/pkg/generated/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func mqtOwnerRef() metav1.OwnerReference {
+	return metav1.OwnerReference{Kind: mqtKind, Name: "my-mqt", APIVersion: "fission.io/v1"}
+}
+
+// dumpedFiles returns the base names written into dir.
+func dumpedFiles(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+func TestKedaDumperDumpsOnlyMessageQueueTriggerOwnedObjects(t *testing.T) {
+	t.Parallel()
+
+	// Created by fission's mqt-keda scaler.
+	ours := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-mqt", Namespace: "default", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+		},
+	}
+	// Someone else's ScaledObject: KEDA is cluster-wide, and a support bundle
+	// must not carry an unrelated team's scaling config.
+	theirs := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-teams-app", Namespace: "other", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "web"}},
+		},
+	}
+	// No owner at all — hand-written by an operator, also not ours.
+	orphan := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{Name: "orphan", Namespace: "default", ResourceVersion: "1"},
+	}
+
+	dir := t.TempDir()
+	d := KedaDumper{
+		client:   kedafake.NewSimpleClientset(ours, theirs, orphan),
+		kedaType: KedaScaledObject,
+	}
+	d.Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1, "only the MessageQueueTrigger-owned ScaledObject should be dumped")
+	assert.Contains(t, files[0], "my-mqt")
+}
+
+func TestKedaDumperMasksVaultToken(t *testing.T) {
+	t.Parallel()
+
+	ta := &kedav1alpha1.TriggerAuthentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-mqt-auth", Namespace: "default", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+		},
+		Spec: kedav1alpha1.TriggerAuthenticationSpec{
+			HashiCorpVault: &kedav1alpha1.HashiCorpVault{
+				Address:    "https://vault.example.com",
+				Credential: &kedav1alpha1.Credential{Token: "s.verysecrettoken"},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	d := KedaDumper{
+		client:   kedafake.NewSimpleClientset(ta),
+		kedaType: KedaTriggerAuthentication,
+	}
+	d.Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1)
+
+	content, err := os.ReadFile(filepath.Join(dir, files[0]))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(content), "s.verysecrettoken",
+		"the vault token must never reach a support bundle")
+	assert.Contains(t, string(content), "token: '-'",
+		"the field should be masked, not dropped, so it is clear it was set")
+}
+
+func TestKedaDumperLeavesTheListedObjectUnmutated(t *testing.T) {
+	t.Parallel()
+
+	// Masking must not edit the object the API returned — triggerAuthClean
+	// copies first because the token sits behind a shared pointer.
+	ta := &kedav1alpha1.TriggerAuthentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-mqt-auth", Namespace: "default", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+		},
+		Spec: kedav1alpha1.TriggerAuthenticationSpec{
+			HashiCorpVault: &kedav1alpha1.HashiCorpVault{
+				Credential: &kedav1alpha1.Credential{Token: "s.verysecrettoken"},
+			},
+		},
+	}
+
+	cleaned := triggerAuthClean(ta)
+	assert.Equal(t, "-", cleaned.Spec.HashiCorpVault.Credential.Token)
+	assert.Equal(t, "s.verysecrettoken", ta.Spec.HashiCorpVault.Credential.Token,
+		"the input object must not be modified in place")
+}
+
+func TestKedaDumperUnknownTypeWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	d := KedaDumper{client: kedafake.NewSimpleClientset(), kedaType: "NotAKedaKind"}
+	d.Dump(t.Context(), dir)
+
+	assert.Empty(t, dumpedFiles(t, dir))
+}
+
+func TestKedaAbsent(t *testing.T) {
+	t.Parallel()
+
+	gvk := schema.GroupVersionKind{Group: "keda.sh", Version: "v1alpha1", Kind: "ScaledObject"}
+	gr := schema.GroupResource{Group: "keda.sh", Resource: "scaledobjects"}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			// What a cluster without the KEDA CRDs actually returns.
+			name: "no kind match means keda is not installed",
+			err:  &apimeta.NoKindMatchError{GroupKind: gvk.GroupKind()},
+			want: true,
+		},
+		{
+			name: "not found means keda is not installed",
+			err:  apierrors.NewNotFound(gr, "scaledobjects"),
+			want: true,
+		},
+		{
+			// Must stay a visible warning: this is a real problem worth seeing.
+			name: "forbidden is a real error",
+			err:  apierrors.NewForbidden(gr, "scaledobjects", assert.AnError),
+			want: false,
+		},
+		{
+			name: "arbitrary error is a real error",
+			err:  assert.AnError,
+			want: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, kedaAbsent(tc.err))
+		})
+	}
+}

--- a/pkg/fission-cli/cmd/support/resources/keda_test.go
+++ b/pkg/fission-cli/cmd/support/resources/keda_test.go
@@ -86,15 +86,29 @@ func TestKedaDumperMasksVaultToken(t *testing.T) {
 		},
 	}
 
+	// Not ours. The ownership filter is what keeps another team's Vault address
+	// and secret names out of a bundle that gets sent to a third party, and it
+	// is applied on this branch too — not only to ScaledObjects.
+	theirs := &kedav1alpha1.TriggerAuthentication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "other-teams-auth", Namespace: "other", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "web"}},
+		},
+		Spec: kedav1alpha1.TriggerAuthenticationSpec{
+			HashiCorpVault: &kedav1alpha1.HashiCorpVault{Address: "https://vault.other.example.com"},
+		},
+	}
+
 	dir := t.TempDir()
 	d := KedaDumper{
-		client:   kedafake.NewSimpleClientset(ta),
+		client:   kedafake.NewSimpleClientset(ta, theirs),
 		kedaType: KedaTriggerAuthentication,
 	}
 	d.Dump(t.Context(), dir)
 
 	files := dumpedFiles(t, dir)
-	require.Len(t, files, 1)
+	require.Len(t, files, 1, "only the MessageQueueTrigger-owned TriggerAuthentication should be dumped")
+	assert.Contains(t, files[0], "my-mqt-auth")
 
 	content, err := os.ReadFile(filepath.Join(dir, files[0]))
 	require.NoError(t, err)
@@ -131,8 +145,22 @@ func TestKedaDumperLeavesTheListedObjectUnmutated(t *testing.T) {
 func TestKedaDumperUnknownTypeWritesNothing(t *testing.T) {
 	t.Parallel()
 
+	// Seed both kinds, owned, so the assertion discriminates: with an empty
+	// clientset "wrote nothing" would hold however the default branch behaved.
 	dir := t.TempDir()
-	d := KedaDumper{client: kedafake.NewSimpleClientset(), kedaType: "NotAKedaKind"}
+	d := KedaDumper{
+		client: kedafake.NewSimpleClientset(
+			&kedav1alpha1.ScaledObject{ObjectMeta: metav1.ObjectMeta{
+				Name: "my-mqt", Namespace: "default", ResourceVersion: "1",
+				OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+			}},
+			&kedav1alpha1.TriggerAuthentication{ObjectMeta: metav1.ObjectMeta{
+				Name: "my-mqt-auth", Namespace: "default", ResourceVersion: "1",
+				OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+			}},
+		),
+		kedaType: "NotAKedaKind",
+	}
 	d.Dump(t.Context(), dir)
 
 	assert.Empty(t, dumpedFiles(t, dir))


### PR DESCRIPTION
Closes #1914.

## What

A `MessageQueueTrigger` of type `keda` causes the scaler manager to create a `ScaledObject` and, for secret-bearing triggers, a `TriggerAuthentication` (`pkg/mqtrigger/scalermanager.go`). Neither appeared in `fission support dump`, so a scaling problem on a keda mqt had to be diagnosed without the objects that actually drive the scaling.

Adds a `KedaDumper` for both kinds, registered as `fission-keda-scaledobjects` and `fission-keda-triggerauthentications`.

## Three decisions worth reviewing

**1. Ownership filter, not "dump everything."** KEDA is a cluster-wide component that other workloads use too, so listing every `ScaledObject` would put an unrelated team's scaling config into a fission support bundle. Only objects whose `ownerReferences` contain a `MessageQueueTrigger` are dumped.

This is also why it can't reuse the existing label-selector-based `KubernetesObjectDumper`: `getScaledObject`/`getAuthTriggerSpec` set **no labels** on what they create — only `newOwnerReference(...)` — so ownership is the only selector available.

**2. A cluster without KEDA is not an error.** That's the normal case for anyone not using keda mqts. `NoKindMatch`/`NotFound` from the list is reported via `console.Verbose(2, ...)` rather than `console.Warn`, so a warning doesn't appear in every bundle from every non-KEDA install. A `Forbidden` or any other error still warns — there's a table test pinning that distinction.

**3. The Vault token is masked.** `TriggerAuthenticationSpec.HashiCorpVault.Credential.Token` is a **plaintext token**, and it is the one field in the spec that carries a credential inline — `secretTargetRef`, `configMapTargetRef`, `env` and even `azureKeyVault`'s `clientSecret.valueFrom` all *name* a Secret or ConfigMap rather than holding its value, so those are safe to dump as-is.

Masked with `"-"`, matching what `pkgClean` already does for archive literals. Fission's own scaler only ever sets `secretTargetRef`, so in practice this never fires — but a support dump is sent to a third party, and nothing stops an operator editing the object the scaler created. The masking deep-copies first, since the token sits behind a pointer shared with the List result.

## Tests

`keda_test.go`, 5 tests + 4 subtests, all passing:

- **Ownership** — of three ScaledObjects (MQT-owned, Deployment-owned, unowned), only the MQT-owned one is written.
- **Masking** — the token string never appears in the dumped file, and the field is present as `token: '-'` so it is clear it *was* set rather than absent.
- **No mutation** — `triggerAuthClean` leaves the input object's token intact.
- **Unknown kind** — writes nothing, doesn't panic.
- **`kedaAbsent`** — table test: `NoKindMatchError` and `NotFound` → quiet skip; `Forbidden` and an arbitrary error → real warning.

## Verification

```
go build ./...                              clean
go vet ./pkg/fission-cli/cmd/support/...    clean
go test ./pkg/fission-cli/cmd/support/...   ok  (5 tests, 4 subtests)
gofmt                                       clean
```

`go.mod`/`go.sum` are untouched — `github.com/kedacore/keda/v2` is already a direct dependency, and both the typed and fake clientsets come from that module. No codegen, no API or CRD change.

## Note

I used `console.Verbose(2, ...)` for the KEDA-absent path to keep bundles from non-KEDA clusters clean. If you'd rather that be `Warn` for discoverability, it's a one-line change — say the word.
