### PR TITLE
timer: phase-anchor @every schedules to the trigger, not to process start (#2660)

### DIFF
--- a/pkg/timer/reconciler.go
+++ b/pkg/timer/reconciler.go
@@ -66,7 +66,24 @@ func (r *TimeTriggerReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	r.timer.addUpdate(tt)
+	if err := r.timer.addUpdate(tt); err != nil {
+		// Only reachable if this parser and IsValidCronSpec's disagree. Report it
+		// the same way an invalid spec is reported rather than stamping Ready=True
+		// on a trigger that has no cron entry behind it.
+		controller.SetConditions(ctx, r.logger, r.client, tt,
+			metav1.Condition{
+				Type: fv1.TimeTriggerConditionScheduled, Status: metav1.ConditionFalse,
+				Reason:  fv1.TimeTriggerReasonInvalidCron,
+				Message: fmt.Sprintf("could not schedule cron %q: %v", tt.Spec.Cron, err),
+			},
+			metav1.Condition{
+				Type: fv1.TimeTriggerConditionReady, Status: metav1.ConditionFalse,
+				Reason:  fv1.TimeTriggerReasonInvalidCron,
+				Message: "trigger is not firing: cron schedule could not be registered",
+			},
+		)
+		return ctrl.Result{}, nil
+	}
 
 	// Best-effort Scheduled + Ready conditions. Status writes never gate the
 	// schedule; SetConditions skips the write when nothing changed.

--- a/pkg/timer/timer.go
+++ b/pkg/timer/timer.go
@@ -6,6 +6,8 @@ package timer
 
 import (
 	"context"
+	"math"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/robfig/cron/v3"
@@ -42,24 +44,34 @@ func MakeTimer(logger logr.Logger, routerUrl string) *Timer {
 // for the same trigger is stopped and replaced so a changed schedule takes
 // effect. Keyed by namespaced name so the reconciler can tear it down on a
 // delete (when only the name is known).
-func (timer *Timer) addUpdate(timeTrigger *fv1.TimeTrigger) {
+//
+// Returns the schedule error rather than swallowing it: the reconciler stamps
+// Scheduled/Ready=True on whatever addUpdate leaves behind, so an error absorbed
+// here would surface as a trigger reported healthy that never fires.
+func (timer *Timer) addUpdate(timeTrigger *fv1.TimeTrigger) error {
 	key := types.NamespacedName{Namespace: timeTrigger.Namespace, Name: timeTrigger.Name}
 	logger := timer.logger.WithValues("trigger_name", timeTrigger.Name, "trigger_namespace", timeTrigger.Namespace)
+
+	c, err := timer.newCron(*timeTrigger, timer.routerUrl)
+	if err != nil {
+		// Drop any prior schedule: leaving the old cron running would fire the
+		// trigger on a schedule the spec no longer asks for.
+		timer.remove(key)
+		return err
+	}
 
 	if item, ok := timer.triggers[key]; ok {
 		if item.cron != nil {
 			item.cron.Stop()
 		}
 		item.trigger = *timeTrigger
-		item.cron = timer.newCron(*timeTrigger, timer.routerUrl)
+		item.cron = c
 		logger.V(1).Info("cron updated")
-		return
+		return nil
 	}
-	timer.triggers[key] = &timerTriggerWithCron{
-		trigger: *timeTrigger,
-		cron:    timer.newCron(*timeTrigger, timer.routerUrl),
-	}
+	timer.triggers[key] = &timerTriggerWithCron{trigger: *timeTrigger, cron: c}
 	logger.V(1).Info("cron added")
+	return nil
 }
 
 // remove stops and drops the cron entry for a deleted time trigger. No-op if
@@ -90,17 +102,95 @@ func functionTargetURL(t fv1.TimeTrigger) string {
 	return utils.UrlForFunctionReference(t.Spec.FunctionReference, t.Namespace) + t.Spec.Subpath
 }
 
-func (timer *Timer) newCron(t fv1.TimeTrigger, routerUrl string) *cron.Cron {
+// cronParser is the spec grammar Fission accepts: standard five-field cron with
+// an optional leading seconds field, plus the @descriptors (@hourly, @daily,
+// @every <duration>).
+var cronParser = cron.NewParser(
+	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+// anchoredSchedule phase-locks a fixed-interval schedule to a fixed instant, so
+// the firing times are a property of the TRIGGER rather than of whenever the
+// timer process last started.
+//
+// robfig/cron's ConstantDelaySchedule — what "@every 6h" parses to — computes
+// Next(t) as t + delay, so the phase is set by whenever the process last
+// started. That both synchronises every @every trigger on restart and, when a
+// pod restarts more often than the interval, starves the trigger entirely.
+//
+// Standard cron expressions are already wall-clock anchored and are left alone.
+type anchoredSchedule struct {
+	interval time.Duration
+	anchor   time.Time
+}
+
+// Next returns the first firing strictly after t that is in phase with the
+// anchor: the smallest anchor+k*interval greater than t. cron.Schedule requires
+// strictly-after; returning t itself would spin the scheduler.
+func (s anchoredSchedule) Next(t time.Time) time.Time {
+	if s.interval <= 0 {
+		return time.Time{} // a zero Next tells cron to never run this entry
+	}
+	// k is at least 1 even when t precedes the anchor. The API server sets
+	// CreationTimestamp, so a timer pod whose clock trails it briefly sees a
+	// trigger created in its own future; firing at the anchor itself would fire
+	// the trigger seconds after creation instead of one interval later, unlike
+	// every subsequent firing.
+	k := int64(1)
+	if !t.Before(s.anchor) {
+		elapsed := t.Sub(s.anchor)
+		// Guard the multiply below: time.Sub saturates at ~292 years rather than
+		// wrapping, so a far-past anchor would overflow int64 and yield a time in
+		// the PAST, which cron fires immediately and then recomputes forever.
+		// Unreachable while CreationTimestamp is server-set, cheap to exclude.
+		if int64(elapsed) > math.MaxInt64-int64(s.interval) {
+			return t.Add(s.interval)
+		}
+		k = int64(elapsed/s.interval) + 1
+	}
+	return s.anchor.Add(time.Duration(k) * s.interval)
+}
+
+// scheduleFor parses a trigger's spec and, for fixed-interval schedules only,
+// phase-anchors it to the trigger's creation time.
+//
+// A trigger with no creation timestamp (never round-tripped through the API
+// server — hand-built objects, unit tests) keeps the unanchored schedule, since
+// there is nothing stable to anchor to.
+func scheduleFor(t fv1.TimeTrigger) (cron.Schedule, error) {
+	schedule, err := cronParser.Parse(t.Spec.Cron)
+	if err != nil {
+		return nil, err
+	}
+	delay, isInterval := schedule.(cron.ConstantDelaySchedule)
+	if !isInterval || t.CreationTimestamp.IsZero() {
+		return schedule, nil
+	}
+	return anchoredSchedule{interval: delay.Delay, anchor: t.CreationTimestamp.Time}, nil
+}
+
+func (timer *Timer) newCron(t fv1.TimeTrigger, routerUrl string) (*cron.Cron, error) {
 	target := functionTargetURL(t)
 
 	// create one publisher per-cron timer
 	timerPublisher := publisher.MakeWebhookPublisher(timer.logger, routerUrl)
 
-	c := cron.New(
-		cron.WithParser(
-			cron.NewParser(
-				cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)))
-	c.AddFunc(t.Spec.Cron, func() { //nolint: errCheck
+	// No WithParser: nothing here goes through AddFunc/AddJob, which are the only
+	// entry points that consult the cron's parser. scheduleFor parses instead, and
+	// the schedule is installed directly with c.Schedule.
+	c := cron.New()
+
+	schedule, err := scheduleFor(t)
+	if err != nil {
+		// There is no TimeTrigger admission webhook — the reconciler is the gate,
+		// rejecting an unparseable spec with Scheduled=False/InvalidCron before it
+		// ever calls addUpdate (pkg/timer/reconciler.go). So this is belt and
+		// braces against that parser and this one drifting apart. Returning the
+		// error rather than discarding it, as AddFunc's was, is what keeps the
+		// reconciler from stamping Ready=True on a trigger with no entries.
+		return nil, err
+	}
+
+	c.Schedule(schedule, cron.FuncJob(func() {
 		headers := map[string]string{
 			"X-Fission-Timer-Name": t.Name,
 		}
@@ -109,8 +199,10 @@ func (timer *Timer) newCron(t fv1.TimeTrigger, routerUrl string) *cron.Cron {
 		// the triggers can only be created in the same namespace as the function.
 		// so essentially, function namespace = trigger namespace.
 		(timerPublisher).Publish(context.Background(), "", headers, t.Spec.Method, target)
-	})
+	}))
 	c.Start()
-	timer.logger.Info("started cron for time trigger", "trigger_name", t.Name, "trigger_namespace", t.Namespace, "cron", t.Spec.Cron)
-	return c
+	timer.logger.Info("started cron for time trigger",
+		"trigger_name", t.Name, "trigger_namespace", t.Namespace, "cron", t.Spec.Cron,
+		"next_fire", schedule.Next(time.Now()))
+	return c, nil
 }

--- a/pkg/timer/timer_test.go
+++ b/pkg/timer/timer_test.go
@@ -6,11 +6,163 @@ package timer
 
 import (
 	"testing"
+	"time"
 
+	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
+
+// trigger builds a TimeTrigger with a cron spec and a creation time.
+func trigger(spec string, created time.Time) fv1.TimeTrigger {
+	tt := fv1.TimeTrigger{Spec: fv1.TimeTriggerSpec{Cron: spec}}
+	tt.Name, tt.Namespace = "tt", "default"
+	if !created.IsZero() {
+		tt.CreationTimestamp = metav1.NewTime(created)
+	}
+	return tt
+}
+
+// TestAnchoredScheduleNext pins the phase arithmetic: firings are always
+// anchor + k*interval, and always strictly after the time asked about.
+func TestAnchoredScheduleNext(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := anchoredSchedule{interval: 6 * time.Hour, anchor: anchor}
+
+	for _, tc := range []struct {
+		name string
+		from time.Time
+		want time.Time
+	}{
+		// Clock skew: the API server sets CreationTimestamp, so a timer pod whose
+		// clock trails it sees a trigger created in its own future. It must still
+		// wait a full interval, like every subsequent firing.
+		{"before the anchor still waits a full interval", anchor.Add(-time.Hour), anchor.Add(6 * time.Hour)},
+		{"at the anchor moves a full interval", anchor, anchor.Add(6 * time.Hour)},
+		{"mid-interval snaps to the boundary", anchor.Add(7 * time.Hour), anchor.Add(12 * time.Hour)},
+		{"exactly on a boundary moves to the next", anchor.Add(12 * time.Hour), anchor.Add(18 * time.Hour)},
+		{"far in the future stays in phase", anchor.Add(100*time.Hour + 30*time.Minute), anchor.Add(102 * time.Hour)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := s.Next(tc.from)
+			assert.Equal(t, tc.want, got)
+			assert.True(t, got.After(tc.from), "Next must be strictly after the time asked about")
+		})
+	}
+}
+
+// TestAnchoredScheduleNextIsAlwaysFuture guards the one way this schedule could
+// wedge the scheduler: cron fires whatever Next returns and then asks again, so
+// a Next in the past becomes an unbounded fire loop hammering the function.
+// time.Sub saturates rather than wrapping, so a far-past anchor would otherwise
+// overflow the multiply into a negative offset.
+func TestAnchoredScheduleNextIsAlwaysFuture(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, anchor := range []time.Time{
+		now.Add(-time.Second),
+		now.Add(-100 * 365 * 24 * time.Hour),
+		time.Date(1700, 1, 1, 0, 0, 0, 0, time.UTC),
+		// the zero time, ~year 1
+		{},
+	} {
+		s := anchoredSchedule{interval: 24 * time.Hour, anchor: anchor}
+		assert.Truef(t, s.Next(now).After(now), "anchor %v produced a non-future firing %v", anchor, s.Next(now))
+	}
+}
+
+// TestAnchoredScheduleSurvivesRestart is the #2660 fix stated as a property:
+// the firing times do not depend on when the process asked.
+//
+// This is the half the issue does not mention and that matters more. With the
+// stock ConstantDelaySchedule the phase resets on every restart, so a timer pod
+// restarting more often than the interval starves the trigger completely — an
+// "@every 24h" trigger under a daily rollout never fires at all.
+func TestAnchoredScheduleSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	anchor := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	s := anchoredSchedule{interval: 24 * time.Hour, anchor: anchor}
+	stock := cron.ConstantDelaySchedule{Delay: 24 * time.Hour}
+
+	// A pod that restarts every 20 hours, five times over.
+	var anchoredFires, stockFires int
+	for i := 1; i <= 5; i++ {
+		restart := anchor.Add(time.Duration(i) * 20 * time.Hour)
+		nextRestart := restart.Add(20 * time.Hour)
+		if s.Next(restart).Before(nextRestart) {
+			anchoredFires++
+		}
+		if stock.Next(restart).Before(nextRestart) {
+			stockFires++
+		}
+	}
+	assert.Positive(t, anchoredFires, "an anchored schedule keeps firing across restarts")
+	assert.Zero(t, stockFires, "the stock schedule never fires when restarts outpace the interval — the bug being fixed")
+}
+
+// TestAnchoredScheduleDesynchronises covers the reported symptom: triggers
+// created at different times must not collapse onto one firing instant just
+// because they were registered together at process start.
+func TestAnchoredScheduleDesynchronises(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	start := base.Add(50 * time.Hour) // a much later process start
+	fires := map[time.Time]bool{}
+	for _, offset := range []time.Duration{0, 37 * time.Minute, 2 * time.Hour, 5*time.Hour + 13*time.Minute} {
+		s := anchoredSchedule{interval: 6 * time.Hour, anchor: base.Add(offset)}
+		fires[s.Next(start)] = true
+	}
+	assert.Len(t, fires, 4, "triggers created at different times must fire at different times")
+}
+
+// TestScheduleFor covers which specs get anchored. Standard cron expressions are
+// already wall-clock anchored, so wrapping them would change their meaning.
+func TestScheduleFor(t *testing.T) {
+	t.Parallel()
+	created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("@every is anchored to the creation time", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduleFor(trigger("@every 6h", created))
+		require.NoError(t, err)
+		require.IsType(t, anchoredSchedule{}, s)
+		assert.Equal(t, created.Add(6*time.Hour), s.Next(created))
+	})
+
+	t.Run("standard cron is left alone", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduleFor(trigger("0 */6 * * *", created))
+		require.NoError(t, err)
+		_, anchored := s.(anchoredSchedule)
+		assert.False(t, anchored, "a wall-clock cron must keep its own phase")
+	})
+
+	t.Run("a descriptor is left alone", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduleFor(trigger("@daily", created))
+		require.NoError(t, err)
+		_, anchored := s.(anchoredSchedule)
+		assert.False(t, anchored, "a wall-clock descriptor must keep its own phase")
+	})
+
+	t.Run("no creation timestamp falls back to the stock schedule", func(t *testing.T) {
+		t.Parallel()
+		s, err := scheduleFor(trigger("@every 6h", time.Time{}))
+		require.NoError(t, err)
+		assert.IsType(t, cron.ConstantDelaySchedule{}, s)
+	})
+
+	t.Run("an unparseable spec is an error, not a silent no-op", func(t *testing.T) {
+		t.Parallel()
+		_, err := scheduleFor(trigger("not a cron spec", created))
+		assert.Error(t, err)
+	})
+}
 
 // TestFunctionTargetURL is the timer publisher's wiring test for RFC-0025:
 // a TimeTrigger's embedded FunctionReference.Alias/Version threads through to


### PR DESCRIPTION
# timer: phase-anchor `@every` schedules to the trigger, not to process start

Closes #2660.

## TL;DR

`@every` schedules were phase-locked to whenever the timer process last started.
That synchronises every such trigger on restart (the reported bug) and, when a pod restarts
more often than the interval, **starves the trigger completely** (not reported, worse).
Anchoring to the trigger's own `CreationTimestamp` fixes both, with no API change.

**Start with `anchoredSchedule.Next` and `scheduleFor` in `pkg/timer/timer.go`** — about 40
lines, and the whole of the fix. The rest is one reconciler branch and tests.

| file | lines | what it is |
| --- | ---: | --- |
| `pkg/timer/timer.go` | +108/-16 | the fix: the schedule type, spec selection, error propagation |
| `pkg/timer/timer_test.go` | +152 | phase arithmetic, restart survival, desynchronisation |
| `pkg/timer/reconciler.go` | +18/-1 | report a schedule error as `Scheduled=False` instead of `Ready=True` |

## The bug

```go
// robfig/cron v3, constantdelay.go
func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
	return t.Add(schedule.Delay - ...)
}
```

Purely relative to *now*, and `newCron` starts the cron at registration.

**Reported:** every `@every` trigger registered at process start fires at `start+d`, `+2d`,
… so a restart collapses independently-authored schedules into one thundering herd.
The issue states the expectation exactly — *"the schedule is relative to when the function
was deployed"* — and that is what was not true.

**Unreported, and worse:** the phase resets on *every* restart, so a timer pod restarting
more often than the interval means the trigger **never fires at all**.
`@every 24h` under a daily rollout is permanently starved.

## The fix

Next firing is the smallest `creation + k*interval` after now, so firing times are a
property of the **trigger**: they survive restarts, and spread out on their own because
creation times differ.

This is the issue's own **option 2** and needs no API change.
Option 1 (a configurable offset field) would need a CRD change and would still leave the
starvation, since the phase would keep resetting.

Deliberately **not** wrapped: standard cron expressions and `@daily`/`@hourly` are already
wall-clock anchored, so anchoring them would change what they mean.
A trigger with no `CreationTimestamp` keeps the stock schedule — nothing stable to anchor
to.

## Two edge cases the arithmetic has to exclude

- **`k` is at least 1 even when the timer asks about a time before the anchor.**
  `CreationTimestamp` is server-set, so a pod whose clock trails the API server sees a
  trigger created in its own future; firing at the anchor itself would fire it seconds
  after creation rather than an interval later.
- **`time.Sub` saturates at ~292 years rather than wrapping**, so a far-past anchor would
  otherwise overflow the multiply into a time in the *past* — which cron fires immediately,
  then recomputes, forever.

## The status bug this also closes

Registration used to discard `AddFunc`'s error, leaving a running cron with **no entries**.
Worse, the reconciler stamps `Scheduled/Ready=True` on whatever `addUpdate` leaves behind —
so a swallowed error means a trigger reporting *"trigger is firing on schedule"* while it
has no cron entry at all.
The error now propagates and is reported as `Scheduled=False/InvalidCron`, the same as a
spec rejected up front.

For the record: there is **no TimeTrigger admission webhook** (`pkg/webhook/service.go`);
the reconciler's `IsValidCronSpec` is the gate, and this branch is belt and braces against
that parser and this one drifting apart.

## Behaviour change on upgrade

An existing `@every` trigger's next firing moves to its creation-time phase, which may be
**sooner** than the old code would have scheduled it — the old code always pushed it a full
interval out from restart.
That is the fix working; the old delay was the starvation.
There is no opt-out flag: the previous semantics are the bug.

## Reviewing the tests

`TestAnchoredScheduleSurvivesRestart` asserts the **stock** library schedule fires **zero**
times across a restart cycle that outpaces the interval.
That pins the bug itself, not just the fix — if a future cron upgrade changes
`ConstantDelaySchedule`, the test says so.

`go test ./pkg/timer/...` green (including the pre-existing reconciler tests);
`go build ./...`, `golangci-lint`, `make antislop`, `make license-check` clean.
