### PR TITLE
support: close out the dump follow-ups, and two gaps they uncovered

### DIFF
--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -32,7 +32,7 @@ const (
 	// with the svc: labels in charts/fission-all/templates/*/deployment.yaml —
 	// a component absent here has no spec and no logs in the bundle at all.
 	componentSelector = "svc in (buildermgr, canaryconfig, executor, kubewatcher, mcp, mqtrigger, " +
-		"mqtrigger-keda, router, statestore, statesvc, storagesvc, tenantcontroller, timer, " +
+		"mqtrigger-keda, router, router-internal, statestore, statesvc, storagesvc, tenantcontroller, timer, " +
 		"webhook-service, workflow)"
 
 	builderSelector = "owner=buildermgr"

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -125,6 +125,9 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"fission-function-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, functionSelector),
 		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, functionSelector),
 		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, functionSelector, podEvents),
+		// The HPA is what decides whether a function scales at all, and the
+		// dumper for it existed but was never registered.
+		"fission-function-hpa": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesHPA, functionSelector),
 
 		// Events of fission pods that no longer exist — the OOMKilled or evicted
 		// pod is usually the one being investigated.

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -57,6 +57,11 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 
 	k8sClient := opts.Client().KubernetesClient
 
+	// Every pod-event dumper shares one index. The dumpers below run
+	// concurrently, so a list each would mean three full-cluster Event LISTs in
+	// flight at once.
+	podEvents := resources.NewPodEventIndex(k8sClient)
+
 	ress := map[string]resources.Resource{
 		// kubernetes info
 		"kubernetes-version": resources.NewKubernetesVersion(k8sClient),
@@ -77,21 +82,21 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"fission-components-pod-log": resources.NewKubernetesPodLogDumper(k8sClient,
 			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
 		"fission-components-pod-events": resources.NewKubernetesPodEventDumper(k8sClient,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)", podEvents),
 
 		// fission builder logs & spec
 		"fission-builder-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, "owner=buildermgr"),
 		"fission-builder-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, "owner=buildermgr"),
 		"fission-builder-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, "owner=buildermgr"),
 		"fission-builder-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "owner=buildermgr"),
-		"fission-builder-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "owner=buildermgr"),
+		"fission-builder-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "owner=buildermgr", podEvents),
 
 		// fission function logs & spec
 		"fission-function-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, "executorType=newdeploy"),
 		"fission-function-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, "executorType in (poolmgr, newdeploy)"),
 		"fission-function-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, "executorType in (poolmgr, newdeploy)"),
 		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
-		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
+		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "executorType in (poolmgr, newdeploy)", podEvents),
 
 		// CRD resources
 		"fission-crd-packages":      resources.NewCrdDumper(opts.Client(), resources.CrdPackage),

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -23,6 +23,29 @@ const (
 	DEFAULT_OUTPUT_DIR  = "fission-dump"
 )
 
+// Label selectors for the workloads a support bundle collects. Hoisted into
+// constants because each is used by three or four dumpers, and when the list
+// was repeated inline it drifted: eight of the components the chart ships were
+// missing from every bundle, mqt-keda among them.
+const (
+	// componentSelector matches the control-plane Deployments. Keep in sync
+	// with the svc: labels in charts/fission-all/templates/*/deployment.yaml —
+	// a component absent here has no spec and no logs in the bundle at all.
+	componentSelector = "svc in (buildermgr, canaryconfig, executor, kubewatcher, mcp, mqtrigger, " +
+		"mqtrigger-keda, router, statestore, statesvc, storagesvc, tenantcontroller, timer, " +
+		"webhook-service, workflow)"
+
+	builderSelector = "owner=buildermgr"
+
+	// functionSelector covers all three execution backends. container was
+	// missing, so container-executor functions had no spec, pods or logs.
+	functionSelector = "executorType in (poolmgr, newdeploy, container)"
+
+	// functionSvcSelector is narrower: poolmgr serves from the shared pool and
+	// creates no per-function Service, while newdeploy and container both do.
+	functionSvcSelector = "executorType in (newdeploy, container)"
+)
+
 type DumpSubCommand struct {
 	cmd.CommandActioner
 }
@@ -72,31 +95,31 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 
 		// fission component logs & spec
 		"fission-components-svc-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+			componentSelector),
 		"fission-components-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+			componentSelector),
 		"fission-components-daemonset-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDaemonSet,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+			componentSelector),
 		"fission-components-pod-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+			componentSelector),
 		"fission-components-pod-log": resources.NewKubernetesPodLogDumper(k8sClient,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)"),
+			componentSelector),
 		"fission-components-pod-events": resources.NewKubernetesPodEventDumper(k8sClient,
-			"svc in (buildermgr, executor, kubewatcher, mqtrigger, router, storagesvc, timer)", podEvents),
+			componentSelector, podEvents),
 
 		// fission builder logs & spec
-		"fission-builder-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, "owner=buildermgr"),
-		"fission-builder-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, "owner=buildermgr"),
-		"fission-builder-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, "owner=buildermgr"),
-		"fission-builder-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "owner=buildermgr"),
-		"fission-builder-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "owner=buildermgr", podEvents),
+		"fission-builder-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, builderSelector),
+		"fission-builder-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, builderSelector),
+		"fission-builder-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, builderSelector),
+		"fission-builder-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, builderSelector),
+		"fission-builder-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, builderSelector, podEvents),
 
 		// fission function logs & spec
-		"fission-function-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, "executorType=newdeploy"),
-		"fission-function-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, "executorType in (poolmgr, newdeploy)"),
-		"fission-function-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, "executorType in (poolmgr, newdeploy)"),
-		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, "executorType in (poolmgr, newdeploy)"),
-		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, "executorType in (poolmgr, newdeploy)", podEvents),
+		"fission-function-svc-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesService, functionSvcSelector),
+		"fission-function-deployment-spec": resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesDeployment, functionSelector),
+		"fission-function-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, functionSelector),
+		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, functionSelector),
+		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, functionSelector, podEvents),
 
 		// CRD resources
 		"fission-crd-packages":      resources.NewCrdDumper(opts.Client(), resources.CrdPackage),

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -85,6 +85,11 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 	// flight at once.
 	podEvents := resources.NewPodEventIndex(k8sClient)
 
+	// Likewise for the Deployment list: the mqt-consumer dumpers select on owner
+	// reference rather than a label, and the orphaned-event dumper needs the
+	// same list to attribute a pod that no longer exists.
+	deployments := resources.NewDeploymentIndex(k8sClient)
+
 	ress := map[string]resources.Resource{
 		// kubernetes info
 		"kubernetes-version": resources.NewKubernetesVersion(k8sClient),
@@ -120,6 +125,20 @@ func (opts *DumpSubCommand) do(input cli.Input) error {
 		"fission-function-pod-spec":        resources.NewKubernetesObjectDumper(k8sClient, resources.KubernetesPod, functionSelector),
 		"fission-function-pod-log":         resources.NewKubernetesPodLogDumper(k8sClient, functionSelector),
 		"fission-function-pod-events":      resources.NewKubernetesPodEventDumper(k8sClient, functionSelector, podEvents),
+
+		// Events of fission pods that no longer exist — the OOMKilled or evicted
+		// pod is usually the one being investigated.
+		"fission-orphaned-pod-events": resources.NewOrphanedPodEventDumper(k8sClient, podEvents, deployments,
+			componentSelector, builderSelector, functionSelector),
+
+		// The workload a keda MessageQueueTrigger scales. Selected by owner
+		// reference: the scaler labels it app=<mqt name> and nothing else.
+		"fission-mqt-consumer-deployment-spec": resources.NewMqtConsumerDumper(k8sClient, deployments,
+			resources.MqtConsumerDeployment),
+		"fission-mqt-consumer-pod-spec": resources.NewMqtConsumerDumper(k8sClient, deployments,
+			resources.MqtConsumerPod),
+		"fission-mqt-consumer-pod-log": resources.NewMqtConsumerDumper(k8sClient, deployments,
+			resources.MqtConsumerLog),
 
 		// CRD resources
 		"fission-crd-packages":      resources.NewCrdDumper(opts.Client(), resources.CrdPackage),

--- a/pkg/fission-cli/cmd/support/dump_test.go
+++ b/pkg/fission-cli/cmd/support/dump_test.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package support
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// svcLabel matches the literal `svc: <name>` the chart stamps on each
+// control-plane Deployment. The templates are Helm, not plain YAML, so this
+// reads the labels textually rather than unmarshalling.
+var svcLabel = regexp.MustCompile(`(?m)^\s*svc:\s*([a-z0-9-]+)\s*$`)
+
+// A component missing from componentSelector has no spec, no pods and no logs
+// in any support bundle, silently — which is how eight of them went missing.
+// Pin the selector to what the chart actually ships.
+func TestComponentSelectorCoversEveryChartComponent(t *testing.T) {
+	t.Parallel()
+
+	sel, err := labels.Parse(componentSelector)
+	require.NoError(t, err)
+
+	root := filepath.Join("..", "..", "..", "..", "charts", "fission-all", "templates")
+	files, err := filepath.Glob(filepath.Join(root, "*", "deployment.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "chart templates not found under %v", root)
+
+	seen := 0
+	for _, f := range files {
+		content, err := os.ReadFile(f) //nolint:gosec // fixed path inside the repo
+		require.NoError(t, err)
+
+		for _, m := range svcLabel.FindAllStringSubmatch(string(content), -1) {
+			seen++
+			assert.True(t, sel.Matches(labels.Set{"svc": m[1]}),
+				"%v ships svc=%q, which componentSelector does not match — that component's "+
+					"spec and logs would be missing from every support bundle", f, m[1])
+		}
+	}
+	require.NotZero(t, seen, "found no svc: labels; the regex or the chart layout changed")
+}
+
+// The three execution backends must all be collectable. container was missing
+// from the function selectors, so container-executor functions had no spec,
+// pods or logs in a bundle.
+func TestFunctionSelectorsCoverEveryExecutorType(t *testing.T) {
+	t.Parallel()
+
+	all, err := labels.Parse(functionSelector)
+	require.NoError(t, err)
+	for _, et := range []string{"poolmgr", "newdeploy", "container"} {
+		assert.True(t, all.Matches(labels.Set{"executorType": et}), "functionSelector misses %v", et)
+	}
+
+	// Narrower on purpose: poolmgr serves from the shared pool and creates no
+	// per-function Service, so it must not be here.
+	svc, err := labels.Parse(functionSvcSelector)
+	require.NoError(t, err)
+	assert.False(t, svc.Matches(labels.Set{"executorType": "poolmgr"}),
+		"poolmgr creates no per-function Service")
+	for _, et := range []string{"newdeploy", "container"} {
+		assert.True(t, svc.Matches(labels.Set{"executorType": et}), "functionSvcSelector misses %v", et)
+	}
+}

--- a/pkg/fission-cli/cmd/support/dump_test.go
+++ b/pkg/fission-cli/cmd/support/dump_test.go
@@ -30,7 +30,9 @@ func TestComponentSelectorCoversEveryChartComponent(t *testing.T) {
 	require.NoError(t, err)
 
 	root := filepath.Join("..", "..", "..", "..", "charts", "fission-all", "templates")
-	files, err := filepath.Glob(filepath.Join(root, "*", "deployment.yaml"))
+	// Every template, not just deployment.yaml: router-internal is a
+	// Service-only component, and globbing deployments alone could not see it.
+	files, err := filepath.Glob(filepath.Join(root, "*", "*.yaml"))
 	require.NoError(t, err)
 	require.NotEmpty(t, files, "chart templates not found under %v", root)
 
@@ -46,7 +48,8 @@ func TestComponentSelectorCoversEveryChartComponent(t *testing.T) {
 					"spec and logs would be missing from every support bundle", f, m[1])
 		}
 	}
-	require.NotZero(t, seen, "found no svc: labels; the regex or the chart layout changed")
+	require.GreaterOrEqual(t, seen, 16,
+		"found only %v svc: labels; the regex or the chart layout changed and this guard has stopped guarding", seen)
 }
 
 // The three execution backends must all be collectable. container was missing

--- a/pkg/fission-cli/cmd/support/resources/crd.go
+++ b/pkg/fission-cli/cmd/support/resources/crd.go
@@ -112,6 +112,7 @@ func (res CrdDumper) Dump(ctx context.Context, dumpDir string) {
 		triggers = append(triggers, l.Items...)
 
 		for _, item := range triggers {
+			item = mqtClean(item)
 			f := getFileName(dumpDir, item.ObjectMeta)
 			writeToFile(f, item)
 		}
@@ -143,6 +144,21 @@ func (res CrdDumper) Dump(ctx context.Context, dumpDir string) {
 	default:
 		console.Warn(fmt.Sprintf("Unknown type: %v", res.crdType))
 	}
+}
+
+// mqtClean masks credential-bearing values in a MessageQueueTrigger's metadata.
+//
+// This is the same map the keda scaler copies into ScaledObject.spec.triggers,
+// so masking only there would leave the values in the bundle anyway via this
+// dumper. Both call sites have to agree or neither is worth doing.
+//
+// mqt is a value copy, and maskCredentialValues returns a new map, so assigning
+// the result cannot reach the List-owned object — no DeepCopy needed here.
+func mqtClean(mqt fv1.MessageQueueTrigger) fv1.MessageQueueTrigger {
+	if masked, changed := maskCredentialValues(mqt.Spec.Metadata); changed {
+		mqt.Spec.Metadata = masked
+	}
+	return mqt
 }
 
 func pkgClean(pkg fv1.Package) fv1.Package {

--- a/pkg/fission-cli/cmd/support/resources/crd_test.go
+++ b/pkg/fission-cli/cmd/support/resources/crd_test.go
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+func TestMqtCleanMasksMetadataCredentials(t *testing.T) {
+	t.Parallel()
+
+	// This is the same map the keda scaler copies into the ScaledObject, so
+	// masking it in only one of the two dumpers would leave the value in the
+	// bundle regardless.
+	mqt := fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-mqt", Namespace: "default"},
+		Spec: fv1.MessageQueueTriggerSpec{
+			Metadata: map[string]string{
+				"host":      "amqp://user:hunter2@rabbit:5672/",
+				"queueName": "orders",
+			},
+		},
+	}
+
+	cleaned := mqtClean(mqt)
+
+	assert.Equal(t, "-", cleaned.Spec.Metadata["host"])
+	assert.Equal(t, "orders", cleaned.Spec.Metadata["queueName"],
+		"non-credential metadata stays diagnostic")
+	assert.Equal(t, "amqp://user:hunter2@rabbit:5672/", mqt.Spec.Metadata["host"],
+		"the map is shared with the List result and must not be edited in place")
+}
+
+func TestMqtCleanLeavesTriggersWithoutCredentialsAlone(t *testing.T) {
+	t.Parallel()
+
+	mqt := fv1.MessageQueueTrigger{
+		Spec: fv1.MessageQueueTriggerSpec{
+			Metadata: map[string]string{"topic": "orders", "consumerGroup": "g1"},
+		},
+	}
+
+	assert.Equal(t, mqt.Spec.Metadata, mqtClean(mqt).Spec.Metadata)
+}
+
+func TestCrdDumperMasksMessageQueueTriggerMetadata(t *testing.T) {
+	t.Parallel()
+
+	// Guards the wiring, not the helper: without mqtClean at the call site the
+	// masking function can be perfectly correct and still never run.
+	mqt := &fv1.MessageQueueTrigger{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-mqt", Namespace: "default", ResourceVersion: "1"},
+		Spec: fv1.MessageQueueTriggerSpec{
+			Metadata: map[string]string{
+				"host":      "amqp://user:hunter2@rabbit:5672/",
+				"queueName": "orders",
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	d := CrdDumper{
+		client:  cmd.Client{FissionClientSet: fissionfake.NewSimpleClientset(mqt)},
+		crdType: CrdMessageQueueTrigger,
+	}
+	d.Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1)
+	content, err := os.ReadFile(filepath.Join(dir, files[0]))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(content), "hunter2",
+		"the mqt CRD dumper exposes the same metadata map as the ScaledObject dumper")
+	assert.Contains(t, string(content), "orders")
+}

--- a/pkg/fission-cli/cmd/support/resources/keda.go
+++ b/pkg/fission-cli/cmd/support/resources/keda.go
@@ -6,6 +6,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
@@ -23,11 +24,18 @@ const (
 	KedaTriggerAuthentication = "TriggerAuthentication"
 )
 
-// mqtKind mirrors mqtrigger.MqtKind, the Kind the mqt-keda scaler stamps into
-// the OwnerReferences of every KEDA object it creates. Duplicated rather than
-// imported because pkg/mqtrigger would pull the controller-runtime scaler
-// machinery into the CLI binary.
-const mqtKind = "MessageQueueTrigger"
+// The Kind and APIVersion the mqt-keda scaler stamps into the OwnerReferences
+// of every KEDA object it creates, mirroring mqtrigger.MqtKind and
+// mqtrigger.MqtAPIVersion.
+//
+// Kept local rather than imported so this leaf CLI package does not pull the
+// controller-runtime scaler machinery into its build for two string constants.
+// TestMqtOwnerConstantsMatchScaler pins them to the originals, so the copies
+// cannot drift silently.
+const (
+	mqtKind       = "MessageQueueTrigger"
+	mqtAPIVersion = "fission.io/v1"
+)
 
 // KedaDumper dumps the KEDA objects that fission's mqt-keda scaler manager
 // creates for MessageQueueTriggers (see pkg/mqtrigger/scalermanager.go).
@@ -47,15 +55,26 @@ type KedaDumper struct {
 }
 
 func NewKedaDumper(client cmd.Client, kedaType string) Resource {
+	if client.RestConfig == nil {
+		// kedaClient.NewForConfig dereferences its argument, so a nil config
+		// panics rather than returning an error — and the dumpers are built in
+		// a map literal, so that panic would take the whole support bundle down
+		// before any dumper runs. Route it through clientErr, which exists
+		// precisely so one unavailable client cannot abort the bundle.
+		return KedaDumper{kedaType: kedaType, clientErr: errors.New("no kubernetes rest config available")}
+	}
 	kc, err := kedaClient.NewForConfig(client.RestConfig)
 	return KedaDumper{client: kc, kedaType: kedaType, clientErr: err}
 }
 
 // ownedByMessageQueueTrigger reports whether obj was created by fission's
-// mqt-keda scaler for a MessageQueueTrigger.
+// mqt-keda scaler for a MessageQueueTrigger. The APIVersion is checked as well
+// as the Kind: this filter is what keeps an unrelated team's objects out of a
+// bundle that gets sent to a third party, and "MessageQueueTrigger" is not a
+// name fission owns across every API group.
 func ownedByMessageQueueTrigger(meta metav1.ObjectMeta) bool {
 	for _, ref := range meta.OwnerReferences {
-		if ref.Kind == mqtKind {
+		if ref.Kind == mqtKind && ref.APIVersion == mqtAPIVersion {
 			return true
 		}
 	}
@@ -66,6 +85,11 @@ func ownedByMessageQueueTrigger(meta metav1.ObjectMeta) bool {
 // opposed to a real failure. A cluster with no KEDA is the normal case for
 // anyone not using mqt of type keda, so it is reported as a verbose note
 // rather than a warning that would look like a problem in every bundle.
+//
+// IsNotFound is the branch that actually fires: the typed KEDA clientset issues
+// REST calls directly, and a missing CRD comes back from the apiserver as a
+// plain 404. IsNoMatchError is defensive breadth for a RESTMapper-backed client
+// (dynamic or controller-runtime) and is unreachable through this one.
 func kedaAbsent(err error) bool {
 	return apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err)
 }

--- a/pkg/fission-cli/cmd/support/resources/keda.go
+++ b/pkg/fission-cli/cmd/support/resources/keda.go
@@ -131,8 +131,9 @@ func (res KedaDumper) Dump(ctx context.Context, dumpDir string) {
 			if !ownedByMessageQueueTrigger(item.ObjectMeta) {
 				continue
 			}
-			f := getFileName(dumpDir, item.ObjectMeta)
-			writeToFile(f, item)
+			cleaned := scaledObjectClean(&item)
+			f := getFileName(dumpDir, cleaned.ObjectMeta)
+			writeToFile(f, cleaned)
 		}
 
 	case KedaTriggerAuthentication:
@@ -154,6 +155,33 @@ func (res KedaDumper) Dump(ctx context.Context, dumpDir string) {
 	default:
 		console.Warn(fmt.Sprintf("Unknown keda type: %v", res.kedaType))
 	}
+}
+
+// scaledObjectClean masks credential-bearing values in the scaler's trigger
+// metadata. That map is mqt.Spec.Metadata copied verbatim (see
+// pkg/mqtrigger/scalermanager.go), and for several KEDA scalers it is the
+// documented place to put an inline connection string — rabbitmq's host, redis'
+// address — so it can hold a password even though fission's own path routes
+// credentials through Spec.Secret into a TriggerAuthentication instead.
+//
+// Spec.Triggers is a slice, so writing through it would mutate the backing
+// array shared with the List result. Copy first.
+func scaledObjectClean(so *kedav1alpha1.ScaledObject) *kedav1alpha1.ScaledObject {
+	var out *kedav1alpha1.ScaledObject
+	for i := range so.Spec.Triggers {
+		masked, changed := maskCredentialValues(so.Spec.Triggers[i].Metadata)
+		if !changed {
+			continue
+		}
+		if out == nil {
+			out = so.DeepCopy()
+		}
+		out.Spec.Triggers[i].Metadata = masked
+	}
+	if out == nil {
+		return so
+	}
+	return out
 }
 
 // triggerAuthClean masks the one field of a TriggerAuthentication that holds a

--- a/pkg/fission-cli/cmd/support/resources/keda.go
+++ b/pkg/fission-cli/cmd/support/resources/keda.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	kedav1alpha1 "github.com/kedacore/keda/v2/apis/keda/v1alpha1"
 	kedaClient "github.com/kedacore/keda/v2/pkg/generated/clientset/versioned"
@@ -94,6 +95,24 @@ func kedaAbsent(err error) bool {
 	return apimeta.IsNoMatchError(err) || apierrors.IsNotFound(err)
 }
 
+// noteListErr records a failed KEDA list.
+//
+// A missing CRD is the normal case for anyone not using mqt of type keda, so it
+// is a verbose note rather than a warning that would appear in every bundle
+// from every non-KEDA install — plus a marker file, because an empty directory
+// on its own cannot be told apart from a list that failed, and whoever reads
+// the tarball weeks later has no other way to know which happened. Anything
+// else is a real problem and stays a warning.
+func noteListErr(kedaType, dumpDir string, err error) {
+	if kedaAbsent(err) {
+		console.Verbose(2, "KEDA %v not available in this cluster, skipping", kedaType)
+		writeToFile(filepath.Join(dumpDir, "keda-not-installed.txt"),
+			fmt.Sprintf("no %v dumped: the KEDA CRDs are not installed in this cluster (%v)", kedaType, err))
+		return
+	}
+	console.Warn(fmt.Sprintf("Error getting %v list: %v", kedaType, err))
+}
+
 func (res KedaDumper) Dump(ctx context.Context, dumpDir string) {
 	if res.clientErr != nil {
 		console.Warn(fmt.Sprintf("Error creating keda client for %v: %v", res.kedaType, res.clientErr))
@@ -104,11 +123,7 @@ func (res KedaDumper) Dump(ctx context.Context, dumpDir string) {
 	case KedaScaledObject:
 		items, err := res.client.KedaV1alpha1().ScaledObjects(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			if kedaAbsent(err) {
-				console.Verbose(2, "KEDA ScaledObjects not available in this cluster, skipping")
-				return
-			}
-			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.kedaType, err))
+			noteListErr(res.kedaType, dumpDir, err)
 			return
 		}
 
@@ -123,11 +138,7 @@ func (res KedaDumper) Dump(ctx context.Context, dumpDir string) {
 	case KedaTriggerAuthentication:
 		items, err := res.client.KedaV1alpha1().TriggerAuthentications(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
 		if err != nil {
-			if kedaAbsent(err) {
-				console.Verbose(2, "KEDA TriggerAuthentications not available in this cluster, skipping")
-				return
-			}
-			console.Warn(fmt.Sprintf("Error getting %v list: %v", res.kedaType, err))
+			noteListErr(res.kedaType, dumpDir, err)
 			return
 		}
 

--- a/pkg/fission-cli/cmd/support/resources/keda_test.go
+++ b/pkg/fission-cli/cmd/support/resources/keda_test.go
@@ -272,21 +272,23 @@ func TestNewKedaDumperWithoutRestConfigDoesNotPanic(t *testing.T) {
 	assert.Empty(t, dumpedFiles(t, dir))
 }
 
-func TestKedaDumperListErrorsWriteNothing(t *testing.T) {
+func TestKedaDumperListErrorBranches(t *testing.T) {
 	t.Parallel()
 
 	gr := schema.GroupResource{Group: "keda.sh", Resource: "scaledobjects"}
 
-	// Both branches of the kedaAbsent split must leave the bundle intact. The
-	// branches differ only in console output, which this package cannot capture
-	// without swapping a global that t.Parallel would race — so this pins the
-	// half that is observable: neither aborts, neither writes.
+	// The two kedaAbsent branches are now observably different in the bundle
+	// itself: a missing CRD leaves a marker naming the reason, a real failure
+	// leaves nothing (it was warned about on the console instead). An empty
+	// directory alone could not tell those apart, which is the whole point of
+	// the marker. Neither branch may abort the dump.
 	tests := []struct {
-		name string
-		err  error
+		name       string
+		err        error
+		wantMarker bool
 	}{
-		{"keda not installed", apierrors.NewNotFound(gr, "scaledobjects")},
-		{"forbidden is a real error", apierrors.NewForbidden(gr, "scaledobjects", assert.AnError)},
+		{"keda not installed leaves a marker", apierrors.NewNotFound(gr, "scaledobjects"), true},
+		{"forbidden is a real error, not an absent CRD", apierrors.NewForbidden(gr, "scaledobjects", assert.AnError), false},
 	}
 
 	for _, tc := range tests {
@@ -301,7 +303,18 @@ func TestKedaDumperListErrorsWriteNothing(t *testing.T) {
 			dir := t.TempDir()
 			d := KedaDumper{client: c, kedaType: KedaScaledObject}
 			require.NotPanics(t, func() { d.Dump(t.Context(), dir) })
-			assert.Empty(t, dumpedFiles(t, dir))
+
+			files := dumpedFiles(t, dir)
+			if !tc.wantMarker {
+				assert.Empty(t, files, "a real error must not be recorded as an absent CRD")
+				return
+			}
+
+			require.Equal(t, []string{"keda-not-installed.txt"}, files)
+			content, err := os.ReadFile(filepath.Join(dir, files[0]))
+			require.NoError(t, err)
+			assert.Contains(t, string(content), KedaScaledObject,
+				"the marker should name which kind was skipped")
 		})
 	}
 }

--- a/pkg/fission-cli/cmd/support/resources/keda_test.go
+++ b/pkg/fission-cli/cmd/support/resources/keda_test.go
@@ -318,3 +318,58 @@ func TestKedaDumperListErrorBranches(t *testing.T) {
 		})
 	}
 }
+
+func TestKedaDumperMasksTriggerMetadataCredentials(t *testing.T) {
+	t.Parallel()
+
+	so := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-mqt", Namespace: "default", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+		},
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			Triggers: []kedav1alpha1.ScaleTriggers{{
+				Type: "rabbitmq",
+				Metadata: map[string]string{
+					"host":       "amqp://user:hunter2@rabbit:5672/",
+					"queueName":  "orders",
+					"queueLengt": "5",
+				},
+			}},
+		},
+	}
+
+	dir := t.TempDir()
+	d := KedaDumper{client: kedafake.NewSimpleClientset(so), kedaType: KedaScaledObject}
+	d.Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1)
+	content, err := os.ReadFile(filepath.Join(dir, files[0]))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(content), "hunter2",
+		"an inline connection string must not reach a support bundle")
+	assert.Contains(t, string(content), "queueName", "non-credential metadata stays diagnostic")
+	assert.Contains(t, string(content), "orders")
+}
+
+func TestScaledObjectCleanLeavesTheListedObjectUnmutated(t *testing.T) {
+	t.Parallel()
+
+	// Spec.Triggers is a slice, so writing through it would edit the backing
+	// array shared with the List result.
+	so := &kedav1alpha1.ScaledObject{
+		Spec: kedav1alpha1.ScaledObjectSpec{
+			Triggers: []kedav1alpha1.ScaleTriggers{{
+				Metadata: map[string]string{"password": "hunter2"},
+			}},
+		},
+	}
+
+	cleaned := scaledObjectClean(so)
+
+	assert.Equal(t, "-", cleaned.Spec.Triggers[0].Metadata["password"])
+	assert.Equal(t, "hunter2", so.Spec.Triggers[0].Metadata["password"],
+		"the input object must not be modified in place")
+}

--- a/pkg/fission-cli/cmd/support/resources/keda_test.go
+++ b/pkg/fission-cli/cmd/support/resources/keda_test.go
@@ -16,7 +16,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	clienttesting "k8s.io/client-go/testing"
+
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/mqtrigger"
 )
 
 func mqtOwnerRef() metav1.OwnerReference {
@@ -205,6 +210,98 @@ func TestKedaAbsent(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			assert.Equal(t, tc.want, kedaAbsent(tc.err))
+		})
+	}
+}
+
+func TestMqtOwnerConstantsMatchScaler(t *testing.T) {
+	t.Parallel()
+
+	// The constants are copied rather than imported so this package does not
+	// pull the scaler machinery into its build. This test is what makes that
+	// trade safe: it fails the moment the originals move.
+	assert.Equal(t, mqtrigger.MqtKind, mqtKind)
+	assert.Equal(t, mqtrigger.MqtAPIVersion, mqtAPIVersion)
+}
+
+func TestKedaDumperIgnoresSameKindFromAnotherGroup(t *testing.T) {
+	t.Parallel()
+
+	// "MessageQueueTrigger" is not a Kind fission owns across every API group,
+	// and this filter decides what reaches a third party.
+	impostor := &kedav1alpha1.ScaledObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "someone-elses-mqt", Namespace: "other", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: mqtKind, Name: "their-mqt", APIVersion: "queues.example.com/v1"},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	d := KedaDumper{client: kedafake.NewSimpleClientset(impostor), kedaType: KedaScaledObject}
+	d.Dump(t.Context(), dir)
+
+	assert.Empty(t, dumpedFiles(t, dir),
+		"a same-named Kind from another API group is not fission's")
+}
+
+func TestKedaDumperWithUnusableClientWritesNothing(t *testing.T) {
+	t.Parallel()
+
+	// The deferred-error design exists so a bad RestConfig cannot abort the
+	// whole bundle. Without the guard this dereferences a nil client.
+	dir := t.TempDir()
+	d := KedaDumper{client: nil, kedaType: KedaScaledObject, clientErr: assert.AnError}
+
+	require.NotPanics(t, func() { d.Dump(t.Context(), dir) })
+	assert.Empty(t, dumpedFiles(t, dir))
+}
+
+func TestNewKedaDumperWithoutRestConfigDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// kedaClient.NewForConfig dereferences its argument, and the dumpers are
+	// built in a map literal, so a panic here would take the whole dump down
+	// before any dumper runs.
+	var d Resource
+	require.NotPanics(t, func() { d = NewKedaDumper(cmd.Client{}, KedaScaledObject) })
+
+	dir := t.TempDir()
+	require.NotPanics(t, func() { d.Dump(t.Context(), dir) })
+	assert.Empty(t, dumpedFiles(t, dir))
+}
+
+func TestKedaDumperListErrorsWriteNothing(t *testing.T) {
+	t.Parallel()
+
+	gr := schema.GroupResource{Group: "keda.sh", Resource: "scaledobjects"}
+
+	// Both branches of the kedaAbsent split must leave the bundle intact. The
+	// branches differ only in console output, which this package cannot capture
+	// without swapping a global that t.Parallel would race — so this pins the
+	// half that is observable: neither aborts, neither writes.
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"keda not installed", apierrors.NewNotFound(gr, "scaledobjects")},
+		{"forbidden is a real error", apierrors.NewForbidden(gr, "scaledobjects", assert.AnError)},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := kedafake.NewSimpleClientset()
+			c.PrependReactor("list", "scaledobjects", func(clienttesting.Action) (bool, runtime.Object, error) {
+				return true, nil, tc.err
+			})
+
+			dir := t.TempDir()
+			d := KedaDumper{client: c, kedaType: KedaScaledObject}
+			require.NotPanics(t, func() { d.Dump(t.Context(), dir) })
+			assert.Empty(t, dumpedFiles(t, dir))
 		})
 	}
 }

--- a/pkg/fission-cli/cmd/support/resources/kubernetes.go
+++ b/pkg/fission-cli/cmd/support/resources/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -210,39 +211,48 @@ func dumpPodContainerLogs(ctx context.Context, client kubernetes.Interface, pod 
 	// would write into Containers' spare capacity when it has any, editing the
 	// pod object this function was handed.
 	for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
-		req := client.CoreV1().Pods(pod.Namespace).
-			GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name})
-
-		stream, err := req.Stream(ctx)
-		if err != nil {
-			console.Error(fmt.Sprintf("Error streaming logs for pod %v: %v", pod.Name, err))
-			return
-		}
-
-		reader := bufio.NewReader(stream)
-		var buffer bytes.Buffer
-
-		for {
-			line, _, err := reader.ReadLine()
-			if err != nil {
-				if err == io.EOF {
-					stream.Close()
-					break
-				}
-				console.Error(fmt.Sprintf("Error reading logs from buffer: %v", err))
-				return
-			}
-
-			_, err = buffer.WriteString(string(line) + "\n")
-			if err != nil {
-				console.Error(fmt.Sprintf("Error writing bytes to buffer: %v", err))
-				return
-			}
-		}
-
-		f := getPodFileName(dumpDir, pod.ObjectMeta, container.Name)
-		writeToFile(f, buffer.String())
-
-		stream.Close()
+		dumpOneContainerLog(ctx, client, pod, container.Name, dumpDir)
 	}
+}
+
+// dumpOneContainerLog writes a single container's log.
+//
+// Every failure here is per-container. The common one is a container still
+// PodInitializing, and since regular containers are streamed before init
+// containers, aborting the pod on the first failure would leave the stuck pod —
+// the one someone is collecting a bundle about — with no log files at all, which
+// reads exactly like a pod that logged nothing.
+func dumpOneContainerLog(ctx context.Context, client kubernetes.Interface,
+	pod corev1.Pod, container, dumpDir string) {
+	req := client.CoreV1().Pods(pod.Namespace).
+		GetLogs(pod.Name, &corev1.PodLogOptions{Container: container})
+
+	stream, err := req.Stream(ctx)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error streaming logs for pod %v container %v: %v", pod.Name, container, err))
+		return
+	}
+	defer stream.Close()
+
+	reader := bufio.NewReader(stream)
+	var buffer bytes.Buffer
+
+	for {
+		line, _, err := reader.ReadLine()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			// Keep what was read. A truncated log still shows how far the
+			// container got, and the trailer keeps the reader from mistaking
+			// the cut for the end of the container's output.
+			console.Error(fmt.Sprintf("Error reading logs for pod %v container %v: %v", pod.Name, container, err))
+			fmt.Fprintf(&buffer, "\n--- log collection failed after %v bytes: %v ---\n", buffer.Len(), err)
+			break
+		}
+		buffer.Write(line)
+		buffer.WriteByte('\n')
+	}
+
+	writeToFile(getPodFileName(dumpDir, pod.ObjectMeta, container), buffer.String())
 }

--- a/pkg/fission-cli/cmd/support/resources/kubernetes.go
+++ b/pkg/fission-cli/cmd/support/resources/kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"sync"
 
 	corev1 "k8s.io/api/core/v1"
@@ -196,48 +197,52 @@ func (res KubernetesPodLogDumper) Dump(ctx context.Context, dumpDir string) {
 
 	for _, p := range l.Items {
 		wg.Go(func() {
-			func(pod corev1.Pod) {
-				// dump logs from each containers
-				for _, container := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
-					req := res.client.CoreV1().Pods(pod.Namespace).
-						GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name})
-
-					stream, err := req.Stream(ctx)
-					if err != nil {
-						console.Error(fmt.Sprintf("Error streaming logs for pod %v: %v", pod.Name, err))
-						return
-					}
-
-					reader := bufio.NewReader(stream)
-					var buffer bytes.Buffer
-
-					for {
-						line, _, err := reader.ReadLine()
-						if err != nil {
-							if err == io.EOF {
-								stream.Close()
-								break
-							}
-							console.Error(fmt.Sprintf("Error reading logs from buffer: %v", err))
-							return
-						}
-
-						_, err = buffer.WriteString(string(line) + "\n")
-						if err != nil {
-							console.Error(fmt.Sprintf("Error writing bytes to buffer: %v", err))
-							return
-						}
-					}
-
-					f := getPodFileName(dumpDir, pod.ObjectMeta, container.Name)
-					writeToFile(f, buffer.String())
-
-					stream.Close()
-				}
-			}(p)
+			dumpPodContainerLogs(ctx, res.client, p, dumpDir)
 		})
-
 	}
 
 	wg.Wait()
+}
+
+// dumpPodContainerLogs writes one file per container in pod.
+func dumpPodContainerLogs(ctx context.Context, client kubernetes.Interface, pod corev1.Pod, dumpDir string) {
+	// slices.Concat rather than append(Containers, InitContainers...): append
+	// would write into Containers' spare capacity when it has any, editing the
+	// pod object this function was handed.
+	for _, container := range slices.Concat(pod.Spec.Containers, pod.Spec.InitContainers) {
+		req := client.CoreV1().Pods(pod.Namespace).
+			GetLogs(pod.Name, &corev1.PodLogOptions{Container: container.Name})
+
+		stream, err := req.Stream(ctx)
+		if err != nil {
+			console.Error(fmt.Sprintf("Error streaming logs for pod %v: %v", pod.Name, err))
+			return
+		}
+
+		reader := bufio.NewReader(stream)
+		var buffer bytes.Buffer
+
+		for {
+			line, _, err := reader.ReadLine()
+			if err != nil {
+				if err == io.EOF {
+					stream.Close()
+					break
+				}
+				console.Error(fmt.Sprintf("Error reading logs from buffer: %v", err))
+				return
+			}
+
+			_, err = buffer.WriteString(string(line) + "\n")
+			if err != nil {
+				console.Error(fmt.Sprintf("Error writing bytes to buffer: %v", err))
+				return
+			}
+		}
+
+		f := getPodFileName(dumpDir, pod.ObjectMeta, container.Name)
+		writeToFile(f, buffer.String())
+
+		stream.Close()
+	}
 }

--- a/pkg/fission-cli/cmd/support/resources/kubernetes_test.go
+++ b/pkg/fission-cli/cmd/support/resources/kubernetes_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func loggingPod() *corev1.Pod {
+	p := fissionPod("router-abc", "uid-router")
+	p.Spec.Containers = []corev1.Container{{Name: "router"}, {Name: "sidecar"}}
+	p.Spec.InitContainers = []corev1.Container{{Name: "fetcher"}}
+	return p
+}
+
+func TestPodLogDumperWritesAFilePerContainerIncludingInitContainers(t *testing.T) {
+	t.Parallel()
+
+	// Init container logs are what explain a pod that never reached Running,
+	// which is the pod a support bundle is usually collected for.
+	client := k8sfake.NewClientset(loggingPod())
+
+	dir := t.TempDir()
+	NewKubernetesPodLogDumper(client, "svc in (router)").Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 3)
+
+	joined := strings.Join(files, " ")
+	assert.Contains(t, joined, "router")
+	assert.Contains(t, joined, "sidecar")
+	assert.Contains(t, joined, "fetcher", "init containers must be collected too")
+}
+
+func TestPodLogDumperKeepsGoingWhenOneContainerFails(t *testing.T) {
+	t.Parallel()
+
+	// The usual failure is a container still PodInitializing. Regular
+	// containers stream before init containers, so aborting the pod on the
+	// first failure would leave the stuck pod with no logs at all — which reads
+	// exactly like a pod that logged nothing.
+	client := k8sfake.NewClientset(loggingPod())
+	client.PrependReactor("get", "pods", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, assert.AnError
+	})
+
+	dir := t.TempDir()
+	require.NotPanics(t, func() {
+		NewKubernetesPodLogDumper(client, "svc in (router)").Dump(t.Context(), dir)
+	})
+}

--- a/pkg/fission-cli/cmd/support/resources/mask_test.go
+++ b/pkg/fission-cli/cmd/support/resources/mask_test.go
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskCredentialValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		in     map[string]string
+		want   map[string]string
+		masked bool
+	}{
+		{
+			name:   "credential-named keys are masked, keys preserved",
+			in:     map[string]string{"password": "hunter2", "topic": "orders"},
+			want:   map[string]string{"password": "-", "topic": "orders"},
+			masked: true,
+		},
+		{
+			name:   "a url carrying a password is masked whatever the key",
+			in:     map[string]string{"host": "amqp://user:hunter2@rabbit:5672/"},
+			want:   map[string]string{"host": "-"},
+			masked: true,
+		},
+		{
+			name: "a url with no password is configuration, not a secret",
+			in:   map[string]string{"host": "amqp://rabbit:5672/", "address": "redis:6379"},
+			want: map[string]string{"host": "amqp://rabbit:5672/", "address": "redis:6379"},
+		},
+		{
+			name: "sasl names a mechanism, not a secret",
+			in:   map[string]string{"sasl": "scram_sha512", "saslType": "plaintext"},
+			want: map[string]string{"sasl": "scram_sha512", "saslType": "plaintext"},
+		},
+		{
+			name:   "saslPassword is a secret",
+			in:     map[string]string{"saslPassword": "hunter2"},
+			want:   map[string]string{"saslPassword": "-"},
+			masked: true,
+		},
+		{
+			name:   "matching is case-insensitive and substring-based",
+			in:     map[string]string{"AwsAccessKeyID": "AKIA", "bearerToken": "t"},
+			want:   map[string]string{"AwsAccessKeyID": "-", "bearerToken": "-"},
+			masked: true,
+		},
+		{
+			name: "an empty value is left alone, so absent stays distinguishable",
+			in:   map[string]string{"password": ""},
+			want: map[string]string{"password": ""},
+		},
+		{name: "nil in, nil out"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, masked := maskCredentialValues(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.Equal(t, tc.masked, masked)
+		})
+	}
+}
+
+func TestMaskCredentialValuesDoesNotMutateItsInput(t *testing.T) {
+	t.Parallel()
+
+	in := map[string]string{"password": "hunter2"}
+	got, _ := maskCredentialValues(in)
+
+	assert.Equal(t, "-", got["password"])
+	assert.Equal(t, "hunter2", in["password"], "the caller's map is shared with the List result")
+}

--- a/pkg/fission-cli/cmd/support/resources/mask_test.go
+++ b/pkg/fission-cli/cmd/support/resources/mask_test.go
@@ -33,8 +33,40 @@ func TestMaskCredentialValues(t *testing.T) {
 		},
 		{
 			name: "a url with no password is configuration, not a secret",
-			in:   map[string]string{"host": "amqp://rabbit:5672/", "address": "redis:6379"},
-			want: map[string]string{"host": "amqp://rabbit:5672/", "address": "redis:6379"},
+			in: map[string]string{
+				"host": "amqp://rabbit:5672/", "address": "redis:6379",
+				// userinfo present but no password — still not a secret.
+				"broker": "amqp://user@rabbit:5672/",
+			},
+			want: map[string]string{
+				"host": "amqp://rabbit:5672/", "address": "redis:6379",
+				"broker": "amqp://user@rabbit:5672/",
+			},
+		},
+		{
+			// url.Parse reads this as scheme "user" with an opaque body, so
+			// u.User is nil and the parse-based check alone would miss it.
+			name:   "a schemeless connection string is still masked",
+			in:     map[string]string{"host": "user:hunter2@rabbit:5672"},
+			want:   map[string]string{"host": "-"},
+			masked: true,
+		},
+		{
+			// An unencoded character in the password makes url.Parse fail
+			// outright, while the client library still accepts the string.
+			name:   "an unparseable connection string is masked rather than trusted",
+			in:     map[string]string{"host": "amqp://user:hun[ter2@rabbit:5672/"},
+			want:   map[string]string{"host": "-"},
+			masked: true,
+		},
+		{
+			name: "a *FromEnv value names an env var, not a secret",
+			in: map[string]string{
+				"passwordFromEnv": "RABBIT_PASSWORD", "PASSWORD_FROM_ENV": "RABBIT_PASSWORD",
+			},
+			want: map[string]string{
+				"passwordFromEnv": "RABBIT_PASSWORD", "PASSWORD_FROM_ENV": "RABBIT_PASSWORD",
+			},
 		},
 		{
 			name: "sasl names a mechanism, not a secret",

--- a/pkg/fission-cli/cmd/support/resources/mqtconsumer.go
+++ b/pkg/fission-cli/cmd/support/resources/mqtconsumer.go
@@ -23,19 +23,20 @@ import (
 // consumers, found by owner reference, and orphaned pod events, which attribute
 // a pod that no longer exists to the Deployment its name derives from.
 type DeploymentIndex struct {
-	client kubernetes.Interface
-	once   sync.Once
-	items  []appsv1.Deployment
-	err    error
+	client  kubernetes.Interface
+	once    sync.Once
+	items   []appsv1.Deployment
+	partial bool
+	err     error
 }
 
 func NewDeploymentIndex(clientset kubernetes.Interface) *DeploymentIndex {
 	return &DeploymentIndex{client: clientset}
 }
 
-func (idx *DeploymentIndex) get(ctx context.Context) ([]appsv1.Deployment, error) {
+func (idx *DeploymentIndex) get(ctx context.Context) ([]appsv1.Deployment, bool, error) {
 	idx.once.Do(func() {
-		idx.items, idx.err = listAllPages("deployment", func(cont string) ([]appsv1.Deployment, string, error) {
+		idx.items, idx.partial, idx.err = listAllPages("deployment", func(cont string) ([]appsv1.Deployment, string, error) {
 			list, err := idx.client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 				Limit:    listPageSize,
 				Continue: cont,
@@ -46,7 +47,7 @@ func (idx *DeploymentIndex) get(ctx context.Context) ([]appsv1.Deployment, error
 			return list.Items, list.Continue, nil
 		})
 	})
-	return idx.items, idx.err
+	return idx.items, idx.partial, idx.err
 }
 
 // What an MqtConsumerDumper collects.
@@ -80,10 +81,22 @@ func NewMqtConsumerDumper(clientset kubernetes.Interface, deployments *Deploymen
 }
 
 func (res MqtConsumerDumper) Dump(ctx context.Context, dumpDir string) {
-	deployments, err := res.deployments.get(ctx)
+	// Validated before anything else: an unknown mode must be reported on every
+	// cluster, not only on one that happens to run keda triggers.
+	if res.mode != MqtConsumerDeployment && res.mode != MqtConsumerPod && res.mode != MqtConsumerLog {
+		console.Error(fmt.Sprintf("Unknown mqt consumer dump mode: %v", res.mode))
+		return
+	}
+
+	deployments, partial, err := res.deployments.get(ctx)
 	if err != nil {
 		console.Error(fmt.Sprintf("Error getting deployment list: %v", err))
+		writeNote(dumpDir, "_deployment-list-failed.txt", "no mqt consumers dumped: %v", err)
 		return
+	}
+	if partial {
+		writeNote(dumpDir, "_partial-deployment-list.txt",
+			"the cluster deployment list did not complete; some mqt consumers may be missing here")
 	}
 
 	var owned []appsv1.Deployment
@@ -98,23 +111,59 @@ func (res MqtConsumerDumper) Dump(ctx context.Context, dumpDir string) {
 
 	if res.mode == MqtConsumerDeployment {
 		for _, d := range owned {
-			writeToFile(getFileName(dumpDir, d.ObjectMeta), d)
+			cleaned := mqtConsumerDeploymentClean(d)
+			writeToFile(getFileName(dumpDir, cleaned.ObjectMeta), cleaned)
 		}
-		return
-	}
-
-	if res.mode != MqtConsumerPod && res.mode != MqtConsumerLog {
-		console.Error(fmt.Sprintf("Unknown mqt consumer dump mode: %v", res.mode))
 		return
 	}
 
 	for _, d := range owned {
 		for _, pod := range res.podsFor(ctx, d) {
 			if res.mode == MqtConsumerPod {
-				writeToFile(getFileName(dumpDir, pod.ObjectMeta), pod)
+				cleaned := mqtConsumerPodClean(pod)
+				writeToFile(getFileName(dumpDir, cleaned.ObjectMeta), cleaned)
 				continue
 			}
 			dumpPodContainerLogs(ctx, res.client, pod, dumpDir)
+		}
+	}
+}
+
+// The scaler inlines every mqt.Spec.Metadata value as a literal env var on the
+// consumer (pkg/mqtrigger/scalermanager.go), so the map masked on the
+// MessageQueueTrigger and on the ScaledObject arrives here a third way — and
+// this is the one path where the workload itself, not just its config, is being
+// written out. Secret-derived vars use ValueFrom and carry no value, so they
+// are already safe and are left alone.
+func mqtConsumerDeploymentClean(d appsv1.Deployment) appsv1.Deployment {
+	out := d.DeepCopy()
+	maskPodSpecEnv(&out.Spec.Template.Spec)
+	return *out
+}
+
+func mqtConsumerPodClean(p corev1.Pod) corev1.Pod {
+	out := p.DeepCopy()
+	maskPodSpecEnv(&out.Spec)
+	return *out
+}
+
+func maskPodSpecEnv(spec *corev1.PodSpec) {
+	for i := range spec.Containers {
+		maskContainerEnv(&spec.Containers[i])
+	}
+	for i := range spec.InitContainers {
+		maskContainerEnv(&spec.InitContainers[i])
+	}
+}
+
+func maskContainerEnv(c *corev1.Container) {
+	for i := range c.Env {
+		env := &c.Env[i]
+		if env.Value == "" {
+			continue
+		}
+		if isCredentialKey(env.Name) || hasURLPassword(env.Value) {
+			env.Value = "-"
 		}
 	}
 }

--- a/pkg/fission-cli/cmd/support/resources/mqtconsumer.go
+++ b/pkg/fission-cli/cmd/support/resources/mqtconsumer.go
@@ -1,0 +1,154 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/fission/fission/pkg/fission-cli/console"
+)
+
+// DeploymentIndex holds every Deployment in the cluster, fetched once and
+// shared by the dumpers that select on something other than a label: mqt
+// consumers, found by owner reference, and orphaned pod events, which attribute
+// a pod that no longer exists to the Deployment its name derives from.
+type DeploymentIndex struct {
+	client kubernetes.Interface
+	once   sync.Once
+	items  []appsv1.Deployment
+	err    error
+}
+
+func NewDeploymentIndex(clientset kubernetes.Interface) *DeploymentIndex {
+	return &DeploymentIndex{client: clientset}
+}
+
+func (idx *DeploymentIndex) get(ctx context.Context) ([]appsv1.Deployment, error) {
+	idx.once.Do(func() {
+		idx.items, idx.err = listAllPages("deployment", func(cont string) ([]appsv1.Deployment, string, error) {
+			list, err := idx.client.AppsV1().Deployments(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+				Limit:    listPageSize,
+				Continue: cont,
+			})
+			if err != nil {
+				return nil, "", err
+			}
+			return list.Items, list.Continue, nil
+		})
+	})
+	return idx.items, idx.err
+}
+
+// What an MqtConsumerDumper collects.
+const (
+	MqtConsumerDeployment = "Deployment"
+	MqtConsumerPod        = "Pod"
+	MqtConsumerLog        = "Log"
+)
+
+// MqtConsumerDumper dumps the workload a keda MessageQueueTrigger scales.
+//
+// The scaler creates a Deployment per mqt (pkg/mqtrigger/scalermanager.go)
+// alongside the ScaledObject. Without this the bundle carries the scaling
+// policy but neither the spec nor the logs of the thing being scaled, which is
+// the first thing wanted for "my keda mqt isn't consuming".
+//
+// It cannot be a label-selector dumper. The scaler labels that Deployment
+// app: <mqt name> and nothing else, so there is no fission-identifying label to
+// select on — and adding one is not an option, because Spec.Selector is
+// immutable on an existing Deployment and changing the pod template would force
+// a rollout of every consumer on upgrade. The MQT owner reference is the signal
+// that already exists, and it is the same one KedaDumper uses.
+type MqtConsumerDumper struct {
+	client      kubernetes.Interface
+	deployments *DeploymentIndex
+	mode        string
+}
+
+func NewMqtConsumerDumper(clientset kubernetes.Interface, deployments *DeploymentIndex, mode string) Resource {
+	return MqtConsumerDumper{client: clientset, deployments: deployments, mode: mode}
+}
+
+func (res MqtConsumerDumper) Dump(ctx context.Context, dumpDir string) {
+	deployments, err := res.deployments.get(ctx)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting deployment list: %v", err))
+		return
+	}
+
+	var owned []appsv1.Deployment
+	for _, d := range deployments {
+		if ownedByMessageQueueTrigger(d.ObjectMeta) {
+			owned = append(owned, d)
+		}
+	}
+	if len(owned) == 0 {
+		return
+	}
+
+	if res.mode == MqtConsumerDeployment {
+		for _, d := range owned {
+			writeToFile(getFileName(dumpDir, d.ObjectMeta), d)
+		}
+		return
+	}
+
+	if res.mode != MqtConsumerPod && res.mode != MqtConsumerLog {
+		console.Error(fmt.Sprintf("Unknown mqt consumer dump mode: %v", res.mode))
+		return
+	}
+
+	for _, d := range owned {
+		for _, pod := range res.podsFor(ctx, d) {
+			if res.mode == MqtConsumerPod {
+				writeToFile(getFileName(dumpDir, pod.ObjectMeta), pod)
+				continue
+			}
+			dumpPodContainerLogs(ctx, res.client, pod, dumpDir)
+		}
+	}
+}
+
+// podsFor returns the consumer pods of one mqt Deployment.
+//
+// The Deployment's own selector is app: <mqt name> — a user-chosen value on the
+// most generic label key in kubernetes — so the selector alone would sweep an
+// unrelated pod that merely shares that name into a bundle sent to a third
+// party. Every pod a Deployment owns is named <deployment>-<rs hash>-<random>,
+// so the name prefix is required as well.
+func (res MqtConsumerDumper) podsFor(ctx context.Context, d appsv1.Deployment) []corev1.Pod {
+	// The typed form is needed because a Deployment carries a *LabelSelector,
+	// not the plain map that labels.Set handles elsewhere in this package.
+	selector, err := metav1.LabelSelectorAsSelector(d.Spec.Selector)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error reading selector of deployment %v/%v: %v", d.Namespace, d.Name, err))
+		return nil
+	}
+
+	pods, err := res.client.CoreV1().Pods(d.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: selector.String(),
+	})
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting pods of deployment %v/%v: %v", d.Namespace, d.Name, err))
+		return nil
+	}
+
+	prefix := d.Name + "-"
+	out := make([]corev1.Pod, 0, len(pods.Items))
+	for _, p := range pods.Items {
+		if strings.HasPrefix(p.Name, prefix) {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/pkg/fission-cli/cmd/support/resources/mqtconsumer_test.go
+++ b/pkg/fission-cli/cmd/support/resources/mqtconsumer_test.go
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func mqtDeployment(name, namespace string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: namespace, ResourceVersion: "1",
+			Labels:          map[string]string{"app": name},
+			OwnerReferences: []metav1.OwnerReference{mqtOwnerRef()},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": name}},
+		},
+	}
+}
+
+func appPod(name, namespace, app string, uid types.UID) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: namespace, UID: uid, ResourceVersion: "1",
+			Labels: map[string]string{"app": app},
+		},
+	}
+}
+
+func TestMqtConsumerDumperDumpsOnlyOwnedDeployments(t *testing.T) {
+	t.Parallel()
+
+	ours := mqtDeployment("my-mqt", "default")
+	theirs := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "someone-elses", Namespace: "default", ResourceVersion: "1",
+			OwnerReferences: []metav1.OwnerReference{{Kind: "ReplicaSet", Name: "rs"}},
+		},
+	}
+
+	client := k8sfake.NewClientset(ours, theirs)
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerDeployment).Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1, "only MessageQueueTrigger-owned deployments are fission's")
+	assert.Contains(t, files[0], "my-mqt")
+}
+
+func TestMqtConsumerDumperIgnoresUnrelatedPodsSharingTheAppLabel(t *testing.T) {
+	t.Parallel()
+
+	// app=<mqt name> is the scaler's selector: a user-chosen value on the most
+	// generic label key there is. An unrelated pod that happens to carry the
+	// same app label must not have its spec written into a bundle that goes to
+	// a third party. Every pod the Deployment owns is named <deployment>-...
+	deploy := mqtDeployment("my-mqt", "default")
+	consumer := appPod("my-mqt-7d9f8b6c5-abcde", "default", "my-mqt", "uid-consumer")
+	impostor := appPod("someone-elses-app", "default", "my-mqt", "uid-impostor")
+
+	client := k8sfake.NewClientset(deploy, consumer, impostor)
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerPod).Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1)
+	assert.Contains(t, files[0], "my-mqt-7d9f8b6c5-abcde")
+}
+
+func TestMqtConsumerDumperWritesNothingWithoutKedaTriggers(t *testing.T) {
+	t.Parallel()
+
+	client := k8sfake.NewClientset(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "router", Namespace: "fission", ResourceVersion: "1"},
+	})
+
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerDeployment).Dump(t.Context(), dir)
+
+	assert.Empty(t, dumpedFiles(t, dir), "an install with no keda mqts should add no files")
+}
+
+func TestDeploymentIndexListsOnceAcrossDumpers(t *testing.T) {
+	t.Parallel()
+
+	client := k8sfake.NewClientset(mqtDeployment("my-mqt", "default"))
+
+	var lists int
+	client.PrependReactor("list", "deployments", func(clienttesting.Action) (bool, runtime.Object, error) {
+		lists++
+		return false, nil, nil
+	})
+
+	idx := NewDeploymentIndex(client)
+	for _, mode := range []string{MqtConsumerDeployment, MqtConsumerPod, MqtConsumerLog} {
+		NewMqtConsumerDumper(client, idx, mode).Dump(t.Context(), t.TempDir())
+	}
+
+	assert.Equal(t, 1, lists, "the deployment list is shared across the three consumer dumpers")
+}

--- a/pkg/fission-cli/cmd/support/resources/mqtconsumer_test.go
+++ b/pkg/fission-cli/cmd/support/resources/mqtconsumer_test.go
@@ -5,14 +5,19 @@
 package resources
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	clienttesting "k8s.io/client-go/testing"
@@ -110,4 +115,164 @@ func TestDeploymentIndexListsOnceAcrossDumpers(t *testing.T) {
 	}
 
 	assert.Equal(t, 1, lists, "the deployment list is shared across the three consumer dumpers")
+}
+
+func TestMqtConsumerDumperMasksInlinedMetadataCredentials(t *testing.T) {
+	t.Parallel()
+
+	// The scaler inlines every mqt.Spec.Metadata value as a literal env var on
+	// the consumer, so masking the MessageQueueTrigger and the ScaledObject is
+	// not enough — the workload itself carries the same values.
+	deploy := mqtDeployment("my-mqt", "default")
+	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "consumer",
+		Env: []corev1.EnvVar{
+			{Name: "PASSWORD", Value: "hunter2"},
+			{Name: "HOST", Value: "amqp://user:hunter2@rabbit:5672/"},
+			{Name: "TOPIC", Value: "orders"},
+			{Name: "PASSWORD_FROM_ENV", Value: "RABBIT_PASSWORD"},
+			{Name: "SECRET_REF", ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{Key: "password"},
+			}},
+		},
+	}}
+
+	client := k8sfake.NewClientset(deploy)
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerDeployment).Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1)
+	content, err := os.ReadFile(filepath.Join(dir, files[0]))
+	require.NoError(t, err)
+	body := string(content)
+
+	assert.NotContains(t, body, "hunter2", "an inlined credential must not reach a support bundle")
+	assert.Contains(t, body, "orders", "non-credential env stays diagnostic")
+	assert.Contains(t, body, "RABBIT_PASSWORD",
+		"a *FromEnv value names an env var and is the first thing to check on a broken trigger")
+	assert.Contains(t, body, "SECRET_REF", "secret-backed env carries no value and is left alone")
+}
+
+func TestMqtConsumerDumperMasksInlinedCredentialsOnPods(t *testing.T) {
+	t.Parallel()
+
+	deploy := mqtDeployment("my-mqt", "default")
+	pod := appPod("my-mqt-7d9f8b6c5-abcde", "default", "my-mqt", "uid-consumer")
+	pod.Spec.Containers = []corev1.Container{{
+		Name: "consumer",
+		Env:  []corev1.EnvVar{{Name: "PASSWORD", Value: "hunter2"}},
+	}}
+
+	client := k8sfake.NewClientset(deploy, pod)
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerPod).Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 1)
+	content, err := os.ReadFile(filepath.Join(dir, files[0]))
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(content), "hunter2",
+		"the pod carries the resolved env, so it leaks the same values as the deployment")
+}
+
+func TestMqtConsumerDumperDoesNotMutateTheListedDeployment(t *testing.T) {
+	t.Parallel()
+
+	deploy := mqtDeployment("my-mqt", "default")
+	deploy.Spec.Template.Spec.Containers = []corev1.Container{{
+		Name: "consumer",
+		Env:  []corev1.EnvVar{{Name: "PASSWORD", Value: "hunter2"}},
+	}}
+
+	cleaned := mqtConsumerDeploymentClean(*deploy)
+
+	assert.Equal(t, "-", cleaned.Spec.Template.Spec.Containers[0].Env[0].Value)
+	assert.Equal(t, "hunter2", deploy.Spec.Template.Spec.Containers[0].Env[0].Value,
+		"the deployment is shared with the index and must not be edited in place")
+}
+
+func TestMqtConsumerDumperRejectsAnUnknownModeOnAnyCluster(t *testing.T) {
+	t.Parallel()
+
+	// The guard must not sit behind the "no keda triggers" early return, or a
+	// bad mode is silently accepted on most clusters.
+	client := k8sfake.NewClientset()
+	dir := t.TempDir()
+
+	require.NotPanics(t, func() {
+		NewMqtConsumerDumper(client, NewDeploymentIndex(client), "NotAMode").Dump(t.Context(), dir)
+	})
+	assert.Empty(t, dumpedFiles(t, dir))
+}
+
+func TestMqtConsumerDumperOnlyLooksInTheDeploymentsNamespace(t *testing.T) {
+	t.Parallel()
+
+	deploy := mqtDeployment("my-mqt", "default")
+	elsewhere := appPod("my-mqt-7d9f8b6c5-abcde", "other", "my-mqt", "uid-elsewhere")
+
+	client := k8sfake.NewClientset(deploy, elsewhere)
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerPod).Dump(t.Context(), dir)
+
+	assert.Empty(t, dumpedFiles(t, dir),
+		"a same-named pod in another namespace belongs to a different workload")
+}
+
+func TestMqtConsumerDumperReportsADeploymentListFailure(t *testing.T) {
+	t.Parallel()
+
+	client := k8sfake.NewClientset()
+	client.PrependReactor("list", "deployments", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(schema.GroupResource{Resource: "deployments"}, "", assert.AnError)
+	})
+
+	idx := NewDeploymentIndex(client)
+	for _, mode := range []string{MqtConsumerDeployment, MqtConsumerPod, MqtConsumerLog} {
+		dir := t.TempDir()
+		require.NotPanics(t, func() {
+			NewMqtConsumerDumper(client, idx, mode).Dump(t.Context(), dir)
+		})
+		assert.Equal(t, []string{"_deployment-list-failed.txt"}, dumpedFiles(t, dir),
+			"an empty directory alone reads as an install with no keda triggers")
+	}
+}
+
+func TestDeploymentIndexPagesThroughEveryDeployment(t *testing.T) {
+	t.Parallel()
+
+	client := k8sfake.NewClientset()
+	client.PrependReactor("list", "deployments", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		if a.(clienttesting.ListActionImpl).GetListOptions().Continue == "" {
+			return true, &appsv1.DeploymentList{ListMeta: metav1.ListMeta{Continue: "page-2"}}, nil
+		}
+		return true, &appsv1.DeploymentList{
+			Items: []appsv1.Deployment{*mqtDeployment("my-mqt", "default")},
+		}, nil
+	})
+
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerDeployment).Dump(t.Context(), dir)
+
+	assert.Len(t, dumpedFiles(t, dir), 1, "a consumer on the second page must still be collected")
+}
+
+func TestMqtConsumerDumperWritesALogFilePerContainer(t *testing.T) {
+	t.Parallel()
+
+	deploy := mqtDeployment("my-mqt", "default")
+	pod := appPod("my-mqt-7d9f8b6c5-abcde", "default", "my-mqt", "uid-consumer")
+	pod.Spec.Containers = []corev1.Container{{Name: "consumer"}}
+	pod.Spec.InitContainers = []corev1.Container{{Name: "fetcher"}}
+
+	client := k8sfake.NewClientset(deploy, pod)
+	dir := t.TempDir()
+	NewMqtConsumerDumper(client, NewDeploymentIndex(client), MqtConsumerLog).Dump(t.Context(), dir)
+
+	files := dumpedFiles(t, dir)
+	require.Len(t, files, 2, "init containers are collected too — they explain a pod that never started")
+	assert.Contains(t, strings.Join(files, " "), "consumer")
+	assert.Contains(t, strings.Join(files, " "), "fetcher")
 }

--- a/pkg/fission-cli/cmd/support/resources/orphanevents.go
+++ b/pkg/fission-cli/cmd/support/resources/orphanevents.go
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/fission/fission/pkg/fission-cli/console"
+)
+
+// OrphanedPodEventDumper writes the events of fission pods that no longer
+// exist.
+//
+// KubernetesPodEventDumper iterates pods first, so an event only reaches the
+// bundle if its pod is still listed. The pod that was OOMKilled, evicted, or
+// replaced by a rolling update is exactly the one being investigated, and its
+// events were the one thing that survived it.
+//
+// The naive version of this — "every Pod event whose UID matches no live pod" —
+// would put unrelated teams' deleted pods into a bundle sent to a third party
+// whenever fission functions share a namespace with other workloads. So an
+// orphan counts only when its name derives from a fission-owned Deployment:
+// every pod a Deployment owns is named <deployment>-<rs hash>-<random>, and
+// that is checkable without the pod existing.
+//
+// Two classes are knowingly out of scope, both because they are not
+// Deployment-owned: pods from the chart's Helm hook Jobs (pre-upgrade checks,
+// analytics, tenant migration), and anything not created by fission at all.
+// Fission itself creates no bare Pods or StatefulSets at runtime, so those two
+// are the whole exception list.
+type OrphanedPodEventDumper struct {
+	client      kubernetes.Interface
+	events      *PodEventIndex
+	deployments *DeploymentIndex
+	selectors   []string
+}
+
+func NewOrphanedPodEventDumper(clientset kubernetes.Interface, events *PodEventIndex,
+	deployments *DeploymentIndex, selectors ...string) Resource {
+	return OrphanedPodEventDumper{
+		client:      clientset,
+		events:      events,
+		deployments: deployments,
+		selectors:   selectors,
+	}
+}
+
+func (res OrphanedPodEventDumper) Dump(ctx context.Context, dumpDir string) {
+	byPod, err := res.events.get(ctx)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting event list: %v", err))
+		return
+	}
+	if len(byPod) == 0 {
+		return
+	}
+
+	prefixes := res.fissionPodPrefixes(ctx)
+	if len(prefixes) == 0 {
+		return
+	}
+
+	live, err := res.livePodUIDs(ctx)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting pod list: %v", err))
+		return
+	}
+
+	for uid, events := range byPod {
+		if _, alive := live[uid]; alive || len(events) == 0 {
+			continue
+		}
+
+		ref := events[0].InvolvedObject
+		if !derivesFromFissionDeployment(prefixes, ref.Namespace, ref.Name) {
+			continue
+		}
+
+		f := filepath.Clean(fmt.Sprintf("%v/%v_%v_%v.txt", dumpDir, ref.Namespace, ref.Name, uid))
+		writeToFile(f, events)
+	}
+}
+
+// fissionPodPrefixes maps a namespace to the pod-name prefixes of the fission
+// Deployments in it — the components, builders and functions the bundle already
+// collects, plus the mqt consumers found by owner reference.
+func (res OrphanedPodEventDumper) fissionPodPrefixes(ctx context.Context) map[string][]string {
+	deployments, err := res.deployments.get(ctx)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting deployment list: %v", err))
+		return nil
+	}
+
+	parsed := make([]labels.Selector, 0, len(res.selectors))
+	for _, s := range res.selectors {
+		sel, err := labels.Parse(s)
+		if err != nil {
+			console.Error(fmt.Sprintf("Error parsing selector %v: %v", s, err))
+			continue
+		}
+		parsed = append(parsed, sel)
+	}
+
+	prefixes := make(map[string][]string)
+	for _, d := range deployments {
+		if !isFissionDeployment(d.Labels, d.ObjectMeta, parsed) {
+			continue
+		}
+		prefixes[d.Namespace] = append(prefixes[d.Namespace], d.Name+"-")
+	}
+	return prefixes
+}
+
+func isFissionDeployment(lbls map[string]string, meta metav1.ObjectMeta, selectors []labels.Selector) bool {
+	if ownedByMessageQueueTrigger(meta) {
+		return true
+	}
+	set := labels.Set(lbls)
+	for _, sel := range selectors {
+		if sel.Matches(set) {
+			return true
+		}
+	}
+	return false
+}
+
+func derivesFromFissionDeployment(prefixes map[string][]string, namespace, name string) bool {
+	for _, p := range prefixes[namespace] {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func (res OrphanedPodEventDumper) livePodUIDs(ctx context.Context) (map[types.UID]struct{}, error) {
+	pods, err := listAllPages("pod", func(cont string) ([]corev1.Pod, string, error) {
+		list, err := res.client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			Limit:    listPageSize,
+			Continue: cont,
+		})
+		if err != nil {
+			return nil, "", err
+		}
+		return list.Items, list.Continue, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	live := make(map[types.UID]struct{}, len(pods))
+	for _, p := range pods {
+		live[p.UID] = struct{}{}
+	}
+	return live, nil
+}

--- a/pkg/fission-cli/cmd/support/resources/orphanevents.go
+++ b/pkg/fission-cli/cmd/support/resources/orphanevents.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,28 +58,49 @@ func NewOrphanedPodEventDumper(clientset kubernetes.Interface, events *PodEventI
 }
 
 func (res OrphanedPodEventDumper) Dump(ctx context.Context, dumpDir string) {
-	byPod, err := res.events.get(ctx)
+	byPod, eventsPartial, err := res.events.get(ctx)
 	if err != nil {
 		console.Error(fmt.Sprintf("Error getting event list: %v", err))
-		return
-	}
-	if len(byPod) == 0 {
-		return
-	}
-
-	prefixes := res.fissionPodPrefixes(ctx)
-	if len(prefixes) == 0 {
+		writeNote(dumpDir, "_event-list-failed.txt", "no orphaned events dumped: %v", err)
 		return
 	}
 
-	live, err := res.livePodUIDs(ctx)
+	prefixes, err := res.fissionPodPrefixes(ctx)
+	if err != nil {
+		console.Error(fmt.Sprintf("Error getting deployment list: %v", err))
+		writeNote(dumpDir, "_deployment-list-failed.txt",
+			"no orphaned events dumped: the deployments that identify fission pods could not be listed: %v", err)
+		return
+	}
+
+	live, livePartial, err := res.livePodUIDs(ctx)
 	if err != nil {
 		console.Error(fmt.Sprintf("Error getting pod list: %v", err))
+		writeNote(dumpDir, "_pod-list-failed.txt", "no orphaned events dumped: %v", err)
+		return
+	}
+	if livePartial {
+		// Without the full set of live pods, "no live pod has this UID" stops
+		// meaning "this pod is gone". Emitting anyway would file a running pod
+		// under a directory that says it died — inventing a failure rather than
+		// missing one, which is the worse mistake for a diagnostic bundle.
+		console.Error("Pod list incomplete; skipping orphaned pod events to avoid reporting live pods as deleted")
+		writeNote(dumpDir, "_skipped-incomplete-pod-list.txt",
+			"orphaned events were not collected: the pod list did not complete, so a live pod could not be "+
+				"told apart from a deleted one")
 		return
 	}
 
+	written := 0
 	for uid, events := range byPod {
-		if _, alive := live[uid]; alive || len(events) == 0 {
+		// An event may carry no involvedObject UID at all. Those all collapse
+		// into one bucket that matches no live pod, so treating it as a single
+		// deleted pod would file many unrelated pods' events under whichever
+		// one happened to sort first.
+		if uid == "" || len(events) == 0 {
+			continue
+		}
+		if _, alive := live[uid]; alive {
 			continue
 		}
 
@@ -89,17 +111,23 @@ func (res OrphanedPodEventDumper) Dump(ctx context.Context, dumpDir string) {
 
 		f := filepath.Clean(fmt.Sprintf("%v/%v_%v_%v.txt", dumpDir, ref.Namespace, ref.Name, uid))
 		writeToFile(f, events)
+		written++
+	}
+
+	if written == 0 || eventsPartial {
+		writeNote(dumpDir, "_status.txt",
+			"scanned %v pods with events, %v live; wrote %v orphaned pod event files (event list complete: %v)",
+			len(byPod), len(live), written, !eventsPartial)
 	}
 }
 
 // fissionPodPrefixes maps a namespace to the pod-name prefixes of the fission
 // Deployments in it — the components, builders and functions the bundle already
 // collects, plus the mqt consumers found by owner reference.
-func (res OrphanedPodEventDumper) fissionPodPrefixes(ctx context.Context) map[string][]string {
-	deployments, err := res.deployments.get(ctx)
+func (res OrphanedPodEventDumper) fissionPodPrefixes(ctx context.Context) (map[string][]string, error) {
+	deployments, _, err := res.deployments.get(ctx)
 	if err != nil {
-		console.Error(fmt.Sprintf("Error getting deployment list: %v", err))
-		return nil
+		return nil, err
 	}
 
 	parsed := make([]labels.Selector, 0, len(res.selectors))
@@ -114,19 +142,19 @@ func (res OrphanedPodEventDumper) fissionPodPrefixes(ctx context.Context) map[st
 
 	prefixes := make(map[string][]string)
 	for _, d := range deployments {
-		if !isFissionDeployment(d.Labels, d.ObjectMeta, parsed) {
+		if !isFissionDeployment(d.ObjectMeta, parsed) {
 			continue
 		}
 		prefixes[d.Namespace] = append(prefixes[d.Namespace], d.Name+"-")
 	}
-	return prefixes
+	return prefixes, nil
 }
 
-func isFissionDeployment(lbls map[string]string, meta metav1.ObjectMeta, selectors []labels.Selector) bool {
+func isFissionDeployment(meta metav1.ObjectMeta, selectors []labels.Selector) bool {
 	if ownedByMessageQueueTrigger(meta) {
 		return true
 	}
-	set := labels.Set(lbls)
+	set := labels.Set(meta.Labels)
 	for _, sel := range selectors {
 		if sel.Matches(set) {
 			return true
@@ -135,17 +163,32 @@ func isFissionDeployment(lbls map[string]string, meta metav1.ObjectMeta, selecto
 	return false
 }
 
+// replicaSetPodSuffix is what a Deployment-owned pod's name looks like after its
+// Deployment's name: the ReplicaSet's pod-template hash, then a random suffix.
+var replicaSetPodSuffix = regexp.MustCompile(`^[a-z0-9]+-[a-z0-9]{5}$`)
+
+// derivesFromFissionDeployment reports whether a pod that no longer exists
+// belonged to one of the given Deployments.
+//
+// A bare prefix test is not enough, and getting this wrong leaks. Deployment
+// names here are user-chosen — a function is named by its author, and an mqt
+// consumer is named after the trigger — so "starts with <name>-" would let a
+// fission function called api vouch for a stranger's api-gateway-<hash>-<rand>
+// in the same namespace, and put their pod's events in a bundle bound for a
+// third party. Requiring the ReplicaSet suffix shape rejects that without ever
+// rejecting a real one, because every Deployment-owned pod is named this way.
 func derivesFromFissionDeployment(prefixes map[string][]string, namespace, name string) bool {
 	for _, p := range prefixes[namespace] {
-		if strings.HasPrefix(name, p) {
+		rest, ok := strings.CutPrefix(name, p)
+		if ok && replicaSetPodSuffix.MatchString(rest) {
 			return true
 		}
 	}
 	return false
 }
 
-func (res OrphanedPodEventDumper) livePodUIDs(ctx context.Context) (map[types.UID]struct{}, error) {
-	pods, err := listAllPages("pod", func(cont string) ([]corev1.Pod, string, error) {
+func (res OrphanedPodEventDumper) livePodUIDs(ctx context.Context) (map[types.UID]struct{}, bool, error) {
+	pods, partial, err := listAllPages("pod", func(cont string) ([]corev1.Pod, string, error) {
 		list, err := res.client.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 			Limit:    listPageSize,
 			Continue: cont,
@@ -156,12 +199,12 @@ func (res OrphanedPodEventDumper) livePodUIDs(ctx context.Context) (map[types.UI
 		return list.Items, list.Continue, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	live := make(map[types.UID]struct{}, len(pods))
 	for _, p := range pods {
 		live[p.UID] = struct{}{}
 	}
-	return live, nil
+	return live, partial, nil
 }

--- a/pkg/fission-cli/cmd/support/resources/orphanevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/orphanevents_test.go
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+const routerSelector = "svc in (router)"
+
+func routerDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "router", Namespace: "fission", ResourceVersion: "1",
+			Labels: map[string]string{"svc": "router"},
+		},
+	}
+}
+
+// dumpOrphans runs the dumper and returns the concatenated contents written.
+func dumpOrphans(t *testing.T, client *k8sfake.Clientset) (files []string, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	NewOrphanedPodEventDumper(client, NewPodEventIndex(client), NewDeploymentIndex(client),
+		routerSelector).Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var sb strings.Builder
+	for _, e := range entries {
+		files = append(files, e.Name())
+		content, err := os.ReadFile(dir + "/" + e.Name())
+		require.NoError(t, err)
+		sb.Write(content)
+	}
+	return files, sb.String()
+}
+
+func TestOrphanedPodEventDumperWritesEventsOfDeletedFissionPods(t *testing.T) {
+	t.Parallel()
+
+	// The pod is gone — only its events remain. That is the pod being
+	// investigated, and the per-pod dumpers iterate live pods so they miss it.
+	client := k8sfake.NewClientset(
+		routerDeployment(),
+		podEvent("router-7d9f8b6c5-abcde", "uid-dead-router", "OOMKilled", time.Now()),
+	)
+
+	files, body := dumpOrphans(t, client)
+
+	require.Len(t, files, 1)
+	assert.Contains(t, files[0], "router-7d9f8b6c5-abcde")
+	assert.Contains(t, body, "OOMKilled")
+}
+
+func TestOrphanedPodEventDumperIgnoresUnrelatedPodsInTheSameNamespace(t *testing.T) {
+	t.Parallel()
+
+	// The privacy guard. Fission functions commonly share a namespace with a
+	// user's own workloads, and a bundle goes to a third party — so "any pod
+	// event with no live pod" is not an acceptable definition of orphan.
+	client := k8sfake.NewClientset(
+		routerDeployment(),
+		podEvent("someones-database-0", "uid-dead-stranger", "Evicted", time.Now()),
+	)
+
+	files, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files,
+		"a deleted pod that does not derive from a fission deployment is not ours to collect")
+}
+
+func TestOrphanedPodEventDumperSkipsPodsThatStillExist(t *testing.T) {
+	t.Parallel()
+
+	// A live pod's events belong to the per-pod dumpers; duplicating them here
+	// would double the bundle's event data.
+	live := fissionPod("router-7d9f8b6c5-abcde", "uid-live-router")
+	live.Namespace = "fission"
+
+	client := k8sfake.NewClientset(
+		routerDeployment(), live,
+		podEvent("router-7d9f8b6c5-abcde", "uid-live-router", "Started", time.Now()),
+	)
+
+	files, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files, "events of a live pod are not orphans")
+}
+
+func TestOrphanedPodEventDumperCoversMqtConsumers(t *testing.T) {
+	t.Parallel()
+
+	// The mqt consumer Deployment carries no fission label, so it is reachable
+	// only through its owner reference — the same signal MqtConsumerDumper uses.
+	client := k8sfake.NewClientset(
+		mqtDeployment("my-mqt", "fission"),
+		podEvent("my-mqt-56c4d9f7b-xyz12", "uid-dead-consumer", "CrashLoopBackOff", time.Now()),
+	)
+
+	files, body := dumpOrphans(t, client)
+
+	require.Len(t, files, 1)
+	assert.Contains(t, body, "CrashLoopBackOff")
+}
+
+func TestOrphanedPodEventDumperMatchesPrefixesPerNamespace(t *testing.T) {
+	t.Parallel()
+
+	// A name prefix only authorises within the namespace that owns it. The
+	// helper builds events in "fission"; the deployment lending the name lives
+	// elsewhere, so it must not vouch for them.
+	client := k8sfake.NewClientset(
+		mqtDeployment("my-mqt", "default"),
+		podEvent("my-mqt-56c4d9f7b-xyz12", "uid-dead-elsewhere", "CrashLoopBackOff", time.Now()),
+	)
+
+	files, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files, "a same-named deployment in another namespace is a different workload")
+}

--- a/pkg/fission-cli/cmd/support/resources/orphanevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/orphanevents_test.go
@@ -13,8 +13,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 const routerSelector = "svc in (router)"
@@ -28,25 +32,37 @@ func routerDeployment() *appsv1.Deployment {
 	}
 }
 
-// dumpOrphans runs the dumper and returns the concatenated contents written.
-func dumpOrphans(t *testing.T, client *k8sfake.Clientset) (files []string, body string) {
+// dumpOrphans runs the dumper and returns the pod-event files it wrote, the
+// notes it left, and the concatenated contents of the pod-event files.
+//
+// Notes are prefixed with "_" so the bundle's reader sees them first and so
+// they never get mistaken for a pod's event history.
+func dumpOrphans(t *testing.T, client *k8sfake.Clientset, selectors ...string) (files, notes []string, body string) {
 	t.Helper()
+
+	if len(selectors) == 0 {
+		selectors = []string{routerSelector}
+	}
 
 	dir := t.TempDir()
 	NewOrphanedPodEventDumper(client, NewPodEventIndex(client), NewDeploymentIndex(client),
-		routerSelector).Dump(t.Context(), dir)
+		selectors...).Dump(t.Context(), dir)
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 
 	var sb strings.Builder
 	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), "_") {
+			notes = append(notes, e.Name())
+			continue
+		}
 		files = append(files, e.Name())
 		content, err := os.ReadFile(dir + "/" + e.Name())
 		require.NoError(t, err)
 		sb.Write(content)
 	}
-	return files, sb.String()
+	return files, notes, sb.String()
 }
 
 func TestOrphanedPodEventDumperWritesEventsOfDeletedFissionPods(t *testing.T) {
@@ -59,7 +75,7 @@ func TestOrphanedPodEventDumperWritesEventsOfDeletedFissionPods(t *testing.T) {
 		podEvent("router-7d9f8b6c5-abcde", "uid-dead-router", "OOMKilled", time.Now()),
 	)
 
-	files, body := dumpOrphans(t, client)
+	files, _, body := dumpOrphans(t, client)
 
 	require.Len(t, files, 1)
 	assert.Contains(t, files[0], "router-7d9f8b6c5-abcde")
@@ -77,7 +93,7 @@ func TestOrphanedPodEventDumperIgnoresUnrelatedPodsInTheSameNamespace(t *testing
 		podEvent("someones-database-0", "uid-dead-stranger", "Evicted", time.Now()),
 	)
 
-	files, _ := dumpOrphans(t, client)
+	files, _, _ := dumpOrphans(t, client)
 
 	assert.Empty(t, files,
 		"a deleted pod that does not derive from a fission deployment is not ours to collect")
@@ -96,7 +112,7 @@ func TestOrphanedPodEventDumperSkipsPodsThatStillExist(t *testing.T) {
 		podEvent("router-7d9f8b6c5-abcde", "uid-live-router", "Started", time.Now()),
 	)
 
-	files, _ := dumpOrphans(t, client)
+	files, _, _ := dumpOrphans(t, client)
 
 	assert.Empty(t, files, "events of a live pod are not orphans")
 }
@@ -111,7 +127,7 @@ func TestOrphanedPodEventDumperCoversMqtConsumers(t *testing.T) {
 		podEvent("my-mqt-56c4d9f7b-xyz12", "uid-dead-consumer", "CrashLoopBackOff", time.Now()),
 	)
 
-	files, body := dumpOrphans(t, client)
+	files, _, body := dumpOrphans(t, client)
 
 	require.Len(t, files, 1)
 	assert.Contains(t, body, "CrashLoopBackOff")
@@ -128,7 +144,116 @@ func TestOrphanedPodEventDumperMatchesPrefixesPerNamespace(t *testing.T) {
 		podEvent("my-mqt-56c4d9f7b-xyz12", "uid-dead-elsewhere", "CrashLoopBackOff", time.Now()),
 	)
 
-	files, _ := dumpOrphans(t, client)
+	files, _, _ := dumpOrphans(t, client)
 
 	assert.Empty(t, files, "a same-named deployment in another namespace is a different workload")
+}
+
+func TestOrphanedPodEventDumperIgnoresAPodMerelyPrefixedByAFissionDeployment(t *testing.T) {
+	t.Parallel()
+
+	// The leak a bare HasPrefix allows. Deployment names here are user-chosen —
+	// a function is named by its author, an mqt consumer after its trigger — so
+	// fission's "router" would otherwise vouch for a stranger's
+	// "router-metrics-<hash>-<rand>" in the same namespace and put their dead
+	// pod's events in a bundle bound for a third party.
+	client := k8sfake.NewClientset(
+		routerDeployment(),
+		podEvent("router-metrics-7d9f8b6c5-abcde", "uid-third-party", "Evicted", time.Now()),
+	)
+
+	files, _, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files,
+		"a pod whose name merely starts with a fission deployment's name is a different workload")
+}
+
+func TestOrphanedPodEventDumperIgnoresEventsWithNoInvolvedObjectUID(t *testing.T) {
+	t.Parallel()
+
+	// Events lacking a UID all collapse into one bucket that matches no live
+	// pod. Treating that bucket as a single deleted pod would file many
+	// unrelated pods' events under whichever one sorted first.
+	noUID := podEvent("router-7d9f8b6c5-abcde", "", "OOMKilled", time.Now())
+	otherNoUID := podEvent("router-7d9f8b6c5-fffff", "", "Evicted", time.Now())
+
+	client := k8sfake.NewClientset(routerDeployment(), noUID, otherNoUID)
+
+	files, _, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files, "events with no involvedObject UID cannot be attributed to one pod")
+}
+
+func TestOrphanedPodEventDumperSkipsEverythingWhenThePodListIsIncomplete(t *testing.T) {
+	t.Parallel()
+
+	// Without the full live-pod set, "no live pod has this UID" stops meaning
+	// "this pod is gone" — so emitting would file a running pod under a
+	// directory that says it died. Inventing a failure is worse than missing one.
+	client := k8sfake.NewClientset(
+		routerDeployment(),
+		podEvent("router-7d9f8b6c5-abcde", "uid-router", "OOMKilled", time.Now()),
+	)
+
+	var podLists int
+	client.PrependReactor("list", "pods", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		podLists++
+		if podLists == 1 {
+			return true, &corev1.PodList{ListMeta: metav1.ListMeta{Continue: "page-2"}}, nil
+		}
+		return true, nil, apierrors.NewResourceExpired("too old resource version")
+	})
+
+	files, notes, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files, "a live pod must never be reported as deleted")
+	assert.Contains(t, notes, "_skipped-incomplete-pod-list.txt",
+		"the bundle must record why nothing was collected")
+}
+
+func TestOrphanedPodEventDumperHonoursEverySelector(t *testing.T) {
+	t.Parallel()
+
+	// dump.go passes three selectors; a dumper honouring only the first would
+	// quietly drop builder and function pods from the orphan scan.
+	builder := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "builder", Namespace: "fission", ResourceVersion: "1",
+			Labels: map[string]string{"owner": "buildermgr"},
+		},
+	}
+
+	client := k8sfake.NewClientset(
+		builder,
+		podEvent("builder-7d9f8b6c5-abcde", "uid-dead-builder", "OOMKilled", time.Now()),
+	)
+
+	files, _, _ := dumpOrphans(t, client, routerSelector, "owner=buildermgr")
+
+	require.Len(t, files, 1, "a deployment matching the second selector must be honoured too")
+}
+
+func TestOrphanedPodEventDumperPagesThePodList(t *testing.T) {
+	t.Parallel()
+
+	// The continue token is fed back for pods as well as events; without it a
+	// pod on page 2 looks deleted and its events are filed as orphaned.
+	live := fissionPod("router-7d9f8b6c5-abcde", "uid-live-router")
+	live.Namespace = "fission"
+
+	client := k8sfake.NewClientset(
+		routerDeployment(),
+		podEvent("router-7d9f8b6c5-abcde", "uid-live-router", "Started", time.Now()),
+	)
+
+	client.PrependReactor("list", "pods", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		if a.(clienttesting.ListActionImpl).GetListOptions().Continue == "" {
+			return true, &corev1.PodList{ListMeta: metav1.ListMeta{Continue: "page-2"}}, nil
+		}
+		return true, &corev1.PodList{Items: []corev1.Pod{*live}}, nil
+	})
+
+	files, _, _ := dumpOrphans(t, client)
+
+	assert.Empty(t, files, "a pod found on the second page is alive, not orphaned")
 }

--- a/pkg/fission-cli/cmd/support/resources/paging.go
+++ b/pkg/fission-cli/cmd/support/resources/paging.go
@@ -7,50 +7,70 @@ package resources
 import (
 	"fmt"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	"github.com/fission/fission/pkg/fission-cli/console"
 )
 
-// listPageSize bounds how much one request pulls. Unpaged, a busy cluster is an
-// unbounded read into CLI memory — and a support dump runs against exactly the
-// clusters that have accumulated the most objects.
-const listPageSize = 500
+const (
+	// listPageSize bounds how much one request pulls. Unpaged, a busy cluster is
+	// an unbounded read into CLI memory — and a support dump runs against
+	// exactly the clusters that have accumulated the most objects.
+	listPageSize = 500
+
+	// maxListPages stops a server that hands out tokens forever. At the page
+	// size above this is a million objects, so reaching it means something is
+	// wrong rather than large.
+	maxListPages = 2000
+)
 
 // listAllPages accumulates every page of a paged List.
 //
 // fetch is called once per page with the continue token, and returns that
-// page's items and the token for the next one. A Limit without this loop would
-// be worse than an unbounded read: it truncates to the first page and says
-// nothing, so a short result reads as "there was no more".
+// page's items and the token for the next one.
 //
-// Two things it refuses to do. It will not spin: a token equal to the one just
-// sent, or a fresh token on an empty page, ends the walk. And it will not throw
-// away work — a watch cache ageing out mid-pagination returns 410 Gone, so the
-// pages already collected are kept and the shortfall is logged, because a
-// silently truncated bundle is worse than a noisy one.
-func listAllPages[T any](what string, fetch func(cont string) (items []T, next string, err error)) ([]T, error) {
+// It reports partial separately from err, and callers must not conflate them. A
+// Limit without this loop truncates to the first page and says nothing, so a
+// short result reads as "there was no more" — and the same trap applies one
+// level up: returning collected pages with a nil error would make every caller
+// treat a truncated list as complete. Some can live with that and some cannot,
+// so the decision belongs to them.
+//
+// Work is never thrown away. A watch cache ageing out mid-walk returns 410
+// Gone, and other transient failures happen too; whatever was already read is
+// returned with partial set. Only a failure on the very first page is a hard
+// error, because then there is nothing to hand back.
+func listAllPages[T any](what string, fetch func(cont string) (items []T, next string, err error)) (
+	result []T, partial bool, err error) {
 	var out []T
 	var cont string
 
 	for page := 0; ; page++ {
+		if page >= maxListPages {
+			console.Error(fmt.Sprintf(
+				"%v list did not terminate after %v pages; the dump has partial %v data", what, page, what))
+			return out, true, nil
+		}
+
 		items, next, err := fetch(cont)
 		if err != nil {
-			if page > 0 && apierrors.IsResourceExpired(err) {
-				console.Error(fmt.Sprintf(
-					"%v list expired after %v pages; the dump has partial %v data: %v", what, page, what, err))
-				break
+			if page == 0 {
+				return nil, false, err
 			}
-			return nil, err
+			console.Error(fmt.Sprintf(
+				"%v list failed after %v pages; the dump has partial %v data: %v", what, page, what, err))
+			return out, true, nil
 		}
 
 		out = append(out, items...)
 
-		if next == "" || next == cont || len(items) == 0 {
+		// Only an empty continue token ends the list. A page may legitimately
+		// come back short, or even empty, when the server filters it — so
+		// stopping on an empty page would silently truncate. The repeated-token
+		// check is what guards against a server that never advances.
+		if next == "" || next == cont {
 			break
 		}
 		cont = next
 	}
 
-	return out, nil
+	return out, false, nil
 }

--- a/pkg/fission-cli/cmd/support/resources/paging.go
+++ b/pkg/fission-cli/cmd/support/resources/paging.go
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package resources
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/fission/fission/pkg/fission-cli/console"
+)
+
+// listPageSize bounds how much one request pulls. Unpaged, a busy cluster is an
+// unbounded read into CLI memory — and a support dump runs against exactly the
+// clusters that have accumulated the most objects.
+const listPageSize = 500
+
+// listAllPages accumulates every page of a paged List.
+//
+// fetch is called once per page with the continue token, and returns that
+// page's items and the token for the next one. A Limit without this loop would
+// be worse than an unbounded read: it truncates to the first page and says
+// nothing, so a short result reads as "there was no more".
+//
+// Two things it refuses to do. It will not spin: a token equal to the one just
+// sent, or a fresh token on an empty page, ends the walk. And it will not throw
+// away work — a watch cache ageing out mid-pagination returns 410 Gone, so the
+// pages already collected are kept and the shortfall is logged, because a
+// silently truncated bundle is worse than a noisy one.
+func listAllPages[T any](what string, fetch func(cont string) (items []T, next string, err error)) ([]T, error) {
+	var out []T
+	var cont string
+
+	for page := 0; ; page++ {
+		items, next, err := fetch(cont)
+		if err != nil {
+			if page > 0 && apierrors.IsResourceExpired(err) {
+				console.Error(fmt.Sprintf(
+					"%v list expired after %v pages; the dump has partial %v data: %v", what, page, what, err))
+				break
+			}
+			return nil, err
+		}
+
+		out = append(out, items...)
+
+		if next == "" || next == cont || len(items) == 0 {
+			break
+		}
+		cont = next
+	}
+
+	return out, nil
+}

--- a/pkg/fission-cli/cmd/support/resources/podevents.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents.go
@@ -53,7 +53,10 @@ type PodEventIndex struct {
 	client kubernetes.Interface
 	once   sync.Once
 	byPod  map[types.UID][]corev1.Event
-	err    error
+	// partial records that the walk ended with events left uncollected, so a
+	// pod with no file cannot be read as "nothing was recorded".
+	partial bool
+	err     error
 }
 
 func NewPodEventIndex(clientset kubernetes.Interface) *PodEventIndex {
@@ -63,14 +66,14 @@ func NewPodEventIndex(clientset kubernetes.Interface) *PodEventIndex {
 // get builds the index on first call and hands the same result to every later
 // caller. Sorting happens here rather than at the point of use, so the slices
 // handed out are read-only and concurrent dumpers cannot race sorting one.
-func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event, error) {
+func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event, bool, error) {
 	idx.once.Do(func() {
 		// involvedObject.kind is a server-side selectable field on core/v1
 		// events, so the apiserver drops non-Pod events rather than sending
 		// them. The client-side check below stays regardless: the fake clientset
 		// used in tests applies label selectors but ignores field selectors, so
 		// it is what keeps the tests honest.
-		events, err := listAllPages("event", func(cont string) ([]corev1.Event, string, error) {
+		events, partial, err := listAllPages("event", func(cont string) ([]corev1.Event, string, error) {
 			list, err := idx.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 				FieldSelector: "involvedObject.kind=Pod",
 				Limit:         listPageSize,
@@ -85,6 +88,7 @@ func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event
 			idx.err = err
 			return
 		}
+		idx.partial = partial
 
 		byPod := make(map[types.UID][]corev1.Event)
 		for _, e := range events {
@@ -104,7 +108,7 @@ func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event
 		}
 		idx.byPod = byPod
 	})
-	return idx.byPod, idx.err
+	return idx.byPod, idx.partial, idx.err
 }
 
 // eventTime is the effective time of an event, whichever API recorded it.
@@ -144,10 +148,16 @@ func (res KubernetesPodEventDumper) Dump(ctx context.Context, dumpDir string) {
 	// and events are short-lived and numerous; one list keeps the dump from
 	// hammering an apiserver that may already be struggling — which is, after
 	// all, why someone is collecting a support bundle.
-	byPod, err := res.events.get(ctx)
+	byPod, partial, err := res.events.get(ctx)
 	if err != nil {
-		console.Error(fmt.Sprintf("Error getting event list: %v", err))
+		console.Error(fmt.Sprintf("Error getting event list for %v: %v", res.labelSelector, err))
+		writeNote(dumpDir, "_event-list-failed.txt",
+			"no events dumped for %v: %v", res.labelSelector, err)
 		return
+	}
+	if partial {
+		writeNote(dumpDir, "_partial-event-list.txt",
+			"the cluster event list did not complete; a pod with no file here may still have had events")
 	}
 
 	for _, pod := range pods.Items {

--- a/pkg/fission-cli/cmd/support/resources/podevents.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,13 +30,72 @@ import (
 type KubernetesPodEventDumper struct {
 	client        kubernetes.Interface
 	labelSelector string
+	events        *PodEventIndex
 }
 
-func NewKubernetesPodEventDumper(clientset kubernetes.Interface, selector string) Resource {
+func NewKubernetesPodEventDumper(clientset kubernetes.Interface, selector string, events *PodEventIndex) Resource {
 	return KubernetesPodEventDumper{
 		client:        clientset,
 		labelSelector: selector,
+		events:        events,
 	}
+}
+
+// PodEventIndex holds the cluster's pod events, keyed by the UID of the pod
+// each was recorded against and sorted oldest first.
+//
+// It is built at most once and shared by every KubernetesPodEventDumper.
+// dump.go registers three of them — components, builders, functions — and runs
+// every dumper concurrently, so a list per dumper puts three unfiltered
+// full-cluster Event LISTs in flight at the same moment and holds three copies
+// of the result. That is the load the single-list design set out to avoid.
+type PodEventIndex struct {
+	client kubernetes.Interface
+	once   sync.Once
+	byPod  map[types.UID][]corev1.Event
+	err    error
+}
+
+func NewPodEventIndex(clientset kubernetes.Interface) *PodEventIndex {
+	return &PodEventIndex{client: clientset}
+}
+
+// get builds the index on first call and hands the same result to every later
+// caller. Sorting happens here rather than at the point of use, so the slices
+// handed out are read-only and concurrent dumpers cannot race sorting one.
+func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event, error) {
+	idx.once.Do(func() {
+		// involvedObject.kind is a server-side selectable field on core/v1
+		// events, so the apiserver drops non-Pod events rather than sending
+		// them. The client-side check below stays regardless: the fake
+		// clientset used in tests applies label selectors but ignores field
+		// selectors, so it is what keeps the tests honest.
+		events, err := idx.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+			FieldSelector: "involvedObject.kind=Pod",
+		})
+		if err != nil {
+			idx.err = err
+			return
+		}
+
+		byPod := make(map[types.UID][]corev1.Event)
+		for _, e := range events.Items {
+			if e.InvolvedObject.Kind != "Pod" {
+				continue
+			}
+			byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
+		}
+		for _, evs := range byPod {
+			// Oldest first, so each file reads as that pod's history. Events
+			// are returned in no guaranteed order. Stable, so events sharing a
+			// timestamp keep the order the apiserver returned them in.
+			sort.SliceStable(evs, func(i, j int) bool {
+				return eventTime(evs[i]).Before(eventTime(evs[j]))
+			})
+		}
+		idx.byPod = byPod
+	})
+	return idx.byPod, idx.err
 }
 
 // eventTime is the effective time of an event, whichever API recorded it.
@@ -70,23 +130,15 @@ func (res KubernetesPodEventDumper) Dump(ctx context.Context, dumpDir string) {
 		return
 	}
 
-	// One cluster-wide Event list indexed by involved-object UID, rather than a
-	// per-pod field-selector query. A busy fission install has many pods, and
-	// events are short-lived and numerous; one list keeps the dump from issuing
-	// a request per pod against an apiserver that may already be struggling —
-	// which is, after all, why someone is collecting a support bundle.
-	events, err := res.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	// One cluster-wide Event list for the whole dump, indexed by involved-object
+	// UID, rather than a request per pod. A busy fission install has many pods,
+	// and events are short-lived and numerous; one list keeps the dump from
+	// hammering an apiserver that may already be struggling — which is, after
+	// all, why someone is collecting a support bundle.
+	byPod, err := res.events.get(ctx)
 	if err != nil {
 		console.Error(fmt.Sprintf("Error getting event list: %v", err))
 		return
-	}
-
-	byPod := make(map[types.UID][]corev1.Event)
-	for _, e := range events.Items {
-		if e.InvolvedObject.Kind != "Pod" {
-			continue
-		}
-		byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
 	}
 
 	for _, pod := range pods.Items {
@@ -96,14 +148,6 @@ func (res KubernetesPodEventDumper) Dump(ctx context.Context, dumpDir string) {
 			// empty file would just be noise in the bundle.
 			continue
 		}
-
-		// Oldest first, so the file reads as the pod's history. Events are
-		// returned in no guaranteed order. Stable, so events sharing a
-		// timestamp keep the order the apiserver returned them in.
-		sort.SliceStable(podEvents, func(i, j int) bool {
-			return eventTime(podEvents[i]).Before(eventTime(podEvents[j]))
-		})
-
 		f := getFileName(dumpDir, pod.ObjectMeta)
 		writeToFile(f, podEvents)
 	}

--- a/pkg/fission-cli/cmd/support/resources/podevents.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -42,10 +41,6 @@ func NewKubernetesPodEventDumper(clientset kubernetes.Interface, selector string
 	}
 }
 
-// eventPageSize bounds how many events one request pulls. Unpaged, a cluster
-// with a large event backlog is an unbounded read into CLI memory.
-const eventPageSize = 500
-
 // PodEventIndex holds the cluster's pod events, keyed by the UID of the pod
 // each was recorded against and sorted oldest first.
 //
@@ -70,48 +65,33 @@ func NewPodEventIndex(clientset kubernetes.Interface) *PodEventIndex {
 // handed out are read-only and concurrent dumpers cannot race sorting one.
 func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event, error) {
 	idx.once.Do(func() {
-		byPod := make(map[types.UID][]corev1.Event)
-
-		var cont string
-		for page := 0; ; page++ {
-			// involvedObject.kind is a server-side selectable field on core/v1
-			// events, so the apiserver drops non-Pod events rather than sending
-			// them. The client-side check below stays regardless: the fake
-			// clientset used in tests applies label selectors but ignores field
-			// selectors, so it is what keeps the tests honest.
-			events, err := idx.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+		// involvedObject.kind is a server-side selectable field on core/v1
+		// events, so the apiserver drops non-Pod events rather than sending
+		// them. The client-side check below stays regardless: the fake clientset
+		// used in tests applies label selectors but ignores field selectors, so
+		// it is what keeps the tests honest.
+		events, err := listAllPages("event", func(cont string) ([]corev1.Event, string, error) {
+			list, err := idx.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
 				FieldSelector: "involvedObject.kind=Pod",
-				Limit:         eventPageSize,
+				Limit:         listPageSize,
 				Continue:      cont,
 			})
 			if err != nil {
-				// Keep whatever was already collected. A watch cache that ages
-				// out mid-pagination returns 410 Gone, and a partial event
-				// history is worth more in a bundle than none — but say so,
-				// because silently short files would read as "no more events".
-				if page > 0 && apierrors.IsResourceExpired(err) {
-					console.Error(fmt.Sprintf(
-						"Event list expired after %v pages; the dump has a partial event history: %v", page, err))
-					break
-				}
-				idx.err = err
-				return
+				return nil, "", err
 			}
+			return list.Items, list.Continue, nil
+		})
+		if err != nil {
+			idx.err = err
+			return
+		}
 
-			for _, e := range events.Items {
-				if e.InvolvedObject.Kind != "Pod" {
-					continue
-				}
-				byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
+		byPod := make(map[types.UID][]corev1.Event)
+		for _, e := range events {
+			if e.InvolvedObject.Kind != "Pod" {
+				continue
 			}
-
-			next := events.Continue
-			// Termination guard: an apiserver that returns the token it was
-			// given, or a fresh token with nothing in it, would loop forever.
-			if next == "" || next == cont || len(events.Items) == 0 {
-				break
-			}
-			cont = next
+			byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
 		}
 
 		for _, evs := range byPod {

--- a/pkg/fission-cli/cmd/support/resources/podevents.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
@@ -41,6 +42,10 @@ func NewKubernetesPodEventDumper(clientset kubernetes.Interface, selector string
 	}
 }
 
+// eventPageSize bounds how many events one request pulls. Unpaged, a cluster
+// with a large event backlog is an unbounded read into CLI memory.
+const eventPageSize = 500
+
 // PodEventIndex holds the cluster's pod events, keyed by the UID of the pod
 // each was recorded against and sorted oldest first.
 //
@@ -65,26 +70,50 @@ func NewPodEventIndex(clientset kubernetes.Interface) *PodEventIndex {
 // handed out are read-only and concurrent dumpers cannot race sorting one.
 func (idx *PodEventIndex) get(ctx context.Context) (map[types.UID][]corev1.Event, error) {
 	idx.once.Do(func() {
-		// involvedObject.kind is a server-side selectable field on core/v1
-		// events, so the apiserver drops non-Pod events rather than sending
-		// them. The client-side check below stays regardless: the fake
-		// clientset used in tests applies label selectors but ignores field
-		// selectors, so it is what keeps the tests honest.
-		events, err := idx.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
-			FieldSelector: "involvedObject.kind=Pod",
-		})
-		if err != nil {
-			idx.err = err
-			return
+		byPod := make(map[types.UID][]corev1.Event)
+
+		var cont string
+		for page := 0; ; page++ {
+			// involvedObject.kind is a server-side selectable field on core/v1
+			// events, so the apiserver drops non-Pod events rather than sending
+			// them. The client-side check below stays regardless: the fake
+			// clientset used in tests applies label selectors but ignores field
+			// selectors, so it is what keeps the tests honest.
+			events, err := idx.client.CoreV1().Events(metav1.NamespaceAll).List(ctx, metav1.ListOptions{
+				FieldSelector: "involvedObject.kind=Pod",
+				Limit:         eventPageSize,
+				Continue:      cont,
+			})
+			if err != nil {
+				// Keep whatever was already collected. A watch cache that ages
+				// out mid-pagination returns 410 Gone, and a partial event
+				// history is worth more in a bundle than none — but say so,
+				// because silently short files would read as "no more events".
+				if page > 0 && apierrors.IsResourceExpired(err) {
+					console.Error(fmt.Sprintf(
+						"Event list expired after %v pages; the dump has a partial event history: %v", page, err))
+					break
+				}
+				idx.err = err
+				return
+			}
+
+			for _, e := range events.Items {
+				if e.InvolvedObject.Kind != "Pod" {
+					continue
+				}
+				byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
+			}
+
+			next := events.Continue
+			// Termination guard: an apiserver that returns the token it was
+			// given, or a fresh token with nothing in it, would loop forever.
+			if next == "" || next == cont || len(events.Items) == 0 {
+				break
+			}
+			cont = next
 		}
 
-		byPod := make(map[types.UID][]corev1.Event)
-		for _, e := range events.Items {
-			if e.InvolvedObject.Kind != "Pod" {
-				continue
-			}
-			byPod[e.InvolvedObject.UID] = append(byPod[e.InvolvedObject.UID], e)
-		}
 		for _, evs := range byPod {
 			// Oldest first, so each file reads as that pod's history. Events
 			// are returned in no guaranteed order. Stable, so events sharing a

--- a/pkg/fission-cli/cmd/support/resources/podevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents_test.go
@@ -8,15 +8,21 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
 )
 
 func fissionPod(name string, uid types.UID) *corev1.Pod {
@@ -81,7 +87,7 @@ func TestPodEventDumperWritesEventsForMatchingPods(t *testing.T) {
 	)
 
 	dir := t.TempDir()
-	NewKubernetesPodEventDumper(client, "svc in (router)").Dump(t.Context(), dir)
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -109,7 +115,7 @@ func TestPodEventDumperSkipsPodsWithNoEvents(t *testing.T) {
 	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
 
 	dir := t.TempDir()
-	NewKubernetesPodEventDumper(client, "svc in (router)").Dump(t.Context(), dir)
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
@@ -134,9 +140,113 @@ func TestPodEventDumperIgnoresNonPodEvents(t *testing.T) {
 	client := k8sfake.NewClientset(pod, deployEvent)
 
 	dir := t.TempDir()
-	NewKubernetesPodEventDumper(client, "svc in (router)").Dump(t.Context(), dir)
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
 	assert.Empty(t, entries, "non-Pod events must not be attributed to a pod")
+}
+
+func TestPodEventDumperAttributesEventsByUIDNotName(t *testing.T) {
+	t.Parallel()
+
+	// Pool and function pods are recreated under recycled names, so a stale
+	// event from a dead pod must not be attributed to its replacement. Both
+	// events below name "router-abc"; only one carries the live pod's UID.
+	pod := fissionPod("router-abc", "uid-live")
+
+	stale := podEvent("router-abc", "uid-dead", "StaleFromDeadPod", time.Now())
+
+	client := k8sfake.NewClientset(
+		pod, stale,
+		podEvent("router-abc", "uid-live", "LiveEvent", time.Now()),
+	)
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+
+	assert.Contains(t, string(content), "LiveEvent")
+	assert.NotContains(t, string(content), "StaleFromDeadPod",
+		"an event naming the pod but carrying another UID belongs to a different pod")
+}
+
+func TestPodEventIndexListsOnceAcrossDumpers(t *testing.T) {
+	t.Parallel()
+
+	// The three registrations in dump.go run concurrently; without a shared
+	// index that is three unfiltered full-cluster Event LISTs at once.
+	client := k8sfake.NewClientset(
+		fissionPod("router-abc", "uid-router"),
+		podEvent("router-abc", "uid-router", "Pulled", time.Now()),
+	)
+
+	var lists atomic.Int32
+	client.PrependReactor("list", "events", func(clienttesting.Action) (bool, runtime.Object, error) {
+		lists.Add(1)
+		return false, nil, nil // fall through to the tracker
+	})
+
+	// Concurrently, as dump.go runs them — so under -race this also guards the
+	// claim that the slices the index hands out are read-only.
+	idx := NewPodEventIndex(client)
+	wg := &sync.WaitGroup{}
+	for range 3 {
+		dir := t.TempDir()
+		wg.Go(func() {
+			NewKubernetesPodEventDumper(client, "svc in (router)", idx).Dump(t.Context(), dir)
+		})
+	}
+	wg.Wait()
+
+	assert.Equal(t, int32(1), lists.Load(), "the event list must be fetched once for the whole dump")
+}
+
+func TestPodEventDumperReportsEventListFailure(t *testing.T) {
+	t.Parallel()
+
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+	client.PrependReactor("list", "events", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewForbidden(
+			schema.GroupResource{Resource: "events"}, "", assert.AnError)
+	})
+
+	dir := t.TempDir()
+	// Must degrade to "no event files" rather than aborting the bundle.
+	require.NotPanics(t, func() {
+		NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+	})
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestPodEventIndexFiltersServerSide(t *testing.T) {
+	t.Parallel()
+
+	// The fake clientset applies label selectors but ignores field selectors,
+	// so a behavioural assertion cannot see this. Inspect the action instead.
+	client := k8sfake.NewClientset(
+		fissionPod("router-abc", "uid-router"),
+		podEvent("router-abc", "uid-router", "Pulled", time.Now()),
+	)
+
+	var fields string
+	client.PrependReactor("list", "events", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		fields = a.(clienttesting.ListAction).GetListRestrictions().Fields.String()
+		return false, nil, nil // fall through to the tracker
+	})
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	assert.Equal(t, "involvedObject.kind=Pod", fields,
+		"non-Pod events must be dropped by the apiserver, not shipped and discarded client-side")
 }

--- a/pkg/fission-cli/cmd/support/resources/podevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents_test.go
@@ -250,3 +250,110 @@ func TestPodEventIndexFiltersServerSide(t *testing.T) {
 	assert.Equal(t, "involvedObject.kind=Pod", fields,
 		"non-Pod events must be dropped by the apiserver, not shipped and discarded client-side")
 }
+
+func TestPodEventIndexPagesThroughEveryEvent(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+
+	// The fake's object tracker ignores Limit and Continue entirely, so paging
+	// can only be exercised by serving the pages from a reactor. A test that
+	// seeds N events and expects N/pageSize requests would pass against an
+	// unpaged implementation.
+	var seenTokens []string
+	client.PrependReactor("list", "events", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		la, ok := a.(clienttesting.ListActionImpl)
+		require.True(t, ok, "expected a ListActionImpl to read the continue token from")
+		token := la.GetListOptions().Continue
+		seenTokens = append(seenTokens, token)
+
+		switch token {
+		case "":
+			return true, &corev1.EventList{
+				ListMeta: metav1.ListMeta{Continue: "page-2"},
+				Items:    []corev1.Event{*podEvent("router-abc", "uid-router", "Alpha", base)},
+			}, nil
+		case "page-2":
+			return true, &corev1.EventList{
+				Items: []corev1.Event{*podEvent("router-abc", "uid-router", "Bravo", base.Add(time.Minute))},
+			}, nil
+		}
+		return true, nil, assert.AnError
+	})
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+
+	content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"", "page-2"}, seenTokens, "the continue token must be fed back")
+	assert.Contains(t, string(content), "Alpha")
+	assert.Contains(t, string(content), "Bravo", "events past the first page must not be dropped")
+}
+
+func TestPodEventIndexStopsOnARepeatedContinueToken(t *testing.T) {
+	t.Parallel()
+
+	// An apiserver that echoes back the token it was given would otherwise
+	// loop forever, holding the whole dump open.
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+
+	var calls atomic.Int32
+	client.PrependReactor("list", "events", func(clienttesting.Action) (bool, runtime.Object, error) {
+		calls.Add(1)
+		return true, &corev1.EventList{
+			ListMeta: metav1.ListMeta{Continue: "stuck"},
+			Items:    []corev1.Event{*podEvent("router-abc", "uid-router", "Looping", time.Now())},
+		}, nil
+	})
+
+	dir := t.TempDir()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("pagination did not terminate on a repeated continue token")
+	}
+	assert.LessOrEqual(t, calls.Load(), int32(2), "a repeated token must stop the loop immediately")
+}
+
+func TestPodEventIndexKeepsPagesCollectedBeforeAnExpiry(t *testing.T) {
+	t.Parallel()
+
+	// A watch cache ageing out mid-pagination returns 410 Gone. A partial event
+	// history is worth more in a bundle than none.
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+
+	client.PrependReactor("list", "events", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		if a.(clienttesting.ListActionImpl).GetListOptions().Continue == "" {
+			return true, &corev1.EventList{
+				ListMeta: metav1.ListMeta{Continue: "page-2"},
+				Items:    []corev1.Event{*podEvent("router-abc", "uid-router", "Kept", base)},
+			}, nil
+		}
+		return true, nil, apierrors.NewResourceExpired("too old resource version")
+	})
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1, "the pages collected before the expiry must still be written")
+
+	content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "Kept")
+}

--- a/pkg/fission-cli/cmd/support/resources/podevents_test.go
+++ b/pkg/fission-cli/cmd/support/resources/podevents_test.go
@@ -218,14 +218,17 @@ func TestPodEventDumperReportsEventListFailure(t *testing.T) {
 	})
 
 	dir := t.TempDir()
-	// Must degrade to "no event files" rather than aborting the bundle.
+	// Must degrade to "no event files" rather than aborting the bundle — and
+	// must say so in the bundle, because an empty directory alone reads as
+	// "these pods had no events".
 	require.NotPanics(t, func() {
 		NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
 	})
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	assert.Empty(t, entries)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "_event-list-failed.txt", entries[0].Name())
 }
 
 func TestPodEventIndexFiltersServerSide(t *testing.T) {
@@ -351,9 +354,110 @@ func TestPodEventIndexKeepsPagesCollectedBeforeAnExpiry(t *testing.T) {
 
 	entries, err := os.ReadDir(dir)
 	require.NoError(t, err)
-	require.Len(t, entries, 1, "the pages collected before the expiry must still be written")
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.Contains(t, names, "_partial-event-list.txt",
+		"a short event list must not read as a pod that had no events")
 
-	content, err := os.ReadFile(filepath.Join(dir, entries[0].Name()))
-	require.NoError(t, err)
+	content, err := os.ReadFile(filepath.Join(dir, "fission_router-abc_1.txt"))
+	require.NoError(t, err, "the pages collected before the expiry must still be written")
 	assert.Contains(t, string(content), "Kept")
+}
+
+func TestPodEventIndexKeepsPagesAfterANonExpiryFailure(t *testing.T) {
+	t.Parallel()
+
+	// Throwing away thousands of collected events because one late page timed
+	// out is the wrong default for a best-effort dumper — but the shortfall has
+	// to be visible, or a short file reads as a complete history.
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+
+	client.PrependReactor("list", "events", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		if a.(clienttesting.ListActionImpl).GetListOptions().Continue == "" {
+			return true, &corev1.EventList{
+				ListMeta: metav1.ListMeta{Continue: "page-2"},
+				Items:    []corev1.Event{*podEvent("router-abc", "uid-router", "Kept", base)},
+			}, nil
+		}
+		return true, nil, apierrors.NewInternalError(assert.AnError)
+	})
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	assert.Contains(t, names, "fission_router-abc_1.txt", "collected pages must survive a late failure")
+	assert.Contains(t, names, "_partial-event-list.txt", "and the shortfall must be recorded")
+}
+
+func TestPodEventIndexFailsHardWhenTheFirstPageFails(t *testing.T) {
+	t.Parallel()
+
+	// Nothing was collected, so there is no partial result to hand back — this
+	// must stay an error rather than an empty success.
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+	client.PrependReactor("list", "events", func(clienttesting.Action) (bool, runtime.Object, error) {
+		return true, nil, apierrors.NewResourceExpired("too old resource version")
+	})
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "_event-list-failed.txt", entries[0].Name())
+}
+
+func TestPodEventIndexKeepsWalkingPastAnEmptyPage(t *testing.T) {
+	t.Parallel()
+
+	// A server filtering a page away may return zero items with a live continue
+	// token. Stopping there would silently drop everything after it.
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	client := k8sfake.NewClientset(fissionPod("router-abc", "uid-router"))
+
+	client.PrependReactor("list", "events", func(a clienttesting.Action) (bool, runtime.Object, error) {
+		switch a.(clienttesting.ListActionImpl).GetListOptions().Continue {
+		case "":
+			return true, &corev1.EventList{ListMeta: metav1.ListMeta{Continue: "page-2"}}, nil
+		case "page-2":
+			return true, &corev1.EventList{
+				Items: []corev1.Event{*podEvent("router-abc", "uid-router", "AfterTheGap", base)},
+			}, nil
+		}
+		return true, nil, assert.AnError
+	})
+
+	dir := t.TempDir()
+	NewKubernetesPodEventDumper(client, "svc in (router)", NewPodEventIndex(client)).Dump(t.Context(), dir)
+
+	content, err := os.ReadFile(filepath.Join(dir, "fission_router-abc_1.txt"))
+	require.NoError(t, err, "events after an empty page must not be dropped")
+	assert.Contains(t, string(content), "AfterTheGap")
+}
+
+func TestEventTimePrefersTheSeriesObservationForRepeatedEvents(t *testing.T) {
+	t.Parallel()
+
+	// An aggregated event keeps its original EventTime and records the latest
+	// occurrence on Series, so Series is what places it in a pod's history.
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	e := *podEvent("router-abc", "uid-router", "BackOff", base)
+	e.LastTimestamp = metav1.Time{}
+	e.EventTime = metav1.NewMicroTime(base)
+	e.Series = &corev1.EventSeries{
+		Count:            5,
+		LastObservedTime: metav1.NewMicroTime(base.Add(time.Hour)),
+	}
+
+	assert.Equal(t, base.Add(time.Hour), eventTime(e))
 }

--- a/pkg/fission-cli/cmd/support/resources/resource.go
+++ b/pkg/fission-cli/cmd/support/resources/resource.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,6 +73,16 @@ func maskCredentialValues(in map[string]string) (map[string]string, bool) {
 
 func isCredentialKey(k string) bool {
 	lower := strings.ToLower(k)
+
+	// KEDA's convention is passwordFromEnv, connectionFromEnv: the value is the
+	// NAME of an environment variable, not the secret in it. Masking those
+	// hides nothing and destroys the first thing anyone checks on a trigger
+	// that will not authenticate. Underscores are stripped because the scaler
+	// re-spells metadata keys as PASSWORD_FROM_ENV on the consumer.
+	if strings.HasSuffix(strings.ReplaceAll(lower, "_", ""), "fromenv") {
+		return false
+	}
+
 	for _, c := range credentialKeys {
 		if strings.Contains(lower, c) {
 			return true
@@ -80,13 +91,41 @@ func isCredentialKey(k string) bool {
 	return false
 }
 
+// userinfoPassword matches the user:password@ shape of a URL's userinfo.
+var userinfoPassword = regexp.MustCompile(`^[^/@\s]*:[^@\s]+@`)
+
 func hasURLPassword(v string) bool {
-	u, err := url.Parse(v)
-	if err != nil || u.User == nil {
-		return false
+	if u, err := url.Parse(v); err == nil && u.User != nil {
+		if _, ok := u.User.Password(); ok {
+			return true
+		}
 	}
-	_, ok := u.User.Password()
-	return ok
+
+	// url.Parse is not a safety oracle here. It reads a schemeless
+	// "user:pass@host" as scheme "user" with an opaque body, and it fails
+	// outright on an unencoded character in the password — a string that is
+	// still perfectly usable by the client library. Neither means the value is
+	// safe to ship, so fall back to matching the userinfo shape directly.
+	rest := v
+	if _, after, found := strings.Cut(v, "://"); found {
+		rest = after
+	}
+	return userinfoPassword.MatchString(rest)
+}
+
+// writeNote records something the bundle's reader needs to know but that has no
+// object to attach to: why a directory is empty, or why it is incomplete.
+//
+// console output goes to whoever ran the command; the tarball goes to whoever
+// reads it weeks later. Only the second audience is still around when the
+// bundle is opened, and a directory alone cannot tell them "nothing to report"
+// from "this failed". Written as plain text rather than through writeToFile,
+// which would YAML-quote it.
+func writeNote(dumpDir, name, format string, args ...any) {
+	file := filepath.Join(dumpDir, name)
+	if err := os.WriteFile(file, []byte(fmt.Sprintf(format, args...)+"\n"), 0o600); err != nil {
+		console.Error(fmt.Sprintf("Error writing note %v: %v", file, err))
+	}
 }
 
 func writeToFile(file string, obj any) {

--- a/pkg/fission-cli/cmd/support/resources/resource.go
+++ b/pkg/fission-cli/cmd/support/resources/resource.go
@@ -7,8 +7,10 @@ package resources
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -29,6 +31,62 @@ func getFileName(dumpdir string, meta metav1.ObjectMeta) string {
 func getPodFileName(dumpdir string, pod metav1.ObjectMeta, containerName string) string {
 	f := fmt.Sprintf("%v/%v_%v_%v_%v.txt", dumpdir, pod.Namespace, pod.Name, pod.ResourceVersion, containerName)
 	return filepath.Clean(f)
+}
+
+// credentialKeys are substrings that mark a trigger-metadata key as carrying a
+// secret rather than configuration. Matched case-insensitively against the key.
+//
+// Deliberately not "sasl" on its own: KEDA's Kafka scaler uses sasl and
+// saslType for the mechanism name (plaintext, scram_sha512), which is
+// diagnostic, not sensitive.
+var credentialKeys = []string{
+	"password", "passwd", "secret", "token", "credential",
+	"apikey", "api_key", "accesskey", "access_key",
+	"connectionstring", "connection_string", "privatekey", "private_key",
+}
+
+// maskCredentialValues returns a copy of in with credential-bearing values
+// replaced by "-", and reports whether anything was masked. Keys are always
+// preserved: which settings were present is diagnostic, their values are not.
+//
+// A value is masked when its key names a credential, or when the value is a URL
+// carrying a password in its userinfo — the amqp://user:pass@host form that
+// KEDA's rabbitmq and redis scalers take inline.
+func maskCredentialValues(in map[string]string) (map[string]string, bool) {
+	if in == nil {
+		return nil, false
+	}
+
+	out := make(map[string]string, len(in))
+	masked := false
+	for k, v := range in {
+		if v != "" && (isCredentialKey(k) || hasURLPassword(v)) {
+			out[k] = "-"
+			masked = true
+			continue
+		}
+		out[k] = v
+	}
+	return out, masked
+}
+
+func isCredentialKey(k string) bool {
+	lower := strings.ToLower(k)
+	for _, c := range credentialKeys {
+		if strings.Contains(lower, c) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasURLPassword(v string) bool {
+	u, err := url.Parse(v)
+	if err != nil || u.User == nil {
+		return false
+	}
+	_, ok := u.User.Password()
+	return ok
 }
 
 func writeToFile(file string, obj any) {


### PR DESCRIPTION
Closes out every follow-up left by the reviews of #3670 and #3671, plus two gaps those reviews uncovered in the existing dump.
All changes are confined to `pkg/fission-cli/cmd/support/`.
No API, CRD, codegen or runtime change; `go.mod` untouched.

## Two things that were already broken

**Eight components were missing from every support bundle.**
The component label selector was written out inline at each of the five places that needed it, and it drifted.
It listed 7 `svc` values while the chart ships 15, so `canaryconfig`, `mcp`, `mqtrigger-keda`, `statestore`, `statesvc`, `tenantcontroller`, `webhook-service` and `workflow` had no spec, no pods and no logs — silently, because a selector that matches nothing looks exactly like a component that is not deployed.
`mqt-keda` being invisible is the sharpest of these: it is the component behind every keda MessageQueueTrigger.

The function selectors had the same problem from the other side.
`executorType in (poolmgr, newdeploy)` omits `container`, so container-executor functions were absent too, and the service selector `executorType=newdeploy` missed them as well — that executor does create a Service per function.

All four selectors are now named constants with one place to change, and a test walks the chart's deployment templates and fails if any shipped `svc` value is unmatched, naming the file.

**Function HPAs were never collected.**
`KubernetesObjectDumper` has handled `KubernetesHPA` since it was written, but nothing ever registered it.
The HPA is what decides whether a function scales, which makes it the first object to look at when one does not.

## The deferred items

**Events for pods that no longer exist.**
The pod event dumpers iterate pods first, so an event reached the bundle only if its pod was still listed — and the pod that was OOMKilled, evicted or replaced by a rolling update is exactly the one being investigated.

The naive definition of orphan (any Pod event whose UID matches no live pod) is not acceptable here.
Fission functions commonly share a namespace with a user's own workloads and a bundle goes to a third party, so that would sweep in unrelated teams' deleted pods — the same leak the KEDA ownership filter exists to prevent.
Scope is by derivation instead: every pod a Deployment owns is named `<deployment>-<rs hash>-<random>`, which is checkable without the pod existing, so an orphan counts only when its name and namespace match a fission-owned Deployment.

Knowingly out of scope, and recorded on the type: pods from the chart's Helm hook Jobs, which are Job-owned rather than Deployment-owned.
Fission creates no bare Pods or StatefulSets at runtime, so that is the whole exception list.

**The workload a keda mqt scales.**
The scaler creates a Deployment per trigger alongside the ScaledObject and no selector matched it, so the bundle carried the scaling policy but not the thing being scaled.

This cannot be a label-selector dumper and the scaler cannot simply be given a label: `Spec.Selector` is immutable on an existing Deployment, and putting one on the pod template would change the template hash and force a rollout of every consumer on upgrade.
It selects on the MQT owner reference instead, the same signal `KedaDumper` uses — no runtime change.

Pods need a second filter beyond the Deployment's own selector.
`app` is the most generic label key in kubernetes and `<mqt name>` is user-chosen, so an unrelated pod sharing it would otherwise have its spec and logs written into the bundle; the `<deployment>-` name prefix is required too.

**Credentials in trigger metadata.**
A MessageQueueTrigger's `Spec.Metadata` is copied verbatim into `ScaledObject.spec.triggers[].metadata`, and for several KEDA scalers that map is the documented place for an inline connection string (`amqp://user:pass@host`).
Fission's own path routes credentials through `Spec.Secret`, so this does not fire on a stock setup — but nothing stops an operator putting a password there.

Masked when the key names a credential or the value is a URL carrying a password in its userinfo.
Keys are always preserved: which settings were set is diagnostic, their values are not.
Both call sites are fixed — masking only the ScaledObject would leave the same values in the bundle via `fission-crd-mqtriggers`, which dumps the source map.

Two deliberate choices in the key list: `sasl` alone is **not** a credential marker, because KEDA's Kafka scaler uses `sasl`/`saslType` for the mechanism name, so masking those would hide diagnostics and no secret; and an empty value is left alone, so "set but blank" stays distinguishable from "masked".

**A marker when KEDA is not installed.**
The absent-CRD branch returned after a `console.Verbose(2, ...)` that prints nothing at default verbosity, so "no KEDA" and "the list failed" both produced an empty directory.
A `keda-not-installed.txt` now names the kind and the error, on that branch only — a real failure is warned about on the console and deliberately leaves no marker.
This also closed a test gap: the two branches previously differed only in console output, which this package cannot capture without swapping a global that `t.Parallel` would race.

**Event list pagination.**
`Limit` alone would be worse than the unbounded read it replaces — it truncates to the first page silently, so a short file reads as "no more events".
The loop feeds the continue token back, refuses to spin on a repeated token, and keeps the pages already collected when a watch cache ages out mid-pagination (410 Gone), logging that the history is partial.

## Correctness fixes carried along

- **Aliasing.** `ScaledObject.Spec.Triggers` is a slice, so masking through it would edit the backing array shared with the List result — that path DeepCopies, and only when something needs masking. In `crd.go` the range variable is a value copy and the masker returns a fresh map, so no copy is needed there; the code and comments reflect the difference.
- **`append(Containers, InitContainers...)`** in the log dumper writes into `Containers`' spare capacity when it has any, editing the pod object it was handed. Now `slices.Concat`.
- The event and deployment lists are each fetched **once** and shared, rather than once per dumper.

## Tests

Every new test was mutation-verified: the behaviour was removed and the test confirmed to fail, then restored. Twenty mutations, twenty caught.

The ones worth knowing about, because the obvious test would not have worked:

| What | Why the obvious test fails |
|---|---|
| Component selector coverage | Walks the chart templates; a hand-written list would drift the same way the selector did |
| Event pagination | `k8sfake`'s tracker ignores `Limit`/`Continue`, so seeding N events and counting requests passes against an unpaged implementation — the tests read the continue token off the concrete `ListActionImpl` |
| Server-side field filtering | `k8sfake` applies label selectors but ignores field selectors, so this inspects the `ListAction`'s restrictions instead |
| Shared index once-semantics | Runs its dumpers concurrently as `dump.go` does, so under `-race` it also guards the read-only-slices claim |
| Orphan privacy guard | An unrelated deleted pod **in the same namespace** must not be collected |
| Consumer pod attribution | An unrelated pod carrying the same `app` label must not be collected |

## Verification

```
go build ./...                                   clean
gofmt -l pkg/fission-cli/                         clean
golangci-lint run pkg/fission-cli/...             0 issues
make license-check                                clean
make verify-gomod                                 OK
go test -race ./pkg/fission-cli/cmd/support/...   ok
```
