### PR TITLE
cli: --watch to stream build logs during package create/update/rebuild and fn create

### DIFF
--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -111,11 +111,11 @@ const (
 )
 
 const (
-	BuildStatusPending   = "pending"
-	BuildStatusRunning   = "running"
-	BuildStatusSucceeded = "succeeded"
-	BuildStatusFailed    = "failed"
-	BuildStatusNone      = "none"
+	BuildStatusPending   BuildStatus = "pending"
+	BuildStatusRunning   BuildStatus = "running"
+	BuildStatusSucceeded BuildStatus = "succeeded"
+	BuildStatusFailed    BuildStatus = "failed"
+	BuildStatusNone      BuildStatus = "none"
 )
 
 const (

--- a/pkg/apis/core/v1/const.go
+++ b/pkg/apis/core/v1/const.go
@@ -416,3 +416,16 @@ const (
 const (
 	BuilderContainerName = "builder"
 )
+
+// Labels buildermgr's EnvironmentReconciler stamps on every environment
+// builder Service/Deployment/pod. Shared here so the CLI's build watch can
+// select builder pods without importing pkg/buildermgr. Note the
+// BuilderLabelEnvNamespace value is the BUILDER namespace (where the pod
+// runs), not the Environment's own namespace.
+const (
+	BuilderLabelEnvName            = "envName"
+	BuilderLabelEnvNamespace       = "envNamespace"
+	BuilderLabelEnvResourceVersion = "envResourceVersion"
+	BuilderLabelOwner              = "owner"
+	BuilderOwnerBuilderMgr         = "buildermgr"
+)

--- a/pkg/apis/core/v1/types.go
+++ b/pkg/apis/core/v1/types.go
@@ -2455,6 +2455,15 @@ func (a Archive) IsEmpty() bool {
 	return len(a.Literal) == 0 && len(a.URL) == 0 && a.OCI == nil
 }
 
+// HasBuilder reports whether this environment can run package builds: v1
+// environments predate builders, and without a builder image there is nothing
+// to run one in. Shared by buildermgr's EnvironmentReconciler (which skips
+// builder creation on !HasBuilder) and the CLI's build watch (which refuses
+// to wait on a build that can never start).
+func (env Environment) HasBuilder() bool {
+	return env.Spec.Version != 1 && len(env.Spec.Builder.Image) > 0
+}
+
 func (fn Function) GetConcurrency() int {
 	if fn.Spec.Concurrency == 0 {
 		return DefaultConcurrency

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -33,11 +33,13 @@ import (
 )
 
 const (
-	LABEL_ENV_NAME            = "envName"
-	LABEL_ENV_NAMESPACE       = "envNamespace"
-	LABEL_ENV_RESOURCEVERSION = "envResourceVersion"
-	LABEL_DEPLOYMENT_OWNER    = "owner"
-	BUILDER_MGR               = "buildermgr"
+	// Aliases of the shared fv1.BuilderLabel* constants (the CLI's build
+	// watch selects builder pods by the same labels).
+	LABEL_ENV_NAME            = fv1.BuilderLabelEnvName
+	LABEL_ENV_NAMESPACE       = fv1.BuilderLabelEnvNamespace
+	LABEL_ENV_RESOURCEVERSION = fv1.BuilderLabelEnvResourceVersion
+	LABEL_DEPLOYMENT_OWNER    = fv1.BuilderLabelOwner
+	BUILDER_MGR               = fv1.BuilderOwnerBuilderMgr
 
 	// builderSpecHashAnnotation carries a hash of the builder pod template the
 	// reconciler last applied, so drift that does NOT bump the Environment's

--- a/pkg/buildermgr/environment_reconciler.go
+++ b/pkg/buildermgr/environment_reconciler.go
@@ -126,7 +126,7 @@ func (r *EnvironmentReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// builder is not supported with the v1 interface; ignore envs without a
 	// builder image.
-	if env.Spec.Version == 1 || len(env.Spec.Builder.Image) == 0 {
+	if !env.HasBuilder() {
 		return ctrl.Result{}, nil
 	}
 

--- a/pkg/buildermgr/package_reconciler_test.go
+++ b/pkg/buildermgr/package_reconciler_test.go
@@ -160,7 +160,7 @@ func TestPackageReconcileGate(t *testing.T) {
 
 		got, err := fc.CoreV1().Packages("default").Get(t.Context(), "init", metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, fv1.BuildStatusPending, string(got.Status.BuildStatus),
+		assert.Equal(t, fv1.BuildStatusPending, got.Status.BuildStatus,
 			"empty-status source package must be initialised to pending")
 	})
 
@@ -175,7 +175,7 @@ func TestPackageReconcileGate(t *testing.T) {
 
 		got, err := fc.CoreV1().Packages("default").Get(t.Context(), "done", metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, fv1.BuildStatusSucceeded, string(got.Status.BuildStatus), "terminal status must be left untouched")
+		assert.Equal(t, fv1.BuildStatusSucceeded, got.Status.BuildStatus, "terminal status must be left untouched")
 	})
 
 	t.Run("pending with missing environment fails terminally", func(t *testing.T) {
@@ -189,7 +189,7 @@ func TestPackageReconcileGate(t *testing.T) {
 
 		got, err := fc.CoreV1().Packages("default").Get(t.Context(), "noenv", metav1.GetOptions{})
 		require.NoError(t, err)
-		assert.Equal(t, fv1.BuildStatusFailed, string(got.Status.BuildStatus))
+		assert.Equal(t, fv1.BuildStatusFailed, got.Status.BuildStatus)
 		assert.Contains(t, got.Status.BuildLog, "environment does not exist")
 	})
 

--- a/pkg/fission-cli/cmd/function/command.go
+++ b/pkg/fission-cli/cmd/function/command.go
@@ -42,7 +42,7 @@ func Commands() *cobra.Command {
 			// TODO retired pkg & trigger related flags from function cmd
 			flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure,
-			flag.PkgOCI, flag.FnBuildCmd,
+			flag.PkgOCI, flag.FnBuildCmd, flag.PkgWatch, flag.PkgWatchTimeout,
 
 			flag.HtUrl, flag.HtPrefix, flag.HtMethod,
 

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -41,10 +41,6 @@ type CreateSubCommand struct {
 	cmd.CommandActioner
 	function *fv1.Function
 	specFile string
-	// createdPackage records that THIS command created the function's package
-	// (vs. --pkg pointing at an existing one), so --watch knows whether a
-	// terminal build status is this command's outcome or stale history.
-	createdPackage bool
 }
 
 func Create(input cli.Input) error {
@@ -530,7 +526,6 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		if err != nil {
 			return fmt.Errorf("error creating package: %w", err)
 		}
-		opts.createdPackage = true
 	}
 
 	// Secret/configmap references point at the function namespace when creating
@@ -642,9 +637,8 @@ func generatePackageName(fnName string, id string) string {
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) error {
-	if input.Bool(flagkey.PkgWatch) && (input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry)) {
-		return fmt.Errorf("--%v cannot be combined with --%v or --%v: a spec file does not trigger a build",
-			flagkey.PkgWatch, flagkey.SpecSave, flagkey.SpecDry)
+	if err := _package.ValidateWatchNotSpecMode(input); err != nil {
+		return err
 	}
 
 	// if we're writing a spec, don't create the function; save/print and return.
@@ -712,25 +706,23 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 // failed build never blocks those; the non-nil error on a failed build only
 // sets the exit code.
 //
-// For a package THIS command created, any state — including an already
-// terminal one — is this command's own build outcome, so the watch always
-// runs. For `--pkg <existing>`, fn create triggers no build: only a build
-// already in flight is worth attaching to, and a terminal status is stale
-// history that must not be replayed as if it were this command's result.
+// For a package THIS command created (no --pkg given), any state — including
+// an already terminal one — is this command's own build outcome, so the watch
+// always runs. For `--pkg <existing>`, fn create triggers no build: only a
+// build already in flight is worth attaching to, and a terminal status is
+// stale history that must not be replayed as if it were this command's
+// result.
 func (opts *CreateSubCommand) watchBuildIfRequested(input cli.Input) error {
 	if !input.Bool(flagkey.PkgWatch) {
 		return nil
 	}
 	ref := opts.function.Spec.Package.PackageRef
-	if !opts.createdPackage {
+	if usedExistingPackage := len(input.String(flagkey.FnPackageName)) > 0; usedExistingPackage {
 		pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(ref.Namespace).Get(input.Context(), ref.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("error getting package for --%v: %w", flagkey.PkgWatch, err)
 		}
-		switch pkg.Status.BuildStatus {
-		case "", fv1.BuildStatusPending, fv1.BuildStatusRunning:
-			// in-flight build: attach to it
-		default:
+		if !_package.IsBuildInFlight(pkg.Status.BuildStatus) {
 			fmt.Fprintf(input.Stdout(), "Package '%v' already exists and no build was triggered; nothing to watch\n", ref.Name)
 			return nil
 		}

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -41,6 +41,10 @@ type CreateSubCommand struct {
 	cmd.CommandActioner
 	function *fv1.Function
 	specFile string
+	// createdPackage records that THIS command created the function's package
+	// (vs. --pkg pointing at an existing one), so --watch knows whether a
+	// terminal build status is this command's outcome or stale history.
+	createdPackage bool
 }
 
 func Create(input cli.Input) error {
@@ -526,6 +530,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		if err != nil {
 			return fmt.Errorf("error creating package: %w", err)
 		}
+		opts.createdPackage = true
 	}
 
 	// Secret/configmap references point at the function namespace when creating
@@ -706,11 +711,30 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 // trigger a build (issue #3676). It runs after function/trigger creation so a
 // failed build never blocks those; the non-nil error on a failed build only
 // sets the exit code.
+//
+// For a package THIS command created, any state — including an already
+// terminal one — is this command's own build outcome, so the watch always
+// runs. For `--pkg <existing>`, fn create triggers no build: only a build
+// already in flight is worth attaching to, and a terminal status is stale
+// history that must not be replayed as if it were this command's result.
 func (opts *CreateSubCommand) watchBuildIfRequested(input cli.Input) error {
 	if !input.Bool(flagkey.PkgWatch) {
 		return nil
 	}
 	ref := opts.function.Spec.Package.PackageRef
+	if !opts.createdPackage {
+		pkg, err := opts.Client().FissionClientSet.CoreV1().Packages(ref.Namespace).Get(input.Context(), ref.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting package for --%v: %w", flagkey.PkgWatch, err)
+		}
+		switch pkg.Status.BuildStatus {
+		case "", fv1.BuildStatusPending, fv1.BuildStatusRunning:
+			// in-flight build: attach to it
+		default:
+			fmt.Fprintf(input.Stdout(), "Package '%v' already exists and no build was triggered; nothing to watch\n", ref.Name)
+			return nil
+		}
+	}
 	return _package.WatchPackageBuild(input, opts.Client(), ref.Namespace, ref.Name)
 }
 

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -637,6 +637,11 @@ func generatePackageName(fnName string, id string) string {
 // run write the resource to a spec file or create a fission CRD with remote fission server.
 // It also prints warning/error if necessary.
 func (opts *CreateSubCommand) run(input cli.Input) error {
+	if input.Bool(flagkey.PkgWatch) && (input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry)) {
+		return fmt.Errorf("--%v cannot be combined with --%v or --%v: a spec file does not trigger a build",
+			flagkey.PkgWatch, flagkey.SpecSave, flagkey.SpecDry)
+	}
+
 	// if we're writing a spec, don't create the function; save/print and return.
 	if handled, err := spec.SaveOrDry(input, *opts.function, opts.specFile); handled {
 		return err
@@ -653,7 +658,7 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	triggerUrl := input.String(flagkey.HtUrl)
 	prefix := input.String(flagkey.HtPrefix)
 	if len(triggerUrl) == 0 && len(prefix) == 0 {
-		return nil
+		return opts.watchBuildIfRequested(input)
 	}
 	if len(prefix) != 0 && len(triggerUrl) > 0 {
 		console.Warn("Prefix will take precedence over URL/RelativeURL")
@@ -693,7 +698,20 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 	}
 
 	fmt.Printf("route created: %s %s -> %s\n", methods, triggerUrl, opts.function.Name)
-	return nil
+	return opts.watchBuildIfRequested(input)
+}
+
+// watchBuildIfRequested follows the referenced package's build to completion
+// when --watch was given — `fn create --src` is the most common way users
+// trigger a build (issue #3676). It runs after function/trigger creation so a
+// failed build never blocks those; the non-nil error on a failed build only
+// sets the exit code.
+func (opts *CreateSubCommand) watchBuildIfRequested(input cli.Input) error {
+	if !input.Bool(flagkey.PkgWatch) {
+		return nil
+	}
+	ref := opts.function.Spec.Package.PackageRef
+	return _package.WatchPackageBuild(input, opts.Client(), ref.Namespace, ref.Name)
 }
 
 func getInvokeStrategy(input cli.Input, existingInvokeStrategy *fv1.InvokeStrategy) (strategy *fv1.InvokeStrategy, err error) {

--- a/pkg/fission-cli/cmd/package/buildwatch.go
+++ b/pkg/fission-cli/cmd/package/buildwatch.go
@@ -23,23 +23,16 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
 	"github.com/fission/fission/pkg/fission-cli/util"
-)
-
-// Label keys/values buildermgr's EnvironmentReconciler stamps on every
-// environment builder pod (pkg/buildermgr/environment_reconciler.go). The
-// envResourceVersion label additionally pins a pod to one revision of the
-// Environment, but it goes stale between an env edit and the rollout, so it is
-// only ever a preference here, never a hard filter. Note the reconciler's
-// envNamespace label holds the BUILDER namespace, not the Environment's — it
-// carries no cross-namespace identity, so it is useless as a selector.
-const (
-	builderLabelEnvName            = "envName"
-	builderLabelEnvResourceVersion = "envResourceVersion"
-	builderLabelOwner              = "owner"
-	builderOwnerBuilderMgr         = "buildermgr"
+	"github.com/fission/fission/pkg/utils"
 )
 
 const buildWatchPollInterval = time.Second
+
+// buildWatchMaxConsecutiveGetErrors bounds how long the status poll tolerates
+// consecutive non-NotFound API errors before surfacing the last one. Without
+// it a persistent failure (expired token, RBAC deny) combined with the
+// default no-timeout watch would hang forever with zero output.
+const buildWatchMaxConsecutiveGetErrors = 5
 
 // WatchPackageBuild is the cli.Input-facing wrapper around watchPackageBuild:
 // it applies --timeout only when positive (flag.PkgWatchTimeout defaults to 0
@@ -64,6 +57,13 @@ func WatchPackageBuild(input cli.Input, client cmd.Client, namespace, name strin
 // cross-namespace pod list) silently degrades to "wait and print the final
 // log", never to a hang or a spurious command failure.
 func watchPackageBuild(ctx context.Context, client cmd.Client, out io.Writer, namespace, name string) error {
+	// Fail fast on an environment that can never run this build — otherwise a
+	// source package against a builder-less env stays pending and a default
+	// (no-timeout) watch would wait forever.
+	if err := refuseBuilderlessEnv(ctx, client, namespace, name); err != nil {
+		return err
+	}
+
 	lw := &lockedWriter{w: out}
 
 	streamCtx, stopStream := context.WithCancel(ctx)
@@ -80,6 +80,7 @@ func watchPackageBuild(ctx context.Context, client cmd.Client, out io.Writer, na
 	// Sentinel that matches no real status, so the very first poll announces
 	// the current state.
 	lastStatus := fv1.BuildStatus("\x00")
+	consecutiveGetErrors := 0
 	check := func(ctx context.Context) (bool, error) {
 		p, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
@@ -88,9 +89,16 @@ func watchPackageBuild(ctx context.Context, client cmd.Client, out io.Writer, na
 				// means it was deleted underneath the watch.
 				return false, fmt.Errorf("package %s/%s no longer exists: %w", namespace, name, err)
 			}
-			// Transient API error: keep polling, the status decides.
+			// Tolerate a transient API blip, but a persistent failure
+			// (expired token, RBAC deny) must surface rather than spin
+			// silently forever under the default no-timeout watch.
+			consecutiveGetErrors++
+			if consecutiveGetErrors >= buildWatchMaxConsecutiveGetErrors {
+				return false, fmt.Errorf("getting package %s/%s repeatedly failed while watching the build: %w", namespace, name, err)
+			}
 			return false, nil
 		}
+		consecutiveGetErrors = 0
 		pkg = p
 		// An empty status is a fresh create the buildermgr hasn't classified
 		// yet (the /status subresource strips client-set status); to the user
@@ -155,6 +163,39 @@ func printFinalBuildLog(out io.Writer, pkg *fv1.Package) {
 	fmt.Fprintf(out, "\n========= build log =========\n%s========= end build log =========\n", log)
 }
 
+// refuseBuilderlessEnv returns an error when the package has a source archive
+// to build but its Environment can never build it (no builder image, or a v1
+// env — the same predicate EnvironmentReconciler uses to skip builder
+// creation). Such a package stays pending forever, so a no-timeout watch
+// must refuse up front rather than hang. Lookup failures (RBAC, env not yet
+// created) are NOT terminal — the watch proceeds and the status decides.
+func refuseBuilderlessEnv(ctx context.Context, client cmd.Client, namespace, name string) error {
+	pkg, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil || pkg.Spec.Source.IsEmpty() {
+		return nil
+	}
+	switch pkg.Status.BuildStatus {
+	case "", fv1.BuildStatusPending:
+		// Only a build that has not started can wait forever on a missing
+		// builder; running/terminal statuses prove a builder exists(ed).
+	default:
+		return nil
+	}
+	envNamespace := pkg.Spec.Environment.Namespace
+	if envNamespace == "" {
+		envNamespace = namespace
+	}
+	env, err := client.FissionClientSet.CoreV1().Environments(envNamespace).Get(ctx, pkg.Spec.Environment.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	if env.Spec.Version == 1 || len(env.Spec.Builder.Image) == 0 {
+		return fmt.Errorf("environment %s/%s has no builder (builder image unset or v1 env): the source package can never be built, so there is no build to watch",
+			envNamespace, env.Name)
+	}
+	return nil
+}
+
 // streamBuilderLogs tails the builder container of the package's environment
 // builder pod onto out until ctx is cancelled. Purely best-effort: every
 // failure path retries after a poll interval and nothing is ever reported as
@@ -210,10 +251,14 @@ func copyLogLines(out io.Writer, stream io.Reader) {
 }
 
 // findBuilderPod locates the newest ready builder pod for the package's
-// environment, or nil if none can be found right now. Primary lookup is in the
-// Environment's own namespace; when that yields nothing (an install with a
-// remapped builder namespace runs builder pods elsewhere) it falls back to a
-// cluster-wide list. Both lookups may fail for RBAC or availability reasons —
+// environment, or nil if none can be found right now. Primary lookup is in
+// the Environment's own namespace. When that yields nothing AND the env lives
+// in `default` — the only namespace the server's GetBuilderNS remap moves
+// builder pods out of (pkg/utils/namespace.go) — it falls back to a
+// cluster-wide list; because the builder labels carry no env-namespace
+// identity, that fallback additionally requires the envResourceVersion label
+// to match the live Environment, so a same-named env in another namespace
+// can't be picked. All lookups may fail for RBAC or availability reasons —
 // that only degrades the live stream, so errors just yield nil.
 func findBuilderPod(ctx context.Context, client cmd.Client, namespace, name string) *corev1.Pod {
 	pkg, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -226,27 +271,37 @@ func findBuilderPod(ctx context.Context, client cmd.Client, namespace, name stri
 		envNamespace = namespace
 	}
 
-	// Prefer pods matching the Environment's current ResourceVersion (the
-	// reconciler labels each builder generation with it), but never require
-	// it: the label lags behind env edits until the new builder rolls out.
+	// In the primary (namespace-scoped) lookup the Environment's current
+	// ResourceVersion is only a preference, never a requirement: the label
+	// lags behind env edits until the new builder generation rolls out.
 	var envResourceVersion string
 	if env, err := client.FissionClientSet.CoreV1().Environments(envNamespace).Get(ctx, envName, metav1.GetOptions{}); err == nil {
 		envResourceVersion = env.ResourceVersion
 	}
 
 	selector := labels.Set{
-		builderLabelOwner:   builderOwnerBuilderMgr,
-		builderLabelEnvName: envName,
+		fv1.BuilderLabelOwner:   fv1.BuilderOwnerBuilderMgr,
+		fv1.BuilderLabelEnvName: envName,
 	}.AsSelector().String()
 
 	podList, err := client.KubernetesClient.CoreV1().Pods(envNamespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
-	if err != nil || len(podList.Items) == 0 {
-		podList, err = client.KubernetesClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: selector})
-		if err != nil {
-			return nil
+	if err == nil && len(podList.Items) > 0 {
+		return pickBuilderPod(podList.Items, envResourceVersion)
+	}
+	if envNamespace != metav1.NamespaceDefault || envResourceVersion == "" {
+		return nil
+	}
+	podList, err = client.KubernetesClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil
+	}
+	candidates := podList.Items[:0]
+	for i := range podList.Items {
+		if podList.Items[i].Labels[fv1.BuilderLabelEnvResourceVersion] == envResourceVersion {
+			candidates = append(candidates, podList.Items[i])
 		}
 	}
-	return pickBuilderPod(podList.Items, envResourceVersion)
+	return pickBuilderPod(candidates, envResourceVersion)
 }
 
 // pickBuilderPod orders candidate builder pods by (ready, matches current env
@@ -256,8 +311,8 @@ func pickBuilderPod(pods []corev1.Pod, envResourceVersion string) *corev1.Pod {
 		return nil
 	}
 	rank := func(p *corev1.Pod) (ready, rvMatch bool) {
-		ready = builderPodReady(p)
-		rvMatch = envResourceVersion != "" && p.Labels[builderLabelEnvResourceVersion] == envResourceVersion
+		ready = utils.IsReadyPod(p)
+		rvMatch = envResourceVersion != "" && p.Labels[fv1.BuilderLabelEnvResourceVersion] == envResourceVersion
 		return ready, rvMatch
 	}
 	sort.SliceStable(pods, func(i, j int) bool {
@@ -272,20 +327,6 @@ func pickBuilderPod(pods []corev1.Pod, envResourceVersion string) *corev1.Pod {
 		return pods[j].CreationTimestamp.Before(&pods[i].CreationTimestamp)
 	})
 	return &pods[0]
-}
-
-// builderPodReady mirrors buildermgr's readyBuilderPod predicate: every
-// container reported and ready.
-func builderPodReady(pod *corev1.Pod) bool {
-	if len(pod.Status.ContainerStatuses) == 0 {
-		return false
-	}
-	for _, cs := range pod.Status.ContainerStatuses {
-		if !cs.Ready {
-			return false
-		}
-	}
-	return true
 }
 
 // lockedWriter serializes concurrent writes (status breadcrumbs vs. streamed

--- a/pkg/fission-cli/cmd/package/buildwatch.go
+++ b/pkg/fission-cli/cmd/package/buildwatch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
 	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/logdb"
 	"github.com/fission/fission/pkg/fission-cli/util"
 	"github.com/fission/fission/pkg/utils"
 )
@@ -57,29 +58,45 @@ func WatchPackageBuild(input cli.Input, client cmd.Client, namespace, name strin
 // cross-namespace pod list) silently degrades to "wait and print the final
 // log", never to a hang or a spurious command failure.
 func watchPackageBuild(ctx context.Context, client cmd.Client, out io.Writer, namespace, name string) error {
-	// Fail fast on an environment that can never run this build — otherwise a
-	// source package against a builder-less env stays pending and a default
-	// (no-timeout) watch would wait forever.
-	if err := refuseBuilderlessEnv(ctx, client, namespace, name); err != nil {
-		return err
+	// One startup read fails fast on an environment that can never run this
+	// build (otherwise a source package against a builder-less env stays
+	// pending and a default no-timeout watch would wait forever) and seeds
+	// the log stream's env identity so it needn't re-derive it every tick. A
+	// transient read error here is not terminal — the poll's error budget
+	// below decides.
+	var envName, envNamespace string
+	if initial, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{}); err == nil {
+		if err := refuseBuilderlessEnv(ctx, client, namespace, initial); err != nil {
+			return err
+		}
+		envName = initial.Spec.Environment.Name
+		envNamespace = initial.Spec.Environment.Namespace
+		if envNamespace == "" {
+			envNamespace = namespace
+		}
+	} else if util.IsNotFound(err) {
+		return fmt.Errorf("package %s/%s not found: %w", namespace, name, err)
 	}
 
-	lw := &lockedWriter{w: out}
+	lw := logdb.NewLockedWriter(out)
 
 	streamCtx, stopStream := context.WithCancel(ctx)
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		streamBuilderLogs(streamCtx, client, lw, namespace, name)
+		streamBuilderLogs(streamCtx, client, lw, namespace, name, envName, envNamespace)
 	})
 	// Stop the log stream before the final build-log print regardless of how
 	// the poll ends, so stream lines can't interleave into the final report.
-	defer wg.Wait()
-	defer stopStream()
+	stopAndWait := sync.OnceFunc(func() {
+		stopStream()
+		wg.Wait()
+	})
+	defer stopAndWait()
 
 	var pkg *fv1.Package
-	// Sentinel that matches no real status, so the very first poll announces
-	// the current state.
-	lastStatus := fv1.BuildStatus("\x00")
+	// Zero value matches no status the poll can observe (an empty status is
+	// normalized to pending below), so the first poll announces the state.
+	var lastStatus fv1.BuildStatus
 	consecutiveGetErrors := 0
 	check := func(ctx context.Context) (bool, error) {
 		p, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -132,8 +149,7 @@ func watchPackageBuild(ctx context.Context, client cmd.Client, out io.Writer, na
 	}
 
 	// Silence the live stream before printing the authoritative report.
-	stopStream()
-	wg.Wait()
+	stopAndWait()
 
 	switch pkg.Status.BuildStatus {
 	case fv1.BuildStatusNone:
@@ -163,15 +179,25 @@ func printFinalBuildLog(out io.Writer, pkg *fv1.Package) {
 	fmt.Fprintf(out, "\n========= build log =========\n%s========= end build log =========\n", log)
 }
 
+// IsBuildInFlight reports whether the status means a build is coming or
+// running: an empty status is a fresh create the buildermgr has not
+// classified yet. Shared by the `pkg update` and `fn create` watch gates.
+func IsBuildInFlight(status fv1.BuildStatus) bool {
+	switch status {
+	case "", fv1.BuildStatusPending, fv1.BuildStatusRunning:
+		return true
+	}
+	return false
+}
+
 // refuseBuilderlessEnv returns an error when the package has a source archive
-// to build but its Environment can never build it (no builder image, or a v1
-// env — the same predicate EnvironmentReconciler uses to skip builder
-// creation). Such a package stays pending forever, so a no-timeout watch
-// must refuse up front rather than hang. Lookup failures (RBAC, env not yet
-// created) are NOT terminal — the watch proceeds and the status decides.
-func refuseBuilderlessEnv(ctx context.Context, client cmd.Client, namespace, name string) error {
-	pkg, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil || pkg.Spec.Source.IsEmpty() {
+// to build but its Environment can never build it (fv1.Environment.HasBuilder
+// — the same predicate EnvironmentReconciler uses to skip builder creation).
+// Such a package stays pending forever, so a no-timeout watch must refuse up
+// front rather than hang. Env lookup failures (RBAC, env not yet created) are
+// NOT terminal — the watch proceeds and the status decides.
+func refuseBuilderlessEnv(ctx context.Context, client cmd.Client, namespace string, pkg *fv1.Package) error {
+	if pkg.Spec.Source.IsEmpty() {
 		return nil
 	}
 	switch pkg.Status.BuildStatus {
@@ -189,7 +215,7 @@ func refuseBuilderlessEnv(ctx context.Context, client cmd.Client, namespace, nam
 	if err != nil {
 		return nil
 	}
-	if env.Spec.Version == 1 || len(env.Spec.Builder.Image) == 0 {
+	if !env.HasBuilder() {
 		return fmt.Errorf("environment %s/%s has no builder (builder image unset or v1 env): the source package can never be built, so there is no build to watch",
 			envNamespace, env.Name)
 	}
@@ -200,11 +226,22 @@ func refuseBuilderlessEnv(ctx context.Context, client cmd.Client, namespace, nam
 // builder pod onto out until ctx is cancelled. Purely best-effort: every
 // failure path retries after a poll interval and nothing is ever reported as
 // an error. SinceTime advances across reconnects so a re-established stream
-// does not re-dump lines already printed.
-func streamBuilderLogs(ctx context.Context, client cmd.Client, out io.Writer, namespace, name string) {
+// does not re-dump lines already printed. The env identity is normally seeded
+// by the caller's startup read; when that read failed, it is resolved here
+// once (per tick until it succeeds) rather than on every reconnect.
+func streamBuilderLogs(ctx context.Context, client cmd.Client, out io.Writer, pkgNamespace, pkgName, envName, envNamespace string) {
 	since := metav1.Now()
 	for {
-		if pod := findBuilderPod(ctx, client, namespace, name); pod != nil {
+		if envName == "" {
+			if pkg, err := client.FissionClientSet.CoreV1().Packages(pkgNamespace).Get(ctx, pkgName, metav1.GetOptions{}); err == nil {
+				envName = pkg.Spec.Environment.Name
+				envNamespace = pkg.Spec.Environment.Namespace
+				if envNamespace == "" {
+					envNamespace = pkgNamespace
+				}
+			}
+		}
+		if pod := findBuilderPod(ctx, client, envName, envNamespace); pod != nil {
 			sinceCopy := since
 			opts := &corev1.PodLogOptions{
 				Container: fv1.BuilderContainerName,
@@ -250,25 +287,19 @@ func copyLogLines(out io.Writer, stream io.Reader) {
 	}
 }
 
-// findBuilderPod locates the newest ready builder pod for the package's
-// environment, or nil if none can be found right now. Primary lookup is in
-// the Environment's own namespace. When that yields nothing AND the env lives
-// in `default` — the only namespace the server's GetBuilderNS remap moves
-// builder pods out of (pkg/utils/namespace.go) — it falls back to a
-// cluster-wide list; because the builder labels carry no env-namespace
-// identity, that fallback additionally requires the envResourceVersion label
-// to match the live Environment, so a same-named env in another namespace
-// can't be picked. All lookups may fail for RBAC or availability reasons —
-// that only degrades the live stream, so errors just yield nil.
-func findBuilderPod(ctx context.Context, client cmd.Client, namespace, name string) *corev1.Pod {
-	pkg, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
+// findBuilderPod locates the newest ready builder pod for the environment, or
+// nil if none can be found right now. Primary lookup is in the Environment's
+// own namespace. When that yields nothing AND the env lives in `default` —
+// the only namespace the server's GetBuilderNS remap moves builder pods out
+// of (pkg/utils/namespace.go) — it falls back to a cluster-wide list; because
+// the builder labels carry no env-namespace identity, that fallback
+// additionally requires the envResourceVersion label to match the live
+// Environment, so a same-named env in another namespace can't be picked. All
+// lookups may fail for RBAC or availability reasons — that only degrades the
+// live stream, so errors just yield nil.
+func findBuilderPod(ctx context.Context, client cmd.Client, envName, envNamespace string) *corev1.Pod {
+	if envName == "" {
 		return nil
-	}
-	envName := pkg.Spec.Environment.Name
-	envNamespace := pkg.Spec.Environment.Namespace
-	if envNamespace == "" {
-		envNamespace = namespace
 	}
 
 	// In the primary (namespace-scoped) lookup the Environment's current
@@ -327,17 +358,4 @@ func pickBuilderPod(pods []corev1.Pod, envResourceVersion string) *corev1.Pod {
 		return pods[j].CreationTimestamp.Before(&pods[i].CreationTimestamp)
 	})
 	return &pods[0]
-}
-
-// lockedWriter serializes concurrent writes (status breadcrumbs vs. streamed
-// log lines) onto one writer, same as logdb's.
-type lockedWriter struct {
-	mu sync.Mutex
-	w  io.Writer
-}
-
-func (l *lockedWriter) Write(p []byte) (int, error) {
-	l.mu.Lock()
-	defer l.mu.Unlock()
-	return l.w.Write(p)
 }

--- a/pkg/fission-cli/cmd/package/buildwatch.go
+++ b/pkg/fission-cli/cmd/package/buildwatch.go
@@ -1,0 +1,302 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package _package
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+)
+
+// Label keys/values buildermgr's EnvironmentReconciler stamps on every
+// environment builder pod (pkg/buildermgr/environment_reconciler.go). The
+// envResourceVersion label additionally pins a pod to one revision of the
+// Environment, but it goes stale between an env edit and the rollout, so it is
+// only ever a preference here, never a hard filter. Note the reconciler's
+// envNamespace label holds the BUILDER namespace, not the Environment's — it
+// carries no cross-namespace identity, so it is useless as a selector.
+const (
+	builderLabelEnvName            = "envName"
+	builderLabelEnvResourceVersion = "envResourceVersion"
+	builderLabelOwner              = "owner"
+	builderOwnerBuilderMgr         = "buildermgr"
+)
+
+const buildWatchPollInterval = time.Second
+
+// WatchPackageBuild is the cli.Input-facing wrapper around watchPackageBuild:
+// it applies --timeout only when positive (flag.PkgWatchTimeout defaults to 0
+// — a build has no natural upper bound, so the default is to wait
+// indefinitely, like `kubectl logs -f`) and writes to the input's stdout.
+func WatchPackageBuild(input cli.Input, client cmd.Client, namespace, name string) error {
+	ctx := input.Context()
+	if timeout := input.Duration(flagkey.WaitTimeout); timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	return watchPackageBuild(ctx, client, input.Stdout(), namespace, name)
+}
+
+// watchPackageBuild follows the build of the package at namespace/name to a
+// terminal state. The guarantee is the status poll: it decides completion,
+// prints the final Status.BuildLog (the source of truth), and returns non-nil
+// on a failed build so the command exits non-zero. Streaming live lines from
+// the environment's builder pod is strictly best-effort decoration on top —
+// any failure there (builder pod not up yet, rolled mid-build, RBAC denying a
+// cross-namespace pod list) silently degrades to "wait and print the final
+// log", never to a hang or a spurious command failure.
+func watchPackageBuild(ctx context.Context, client cmd.Client, out io.Writer, namespace, name string) error {
+	lw := &lockedWriter{w: out}
+
+	streamCtx, stopStream := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		streamBuilderLogs(streamCtx, client, lw, namespace, name)
+	})
+	// Stop the log stream before the final build-log print regardless of how
+	// the poll ends, so stream lines can't interleave into the final report.
+	defer wg.Wait()
+	defer stopStream()
+
+	var pkg *fv1.Package
+	// Sentinel that matches no real status, so the very first poll announces
+	// the current state.
+	lastStatus := fv1.BuildStatus("\x00")
+	check := func(ctx context.Context) (bool, error) {
+		p, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			if util.IsNotFound(err) {
+				// The caller just created/updated this package; NotFound now
+				// means it was deleted underneath the watch.
+				return false, fmt.Errorf("package %s/%s no longer exists: %w", namespace, name, err)
+			}
+			// Transient API error: keep polling, the status decides.
+			return false, nil
+		}
+		pkg = p
+		// An empty status is a fresh create the buildermgr hasn't classified
+		// yet (the /status subresource strips client-set status); to the user
+		// that is the same as pending, including for the breadcrumb dedupe.
+		st := p.Status.BuildStatus
+		if st == "" {
+			st = fv1.BuildStatusPending
+		}
+		if st != lastStatus {
+			lastStatus = st
+			switch st {
+			case fv1.BuildStatusPending:
+				fmt.Fprintf(lw, "Waiting for package '%v' build to start...\n", name)
+			case fv1.BuildStatusRunning:
+				fmt.Fprintf(lw, "Package '%v' build running...\n", name)
+			}
+		}
+		switch st {
+		case fv1.BuildStatusSucceeded, fv1.BuildStatusFailed, fv1.BuildStatusNone:
+			return true, nil
+		}
+		return false, nil
+	}
+
+	if err := util.PollUntil(ctx, buildWatchPollInterval, check); err != nil {
+		if util.PollEnded(err) {
+			return fmt.Errorf("%s waiting for package %s/%s build to finish: %w",
+				util.PollDeadlineVerb(ctx), namespace, name, ctx.Err())
+		}
+		return err
+	}
+
+	// Silence the live stream before printing the authoritative report.
+	stopStream()
+	wg.Wait()
+
+	switch pkg.Status.BuildStatus {
+	case fv1.BuildStatusNone:
+		fmt.Fprintf(out, "Package '%v' has nothing to build\n", name)
+		return nil
+	case fv1.BuildStatusFailed:
+		printFinalBuildLog(out, pkg)
+		return fmt.Errorf("package %s/%s build failed", namespace, name)
+	default: // BuildStatusSucceeded
+		printFinalBuildLog(out, pkg)
+		fmt.Fprintf(out, "Package '%v' build succeeded\n", name)
+		return nil
+	}
+}
+
+// printFinalBuildLog prints Status.BuildLog — the authoritative build record
+// (the live stream is best-effort and, on a shared builder pod, may interleave
+// concurrent builds; this is only this build's output).
+func printFinalBuildLog(out io.Writer, pkg *fv1.Package) {
+	log := pkg.Status.BuildLog
+	if strings.TrimSpace(log) == "" {
+		return
+	}
+	if !strings.HasSuffix(log, "\n") {
+		log += "\n"
+	}
+	fmt.Fprintf(out, "\n========= build log =========\n%s========= end build log =========\n", log)
+}
+
+// streamBuilderLogs tails the builder container of the package's environment
+// builder pod onto out until ctx is cancelled. Purely best-effort: every
+// failure path retries after a poll interval and nothing is ever reported as
+// an error. SinceTime advances across reconnects so a re-established stream
+// does not re-dump lines already printed.
+func streamBuilderLogs(ctx context.Context, client cmd.Client, out io.Writer, namespace, name string) {
+	since := metav1.Now()
+	for {
+		if pod := findBuilderPod(ctx, client, namespace, name); pod != nil {
+			sinceCopy := since
+			opts := &corev1.PodLogOptions{
+				Container: fv1.BuilderContainerName,
+				Follow:    true,
+				SinceTime: &sinceCopy,
+			}
+			stream, err := client.KubernetesClient.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, opts).Stream(ctx)
+			if err == nil {
+				copyLogLines(out, stream)
+				stream.Close()
+				// The stream ended (pod rolled, kubelet rotation, ...); on
+				// reconnect only fetch lines newer than what we've shown.
+				since = metav1.Now()
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(buildWatchPollInterval):
+		}
+	}
+}
+
+// copyLogLines copies whole lines from the log stream to out (which serializes
+// writes), so stream lines and status breadcrumbs never interleave mid-line.
+// bufio.Reader rather than Scanner: an oversized log line must not abort the
+// follow (same rationale as logdb.followContainer).
+func copyLogLines(out io.Writer, stream io.Reader) {
+	r := bufio.NewReader(stream)
+	for {
+		line, err := r.ReadString('\n')
+		if len(line) > 0 {
+			if !strings.HasSuffix(line, "\n") {
+				line += "\n"
+			}
+			if _, werr := io.WriteString(out, line); werr != nil {
+				return
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// findBuilderPod locates the newest ready builder pod for the package's
+// environment, or nil if none can be found right now. Primary lookup is in the
+// Environment's own namespace; when that yields nothing (an install with a
+// remapped builder namespace runs builder pods elsewhere) it falls back to a
+// cluster-wide list. Both lookups may fail for RBAC or availability reasons —
+// that only degrades the live stream, so errors just yield nil.
+func findBuilderPod(ctx context.Context, client cmd.Client, namespace, name string) *corev1.Pod {
+	pkg, err := client.FissionClientSet.CoreV1().Packages(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil
+	}
+	envName := pkg.Spec.Environment.Name
+	envNamespace := pkg.Spec.Environment.Namespace
+	if envNamespace == "" {
+		envNamespace = namespace
+	}
+
+	// Prefer pods matching the Environment's current ResourceVersion (the
+	// reconciler labels each builder generation with it), but never require
+	// it: the label lags behind env edits until the new builder rolls out.
+	var envResourceVersion string
+	if env, err := client.FissionClientSet.CoreV1().Environments(envNamespace).Get(ctx, envName, metav1.GetOptions{}); err == nil {
+		envResourceVersion = env.ResourceVersion
+	}
+
+	selector := labels.Set{
+		builderLabelOwner:   builderOwnerBuilderMgr,
+		builderLabelEnvName: envName,
+	}.AsSelector().String()
+
+	podList, err := client.KubernetesClient.CoreV1().Pods(envNamespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil || len(podList.Items) == 0 {
+		podList, err = client.KubernetesClient.CoreV1().Pods(metav1.NamespaceAll).List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return nil
+		}
+	}
+	return pickBuilderPod(podList.Items, envResourceVersion)
+}
+
+// pickBuilderPod orders candidate builder pods by (ready, matches current env
+// ResourceVersion, newest) and returns the best one.
+func pickBuilderPod(pods []corev1.Pod, envResourceVersion string) *corev1.Pod {
+	if len(pods) == 0 {
+		return nil
+	}
+	rank := func(p *corev1.Pod) (ready, rvMatch bool) {
+		ready = builderPodReady(p)
+		rvMatch = envResourceVersion != "" && p.Labels[builderLabelEnvResourceVersion] == envResourceVersion
+		return ready, rvMatch
+	}
+	sort.SliceStable(pods, func(i, j int) bool {
+		iReady, iRV := rank(&pods[i])
+		jReady, jRV := rank(&pods[j])
+		if iReady != jReady {
+			return iReady
+		}
+		if iRV != jRV {
+			return iRV
+		}
+		return pods[j].CreationTimestamp.Before(&pods[i].CreationTimestamp)
+	})
+	return &pods[0]
+}
+
+// builderPodReady mirrors buildermgr's readyBuilderPod predicate: every
+// container reported and ready.
+func builderPodReady(pod *corev1.Pod) bool {
+	if len(pod.Status.ContainerStatuses) == 0 {
+		return false
+	}
+	for _, cs := range pod.Status.ContainerStatuses {
+		if !cs.Ready {
+			return false
+		}
+	}
+	return true
+}
+
+// lockedWriter serializes concurrent writes (status breadcrumbs vs. streamed
+// log lines) onto one writer, same as logdb's.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}

--- a/pkg/fission-cli/cmd/package/buildwatch_test.go
+++ b/pkg/fission-cli/cmd/package/buildwatch_test.go
@@ -7,6 +7,7 @@ package _package
 import (
 	"bytes"
 	"context"
+	"errors"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -15,7 +16,9 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/fission-cli/cmd"
@@ -44,12 +47,13 @@ func watchTestBuilderPod() *corev1.Pod {
 			Name:      watchTestEnv + "-1234-abc",
 			Namespace: watchTestNS,
 			Labels: map[string]string{
-				builderLabelOwner:   builderOwnerBuilderMgr,
-				builderLabelEnvName: watchTestEnv,
+				fv1.BuilderLabelOwner:   fv1.BuilderOwnerBuilderMgr,
+				fv1.BuilderLabelEnvName: watchTestEnv,
 			},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: fv1.BuilderContainerName}}},
 		Status: corev1.PodStatus{
+			PodIP:             "10.1.2.3",
 			ContainerStatuses: []corev1.ContainerStatus{{Name: fv1.BuilderContainerName, Ready: true}},
 		},
 	}
@@ -57,15 +61,19 @@ func watchTestBuilderPod() *corev1.Pod {
 
 // setBuildStatus flips the package's build status (and optionally the build
 // log) through the fake clientset's status subresource, the way buildermgr
-// does.
+// does. It is called from spawned goroutines, so it must not use require
+// (t.FailNow is only legal on the test goroutine); assert's t.Errorf is safe
+// and still fails the test with the real error.
 func setBuildStatus(t *testing.T, client cmd.Client, status fv1.BuildStatus, buildLog string) {
 	t.Helper()
 	pkg, err := client.FissionClientSet.CoreV1().Packages(watchTestNS).Get(t.Context(), watchTestPkg, metav1.GetOptions{})
-	require.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
 	pkg.Status.BuildStatus = status
 	pkg.Status.BuildLog = buildLog
 	_, err = client.FissionClientSet.CoreV1().Packages(watchTestNS).UpdateStatus(t.Context(), pkg, metav1.UpdateOptions{})
-	require.NoError(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWatchPackageBuildSucceeds(t *testing.T) {
@@ -163,13 +171,49 @@ func TestWatchPackageBuildPackageDeleted(t *testing.T) {
 		go func() {
 			time.Sleep(2 * time.Second)
 			err := client.FissionClientSet.CoreV1().Packages(watchTestNS).Delete(t.Context(), watchTestPkg, metav1.DeleteOptions{})
-			require.NoError(t, err)
+			assert.NoError(t, err) // not require: FailNow is illegal off the test goroutine
 		}()
 
 		var out bytes.Buffer
 		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no longer exists")
+	})
+}
+
+func TestWatchPackageBuildSurfacesPersistentAPIErrors(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		fc := fissionfake.NewSimpleClientset(watchTestPackage(fv1.BuildStatusPending))
+		fc.PrependReactor("get", "packages", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("the server has asked for the client to provide credentials")
+		})
+		client := cmd.Client{FissionClientSet: fc, KubernetesClient: k8sfake.NewSimpleClientset()}
+
+		var out bytes.Buffer
+		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "repeatedly failed")
+		assert.Contains(t, err.Error(), "provide credentials")
+	})
+}
+
+func TestWatchPackageBuildRefusesBuilderlessEnv(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		pkg := watchTestPackage(fv1.BuildStatusPending)
+		pkg.Spec.Source = fv1.Archive{Type: fv1.ArchiveTypeUrl, URL: "http://storage/src.zip"}
+		env := &fv1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: watchTestEnv, Namespace: watchTestNS},
+			// No Builder.Image: this env can never run a build.
+		}
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewSimpleClientset(pkg, env),
+			KubernetesClient: k8sfake.NewSimpleClientset(),
+		}
+
+		var out bytes.Buffer
+		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no builder")
 	})
 }
 
@@ -182,12 +226,13 @@ func TestPickBuilderPod(t *testing.T) {
 				Name:              name,
 				CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
 				Labels: map[string]string{
-					builderLabelOwner:              builderOwnerBuilderMgr,
-					builderLabelEnvName:            watchTestEnv,
-					builderLabelEnvResourceVersion: rv,
+					fv1.BuilderLabelOwner:              fv1.BuilderOwnerBuilderMgr,
+					fv1.BuilderLabelEnvName:            watchTestEnv,
+					fv1.BuilderLabelEnvResourceVersion: rv,
 				},
 			},
 			Status: corev1.PodStatus{
+				PodIP:             "10.1.2.3",
 				ContainerStatuses: []corev1.ContainerStatus{{Ready: ready}},
 			},
 		}

--- a/pkg/fission-cli/cmd/package/buildwatch_test.go
+++ b/pkg/fission-cli/cmd/package/buildwatch_test.go
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package _package
+
+import (
+	"bytes"
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+)
+
+const (
+	watchTestNS  = "default"
+	watchTestPkg = "watch-pkg"
+	watchTestEnv = "watch-env"
+)
+
+func watchTestPackage(status fv1.BuildStatus) *fv1.Package {
+	return &fv1.Package{
+		ObjectMeta: metav1.ObjectMeta{Name: watchTestPkg, Namespace: watchTestNS},
+		Spec: fv1.PackageSpec{
+			Environment: fv1.EnvironmentReference{Name: watchTestEnv, Namespace: watchTestNS},
+		},
+		Status: fv1.PackageStatus{BuildStatus: status},
+	}
+}
+
+func watchTestBuilderPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      watchTestEnv + "-1234-abc",
+			Namespace: watchTestNS,
+			Labels: map[string]string{
+				builderLabelOwner:   builderOwnerBuilderMgr,
+				builderLabelEnvName: watchTestEnv,
+			},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: fv1.BuilderContainerName}}},
+		Status: corev1.PodStatus{
+			ContainerStatuses: []corev1.ContainerStatus{{Name: fv1.BuilderContainerName, Ready: true}},
+		},
+	}
+}
+
+// setBuildStatus flips the package's build status (and optionally the build
+// log) through the fake clientset's status subresource, the way buildermgr
+// does.
+func setBuildStatus(t *testing.T, client cmd.Client, status fv1.BuildStatus, buildLog string) {
+	t.Helper()
+	pkg, err := client.FissionClientSet.CoreV1().Packages(watchTestNS).Get(t.Context(), watchTestPkg, metav1.GetOptions{})
+	require.NoError(t, err)
+	pkg.Status.BuildStatus = status
+	pkg.Status.BuildLog = buildLog
+	_, err = client.FissionClientSet.CoreV1().Packages(watchTestNS).UpdateStatus(t.Context(), pkg, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func TestWatchPackageBuildSucceeds(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewSimpleClientset(watchTestPackage(fv1.BuildStatusPending)),
+			KubernetesClient: k8sfake.NewSimpleClientset(watchTestBuilderPod()),
+		}
+
+		go func() {
+			time.Sleep(2 * time.Second)
+			setBuildStatus(t, client, fv1.BuildStatusRunning, "")
+			time.Sleep(2 * time.Second)
+			setBuildStatus(t, client, fv1.BuildStatusSucceeded, "collecting deps\nbuild ok\n")
+		}()
+
+		var out bytes.Buffer
+		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
+		require.NoError(t, err)
+
+		got := out.String()
+		assert.Contains(t, got, "Waiting for package 'watch-pkg' build to start")
+		assert.Contains(t, got, "Package 'watch-pkg' build running")
+		// The live stream is plumbed through the fake pod-log endpoint, whose
+		// canned body is "fake logs" — content fidelity is integration-tested.
+		assert.Contains(t, got, "fake logs")
+		// The final report is the authoritative Status.BuildLog.
+		assert.Contains(t, got, "========= build log =========")
+		assert.Contains(t, got, "collecting deps\nbuild ok\n")
+		assert.Contains(t, got, "Package 'watch-pkg' build succeeded")
+	})
+}
+
+func TestWatchPackageBuildFails(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewSimpleClientset(watchTestPackage(fv1.BuildStatusPending)),
+			KubernetesClient: k8sfake.NewSimpleClientset(), // no builder pod at all: stream must degrade silently
+		}
+
+		go func() {
+			time.Sleep(2 * time.Second)
+			setBuildStatus(t, client, fv1.BuildStatusFailed, "error: no module named flask\n")
+		}()
+
+		var out bytes.Buffer
+		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "build failed")
+
+		got := out.String()
+		assert.Contains(t, got, "error: no module named flask")
+	})
+}
+
+func TestWatchPackageBuildNothingToBuild(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewSimpleClientset(watchTestPackage(fv1.BuildStatusNone)),
+			KubernetesClient: k8sfake.NewSimpleClientset(),
+		}
+
+		var out bytes.Buffer
+		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
+		require.NoError(t, err)
+		assert.Contains(t, out.String(), "has nothing to build")
+		assert.NotContains(t, out.String(), "========= build log =========")
+	})
+}
+
+func TestWatchPackageBuildTimesOut(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewSimpleClientset(watchTestPackage(fv1.BuildStatusPending)),
+			KubernetesClient: k8sfake.NewSimpleClientset(),
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+
+		var out bytes.Buffer
+		err := watchPackageBuild(ctx, client, &out, watchTestNS, watchTestPkg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "timed out")
+	})
+}
+
+func TestWatchPackageBuildPackageDeleted(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		client := cmd.Client{
+			FissionClientSet: fissionfake.NewSimpleClientset(watchTestPackage(fv1.BuildStatusPending)),
+			KubernetesClient: k8sfake.NewSimpleClientset(),
+		}
+
+		go func() {
+			time.Sleep(2 * time.Second)
+			err := client.FissionClientSet.CoreV1().Packages(watchTestNS).Delete(t.Context(), watchTestPkg, metav1.DeleteOptions{})
+			require.NoError(t, err)
+		}()
+
+		var out bytes.Buffer
+		err := watchPackageBuild(t.Context(), client, &out, watchTestNS, watchTestPkg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no longer exists")
+	})
+}
+
+func TestPickBuilderPod(t *testing.T) {
+	t.Parallel()
+
+	mkPod := func(name, rv string, ready bool, age time.Duration) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				CreationTimestamp: metav1.NewTime(time.Now().Add(-age)),
+				Labels: map[string]string{
+					builderLabelOwner:              builderOwnerBuilderMgr,
+					builderLabelEnvName:            watchTestEnv,
+					builderLabelEnvResourceVersion: rv,
+				},
+			},
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{{Ready: ready}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		pods  []corev1.Pod
+		envRV string
+		want  string // expected pod name, "" for nil
+	}{
+		{name: "empty list", pods: nil, envRV: "5", want: ""},
+		{
+			name: "ready beats newer non-ready",
+			pods: []corev1.Pod{
+				mkPod("young-notready", "5", false, time.Minute),
+				mkPod("old-ready", "5", true, time.Hour),
+			},
+			envRV: "5",
+			want:  "old-ready",
+		},
+		{
+			name: "current env generation beats stale",
+			pods: []corev1.Pod{
+				mkPod("stale-rv", "4", true, time.Hour),
+				mkPod("current-rv", "5", true, 2*time.Hour),
+			},
+			envRV: "5",
+			want:  "current-rv",
+		},
+		{
+			name: "newest wins on equal rank",
+			pods: []corev1.Pod{
+				mkPod("older", "5", true, time.Hour),
+				mkPod("newer", "5", true, time.Minute),
+			},
+			envRV: "5",
+			want:  "newer",
+		},
+		{
+			name: "unknown env RV falls back to newest ready",
+			pods: []corev1.Pod{
+				mkPod("older", "4", true, time.Hour),
+				mkPod("newer", "6", true, time.Minute),
+			},
+			envRV: "",
+			want:  "newer",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := pickBuilderPod(tc.pods, tc.envRV)
+			if tc.want == "" {
+				assert.Nil(t, got)
+				return
+			}
+			require.NotNil(t, got)
+			assert.Equal(t, tc.want, got.Name)
+		})
+	}
+}

--- a/pkg/fission-cli/cmd/package/command.go
+++ b/pkg/fission-cli/cmd/package/command.go
@@ -19,7 +19,7 @@ func Commands() *cobra.Command {
 		Required: []flag.Flag{flag.PkgEnvironment},
 		Optional: []flag.Flag{flag.PkgName, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
 			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgOCI, flag.PkgBuildCmd,
-			flag.SpecSave, flag.SpecDry},
+			flag.SpecSave, flag.SpecDry, flag.PkgWatch, flag.PkgWatchTimeout},
 	})
 
 	getSrcCmd := wrapper.SubCommand(&cobra.Command{
@@ -44,7 +44,8 @@ func Commands() *cobra.Command {
 	}, Update, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
 		Optional: []flag.Flag{flag.PkgEnvironment, flag.PkgCode, flag.PkgSrcArchive, flag.PkgDeployArchive,
-			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgOCI, flag.PkgBuildCmd, flag.PkgForce},
+			flag.PkgSrcChecksum, flag.PkgDeployChecksum, flag.PkgInsecure, flag.PkgOCI, flag.PkgBuildCmd, flag.PkgForce,
+			flag.PkgWatch, flag.PkgWatchTimeout},
 	})
 
 	deleteCmd := wrapper.SubCommand(&cobra.Command{
@@ -75,7 +76,7 @@ func Commands() *cobra.Command {
 		Short: "Rebuild a failed package",
 	}, Rebuild, flag.FlagSet{
 		Required: []flag.Flag{flag.PkgName},
-		Optional: []flag.Flag{},
+		Optional: []flag.Flag{flag.PkgWatch, flag.PkgWatchTimeout},
 	})
 
 	command := &cobra.Command{

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -49,9 +49,8 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		}
 	}
 
-	if input.Bool(flagkey.PkgWatch) && (input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry)) {
-		return fmt.Errorf("--%v cannot be combined with --%v or --%v: a spec file does not trigger a build",
-			flagkey.PkgWatch, flagkey.SpecSave, flagkey.SpecDry)
+	if err := ValidateWatchNotSpecMode(input); err != nil {
+		return err
 	}
 
 	envName := input.String(flagkey.PkgEnvironment)
@@ -147,6 +146,18 @@ func splitImageDigest(ref string) (image, digest string) {
 		return ref[:i], ref[i+1:]
 	}
 	return ref, ""
+}
+
+// ValidateWatchNotSpecMode rejects --watch combined with --spec-save or
+// --spec-dry: a spec file does not trigger a build, so there is nothing to
+// watch. Shared by `package create` and `fn create`, like
+// ValidateArchiveSources.
+func ValidateWatchNotSpecMode(input cli.Input) error {
+	if input.Bool(flagkey.PkgWatch) && (input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry)) {
+		return fmt.Errorf("--%v cannot be combined with --%v or --%v: a spec file does not trigger a build",
+			flagkey.PkgWatch, flagkey.SpecSave, flagkey.SpecDry)
+	}
+	return nil
 }
 
 func ValidateArchiveSources(code string, srcArchiveFiles, deployArchiveFiles []string, ociImage string) error {

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -193,7 +193,7 @@ func CreatePackage(input cli.Input, client cmd.Client, pkgName string, pkgNamesp
 		}
 	}
 
-	var pkgStatus fv1.BuildStatus = fv1.BuildStatusSucceeded
+	pkgStatus := fv1.BuildStatusSucceeded
 
 	if len(ociImage) > 0 {
 		// The OCI archive is built inline: no file globbing, zipping, or

--- a/pkg/fission-cli/cmd/package/create.go
+++ b/pkg/fission-cli/cmd/package/create.go
@@ -49,6 +49,11 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		}
 	}
 
+	if input.Bool(flagkey.PkgWatch) && (input.Bool(flagkey.SpecSave) || input.Bool(flagkey.SpecDry)) {
+		return fmt.Errorf("--%v cannot be combined with --%v or --%v: a spec file does not trigger a build",
+			flagkey.PkgWatch, flagkey.SpecSave, flagkey.SpecDry)
+	}
+
 	envName := input.String(flagkey.PkgEnvironment)
 
 	userProvidedNS, pkgNamespace, err := opts.GetResourceNamespace(input)
@@ -106,10 +111,16 @@ func (opts *CreateSubCommand) run(input cli.Input) error {
 		specFile = fmt.Sprintf("package-%s.yaml", pkgName)
 	}
 
-	_, err = CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName,
+	pkgMeta, err := CreatePackage(input, opts.Client(), pkgName, pkgNamespace, envName,
 		srcArchiveFiles, deployArchiveFiles, buildcmd, specDir, specFile, noZip, userProvidedNS, ociImage)
+	if err != nil {
+		return err
+	}
 
-	return err
+	if input.Bool(flagkey.PkgWatch) {
+		return WatchPackageBuild(input, opts.Client(), pkgMeta.Namespace, pkgMeta.Name)
+	}
+	return nil
 }
 
 // ValidateArchiveSources enforces that --oci is not combined with

--- a/pkg/fission-cli/cmd/package/package_test.go
+++ b/pkg/fission-cli/cmd/package/package_test.go
@@ -150,7 +150,7 @@ func TestUpdatePackageOCI(t *testing.T) {
 	assert.Empty(t, got.Spec.Deployment.URL, "the old deploy URL must be cleared")
 	assert.Empty(t, got.Spec.Deployment.Checksum.Sum, "the old checksum must be cleared")
 	assert.Equal(t, "http://storage/src.zip", got.Spec.Source.URL, "the source archive must survive")
-	assert.Equal(t, fv1.BuildStatus(fv1.BuildStatusNone), got.Status.BuildStatus,
+	assert.Equal(t, fv1.BuildStatusNone, got.Status.BuildStatus,
 		"a stale failed status must reset so the fetcher serves the OCI package")
 }
 

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -58,12 +58,10 @@ func (opts *RebuildSubCommand) run(input cli.Input) error {
 		return fmt.Errorf("update package status: %w", err)
 	}
 
+	fmt.Fprintf(input.Stdout(), "Retrying build for pkg %v\n", pkg.Name)
 	if input.Bool(flagkey.PkgWatch) {
-		fmt.Fprintf(input.Stdout(), "Retrying build for pkg %v\n", pkg.Name)
 		return WatchPackageBuild(input, opts.Client(), opts.namespace, opts.name)
 	}
-
-	fmt.Printf("Retrying build for pkg %v. Use \"fission pkg info --name %v\" to view status\n", pkg.Name, pkg.Name)
-
+	fmt.Fprintf(input.Stdout(), "Use \"fission pkg info --name %v\" to view status\n", pkg.Name)
 	return nil
 }

--- a/pkg/fission-cli/cmd/package/rebuild.go
+++ b/pkg/fission-cli/cmd/package/rebuild.go
@@ -58,6 +58,11 @@ func (opts *RebuildSubCommand) run(input cli.Input) error {
 		return fmt.Errorf("update package status: %w", err)
 	}
 
+	if input.Bool(flagkey.PkgWatch) {
+		fmt.Fprintf(input.Stdout(), "Retrying build for pkg %v\n", pkg.Name)
+		return WatchPackageBuild(input, opts.Client(), opts.namespace, opts.name)
+	}
+
 	fmt.Printf("Retrying build for pkg %v. Use \"fission pkg info --name %v\" to view status\n", pkg.Name, pkg.Name)
 
 	return nil

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -82,19 +82,28 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 	}
 
 	if input.Bool(flagkey.PkgWatch) {
-		// UpdatePackage sets BuildStatusPending synchronously (via UpdateStatus)
-		// whenever the update triggers a rebuild, so a fresh read reliably
-		// tells whether there is a build to watch.
+		// UpdatePackage sets BuildStatusPending synchronously (via
+		// UpdateStatus, which also stamps LastUpdateTimestamp) whenever the
+		// update triggers a rebuild. A fresh read that is still non-terminal
+		// obviously needs watching; a fresh read that is ALREADY terminal is
+		// only "nothing to watch" when the status timestamp did not move —
+		// an advanced timestamp means this update did trigger a build and
+		// buildermgr merely finished (or failed) it before our read, so the
+		// watch must still run to report the outcome and set the exit code.
 		fresh, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.pkgNamespace).Get(input.Context(), newPkgMeta.Name, metav1.GetOptions{})
 		if err != nil {
 			return fmt.Errorf("error getting package after update: %w", err)
 		}
+		buildTriggered := !fresh.Status.LastUpdateTimestamp.Equal(&pkg.Status.LastUpdateTimestamp)
 		switch fresh.Status.BuildStatus {
 		case "", fv1.BuildStatusPending, fv1.BuildStatusRunning:
-			return WatchPackageBuild(input, opts.Client(), fresh.Namespace, fresh.Name)
-		default:
-			fmt.Fprintf(input.Stdout(), "Update of package '%v' did not trigger a build; nothing to watch\n", fresh.Name)
+			buildTriggered = true
 		}
+		if !buildTriggered {
+			fmt.Fprintf(input.Stdout(), "Update of package '%v' did not trigger a build; nothing to watch\n", fresh.Name)
+			return nil
+		}
+		return WatchPackageBuild(input, opts.Client(), fresh.Namespace, fresh.Name)
 	}
 
 	return nil

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -81,6 +81,22 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		}
 	}
 
+	if input.Bool(flagkey.PkgWatch) {
+		// UpdatePackage sets BuildStatusPending synchronously (via UpdateStatus)
+		// whenever the update triggers a rebuild, so a fresh read reliably
+		// tells whether there is a build to watch.
+		fresh, err := opts.Client().FissionClientSet.CoreV1().Packages(opts.pkgNamespace).Get(input.Context(), newPkgMeta.Name, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("error getting package after update: %w", err)
+		}
+		switch fresh.Status.BuildStatus {
+		case "", fv1.BuildStatusPending, fv1.BuildStatusRunning:
+			return WatchPackageBuild(input, opts.Client(), fresh.Namespace, fresh.Name)
+		default:
+			fmt.Fprintf(input.Stdout(), "Update of package '%v' did not trigger a build; nothing to watch\n", fresh.Name)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/fission-cli/cmd/package/update.go
+++ b/pkg/fission-cli/cmd/package/update.go
@@ -94,11 +94,8 @@ func (opts *UpdateSubCommand) run(input cli.Input) error {
 		if err != nil {
 			return fmt.Errorf("error getting package after update: %w", err)
 		}
-		buildTriggered := !fresh.Status.LastUpdateTimestamp.Equal(&pkg.Status.LastUpdateTimestamp)
-		switch fresh.Status.BuildStatus {
-		case "", fv1.BuildStatusPending, fv1.BuildStatusRunning:
-			buildTriggered = true
-		}
+		buildTriggered := IsBuildInFlight(fresh.Status.BuildStatus) ||
+			!fresh.Status.LastUpdateTimestamp.Equal(&pkg.Status.LastUpdateTimestamp)
 		if !buildTriggered {
 			fmt.Fprintf(input.Stdout(), "Update of package '%v' did not trigger a build; nothing to watch\n", fresh.Name)
 			return nil

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -318,6 +318,11 @@ var (
 	PkgSrcChecksum    = Flag{Type: String, Name: flagkey.PkgSrcChecksum, Usage: "SHA256 checksum of source archive when providing URL"}
 	PkgInsecure       = Flag{Type: Bool, Name: flagkey.PkgInsecure, Usage: "Skip generating SHA256 checksum for file integrity validation"}
 	PkgOCI            = Flag{Type: String, Name: flagkey.PkgOCI, Usage: "Pre-built OCI image reference containing the deployment code (registry/repo:tag[@digest])"}
+	PkgWatch          = Flag{Type: Bool, Name: flagkey.PkgWatch, Short: "w", Aliases: []string{"follow"}, Usage: "Wait for the package build to finish, streaming builder logs while it runs; exits non-zero if the build fails"}
+	// PkgWatchTimeout shares --timeout's key but defaults to 0 (wait
+	// indefinitely, like `kubectl logs -f`) instead of WaitTimeout's 60s —
+	// a build has no natural upper bound.
+	PkgWatchTimeout = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: time.Duration(0), Usage: "Maximum time to wait for the build with --watch; 0 waits indefinitely"}
 
 	SpecSave             = Flag{Type: Bool, Name: flagkey.SpecSave, Usage: "Save to the spec directory instead of creating on cluster"}
 	SpecDir              = Flag{Type: String, Name: flagkey.SpecDir, Usage: "Directory to store specs, defaults to ./specs"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -321,7 +321,8 @@ var (
 	PkgWatch          = Flag{Type: Bool, Name: flagkey.PkgWatch, Short: "w", Aliases: []string{"follow"}, Usage: "Wait for the package build to finish, streaming builder logs while it runs; exits non-zero if the build fails"}
 	// PkgWatchTimeout shares --timeout's key but defaults to 0 (wait
 	// indefinitely, like `kubectl logs -f`) instead of WaitTimeout's 60s —
-	// a build has no natural upper bound.
+	// a build has no natural upper bound. Never list it in the same
+	// command's flag set as WaitTimeout: they register the same pflag name.
 	PkgWatchTimeout = Flag{Type: Duration, Name: flagkey.WaitTimeout, DefaultValue: time.Duration(0), Usage: "Maximum time to wait for the build with --watch; 0 waits indefinitely"}
 
 	SpecSave             = Flag{Type: Bool, Name: flagkey.SpecSave, Usage: "Save to the spec directory instead of creating on cluster"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -247,6 +247,7 @@ const (
 	PkgOutput         = Output
 	PkgStatus         = "status"
 	PkgOrphan         = "orphan"
+	PkgWatch          = "watch"
 
 	SpecSave             = "spec"
 	SpecDir              = "specdir"

--- a/pkg/fission-cli/logdb/kubernetes_log.go
+++ b/pkg/fission-cli/logdb/kubernetes_log.go
@@ -135,7 +135,7 @@ func (k kubernetesLogs) StreamLogs(ctx context.Context, filter LogFilter, out io
 	if err != nil {
 		return err
 	}
-	lw := &lockedWriter{w: out}
+	lw := NewLockedWriter(out)
 	multi := len(pods) > 1
 	g, gctx := errgroup.WithContext(ctx)
 	for i := range pods {
@@ -201,14 +201,17 @@ func followContainer(ctx context.Context, kc kubernetes.Interface, ns, podName, 
 	}
 }
 
-// lockedWriter serializes concurrent writes from multiple pod-log streams onto
-// one writer, so whole lines from different pods don't interleave mid-line.
-type lockedWriter struct {
+// LockedWriter serializes concurrent writes from multiple pod-log streams onto
+// one writer, so whole lines from different streams don't interleave mid-line.
+// Exported: the package build watch (cmd/package) shares it for the same job.
+type LockedWriter struct {
 	mu sync.Mutex
 	w  io.Writer
 }
 
-func (l *lockedWriter) Write(p []byte) (int, error) {
+func NewLockedWriter(w io.Writer) *LockedWriter { return &LockedWriter{w: w} }
+
+func (l *LockedWriter) Write(p []byte) (int, error) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.w.Write(p)

--- a/test/integration/suites/common/package_watch_test.go
+++ b/test/integration/suites/common/package_watch_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestPackageBuildWatch exercises `fission package create/update/rebuild
+// --watch` (issue #3676): the CLI blocks until the build reaches a terminal
+// state, streams the builder pod's live output while it runs, prints the
+// final Status.BuildLog as the authoritative record, and exits non-zero when
+// the build fails.
+func TestPackageBuildWatch(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	runtime := f.Images().RequirePython(t)
+	builder := f.Images().RequirePythonBuilder(t)
+
+	ns := f.NewTestNamespace(t)
+	envName := "python-pkgwatch-" + ns.ID
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: runtime, Builder: builder})
+	ns.WaitForBuilderReady(t, ctx, envName)
+
+	zipPath := framework.ZipTestDataDir(t, "python/sourcepkg", "watch-src-pkg.zip")
+
+	// Warm-up build: the very first build against a fresh env can fail with
+	// the transient kube-proxy dial timeout (see waitForPackageBuildStatus),
+	// which that helper retries. Doing one ordinary build first means the
+	// --watch subtests below observe real build outcomes, not infra races.
+	warmupPkg := "pkg-watch-warmup-" + ns.ID
+	ns.CreatePackage(t, ctx, framework.PackageOptions{
+		Name: warmupPkg, Env: envName, Src: zipPath, BuildCmd: "./build.sh",
+	})
+	ns.WaitForPackageBuildSucceeded(t, ctx, warmupPkg)
+
+	// Packages created through raw CLI calls (rather than ns.CreatePackage)
+	// need their own cleanup registration.
+	deletePkgOnCleanup := func(t *testing.T, name string) {
+		t.Cleanup(func() {
+			err := f.FissionClient().CoreV1().Packages(ns.Name).Delete(context.Background(), name, metav1.DeleteOptions{})
+			if err != nil && !apierrors.IsNotFound(err) {
+				t.Logf("cleanup package %s: %v", name, err)
+			}
+		})
+	}
+
+	t.Run("create_watch_success", func(t *testing.T) {
+		pkgName := "pkg-watch-ok-" + ns.ID
+		deletePkgOnCleanup(t, pkgName)
+		out := ns.CLI(t, ctx, "package", "create", "--name", pkgName, "--env", envName,
+			"--src", zipPath, "--buildcmd", "./build.sh", "--watch")
+
+		// The builder container prints its START/END markers to stdout only —
+		// they never land in Status.BuildLog — so seeing one proves the live
+		// stream from the builder pod worked, not just the final log print.
+		assert.Contains(t, out, "========= START =========")
+		// The final report is the authoritative Status.BuildLog.
+		assert.Contains(t, out, "========= build log =========")
+		assert.Contains(t, out, "Package '"+pkgName+"' build succeeded")
+
+		pkg := ns.GetPackage(t, ctx, pkgName)
+		assert.Equal(t, fv1.BuildStatusSucceeded, pkg.Status.BuildStatus)
+	})
+
+	t.Run("failed_build_exit_code_and_recovery", func(t *testing.T) {
+		pkgName := "pkg-watch-bad-" + ns.ID
+		deletePkgOnCleanup(t, pkgName)
+
+		// A build command that cannot exist: the build must fail, the final
+		// build log must be shown, and the CLI must exit non-zero — the
+		// contract PR #2643 never had.
+		out, err := ns.CLIExpectError(t, ctx, "package", "create", "--name", pkgName, "--env", envName,
+			"--src", zipPath, "--buildcmd", "./no-such-build-script.sh", "--watch")
+		require.ErrorContains(t, err, "build failed")
+		assert.Contains(t, out, "========= build log =========")
+
+		// rebuild --watch re-runs the same (still broken) build and again
+		// exits non-zero at its terminal state.
+		out, err = ns.CLIExpectError(t, ctx, "package", "rebuild", "--name", pkgName, "--watch")
+		require.ErrorContains(t, err, "build failed")
+		assert.Contains(t, out, "========= build log =========")
+
+		// update --watch with a corrected build command follows the rebuild
+		// to success.
+		out = ns.CLI(t, ctx, "package", "update", "--name", pkgName,
+			"--buildcmd", "./build.sh", "--watch")
+		assert.Contains(t, out, "Package '"+pkgName+"' build succeeded")
+		pkg := ns.GetPackage(t, ctx, pkgName)
+		assert.Equal(t, fv1.BuildStatusSucceeded, pkg.Status.BuildStatus)
+	})
+
+	t.Run("update_without_rebuild_has_nothing_to_watch", func(t *testing.T) {
+		out := ns.CLI(t, ctx, "package", "update", "--name", warmupPkg, "--watch")
+		assert.Contains(t, out, "did not trigger a build; nothing to watch")
+	})
+
+	t.Run("watch_refuses_spec_mode", func(t *testing.T) {
+		_, err := ns.CLIExpectError(t, ctx, "package", "create", "--name", "pkg-watch-spec-"+ns.ID,
+			"--env", envName, "--src", zipPath, "--dry", "--watch")
+		require.ErrorContains(t, err, "cannot be combined")
+	})
+}

--- a/test/integration/suites/common/package_watch_test.go
+++ b/test/integration/suites/common/package_watch_test.go
@@ -28,7 +28,7 @@ import (
 func TestPackageBuildWatch(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)
@@ -73,6 +73,11 @@ func TestPackageBuildWatch(t *testing.T) {
 		// The builder container prints its START/END markers to stdout only —
 		// they never land in Status.BuildLog — so seeing one proves the live
 		// stream from the builder pod worked, not just the final log print.
+		// This is safe to assert even though streaming is best-effort:
+		// SinceTime is captured at watch start, so a stream that attaches
+		// late still receives every line logged since then; the marker could
+		// only be missed if the whole build finished within the first ~1s
+		// poll, and a pip build (fetch + install + archive + upload) cannot.
 		assert.Contains(t, out, "========= START =========")
 		// The final report is the authoritative Status.BuildLog.
 		assert.Contains(t, out, "========= build log =========")


### PR DESCRIPTION
Closes #3676.

## TL;DR

`fission package create/update/rebuild --watch` (and `fn create --watch`) now block until the package build reaches a terminal state, stream the environment builder pod's live output while it runs, print the final `Status.BuildLog` as the authoritative record, and exit non-zero when the build fails. `--timeout` (default 0 = wait indefinitely, `kubectl logs -f` semantics) bounds the wait; `--watch` is rejected in `--spec-save`/`--spec-dry` mode since a spec file triggers no build.

## Design

Watching is two decoupled halves:

- **The guarantee is the status poll.** It decides completion, prints the final `Status.BuildLog`, and sets the exit code. It fails fast on a builder-less environment (`fv1.Environment.HasBuilder`, the same predicate buildermgr uses), surfaces persistent API errors after 5 consecutive failures, and treats a deleted package as terminal.
- **Live streaming is best-effort decoration.** The builder pod is found by the `owner=buildermgr,envName=<env>` labels (shared `fv1.BuilderLabel*` constants, aliased by buildermgr); pod lookup or log-follow failures silently degrade to "wait and print the final log", never to a hang or a spurious command failure. `SinceTime` advances across reconnects so nothing is re-dumped.

This closes every structural flaw of the abandoned `--streamlog` attempt (#2643): logs come from the env's builder pod rather than the buildermgr pod, no namespace is hardcoded (env namespace first; the cluster-wide fallback applies only to `default`-namespace envs — the only ones `GetBuilderNS` remaps — and requires an `envResourceVersion` label match so a same-named env elsewhere can't be picked), termination is the package's terminal build status rather than `Follow` forever, and an empty pod list is a retry, not a panic.

Gate subtleties: `pkg update --watch` distinguishes "no rebuild triggered" from "the triggered build finished before my read" via the status timestamp, so a fast-failing rebuild still exits non-zero; `fn create --pkg <existing> --watch` attaches only to a build already in flight instead of replaying stale history.

## Review order

1. `pkg/fission-cli/cmd/package/buildwatch.go` — the whole mechanism (status poll + streaming + pod selection).
2. `pkg/fission-cli/cmd/package/{create,update,rebuild}.go`, `pkg/fission-cli/cmd/function/create.go` — command wiring and watch gates.
3. `pkg/apis/core/v1/{const,types}.go`, `pkg/buildermgr/environment_reconciler.go`, `pkg/fission-cli/logdb/kubernetes_log.go` — shared constants/predicate/writer extractions (no behavior change server-side).
4. `pkg/fission-cli/flag/*` — `--watch`/`-w`/`--follow` and the 0-default `--timeout` variant.
5. Tests: `buildwatch_test.go` (synctest, fake clientsets: success/failure/none/timeout/deleted/persistent-API-error/builder-less paths, pod ranking) and `test/integration/suites/common/package_watch_test.go` (real builds: live-stream marker, failed-build exit code, rebuild/update recovery, no-rebuild update, spec-mode rejection).

## Risk

CLI-only; the only non-CLI edits are constant/predicate extractions that buildermgr aliases (byte-identical values, covered by existing buildermgr tests). Commands without `--watch` behave as before, except `pkg rebuild`'s status line now goes through the command's stdout writer.
