### PR TITLE
chart: annotations and labels on every ServiceAccount, for cloud workload identity (#3166)

### DIFF
--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -607,10 +607,16 @@ component and emit it as bare, unindented YAML entries. Callers wrap them in
 
 merge's first argument wins, so the component map overrides the chart-wide one
 key by key rather than replacing it wholesale.
+
+BOTH arguments are deep-copied. merge mutates its destination, and these helpers
+run once per account against the same chart-wide map, so a version of sprig that
+writes through to either argument would let the first account's keys contaminate
+the other eighteen. Current sprig does not, and TestServiceAccountNoCrossAccountLeak
+is what keeps that from becoming a silent regression on a helm bump.
 */}}
 {{- define "fission.saAnnotations" -}}
 {{- $sa := .root.Values.serviceAccounts | default dict -}}
-{{- $merged := merge (deepCopy (dig .component "annotations" dict $sa)) ($sa.annotations | default dict) -}}
+{{- $merged := merge (deepCopy (dig .component "annotations" dict $sa)) (deepCopy ($sa.annotations | default dict)) -}}
 {{- range $k, $v := $merged -}}
 {{- if hasPrefix "helm.sh/" $k -}}
 {{- fail (printf "serviceAccounts.%s: %q is reserved — the chart owns helm.sh/* annotations (hook ordering and delete policy on the pre-upgrade account); overriding one would emit a duplicate key and change when the hook runs" $.component $k) -}}
@@ -625,7 +631,7 @@ key by key rather than replacing it wholesale.
 
 {{- define "fission.saLabels" -}}
 {{- $sa := .root.Values.serviceAccounts | default dict -}}
-{{- $merged := merge (deepCopy (dig .component "labels" dict $sa)) ($sa.labels | default dict) -}}
+{{- $merged := merge (deepCopy (dig .component "labels" dict $sa)) (deepCopy ($sa.labels | default dict)) -}}
 {{- range $k, $v := $merged -}}
 {{- if has $k (list "svc" "application" "chart") -}}
 {{- fail (printf "serviceAccounts.%s: %q is reserved — the chart owns it as a component identity label. `svc` in particular selects components in the router NetworkPolicy and the support dump, so overriding it would emit a duplicate key and detach this account from both" $.component $k) -}}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -540,3 +540,128 @@ annotation would fight that design — hence the same tenancy gate.
 {{- end -}}
 {{- join " " $namespaces -}}
 {{- end -}}
+
+{{/*
+fission.saMetadata renders the annotations and labels a ServiceAccount inherits
+from the `serviceAccounts` values block, as complete metadata sub-blocks.
+
+  {{- include "fission.saMetadata" (dict "root" . "component" "storagesvc") }}
+
+Each component key merges over the chart-wide default, so an operator can stamp
+an ownership label on every account and still give storagesvc its own IRSA role
+annotation. Nothing renders when both maps are empty, which keeps the manifest
+byte-identical for anyone not using the feature.
+
+Cloud workload identity (#3166) is the motivating case, and it is why the
+annotations are per-component rather than chart-wide only: an EKS IRSA role ARN
+is scoped to one component's permissions, so a single shared value would either
+over-grant every account or fit none of them.
+
+The component key is the account's own name, not the deployment's — several
+components own more than one (misc-functions owns both `fetcher` and `builder`)
+and two accounts have no component block of their own. `fission.saComponents`
+below is the canonical list, and the chart test walks it against the rendered
+accounts so a new one cannot silently miss this include.
+*/}}
+{{- define "fission.saMetadata" -}}
+{{- include "fission.saAnnotationsBlock" . }}
+{{- include "fission.saLabelsBlock" . }}
+{{- end -}}
+
+{{/*
+fission.saAnnotationsBlock and fission.saLabelsBlock are fission.saMetadata's
+halves, for the accounts that already own one of the two blocks: pre-upgrade
+checks owns Helm hook annotations, and four accounts carry chart labels. Those
+templates merge the entry helpers into the block they own and include only the
+missing half from here — emitting a second `annotations:` key in the same
+mapping would be invalid YAML, and Helm would not catch it.
+
+All three carry their own indentation, two spaces, for the `metadata:` level
+every ServiceAccount in this chart sits at. That is what lets a call site write
+a bare `{{- include ... }}`: piping an empty include through `nindent` yields a
+line of spaces rather than nothing, so a chart with no serviceAccounts values
+set would grow whitespace-only lines in every account it renders.
+*/}}
+{{- define "fission.saAnnotationsBlock" -}}
+{{- $annotations := include "fission.saAnnotations" . -}}
+{{- if $annotations }}
+  annotations:
+{{- $annotations | nindent 4 }}
+{{- end }}
+{{- end -}}
+
+{{- define "fission.saLabelsBlock" -}}
+{{- $labels := include "fission.saLabels" . -}}
+{{- if $labels }}
+  labels:
+{{- $labels | nindent 4 }}
+{{- end }}
+{{- end -}}
+
+{{/*
+fission.saAnnotations and fission.saLabels resolve the merged map for one
+component and emit it as bare, unindented YAML entries. Callers wrap them in
+`with` so an empty map renders nothing:
+
+  {{- with include "fission.saLabels" (dict "root" . "component" "workflow") }}{{ . | nindent 4 }}{{- end }}
+
+merge's first argument wins, so the component map overrides the chart-wide one
+key by key rather than replacing it wholesale.
+*/}}
+{{- define "fission.saAnnotations" -}}
+{{- $sa := .root.Values.serviceAccounts | default dict -}}
+{{- $merged := merge (deepCopy (dig .component "annotations" dict $sa)) ($sa.annotations | default dict) -}}
+{{- range $k, $v := $merged -}}
+{{- if hasPrefix "helm.sh/" $k -}}
+{{- fail (printf "serviceAccounts.%s: %q is reserved — the chart owns helm.sh/* annotations (hook ordering and delete policy on the pre-upgrade account); overriding one would emit a duplicate key and change when the hook runs" $.component $k) -}}
+{{- end -}}
+{{- end -}}
+{{- $entries := list -}}
+{{- range $k, $v := $merged -}}
+{{- $entries = append $entries (printf "%s: %s" $k ($v | quote)) -}}
+{{- end -}}
+{{- join "\n" $entries -}}
+{{- end -}}
+
+{{- define "fission.saLabels" -}}
+{{- $sa := .root.Values.serviceAccounts | default dict -}}
+{{- $merged := merge (deepCopy (dig .component "labels" dict $sa)) ($sa.labels | default dict) -}}
+{{- range $k, $v := $merged -}}
+{{- if has $k (list "svc" "application" "chart") -}}
+{{- fail (printf "serviceAccounts.%s: %q is reserved — the chart owns it as a component identity label. `svc` in particular selects components in the router NetworkPolicy and the support dump, so overriding it would emit a duplicate key and detach this account from both" $.component $k) -}}
+{{- end -}}
+{{- end -}}
+{{- $entries := list -}}
+{{- range $k, $v := $merged -}}
+{{- $entries = append $entries (printf "%s: %s" $k ($v | quote)) -}}
+{{- end -}}
+{{- join "\n" $entries -}}
+{{- end -}}
+
+{{/*
+fission.saComponents is the canonical list of ServiceAccount component keys —
+the contract between values.yaml, the templates, and the two things that hold
+them together: fission.validateSaComponents rejects a key that is not on it, and
+the chart test proves every key on it annotates exactly one rendered account.
+
+Keep it sorted, and add to it in the same commit that adds a ServiceAccount.
+*/}}
+{{- define "fission.saComponents" -}}
+builder buildermgr canaryconfig executor fetcher kafka kubewatcher mcp mqtKeda preupgrade router statestore statestoreMqt statesvc storagesvc tenantController timer webhook workflow
+{{- end -}}
+
+{{/*
+fission.validateSaComponents fails the render on an unrecognised key under
+`serviceAccounts`. Without it a typo is silent and total: `serviceAccounts.storagesv`
+parses fine, renders fine, and produces an account with no role annotation — so
+the first symptom is storagesvc getting AccessDenied from S3 at runtime, a long
+way from the values file that caused it.
+*/}}
+{{- define "fission.validateSaComponents" -}}
+{{- $known := concat (splitList " " (include "fission.saComponents" .)) (list "annotations" "labels") -}}
+{{- range $k, $v := (.Values.serviceAccounts | default dict) -}}
+{{- if not (has $k $known) -}}
+{{- fail (printf "serviceAccounts.%s: unknown key. Expected `annotations`, `labels`, or one of: %s" $k (include "fission.saComponents" $)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/fission-all/templates/buildermgr/serviceaccount.yaml
+++ b/charts/fission-all/templates/buildermgr/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-buildermgr
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "buildermgr") }}

--- a/charts/fission-all/templates/canary-config/serviceaccount.yaml
+++ b/charts/fission-all/templates/canary-config/serviceaccount.yaml
@@ -4,4 +4,5 @@ kind: ServiceAccount
 metadata:
   name: fission-canaryconfig
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "canaryconfig") }}
 {{- end -}}

--- a/charts/fission-all/templates/executor/serviceaccount.yaml
+++ b/charts/fission-all/templates/executor/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-executor
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "executor") }}

--- a/charts/fission-all/templates/kubewatcher/serviceaccount.yaml
+++ b/charts/fission-all/templates/kubewatcher/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-kubewatcher
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "kubewatcher") }}

--- a/charts/fission-all/templates/mcp/serviceaccount.yaml
+++ b/charts/fission-all/templates/mcp/serviceaccount.yaml
@@ -4,4 +4,5 @@ kind: ServiceAccount
 metadata:
   name: fission-mcp
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "mcp") }}
 {{- end }}

--- a/charts/fission-all/templates/misc-functions/serviceaccount.yaml
+++ b/charts/fission-all/templates/misc-functions/serviceaccount.yaml
@@ -3,6 +3,7 @@ kind: ServiceAccount
 metadata:
   name: fission-fetcher
   namespace: {{ template "fission-function-ns" . }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "fetcher") }}
 
 ---
 apiVersion: v1
@@ -10,3 +11,4 @@ kind: ServiceAccount
 metadata:
   name: fission-builder
   namespace: {{ template "fission-builder-ns" . }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "builder") }}

--- a/charts/fission-all/templates/mqt-fission-kafka/serviceaccount.yaml
+++ b/charts/fission-all/templates/mqt-fission-kafka/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-kafka
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "kafka") }}

--- a/charts/fission-all/templates/mqt-fission-statestore/serviceaccount.yaml
+++ b/charts/fission-all/templates/mqt-fission-statestore/serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 metadata:
   name: fission-statestore-mqt
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "statestoreMqt") }}
 {{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "statestore-mqt") .) }}
 
 {{- if gt (len .Values.additionalFissionNamespaces) 0 }}

--- a/charts/fission-all/templates/mqt-keda/serviceaccount.yaml
+++ b/charts/fission-all/templates/mqt-keda/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-keda
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "mqtKeda") }}

--- a/charts/fission-all/templates/pre-upgrade-checks/serviceaccount.yaml
+++ b/charts/fission-all/templates/pre-upgrade-checks/serviceaccount.yaml
@@ -12,3 +12,5 @@ metadata:
     # Strictly below the Job's weight, or Helm may order the Job before the
     # identity it runs as.
     helm.sh/hook-weight: "-3"
+    {{- with include "fission.saAnnotations" (dict "root" . "component" "preupgrade") }}{{ . | nindent 4 }}{{- end }}
+  {{- include "fission.saLabelsBlock" (dict "root" . "component" "preupgrade") }}

--- a/charts/fission-all/templates/router/serviceaccount.yaml
+++ b/charts/fission-all/templates/router/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-router
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "router") }}

--- a/charts/fission-all/templates/statestore/serviceaccount.yaml
+++ b/charts/fission-all/templates/statestore/serviceaccount.yaml
@@ -3,8 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fission-statestore
+  namespace: {{ .Release.Namespace }}
+  {{- include "fission.saAnnotationsBlock" (dict "root" . "component" "statestore") }}
   labels:
     svc: statestore
     application: fission-statestore
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- with include "fission.saLabels" (dict "root" . "component" "statestore") }}{{ . | nindent 4 }}{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/statesvc/serviceaccount.yaml
+++ b/charts/fission-all/templates/statesvc/serviceaccount.yaml
@@ -7,8 +7,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: fission-statesvc
+  namespace: {{ .Release.Namespace }}
+  {{- include "fission.saAnnotationsBlock" (dict "root" . "component" "statesvc") }}
   labels:
     svc: statesvc
     application: fission-statesvc
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- with include "fission.saLabels" (dict "root" . "component" "statesvc") }}{{ . | nindent 4 }}{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/storagesvc/serviceaccount.yaml
+++ b/charts/fission-all/templates/storagesvc/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-storagesvc
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "storagesvc") }}

--- a/charts/fission-all/templates/tenant-controller/serviceaccount.yaml
+++ b/charts/fission-all/templates/tenant-controller/serviceaccount.yaml
@@ -4,7 +4,9 @@ kind: ServiceAccount
 metadata:
   name: fission-tenant-controller
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saAnnotationsBlock" (dict "root" . "component" "tenantController") }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     svc: tenantcontroller
+    {{- with include "fission.saLabels" (dict "root" . "component" "tenantController") }}{{ . | nindent 4 }}{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/timer/serviceaccount.yaml
+++ b/charts/fission-all/templates/timer/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-timer
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "timer") }}

--- a/charts/fission-all/templates/validate-serviceaccounts.yaml
+++ b/charts/fission-all/templates/validate-serviceaccounts.yaml
@@ -1,0 +1,6 @@
+{{- /*
+Render-time gate for the `serviceAccounts` block, mirroring the statestore and
+tenant-controller gates. Emits no manifests; it only fails the render on a
+component key the chart does not recognise.
+*/ -}}
+{{- include "fission.validateSaComponents" . }}

--- a/charts/fission-all/templates/webhook-server/serviceaccount.yaml
+++ b/charts/fission-all/templates/webhook-server/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: fission-webhook
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "webhook") }}

--- a/charts/fission-all/templates/workflow/serviceaccount.yaml
+++ b/charts/fission-all/templates/workflow/serviceaccount.yaml
@@ -4,8 +4,10 @@ kind: ServiceAccount
 metadata:
   name: fission-workflow
   namespace: {{ .Release.Namespace }}
+  {{- include "fission.saAnnotationsBlock" (dict "root" . "component" "workflow") }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     svc: workflow
     application: fission-workflow
+    {{- with include "fission.saLabels" (dict "root" . "component" "workflow") }}{{ . | nindent 4 }}{{- end }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1422,6 +1422,61 @@ authentication:
 ##
 nameFormat: standard
 
+## Annotations and labels to stamp onto the ServiceAccounts this chart creates.
+##
+## The motivating case is cloud workload identity — EKS IRSA, GKE Workload
+## Identity, Azure Workload Identity — where a component assumes a cloud role by
+## carrying an annotation on its ServiceAccount. storagesvc talking to S3 with an
+## IAM role instead of a static access key is the common one.
+##
+## `annotations` and `labels` at this level apply to EVERY account; a key under a
+## component name applies to that account alone and overrides the chart-wide
+## value key by key. Components are keyed by ACCOUNT, not by deployment: two of
+## them (fetcher, builder) live in the function and builder namespaces rather
+## than the release namespace, and neither has a component block elsewhere in
+## this file.
+##
+## A role ARN is scoped to one component's permissions, so it belongs under that
+## component, never at the chart-wide level:
+##
+##   serviceAccounts:
+##     labels:
+##       my-org/owner: platform-team
+##     storagesvc:
+##       annotations:
+##         eks.amazonaws.com/role-arn: arn:aws:iam::012345678901:role/fission-storagesvc
+##     kafka:
+##       annotations:
+##         eks.amazonaws.com/role-arn: arn:aws:iam::012345678901:role/fission-kafka
+##
+serviceAccounts:
+  ## Applied to every Fission ServiceAccount.
+  annotations: {}
+  labels: {}
+
+  ## Per-account overrides. Every account this chart can create is listed, so
+  ## the set is discoverable without reading the templates; an account only
+  ## renders when its component is enabled.
+  builder: {}
+  buildermgr: {}
+  canaryconfig: {}
+  executor: {}
+  fetcher: {}
+  kafka: {}
+  kubewatcher: {}
+  mcp: {}
+  mqtKeda: {}
+  preupgrade: {}
+  router: {}
+  statestore: {}
+  statestoreMqt: {}
+  statesvc: {}
+  storagesvc: {}
+  tenantController: {}
+  timer: {}
+  webhook: {}
+  workflow: {}
+
 ## OpenTelemetry is a set of tools for collecting, analyzing, and visualizing
 ## distributed tracing data across function calls.
 ##

--- a/test/helm/serviceaccount_test.go
+++ b/test/helm/serviceaccount_test.go
@@ -1,0 +1,289 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+package helm
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/yaml"
+)
+
+// allComponentsValues enables every optional component, so a render sees every
+// ServiceAccount the chart can produce rather than the default subset.
+const allComponentsValues = `
+statestore:
+  enabled: true
+  mode: embedded
+eventing:
+  enabled: true
+functionState:
+  enabled: true
+workflows:
+  enabled: true
+mcp:
+  enabled: true
+  allowInsecure: true
+canaryDeployment:
+  enabled: true
+tenancy:
+  mode: dynamic
+`
+
+// renderWithValues writes a values file and renders the chart against it.
+func renderWithValues(t *testing.T, values string, extraArgs ...string) manifests {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(values), 0o600))
+	return render(t, append([]string{"-f", f}, extraArgs...)...)
+}
+
+// renderErrWithValues is renderWithValues for the cases that must FAIL to render.
+func renderErrWithValues(t *testing.T, values string) (string, error) {
+	t.Helper()
+	f := filepath.Join(t.TempDir(), "values.yaml")
+	require.NoError(t, os.WriteFile(f, []byte(values), 0o600))
+	return renderErr(t, "-f", f)
+}
+
+// serviceAccounts decodes every rendered ServiceAccount.
+func serviceAccounts(t *testing.T, ms manifests) []corev1.ServiceAccount {
+	t.Helper()
+	var out []corev1.ServiceAccount
+	for _, m := range ms.ofKind("ServiceAccount") {
+		out = append(out, *decodeAs[corev1.ServiceAccount](t, &m))
+	}
+	require.NotEmpty(t, out)
+	return out
+}
+
+// saComponents is the component-key list from the fission.saComponents helper.
+// It is duplicated here on purpose: TestServiceAccountEveryAccountIsAnnotatable
+// proves this list and the rendered accounts agree, and a copy the test owns is
+// what makes that a real assertion rather than a tautology against the helper.
+var saComponents = []string{
+	"builder", "buildermgr", "canaryconfig", "executor", "fetcher", "kafka",
+	"kubewatcher", "mcp", "mqtKeda", "preupgrade", "router", "statestore",
+	"statestoreMqt", "statesvc", "storagesvc", "tenantController", "timer",
+	"webhook", "workflow",
+}
+
+// TestServiceAccountAnnotationsDefaultToNothing pins the upgrade-safety
+// property: an operator who never sets `serviceAccounts` must get exactly the
+// manifest they got before this feature existed. Helm's `nindent` turns an
+// empty include into a line of spaces rather than nothing, which is why the
+// helpers carry their own indentation — this test is what keeps that true.
+func TestServiceAccountAnnotationsDefaultToNothing(t *testing.T) {
+	for _, sa := range serviceAccounts(t, renderWithValues(t, allComponentsValues)) {
+		for k := range sa.Annotations {
+			assert.Truef(t, strings.HasPrefix(k, "helm.sh/"),
+				"ServiceAccount %q carries annotation %q by default; only the chart's own helm.sh/* hook annotations may be present", sa.Name, k)
+		}
+		for k := range sa.Labels {
+			assert.Containsf(t, []string{"svc", "application", "chart"}, k,
+				"ServiceAccount %q carries label %q by default", sa.Name, k)
+		}
+	}
+}
+
+// TestServiceAccountChartWideMetadata covers the flat case: one value, every
+// account.
+func TestServiceAccountChartWideMetadata(t *testing.T) {
+	ms := renderWithValues(t, allComponentsValues+`
+serviceAccounts:
+  annotations:
+    my-org/managed-by: helm
+  labels:
+    my-org/owner: platform-team
+`)
+	accounts := serviceAccounts(t, ms)
+	require.Len(t, accounts, len(saComponents), "every component key must produce exactly one account")
+	for _, sa := range accounts {
+		assert.Equalf(t, "helm", sa.Annotations["my-org/managed-by"], "ServiceAccount %q missing the chart-wide annotation", sa.Name)
+		assert.Equalf(t, "platform-team", sa.Labels["my-org/owner"], "ServiceAccount %q missing the chart-wide label", sa.Name)
+	}
+}
+
+// TestServiceAccountEveryAccountIsAnnotatable is the drift guard, and the
+// reason this file exists rather than a single storagesvc test.
+//
+// It sets a component-unique annotation for every key in saComponents and
+// asserts each one lands on exactly one account. A new ServiceAccount template
+// that forgets the include fails the count assertion; a component key that no
+// longer renders an account fails its own subtest. Without this, the next
+// account added to the chart would silently have no annotation support — which
+// is precisely how the support-dump selectors drifted to missing eight
+// components before #3675.
+func TestServiceAccountEveryAccountIsAnnotatable(t *testing.T) {
+	var b strings.Builder
+	b.WriteString(allComponentsValues)
+	b.WriteString("serviceAccounts:\n")
+	for _, c := range saComponents {
+		fmt.Fprintf(&b, "  %s:\n    annotations:\n      fission.test/component: %s\n", c, c)
+	}
+	accounts := serviceAccounts(t, renderWithValues(t, b.String()))
+
+	require.Len(t, accounts, len(saComponents),
+		"the chart renders %d ServiceAccounts but fission.saComponents lists %d — add the new account's key to the helper, values.yaml and saComponents here",
+		len(accounts), len(saComponents))
+
+	got := map[string]string{}
+	for _, sa := range accounts {
+		c, ok := sa.Annotations["fission.test/component"]
+		require.Truef(t, ok, "ServiceAccount %q has no per-component annotation — its template is missing the fission.saMetadata include", sa.Name)
+		assert.NotContainsf(t, got, c, "component key %q annotated more than one account (%q and %q)", c, got[c], sa.Name)
+		got[c] = sa.Name
+	}
+	keys := make([]string, 0, len(got))
+	for c := range got {
+		keys = append(keys, c)
+	}
+	sort.Strings(keys)
+	assert.Equal(t, saComponents, keys, "every component key must annotate exactly one rendered account")
+}
+
+// TestServiceAccountComponentOverridesChartWide pins the merge direction. This
+// is the case #3166 is actually about: an IRSA role ARN is scoped to one
+// component's permissions, so a chart-wide value can never be the right answer
+// for it.
+func TestServiceAccountComponentOverridesChartWide(t *testing.T) {
+	const roleARN = "arn:aws:iam::012345678901:role/fission-storagesvc"
+	ms := renderWithValues(t, allComponentsValues+`
+serviceAccounts:
+  annotations:
+    my-org/managed-by: chart-wide
+  storagesvc:
+    annotations:
+      eks.amazonaws.com/role-arn: `+roleARN+`
+      my-org/managed-by: storagesvc-only
+`)
+	storagesvc := findAs[corev1.ServiceAccount](t, ms, "ServiceAccount", "fission-storagesvc")
+	assert.Equal(t, roleARN, storagesvc.Annotations["eks.amazonaws.com/role-arn"], "the IRSA annotation must reach the account")
+	assert.Equal(t, "storagesvc-only", storagesvc.Annotations["my-org/managed-by"], "the component value must win over the chart-wide one, key by key")
+
+	router := findAs[corev1.ServiceAccount](t, ms, "ServiceAccount", "fission-router")
+	assert.Equal(t, "chart-wide", router.Annotations["my-org/managed-by"], "an untouched account keeps the chart-wide value")
+	assert.NotContains(t, router.Annotations, "eks.amazonaws.com/role-arn",
+		"a component-scoped role ARN must not leak onto other accounts — that is the whole reason it is per-component")
+}
+
+// TestServiceAccountPreUpgradeKeepsHookAnnotations covers the one account that
+// already owns an annotations block. User annotations merge into it; the Helm
+// hook annotations that decide when the account exists must survive, because
+// losing hook-weight would let the Job be ordered before the identity it runs
+// as.
+func TestServiceAccountPreUpgradeKeepsHookAnnotations(t *testing.T) {
+	ms := renderWithValues(t, allComponentsValues+`
+serviceAccounts:
+  preupgrade:
+    annotations:
+      my-org/reviewed: "true"
+`)
+	sa := findAs[corev1.ServiceAccount](t, ms, "ServiceAccount", "fission-preupgrade")
+	assert.Equal(t, "true", sa.Annotations["my-org/reviewed"])
+	assert.Equal(t, "pre-install,pre-upgrade", sa.Annotations["helm.sh/hook"], "the hook annotation must survive the merge")
+	assert.Equal(t, "-3", sa.Annotations["helm.sh/hook-weight"], "hook-weight orders the account before the Job that runs as it")
+	assert.Contains(t, sa.Annotations["helm.sh/hook-delete-policy"], "hook-succeeded")
+}
+
+// TestServiceAccountLabelsMergeWithChartLabels covers the four accounts that
+// already own a labels block.
+func TestServiceAccountLabelsMergeWithChartLabels(t *testing.T) {
+	ms := renderWithValues(t, allComponentsValues+`
+serviceAccounts:
+  labels:
+    my-org/owner: platform-team
+  workflow:
+    labels:
+      my-org/owner: workflow-team
+`)
+	wf := findAs[corev1.ServiceAccount](t, ms, "ServiceAccount", "fission-workflow")
+	assert.Equal(t, "workflow-team", wf.Labels["my-org/owner"], "the component label must win over the chart-wide one")
+	assert.Equal(t, "workflow", wf.Labels["svc"], "the chart's own svc label must survive")
+	assert.Equal(t, "fission-workflow", wf.Labels["application"], "the chart's own application label must survive")
+}
+
+// TestServiceAccountReservedKeysFailRender pins the fail-closed guards. Both
+// reserved sets would otherwise emit a DUPLICATE key in one YAML mapping, which
+// neither Helm nor the API server reports — the value that wins is undefined,
+// and for `svc` the loser is detached from the router NetworkPolicy and the
+// support dump.
+func TestServiceAccountReservedKeysFailRender(t *testing.T) {
+	for _, tc := range []struct {
+		name, values, wantErr string
+	}{
+		{
+			name:    "component identity label",
+			values:  "serviceAccounts:\n  router:\n    labels:\n      svc: hijacked\n",
+			wantErr: "reserved",
+		},
+		{
+			name:    "chart-wide identity label",
+			values:  "serviceAccounts:\n  labels:\n    application: hijacked\n",
+			wantErr: "reserved",
+		},
+		{
+			name:    "helm hook annotation",
+			values:  "serviceAccounts:\n  preupgrade:\n    annotations:\n      helm.sh/hook: post-install\n",
+			wantErr: "reserved",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := renderErrWithValues(t, allComponentsValues+tc.values)
+			require.Error(t, err, "the render must fail rather than emit a duplicate key")
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}
+
+// TestServiceAccountUnknownComponentKeyFailsRender pins the typo gate. A key
+// the chart does not recognise is the worst failure mode this feature has:
+// `serviceAccounts.storagesv` parses, renders, and produces an account with no
+// role annotation, so the first symptom is an AccessDenied from S3 at runtime —
+// a long way from the values file that caused it.
+func TestServiceAccountUnknownComponentKeyFailsRender(t *testing.T) {
+	_, err := renderErrWithValues(t, "serviceAccounts:\n  storagesv:\n    annotations:\n      a: b\n")
+	require.Error(t, err, "an unknown component key must fail the render, not silently do nothing")
+	assert.Contains(t, err.Error(), "unknown key")
+	assert.Contains(t, err.Error(), "storagesvc", "the error must list the valid keys so the typo is obvious")
+}
+
+// TestServiceAccountComponentsHelperMatchesValues proves values.yaml documents
+// every component key. The block is the feature's discovery surface: a key that
+// works but is absent there is a feature nobody finds.
+func TestServiceAccountComponentsHelperMatchesValues(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "charts", "fission-all", "values.yaml"))
+	require.NoError(t, err)
+	var vals struct {
+		ServiceAccounts map[string]any `json:"serviceAccounts"`
+	}
+	require.NoError(t, yaml.Unmarshal(raw, &vals))
+	documented := make([]string, 0, len(vals.ServiceAccounts))
+	for k := range vals.ServiceAccounts {
+		if k != "annotations" && k != "labels" {
+			documented = append(documented, k)
+		}
+	}
+	sort.Strings(documented)
+	assert.Equal(t, saComponents, documented, "values.yaml must list exactly the component keys the chart accepts")
+}
+
+// TestServiceAccountsSetNamespaceExplicitly pins the consistency fix that came
+// with this feature: statestore and statesvc omitted metadata.namespace while
+// their 17 siblings set it. It rendered correctly only because `helm template`
+// and `helm install` both default to the release namespace — an omission that
+// is invisible until someone applies the rendered manifest with a different
+// active context.
+func TestServiceAccountsSetNamespaceExplicitly(t *testing.T) {
+	for _, sa := range serviceAccounts(t, renderWithValues(t, allComponentsValues)) {
+		assert.NotEmptyf(t, sa.Namespace, "ServiceAccount %q must set metadata.namespace explicitly", sa.Name)
+	}
+}

--- a/test/helm/serviceaccount_test.go
+++ b/test/helm/serviceaccount_test.go
@@ -4,6 +4,7 @@
 package helm
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -306,8 +307,11 @@ func TestServiceAccountUnknownComponentKeyFailsRender(t *testing.T) {
 func TestServiceAccountComponentsHelperMatchesValues(t *testing.T) {
 	raw, err := os.ReadFile(filepath.Join("..", "..", "charts", "fission-all", "values.yaml"))
 	require.NoError(t, err)
+	// RawMessage, not `any`: this test reads the KEYS of the block and never
+	// looks inside a value, so decoding them would claim a knowledge of their
+	// shape it does not have and cannot check.
 	var vals struct {
-		ServiceAccounts map[string]any `json:"serviceAccounts"`
+		ServiceAccounts map[string]json.RawMessage `json:"serviceAccounts"`
 	}
 	require.NoError(t, yaml.Unmarshal(raw, &vals))
 	documented := make([]string, 0, len(vals.ServiceAccounts))

--- a/test/helm/serviceaccount_test.go
+++ b/test/helm/serviceaccount_test.go
@@ -175,6 +175,50 @@ serviceAccounts:
 		"a component-scoped role ARN must not leak onto other accounts — that is the whole reason it is per-component")
 }
 
+// TestServiceAccountNoCrossAccountLeak proves account isolation when a
+// chart-wide map and several component maps are in play at once.
+//
+// The helpers run once per account against the same chart-wide map, and sprig's
+// merge mutates its destination — so a helm bump whose merge writes through to
+// either argument would let the first account rendered contaminate the other
+// eighteen. For an IRSA role ARN that is not a cosmetic bug: it would grant every
+// component storagesvc's S3 permissions.
+func TestServiceAccountNoCrossAccountLeak(t *testing.T) {
+	exclusive := map[string]string{
+		"fission-storagesvc": "only/storagesvc",
+		"fission-router":     "only/router",
+		"fission-kafka":      "only/kafka",
+		"fission-builder":    "only/builder",
+	}
+	ms := renderWithValues(t, allComponentsValues+`
+serviceAccounts:
+  annotations:
+    shared/everywhere: global
+  storagesvc:
+    annotations:
+      only/storagesvc: s3-role
+  router:
+    annotations:
+      only/router: router-role
+  kafka:
+    annotations:
+      only/kafka: msk-role
+  builder:
+    annotations:
+      only/builder: builder-role
+`)
+	for _, sa := range serviceAccounts(t, ms) {
+		assert.Equalf(t, "global", sa.Annotations["shared/everywhere"], "ServiceAccount %q must carry the chart-wide annotation", sa.Name)
+		for owner, key := range exclusive {
+			if owner == sa.Name {
+				assert.Containsf(t, sa.Annotations, key, "ServiceAccount %q must carry its own annotation", sa.Name)
+				continue
+			}
+			assert.NotContainsf(t, sa.Annotations, key, "ServiceAccount %q leaked %q, which belongs to %q", sa.Name, key, owner)
+		}
+	}
+}
+
 // TestServiceAccountPreUpgradeKeepsHookAnnotations covers the one account that
 // already owns an annotations block. User annotations merge into it; the Helm
 // hook annotations that decide when the account exists must survive, because


### PR DESCRIPTION
# chart: annotations and labels on every ServiceAccount, for cloud workload identity

Closes #3166. Also covers #2199, which asked for the same thing in 2022.

## The problem

The chart creates 19 ServiceAccounts and, apart from the pre-upgrade hook's own Helm
annotations, none of them could carry an annotation.
That closes the door on every cloud workload-identity mechanism at once —
EKS IRSA, GKE Workload Identity and Azure Workload Identity all work by annotating the
account a pod runs as.

The concrete ask on the issue is storagesvc reaching S3 through an IAM role instead of a
static access key and secret checked into a values file.
Two users are on the thread and a third arrived from the SQS side.

## What this adds

A `serviceAccounts` values block with chart-wide `annotations` and `labels`, plus a
per-account override merged key by key with the account winning:

```yaml
serviceAccounts:
  labels:
    my-org/owner: platform-team
  storagesvc:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::012345678901:role/fission-storagesvc
  kafka:
    annotations:
      eks.amazonaws.com/role-arn: arn:aws:iam::012345678901:role/fission-kafka
```

The per-account override is not a convenience.
A role ARN grants one component's permissions, so a single chart-wide value would either
over-grant every account or fit none of them.

Accounts are keyed by their own name rather than by deployment,
because two of them (`fetcher`, `builder`) live in the function and builder namespaces and
have no component block anywhere else in `values.yaml`.

## What is refused at render time

Three things fail the render rather than surfacing at runtime:

- **an unknown key under `serviceAccounts`** — `storagesv` parses fine, renders fine, and
  yields an account with no role annotation, so the first symptom would be AccessDenied
  from S3, a long way from the values file that caused it;
- **a user label named `svc`, `application` or `chart`** — the chart owns these as component
  identity. `svc` selects components in the router NetworkPolicy and the support dump, and
  overriding it would emit a duplicate YAML key that neither Helm nor the API server reports;
- **a user annotation under `helm.sh/`** — it would reorder or un-delete the pre-upgrade hook.

## Review notes

**The default render is byte-identical** for anyone who does not set the new block, and a test
pins that.
This is less obvious than it sounds: piping an empty include through `nindent` yields a line
of spaces rather than nothing, so the natural call-site form would have grown whitespace-only
lines in all 19 accounts. The helpers carry their own indentation to avoid it.

**The drift guard is the point of the test file.**
It annotates every component key and asserts each lands on exactly one account, so a
ServiceAccount added later without the include fails by name.
Verified by mutation: removing the include from `timer/serviceaccount.yaml` fails with
`ServiceAccount "fission-timer" has no per-component annotation`.
This is the same failure the support-dump selectors had before #3675, where a
hand-maintained component list silently drifted to missing eight components.

**Second commit is insurance, not a fix.**
sprig's `merge` mutates its destination and the helpers run 19 times against the same
chart-wide map. Current sprig does not write through, and the render is clean on helm 4.2.4 —
but the failure would be silent and would leak storagesvc's IRSA role onto every account, so
both sides are deep-copied and a test pins the isolation.

**Drive-by:** the statestore and statesvc accounts omitted `metadata.namespace` while their 17
siblings set it. It rendered correctly only because helm defaults to the release namespace —
invisible until the manifest is applied with a different active context.

## Testing

`test/helm/serviceaccount_test.go`, 11 tests: default-render parity, chart-wide application,
the per-component drift guard, override precedence, cross-account isolation, hook-annotation
survival on pre-upgrade, label merging on the four accounts that own a labels block, both
reserved-key gates, the unknown-key gate, values.yaml/helper parity, and explicit namespaces.

`go test ./test/helm/` green, `helm lint` clean, `make license-check` clean,
`golangci-lint` clean.
