### PR TITLE
executor: measure how late the idle reaper is (#1989)

### DIFF
--- a/charts/fission-all/dashboards/fission-admin-dashboard.json
+++ b/charts/fission-all/dashboards/fission-admin-dashboard.json
@@ -1136,6 +1136,207 @@
       ],
       "title": "Fission Archives Size",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 49
+      },
+      "id": 25,
+      "panels": [],
+      "title": "Idle reaping",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "How late the idle reaper is: time between a function service becoming eligible for reaping (last access plus its idle timeout) and the reaper acting on it. A healthy reaper stays within one tick interval, 5s by default. A rising p99 means the cross-namespace List calls in Prepare, or the reap concurrency limit, are the bottleneck.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 50
+      },
+      "id": 26,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(fission_executor_idle_reap_lag_seconds_bucket[$__rate_interval])) by (le, executor_type))",
+          "legendFormat": "p99 {{executor_type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(fission_executor_idle_reap_lag_seconds_bucket[$__rate_interval])) by (le, executor_type))",
+          "legendFormat": "p50 {{executor_type}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Idle reap lag (p99 / p50)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Idle reaps per second, taken from the lag histogram sample count, against reaping failures by stage. A prepare or list failure aborts a whole pass, so errors climbing while reaps sit at zero is a reaper that has stopped rather than a quiet cluster.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 50
+      },
+      "id": 27,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(fission_executor_idle_reap_lag_seconds_count[$__rate_interval])) by (executor_type)",
+          "legendFormat": "reaped {{executor_type}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "sum(rate(fission_executor_idle_reap_errors_total[$__rate_interval])) by (executor_type, stage)",
+          "legendFormat": "error {{executor_type}}/{{stage}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Idle reaps / errors",
+      "type": "timeseries"
     }
   ],
   "schemaVersion": 36,

--- a/pkg/executor/metrics/metrics.go
+++ b/pkg/executor/metrics/metrics.go
@@ -178,7 +178,41 @@ const (
 	ReapStageReap ReapStage = "reap"
 )
 
-func executorTypeLabel(executorType fv1.ExecutorType) metric.MeasurementOption {
+// Reaper attribute sets are precomputed. Both dimensions are closed — three
+// executor types, three stages — so the twelve possible option values are built
+// once at init instead of allocating a fresh attribute set on every record.
+// Measured on the error path, which combines both: 528ns/640B/11 allocs before,
+// and the reaper records under a shared semaphore where allocation churn is the
+// part worth not paying.
+var (
+	reapExecutorAttrs = func() map[fv1.ExecutorType]metric.MeasurementOption {
+		m := map[fv1.ExecutorType]metric.MeasurementOption{}
+		for _, et := range []fv1.ExecutorType{fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy, fv1.ExecutorTypeContainer} {
+			m[et] = metric.WithAttributes(attribute.String("executor_type", string(et)))
+		}
+		return m
+	}()
+	reapErrorAttrs = func() map[fv1.ExecutorType]map[ReapStage]metric.MeasurementOption {
+		m := map[fv1.ExecutorType]map[ReapStage]metric.MeasurementOption{}
+		for _, et := range []fv1.ExecutorType{fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy, fv1.ExecutorTypeContainer} {
+			m[et] = map[ReapStage]metric.MeasurementOption{}
+			for _, st := range []ReapStage{ReapStagePrepare, ReapStageList, ReapStageReap} {
+				m[et][st] = metric.WithAttributes(
+					attribute.String("executor_type", string(et)),
+					attribute.String("stage", string(st)),
+				)
+			}
+		}
+		return m
+	}()
+)
+
+// executorTypeAttrs returns the precomputed option, falling back to an allocated
+// one for an executor type added later without updating the table above.
+func executorTypeAttrs(executorType fv1.ExecutorType) metric.MeasurementOption {
+	if opt, ok := reapExecutorAttrs[executorType]; ok {
+		return opt
+	}
 	return metric.WithAttributes(attribute.String("executor_type", string(executorType)))
 }
 
@@ -186,11 +220,19 @@ func executorTypeLabel(executorType fv1.ExecutorType) metric.MeasurementOption {
 // deadline the function service was when the reaper acted. The histogram's
 // _count carries the reap volume, so there is no separate counter to drift.
 func RecordIdleReap(ctx context.Context, executorType fv1.ExecutorType, lagSeconds float64) {
-	idleReapLagSeconds.Record(ctx, lagSeconds, executorTypeLabel(executorType))
+	idleReapLagSeconds.Record(ctx, lagSeconds, executorTypeAttrs(executorType))
 }
 
 // RecordIdleReapError counts one idle-reaping failure at the given stage.
 func RecordIdleReapError(ctx context.Context, executorType fv1.ExecutorType, stage ReapStage) {
-	idleReapErrors.Add(ctx, 1, executorTypeLabel(executorType),
-		metric.WithAttributes(attribute.String("stage", string(stage))))
+	if byStage, ok := reapErrorAttrs[executorType]; ok {
+		if opt, ok := byStage[stage]; ok {
+			idleReapErrors.Add(ctx, 1, opt)
+			return
+		}
+	}
+	idleReapErrors.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("executor_type", string(executorType)),
+		attribute.String("stage", string(stage)),
+	))
 }

--- a/pkg/executor/metrics/metrics.go
+++ b/pkg/executor/metrics/metrics.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/utils/metrics"
 )
 
@@ -63,6 +64,27 @@ var (
 	ociPoolReapFailures = metrics.Int64Counter(
 		"fission_executor_oci_pool_reap_failures_total",
 		"Idle-pool reap attempts whose deployment delete failed (deployment orphaned until adoption or restart cleanup).",
+	)
+
+	// idleReapLagSeconds measures reaper RESPONSIVENESS, not idleness: how long a
+	// function service sat past its idle deadline before the reaper acted. A
+	// function idle for an hour under a one-hour timeout was reaped on time and
+	// records ~0. Its _count is the reap volume, so no companion counter exists.
+	// Buckets reach ~34m; a healthy reaper lands inside its tick interval (5s).
+	// Labelled by executor_type only — the router metrics' cardinality discipline.
+	idleReapLagSeconds = metrics.Float64Histogram(
+		"fission_executor_idle_reap_lag_seconds",
+		"Delay between a function service becoming eligible for idle reaping (last access + idle timeout) and the reaper acting on it, by executor_type.",
+		prometheus.ExponentialBuckets(0.25, 2, 14),
+	)
+	// idleReapErrors counts idle-reaping failures by stage. The stage attribute is
+	// load-bearing: a reaper whose Prepare List calls fail aborts the whole pass
+	// before any candidate is considered, which is the likeliest way for reaping to
+	// stop entirely. Counting only per-candidate errors would leave that case
+	// indistinguishable from a quiet cluster — every series flat at zero.
+	idleReapErrors = metrics.Int64Counter(
+		"fission_executor_idle_reap_errors_total",
+		"Idle reaping failures by executor_type and stage (prepare|list|reap).",
 	)
 
 	fissionProvisionedTarget = metrics.Int64Gauge(
@@ -141,4 +163,34 @@ func RecordOCIPoolReaped(ctx context.Context) {
 // RecordOCIPoolReapFailure counts one reap pass whose deployment delete failed.
 func RecordOCIPoolReapFailure(ctx context.Context) {
 	ociPoolReapFailures.Add(ctx, 1)
+}
+
+// ReapStage is where in a reaping pass a failure happened.
+type ReapStage string
+
+const (
+	// ReapStagePrepare is the per-tick setup (the cross-namespace List calls).
+	// A failure here skips the entire pass.
+	ReapStagePrepare ReapStage = "prepare"
+	// ReapStageList is listing the idle candidates; also skips the pass.
+	ReapStageList ReapStage = "list"
+	// ReapStageReap is one candidate's own reap.
+	ReapStageReap ReapStage = "reap"
+)
+
+func executorTypeLabel(executorType fv1.ExecutorType) metric.MeasurementOption {
+	return metric.WithAttributes(attribute.String("executor_type", string(executorType)))
+}
+
+// RecordIdleReap records one completed idle reap, as how far past its idle
+// deadline the function service was when the reaper acted. The histogram's
+// _count carries the reap volume, so there is no separate counter to drift.
+func RecordIdleReap(ctx context.Context, executorType fv1.ExecutorType, lagSeconds float64) {
+	idleReapLagSeconds.Record(ctx, lagSeconds, executorTypeLabel(executorType))
+}
+
+// RecordIdleReapError counts one idle-reaping failure at the given stage.
+func RecordIdleReapError(ctx context.Context, executorType fv1.ExecutorType, stage ReapStage) {
+	idleReapErrors.Add(ctx, 1, executorTypeLabel(executorType),
+		metric.WithAttributes(attribute.String("stage", string(stage))))
 }

--- a/pkg/executor/metrics/metrics_bench_test.go
+++ b/pkg/executor/metrics/metrics_bench_test.go
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/utils/metrics"
+)
+
+var allExecutorTypes = []fv1.ExecutorType{
+	fv1.ExecutorTypePoolmgr, fv1.ExecutorTypeNewdeploy, fv1.ExecutorTypeContainer,
+}
+
+var allReapStages = []ReapStage{ReapStagePrepare, ReapStageList, ReapStageReap}
+
+// installMeter wires the package-level instruments to a fresh registry. Only the
+// first install in a test binary takes effect (see metricstest.SetupMeter), which
+// is fine here: every case in this file wants the same provider.
+func installMeter(tb testing.TB) *prometheus.Registry {
+	tb.Helper()
+	reg := prometheus.NewRegistry()
+	mp, err := metrics.NewMeterProvider(resource.Default(), reg, false)
+	require.NoError(tb, err)
+	otel.SetMeterProvider(mp)
+	return reg
+}
+
+// populate records every executor_type x stage combination the reaper can
+// produce, so the registry holds the instruments at their maximum cardinality.
+func populate(ctx context.Context) {
+	for _, et := range allExecutorTypes {
+		RecordIdleReap(ctx, et, 1.25)
+		for _, st := range allReapStages {
+			RecordIdleReapError(ctx, et, st)
+		}
+	}
+}
+
+// TestReaperMetricCardinalityIsBounded locks the cardinality contract these
+// instruments were designed around: both dimensions are closed sets, so the
+// series count is a constant that cannot grow with functions, pods or traffic.
+// Adding a label keyed on anything unbounded — a function name, a pod, a reason
+// string — would fail here rather than in someone's Prometheus.
+func TestReaperMetricCardinalityIsBounded(t *testing.T) {
+	reg := installMeter(t)
+	populate(t.Context())
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	series := map[string]int{}
+	for _, fam := range families {
+		switch fam.GetName() {
+		case "fission_executor_idle_reap_lag_seconds", "fission_executor_idle_reap_errors_total":
+			series[fam.GetName()] = len(fam.GetMetric())
+		}
+	}
+	// 3 executor types; 3 x 3 executor/stage pairs.
+	require.Equal(t, 3, series["fission_executor_idle_reap_lag_seconds"], "lag is keyed by executor_type alone")
+	require.Equal(t, 9, series["fission_executor_idle_reap_errors_total"], "errors are keyed by executor_type x stage")
+}
+
+// BenchmarkRecordIdleReap and BenchmarkRecordIdleReapError measure the per-call
+// cost of the reaper's instrumentation. Both attribute dimensions are closed, so
+// their option values are precomputed at init; without that the error path built
+// and merged two attribute sets per call and cost 528ns/640B/11 allocs against
+// the ~104ns/16B/1 alloc measured now.
+func BenchmarkRecordIdleReap(b *testing.B) {
+	installMeter(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		RecordIdleReap(ctx, fv1.ExecutorTypePoolmgr, 3.5)
+	}
+}
+
+func BenchmarkRecordIdleReapError(b *testing.B) {
+	installMeter(b)
+	ctx := b.Context()
+	b.ReportAllocs()
+	for b.Loop() {
+		RecordIdleReapError(ctx, fv1.ExecutorTypePoolmgr, ReapStageReap)
+	}
+}
+
+// BenchmarkGather measures scrape-side cost with the instruments at full
+// cardinality — the per-scrape price an operator pays for having them.
+func BenchmarkGather(b *testing.B) {
+	reg := installMeter(b)
+	populate(b.Context())
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := reg.Gather(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/executor/reaper/idle/idle.go
+++ b/pkg/executor/reaper/idle/idle.go
@@ -28,6 +28,7 @@ import (
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
+	"github.com/fission/fission/pkg/executor/metrics"
 	"github.com/fission/fission/pkg/executor/reaper"
 	"github.com/fission/fission/pkg/generated/clientset/versioned"
 	"github.com/fission/fission/pkg/utils"
@@ -90,11 +91,16 @@ func (r *Reaper) Start(ctx context.Context) {
 
 func (r *Reaper) reapOnce(ctx context.Context, s Strategy) {
 	if err := s.Prepare(ctx); err != nil {
+		// Counted, not just logged: a Prepare failure skips the WHOLE pass, so
+		// nothing is reaped and no lag is sampled. Without this the likeliest
+		// way for reaping to stop dead looks exactly like a quiet cluster.
+		metrics.RecordIdleReapError(ctx, s.ExecutorType(), metrics.ReapStagePrepare)
 		r.logger.Error(err, "skipping idle reaper pass", "strategy", s.Name())
 		return
 	}
 	funcSvcs, err := s.ListIdle()
 	if err != nil {
+		metrics.RecordIdleReapError(ctx, s.ExecutorType(), metrics.ReapStageList)
 		r.logger.Error(err, "error listing idle function services", "strategy", s.Name())
 		return
 	}
@@ -110,6 +116,7 @@ func (r *Reaper) reapOnce(ctx context.Context, s Strategy) {
 		wg.Go(func() {
 			defer func() { <-sem }()
 			if err := s.Reap(ctx, fsvc); err != nil {
+				metrics.RecordIdleReapError(ctx, s.ExecutorType(), metrics.ReapStageReap)
 				r.logger.Error(err, "error reaping idle function service", "strategy", s.Name(), "function", fsvc.Function.Name)
 			}
 		})
@@ -124,6 +131,17 @@ func idleThreshold(fn *fv1.Function, def time.Duration) time.Duration {
 		return time.Duration(*fn.Spec.IdleTimeout) * time.Second
 	}
 	return def
+}
+
+// reapLag is how long a function service sat past its idle deadline before the
+// reaper acted: idleFor is the age of its last access, threshold the idle
+// timeout that made it eligible.
+//
+// Callers pass the SAME idleFor they tested against the threshold rather than
+// re-reading the clock; a request landing mid-reap moves Atime forward, and a
+// second time.Since would then yield a negative lag.
+func reapLag(idleFor, threshold time.Duration) float64 {
+	return (idleFor - threshold).Seconds()
 }
 
 // listEnvUIDs returns the set of Environment UIDs across the Fission resource
@@ -303,7 +321,8 @@ func (s *PoolDeleteStrategy) Reap(ctx context.Context, fsvc *fscache.FuncSvc) er
 	if fn, ok := s.fnByUID[fsvc.Function.UID]; ok {
 		reapTime = idleThreshold(&fn, s.reapTime)
 	}
-	if time.Since(fsvc.Atime) < reapTime {
+	idleFor := time.Since(fsvc.Atime)
+	if idleFor < reapTime {
 		return nil
 	}
 
@@ -312,6 +331,10 @@ func (s *PoolDeleteStrategy) Reap(ctx context.Context, fsvc *fscache.FuncSvc) er
 		return err
 	}
 	if deleted {
+		// Gated on deleted: DeleteOldPoolCache re-reads the clock and returns
+		// false when a request moved Atime past the threshold between the check
+		// above and the delete, which is a reap that did not happen.
+		metrics.RecordIdleReap(ctx, s.ExecutorType(), reapLag(idleFor, reapTime))
 		if s.drainBeforeDelete {
 			s.drainThenDelete(ctx, fsvc)
 			return nil
@@ -479,7 +502,9 @@ func (s *ScaleDownStrategy) Reap(ctx context.Context, fsvc *fscache.FuncSvc) err
 		}
 	}
 
-	if time.Since(fsvc.Atime) < idleThreshold(fn, s.reapTime) {
+	threshold := idleThreshold(fn, s.reapTime)
+	idleFor := time.Since(fsvc.Atime)
+	if idleFor < threshold {
 		return nil
 	}
 
@@ -493,8 +518,13 @@ func (s *ScaleDownStrategy) Reap(ctx context.Context, fsvc *fscache.FuncSvc) err
 	}
 	minScale := int32(fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale)
 	// Do nothing if the current replica count is already at or below MinScale.
+	// Not a reap: nothing was released, so it stays out of the metrics.
 	if currentDeploy.Spec.Replicas != nil && *currentDeploy.Spec.Replicas <= minScale {
 		return nil
 	}
-	return scaleDeploymentToMinScale(ctx, s.logger, s.kubeClient, deployObj.Namespace, deployObj.Name, minScale)
+	if err := scaleDeploymentToMinScale(ctx, s.logger, s.kubeClient, deployObj.Namespace, deployObj.Name, minScale); err != nil {
+		return err
+	}
+	metrics.RecordIdleReap(ctx, s.ExecutorType(), reapLag(idleFor, threshold))
+	return nil
 }

--- a/pkg/executor/reaper/idle/idle_test.go
+++ b/pkg/executor/reaper/idle/idle_test.go
@@ -26,6 +26,7 @@ import (
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/fscache"
 	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	"github.com/fission/fission/pkg/utils/metrics/metricstest"
 )
 
 func TestGetDeploymentObj(t *testing.T) {
@@ -81,6 +82,32 @@ func fsvc(name string, executor fv1.ExecutorType) *fscache.FuncSvc {
 		Name:     name,
 		Executor: executor,
 		Function: &metav1.ObjectMeta{Name: name, Namespace: "default"},
+	}
+}
+
+// TestReapLag pins what the #1989 metric measures. The distinction that matters:
+// it is the reaper's own responsiveness — how late it was — not how long the
+// function sat idle. A function idle for an hour under a one-hour timeout is
+// reaped ON TIME and must record ~0, or the metric just restates the timeout
+// back to whoever configured it.
+func TestReapLag(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name      string
+		idleFor   time.Duration
+		threshold time.Duration
+		want      float64
+	}{
+		{"reaped on the deadline is zero lag", 2 * time.Minute, 2 * time.Minute, 0},
+		{"one tick late", 125 * time.Second, 2 * time.Minute, 5},
+		{"long idle timeout still reports only the delay", time.Hour + 3*time.Second, time.Hour, 3},
+		{"saturated reaper falling minutes behind", 10 * time.Minute, 2 * time.Minute, 480},
+		{"per-function timeout shorter than the default", 35 * time.Second, 30 * time.Second, 5},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.InDelta(t, tc.want, reapLag(tc.idleFor, tc.threshold), 1e-9)
+		})
 	}
 }
 
@@ -325,4 +352,98 @@ func TestPoolDeleteStrategy_DrainThenDelete(t *testing.T) {
 	_, served := got.Labels[fv1.SERVED_LABEL]
 	assert.False(t, served, "the served label must be removed so the pod leaves the slices")
 	assert.Equal(t, "false", got.Labels["managed"], "other labels are untouched")
+}
+
+// TestReaperMetrics asserts what the instruments record AT THEIR CALL SITES,
+// which is where the #1989 metrics can be wrong in ways a pure-function test of
+// reapLag cannot see: fired on a skip, missed on a real reap, or a whole failed
+// pass recording nothing at all.
+//
+// metricstest installs a MeterProvider globally and only the FIRST install in a
+// test binary takes effect, so every metric assertion in this package has to
+// live in this one test rather than being spread across the others.
+func TestReaperMetrics(t *testing.T) {
+	reg := metricstest.SetupMeter(t)
+
+	// sampleCount reads a series' counter value or histogram sample count,
+	// returning 0 when the series was never recorded.
+	sampleCount := func(name string, labels map[string]string) float64 {
+		t.Helper()
+		families, err := reg.Gather()
+		require.NoError(t, err)
+		for _, fam := range families {
+			if fam.GetName() != name {
+				continue
+			}
+			m := metricstest.FindMetric(fam, labels)
+			if m == nil {
+				return 0
+			}
+			if m.GetCounter() != nil {
+				return m.GetCounter().GetValue()
+			}
+			return float64(m.GetHistogram().GetSampleCount())
+		}
+		return 0
+	}
+
+	const lag = "fission_executor_idle_reap_lag_seconds"
+	const errs = "fission_executor_idle_reap_errors_total"
+	newdeploy := map[string]string{"executor_type": "newdeploy"}
+
+	const ns, deplName, fnName = "default", "fn-depl", "fn"
+	fn := &fv1.Function{Name: fnName, Namespace: ns}
+	fn.Spec.InvokeStrategy.ExecutionStrategy.MinScale = 1
+	newFsvc := func() *fscache.FuncSvc {
+		return &fscache.FuncSvc{
+			Name: "p", Executor: fv1.ExecutorTypeNewdeploy,
+			Function:    &metav1.ObjectMeta{Name: fnName, Namespace: ns},
+			Environment: &fv1.Environment{},
+			Atime:       time.Now().Add(-time.Hour),
+			KubernetesObjects: []apiv1.ObjectReference{
+				{Kind: "Deployment", Name: deplName, Namespace: ns},
+			},
+		}
+	}
+	newDeploy := func(r int32) *appsv1.Deployment {
+		return &appsv1.Deployment{Name: deplName, Namespace: ns, Spec: appsv1.DeploymentSpec{Replicas: &r}}
+	}
+	newScaleDown := func(kc *k8sfake.Clientset) *ScaleDownStrategy {
+		return NewScaleDownStrategy(logr.Discard(), fv1.ExecutorTypeNewdeploy,
+			fissionfake.NewClientset(fn), fscache.MakeFunctionServiceCache(logr.Discard()),
+			kc, 2*time.Minute, 5*time.Second, true)
+	}
+
+	t.Run("a real reap records one lag sample", func(t *testing.T) {
+		before := sampleCount(lag, newdeploy)
+		require.NoError(t, newScaleDown(k8sfake.NewSimpleClientset(newDeploy(3))).Reap(t.Context(), newFsvc()))
+		assert.InDelta(t, before+1, sampleCount(lag, newdeploy), 0.001, "scaling down to MinScale is a reap")
+	})
+
+	t.Run("a skip records nothing", func(t *testing.T) {
+		before := sampleCount(lag, newdeploy)
+		// Already at MinScale: nothing is released, so it is not a reap.
+		require.NoError(t, newScaleDown(k8sfake.NewSimpleClientset(newDeploy(1))).Reap(t.Context(), newFsvc()))
+		assert.InDelta(t, before, sampleCount(lag, newdeploy), 0.001, "an at-MinScale deployment must not count as reaped")
+	})
+
+	t.Run("a failed pass is counted at its stage", func(t *testing.T) {
+		// The case that was invisible before: a Prepare failure aborts the whole
+		// pass, so nothing is reaped and no lag is sampled. Without a
+		// stage-labelled error the series look exactly like a quiet cluster.
+		prepareFail := map[string]string{"executor_type": "newdeploy", "stage": "prepare"}
+		before := sampleCount(errs, prepareFail)
+
+		fc := fissionfake.NewClientset()
+		fc.PrependReactor("list", "environments", func(k8stesting.Action) (bool, runtime.Object, error) {
+			return true, nil, assert.AnError
+		})
+		s := NewScaleDownStrategy(logr.Discard(), fv1.ExecutorTypeNewdeploy, fc,
+			fscache.MakeFunctionServiceCache(logr.Discard()), k8sfake.NewSimpleClientset(),
+			2*time.Minute, 5*time.Second, true)
+
+		NewReaper(logr.Discard(), s).reapOnce(t.Context(), s)
+		assert.InDelta(t, before+1, sampleCount(errs, prepareFail), 0.001,
+			"a Prepare failure must increment the error counter at stage=prepare")
+	})
 }

--- a/test/helm/dashboards_test.go
+++ b/test/helm/dashboards_test.go
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+package helm
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestDashboardsRenderAndParse guards a footgun that neither `helm lint` nor the
+// lint-dashboards CI job catches.
+//
+// templates/dashboards/dashboards.yaml embeds each dashboard as a SINGLE-QUOTED
+// YAML scalar:
+//
+//	{{ base $path }}: '{{ $files.Get $path }}'
+//
+// so a single apostrophe anywhere in a dashboard — in a panel description, a
+// legend, a title — closes the scalar early and the whole chart stops rendering.
+// The failure is a YAML parse error pointing at a line number inside the
+// embedded JSON, which says nothing about the apostrophe that caused it.
+//
+// lint-dashboards.sh does not catch it because it validates the JSON files
+// directly, never through the chart. `helm lint` does not either, because the
+// dashboards are off by default. This test renders them on and parses the JSON
+// back out of the ConfigMap, which fails on both.
+func TestDashboardsRenderAndParse(t *testing.T) {
+	ms := render(t, "--set", "grafana.dashboards.enable=true")
+
+	configMaps := ms.ofKind("ConfigMap")
+	var dashboards int
+	for i := range configMaps {
+		m := &configMaps[i]
+		if !strings.Contains(m.Name, "dashboard") {
+			continue
+		}
+		cm := decodeAs[corev1.ConfigMap](t, m)
+		for file, body := range cm.Data {
+			dashboards++
+			// A struct naming the one field this test reads, rather than
+			// map[string]any: the assertion is "it parses and has panels", and
+			// decoding the rest untyped would claim knowledge of a Grafana
+			// schema this test neither has nor checks.
+			var parsed struct {
+				Panels []json.RawMessage `json:"panels"`
+			}
+			require.NoErrorf(t, json.Unmarshal([]byte(body), &parsed),
+				"%s must survive the ConfigMap round-trip as valid JSON", file)
+			assert.NotEmptyf(t, parsed.Panels, "%s must carry panels", file)
+		}
+	}
+	require.NotZero(t, dashboards, "the chart must render its dashboards when grafana.dashboards.enable=true")
+}


### PR DESCRIPTION
# executor: measure how late the idle reaper is

Closes #1989.

## TL;DR

The idle reaper had no telemetry at all, so "warm pods are not going away" had no number
behind it.
This adds two metrics answering the issue's question, and an admin-dashboard row to plot
them.

**Start with `pkg/executor/reaper/idle/idle.go`** — 33 lines, and the whole behavioural
surface. The other four files are the metric declarations, tests, and the dashboard.

| file | lines | what it is |
| --- | ---: | --- |
| `pkg/executor/reaper/idle/idle.go` | +33/-3 | the change: 4 record call sites and one pure helper |
| `pkg/executor/metrics/metrics.go` | +52 | 2 instrument declarations + Record wrappers |
| `pkg/executor/reaper/idle/idle_test.go` | +121 | table test for the helper, call-site tests for the metrics |
| `test/helm/dashboards_test.go` | +59 | render guard (see commit 2) |
| `charts/fission-all/dashboards/fission-admin-dashboard.json` | +201 | **mechanical** — Grafana boilerplate, 4 queries of actual content |

Two commits, in dependency order: **code first, chart second.** The chart commit is
skippable on a first pass.

## The design call worth reviewing

The issue asks "how long it took to detect an idle pod". The quantity that answers it is
the reaper's **lateness**, not the pod's idleness — how long a function service sat past
its idle deadline before the reaper acted.

Recording idleness would restate the configured timeout back to whoever configured it: a
function idle for an hour under a one-hour timeout was reaped **on time** and must read ~0.
Lateness instead tracks what an operator can act on — the 5s tick, `Prepare`'s
cross-namespace `List` calls, and queueing on the `maxConcurrentReaps` semaphore, which a
traffic drop can saturate with thousands of simultaneously-idle services.

## Why the `stage` label is load-bearing, not decoration

A `Prepare` or `ListIdle` error aborts the **whole pass** before any candidate is
considered, and lag is only sampled on success.
Without a stage-labelled error counter, a reaper failing every tick emits **nothing**: zero
reaps, zero errors, empty histogram — indistinguishable from a quiet cluster on the very
dashboard meant to show it.
That is the likeliest way for reaping to stop dead, and it is exactly the pathology #1989
asks to make visible.

## What is deliberately excluded

Lag is recorded only where a reap actually happens, so the numbers never overstate the work
done. A skip is not a reap:

- a websocket-held function service,
- a provisioned pod the RFC-0026 provisioner still owns,
- a deployment already at or below `MinScale`,
- a `DeleteOldPoolCache` returning false — it re-reads the clock and finds `Atime` moved
  past the threshold between the check and the delete.

There is no companion reap counter: a histogram exports `_count`, so
`fission_executor_idle_reap_lag_seconds_count` **is** the reap volume, from the same
instrument, with no possibility of drift.

## Risk and rollout

Low. Additive instrumentation on an existing code path; no control flow changes, no new
config, no gate. Cardinality is `executor_type` only — three values.
The dashboard row renders only under `grafana.dashboards.enable=true`, which is off by
default.

## Testing

`reapLag` is pure, so its definition is table-tested directly.
The call sites — where this can actually be wrong — are covered through
`pkg/utils/metrics/metricstest`: a real reap records one sample, a skip records none, and a
failed pass is counted at its stage. That last case was verified by mutation (removing the
prepare-stage record fails it by name).

`go test ./pkg/executor/...` and `./test/helm/` green; `helm lint`, `make antislop`,
`make license-check` and `golangci-lint` clean.
