### PR TITLE
router: count sticky-pick teleports per key-hash bucket

### DIFF
--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -125,6 +125,15 @@ type (
 		// eps is the merged endpoint list, swapped copy-on-write. Hot-path
 		// readers load it without taking mu.
 		eps atomic.Pointer[[]Endpoint]
+		// stickyLast remembers, per sticky-key-hash bucket, a hash of the last
+		// admitted endpoint address, so Admit can count sticky-pick CHANGES
+		// ("teleports") with O(buckets) memory instead of per-key state.
+		// Lazily allocated on the first sticky admit; nil for the (common)
+		// functions that never see a sticky key. Best-effort: two keys sharing
+		// a bucket on different pods alternate-count forever — accepted, the
+		// counter is an approximation (see
+		// fission_router_sticky_teleports_total in metrics.go).
+		stickyLast atomic.Pointer[[stickyBuckets]atomic.Uint64]
 	}
 )
 
@@ -461,6 +470,31 @@ func hrwScore(key, address string) uint64 {
 	return h
 }
 
+// stickyBuckets sizes fnEntry.stickyLast: 256 buckets keeps the per-function
+// memory at 2KiB while making same-bucket key collisions rare enough that the
+// teleport counter tracks real churn, not collision noise.
+const stickyBuckets = 256
+
+// noteStickyPick records the admitted address for the sticky key's bucket and
+// reports whether the bucket's pick changed (a "teleport"). First-ever picks
+// are not teleports. Address hashing reuses hrwScore with an empty key, so no
+// second hash implementation exists to drift.
+func noteStickyPick(e *fnEntry, stickyKey, address string) bool {
+	buckets := e.stickyLast.Load()
+	if buckets == nil {
+		e.stickyLast.CompareAndSwap(nil, &[stickyBuckets]atomic.Uint64{})
+		buckets = e.stickyLast.Load()
+	}
+	// Inline FNV-1a 32 of the key (mirrors shard()): bucket index.
+	h := uint32(2166136261)
+	for i := 0; i < len(stickyKey); i++ {
+		h = (h ^ uint32(stickyKey[i])) * 16777619
+	}
+	addrHash := hrwScore("", address)
+	old := buckets[h%stickyBuckets].Swap(addrHash)
+	return old != 0 && old != addrHash
+}
+
 // Admit picks a ready, non-quarantined endpoint with free capacity (below
 // requestsPerPod), increments its in-flight counter, and returns it with a
 // release func that the caller MUST invoke when the request completes
@@ -555,6 +589,9 @@ func (ix *Index) Admit(namespace, name, version string, requestsPerPod int, stic
 			}
 		}
 		if best.inflight.CompareAndSwap(bestLoad, bestLoad+1) {
+			if stickyKey != "" && noteStickyPick(e, stickyKey, best.Address) {
+				RecordStickyTeleport(key.Namespace, key.Name)
+			}
 			counter := best.inflight
 			var once sync.Once
 			release := func() { once.Do(func() { counter.Add(-1) }) }

--- a/pkg/router/endpointcache/index.go
+++ b/pkg/router/endpointcache/index.go
@@ -125,14 +125,11 @@ type (
 		// eps is the merged endpoint list, swapped copy-on-write. Hot-path
 		// readers load it without taking mu.
 		eps atomic.Pointer[[]Endpoint]
-		// stickyLast remembers, per sticky-key-hash bucket, a hash of the last
-		// admitted endpoint address, so Admit can count sticky-pick CHANGES
-		// ("teleports") with O(buckets) memory instead of per-key state.
-		// Lazily allocated on the first sticky admit; nil for the (common)
-		// functions that never see a sticky key. Best-effort: two keys sharing
-		// a bucket on different pods alternate-count forever — accepted, the
-		// counter is an approximation (see
-		// fission_router_sticky_teleports_total in metrics.go).
+		// stickyLast is the sticky teleport-detection sketch: per key-hash
+		// bucket, the last owner pick as (key fingerprint << 32 | address
+		// hash). O(buckets) memory instead of per-key state; lazily allocated
+		// on the first sticky admit, nil for the (common) functions that
+		// never see a sticky key. Counting semantics live in noteStickyPick.
 		stickyLast atomic.Pointer[[stickyBuckets]atomic.Uint64]
 	}
 )
@@ -146,21 +143,26 @@ func NewIndex() *Index {
 	return ix
 }
 
+// fnv1a32 is the 32-bit FNV-1a of s; fnv1a32Add continues an in-progress
+// hash (shard() feeds multiple segments through it). Plain functions over a
+// string instead of hash.Hash32 via fnv.New32a, which would heap-allocate on
+// every call of these per-request paths. Shared by shard() and
+// noteStickyPick so a checksum-sensitive algorithm exists exactly once.
+func fnv1a32(s string) uint32 { return fnv1a32Add(2166136261, s) }
+
+func fnv1a32Add(h uint32, s string) uint32 {
+	for i := 0; i < len(s); i++ {
+		h = (h ^ uint32(s[i])) * 16777619
+	}
+	return h
+}
+
 func (ix *Index) shard(key FnKey) *indexShard {
-	// Inline FNV-1a over the key strings: hash.Hash32 via fnv.New32a would
-	// heap-allocate on every call of this per-request path.
-	h := uint32(2166136261)
-	for i := 0; i < len(key.Namespace); i++ {
-		h = (h ^ uint32(key.Namespace[i])) * 16777619
-	}
+	h := fnv1a32(key.Namespace)
+	h = (h ^ uint32('/')) * 16777619 // one FNV-1a step for the separator byte
+	h = fnv1a32Add(h, key.Name)
 	h = (h ^ uint32('/')) * 16777619
-	for i := 0; i < len(key.Name); i++ {
-		h = (h ^ uint32(key.Name[i])) * 16777619
-	}
-	h = (h ^ uint32('/')) * 16777619
-	for i := 0; i < len(key.Version); i++ {
-		h = (h ^ uint32(key.Version[i])) * 16777619
-	}
+	h = fnv1a32Add(h, key.Version)
 	return &ix.shards[h%shardCount]
 }
 
@@ -470,29 +472,41 @@ func hrwScore(key, address string) uint64 {
 	return h
 }
 
-// stickyBuckets sizes fnEntry.stickyLast: 256 buckets keeps the per-function
-// memory at 2KiB while making same-bucket key collisions rare enough that the
-// teleport counter tracks real churn, not collision noise.
+// stickyBuckets sizes fnEntry.stickyLast: 256 buckets is 2KiB per
+// sticky-using function. The size trades coverage, not accuracy — keys
+// sharing a bucket suppress each other's counting (see noteStickyPick).
 const stickyBuckets = 256
 
 // noteStickyPick records the admitted address for the sticky key's bucket and
-// reports whether the bucket's pick changed (a "teleport"). First-ever picks
-// are not teleports. Address hashing reuses hrwScore with an empty key, so no
-// second hash implementation exists to drift.
+// reports whether THIS key's pick changed (a "teleport"). The bucket stores
+// (key fingerprint << 32 | address hash): a bucket last written by a
+// different key (fingerprint mismatch) or never written reports false, so
+// bucket contention between keys UNDERcounts instead of fabricating
+// teleports from interleaved overwrites. The residual failure odds are two
+// keys colliding in both bucket index AND 32-bit fingerprint — negligible
+// against the churn rates this counter observes.
 func noteStickyPick(e *fnEntry, stickyKey, address string) bool {
 	buckets := e.stickyLast.Load()
 	if buckets == nil {
 		e.stickyLast.CompareAndSwap(nil, &[stickyBuckets]atomic.Uint64{})
 		buckets = e.stickyLast.Load()
 	}
-	// Inline FNV-1a 32 of the key (mirrors shard()): bucket index.
-	h := uint32(2166136261)
-	for i := 0; i < len(stickyKey); i++ {
-		h = (h ^ uint32(stickyKey[i])) * 16777619
+	kh := fnv1a32(stickyKey)
+	packed := uint64(kh)<<32 | uint64(fnv1a32(address))
+	b := &buckets[kh%stickyBuckets]
+	old := b.Load()
+	if old == packed {
+		// Steady state (same key, same owner): a read, not an atomic RMW, so
+		// the hot path doesn't write-invalidate the shared cache line on
+		// every sticky admit.
+		return false
 	}
-	addrHash := hrwScore("", address)
-	old := buckets[h%stickyBuckets].Swap(addrHash)
-	return old != 0 && old != addrHash
+	if !b.CompareAndSwap(old, packed) {
+		// A concurrent admit updated the bucket first; that admit owns the
+		// count — reporting true here too would double-count one move.
+		return false
+	}
+	return old != 0 && uint32(old>>32) == kh
 }
 
 // Admit picks a ready, non-quarantined endpoint with free capacity (below
@@ -550,6 +564,14 @@ func (ix *Index) Admit(namespace, name, version string, requestsPerPod int, stic
 		var best *Endpoint
 		var bestLoad int64
 		var bestScore uint64
+		// ownerAddr is the sticky key's true HRW winner among ready,
+		// non-quarantined endpoints INCLUDING saturated ones (an address is
+		// never "", so "" doubles as the unset sentinel). The teleport
+		// accounting below records a pick only when the admitted endpoint IS
+		// the owner, so a busy-owner overflow (and the later snap-back) is
+		// load shedding, not a counted teleport.
+		var ownerAddr string
+		var ownerScore uint64
 		counted, quarantinedN, busy := 0, 0, 0
 		for i := range *epsp {
 			ep := &(*epsp)[i]
@@ -564,17 +586,22 @@ func (ix *Index) Admit(namespace, name, version string, requestsPerPod int, stic
 				}
 			}
 			load := ep.inflight.Load()
+			var score uint64
+			if stickyKey != "" {
+				score = hrwScore(stickyKey, ep.Address)
+				if ownerAddr == "" || score > ownerScore {
+					ownerAddr, ownerScore = ep.Address, score
+				}
+			}
 			if load >= int64(requestsPerPod) {
 				busy++
 				continue
 			}
 			if stickyKey != "" {
-				if score := hrwScore(stickyKey, ep.Address); best == nil || score > bestScore {
+				if best == nil || score > bestScore {
 					best, bestLoad, bestScore = ep, load, score
 				}
-				continue
-			}
-			if best == nil || load < bestLoad {
+			} else if best == nil || load < bestLoad {
 				best, bestLoad = ep, load
 			}
 		}
@@ -589,8 +616,10 @@ func (ix *Index) Admit(namespace, name, version string, requestsPerPod int, stic
 			}
 		}
 		if best.inflight.CompareAndSwap(bestLoad, bestLoad+1) {
-			if stickyKey != "" && noteStickyPick(e, stickyKey, best.Address) {
-				RecordStickyTeleport(key.Namespace, key.Name)
+			// Overflow picks (admitted != HRW owner) leave the bucket
+			// untouched: neither the detour nor the return counts.
+			if stickyKey != "" && best.Address == ownerAddr && noteStickyPick(e, stickyKey, best.Address) {
+				RecordStickyTeleport(key.Namespace, key.Name, key.Version)
 			}
 			counter := best.inflight
 			var once sync.Once

--- a/pkg/router/endpointcache/metrics.go
+++ b/pkg/router/endpointcache/metrics.go
@@ -66,14 +66,17 @@ var (
 		"fission_router_endpointcache_fallbacks_total",
 		"Warm-path requests routed to the executor instead of the endpoint index, by reason.",
 	)
-	// stickyTeleports counts sticky-keyed admits whose key-hash bucket picked
-	// a different endpoint than its previous admit — the "teleports/sec" an
-	// operator watches during pod churn. Best-effort bucketed approximation
-	// (256 buckets per function): distinct keys sharing a bucket on different
-	// pods overcount; do not read it as exact per-key ownership moves.
+	// stickyTeleports counts sticky admits where the key's HRW owner changed
+	// since the key's last owner-served admit — the "teleports/sec" an
+	// operator watches during pod churn. Best-effort, biased to UNDERcount:
+	// bucket contention between keys suppresses counting (fingerprint guard,
+	// see noteStickyPick), saturation overflow to a non-owner pod is load
+	// shedding and not counted, and only warm-path index admits are observed
+	// — requests served via the executor fallback (e.g. a mass-quarantine
+	// episode) record nothing until warm admits resume.
 	stickyTeleports = metrics.Int64Counter(
 		"fission_router_sticky_teleports_total",
-		"Sticky-keyed admits whose key-hash bucket changed endpoints since its last admit (best-effort bucketed approximation).",
+		"Sticky admits whose key moved to a different HRW-owner endpoint since the key's last owner-served admit (best-effort, undercounts under bucket contention; overflow and executor-fallback traffic not observed).",
 	)
 	// modeInfo is the always-1 info gauge whose labels carry the requested and
 	// effective cache modes (see RegisterModeInfo).
@@ -103,13 +106,17 @@ func RecordQuarantine() { quarantines.Add(context.Background(), 1) }
 // RecordDialTimeoutStrike counts one soft (timeout) dial-failure strike.
 func RecordDialTimeoutStrike() { dialTimeoutStrikes.Add(context.Background(), 1) }
 
-// RecordStickyTeleport counts one sticky-pick change for a function. Teleports
-// are churn-driven and rare, so the attribute set is built inline rather than
-// cached like the per-request paths.
-func RecordStickyTeleport(namespace, name string) {
+// RecordStickyTeleport counts one sticky-pick change for a function's warm
+// pool. version is the RFC-0025 warm-pool selector ("" for the unversioned
+// pool) — empty surfaces as an absent label on the Prometheus bridge, so
+// unversioned series are unchanged, and a canary's versioned-pool churn stays
+// attributable. Teleports are churn-driven and rare, so the attribute set is
+// built inline rather than cached like the per-request paths.
+func RecordStickyTeleport(namespace, name, version string) {
 	stickyTeleports.Add(context.Background(), 1, metric.WithAttributes(
 		attribute.String("function_namespace", namespace),
 		attribute.String("function_name", name),
+		attribute.String("function_version", version),
 	))
 }
 

--- a/pkg/router/endpointcache/metrics.go
+++ b/pkg/router/endpointcache/metrics.go
@@ -66,6 +66,15 @@ var (
 		"fission_router_endpointcache_fallbacks_total",
 		"Warm-path requests routed to the executor instead of the endpoint index, by reason.",
 	)
+	// stickyTeleports counts sticky-keyed admits whose key-hash bucket picked
+	// a different endpoint than its previous admit — the "teleports/sec" an
+	// operator watches during pod churn. Best-effort bucketed approximation
+	// (256 buckets per function): distinct keys sharing a bucket on different
+	// pods overcount; do not read it as exact per-key ownership moves.
+	stickyTeleports = metrics.Int64Counter(
+		"fission_router_sticky_teleports_total",
+		"Sticky-keyed admits whose key-hash bucket changed endpoints since its last admit (best-effort bucketed approximation).",
+	)
 	// modeInfo is the always-1 info gauge whose labels carry the requested and
 	// effective cache modes (see RegisterModeInfo).
 	modeInfo = metrics.Int64Gauge(
@@ -93,6 +102,16 @@ func RecordQuarantine() { quarantines.Add(context.Background(), 1) }
 
 // RecordDialTimeoutStrike counts one soft (timeout) dial-failure strike.
 func RecordDialTimeoutStrike() { dialTimeoutStrikes.Add(context.Background(), 1) }
+
+// RecordStickyTeleport counts one sticky-pick change for a function. Teleports
+// are churn-driven and rare, so the attribute set is built inline rather than
+// cached like the per-request paths.
+func RecordStickyTeleport(namespace, name string) {
+	stickyTeleports.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("function_namespace", namespace),
+		attribute.String("function_name", name),
+	))
+}
 
 // RegisterModeInfo publishes the constant info gauge exposing the requested and
 // effective endpointslice cache modes. Recorded for EVERY mode (including off)

--- a/pkg/router/endpointcache/sticky_test.go
+++ b/pkg/router/endpointcache/sticky_test.go
@@ -232,6 +232,56 @@ func TestStickySaturationOverflow(t *testing.T) {
 	release3()
 }
 
+// TestNoteStickyPick pins the bucketed teleport detector: the first pick for
+// a bucket is never a teleport, a repeat pick is not, and a changed pick is.
+// Collision inflation (two keys sharing a bucket on different pods) is
+// accepted by design — the metric is a best-effort approximation.
+func TestNoteStickyPick(t *testing.T) {
+	t.Parallel()
+	e := &fnEntry{}
+
+	assert.False(t, noteStickyPick(e, "session-1", "10.0.0.1:8888"), "first pick is not a teleport")
+	assert.False(t, noteStickyPick(e, "session-1", "10.0.0.1:8888"), "repeat pick is not a teleport")
+	assert.True(t, noteStickyPick(e, "session-1", "10.0.0.2:8888"), "changed pick is a teleport")
+	assert.False(t, noteStickyPick(e, "session-1", "10.0.0.2:8888"), "sticky again after the move")
+}
+
+// TestAdmitStickyTeleportOnEndpointLoss drives the detector through Admit:
+// removing the sticky winner moves the key to the survivor, which must
+// register as a pick change in the fnEntry's bucket state.
+func TestAdmitStickyTeleportOnEndpointLoss(t *testing.T) {
+	t.Parallel()
+	ix := NewIndex()
+	ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1", "10.0.0.2"))
+
+	const key = "session-teleport"
+	ep1, release1, res := ix.Admit("default", "fn-a", "", 1, key)
+	require.Equal(t, Admitted, res)
+	release1()
+
+	fk := FnKey{Namespace: "default", Name: "fn-a"}
+	e := ix.shard(fk).m[fk]
+	require.NotNil(t, e)
+	assert.False(t, noteStickyPick(e, key, ep1.Address),
+		"Admit must have recorded its pick: re-noting the same address is not a teleport")
+
+	// Drop the winner: the key's next admit lands on the survivor and must
+	// register as exactly one pick change in the bucket state.
+	survivor := "10.0.0.1"
+	if ep1.Address == "10.0.0.1:8888" {
+		survivor = "10.0.0.2"
+	}
+	ix.ApplySlice(slice("s1", "fn-a", "default", 8888, survivor))
+	ep2, release2, res := ix.Admit("default", "fn-a", "", 1, key)
+	require.Equal(t, Admitted, res)
+	release2()
+	require.NotEqual(t, ep1.Address, ep2.Address)
+	assert.False(t, noteStickyPick(e, key, ep2.Address),
+		"Admit after the move must have stored the new pick")
+	assert.True(t, noteStickyPick(e, key, ep1.Address),
+		"moving back to the old address is again a change")
+}
+
 // TestStickyEmptyKeyKeepsLeastOutstanding: no key = today's pick, bit for bit.
 func TestStickyEmptyKeyKeepsLeastOutstanding(t *testing.T) {
 	t.Parallel()

--- a/pkg/router/endpointcache/sticky_test.go
+++ b/pkg/router/endpointcache/sticky_test.go
@@ -10,9 +10,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
+
+	"github.com/fission/fission/pkg/utils/metrics/metricstest"
 )
 
 // RFC-0023 phase-3 sticky-pick properties. S4: the pick is a pure function
@@ -233,9 +236,9 @@ func TestStickySaturationOverflow(t *testing.T) {
 }
 
 // TestNoteStickyPick pins the bucketed teleport detector: the first pick for
-// a bucket is never a teleport, a repeat pick is not, and a changed pick is.
-// Collision inflation (two keys sharing a bucket on different pods) is
-// accepted by design — the metric is a best-effort approximation.
+// a key is never a teleport, a repeat pick is not, a changed pick is, and
+// bucket contention with a DIFFERENT key suppresses counting (undercount)
+// instead of fabricating teleports from interleaved overwrites.
 func TestNoteStickyPick(t *testing.T) {
 	t.Parallel()
 	e := &fnEntry{}
@@ -244,42 +247,87 @@ func TestNoteStickyPick(t *testing.T) {
 	assert.False(t, noteStickyPick(e, "session-1", "10.0.0.1:8888"), "repeat pick is not a teleport")
 	assert.True(t, noteStickyPick(e, "session-1", "10.0.0.2:8888"), "changed pick is a teleport")
 	assert.False(t, noteStickyPick(e, "session-1", "10.0.0.2:8888"), "sticky again after the move")
+
+	// Find a second key sharing session-1's bucket with a different
+	// fingerprint: the two overwriting each other must count nothing.
+	kh := fnv1a32("session-1")
+	var other string
+	for i := 0; ; i++ {
+		cand := fmt.Sprintf("other-%d", i)
+		if ch := fnv1a32(cand); ch%stickyBuckets == kh%stickyBuckets && ch != kh {
+			other = cand
+			break
+		}
+	}
+	assert.False(t, noteStickyPick(e, other, "10.0.0.3:8888"),
+		"a different key overwriting a contested bucket is not a teleport")
+	assert.False(t, noteStickyPick(e, "session-1", "10.0.0.2:8888"),
+		"the original key after contention is suppressed (undercount), not miscounted")
 }
 
-// TestAdmitStickyTeleportOnEndpointLoss drives the detector through Admit:
-// removing the sticky winner moves the key to the survivor, which must
-// register as a pick change in the fnEntry's bucket state.
-func TestAdmitStickyTeleportOnEndpointLoss(t *testing.T) {
-	t.Parallel()
+// teleportCount reads fission_router_sticky_teleports_total for one function
+// (0 when the series does not exist yet).
+func teleportCount(t *testing.T, reg *prometheus.Registry, ns, fn string) float64 {
+	t.Helper()
+	families, err := reg.Gather()
+	require.NoError(t, err)
+	for _, fam := range families {
+		if fam.GetName() != "fission_router_sticky_teleports_total" {
+			continue
+		}
+		if m := metricstest.FindMetric(fam, map[string]string{
+			"function_namespace": ns,
+			"function_name":      fn,
+		}); m != nil {
+			return m.GetCounter().GetValue()
+		}
+	}
+	return 0
+}
+
+// TestAdmitStickyTeleportMetric drives the teleport counter through Admit's
+// exported surface end to end: a busy-owner overflow (and its snap-back)
+// counts nothing, an endpoint loss that moves the key counts exactly once,
+// and repeat owner admits stay flat.
+func TestAdmitStickyTeleportMetric(t *testing.T) {
+	reg := metricstest.SetupMeter(t)
+	// Function coordinates unique to this test so concurrent tests recording
+	// other series can't collide with the assertion below.
+	const ns, fn = "default", "fn-teleport-metric"
 	ix := NewIndex()
-	ix.ApplySlice(slice("s1", "fn-a", "default", 8888, "10.0.0.1", "10.0.0.2"))
+	ix.ApplySlice(slice("s1", fn, ns, 8888, "10.0.0.1", "10.0.0.2"))
 
 	const key = "session-teleport"
-	ep1, release1, res := ix.Admit("default", "fn-a", "", 1, key)
+	ep1, release1, res := ix.Admit(ns, fn, "", 1, key)
 	require.Equal(t, Admitted, res)
+	assert.Zero(t, teleportCount(t, reg, ns, fn), "first pick is not a teleport")
+
+	// Busy owner: the same key overflows to the other pod — load shedding,
+	// not a teleport — and the snap-back after release isn't one either.
+	_, release2, res := ix.Admit(ns, fn, "", 1, key)
+	require.Equal(t, Admitted, res)
+	release2()
 	release1()
+	_, release3, res := ix.Admit(ns, fn, "", 1, key)
+	require.Equal(t, Admitted, res)
+	release3()
+	assert.Zero(t, teleportCount(t, reg, ns, fn), "saturation overflow and snap-back must not count")
 
-	fk := FnKey{Namespace: "default", Name: "fn-a"}
-	e := ix.shard(fk).m[fk]
-	require.NotNil(t, e)
-	assert.False(t, noteStickyPick(e, key, ep1.Address),
-		"Admit must have recorded its pick: re-noting the same address is not a teleport")
-
-	// Drop the winner: the key's next admit lands on the survivor and must
-	// register as exactly one pick change in the bucket state.
+	// Drop the winner: the key's next admit lands on the survivor.
 	survivor := "10.0.0.1"
 	if ep1.Address == "10.0.0.1:8888" {
 		survivor = "10.0.0.2"
 	}
-	ix.ApplySlice(slice("s1", "fn-a", "default", 8888, survivor))
-	ep2, release2, res := ix.Admit("default", "fn-a", "", 1, key)
+	ix.ApplySlice(slice("s1", fn, ns, 8888, survivor))
+	_, release4, res := ix.Admit(ns, fn, "", 1, key)
 	require.Equal(t, Admitted, res)
-	release2()
-	require.NotEqual(t, ep1.Address, ep2.Address)
-	assert.False(t, noteStickyPick(e, key, ep2.Address),
-		"Admit after the move must have stored the new pick")
-	assert.True(t, noteStickyPick(e, key, ep1.Address),
-		"moving back to the old address is again a change")
+	release4()
+	assert.Equal(t, float64(1), teleportCount(t, reg, ns, fn), "endpoint loss moves the key: exactly one teleport")
+
+	_, release5, res := ix.Admit(ns, fn, "", 1, key)
+	require.Equal(t, Admitted, res)
+	release5()
+	assert.Equal(t, float64(1), teleportCount(t, reg, ns, fn), "repeat owner admits stay flat")
 }
 
 // TestStickyEmptyKeyKeepsLeastOutstanding: no key = today's pick, bit for bit.

--- a/pkg/router/metrics.go
+++ b/pkg/router/metrics.go
@@ -52,9 +52,9 @@ var (
 	// sticky key into the resolver; "fallback" counts requests whose sticky
 	// declaration matched nothing in the request (missing header/param), which
 	// silently take the default pick — the metric is how an operator notices a
-	// misdeclared key source. Per-key ownership moves are deliberately NOT
-	// counted: that would need per-key memory in the router; reshuffle is
-	// churn-driven and observable from pod events.
+	// misdeclared key source. Per-key ownership moves are counted (bucketed,
+	// best-effort) by fission_router_sticky_teleports_total in
+	// pkg/router/endpointcache; these two counters stay per-request-shaped.
 	stickyKeyRequests = metrics.Int64Counter(
 		"fission_router_sticky_requests_total",
 		"Requests to sticky-routed functions that carried their sticky key",

--- a/pkg/router/metrics_test.go
+++ b/pkg/router/metrics_test.go
@@ -11,52 +11,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/sdk/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
-	"github.com/fission/fission/pkg/utils/metrics"
+	"github.com/fission/fission/pkg/utils/metrics/metricstest"
 )
-
-// setupRouterMeter installs a MeterProvider backed by a fresh Prometheus
-// registry (mirrors pkg/utils/metrics's own setupMeter test helper): the
-// router's package-level counters/histogram are created against the global
-// MeterProvider delegate at package-init time, so a test-installed provider
-// retroactively wires them to this registry.
-func setupRouterMeter(t *testing.T) *prometheus.Registry {
-	t.Helper()
-	reg := prometheus.NewRegistry()
-	mp, err := metrics.NewMeterProvider(resource.Default(), reg, true)
-	require.NoError(t, err)
-	otel.SetMeterProvider(mp)
-	t.Cleanup(func() { _ = mp.Shutdown(t.Context()) })
-	return reg
-}
-
-func findRouterMetric(fam *dto.MetricFamily, want map[string]string) *dto.Metric {
-	for _, m := range fam.GetMetric() {
-		labels := map[string]string{}
-		for _, l := range m.GetLabel() {
-			labels[l.GetName()] = l.GetValue()
-		}
-		match := true
-		for k, v := range want {
-			if labels[k] != v {
-				match = false
-				break
-			}
-		}
-		if match {
-			return m
-		}
-	}
-	return nil
-}
 
 // TestFunctionCallAttrsCacheKeyIncludesVersion pins the attr-cache key shape
 // (metrics.go: [6]string{namespace,name,version,path,method,code}): two
@@ -88,7 +50,7 @@ func TestFunctionCallAttrsCacheKeyIncludesVersion(t *testing.T) {
 // TestFunctionCallMetrics_VersionLabel drives collectFunctionMetric for both
 // a versioned and an unversioned function against ONE shared registry (the
 // router's counters/histogram bind to the global MeterProvider the first
-// time one is installed in this test binary; a second setupRouterMeter call
+// time one is installed in this test binary; a second metricstest.SetupMeter call
 // in a later test would silently keep recording into the FIRST registry, so
 // both cases share one installation here rather than risking that trap) and
 // asserts:
@@ -100,7 +62,7 @@ func TestFunctionCallAttrsCacheKeyIncludesVersion(t *testing.T) {
 //     treats empty and absent as the same series, so this does not create a
 //     new time series for existing unversioned dashboards/alerts.
 func TestFunctionCallMetrics_VersionLabel(t *testing.T) {
-	reg := setupRouterMeter(t)
+	reg := metricstest.SetupMeter(t)
 
 	call := func(fn *fv1.Function, path string, status int) {
 		fh := functionHandler{function: fn}
@@ -135,7 +97,7 @@ func TestFunctionCallMetrics_VersionLabel(t *testing.T) {
 		for _, name := range []string{"fission_function_calls_total", "fission_function_errors_total", "fission_function_overhead_seconds"} {
 			fam := byName[name]
 			require.NotNil(t, fam, "%s must be exposed", name)
-			m := findRouterMetric(fam, want)
+			m := metricstest.FindMetric(fam, want)
 			require.NotNil(t, m, "%s must carry function_version=hello-v1 (have families: %+v)", name, fam.GetMetric())
 		}
 	})
@@ -143,7 +105,7 @@ func TestFunctionCallMetrics_VersionLabel(t *testing.T) {
 	t.Run("unversioned invocation carries an empty function_version", func(t *testing.T) {
 		fam := byName["fission_function_calls_total"]
 		require.NotNil(t, fam)
-		m := findRouterMetric(fam, map[string]string{
+		m := metricstest.FindMetric(fam, map[string]string{
 			"function_namespace": "default",
 			"function_name":      "classic",
 		})

--- a/pkg/utils/metrics/metricstest/metricstest.go
+++ b/pkg/utils/metrics/metricstest/metricstest.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package metricstest is shared test support for asserting package-level OTel
+// instruments through the Prometheus bridge. It exists because the
+// install-provider + scan-families dance was being copy-pasted per test
+// package (pkg/utils/metrics, pkg/router, pkg/router/endpointcache); import
+// this instead of pasting a fourth copy.
+package metricstest
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	"github.com/fission/fission/pkg/utils/metrics"
+)
+
+// SetupMeter installs a MeterProvider backed by a fresh Prometheus registry
+// and returns the registry. Package-level instruments bind to the global
+// MeterProvider delegate at package init, so a test-installed provider
+// retroactively wires them to this registry. Only ONE test per test binary
+// may install a provider: a second install silently keeps recording into the
+// FIRST registry, so tests of one binary needing metrics must share a single
+// SetupMeter call.
+func SetupMeter(t *testing.T) *prometheus.Registry {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	mp, err := metrics.NewMeterProvider(resource.Default(), reg, true)
+	require.NoError(t, err)
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() { _ = mp.Shutdown(t.Context()) })
+	return reg
+}
+
+// FindMetric returns the first series in fam carrying every label in want,
+// or nil when none matches.
+func FindMetric(fam *dto.MetricFamily, want map[string]string) *dto.Metric {
+	for _, m := range fam.GetMetric() {
+		labels := map[string]string{}
+		for _, l := range m.GetLabel() {
+			labels[l.GetName()] = l.GetValue()
+		}
+		match := true
+		for k, v := range want {
+			if labels[k] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return m
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## What

Adds `fission_router_sticky_teleports_total`,
a per-function (and per-version) counter of sticky-key owner changes — the "teleports/sec" an operator watches while pods churn under a session-affine workload.

## Why

Sticky routing is best-effort by contract:
any pod add/remove can move a key to a different endpoint.
The existing sticky counters are per-request-shaped (carried key / missing key),
so there was no signal for how often keys actually move.
Per-key tracking was previously rejected because it needs per-key memory in the router.

## How

- Each `fnEntry` lazily carries 256 key-hash buckets (`stickyLast`, 2KiB per sticky-using function).
  A bucket stores the last owner pick as `(key fingerprint << 32 | address hash)`.
- **Counting is biased to undercount, never fabricate:**
  - Bucket contention between distinct keys is suppressed by the fingerprint guard —
    interleaved overwrites count nothing (they only lose coverage for the colliding keys).
  - Only owner-served admits are recorded: `Admit` tracks the key's true HRW winner
    *including saturated pods*, so a busy-owner overflow and its snap-back are load shedding, not teleports.
  - Only warm-path index admits are observed; executor-fallback windows
    (e.g. a mass-quarantine episode) record nothing until warm admits resume — stated in the metric help text.
- Labels: `function_namespace`, `function_name`, `function_version`
  (empty = absent for unversioned pools, so existing series are unchanged; a canary's versioned-pool churn stays attributable).
- Hot-path cost: steady state is one bucket **read** (no atomic RMW); a lost CAS defers to the concurrent admit so one move counts once.
  The sticky branch now scores saturated endpoints too (required to know the true owner); non-sticky traffic pays nothing.
- `fnv1a32`/`fnv1a32Add` are shared by `shard()` and the bucket hash — one copy of the checksum-sensitive loop.
- New `pkg/utils/metrics/metricstest` (`SetupMeter`/`FindMetric`) replaces the per-package copies
  of the meter-install + family-scan test helpers (`pkg/router` converted; `pkg/utils/metrics` keeps its origin copy).
- The `pkg/router/metrics.go` comment that said ownership moves are "deliberately NOT counted" now points at the new counter.

## Commit guide

1. The metric with the initial bucketed detector.
2. Review hardening: fingerprint buckets, owner-only recording, version label, read-before-CAS, shared FNV helper, metric-surface tests via the new `metricstest` package.

## Testing

- `TestNoteStickyPick`: detector semantics incl. a constructed same-bucket key collision (suppressed, not miscounted).
- `TestAdmitStickyTeleportMetric`: end-to-end through `Admit`'s exported surface against the real Prometheus-bridged counter —
  overflow + snap-back count nothing, endpoint loss counts exactly once, repeat owner admits stay flat.
- Full `pkg/router/...` suites green under `-race` (HRW property tests included).