### PR TITLE
support: dump kubernetes events for fission pods

### DIFF
--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -76,18 +76,22 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
 		"fission-components-pod-log": resources.NewKubernetesPodLogDumper(k8sClient,
 			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+		"fission-components-pod-events": resources.NewKubernetesPodEventDumper(k8sClient,
+			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
 
 		// fission builder logs & spec
 		"fission-builder-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, "owner=buildermgr"),
 		"fission-builder-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, "owner=buildermgr"),
 		"fission-builder-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, "owner=buildermgr"),
 		"fission-builder-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "owner=buildermgr"),
+		"fission-builder-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "owner=buildermgr"),
 
 		// fission function logs & spec
 		"fission-function-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, "executorType=newdeploy"),
 		"fission-function-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, "executorType in (poolmgr, newdeploy)"),
 		"fission-function-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, "executorType in (poolmgr, newdeploy)"),
 		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
+		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
 
 		// CRD resources
 		"fission-crd-packages":      resources.NewCrdDumper(opts.Client(), resources.CrdPackage),

--- a/pkg/fission-cli/cmd/support/resources/podevents.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,26 @@ func NewKubernetesPodEventDumper(clientset kubernetes.Interface, selector string
 		client:        clientset,
 		labelSelector: selector,
 	}
+}
+
+// eventTime is the effective time of an event, whichever API recorded it.
+// Sorting on LastTimestamp alone is wrong: an event written through
+// events.k8s.io/v1 carries only EventTime, so it reads back through the core/v1
+// endpoint with a zero LastTimestamp and sorts ahead of everything else. That
+// hits FailedScheduling in particular — kube-scheduler has used the newer
+// recorder since 1.19, while kubelet still uses the legacy one — which is the
+// event most worth placing correctly in a pod's history.
+func eventTime(e corev1.Event) time.Time {
+	if e.Series != nil && !e.Series.LastObservedTime.IsZero() {
+		return e.Series.LastObservedTime.Time
+	}
+	if !e.LastTimestamp.IsZero() {
+		return e.LastTimestamp.Time
+	}
+	if !e.EventTime.IsZero() {
+		return e.EventTime.Time
+	}
+	return e.FirstTimestamp.Time
 }
 
 func (res KubernetesPodEventDumper) Dump(ctx context.Context, dumpDir string) {
@@ -77,9 +98,10 @@ func (res KubernetesPodEventDumper) Dump(ctx context.Context, dumpDir string) {
 		}
 
 		// Oldest first, so the file reads as the pod's history. Events are
-		// returned in no guaranteed order.
-		sort.Slice(podEvents, func(i, j int) bool {
-			return podEvents[i].LastTimestamp.Before(&podEvents[j].LastTimestamp)
+		// returned in no guaranteed order. Stable, so events sharing a
+		// timestamp keep the order the apiserver returned them in.
+		sort.SliceStable(podEvents, func(i, j int) bool {
+			return eventTime(podEvents[i]).Before(eventTime(podEvents[j]))
 		})
 
 		f := getFileName(dumpDir, pod.ObjectMeta)

--- a/pkg/fission-cli/cmd/support/resources/podevents.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/fission/fission/pkg/fission-cli/console"
+)
+
+// KubernetesPodEventDumper dumps the Events kubernetes recorded against each
+// pod matching labelSelector.
+//
+// The pod spec dumpers already write the whole Pod object, status included, so
+// the diagnostic left missing was the event stream — FailedScheduling,
+// ImagePullBackOff, Unhealthy, OOMKilled and friends. Those live on Event
+// objects, not on the pod, and they are what explains a pod that never became
+// ready.
+type KubernetesPodEventDumper struct {
+	client        kubernetes.Interface
+	labelSelector string
+}
+
+func NewKubernetesPodEventDumper(clientset kubernetes.Interface, selector string) Resource {
+	return KubernetesPodEventDumper{
+		client:        clientset,
+		labelSelector: selector,
+	}
+}
+
+func (res KubernetesPodEventDumper) Dump(ctx context.Context, dumpDir string) {
+	pods, err := res.client.CoreV1().
+		Pods(metav1.NamespaceAll).
+		List(ctx, metav1.ListOptions{LabelSelector: res.labelSelector})
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting pod list with selector %v: %v", res.labelSelector, err))
+		return
+	}
+	if len(pods.Items) == 0 {
+		return
+	}
+
+	// One cluster-wide Event list indexed by involved-object UID, rather than a
+	// per-pod field-selector query. A busy fission install has many pods, and
+	// events are short-lived and numerous; one list keeps the dump from issuing
+	// a request per pod against an apiserver that may already be struggling —
+	// which is, after all, why someone is collecting a support bundle.
+	events, err := res.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting event list: %v", err))
+		return
+	}
+
+	byPod := make(map[types.UID][]corev1.Event)
+	for _, e := range events.Items {
+		if e.InvolvedObject.Kind != "Pod" {
+			continue
+		}
+		byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
+	}
+
+	for _, pod := range pods.Items {
+		podEvents := byPod[pod.UID]
+		if len(podEvents) == 0 {
+			// Nothing recorded, or the events already aged out of etcd. An
+			// empty file would just be noise in the bundle.
+			continue
+		}
+
+		// Oldest first, so the file reads as the pod's history. Events are
+		// returned in no guaranteed order.
+		sort.Slice(podEvents, func(i, j int) bool {
+			return podEvents[i].LastTimestamp.Before(&podEvents[j].LastTimestamp)
+		})
+
+		f := getFileName(dumpDir, pod.ObjectMeta)
+		writeToFile(f, podEvents)
+	}
+}

--- a/pkg/fission-cli/cmd/support/resources/podevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents_test.go
@@ -28,6 +28,8 @@ func fissionPod(name string, uid types.UID) *corev1.Pod {
 	}
 }
 
+// podEvent builds a legacy core/v1 event, as k8s.io/client-go/tools/record
+// writes them — kubelet's Pulled, Unhealthy, OOMKilled and friends.
 func podEvent(name string, uid types.UID, reason string, at time.Time) *corev1.Event {
 	return &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{Name: name + "." + reason, Namespace: "fission"},
@@ -38,6 +40,17 @@ func podEvent(name string, uid types.UID, reason string, at time.Time) *corev1.E
 		Message:       reason + " happened",
 		LastTimestamp: metav1.NewTime(at),
 	}
+}
+
+// schedulerEvent builds an events.k8s.io/v1 event as it reads back through the
+// core/v1 endpoint: EventTime set, LastTimestamp zero. This is what
+// k8s.io/client-go/tools/events produces, and therefore what kube-scheduler's
+// FailedScheduling looks like to this dumper.
+func schedulerEvent(name string, uid types.UID, reason string, at time.Time) *corev1.Event {
+	e := podEvent(name, uid, reason, at)
+	e.LastTimestamp = metav1.Time{}
+	e.EventTime = metav1.NewMicroTime(at)
+	return e
 }
 
 func TestPodEventDumperWritesEventsForMatchingPods(t *testing.T) {
@@ -54,10 +67,16 @@ func TestPodEventDumperWritesEventsForMatchingPods(t *testing.T) {
 		},
 	}
 
+	// Reasons are named so that alphabetical order is the exact reverse of
+	// chronological order. The fake clientset returns list results name-sorted,
+	// so with chronological names an absent sort would still look correct.
+	// FailedScheduling sits in the middle and carries only EventTime, so a
+	// comparator that reads LastTimestamp alone drops it to the front.
 	client := k8sfake.NewClientset(
 		pod, other,
-		podEvent("router-abc", "uid-router", "Pulled", base.Add(time.Minute)),
-		podEvent("router-abc", "uid-router", "FailedScheduling", base),
+		podEvent("router-abc", "uid-router", "Zulu", base),
+		schedulerEvent("router-abc", "uid-router", "FailedScheduling", base.Add(time.Minute)),
+		podEvent("router-abc", "uid-router", "Alpha", base.Add(2*time.Minute)),
 		podEvent("unrelated", "uid-other", "Started", base),
 	)
 
@@ -73,12 +92,15 @@ func TestPodEventDumperWritesEventsForMatchingPods(t *testing.T) {
 	body := string(content)
 
 	assert.Contains(t, body, "FailedScheduling")
-	assert.Contains(t, body, "Pulled")
+	assert.Contains(t, body, "Zulu")
+	assert.Contains(t, body, "Alpha")
 	assert.NotContains(t, body, "Started", "events of a non-matching pod must not be dumped")
 
 	// Oldest first, so the file reads as the pod's history.
-	assert.Less(t, strings.Index(body, "FailedScheduling"), strings.Index(body, "Pulled"),
-		"events should be ordered oldest first")
+	assert.Less(t, strings.Index(body, "Zulu"), strings.Index(body, "FailedScheduling"),
+		"a legacy event older than an events.k8s.io event must come first")
+	assert.Less(t, strings.Index(body, "FailedScheduling"), strings.Index(body, "Alpha"),
+		"an EventTime-only event must be placed by EventTime, not sorted to the front")
 }
 
 func TestPodEventDumperSkipsPodsWithNoEvents(t *testing.T) {

--- a/pkg/fission-cli/cmd/support/resources/podevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents_test.go
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func fissionPod(name string, uid types.UID) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: "fission", UID: uid, ResourceVersion: "1",
+			Labels: map[string]string{"svc": "router"},
+		},
+	}
+}
+
+func podEvent(name string, uid types.UID, reason string, at time.Time) *corev1.Event {
+	return &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "." + reason, Namespace: "fission"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Pod", Name: name, Namespace: "fission", UID: uid,
+		},
+		Reason:        reason,
+		Message:       reason + " happened",
+		LastTimestamp: metav1.NewTime(at),
+	}
+}
+
+func TestPodEventDumperWritesEventsForMatchingPods(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 5, 12, 0, 0, 0, time.UTC)
+	pod := fissionPod("router-abc", "uid-router")
+
+	// A pod that does not match the selector, with events of its own.
+	other := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "unrelated", Namespace: "default", UID: "uid-other", ResourceVersion: "1",
+			Labels: map[string]string{"app": "someone-else"},
+		},
+	}
+
+	client := k8sfake.NewClientset(
+		pod, other,
+		podEvent("router-abc", "uid-router", "Pulled", base.Add(time.Minute)),
+		podEvent("router-abc", "uid-router", "FailedScheduling", base),
+		podEvent("unrelated", "uid-other", "Started", base),
+	)
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)").Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "only the selected pod should get an events file")
+
+	content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+	body := string(content)
+
+	assert.Contains(t, body, "FailedScheduling")
+	assert.Contains(t, body, "Pulled")
+	assert.NotContains(t, body, "Started", "events of a non-matching pod must not be dumped")
+
+	// Oldest first, so the file reads as the pod's history.
+	assert.Less(t, strings.Index(body, "FailedScheduling"), strings.Index(body, "Pulled"),
+		"events should be ordered oldest first")
+}
+
+func TestPodEventDumperSkipsPodsWithNoEvents(t *testing.T) {
+	t.Parallel()
+
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)").Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "an empty events file would just be noise in the bundle")
+}
+
+func TestPodEventDumperIgnoresNonPodEvents(t *testing.T) {
+	t.Parallel()
+
+	pod := fissionPod("router-abc", "uid-router")
+
+	// A Deployment event that happens to carry the pod's UID would be a bug to
+	// include; the involvedObject Kind is what decides.
+	deployEvent := &corev1.Event{
+		ObjectMeta: metav1.ObjectMeta{Name: "deploy-evt", Namespace: "fission"},
+		InvolvedObject: corev1.ObjectReference{
+			Kind: "Deployment", Name: "router", Namespace: "fission", UID: "uid-router",
+		},
+		Reason: "ScalingReplicaSet",
+	}
+
+	client := k8sfake.NewClientset(pod, deployEvent)
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)").Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "non-Pod events must not be attributed to a pod")
+}


### PR DESCRIPTION
Addresses #1873.

## What

The issue asks for `kubectl describe pod` output in the support dump, because "pod logs and CRDs fail to give a complete picture."

I want to be upfront that this delivers the **information** describe carries rather than describe's text format, and say why — happy to change course if you'd rather have the literal thing.

The dump already writes the whole `Pod` object, `.status` included, via `NewKubernetesObjectDumper(..., KubernetesPod, ...)`. Almost everything `describe` prints is derived from that object, which is already in the bundle. The one section it adds that is genuinely missing is **Events** — `FailedScheduling`, `ImagePullBackOff`, `Unhealthy`, `OOMKilled` — and those live on `Event` objects, not on the pod. That is the part that explains a pod which never became ready.

Reproducing describe's exact rendering would mean taking a dependency on `k8s.io/kubectl` (for `pkg/describe`), which the CLI does not currently have. That felt like a lot of dependency for text formatting when the underlying data is what's diagnostic — so this adds `KubernetesPodEventDumper` instead, registered for all three existing pod groups:

- `fission-components-pod-events`
- `fission-builder-pod-events`
- `fission-function-pod-events`

using the same label selectors as the matching `-pod-spec` / `-pod-log` dumpers.

## Implementation notes

**One event list, not one query per pod.** Events are fetched with a single cluster-wide `List` and indexed by `involvedObject.UID`, rather than a per-pod field-selector query. A busy install has many pods and many short-lived events, and a request per pod would hit an apiserver that may already be struggling — which is usually *why* someone is collecting a support bundle.

**No empty files.** A pod with no events (or whose events have aged out of etcd) is skipped, so the bundle isn't padded with empty files.

**Oldest first.** Events come back in no guaranteed order; they're sorted by `LastTimestamp` so each file reads as that pod's history.

**Kind is checked, not just UID.** Only events whose `involvedObject.Kind` is `Pod` are attributed to a pod.

## Tests

`podevents_test.go`, 3 tests, all passing:

- Selector-matching pod gets a file containing its events; a non-matching pod's events are excluded; ordering is oldest-first.
- A pod with no events produces no file.
- An event whose `involvedObject` is a `Deployment` is not attributed to a pod, even when the UID collides.

## Verification

```
go build ./...                              clean
go vet ./pkg/fission-cli/cmd/support/...    clean
go test ./pkg/fission-cli/cmd/support/...   ok  (3 tests)
gofmt                                       clean
```

No new dependencies — `go.mod`/`go.sum` untouched. No API, CRD, or codegen change.

## Open question

If you do want literal `describe` output, the options are (a) depend on `k8s.io/kubectl/pkg/describe`, or (b) hand-render the describe layout in fission. I didn't want to make that call unilaterally, since (a) is a meaningful dependency and (b) is code to maintain that drifts from upstream. Tell me which you'd prefer and I'll follow up.

Note this touches `dump.go`'s resource map, as does #3670 (KEDA objects, issue #1914) — whichever merges second will need a trivial rebase.
