### PR TITLE
hack/run-tlc: bump the tla2tools pin for the 2026-08-11 rebuild

### DIFF
--- a/hack/run-tlc.sh
+++ b/hack/run-tlc.sh
@@ -22,12 +22,13 @@ TLA2TOOLS_VERSION="${TLA2TOOLS_VERSION:-1.8.0}"
 # re-verify the jar is genuine tla2tools (manifest Main-class tlc2.TLC, Microsoft
 # vendor) and bump this pin. The pin stays so an UNEXPECTED artifact still fails
 # loudly rather than silently running arbitrary downloaded code.
-# Last bumped 2026-08-02 for the upstream rebuild dated 2026-07-31. Verified
+# Last bumped 2026-08-17 for the upstream rebuild dated 2026-08-11. Verified
 # before bumping, per the note above: manifest Main-class tlc2.TLC,
-# Implementation-Vendor "Microsoft Corp.", Implementation-Version "2.0
-# 2026-07-31", tlc2/TLC.class present, downloaded from the official
-# tlaplus/tlaplus v1.8.0 release URL.
-TLA2TOOLS_SHA256="${TLA2TOOLS_SHA256:-e22f8ffb4bacdea0a871f444dd94fe5fb0d8013b3388ae39e82e26f852c735d5}"
+# Implementation-Title "TLA+ Tools", Implementation-Vendor "Microsoft Corp.",
+# Implementation-Version "2.0 2026-08-11", X-Git-Revision
+# 0894c3407f4717fec7cc18bde3bf3c857fa47333 on tlaplus master, tlc2/TLC.class
+# present, downloaded from the official tlaplus/tlaplus v1.8.0 release URL.
+TLA2TOOLS_SHA256="${TLA2TOOLS_SHA256:-ab323b79802aedc3203b3f9af37c6aca3ed43f4e0225b36f2aa77b26de46c05f}"
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SPECS_DIR="${REPO_ROOT}/docs/rfc/specs"


### PR DESCRIPTION
`tlc` is currently **red on main** (`abcb8dec`) and will stay red on every PR until this lands.

The tlaplus project rebuilt and re-uploaded the v1.8.0 release asset again, so the pinned SHA no longer matches and the job fails fast at the checksum step:

```
Verifying checksum...
sha256sum: WARNING: 1 computed checksum did NOT match
```

Same recurring drift the comment above the pin describes. main last ran `tlc` green on 2026-08-04; the rebuild is dated 2026-08-11.

## Verified before bumping

Per the procedure that comment prescribes — this is a re-release, not tampering, and the pin stays so an unexpected artifact still fails loudly:

- downloaded from the official `tlaplus/tlaplus` v1.8.0 release URL
- manifest `Main-class: tlc2.TLC`
- `Implementation-Title: TLA+ Tools`, `Implementation-Vendor: Microsoft Corp.`
- `Implementation-Version: 2.0 2026-08-11`, `Build-TimeStamp: 2026-08-11T12:53:11Z`
- `X-Git-Revision: 0894c3407f4717fec7cc18bde3bf3c857fa47333` on tlaplus master
- `tlc2/TLC.class` present

## Test plan

Full suite run locally against the new jar: every green config passes and all four negative configs fail as designed (`queue-unguarded`, `eventlogsub-blindwrite`, `quota-nonatomic`, `aliasgc-norecheck`).

One line of real change; the rest of the diff is the provenance note the pin carries.