### PR TITLE
test(async): derive the context budget from the retry windows (#3610)

### DIFF
--- a/test/integration/suites/serial/async_destinations_test.go
+++ b/test/integration/suites/serial/async_destinations_test.go
@@ -35,7 +35,7 @@ func setInvocation(t *testing.T, ctx context.Context, f *framework.Framework, ns
 		fn.Spec.Invocation = ic
 		_, err = fc.Update(ctx, fn, metav1.UpdateOptions{})
 		assert.NoError(c, err) // retry on conflict
-	}, 30*time.Second, 1*time.Second)
+	}, asyncUpdateWindow, 1*time.Second)
 }
 
 // warmRoute drives a synchronous POST through the trigger until it 2xxes, so the
@@ -54,7 +54,7 @@ func warmRoute(t *testing.T, ctx context.Context, f *framework.Framework, route 
 		}
 		defer func() { _ = resp.Body.Close() }()
 		assert.Less(c, resp.StatusCode, 400, "route live and function ready")
-	}, 2*time.Minute, 2*time.Second)
+	}, asyncWarmWindow, 2*time.Second)
 }
 
 // warmInternal specializes a route-less destination function by invoking it on the
@@ -68,7 +68,7 @@ func warmInternal(t *testing.T, ctx context.Context, f *framework.Framework, fnN
 			return
 		}
 		assert.Less(c, status, 400, "destination function specialized")
-	}, 2*time.Minute, 2*time.Second)
+	}, asyncWarmWindow, 2*time.Second)
 }
 
 // TestAsyncInvocationOnSuccessFunctionDestination: an async invocation with an
@@ -76,8 +76,7 @@ func warmInternal(t *testing.T, ctx context.Context, f *framework.Framework, fnN
 // the result envelope (the fn→fn chain).
 func TestAsyncInvocationOnSuccessFunctionDestination(t *testing.T) {
 	f := framework.Connect(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
-	defer cancel()
+	ctx := asyncTestContext(t, asyncUpdateWindow, asyncWarmWindow, asyncWarmWindow, asyncAcceptWindow, asyncDeliverWindow)
 
 	requireAsyncEnabled(t, ctx, f)
 	image := f.Images().RequireNode(t)
@@ -108,26 +107,32 @@ func TestAsyncInvocationOnSuccessFunctionDestination(t *testing.T) {
 		status, id := asyncPost(t, ctx, f, route, "dest-once-"+ns.ID)
 		assert.Equal(c, http.StatusAccepted, status)
 		assert.NotEmpty(c, id)
-	}, 2*time.Minute, 2*time.Second)
+	}, asyncAcceptWindow, 2*time.Second)
 
 	marker := ns.Name + "/" + srcFn
-	require.Eventually(t, func() bool {
+	// assert + Fatalf rather than require.Eventually: testify evaluates a failure
+	// message's arguments eagerly, and the remaining context budget is only
+	// meaningful once the wait has actually run out.
+	if !assert.Eventually(t, func() bool {
 		logs, err := ns.FunctionLogsE(t, ctx, dstFn)
 		if err != nil {
 			t.Logf("destination logs: %v (retrying)", err)
 			return false
 		}
 		return strings.Contains(logs, marker)
-	}, 3*time.Minute, 3*time.Second,
-		"onSuccess destination function must execute out-of-band with the result envelope (marker %q)", marker)
+	}, asyncDeliverWindow, 3*time.Second) {
+		t.Fatalf("onSuccess destination function must execute out-of-band with the result envelope (marker %q); %s", marker, budgetLeft(ctx))
+	}
 }
 
 // TestAsyncInvocationDepthCapBounds: a function whose onSuccess points back at
 // itself chains a few hops then STOPS at the depth cap (invariant A6 — no runaway).
 func TestAsyncInvocationDepthCapBounds(t *testing.T) {
 	f := framework.Connect(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
-	defer cancel()
+	// The self-loop chains MaxChainDepth hops, each one a full trip through the
+	// shared queue, so it needs the delivery window more than the single-hop test
+	// does — not less.
+	ctx := asyncTestContext(t, asyncUpdateWindow, asyncWarmWindow, asyncAcceptWindow, asyncDeliverWindow)
 
 	requireAsyncEnabled(t, ctx, f)
 	image := f.Images().RequireNode(t)
@@ -153,7 +158,7 @@ func TestAsyncInvocationDepthCapBounds(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		status, _ := asyncPost(t, ctx, f, route, "loop-once-"+ns.ID)
 		assert.Equal(c, http.StatusAccepted, status)
-	}, 2*time.Minute, 2*time.Second)
+	}, asyncAcceptWindow, 2*time.Second)
 
 	// The chain runs several hops then the depth cap STOPS it: poll until the
 	// execution count has reached the cap AND stopped growing (two equal reads a
@@ -165,12 +170,23 @@ func TestAsyncInvocationDepthCapBounds(t *testing.T) {
 	// depths 0..MaxChainDepth (the depth+1 enqueue past the cap is dropped); the
 	// slack tolerates at-least-once redelivery.
 	settled := -1
-	require.Eventually(t, func() bool {
-		n := strings.Count(ns.FunctionLogs(t, ctx, fnName), logMarker) - baseline
+	if !assert.Eventually(t, func() bool {
+		logs, err := ns.FunctionLogsE(t, ctx, fnName)
+		if err != nil {
+			// FunctionLogs (no E) fails the test outright, which on an expired
+			// context reports a log-read error rather than the timeout that
+			// caused it. Retry instead, and let the wait own the failure.
+			t.Logf("chain logs: %v (retrying)", err)
+			return false
+		}
+		n := strings.Count(logs, logMarker) - baseline
 		converged := n >= asyncinvoke.MaxChainDepth && n == settled
 		settled = n
 		return converged
-	}, 3*time.Minute, 3*time.Second)
+	}, asyncDeliverWindow, 3*time.Second) {
+		t.Fatalf("self-loop chain must reach the depth cap and settle (last count %d, cap %d); %s",
+			settled, asyncinvoke.MaxChainDepth, budgetLeft(ctx))
+	}
 	assert.LessOrEqualf(t, settled, asyncinvoke.MaxChainDepth+3,
 		"depth cap must bound the chain (got %d executions)", settled)
 }

--- a/test/integration/suites/serial/async_invocation_test.go
+++ b/test/integration/suites/serial/async_invocation_test.go
@@ -33,6 +33,69 @@ import (
 // logMarker is the line the nodejs/log/log.js fixture writes on each invocation.
 const logMarker = "log test"
 
+// Retry windows shared by the RFC-0024 async tests, named so a context budget can
+// be derived from them instead of guessed.
+//
+// asyncDeliverWindow is the long pole. After the 202 the dispatcher still has to
+// pick the invocation off the single global queue, invoke the source function and
+// only then settle or fire a destination, with the delivery/redelivery backoff
+// chain riding on top — all of it sharing one queue with whatever else the serial
+// suite is running.
+const (
+	asyncUpdateWindow  = 30 * time.Second
+	asyncWarmWindow    = 2 * time.Minute
+	asyncAcceptWindow  = 2 * time.Minute
+	asyncDeliverWindow = 5 * time.Minute
+
+	// Not a delivery wait: the time for a statestore scale-to-zero to take
+	// effect and for the router to start failing the enqueue.
+	asyncStatestoreDownWindow = 3 * time.Minute
+
+	// asyncSetupHeadroom covers what runs inside the same context BEFORE the
+	// first retry window opens: namespace, environment and function creation,
+	// including a package build.
+	asyncSetupHeadroom = 4 * time.Minute
+)
+
+// asyncTestContext returns a context whose deadline covers every retry window the
+// test can spend, plus setup headroom.
+//
+// This is load-bearing, not tidiness. Until #3610 these tests declared more retry
+// time than their context allowed — the destinations test asked for 9.5 minutes of
+// windows inside an 8-minute context, and TestAsyncInvocationExecutes for exactly
+// its whole budget with nothing left for the setup preceding it. No test could
+// spend the time it claimed: whichever stage ran slow, the context expired and the
+// NEXT require.Eventually then failed for its full window against a dead context.
+//
+// That failure reads as "the destination never fired", which is why the flake was
+// first diagnosed as async-queue contention. Deriving the deadline from the windows
+// keeps the arithmetic honest when someone widens one of them.
+func asyncTestContext(t *testing.T, windows ...time.Duration) context.Context {
+	t.Helper()
+	budget := asyncSetupHeadroom
+	for _, w := range windows {
+		budget += w
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), budget)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// budgetLeft renders a context's remaining time for a failure message, so a wait
+// that times out says whether the wait ran out or the context did. Call it AT
+// failure — testify evaluates msgAndArgs eagerly, so passing it to require.Eventually
+// would report the budget before the wait rather than after.
+func budgetLeft(ctx context.Context) string {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return "context has no deadline"
+	}
+	if remaining := time.Until(deadline); remaining > 0 {
+		return fmt.Sprintf("%s of context budget left", remaining.Truncate(time.Second))
+	}
+	return "context budget was already EXHAUSTED — widen the windows passed to asyncTestContext"
+}
+
 // requireAsyncEnabled skips the test unless the router runs with async invocation
 // on (ASYNC_INVOCATION_ENABLED=true), so the suite passes on installs that leave
 // the feature off.
@@ -108,8 +171,7 @@ func asyncPostE(t *testing.T, ctx context.Context, f *framework.Framework, route
 // to go live into a single durable invocation.
 func TestAsyncInvocationExecutes(t *testing.T) {
 	f := framework.Connect(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
-	defer cancel()
+	ctx := asyncTestContext(t, asyncWarmWindow, asyncAcceptWindow, asyncDeliverWindow)
 
 	requireAsyncEnabled(t, ctx, f)
 	image := f.Images().RequireNode(t)
@@ -140,7 +202,7 @@ func TestAsyncInvocationExecutes(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 		assert.Less(c, resp.StatusCode, 400, "route live and function ready")
-	}, 3*time.Minute, 2*time.Second)
+	}, asyncWarmWindow, 2*time.Second)
 	baseline := strings.Count(ns.FunctionLogs(t, ctx, fn), logMarker)
 
 	// Async POST returns 202 + an invocation id; the dedup key collapses the
@@ -152,7 +214,7 @@ func TestAsyncInvocationExecutes(t *testing.T) {
 		assert.Equal(c, http.StatusAccepted, status)
 		invID = id
 		assert.NotEmpty(c, id)
-	}, 2*time.Minute, 2*time.Second)
+	}, asyncAcceptWindow, 2*time.Second)
 	require.NotEmpty(t, invID, "202 must carry an X-Fission-Invocation-Id")
 
 	// The async invocation runs the function out-of-band: the marker count grows
@@ -161,15 +223,14 @@ func TestAsyncInvocationExecutes(t *testing.T) {
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		got := strings.Count(ns.FunctionLogs(t, ctx, fn), logMarker)
 		assert.Greater(c, got, baseline, "async invocation must execute the function")
-	}, 3*time.Minute, 3*time.Second)
+	}, asyncDeliverWindow, 3*time.Second)
 }
 
 // TestAsyncInvocationStatestoreDown503: with the statestore unreachable, an async
 // enqueue fails loud with 503 and never a silently dropped 202 (invariant A1).
 func TestAsyncInvocationStatestoreDown503(t *testing.T) {
 	f := framework.Connect(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
-	defer cancel()
+	ctx := asyncTestContext(t, asyncWarmWindow, asyncStatestoreDownWindow)
 
 	requireAsyncEnabled(t, ctx, f)
 	if _, err := f.KubeClient().AppsV1().Deployments(f.FissionNamespace()).Get(ctx, "statestore", metav1.GetOptions{}); err != nil {
@@ -201,7 +262,7 @@ func TestAsyncInvocationStatestoreDown503(t *testing.T) {
 		}
 		defer func() { _ = resp.Body.Close() }()
 		assert.Less(c, resp.StatusCode, 400, "route live and function ready")
-	}, 2*time.Minute, 2*time.Second)
+	}, asyncWarmWindow, 2*time.Second)
 
 	// Take the statestore down and confirm the enqueue fails loud (503), restoring
 	// it afterward for the rest of the suite.
@@ -212,5 +273,5 @@ func TestAsyncInvocationStatestoreDown503(t *testing.T) {
 		status, _ := asyncPost(t, ctx, f, route, "")
 		assert.Equal(c, http.StatusServiceUnavailable, status,
 			"async enqueue with the statestore down must 503, never 202")
-	}, 3*time.Minute, 3*time.Second)
+	}, asyncStatestoreDownWindow, 3*time.Second)
 }


### PR DESCRIPTION
# test(async): derive the context budget from the retry windows

Closes #3610.

## The issue's diagnosis was wrong, and its fix would have made things worse

`TestAsyncInvocationOnSuccessFunctionDestination` flaked with `Condition never satisfied`
after 120-190s on unrelated heads.
The issue reasoned from the symptom to async-queue contention — plausible, since the
destination fire rides the single global queue and the redelivery backoff chain sits on top.

The arithmetic says otherwise.
That test declared **9.5 minutes of retry windows inside an 8-minute context**:

| stage | window |
| --- | --- |
| `setInvocation` | 30s |
| `warmRoute` | 2m |
| `warmInternal` | 2m |
| accept (202) | 2m |
| deliver | 3m |
| **total** | **9.5m** — before the namespace, environment and function it creates first |

It could never spend the time it claimed.
Whichever stage ran slow, the context expired and the **next** `require.Eventually` then
failed for its full window against a dead context — which reads exactly like
"the destination never fired".

It was not alone:

| test | declared windows | context |
| --- | --- | --- |
| `OnSuccessFunctionDestination` | 9.5m | 8m |
| `Executes` | 8.0m | 8m |
| `DepthCapBounds` | 7.5m | 8m |
| `StatestoreDown503` | 5.0m | 8m |

Three of the four were structurally unable to finish.

So the issue's proposed fix — widen the delivery wait to 5m — would have put *more*
declared window inside the same short context.
Its other proposal, "make the function respond immediately so only queue latency is in the
budget", is already true: both fixtures (`log.js`, `logbody.js`) return without sleeping.
Function latency was never in the budget.

## The fix

Windows are named constants, and each test's context is derived from the ones it actually
uses plus setup headroom — so widening a window widens the context with it, and the two
cannot drift apart again.

| test | windows | context |
| --- | --- | --- |
| `OnSuccessFunctionDestination` | 11.5m | 15.5m |
| `DepthCapBounds` | 9.5m | 13.5m |
| `Executes` | 9.0m | 13.0m |
| `StatestoreDown503` | 5.0m | 9.0m |

With the arithmetic corrected, the delivery window **does** go to 5m — the queue genuinely is
the long pole.
The depth-cap test gets the same window rather than a shorter one: its self-loop makes
`MaxChainDepth` trips through the queue, so it needs more delivery time than the single-hop
test, not less.
The 503 test keeps its own `asyncStatestoreDownWindow`, because that wait is a scale-to-zero
taking effect, not a delivery.

## So the next failure is readable

- The long waits report the **remaining context budget** on timeout, which distinguishes
  "the queue was slow" from "the budget was gone".
  They use `assert.Eventually` + `t.Fatalf` because testify evaluates a failure message's
  arguments eagerly — passing `budgetLeft(ctx)` to `require.Eventually` would report the
  budget *before* the wait rather than after.
- The depth-cap poll reads logs with `FunctionLogsE`.
  `FunctionLogs` fails the test outright, so an expired context surfaced there as a
  log-read error rather than as the timeout that caused it.

## Review notes

Contexts now parent on `t.Context()` per the repo's test conventions, matching the four
serial tests that already do.
**Teardown is unaffected** — `NewTestNamespace`'s cleanup hook builds its own
`context.Background()` 60s timeout and never captures the test's context, which is what makes
the switch safe.

Test-only change; no production code touched.

**Local verification is compile-and-vet only** — these need a live cluster, so the serial
integration leg in CI is the real check.
`go build -tags=integration`, `go vet`, `golangci-lint --build-tags=integration`,
`make antislop` and `make license-check` are all clean.
