### PR TITLE
Internal communication: targeted transport and HMAC body-handling fixes

### DIFF
--- a/docs/internal-auth/00-design.md
+++ b/docs/internal-auth/00-design.md
@@ -294,12 +294,13 @@ The complexity is not justified when HKDF gives the same isolation from one mast
 The scheme has known limitations operators should plan around.
 
 **Maximum body size.**
-The verifier reads the entire request body into memory before computing the signature so the body bytes can be re-injected for downstream handlers (multipart parsers, etc.).
-That cost is bounded by `VerifierOpts.MaxBodyBytes` (default 256 MiB, set on each registration).
+The verifier must drain the entire request body before computing the signature so the body bytes can be re-injected for downstream handlers (multipart parsers, etc.).
+The size of a body it accepts is bounded by `VerifierOpts.MaxBodyBytes` (default 256 MiB, set on each registration).
 Bodies that exceed the cap are rejected with `413 Request Entity Too Large` *before* signature verification — i.e. an unauthenticated attacker cannot use a giant unsigned body to DoS a signed service.
 Operators that legitimately need to upload archives larger than 256 MiB should bump the cap rather than disable enforcement; the cap is the largest archive size we expect to see in practice.
-For the one bulk-data endpoint, `storagesvc /v1/archive`, the cap is operator-tunable: set the Helm value `storagesvc.maxArchiveSizeMib` (env var `STORAGE_MAX_ARCHIVE_SIZE_MIB`), and size the storagesvc memory request/limit to match, since the body is held in memory during verification.
-The other registrations (fetcher, builder, executor, router-internal) carry small control-plane payloads and keep the 256 MiB default.
+For the one bulk-data endpoint, `storagesvc /v1/archive`, the cap is operator-tunable: set the Helm value `storagesvc.maxArchiveSizeMib` (env var `STORAGE_MAX_ARCHIVE_SIZE_MIB`).
+Whether the drained body is *held in memory* is a separate knob: with `VerifierOpts.SpoolThresholdBytes` set (storagesvc sets 4 MiB), over-threshold bodies are hashed while streaming to a temp file and re-read from it, so verifier memory is bounded by the threshold — raising the archive cap no longer requires raising the storagesvc memory request/limit to match.
+The other registrations (fetcher, builder, executor, router-internal) carry small or latency-sensitive payloads and stay fully in-memory with the 256 MiB default cap (the router internal listener caps at 64 MiB).
 For very large packages, OCI-native delivery (`packageRegistry`) is the better-managed alternative to raising the cap — the code is pulled and mounted from a registry rather than buffered through storagesvc.
 
 **Replay within the skew window.**

--- a/pkg/auth/hmac/hmac.go
+++ b/pkg/auth/hmac/hmac.go
@@ -33,23 +33,53 @@ import (
 	"fmt"
 )
 
+// BodyHashHex returns hex(SHA256(body)) — the body component of the
+// canonical string. A nil body hashes identically to an empty one, so
+// bodiless requests (GETs) canonicalize the same whether the caller
+// passes nil or []byte{}.
+func BodyHashHex(body []byte) string {
+	bodyHash := sha256.Sum256(body)
+	return hex.EncodeToString(bodyHash[:])
+}
+
+// CanonicalFromHash is Canonical for callers that already hold the body's
+// SHA-256 (hex) — computed once across several Verify candidates, or
+// streamed without buffering the body. bodyHashHex MUST be hex(SHA256(body))
+// for the exact bytes on the wire.
+func CanonicalFromHash(method, requestURI, bodyHashHex string, timestampSec int64) string {
+	minute := timestampSec - (timestampSec % 60)
+	return fmt.Sprintf("%s\n%s\n%s\n%d", method, requestURI, bodyHashHex, minute)
+}
+
 // Canonical returns the canonical string that is fed into HMAC-SHA256.
 // timestampSec is rounded down to the nearest minute. The `requestURI`
 // argument should be path + raw query (e.g. r.URL.RequestURI()), not
 // just the path — query parameters MUST be bound to the signature for
 // services like storagesvc that key on `?id=`.
 func Canonical(method, requestURI string, body []byte, timestampSec int64) string {
-	bodyHash := sha256.Sum256(body)
-	minute := timestampSec - (timestampSec % 60)
-	return fmt.Sprintf("%s\n%s\n%s\n%d", method, requestURI, hex.EncodeToString(bodyHash[:]), minute)
+	return CanonicalFromHash(method, requestURI, BodyHashHex(body), timestampSec)
+}
+
+// SignFromHash is Sign for callers that already hold hex(SHA256(body))
+// (see CanonicalFromHash).
+func SignFromHash(secret []byte, method, requestURI, bodyHashHex string, timestampSec int64) string {
+	mac := cryptohmac.New(sha256.New, secret)
+	mac.Write([]byte(CanonicalFromHash(method, requestURI, bodyHashHex, timestampSec)))
+	return hex.EncodeToString(mac.Sum(nil))
 }
 
 // Sign returns hex(HMAC-SHA256(secret, Canonical(...))). `requestURI`
 // is path + raw query (see Canonical).
 func Sign(secret []byte, method, requestURI string, body []byte, timestampSec int64) string {
-	mac := cryptohmac.New(sha256.New, secret)
-	mac.Write([]byte(Canonical(method, requestURI, body, timestampSec)))
-	return hex.EncodeToString(mac.Sum(nil))
+	return SignFromHash(secret, method, requestURI, BodyHashHex(body), timestampSec)
+}
+
+// VerifyFromHash is Verify for callers that already hold hex(SHA256(body)) —
+// the verifier middleware hashes the body once and reuses it across candidate
+// keys (active, rotation, per-namespace) instead of rehashing per candidate.
+func VerifyFromHash(secret []byte, method, requestURI, bodyHashHex string, timestampSec int64, sig string) bool {
+	want := SignFromHash(secret, method, requestURI, bodyHashHex, timestampSec)
+	return cryptohmac.Equal([]byte(want), []byte(sig))
 }
 
 // Verify is a constant-time signature check at the request's own timestamp.
@@ -57,8 +87,7 @@ func Sign(secret []byte, method, requestURI string, body []byte, timestampSec in
 // callers that have already validated freshness (e.g. unit tests).
 // `requestURI` is path + raw query (see Canonical).
 func Verify(secret []byte, method, requestURI string, body []byte, timestampSec int64, sig string) bool {
-	want := Sign(secret, method, requestURI, body, timestampSec)
-	return cryptohmac.Equal([]byte(want), []byte(sig))
+	return VerifyFromHash(secret, method, requestURI, BodyHashHex(body), timestampSec, sig)
 }
 
 // VerifyWithSkew accepts the signature if the request timestamp is within

--- a/pkg/auth/hmac/hmac.go
+++ b/pkg/auth/hmac/hmac.go
@@ -42,6 +42,10 @@ func BodyHashHex(body []byte) string {
 	return hex.EncodeToString(bodyHash[:])
 }
 
+// emptyBodyHashHex is the canonical body component for bodiless requests,
+// precomputed once so signer and verifier don't rehash emptiness per request.
+var emptyBodyHashHex = BodyHashHex(nil)
+
 // CanonicalFromHash is Canonical for callers that already hold the body's
 // SHA-256 (hex) — computed once across several Verify candidates, or
 // streamed without buffering the body. bodyHashHex MUST be hex(SHA256(body))

--- a/pkg/auth/hmac/signer.go
+++ b/pkg/auth/hmac/signer.go
@@ -124,7 +124,7 @@ func bodyHashForRequest(r *http.Request) (string, error) {
 		return hex.EncodeToString(h.Sum(nil)), nil
 	}
 	if r.Body == nil {
-		return BodyHashHex(nil), nil
+		return emptyBodyHashHex, nil
 	}
 	original := r.Body
 	body, err := io.ReadAll(original)

--- a/pkg/auth/hmac/signer.go
+++ b/pkg/auth/hmac/signer.go
@@ -6,6 +6,8 @@ package hmac
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"net/http"
 	"strconv"
@@ -29,7 +31,9 @@ const (
 
 // Signer is an http.RoundTripper wrapper that signs every outgoing request
 // with the HMAC scheme described in the design at docs/internal-auth/00-design.md.
-// It buffers the request body to compute the body hash, then re-injects it.
+// It streams the body hash from GetBody when the request has one, and only
+// falls back to buffering the body (re-injecting it afterwards) when it
+// doesn't — see bodyHashForRequest.
 //
 // A Signer constructed with an empty secret short-circuits to pass-through:
 // it forwards the request to the inner transport unmodified, without
@@ -68,42 +72,75 @@ func (s *Signer) RoundTrip(r *http.Request) (*http.Response, error) {
 	if len(s.secret) == 0 {
 		return s.rt.RoundTrip(r)
 	}
-	var body []byte
-	if r.Body != nil {
-		original := r.Body
-		var err error
-		body, err = io.ReadAll(original)
-		// Close the original body before replacing it: callers that hand
-		// in a real *os.File-backed io.ReadCloser would otherwise leak
-		// the underlying file descriptor.
-		closeErr := original.Close()
-		if err != nil {
-			return nil, err
-		}
-		if closeErr != nil {
-			return nil, closeErr
-		}
-		r.Body = io.NopCloser(bytes.NewReader(body))
-		// GetBody must be repopulated alongside Body. Rewind-aware
-		// retry layers (net/http's replay after a broken connection,
-		// pkg/utils/httpretry) refuse to retry a request whose GetBody
-		// is nil, so leaving it unset silently makes signed requests
-		// un-retryable; and a naive caller re-submitting the same
-		// *http.Request re-reads the consumed reader above and sends —
-		// re-signed on the second pass through this signer — an EMPTY
-		// body, which the verifier happily accepts: silent success with
-		// an empty payload rather than a 401.
-		r.GetBody = func() (io.ReadCloser, error) {
-			return io.NopCloser(bytes.NewReader(body)), nil
-		}
+	bodyHash, err := bodyHashForRequest(r)
+	if err != nil {
+		return nil, err
 	}
 	ts := s.now().Unix()
 	// Sign over the request-URI (path + raw query) so query parameters
 	// like ?id= are bound to the signature. Signing the path alone would
 	// let an attacker replay a captured /v1/archive?id=A signature
 	// against a different ?id=B within the skew window.
-	sig := Sign(s.secret, r.Method, r.URL.RequestURI(), body, ts)
+	sig := SignFromHash(s.secret, r.Method, r.URL.RequestURI(), bodyHash, ts)
 	r.Header.Set(HeaderTimestamp, strconv.FormatInt(ts, 10))
 	r.Header.Set(HeaderSignature, sig)
 	return s.rt.RoundTrip(r)
+}
+
+// bodyHashForRequest returns hex(SHA256(body)) for the request's body,
+// preferring a streaming read over buffering.
+//
+// When GetBody is set (net/http populates it automatically for requests
+// built from *bytes.Buffer / *bytes.Reader / *strings.Reader, and
+// file-backed callers can set it themselves), the hash is streamed from a
+// fresh GetBody reader and the request's Body/GetBody are left untouched —
+// the transport streams the original body, so the signer holds no copy of
+// it. This matters for archive uploads, whose multipart body previously got
+// a second full in-memory copy here just to be hashed.
+//
+// Without GetBody, the body is buffered and re-injected (Body AND GetBody —
+// rewind-aware retry layers, net/http's replay after a broken connection and
+// pkg/utils/httpretry, refuse to retry a request whose GetBody is nil, so
+// leaving it unset silently makes signed requests un-retryable; and a naive
+// caller re-submitting the same *http.Request would re-read the consumed
+// reader and send — re-signed on the second pass — an EMPTY body, which the
+// verifier happily accepts: silent success with an empty payload rather
+// than a 401).
+func bodyHashForRequest(r *http.Request) (string, error) {
+	if r.GetBody != nil {
+		fresh, err := r.GetBody()
+		if err != nil {
+			return "", err
+		}
+		h := sha256.New()
+		_, err = io.Copy(h, fresh)
+		closeErr := fresh.Close()
+		if err != nil {
+			return "", err
+		}
+		if closeErr != nil {
+			return "", closeErr
+		}
+		return hex.EncodeToString(h.Sum(nil)), nil
+	}
+	if r.Body == nil {
+		return BodyHashHex(nil), nil
+	}
+	original := r.Body
+	body, err := io.ReadAll(original)
+	// Close the original body before replacing it: callers that hand
+	// in a real *os.File-backed io.ReadCloser would otherwise leak
+	// the underlying file descriptor.
+	closeErr := original.Close()
+	if err != nil {
+		return "", err
+	}
+	if closeErr != nil {
+		return "", closeErr
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	return BodyHashHex(body), nil
 }

--- a/pkg/auth/hmac/signer_test.go
+++ b/pkg/auth/hmac/signer_test.go
@@ -115,6 +115,52 @@ func TestSignerRepopulatesGetBody(t *testing.T) {
 		"the retried attempt must re-send (and re-sign) the original body, never an empty one")
 }
 
+// TestSignerStreamsHashViaGetBody pins the no-buffer contract: when a
+// request is rewindable (GetBody set — net/http populates it for requests
+// built from bytes/strings readers, which covers every JSON client and the
+// storagesvc archive upload), the signer must stream the body hash from a
+// fresh GetBody reader and leave Body/GetBody untouched, rather than
+// buffering a second full copy of the body just to hash it.
+func TestSignerStreamsHashViaGetBody(t *testing.T) {
+	secret := []byte("test-secret-must-be-32-bytes-min")
+
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		ts, err := strconv.ParseInt(r.Header.Get(HeaderTimestamp), 10, 64)
+		require.NoError(t, err)
+		require.True(t, Verify(secret, r.Method, r.URL.Path, body, ts, r.Header.Get(HeaderSignature)),
+			"the streamed hash must sign the exact bytes on the wire")
+		gotBody = string(body)
+		w.WriteHeader(200)
+	}))
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/archive", strings.NewReader("payload"))
+	require.NoError(t, err)
+	require.NotNil(t, req.GetBody, "precondition: net/http must have made the request rewindable")
+
+	// Count GetBody calls and remember the original hooks so we can assert
+	// the signer read a fresh reader once and replaced nothing.
+	origBody := req.Body
+	origGetBody := req.GetBody
+	getBodyCalls := 0
+	req.GetBody = func() (io.ReadCloser, error) {
+		getBodyCalls++
+		return origGetBody()
+	}
+
+	signer := NewSigner(secret, http.DefaultTransport, time.Now)
+	resp, err := signer.RoundTrip(req)
+	require.NoError(t, err)
+	_ = resp.Body.Close()
+
+	assert.Equal(t, 200, resp.StatusCode)
+	assert.Equal(t, "payload", gotBody, "the transport must still stream the original body")
+	assert.Equal(t, 1, getBodyCalls, "the hash must be streamed from exactly one fresh GetBody reader")
+	assert.True(t, req.Body == origBody, "the signer must not replace a rewindable request's Body")
+}
+
 // TestSignerBindsQueryParameter pins the security-critical contract from
 // the design doc (docs/internal-auth/00-design.md): a captured signature
 // for /v1/archive?id=A must NOT verify against /v1/archive?id=B within

--- a/pkg/auth/hmac/spool.go
+++ b/pkg/auth/hmac/spool.go
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+)
+
+// bodySpool holds a request body the verifier drained while hashing it:
+// in memory when it fit within the spool threshold, in a temp file when it
+// did not. Exactly one of mem/file is set.
+type bodySpool struct {
+	hashHex string
+	mem     []byte
+	file    *os.File
+}
+
+// spoolBody drains src, hashing as it reads. Bodies up to threshold bytes
+// stay in memory (the historical behavior); anything larger spills to a
+// temp file, so the caller's memory stays bounded by the threshold no
+// matter how large the body is. On error the returned spool (if any) has
+// already been cleaned up.
+func spoolBody(src io.Reader, threshold int64) (*bodySpool, error) {
+	h := sha256.New()
+	tee := io.TeeReader(src, h)
+	var buf bytes.Buffer
+	// Read one byte past the threshold: landing EOF at or before
+	// threshold+1 means the whole body fit and stays in memory.
+	_, err := io.CopyN(&buf, tee, threshold+1)
+	if errors.Is(err, io.EOF) {
+		return &bodySpool{hashHex: hex.EncodeToString(h.Sum(nil)), mem: buf.Bytes()}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	f, err := os.CreateTemp("", "fission-hmac-body-*")
+	if err != nil {
+		return nil, err
+	}
+	sp := &bodySpool{file: f}
+	if _, err := f.Write(buf.Bytes()); err != nil {
+		sp.cleanup()
+		return nil, err
+	}
+	if _, err := io.Copy(f, tee); err != nil {
+		sp.cleanup()
+		return nil, err
+	}
+	sp.hashHex = hex.EncodeToString(h.Sum(nil))
+	return sp, nil
+}
+
+// nopCloseReader lets the spool hand out an io.ReadCloser whose Close does
+// not close the underlying temp file — cleanup owns the file's lifecycle, so
+// a handler's defer r.Body.Close() cannot break a later cleanup.
+type nopCloseReader struct{ io.Reader }
+
+func (nopCloseReader) Close() error { return nil }
+
+// reader returns the spooled body, rewound, for re-injection as r.Body.
+// Call it once; Close on the result is a no-op (see cleanup).
+func (s *bodySpool) reader() (io.ReadCloser, error) {
+	if s.file == nil {
+		return io.NopCloser(bytes.NewReader(s.mem)), nil
+	}
+	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
+		return nil, err
+	}
+	return nopCloseReader{s.file}, nil
+}
+
+// cleanup closes and removes the temp file, if any. Idempotent; call it
+// (deferred) once the downstream handler has returned.
+func (s *bodySpool) cleanup() {
+	if s.file == nil {
+		return
+	}
+	name := s.file.Name()
+	_ = s.file.Close()
+	_ = os.Remove(name)
+	s.file = nil
+}

--- a/pkg/auth/hmac/spool.go
+++ b/pkg/auth/hmac/spool.go
@@ -57,15 +57,11 @@ func spoolBody(src io.Reader, threshold int64) (*bodySpool, error) {
 	return sp, nil
 }
 
-// nopCloseReader lets the spool hand out an io.ReadCloser whose Close does
-// not close the underlying temp file — cleanup owns the file's lifecycle, so
-// a handler's defer r.Body.Close() cannot break a later cleanup.
-type nopCloseReader struct{ io.Reader }
-
-func (nopCloseReader) Close() error { return nil }
-
 // reader returns the spooled body, rewound, for re-injection as r.Body.
-// Call it once; Close on the result is a no-op (see cleanup).
+// Call it once. Both arms wrap with io.NopCloser so a handler's deferred
+// r.Body.Close() cannot close the temp file out from under cleanup, which
+// owns the file's lifecycle (io.NopCloser also forwards WriterTo, keeping
+// *os.File's copy fast path available to whoever drains the body).
 func (s *bodySpool) reader() (io.ReadCloser, error) {
 	if s.file == nil {
 		return io.NopCloser(bytes.NewReader(s.mem)), nil
@@ -73,7 +69,7 @@ func (s *bodySpool) reader() (io.ReadCloser, error) {
 	if _, err := s.file.Seek(0, io.SeekStart); err != nil {
 		return nil, err
 	}
-	return nopCloseReader{s.file}, nil
+	return io.NopCloser(s.file), nil
 }
 
 // cleanup closes and removes the temp file, if any. Idempotent; call it

--- a/pkg/auth/hmac/spool_test.go
+++ b/pkg/auth/hmac/spool_test.go
@@ -1,0 +1,180 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package hmac
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// spoolTempDir points os.CreateTemp at a fresh per-test directory so the
+// tests can assert exactly which temp files the spool created and that
+// cleanup removed them.
+func spoolTempDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("TMPDIR", dir)
+	return dir
+}
+
+func requireEmptyDir(t *testing.T, dir, msg string) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Empty(t, entries, msg)
+}
+
+func TestSpoolBodyBoundary(t *testing.T) {
+	dir := spoolTempDir(t)
+
+	// Exactly at the threshold: stays in memory, no temp file.
+	atLimit, err := spoolBody(strings.NewReader("12345678"), 8)
+	require.NoError(t, err)
+	assert.Nil(t, atLimit.file, "a body of exactly threshold bytes must stay in memory")
+	assert.Equal(t, BodyHashHex([]byte("12345678")), atLimit.hashHex)
+	requireEmptyDir(t, dir, "the in-memory path must not create temp files")
+
+	// One byte over: spills to a temp file, same hash as hashing in memory.
+	over, err := spoolBody(strings.NewReader("123456789"), 8)
+	require.NoError(t, err)
+	require.NotNil(t, over.file, "a body of threshold+1 bytes must spill to disk")
+	assert.Equal(t, BodyHashHex([]byte("123456789")), over.hashHex,
+		"the streamed hash must equal the in-memory hash")
+	rd, err := over.reader()
+	require.NoError(t, err)
+	got, err := io.ReadAll(rd)
+	require.NoError(t, err)
+	assert.Equal(t, "123456789", string(got), "the spooled reader must replay the full body")
+	over.cleanup()
+	over.cleanup() // idempotent
+	requireEmptyDir(t, dir, "cleanup must remove the temp file")
+}
+
+// TestVerifierSpoolsLargeBody pins the bounded-memory contract: with
+// SpoolThresholdBytes set, an over-threshold body still verifies, reaches
+// the handler intact from the temp file, and the temp file is gone once
+// the request completes.
+func TestVerifierSpoolsLargeBody(t *testing.T) {
+	dir := spoolTempDir(t)
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	now := func() time.Time { return time.Unix(1715000000, 0) }
+	body := bytes.Repeat([]byte("A"), 64)
+
+	var gotBody []byte
+	h := Verifier(VerifierOpts{Secret: secret, SkewSec: 60, Now: now, SpoolThresholdBytes: 8})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var err error
+			gotBody, err = io.ReadAll(r.Body)
+			require.NoError(t, err)
+			_ = r.Body.Close() // a handler's defer Close must not break cleanup
+			w.WriteHeader(200)
+		}))
+
+	sig := Sign(secret, "POST", "/v1/archive", body, 1715000000)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/archive", bytes.NewReader(body))
+	req.Header.Set(HeaderTimestamp, "1715000000")
+	req.Header.Set(HeaderSignature, sig)
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, 200, rr.Code)
+	assert.Equal(t, body, gotBody, "the handler must read the full body back from the spool")
+	requireEmptyDir(t, dir, "the spool temp file must be removed after the handler returns")
+}
+
+// TestVerifierSpoolSmallBodyStaysInMemory: under the threshold the spool
+// path must behave exactly like the historical in-memory path — no files.
+func TestVerifierSpoolSmallBodyStaysInMemory(t *testing.T) {
+	dir := spoolTempDir(t)
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	now := func() time.Time { return time.Unix(1715000000, 0) }
+	body := []byte("small")
+
+	h := Verifier(VerifierOpts{Secret: secret, SkewSec: 60, Now: now, SpoolThresholdBytes: 1024})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			assert.Equal(t, body, got)
+			w.WriteHeader(200)
+		}))
+
+	sig := Sign(secret, "POST", "/v1/archive", body, 1715000000)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/archive", bytes.NewReader(body))
+	req.Header.Set(HeaderTimestamp, "1715000000")
+	req.Header.Set(HeaderSignature, sig)
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, 200, rr.Code)
+	requireEmptyDir(t, dir, "an under-threshold body must never touch disk")
+}
+
+// TestVerifierSpoolCleansUpOnBadSignature: a spilled body whose signature
+// does not verify must be rejected AND leave no temp file behind.
+func TestVerifierSpoolCleansUpOnBadSignature(t *testing.T) {
+	dir := spoolTempDir(t)
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	now := func() time.Time { return time.Unix(1715000000, 0) }
+	body := bytes.Repeat([]byte("B"), 64)
+
+	called := false
+	h := Verifier(VerifierOpts{Secret: secret, SkewSec: 60, Now: now, SpoolThresholdBytes: 8})(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(200)
+		}))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/archive", bytes.NewReader(body))
+	req.Header.Set(HeaderTimestamp, "1715000000")
+	req.Header.Set(HeaderSignature, "deadbeef")
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, 401, rr.Code)
+	assert.False(t, called, "the handler must not run on a signature mismatch")
+	requireEmptyDir(t, dir, "a rejected request's spool file must be removed")
+}
+
+// TestVerifierSpoolRejectsOversize: MaxBodyBytes still caps the request when
+// spooling — the drain hits the MaxBytesReader limit mid-spool, rejects with
+// 413, and leaves no temp file behind.
+func TestVerifierSpoolRejectsOversize(t *testing.T) {
+	dir := spoolTempDir(t)
+	secret := []byte("test-secret-must-be-32-bytes-min")
+	now := func() time.Time { return time.Unix(1715000000, 0) }
+	body := bytes.Repeat([]byte("C"), 64)
+
+	called := false
+	h := Verifier(VerifierOpts{
+		Secret:              secret,
+		SkewSec:             60,
+		Now:                 now,
+		MaxBodyBytes:        32,
+		SpoolThresholdBytes: 8,
+	})(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(200)
+	}))
+
+	sig := Sign(secret, "POST", "/v1/archive", body, 1715000000)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/archive", bytes.NewReader(body))
+	req.Header.Set(HeaderTimestamp, "1715000000")
+	req.Header.Set(HeaderSignature, sig)
+	h.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rr.Code)
+	assert.False(t, called, "the handler must not run when the body exceeds MaxBodyBytes")
+	requireEmptyDir(t, dir, "an oversize request must not leave a spool file behind")
+}

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -5,10 +5,9 @@
 package hmac
 
 import (
-	"bytes"
 	"context"
 	"errors"
-	"io"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -186,37 +185,34 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 				return
 			}
 
-			bodyHash := BodyHashHex(nil)
+			bodyHash := emptyBodyHashHex
 			if r.Body != nil {
 				if opts.MaxBodyBytes > 0 {
 					r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
 				}
-				if opts.SpoolThresholdBytes > 0 {
-					spool, spoolErr := spoolBody(r.Body, opts.SpoolThresholdBytes)
-					if spoolErr != nil {
-						rejectBodyReadError(w, r, opts.Logger, spoolErr)
-						return
-					}
-					// The temp file (if the body spilled) must outlive the
-					// downstream handler, which reads the re-injected body
-					// from it; remove it once the handler returns.
-					defer spool.cleanup()
-					body, readerErr := spool.reader()
-					if readerErr != nil {
-						rejectBodyReadError(w, r, opts.Logger, readerErr)
-						return
-					}
-					bodyHash = spool.hashHex
-					r.Body = body
-				} else {
-					body, readErr := io.ReadAll(r.Body)
-					if readErr != nil {
-						rejectBodyReadError(w, r, opts.Logger, readErr)
-						return
-					}
-					bodyHash = BodyHashHex(body)
-					r.Body = io.NopCloser(bytes.NewReader(body))
+				// Spooling disabled resolves to an effectively-infinite
+				// threshold: the single drain path below then keeps every
+				// body in memory, which is the historical behavior.
+				spoolAt := opts.SpoolThresholdBytes
+				if spoolAt <= 0 {
+					spoolAt = math.MaxInt64 - 1
 				}
+				spool, spoolErr := spoolBody(r.Body, spoolAt)
+				if spoolErr != nil {
+					rejectBodyReadError(w, r, opts.Logger, spoolErr)
+					return
+				}
+				// The temp file (if the body spilled) must outlive the
+				// downstream handler, which reads the re-injected body
+				// from it; remove it once the handler returns.
+				defer spool.cleanup()
+				body, readerErr := spool.reader()
+				if readerErr != nil {
+					rejectBodyReadError(w, r, opts.Logger, readerErr)
+					return
+				}
+				bodyHash = spool.hashHex
+				r.Body = body
 			}
 
 			// Sign over RequestURI (path + raw query) so query parameters

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -204,12 +204,14 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 			}
 
 			// Sign over RequestURI (path + raw query) so query parameters
-			// like ?id= are bound to the signature. Try each candidate key in
-			// order (active, then rotation, or the per-request namespace keys);
-			// constant-time compare happens inside Verify per candidate.
+			// like ?id= are bound to the signature. Hash the body ONCE and
+			// try each candidate key in order (active, then rotation, or the
+			// per-request namespace keys) against the same hash; constant-time
+			// compare happens inside VerifyFromHash per candidate.
+			bodyHash := BodyHashHex(body)
 			ru := r.URL.RequestURI()
 			for _, c := range opts.labeledCandidates(r) {
-				if len(c.Key) > 0 && Verify(c.Key, r.Method, ru, body, tsNum, sig) {
+				if len(c.Key) > 0 && VerifyFromHash(c.Key, r.Method, ru, bodyHash, tsNum, sig) {
 					// Record the principal whose key matched so downstream
 					// handlers authorize on the authenticated namespace rather
 					// than a caller-controlled header.

--- a/pkg/auth/hmac/verifier.go
+++ b/pkg/auth/hmac/verifier.go
@@ -74,6 +74,16 @@ type VerifierOpts struct {
 	// The cap is only applied when enforcement is on (Secret non-empty); the
 	// pass-through short-circuit deliberately leaves the body untouched.
 	MaxBodyBytes int64
+	// SpoolThresholdBytes, when positive, bounds how much of the request body
+	// the verifier holds in memory while hashing: bodies up to the threshold
+	// stay in memory as before, larger ones spool to a temp file that the
+	// re-injected r.Body reads back from — so verifier memory is bounded by
+	// the threshold (not MaxBodyBytes) per request. Zero or negative keeps
+	// the fully in-memory behavior. The trade is a disk write+read for
+	// spooled bodies: set it on listeners where large bodies are real
+	// (storagesvc archive uploads) and leave it off on latency-sensitive
+	// ones (the router internal listener).
+	SpoolThresholdBytes int64
 	// Logger receives V(1) messages on each rejection. The zero value is
 	// substituted with logr.Discard() at construction so callers that don't
 	// care about audit logs don't crash. Rejection log lines deliberately
@@ -176,39 +186,45 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 				return
 			}
 
-			var body []byte
+			bodyHash := BodyHashHex(nil)
 			if r.Body != nil {
 				if opts.MaxBodyBytes > 0 {
 					r.Body = http.MaxBytesReader(w, r.Body, opts.MaxBodyBytes)
 				}
-				body, err = io.ReadAll(r.Body)
-				if err != nil {
-					var maxErr *http.MaxBytesError
-					if errors.As(err, &maxErr) {
-						opts.Logger.V(1).Info("HMAC verification failed",
-							"reason", "body exceeds MaxBodyBytes",
-							"method", r.Method, "path", r.URL.Path,
-							"remoteAddr", r.RemoteAddr,
-							"limit", maxErr.Limit)
-						w.WriteHeader(http.StatusRequestEntityTooLarge)
+				if opts.SpoolThresholdBytes > 0 {
+					spool, spoolErr := spoolBody(r.Body, opts.SpoolThresholdBytes)
+					if spoolErr != nil {
+						rejectBodyReadError(w, r, opts.Logger, spoolErr)
 						return
 					}
-					opts.Logger.V(1).Info("HMAC verification failed",
-						"reason", "body read error",
-						"method", r.Method, "path", r.URL.Path,
-						"remoteAddr", r.RemoteAddr)
-					w.WriteHeader(http.StatusUnauthorized)
-					return
+					// The temp file (if the body spilled) must outlive the
+					// downstream handler, which reads the re-injected body
+					// from it; remove it once the handler returns.
+					defer spool.cleanup()
+					body, readerErr := spool.reader()
+					if readerErr != nil {
+						rejectBodyReadError(w, r, opts.Logger, readerErr)
+						return
+					}
+					bodyHash = spool.hashHex
+					r.Body = body
+				} else {
+					body, readErr := io.ReadAll(r.Body)
+					if readErr != nil {
+						rejectBodyReadError(w, r, opts.Logger, readErr)
+						return
+					}
+					bodyHash = BodyHashHex(body)
+					r.Body = io.NopCloser(bytes.NewReader(body))
 				}
-				r.Body = io.NopCloser(bytes.NewReader(body))
 			}
 
 			// Sign over RequestURI (path + raw query) so query parameters
-			// like ?id= are bound to the signature. Hash the body ONCE and
-			// try each candidate key in order (active, then rotation, or the
-			// per-request namespace keys) against the same hash; constant-time
-			// compare happens inside VerifyFromHash per candidate.
-			bodyHash := BodyHashHex(body)
+			// like ?id= are bound to the signature. The body was hashed ONCE
+			// while draining it; try each candidate key in order (active,
+			// then rotation, or the per-request namespace keys) against the
+			// same hash; constant-time compare happens inside VerifyFromHash
+			// per candidate.
 			ru := r.URL.RequestURI()
 			for _, c := range opts.labeledCandidates(r) {
 				if len(c.Key) > 0 && VerifyFromHash(c.Key, r.Method, ru, bodyHash, tsNum, sig) {
@@ -227,4 +243,25 @@ func Verifier(opts VerifierOpts) func(http.Handler) http.Handler {
 			w.WriteHeader(http.StatusUnauthorized)
 		})
 	}
+}
+
+// rejectBodyReadError writes the response for a body the verifier could not
+// drain: an *http.MaxBytesError means the body exceeded MaxBodyBytes (413);
+// anything else is a read error (401). Shared by the in-memory and spooling
+// body paths so both reject identically.
+func rejectBodyReadError(w http.ResponseWriter, r *http.Request, logger logr.Logger, err error) {
+	if maxErr, ok := errors.AsType[*http.MaxBytesError](err); ok {
+		logger.V(1).Info("HMAC verification failed",
+			"reason", "body exceeds MaxBodyBytes",
+			"method", r.Method, "path", r.URL.Path,
+			"remoteAddr", r.RemoteAddr,
+			"limit", maxErr.Limit)
+		w.WriteHeader(http.StatusRequestEntityTooLarge)
+		return
+	}
+	logger.V(1).Info("HMAC verification failed",
+		"reason", "body read error",
+		"method", r.Method, "path", r.URL.Path,
+		"remoteAddr", r.RemoteAddr)
+	w.WriteHeader(http.StatusUnauthorized)
 }

--- a/pkg/fetcher/client/client.go
+++ b/pkg/fetcher/client/client.go
@@ -23,7 +23,22 @@ import (
 	ferror "github.com/fission/fission/pkg/error"
 	"github.com/fission/fission/pkg/fetcher"
 	"github.com/fission/fission/pkg/utils/correlation"
+	"github.com/fission/fission/pkg/utils/httpx"
 )
+
+// fetcherIdleConnsPerHost sizes the shared transport's idle pool per target
+// fetcher. Specialization fans out across pods (one host each), but buildermgr
+// runs concurrent builds of the same environment against a single builder
+// pod's fetcher — the stdlib default of 2 idle conns per host churns
+// connections there.
+const fetcherIdleConnsPerHost = 16
+
+// fetcherBaseTransport is shared by every fetcher client in the process. A
+// client is constructed per specialization (see poolmgr's gp_specialize), so
+// the underlying transport must be package-level: a per-client transport
+// would grow a fresh idle pool on every specialization and reuse nothing. The
+// per-client otel/signer wrappers are cheap and layer on top.
+var fetcherBaseTransport = httpx.PooledTransport(fetcherIdleConnsPerHost)
 
 type (
 	ClientInterface interface {
@@ -54,7 +69,7 @@ type (
 // (FISSION_INTERNAL_AUTH_SECRET) backs every internal channel's
 // signing/verification.
 func MakeClient(logger logr.Logger, fetcherUrl string, masterSecret []byte) ClientInterface {
-	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	var rt http.RoundTripper = otelhttp.NewTransport(fetcherBaseTransport)
 	if len(masterSecret) > 0 {
 		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceFetcher, rt, time.Now)
 	}
@@ -68,7 +83,7 @@ func MakeClient(logger logr.Logger, fetcherUrl string, masterSecret []byte) Clie
 // used to specialize another tenant's pod. An empty master yields an unsigned
 // client (pass-through), matching MakeClient.
 func MakeClientNS(logger logr.Logger, fetcherUrl string, masterSecret []byte, namespace string) ClientInterface {
-	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	var rt http.RoundTripper = otelhttp.NewTransport(fetcherBaseTransport)
 	if len(masterSecret) > 0 {
 		rt = hmacauth.ServiceSignerNS(masterSecret, hmacauth.ServiceFetcher, namespace, rt, time.Now)
 	}

--- a/pkg/publisher/webhookPublisher.go
+++ b/pkg/publisher/webhookPublisher.go
@@ -21,8 +21,23 @@ import (
 	"github.com/go-logr/logr"
 
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/utils/httpx"
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
+
+// webhookIdleConnsPerHost sizes the publisher transport's idle pool for its
+// single hot upstream, the router internal listener. Each publisher's send
+// loop is serialized (see svc), so this is not a concurrency bound — the
+// dedicated pool exists so the publisher's keep-alive connection is not
+// evicted by unrelated traffic sharing http.DefaultTransport's process-wide
+// 2-per-host pool, and a process running several publishers (mqtrigger) still
+// has headroom.
+const webhookIdleConnsPerHost = 8
+
+// webhookBaseTransport is shared by every publisher in the process so
+// per-publisher construction does not grow a fresh idle pool each time; the
+// per-publisher signer/otel wrappers are cheap and layer on top of it.
+var webhookBaseTransport = httpx.PooledTransport(webhookIdleConnsPerHost)
 
 type (
 	// WebhookPublisher for a single URL. Satisfies the Publisher interface.
@@ -90,7 +105,7 @@ func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher 
 // newWebhookHTTPClient constructs the HTTP client used to invoke
 // /fission-function/<ns>/<name> on the router's internal listener.
 // The transport stack is hmacauth (outermost, when secret set) ->
-// otelhttp -> http.DefaultTransport: the signer runs first and
+// otelhttp -> webhookBaseTransport: the signer runs first and
 // computes the canonical form over (method, path, body, timestamp);
 // otelhttp then injects trace headers on the inner transport. OTEL
 // trace headers are intentionally NOT part of the signed canonical
@@ -103,7 +118,7 @@ func MakeWebhookPublisher(logger logr.Logger, baseURL string) *WebhookPublisher 
 // (storagesvc, fetcher, builder, executor). See
 // docs/internal-auth/00-design.md.
 func newWebhookHTTPClient() *http.Client {
-	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	var rt http.RoundTripper = otelhttp.NewTransport(webhookBaseTransport)
 	if master := os.Getenv("FISSION_INTERNAL_AUTH_SECRET"); master != "" {
 		rt = hmacauth.ServiceSigner([]byte(master), hmacauth.ServiceRouterInternal, rt, time.Now)
 	}

--- a/pkg/router/resolver_executor.go
+++ b/pkg/router/resolver_executor.go
@@ -24,12 +24,16 @@ import (
 	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
-// executorResolver is the executor-RPC AddressResolver — today's address
-// source, retained as the cold-start path, the strict-mode path, and the
-// universal fallback. Poolmgr lookups always RPC the executor (its PoolCache
-// does per-request concurrency-aware dispatch); newdeploy/container lookups
-// hit the router-side address cache first, coalescing misses through the
-// throttler.
+// executorResolver is the executor-RPC AddressResolver, retained as the
+// cold-start path, the strict-mode path, and the universal fallback. With the
+// EndpointSlice data plane on (the default; RFC-0002), warm poolmgr traffic is
+// admitted from the router's slice-fed endpoint index and never reaches this
+// resolver — poolmgr lookups RPC the executor only on cold start, on
+// saturation (ensureCapacity), and for strict-concurrency/OnceOnly functions
+// (the executor's PoolCache does per-request concurrency-aware dispatch
+// there). With the gate off (legacy mode) every poolmgr lookup takes this RPC.
+// newdeploy/container lookups hit the router-side address cache first,
+// coalescing misses through the throttler.
 type executorResolver struct {
 	logger logr.Logger
 	fmap   *functionServiceMap

--- a/pkg/storagesvc/client/client.go
+++ b/pkg/storagesvc/client/client.go
@@ -27,7 +27,18 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/pkg/storagesvc"
+	"github.com/fission/fission/pkg/utils/httpx"
 )
+
+// storagesvcIdleConnsPerHost sizes the shared transport's idle pool for the
+// single storagesvc upstream; the stdlib default of 2 idle conns per host
+// churns connections when archive fetches and uploads overlap.
+const storagesvcIdleConnsPerHost = 16
+
+// storagesvcBaseTransport is shared by every storagesvc client in the process
+// so repeated MakeClient* calls reuse one idle pool instead of growing a fresh
+// one each time. The per-client otel/signer wrappers layer on top.
+var storagesvcBaseTransport = httpx.PooledTransport(storagesvcIdleConnsPerHost)
 
 // internalAuthSecretKey is the data key inside that Secret.
 const internalAuthSecretKey = "secret"
@@ -70,7 +81,7 @@ type (
 // HMACSecretFromCluster() so they read the same Secret the cluster
 // uses.
 func MakeClient(url string, masterSecret []byte) ClientInterface {
-	var rt http.RoundTripper = otelhttp.NewTransport(http.DefaultTransport)
+	var rt http.RoundTripper = otelhttp.NewTransport(storagesvcBaseTransport)
 	if len(masterSecret) > 0 {
 		rt = hmacauth.ServiceSigner(masterSecret, hmacauth.ServiceStoragesvc, rt, time.Now)
 	}
@@ -115,7 +126,7 @@ func MakeClientNS(url string, masterSecret []byte, namespace string) ClientInter
 		return MakeClient(url, masterSecret)
 	}
 	rt := hmacauth.ServiceSignerNS(masterSecret, hmacauth.ServiceStoragesvc, namespace,
-		otelhttp.NewTransport(http.DefaultTransport), time.Now)
+		otelhttp.NewTransport(storagesvcBaseTransport), time.Now)
 	return MakeClientWithTransport(url, &namespaceHeaderRoundTripper{namespace: namespace, next: rt})
 }
 

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -62,6 +62,13 @@ type (
 	}
 )
 
+// uploadSpoolThresholdBytes bounds the memory the HMAC verifier spends per
+// archive upload: bodies up to this size are hashed in memory, larger ones
+// spool to a temp file (see hmacauth.VerifierOpts.SpoolThresholdBytes). 4 MiB
+// keeps typical source archives fully in memory while capping what a burst of
+// maximum-size uploads can pin.
+const uploadSpoolThresholdBytes int64 = 4 << 20
+
 // Functions handling storage interface
 func getStorageType(storage Storage) string {
 	return string(storage.getStorageType())
@@ -351,11 +358,17 @@ func (ss *StorageService) makeHandler() http.Handler {
 		opts = append(opts, httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(ss.authSecret, ss.authSecretOld, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{
 			SkewSec: 60,
 			Bypass:  []string{"/healthz"},
-			// Caps the body the verifier buffers to check its signature; the
-			// verifier resolves 0 to 256 MiB. Operator-tunable via
+			// Caps the body the verifier accepts while checking its signature;
+			// the verifier resolves 0 to 256 MiB. Operator-tunable via
 			// STORAGE_MAX_ARCHIVE_SIZE_MIB — see the maxUploadBytes field and values.yaml.
 			MaxBodyBytes: ss.maxUploadBytes,
-			Logger:       ss.logger.WithName("hmac"),
+			// Spool over-threshold archive bodies to disk while hashing, so a
+			// concurrent burst of large uploads costs the verifier at most the
+			// threshold in memory each — not MaxBodyBytes each. Storagesvc
+			// writes accepted archives to its backing store anyway, so the
+			// extra disk round-trip is the right trade on this listener.
+			SpoolThresholdBytes: uploadSpoolThresholdBytes,
+			Logger:              ss.logger.WithName("hmac"),
 		})))
 	}
 	m := httpmux.New(opts...)


### PR DESCRIPTION
## TL;DR

Follow-up to the decision to close #2706: the optimization direction for internal comms is removing per-request work, not swapping protocols.
This lands the concrete gaps found while auditing every internal call path: pooled transports for three internal clients, a streamed HMAC body hash, a hash-once verifier, and bounded verifier memory via spool-to-disk for storagesvc uploads.
HMAC wire format and signatures are unchanged throughout — the canonical string already embeds `SHA256_HEX(BODY)`, so a streamed hash is byte-identical.

## Review order (one commit per step)

1. `router: correct stale executorResolver doc comment` — comment-only; establishes why the executor RPC is not the hot path.
2. `publisher: dedicated pooled transport` — keep-alive stability for kubewatcher/timer/mqtrigger publishes; the send loop stays serialized, so no concurrency change.
3. `fetcher/storagesvc clients: shared pooled base transport` — package-level base so per-specialization clients reuse one idle pool.
4. `hmac: stream the signer's body hash, hash once across verify candidates` — the core change; read `bodyHashForRequest` in `signer.go` and the `*FromHash` primitives in `hmac.go`.
5. `hmac: spool over-threshold verifier bodies to disk` — `spool.go` (new), `VerifierOpts.SpoolThresholdBytes`, storagesvc opt-in at 4 MiB.
6. `docs(internal-auth)` — design-doc body-size section catches up.
7. `hmac: fold the verifier's two body paths into one` — post-review cleanup; a disabled threshold resolves to effectively-infinite so one drain path serves both modes, `io.NopCloser` replaces a hand-rolled wrapper, empty-body hash precomputed.

Core files: `pkg/auth/hmac/{signer.go,verifier.go,spool.go,hmac.go}`.
Mechanical/consistency files: `pkg/publisher/webhookPublisher.go`, `pkg/fetcher/client/client.go`, `pkg/storagesvc/client/client.go`, `pkg/router/resolver_executor.go` (comment only), `docs/internal-auth/00-design.md`.

## Behavior notes

- Storagesvc uploads over 4 MiB now transiently touch container disk during verification (they were fully in RAM before); temp files are 0600, read back over the same fd (no TOCTOU), and removed once the handler returns — including on 401/413 rejections.
- The router internal listener deliberately stays fully in-memory — spooling trigger payloads would trade latency for memory on the hot path.
- Re-submitting an already-consumed non-rewindable request now fails signature verification instead of silently sending an empty body.
- Measured: `BenchmarkVerifyNamespaceRequest` 3477 → 2833 ns/op (−18.5%) from hashing once across candidate keys.

## Testing

- `go test -race` green across `pkg/auth/hmac`, `pkg/publisher`, `pkg/fetcher/...`, `pkg/storagesvc/...` (incl. dockertest S3 client suite), `pkg/router/...` (envtest), `pkg/buildermgr`.
- New tests pin the spool threshold boundary (N vs N+1 bytes), spill round-trip, temp-file cleanup on 200/401/413, and the signer's stream-via-GetBody contract (body untouched, exactly one fresh reader).
- Unit tests force the spill path; integration archives may all sit under 4 MiB, so a large-archive integration test is a possible follow-up.
- A focused security review of the branch found no issues (fail-closed on Body/GetBody divergence, ordering of freshness/413/verification preserved, constant-time compare unchanged, no cross-principal state in shared transports).

## Possible follow-ups (out of scope here)

- Operator-tunable spool threshold via Helm/env, mirroring `STORAGE_MAX_ARCHIVE_SIZE_MIB`, if anyone needs to retune the memory/disk trade.
- Streaming multipart in the storagesvc client's `UploadReader` (it still buffers the multipart body once client-side).
