### PR TITLE
Agent runtime slice 2: pkg/agentruntime session dispatcher, registry, and sweeper

### DIFF
--- a/.github/workflows/push_pr.yaml
+++ b/.github/workflows/push_pr.yaml
@@ -196,6 +196,13 @@ jobs:
           # would silently turn all MCP coverage into a green skip — the
           # loop above only waits for deployments that exist.
           kubectl -n fission rollout status deploy/mcp --timeout=3m
+          # deploy/agentruntime must exist and be ready (kind-ci enables
+          # agentRuntime.enabled): the agent-runtime integration test skips
+          # itself when the endpoint is unreachable, so without this
+          # explicit gate a profile regression would silently turn all
+          # agent-runtime coverage into a green skip — the loop above only
+          # waits for deployments that exist.
+          kubectl -n fission rollout status deploy/agentruntime --timeout=3m
 
       # Pin the v1.34 leg back to the legacy data plane (RFC-0002 gates off):
       # kind-ci deploys with the EndpointSlice path on everywhere, so without

--- a/charts/fission-all/templates/_fission-component-roles.tpl
+++ b/charts/fission-all/templates/_fission-component-roles.tpl
@@ -175,6 +175,21 @@ rules:
   - list
   - watch
 {{- end }}
+{{- define "agentruntime-rules" }}
+rules:
+# The agent runtime is read-only against Functions (it watches Spec.Agent to
+# build its per-replica AgentView and resolve dispatch targets). Unlike mcp it
+# writes no status condition in v1 (see pkg/agentruntime/reconciler.go) and
+# touches no other resource.
+- apiGroups:
+  - fission.io
+  resources:
+  - functions
+  verbs:
+  - get
+  - list
+  - watch
+{{- end }}
 {{- define "statesvc-rules" }}
 rules:
 # statesvc watches Functions to index StateConfigs (quota/keyspace resolution,

--- a/charts/fission-all/templates/_fission-role-generator.tpl
+++ b/charts/fission-all/templates/_fission-role-generator.tpl
@@ -26,6 +26,9 @@ metadata:
 {{- if eq "mcp" .component }}
 {{- include "mcp-rules" . }}
 {{- end }}
+{{- if eq "agentruntime" .component }}
+{{- include "agentruntime-rules" . }}
+{{- end }}
 {{- if eq "workflow" .component }}
 {{- include "workflow-rules" . }}
 {{- end }}
@@ -103,6 +106,9 @@ metadata:
 {{- end }}
 {{- if eq "mcp" .component }}
 {{- include "mcp-rules" . }}
+{{- end }}
+{{- if eq "agentruntime" .component }}
+{{- include "agentruntime-rules" . }}
 {{- end }}
 {{- if eq "workflow" .component }}
 {{- include "workflow-rules" . }}

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -661,7 +661,7 @@ the chart test proves every key on it annotates exactly one rendered account.
 Keep it sorted, and add to it in the same commit that adds a ServiceAccount.
 */}}
 {{- define "fission.saComponents" -}}
-builder buildermgr canaryconfig executor fetcher kafka kubewatcher mcp mqtKeda preupgrade router statestore statestoreMqt statesvc storagesvc tenantController timer webhook workflow
+agentruntime builder buildermgr canaryconfig executor fetcher kafka kubewatcher mcp mqtKeda preupgrade router statestore statestoreMqt statesvc storagesvc tenantController timer webhook workflow
 {{- end -}}
 
 {{/*

--- a/charts/fission-all/templates/_helpers.tpl
+++ b/charts/fission-all/templates/_helpers.tpl
@@ -375,6 +375,14 @@ pkg/svcinfo.PortMCP.
 {{- end -}}
 
 {{/*
+fission.agentRuntimePort is the agent runtime dispatcher's port. Mirrored by
+pkg/svcinfo.PortAgentRuntime.
+*/}}
+{{- define "fission.agentRuntimePort" -}}
+{{ (.Values.agentRuntime | default dict).port | default 8894 }}
+{{- end -}}
+
+{{/*
 fission.statestorePort is the embedded statestore's capability API port.
 Mirrored by pkg/svcinfo.PortStatestore (RFC-0021).
 */}}

--- a/charts/fission-all/templates/agentruntime/deployment.yaml
+++ b/charts/fission-all/templates/agentruntime/deployment.yaml
@@ -1,0 +1,125 @@
+{{- if .Values.agentRuntime.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentruntime
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: agentruntime
+    application: fission-agentruntime
+spec:
+  replicas: {{ dig "replicas" 1 (.Values.agentRuntime | default dict) }}
+  selector:
+    matchLabels:
+      svc: agentruntime
+  template:
+    metadata:
+      labels:
+        svc: agentruntime
+        application: fission-agentruntime
+    spec:
+      {{- if .Values.agentRuntime.securityContext.enabled }}
+      securityContext: {{- omit .Values.agentRuntime.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: agentruntime
+        image: {{ include "fission-bundleImage" . | quote }}
+        imagePullPolicy: {{ .Values.pullPolicy }}
+        command: ["/fission-bundle"]
+        args: ["--agentPort", "{{ include "fission.agentRuntimePort" . }}"]
+        env:
+        {{- include "fission.podNamespaceEnv" . | nindent 8 }}
+        - name: DEBUG_ENV
+          value: {{ .Values.debugEnv | quote }}
+        - name: PPROF_ENABLED
+          value: {{ .Values.pprof.enabled | quote }}
+        # The agent runtime dispatches session turns to /fission-function/...
+        # on the internal listener (HMAC-signed, like the publishers above).
+        - name: ROUTER_INTERNAL_URL
+          value: {{ include "fission.routerInternalURL" . | quote }}
+        {{- if .Values.authentication.enabled }}
+        # Callers authenticate with a bearer JWT signed by this key (shared
+        # with the router's signing key). Tokens must carry sub + exp claims
+        # and an allowed_namespaces claim ("*" or a list) that scopes which
+        # sessions a caller may create and drive.
+        - name: JWT_SIGNING_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fission.authenticationSecretName" . }}
+              key: jwtSigningKey
+        {{- else if .Values.agentRuntime.allowInsecure }}
+        # No signing key: the agent runtime endpoint runs UNAUTHENTICATED —
+        # every caller gets a wildcard scope and can create and drive any
+        # session. Explicitly opted in here (dev only); the server fails
+        # closed without this.
+        - name: AGENT_ALLOW_INSECURE
+          value: "true"
+        {{- else }}
+        {{ required "agentRuntime.enabled requires authentication.enabled (so callers are scoped via a signed JWT), or agentRuntime.allowInsecure=true to explicitly run the agent runtime endpoint unauthenticated (dev only)." nil }}
+        {{- end }}
+        # Session records live in the statestore (render-gated: the
+        # statestore validate template fails render when agentRuntime.enabled
+        # && !statestore.enabled).
+        {{- if eq .Values.statestore.mode "embedded" }}
+        - name: STATESTORE_DRIVER
+          value: "client"
+        - name: STATESTORE_DSN
+          value: "http://statestore.{{ .Release.Namespace }}:{{ include "fission.statestorePort" . }}"
+        {{- else if eq .Values.statestore.mode "external" }}
+        - name: STATESTORE_DRIVER
+          value: "postgres"
+        - name: STATESTORE_DSN
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.statestore.external.existingSecret | default "statestore-postgres" }}
+              key: dsn
+        {{- end }}
+        - name: AGENT_SWEEP_INTERVAL
+          value: {{ .Values.agentRuntime.sweepInterval | quote }}
+        - name: AGENT_ARCHIVE_RETENTION
+          value: {{ .Values.agentRuntime.archiveRetention | quote }}
+        {{- include "fission-resource-namespace.envs" . | indent 8 }}
+        {{- include "kube_client.envs" . | indent 8 }}
+        {{- include "opentelemtry.envs" . | indent 8 }}
+        {{- include "internalAuth.envs" . | indent 8 }}
+        {{- include "coverage.envs" . | indent 8 }}
+        # /readyz reports ready only after the agent runtime's caches have
+        # synced, so a warming replica is kept out of the Service endpoints.
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ include "fission.agentRuntimePort" . }}
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ include "fission.agentRuntimePort" . }}
+          periodSeconds: 30
+        resources:
+          {{- toYaml .Values.agentRuntime.resources | nindent 10 }}
+        {{- if .Values.terminationMessagePath }}
+        terminationMessagePath: {{ .Values.terminationMessagePath }}
+        {{- end }}
+        {{- if .Values.terminationMessagePolicy }}
+        terminationMessagePolicy: {{ .Values.terminationMessagePolicy }}
+        {{- end }}
+        {{- if .Values.coverage.enabled }}
+        volumeMounts:
+        {{- include "coverage.volumemount" . | indent 8 }}
+        {{- end }}
+      serviceAccountName: fission-agentruntime
+      {{- if .Values.coverage.enabled }}
+      volumes:
+      {{- include "coverage.volume" . | indent 6 }}
+      {{- end }}
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- if .Values.extraCoreComponentPodConfig }}
+{{ toYaml .Values.extraCoreComponentPodConfig | indent 6 -}}
+{{- end }}
+{{- end }}

--- a/charts/fission-all/templates/agentruntime/role-fission-cr.yaml
+++ b/charts/fission-all/templates/agentruntime/role-fission-cr.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.agentRuntime.enabled }}
+{{- include "fission-role-generator" (merge (dict "namespace" .Values.defaultNamespace "component" "agentruntime") .) }}
+
+{{- if gt (len .Values.additionalFissionNamespaces) 0 }}
+{{- range $namespace := $.Values.additionalFissionNamespaces }}
+{{ include "fission-role-generator" (merge (dict "namespace" $namespace "component" "agentruntime") $) }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/fission-all/templates/agentruntime/service.yaml
+++ b/charts/fission-all/templates/agentruntime/service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.agentRuntime.enabled }}
+# agentruntime is a ClusterIP-only Service: the agent runtime dispatcher is
+# reached only by in-cluster callers (front it with an Ingress / Gateway /
+# port-forward if external access is needed). It never joins the public
+# router listener.
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentruntime
+  labels:
+    svc: agentruntime
+    application: fission-agentruntime
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+spec:
+  type: ClusterIP
+  ports:
+  - name: agentruntime
+    port: {{ include "fission.agentRuntimePort" . }}
+    targetPort: {{ include "fission.agentRuntimePort" . }}
+  selector:
+    svc: agentruntime
+{{- end }}

--- a/charts/fission-all/templates/agentruntime/serviceaccount.yaml
+++ b/charts/fission-all/templates/agentruntime/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.agentRuntime.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fission-agentruntime
+  namespace: {{ .Release.Namespace }}
+  {{- include "fission.saMetadata" (dict "root" . "component" "agentruntime") }}
+{{- end }}

--- a/charts/fission-all/templates/router/networkpolicy.yaml
+++ b/charts/fission-all/templates/router/networkpolicy.yaml
@@ -100,6 +100,11 @@ spec:
         - podSelector:
             matchLabels:
               svc: workflow
+        # The agent runtime dispatches session turns to /fission-function/...
+        # on the internal listener (HMAC-signed, like the publishers above).
+        - podSelector:
+            matchLabels:
+              svc: agentruntime
         {{- if .Values.asyncInvocation.enabled }}
         # RFC-0024: the in-router async dispatcher POSTs deliveries to
         # svc/router-internal, which may land on a DIFFERENT router replica —

--- a/charts/fission-all/templates/statestore/networkpolicy.yaml
+++ b/charts/fission-all/templates/statestore/networkpolicy.yaml
@@ -27,6 +27,8 @@ spec:
         # drains the RFC-0027 mq-egress-kafka queue.
         - podSelector: { matchLabels: { svc: mqtrigger, messagequeue: statestore } }
         - podSelector: { matchLabels: { svc: mqtrigger, messagequeue: kafka } }
+        # The agent runtime keeps session records in the statestore.
+        - podSelector: { matchLabels: { svc: agentruntime } }
       ports:
         - port: {{ include "fission.statestorePort" . }}
           protocol: TCP

--- a/charts/fission-all/templates/statestore/validate.yaml
+++ b/charts/fission-all/templates/statestore/validate.yaml
@@ -12,9 +12,10 @@ This template emits no manifests; it only fails the render on an invalid config.
 {{- end }}
 {{- /*
 Forward-compatible dependent-feature gate: a statestore consumer (RFC-0022
-workflows, RFC-0023 function state, RFC-0024 async invocation) enabled without a
-statestore fails the render. Dormant until those features add their flags.
+workflows, RFC-0023 function state, RFC-0024 async invocation, the agent
+runtime) enabled without a statestore fails the render. Dormant until those
+features add their flags.
 */ -}}
-{{- if and (or (dig "enabled" false (.Values.workflows | default dict)) (dig "enabled" false (.Values.functionState | default dict)) (dig "enabled" false (.Values.asyncInvocation | default dict))) (not .Values.statestore.enabled) }}
-{{  required "a statestore-dependent feature (workflows/functionState/asyncInvocation) is enabled but statestore.enabled is false — set statestore.enabled=true and choose a mode." nil }}
+{{- if and (or (dig "enabled" false (.Values.workflows | default dict)) (dig "enabled" false (.Values.functionState | default dict)) (dig "enabled" false (.Values.asyncInvocation | default dict)) (dig "enabled" false (.Values.agentRuntime | default dict))) (not .Values.statestore.enabled) }}
+{{  required "a statestore-dependent feature (workflows/functionState/asyncInvocation/agentRuntime) is enabled but statestore.enabled is false — set statestore.enabled=true and choose a mode." nil }}
 {{- end }}

--- a/charts/fission-all/templates/tenant-controller/dynamic-cluster-roles.yaml
+++ b/charts/fission-all/templates/tenant-controller/dynamic-cluster-roles.yaml
@@ -8,7 +8,7 @@
 # namespace-scoped (per-namespace Roles + scoped cache); cluster mode grants those
 # cluster-wide via the separate cluster-mode-bindings.yaml. The per-namespace Roles
 # remain for the static path.
-{{- range $component := list "buildermgr" "kubewatcher" "mcp" "kafka" "keda" "router" "timer" "canaryconfig" "executor" "statestore-mqt" "workflow" "statesvc" }}
+{{- range $component := list "buildermgr" "kubewatcher" "mcp" "agentruntime" "kafka" "keda" "router" "timer" "canaryconfig" "executor" "statestore-mqt" "workflow" "statesvc" }}
 {{- include "fission-cluster-role-generator" (merge (dict "component" $component) $) }}
 {{- end }}
 {{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1504,6 +1504,7 @@ serviceAccounts:
   ## Per-account overrides. Every account this chart can create is listed, so
   ## the set is discoverable without reading the templates; an account only
   ## renders when its component is enabled.
+  agentruntime: {}
   builder: {}
   buildermgr: {}
   canaryconfig: {}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -871,6 +871,53 @@ mcp:
     runAsUser: 10001
     runAsGroup: 10001
 
+## The agent runtime dispatches durable, multi-turn agent sessions to
+## Tool-exposed functions. Off by default. When enabled it runs
+## fission-bundle --agentPort as a ClusterIP-only Service, keeps session
+## records in the statestore (requires statestore.enabled, render-validated),
+## and dispatches turns to the router internal listener like the other
+## internal publishers. Agents authenticate with a bearer JWT when
+## authentication.enabled is set. With authentication disabled the dispatcher
+## can only run unauthenticated if you explicitly set allowInsecure below;
+## otherwise enabling the agent runtime without authentication fails the
+## chart render.
+##
+agentRuntime:
+  enabled: false
+  ## Port the agent runtime listens on (ClusterIP Service of the same port).
+  ## 8891-8893 belong to statestore/workflow/statesvc.
+  ##
+  port: 8894
+  ## allowInsecure permits running the dispatcher UNAUTHENTICATED when
+  ## authentication.enabled is false (dev/test only). Leave false in
+  ## production; enable authentication instead so callers are scoped by a
+  ## signed JWT.
+  ##
+  allowInsecure: false
+  ## replicas: the dispatcher is stateless (session truth is the statestore)
+  ## and the sweeper is CAS-idempotent, so replicas need no leader election.
+  ##
+  replicas: 1
+  ## Sweep cadence and archived-record retention.
+  ##
+  sweepInterval: 30s
+  archiveRetention: 168h
+  ## Pod resources.
+  ##
+  resources: {}
+
+  ## Security Context
+  ## It holds pod-level and container level security configuration.
+  ## This is an experimental section, please verify before enabling in production.
+  ## Ref: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#security-context-1
+  securityContext:
+    enabled: true
+    ## Mark it false, if you want to stop the non root user validation
+    runAsNonRoot: true
+    fsGroup: 10001
+    runAsUser: 10001
+    runAsGroup: 10001
+
 ## Statestore — the durable-state substrate (RFC-0021) consumed by workflows
 ## (RFC-0022), stateful functions (RFC-0023), and async invocation (RFC-0024).
 ##

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -17,6 +17,7 @@ import (
 	cnwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/fission/fission/cmd/fission-bundle/mqtrigger"
+	"github.com/fission/fission/pkg/agentruntime"
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/buildermgr"
 	"github.com/fission/fission/pkg/canaryconfigmgr"
@@ -66,6 +67,7 @@ type CommandLineArgs struct {
 	statestorePort     int
 	workflowPort       int
 	stateAPIPort       int
+	agentPort          int
 
 	// URL values — empty means "not set": the resolver derives the
 	// in-cluster default from POD_NAMESPACE (see svcinfo.AddressResolver)
@@ -220,6 +222,7 @@ func setupCommandLineArgs() *CommandLineArgs {
 	flag.IntVar(&args.statestorePort, "statestorePort", 0, "Port that the embedded statestore should listen on (RFC-0021 embedded mode)")
 	flag.IntVar(&args.workflowPort, "workflowPort", 0, "Port that the workflow engine should listen on (RFC-0022)")
 	flag.IntVar(&args.stateAPIPort, "stateApiPort", 0, "Port that the statesvc function-facing state API should listen on (RFC-0023)")
+	flag.IntVar(&args.agentPort, "agentPort", 0, "Port that the agent runtime should listen on")
 
 	// URL flags
 	flag.StringVar(&args.executorUrl, "executorUrl", "", "Executor URL (default http://executor.<POD_NAMESPACE>)")
@@ -350,6 +353,16 @@ func bundleServices() []bundleService {
 			selected: func(a *CommandLineArgs) bool { return a.mcpPort != 0 },
 			run: func(ctx context.Context, d bundleDeps) error {
 				return mcp.Start(ctx, d.clientGen, d.logger, d.mgr, mcp.Options{Port: d.args.mcpPort, RouterInternalURL: d.resolver.RouterInternalURL()})
+			},
+		},
+		{
+			// The agent runtime dispatches session turns to /fission-function/...
+			// on the router internal listener, signed like the other publishers,
+			// and keeps session records in the statestore.
+			name:     "Fission-AgentRuntime",
+			selected: func(a *CommandLineArgs) bool { return a.agentPort != 0 },
+			run: func(ctx context.Context, d bundleDeps) error {
+				return agentruntime.Start(ctx, d.clientGen, d.logger, d.mgr, agentruntime.Options{Port: d.args.agentPort, RouterInternalURL: d.resolver.RouterInternalURL()})
 			},
 		},
 		{

--- a/cmd/fission-bundle/main_test.go
+++ b/cmd/fission-bundle/main_test.go
@@ -32,6 +32,7 @@ func TestBundleDispatchTable(t *testing.T) {
 		{"mqt", CommandLineArgs{mqt: true}, "Fission-MessageQueueTrigger"},
 		{"mqt_keda", CommandLineArgs{mqt_keda: true}, "Fission-Keda-MQTrigger"},
 		{"mcp", CommandLineArgs{mcpPort: 8890}, "Fission-MCP"},
+		{"agentruntime", CommandLineArgs{agentPort: 8894}, "Fission-AgentRuntime"},
 		{"tenantController", CommandLineArgs{tenantController: true}, "Fission-TenantController"},
 		{"builderMgr", CommandLineArgs{builderMgr: true}, "Fission-BuilderMgr"},
 		{"storagesvc", CommandLineArgs{storageServicePort: 8000}, "Fission-StorageSvc"},
@@ -63,5 +64,5 @@ func TestBundleDispatchTableComplete(t *testing.T) {
 		assert.Falsef(t, seen[svc.name], "duplicate service name %s", svc.name)
 		seen[svc.name] = true
 	}
-	assert.Len(t, seen, 16)
+	assert.Len(t, seen, 17)
 }

--- a/pkg/agentruntime/authz.go
+++ b/pkg/agentruntime/authz.go
@@ -1,0 +1,277 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// authz.go is a mirror of pkg/mcp/authz.go: the same JWT bearer verification
+// on JWT_SIGNING_KEY, the same allowed_namespaces claim contract, and the
+// same "empty key = dev pass-through" stance. It differs from the mcp
+// original only in how the verified scope is applied to a request: mcp
+// checks a tool's Function namespace against the scope from inside its MCP
+// server logic, while agentruntime is a plain net/http endpoint, so
+// Middleware below checks the scope against the request's {namespace} path
+// value directly. A shared-package extraction of the common bearer-token
+// verification is a known follow-up (see main.go's package doc); this file
+// stays a faithful duplicate until that lands, rather than diverging the
+// claim contract between the two subsystems.
+package agentruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/modelcontextprotocol/go-sdk/auth"
+)
+
+// claimAllowedNamespaces is the JWT claim carrying the caller's authorized
+// namespaces: either the string "*" (all namespaces) or a JSON array of
+// namespace names. A token with no such claim is authorized for nothing.
+const claimAllowedNamespaces = "allowed_namespaces"
+
+// wildcardNamespace is the sentinel scope entry meaning "all namespaces".
+const wildcardNamespace = "*"
+
+// AuthScope is the namespace authorization derived from a caller's token. It is
+// the single authority for which agent namespace a caller may dispatch turns
+// into. Wildcard takes precedence: when it is true, Namespaces is ignored (the
+// constructors in this file always leave Namespaces nil for a wildcard scope).
+type AuthScope struct {
+	Namespaces []string
+	Wildcard   bool
+}
+
+// Allows reports whether the scope authorizes the given namespace.
+func (s AuthScope) Allows(namespace string) bool {
+	if s.Wildcard {
+		return true
+	}
+	return slices.Contains(s.Namespaces, namespace)
+}
+
+// Authorizer validates bearer tokens for the agent runtime endpoint and
+// derives the namespace scope. When no signing key is configured it runs in
+// pass-through dev mode (every caller gets a wildcard scope), matching the
+// router internal listener's "empty secret = pass-through" stance.
+// Pass-through is fail-closed at startup: Start refuses to run without a key
+// unless AGENT_ALLOW_INSECURE=true, and the Helm chart only deploys
+// unauthenticated when explicitly opted in. A scoped deployment requires a
+// signing key (Helm wires it from the router secret when
+// authentication.enabled) and per-caller JWTs carrying an allowed_namespaces
+// claim.
+type Authorizer struct {
+	signingKey []byte
+}
+
+// NewAuthorizer returns an authorizer. An empty signingKey enables dev
+// pass-through mode.
+func NewAuthorizer(signingKey []byte) *Authorizer {
+	return &Authorizer{signingKey: signingKey}
+}
+
+// Enabled reports whether token verification is active (a signing key is set).
+func (a *Authorizer) Enabled() bool { return len(a.signingKey) > 0 }
+
+// HTTPMiddleware wraps next: when enabled it requires a valid bearer token
+// (the SDK's RequireBearerToken stores the resulting TokenInfo on the
+// request's context). When disabled it is a pass-through: no TokenInfo is
+// attached and ScopeFromTokenInfo yields a wildcard.
+func (a *Authorizer) HTTPMiddleware(next http.Handler) http.Handler {
+	if !a.Enabled() {
+		return next
+	}
+	return auth.RequireBearerToken(a.verifyToken, nil)(next)
+}
+
+// Middleware wraps next with HTTPMiddleware, then enforces that the verified
+// scope allows the request's {namespace} path value (set by the ServeMux
+// pattern this handler is registered under — see main.go). A caller with a
+// valid token but the wrong namespace scope gets 403, distinct from the 401
+// HTTPMiddleware returns for a missing or invalid token.
+func (a *Authorizer) Middleware(next http.Handler) http.Handler {
+	return a.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scope, ok := a.ScopeFromTokenInfo(auth.TokenInfoFromContext(r.Context()))
+		if !ok || !scope.Allows(r.PathValue("namespace")) {
+			http.Error(w, "forbidden: token not authorized for this namespace", http.StatusForbidden)
+			return
+		}
+		next.ServeHTTP(w, r)
+	}))
+}
+
+// verifyToken is the SDK TokenVerifier: it validates the JWT against the signing
+// key and projects the allowed_namespaces claim into TokenInfo. Scopes carries
+// the namespace list (or the "*" sentinel); UserID is the subject. Expiration
+// is required: the SDK's RequireBearerToken rejects a TokenInfo with a zero
+// Expiration, so a token without an exp claim is treated as invalid.
+func (a *Authorizer) verifyToken(_ context.Context, token string, _ *http.Request) (*auth.TokenInfo, error) {
+	var claims agentClaims
+	parsed, err := jwt.ParseWithClaims(token, &claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method %v", t.Header["alg"])
+		}
+		return a.signingKey, nil
+	})
+	if err != nil {
+		// A malformed allowed_namespaces claim surfaces here too: scopeClaim's
+		// UnmarshalJSON rejects it, so the token is refused rather than
+		// silently reduced to an empty scope.
+		return nil, fmt.Errorf("%w: %v", auth.ErrInvalidToken, err)
+	}
+	if !parsed.Valid {
+		return nil, fmt.Errorf("%w: token is invalid", auth.ErrInvalidToken)
+	}
+
+	if claims.ExpiresAt == nil {
+		return nil, fmt.Errorf("%w: missing exp claim", auth.ErrInvalidToken)
+	}
+
+	// A non-empty subject is required, mirroring mcp's contract even though
+	// this transport has no session-hijacking concern of its own: keeping the
+	// same rejection here avoids two verifiers silently accepting different
+	// tokens for the same claim shape.
+	if claims.Subject == "" {
+		return nil, fmt.Errorf("%w: missing sub claim", auth.ErrInvalidToken)
+	}
+
+	scope := AuthScope(claims.AllowedNamespaces)
+	ti := &auth.TokenInfo{Scopes: scope.Namespaces, Expiration: claims.ExpiresAt.Time, UserID: claims.Subject}
+	if scope.Wildcard {
+		ti.Scopes = []string{wildcardNamespace}
+	}
+	return ti, nil
+}
+
+// agentClaims is the decoded shape of an agent-runtime bearer token: the
+// registered claims (exp, sub, ...) plus the allowed_namespaces scope claim.
+type agentClaims struct {
+	jwt.RegisteredClaims
+	AllowedNamespaces scopeClaim `json:"allowed_namespaces"`
+}
+
+// readClaims are the claim names this verifier's decisions depend on, either
+// directly (allowed_namespaces, sub) or through the library's validation
+// (exp, nbf, iat). Their spelling is guarded — see UnmarshalJSON.
+var readClaims = map[string]struct{}{
+	claimAllowedNamespaces: {}, "sub": {}, "exp": {}, "nbf": {}, "iat": {},
+}
+
+// UnmarshalJSON decodes the claim set by EXACT key.
+//
+// encoding/json (v1) matches struct fields case-insensitively, so a plain
+// struct decode would let a token carrying "ALLOWED_NAMESPACES" populate the
+// scope that only "allowed_namespaces" is meant to own — and, with two
+// spellings present, the last one in the document would win. Looking claims
+// up in a map with exact keys closes that hole: any key that differs only in
+// case from a claim this verifier reads is refused outright. (v2's default
+// struct matching is itself case-sensitive, which would already close this
+// hole, but the map-based guard stays: it is what enforces the exact-key
+// contract, not an artifact of v1's matching.)
+func (c *agentClaims) UnmarshalJSON(b []byte) error {
+	// SECURITY boundary: v2 defaults (strict) are used deliberately here —
+	// duplicate JSON member names and invalid UTF-8 in the token's claim set
+	// are rejected rather than silently tolerated, hardening this JWT-claims
+	// decode against ambiguous or malformed tokens.
+	var raw map[string]jsontext.Value
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	for k := range raw {
+		if _, exact := readClaims[k]; exact {
+			continue
+		}
+		if _, collides := readClaims[strings.ToLower(k)]; collides {
+			return fmt.Errorf("claim %q differs only in case from %q", k, strings.ToLower(k))
+		}
+	}
+	if v, ok := raw[claimAllowedNamespaces]; ok {
+		if err := c.AllowedNamespaces.UnmarshalJSON(v); err != nil {
+			return err
+		}
+	}
+	// Registered claims keep the library's own decoding and validation; the
+	// guard above has already ruled out case variants of the ones that matter.
+	return json.Unmarshal(b, &c.RegisteredClaims)
+}
+
+// scopeClaim is the decoded allowed_namespaces claim. On the wire it may be
+// absent (a valid token authorized for nothing), JSON null, the string "*", a
+// single namespace string, or an array of namespace strings. Any other JSON
+// type — or an array with a non-string element — is malformed and fails the
+// decode, so the token is rejected rather than silently reduced to an empty
+// scope that is indistinguishable from "no agents exist".
+//
+// It is an AuthScope so the projection is a conversion rather than a second
+// pair of fields that could disagree with it.
+type scopeClaim AuthScope
+
+// UnmarshalJSON accepts a JSON string, an array of strings, or null.
+//
+// SECURITY boundary: both Unmarshal calls below use v2 strict defaults (no
+// Allow options) — this claim is untrusted token input, and the hardening
+// goal is to reject a malformed or ambiguous encoding rather than tolerate it.
+func (c *scopeClaim) UnmarshalJSON(b []byte) error {
+	*c = scopeClaim{}
+	if bytes.Equal(bytes.TrimSpace(b), []byte("null")) {
+		return nil // explicit null: authorized for nothing
+	}
+	var single string
+	if err := json.Unmarshal(b, &single); err == nil {
+		switch single {
+		case wildcardNamespace:
+			c.Wildcard = true
+		case "":
+		default:
+			c.Namespaces = []string{single}
+		}
+		return nil
+	}
+	// []*string rather than []string: a JSON null element unmarshals into a
+	// string as a no-op, so it would silently become "" and the token would be
+	// accepted where the pre-typed code rejected it. A pointer element is nil
+	// for null and can be refused.
+	var many []*string
+	if err := json.Unmarshal(b, &many); err != nil {
+		return fmt.Errorf("%s claim must be a string or an array of strings", claimAllowedNamespaces)
+	}
+	ns := make([]string, 0, len(many))
+	for _, s := range many {
+		if s == nil {
+			return fmt.Errorf("%s claim has a null element; every element must be a string", claimAllowedNamespaces)
+		}
+		if *s == wildcardNamespace {
+			c.Wildcard = true
+			return nil
+		}
+		ns = append(ns, *s)
+	}
+	c.Namespaces = ns
+	return nil
+}
+
+// ScopeFromTokenInfo derives the namespace scope from a verified token. A nil
+// token means no verification ran: a wildcard in dev mode (no key), deny
+// otherwise (defense in depth — RequireBearerToken should have rejected it).
+func (a *Authorizer) ScopeFromTokenInfo(ti *auth.TokenInfo) (AuthScope, bool) {
+	if ti == nil {
+		if a.Enabled() {
+			return AuthScope{}, false
+		}
+		return AuthScope{Wildcard: true}, true
+	}
+	return scopeFromScopes(ti.Scopes), true
+}
+
+// scopeFromScopes rebuilds an AuthScope from TokenInfo.Scopes (the "*" sentinel
+// means wildcard).
+func scopeFromScopes(scopes []string) AuthScope {
+	if slices.Contains(scopes, wildcardNamespace) {
+		return AuthScope{Wildcard: true}
+	}
+	return AuthScope{Namespaces: scopes}
+}

--- a/pkg/agentruntime/authz_test.go
+++ b/pkg/agentruntime/authz_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agentruntime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mintToken signs a JWT with the given claims and key (HS256).
+func mintToken(t *testing.T, key []byte, claims jwt.MapClaims) string {
+	t.Helper()
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString(key)
+	require.NoError(t, err)
+	return s
+}
+
+// newScopedRequest builds a request whose {namespace} path value is ns, as if
+// it had been matched by the "POST /agents/{namespace}/{name}" pattern — the
+// shape Middleware always runs behind (see main.go).
+func newScopedRequest(ns, bearer string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/agents/"+ns+"/fn", nil)
+	r.SetPathValue("namespace", ns)
+	r.SetPathValue("name", "fn")
+	if bearer != "" {
+		r.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	return r
+}
+
+func okHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+}
+
+// TestMiddleware covers the four states the brief calls out: no key = every
+// caller passes through with a wildcard scope; a valid token scoped to the
+// request's namespace is admitted; a valid token scoped to a DIFFERENT
+// namespace is 403; and a token that fails verification entirely is 401.
+func TestMiddleware(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no key disabled", func(t *testing.T) {
+		t.Parallel()
+		a := NewAuthorizer(nil)
+		require.False(t, a.Enabled())
+
+		w := httptest.NewRecorder()
+		a.Middleware(okHandler()).ServeHTTP(w, newScopedRequest("any-ns", ""))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("valid token scoped to namespace allowed", func(t *testing.T) {
+		t.Parallel()
+		key := []byte("test-signing-key")
+		a := NewAuthorizer(key)
+		tok := mintToken(t, key, jwt.MapClaims{
+			"sub":                "agent-1",
+			"allowed_namespaces": []any{"ns-a"},
+			"exp":                time.Now().Add(time.Hour).Unix(),
+		})
+
+		w := httptest.NewRecorder()
+		a.Middleware(okHandler()).ServeHTTP(w, newScopedRequest("ns-a", tok))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("wrong-namespace token forbidden", func(t *testing.T) {
+		t.Parallel()
+		key := []byte("test-signing-key")
+		a := NewAuthorizer(key)
+		tok := mintToken(t, key, jwt.MapClaims{
+			"sub":                "agent-1",
+			"allowed_namespaces": []any{"ns-a"},
+			"exp":                time.Now().Add(time.Hour).Unix(),
+		})
+
+		w := httptest.NewRecorder()
+		a.Middleware(okHandler()).ServeHTTP(w, newScopedRequest("ns-b", tok))
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+
+	t.Run("garbage token unauthorized", func(t *testing.T) {
+		t.Parallel()
+		a := NewAuthorizer([]byte("test-signing-key"))
+
+		w := httptest.NewRecorder()
+		a.Middleware(okHandler()).ServeHTTP(w, newScopedRequest("ns-a", "not-a-jwt"))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("missing bearer token unauthorized", func(t *testing.T) {
+		t.Parallel()
+		a := NewAuthorizer([]byte("test-signing-key"))
+
+		w := httptest.NewRecorder()
+		a.Middleware(okHandler()).ServeHTTP(w, newScopedRequest("ns-a", ""))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+
+	t.Run("wildcard token allows any namespace", func(t *testing.T) {
+		t.Parallel()
+		key := []byte("test-signing-key")
+		a := NewAuthorizer(key)
+		tok := mintToken(t, key, jwt.MapClaims{
+			"sub":                "agent-1",
+			"allowed_namespaces": "*",
+			"exp":                time.Now().Add(time.Hour).Unix(),
+		})
+
+		w := httptest.NewRecorder()
+		a.Middleware(okHandler()).ServeHTTP(w, newScopedRequest("any-ns", tok))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+func TestScopeAllows(t *testing.T) {
+	t.Parallel()
+	assert.True(t, AuthScope{Wildcard: true}.Allows("anything"))
+	assert.True(t, AuthScope{Namespaces: []string{"a", "b"}}.Allows("b"))
+	assert.False(t, AuthScope{Namespaces: []string{"a"}}.Allows("b"))
+	assert.False(t, AuthScope{}.Allows("a"))
+}
+
+func TestAuthorizerDevPassThrough(t *testing.T) {
+	t.Parallel()
+	a := NewAuthorizer(nil)
+	assert.False(t, a.Enabled())
+
+	scope, ok := a.ScopeFromTokenInfo(nil)
+	require.True(t, ok)
+	assert.True(t, scope.Wildcard)
+}
+
+func TestAuthorizerNilTokenDenyWhenEnabled(t *testing.T) {
+	t.Parallel()
+	a := NewAuthorizer([]byte("k"))
+	// Defense in depth: a nil token when verification is enabled is denied.
+	_, ok := a.ScopeFromTokenInfo(nil)
+	assert.False(t, ok)
+}

--- a/pkg/agentruntime/dispatcher.go
+++ b/pkg/agentruntime/dispatcher.go
@@ -117,8 +117,27 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(HeaderSession, sessionID)
 
 	ctx := r.Context()
+	// bgCtx carries no cancellation from the client connection: the
+	// post-response bookkeeping (and the transport-failure bookkeeping below)
+	// must still land even if the caller has already gone away, since it is
+	// what keeps Stats/Status honest and self-heals nothing on its own.
+	bgCtx := context.WithoutCancel(ctx)
 	liveTTL := entry.IdleAfter + entry.ArchiveAfter + d.retention
 	now := d.now()
+
+	// Read + validate the body BEFORE any session record write: an oversized
+	// or unreadable request must never create or refresh a session (a bad
+	// request is a client-side problem, so a read failure here is a 400, not
+	// a 502 — nothing upstream has been touched yet).
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxTurnBodyBytes+1))
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "reading request body")
+		return
+	}
+	if len(body) > maxTurnBodyBytes {
+		writeErr(w, http.StatusRequestEntityTooLarge, "request body too large")
+		return
+	}
 
 	// Step 3: bookkeep the session record. A registry write is never a
 	// request gate, EXCEPT session quota on Create.
@@ -133,11 +152,23 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 			CreatedAt:    now,
 			LastActiveAt: now,
 		}
-		if cerr := d.store.Create(ctx, newRec, entry.MaxSessions, liveTTL); cerr != nil {
-			if errors.Is(cerr, ErrSessionQuota) {
-				writeErr(w, http.StatusTooManyRequests, "session quota exceeded")
-				return
-			}
+		switch cerr := d.store.Create(ctx, newRec, entry.MaxSessions, liveTTL); {
+		case cerr == nil:
+			// created.
+		case errors.Is(cerr, ErrSessionQuota):
+			writeErr(w, http.StatusTooManyRequests, "session quota exceeded")
+			return
+		case errors.Is(cerr, ErrSessionExists):
+			// Another replica (or a concurrent turn) created the same id
+			// between our Get miss and this Create — a lost race, not a
+			// failure. Fall through to the normal activation path instead of
+			// silently dropping this turn's bookkeeping.
+			d.logger.Info("session created concurrently, activating existing record", "namespace", ns, "agent", name, "session", sessionID)
+			d.casUpdateFresh(ctx, ns, name, sessionID, liveTTL, func(rec *SessionRecord) {
+				rec.Status = StatusActive
+				rec.LastActiveAt = now
+			})
+		default:
 			d.logger.Error(cerr, "creating session record", "namespace", ns, "agent", name, "session", sessionID)
 		}
 	case err != nil:
@@ -150,16 +181,6 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Step 4: forward the turn.
-	body, err := io.ReadAll(io.LimitReader(r.Body, maxTurnBodyBytes+1))
-	if err != nil {
-		writeErr(w, http.StatusBadGateway, "reading request body")
-		return
-	}
-	if len(body) > maxTurnBodyBytes {
-		writeErr(w, http.StatusRequestEntityTooLarge, "request body too large")
-		return
-	}
-
 	upstream := d.routerURL + utils.UrlForFunction(name, ns)
 	if entry.SessionSource == fv1.SessionSourceQueryParam {
 		upstream += "?" + url.Values{entry.SessionName: {sessionID}}.Encode()
@@ -182,12 +203,25 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 	resp, err := d.client.Do(req)
 	if err != nil {
 		d.logger.Error(err, "calling upstream function", "namespace", ns, "agent", name, "session", sessionID)
+		// A failed turn is still a turn: meter it (Errors included) using
+		// bgCtx so the write is not lost if the caller has already gone.
+		d.casUpdateFresh(bgCtx, ns, name, sessionID, liveTTL, func(rec *SessionRecord) {
+			rec.Stats.Turns++
+			rec.Stats.Errors++
+			rec.Status = StatusActive
+			rec.LastActiveAt = d.now()
+		})
 		writeErr(w, http.StatusBadGateway, "calling upstream function")
 		return
 	}
 	defer resp.Body.Close()
 
+	// The yield outcome is surfaced to the caller (not just consumed for our
+	// own bookkeeping below) so callers can observe done-vs-waiting.
 	yield := resp.Header.Get(HeaderYield)
+	if yield != "" {
+		w.Header().Set(HeaderYield, yield)
+	}
 	if ct := resp.Header.Get("Content-Type"); ct != "" {
 		w.Header().Set("Content-Type", ct)
 	}
@@ -198,18 +232,22 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 	// Step 5: post-response bookkeeping. Reads a fresh record — never the
 	// version held from step 3 — because the upstream call above may have
 	// taken long enough for another turn to have CAS-written the record
-	// underneath it.
-	d.casUpdateFresh(ctx, ns, name, sessionID, liveTTL, func(rec *SessionRecord) {
+	// underneath it. Uses bgCtx so a client disconnect during/after the
+	// stream does not lose this turn's meter.
+	d.casUpdateFresh(bgCtx, ns, name, sessionID, liveTTL, func(rec *SessionRecord) {
 		rec.Stats.Turns++
 		rec.Stats.ActiveMillis += elapsed.Milliseconds()
 		if resp.StatusCode >= http.StatusInternalServerError {
 			rec.Stats.Errors++
 		}
+		// LastActiveAt refreshes on BOTH branches: a waiting->idle turn still
+		// just happened just now, it is only the session's next-turn clock
+		// (IdleAfter/ArchiveAfter) that starts running from it.
+		rec.LastActiveAt = d.now()
 		if yield == YieldWaiting {
 			rec.Status = StatusIdle
 		} else {
 			rec.Status = StatusActive
-			rec.LastActiveAt = d.now()
 		}
 	})
 }

--- a/pkg/agentruntime/dispatcher.go
+++ b/pkg/agentruntime/dispatcher.go
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// dispatcher.go implements Dispatcher, the request-path component that turns
+// an inbound "/agents/{namespace}/{name}" turn into a session-scoped call to
+// the router-internal listener: it resolves the calling AgentEntry from
+// AgentView, mints or validates a session id, bookkeeps the SessionRecord in
+// SessionStore, forwards the turn, and streams the function's response back
+// incrementally.
+package agentruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/statestore"
+	"github.com/fission/fission/pkg/utils"
+	"github.com/fission/fission/pkg/utils/uuid"
+)
+
+const (
+	// HeaderSession is the response header carrying the resolved session id —
+	// the single source of truth for which session a turn landed on, whether
+	// the id was supplied by the caller or minted here.
+	HeaderSession = fv1.DefaultAgentSessionHeader
+	// HeaderYield is the function-response header a turn uses to signal it is
+	// done producing output for this session (as opposed to merely finishing
+	// one turn while more are expected soon).
+	HeaderYield = "X-Fission-Agent-Yield"
+	// YieldWaiting is the HeaderYield value that flips a session to idle
+	// immediately, rather than waiting out its normal IdleAfter window.
+	YieldWaiting = "waiting"
+
+	// maxTurnBodyBytes caps a buffered turn request body. The HMAC
+	// ServiceSigner binds the signature to a body hash (pkg/auth/hmac/hmac.go),
+	// so the request body MUST be fully buffered (and replayable via GetBody)
+	// before signing — a streamed client body cannot be signed. 4 MiB,
+	// matching the workflow invoker's maxResultBytes; 413 above it.
+	maxTurnBodyBytes = 4 << 20
+
+	// streamChunkBytes is the read/write/flush buffer size used to relay the
+	// upstream response incrementally, replicating the router's own
+	// ReverseProxy FlushInterval=-1 streaming behavior (functionHandler.go).
+	streamChunkBytes = 32 << 10
+)
+
+// sessionIDPattern bounds a caller-supplied session id: it becomes a
+// statestore key and a URL/header value, so it is restricted to a safe,
+// portable character set.
+var sessionIDPattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,128}$`)
+
+// Dispatcher serves inbound agent turns.
+type Dispatcher struct {
+	logger    logr.Logger
+	view      *AgentView
+	store     *SessionStore
+	client    *http.Client // transport pre-wrapped with the HMAC signer
+	routerURL string
+	retention time.Duration
+	now       func() time.Time
+}
+
+// NewDispatcher returns a Dispatcher. retention is added to an entry's
+// IdleAfter+ArchiveAfter to compute the live-key TTL passed to
+// SessionStore.Create/Update (orphan self-expiry covers idle + archive-wait +
+// archived-copy retention in one live-key lease).
+func NewDispatcher(logger logr.Logger, view *AgentView, store *SessionStore, client *http.Client, routerURL string, retention time.Duration, now func() time.Time) *Dispatcher {
+	return &Dispatcher{
+		logger:    logger,
+		view:      view,
+		store:     store,
+		client:    client,
+		routerURL: routerURL,
+		retention: retention,
+		now:       now,
+	}
+}
+
+// Handler serves POST /agents/{namespace}/{name}; other methods get 405 (the
+// Go 1.22+ ServeMux does this automatically for a method-qualified pattern).
+func (d *Dispatcher) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /agents/{namespace}/{name}", d.dispatch)
+	return mux
+}
+
+func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
+	ns := r.PathValue("namespace")
+	name := r.PathValue("name")
+
+	// Step 1: resolve the agent entry.
+	entry, ok := d.view.Lookup(ns, name)
+	if !ok {
+		writeErr(w, http.StatusNotFound, "not an agent function")
+		return
+	}
+
+	// Step 2: resolve (or reject, or mint) the session id. The response
+	// header is set as soon as the id resolves — it must precede any
+	// WriteHeader call below.
+	sessionID, ok := resolveSessionID(r, entry)
+	if !ok {
+		writeErr(w, http.StatusBadRequest, "invalid session id")
+		return
+	}
+	w.Header().Set(HeaderSession, sessionID)
+
+	ctx := r.Context()
+	liveTTL := entry.IdleAfter + entry.ArchiveAfter + d.retention
+	now := d.now()
+
+	// Step 3: bookkeep the session record. A registry write is never a
+	// request gate, EXCEPT session quota on Create.
+	rec, version, err := d.store.Get(ctx, ns, name, sessionID)
+	switch {
+	case errors.Is(err, statestore.ErrNotFound):
+		newRec := SessionRecord{
+			ID:           sessionID,
+			Agent:        name,
+			Namespace:    ns,
+			Status:       StatusActive,
+			CreatedAt:    now,
+			LastActiveAt: now,
+		}
+		if cerr := d.store.Create(ctx, newRec, entry.MaxSessions, liveTTL); cerr != nil {
+			if errors.Is(cerr, ErrSessionQuota) {
+				writeErr(w, http.StatusTooManyRequests, "session quota exceeded")
+				return
+			}
+			d.logger.Error(cerr, "creating session record", "namespace", ns, "agent", name, "session", sessionID)
+		}
+	case err != nil:
+		d.logger.Error(err, "getting session record", "namespace", ns, "agent", name, "session", sessionID)
+	default:
+		d.casUpdate(ctx, ns, name, sessionID, rec, version, liveTTL, func(rec *SessionRecord) {
+			rec.Status = StatusActive
+			rec.LastActiveAt = now
+		})
+	}
+
+	// Step 4: forward the turn.
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxTurnBodyBytes+1))
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "reading request body")
+		return
+	}
+	if len(body) > maxTurnBodyBytes {
+		writeErr(w, http.StatusRequestEntityTooLarge, "request body too large")
+		return
+	}
+
+	upstream := d.routerURL + utils.UrlForFunction(name, ns)
+	if entry.SessionSource == fv1.SessionSourceQueryParam {
+		upstream += "?" + url.Values{entry.SessionName: {sessionID}}.Encode()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, upstream, bytes.NewReader(body))
+	if err != nil {
+		writeErr(w, http.StatusBadGateway, "building upstream request")
+		return
+	}
+	if ct := r.Header.Get("Content-Type"); ct != "" {
+		req.Header.Set("Content-Type", ct)
+	}
+	req.Header.Set(HeaderSession, sessionID)
+	if entry.SessionSource == fv1.SessionSourceHeader {
+		req.Header.Set(entry.SessionName, sessionID)
+	}
+
+	start := d.now()
+	resp, err := d.client.Do(req)
+	if err != nil {
+		d.logger.Error(err, "calling upstream function", "namespace", ns, "agent", name, "session", sessionID)
+		writeErr(w, http.StatusBadGateway, "calling upstream function")
+		return
+	}
+	defer resp.Body.Close()
+
+	yield := resp.Header.Get(HeaderYield)
+	if ct := resp.Header.Get("Content-Type"); ct != "" {
+		w.Header().Set("Content-Type", ct)
+	}
+	w.WriteHeader(resp.StatusCode)
+	streamResponse(w, resp.Body)
+	elapsed := d.now().Sub(start)
+
+	// Step 5: post-response bookkeeping. Reads a fresh record — never the
+	// version held from step 3 — because the upstream call above may have
+	// taken long enough for another turn to have CAS-written the record
+	// underneath it.
+	d.casUpdateFresh(ctx, ns, name, sessionID, liveTTL, func(rec *SessionRecord) {
+		rec.Stats.Turns++
+		rec.Stats.ActiveMillis += elapsed.Milliseconds()
+		if resp.StatusCode >= http.StatusInternalServerError {
+			rec.Stats.Errors++
+		}
+		if yield == YieldWaiting {
+			rec.Status = StatusIdle
+		} else {
+			rec.Status = StatusActive
+			rec.LastActiveAt = d.now()
+		}
+	})
+}
+
+// resolveSessionID extracts the session id from r per entry's configured
+// source, minting one when absent. It reports false when a caller-supplied
+// id fails sessionIDPattern.
+func resolveSessionID(r *http.Request, entry AgentEntry) (string, bool) {
+	var raw string
+	if entry.SessionSource == fv1.SessionSourceQueryParam {
+		raw = r.URL.Query().Get(entry.SessionName)
+	} else {
+		raw = r.Header.Get(entry.SessionName)
+	}
+	if raw == "" {
+		return uuid.NewString(), true
+	}
+	if !sessionIDPattern.MatchString(raw) {
+		return "", false
+	}
+	return raw, true
+}
+
+// streamResponse relays src to w incrementally: a read/write loop with a
+// streamChunkBytes buffer, flushing after every write. Plain io.Copy buffers
+// until completion; this replicates the router's own ReverseProxy
+// FlushInterval=-1 streaming behavior instead.
+func streamResponse(w http.ResponseWriter, src io.Reader) {
+	rc := http.NewResponseController(w)
+	buf := make([]byte, streamChunkBytes)
+	for {
+		n, rerr := src.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return
+			}
+			_ = rc.Flush()
+		}
+		if rerr != nil {
+			return
+		}
+	}
+}
+
+// casUpdate mutates rec via mutate and CAS-writes it at version with
+// liveTTL. On statestore.ErrVersionConflict it retries exactly once with a
+// freshly fetched record and version — never the stale one. Any other
+// failure, or a second conflict, is logged and swallowed: registry writes are
+// bookkeeping, never a request gate.
+func (d *Dispatcher) casUpdate(ctx context.Context, ns, agent, id string, rec SessionRecord, version int64, liveTTL time.Duration, mutate func(*SessionRecord)) {
+	mutate(&rec)
+	err := d.store.Update(ctx, rec, version, liveTTL)
+	if err == nil {
+		return
+	}
+	if !errors.Is(err, statestore.ErrVersionConflict) {
+		d.logger.Error(err, "updating session record", "namespace", ns, "agent", agent, "session", id)
+		return
+	}
+
+	fresh, freshVersion, gerr := d.store.Get(ctx, ns, agent, id)
+	if gerr != nil {
+		d.logger.Error(gerr, "re-getting session record after conflict", "namespace", ns, "agent", agent, "session", id)
+		return
+	}
+	mutate(&fresh)
+	if uerr := d.store.Update(ctx, fresh, freshVersion, liveTTL); uerr != nil {
+		d.logger.Error(uerr, "updating session record after retry", "namespace", ns, "agent", agent, "session", id)
+	}
+}
+
+// casUpdateFresh re-Gets the record immediately before the CAS write, then
+// delegates to casUpdate. Used whenever an unbounded amount of work (an
+// upstream call) may have happened since any previously held version was
+// read.
+func (d *Dispatcher) casUpdateFresh(ctx context.Context, ns, agent, id string, liveTTL time.Duration, mutate func(*SessionRecord)) {
+	rec, version, err := d.store.Get(ctx, ns, agent, id)
+	if err != nil {
+		d.logger.Error(err, "getting session record for update", "namespace", ns, "agent", agent, "session", id)
+		return
+	}
+	d.casUpdate(ctx, ns, agent, id, rec, version, liveTTL, mutate)
+}
+
+// writeErr answers with a small {"error": msg} JSON object at status.
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	b, err := json.Marshal(map[string]string{"error": msg})
+	if err != nil {
+		w.WriteHeader(status)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(b)
+}

--- a/pkg/agentruntime/dispatcher_test.go
+++ b/pkg/agentruntime/dispatcher_test.go
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agentruntime
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// newTestDispatcher returns a Dispatcher wired to a fresh in-memory
+// SessionStore and empty AgentView, forwarding to upstreamURL.
+func newTestDispatcher(t *testing.T, upstreamURL string) (*Dispatcher, *AgentView, *SessionStore) {
+	t.Helper()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	view := NewAgentView()
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, time.Now)
+	return d, view, store
+}
+
+// headerEntry is the default header-sourced AgentEntry used by most cases.
+func headerEntry(ns, name string, maxSessions int64) AgentEntry {
+	return AgentEntry{
+		Namespace:     ns,
+		Name:          name,
+		SessionSource: fv1.SessionSourceHeader,
+		SessionName:   fv1.DefaultAgentSessionHeader,
+		IdleAfter:     5 * time.Minute,
+		ArchiveAfter:  time.Hour,
+		MaxSessions:   maxSessions,
+	}
+}
+
+func okUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestDispatcher_MintsSessionAndCreatesActiveRecord(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	sessionID := rec.Header().Get(HeaderSession)
+	require.NotEmpty(t, sessionID, "a session id must be minted and returned")
+
+	got, _, err := store.Get(t.Context(), "ns", "fn", sessionID)
+	require.NoError(t, err)
+	assert.Equal(t, StatusActive, got.Status)
+	assert.EqualValues(t, 1, got.Stats.Turns)
+}
+
+func TestDispatcher_ExistingSessionIsReused(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	for range 2 {
+		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+		req.Header.Set(HeaderSession, "sess-existing")
+		rec := httptest.NewRecorder()
+		d.Handler().ServeHTTP(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		require.Equal(t, "sess-existing", rec.Header().Get(HeaderSession))
+	}
+
+	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-existing")
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, got.Stats.Turns, "the second turn must accumulate onto the same record")
+}
+
+func TestDispatcher_YieldWaitingFlipsSessionIdle(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(HeaderYield, YieldWaiting)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("done"))
+	}))
+	t.Cleanup(upstream.Close)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req.Header.Set(HeaderSession, "sess-yield")
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-yield")
+	require.NoError(t, err)
+	assert.Equal(t, StatusIdle, got.Status)
+}
+
+func TestDispatcher_Upstream500IncrementsErrorsAndPassesThrough(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	t.Cleanup(upstream.Close)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req.Header.Set(HeaderSession, "sess-err")
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	assert.Equal(t, "boom", rec.Body.String())
+
+	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-err")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, got.Stats.Errors)
+	assert.EqualValues(t, 1, got.Stats.Turns)
+}
+
+func TestDispatcher_SessionQuotaExceeded(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 1))
+
+	req1 := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req1.Header.Set(HeaderSession, "sess-a")
+	rec1 := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec1, req1)
+	require.Equal(t, http.StatusOK, rec1.Code)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req2.Header.Set(HeaderSession, "sess-b")
+	rec2 := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec2, req2)
+
+	assert.Equal(t, http.StatusTooManyRequests, rec2.Code)
+	assert.Contains(t, rec2.Body.String(), "session quota exceeded")
+}
+
+func TestDispatcher_RequestBodyTooLarge(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	huge := strings.NewReader(strings.Repeat("a", maxTurnBodyBytes+1))
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", huge)
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestDispatcher_NonAgentFunctionNotFound(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, _, _ := newTestDispatcher(t, upstream.URL)
+	// No entry Upserted for ns/fn — it is not an agent function.
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+	assert.Contains(t, rec.Body.String(), "not an agent function")
+	assert.Empty(t, rec.Header().Get(HeaderSession), "no session header on a 404")
+}
+
+func TestDispatcher_GetMethodNotAllowed(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodGet, "/agents/ns/fn", nil)
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestDispatcher_InvalidSessionIDRejected(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req.Header.Set(HeaderSession, "bad session id!")
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestDispatcher_QueryParamSessionSourceForwardsAndResolves(t *testing.T) {
+	t.Parallel()
+	var gotQueryParam string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQueryParam = r.URL.Query().Get("session")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(AgentEntry{
+		Namespace: "ns", Name: "fn",
+		SessionSource: fv1.SessionSourceQueryParam, SessionName: "session",
+		IdleAfter: time.Minute, ArchiveAfter: time.Hour,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn?session=abc-123", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "abc-123", rec.Header().Get(HeaderSession))
+	assert.Equal(t, "abc-123", gotQueryParam, "the session id must be forwarded upstream under the entry's query param name")
+}
+
+func TestDispatcher_ResponseBodyPassesThroughByteIdentically(t *testing.T) {
+	t.Parallel()
+	payload := make([]byte, 1<<20) // 1 MiB
+	_, err := rand.Read(payload)
+	require.NoError(t, err)
+	wantHash := sha256.Sum256(payload)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(payload)
+	}))
+	t.Cleanup(upstream.Close)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	gotHash := sha256.Sum256(rec.Body.Bytes())
+	assert.Equal(t, wantHash, gotHash)
+}
+
+// TestDispatcher_StreamsIncrementallyWithPerWriteFlush is the test that
+// catches a missing per-write flush: it holds the upstream's second chunk
+// behind a gate and asserts the client can read the first chunk before the
+// gate is released. A plain io.Copy (which buffers) would make the first
+// read block until the whole response — including the still-gated second
+// chunk — is available, hanging this test.
+func TestDispatcher_StreamsIncrementallyWithPerWriteFlush(t *testing.T) {
+	t.Parallel()
+	chunk1 := []byte("first-chunk-payload")
+	chunk2 := []byte("second-chunk-payload")
+	release := make(chan struct{})
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rc := http.NewResponseController(w)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(chunk1)
+		require.NoError(t, rc.Flush())
+		<-release
+		_, _ = w.Write(chunk2)
+		require.NoError(t, rc.Flush())
+	}))
+	t.Cleanup(upstream.Close)
+
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	front := httptest.NewServer(d.Handler())
+	t.Cleanup(front.Close)
+
+	req, err := http.NewRequest(http.MethodPost, front.URL+"/agents/ns/fn", strings.NewReader("hello"))
+	require.NoError(t, err)
+	resp, err := front.Client().Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	got := make([]byte, len(chunk1))
+	readDone := make(chan error, 1)
+	go func() {
+		_, rerr := io.ReadFull(resp.Body, got)
+		readDone <- rerr
+	}()
+
+	select {
+	case rerr := <-readDone:
+		require.NoError(t, rerr)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out reading the first chunk before the gate opened: the dispatcher is not flushing incrementally")
+	}
+	assert.Equal(t, chunk1, got)
+
+	close(release)
+
+	rest, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, chunk2, rest)
+}

--- a/pkg/agentruntime/dispatcher_test.go
+++ b/pkg/agentruntime/dispatcher_test.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/statestore"
 )
 
 // newTestDispatcher returns a Dispatcher wired to a fresh in-memory
@@ -30,6 +33,30 @@ func newTestDispatcher(t *testing.T, upstreamURL string) (*Dispatcher, *AgentVie
 	view := NewAgentView()
 	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, time.Now)
 	return d, view, store
+}
+
+// newTestDispatcherWithClock is newTestDispatcher with an injected clock
+// shared by the store and the dispatcher, for tests that need to order two
+// writes unambiguously (real time.Now() calls microseconds apart can tie).
+func newTestDispatcherWithClock(t *testing.T, upstreamURL string, now func() time.Time) (*Dispatcher, *AgentView, *SessionStore) {
+	t.Helper()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, now)
+	view := NewAgentView()
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, now)
+	return d, view, store
+}
+
+// stepClock returns a clock that advances by 1ms on every call, starting
+// after start. Each call is guaranteed strictly greater than the last (safe
+// for concurrent callers), which makes a later write's timestamp
+// unambiguously After() an earlier one — unlike two real time.Now() calls a
+// few instructions apart, which can tie on a coarse system clock.
+func stepClock(start time.Time) func() time.Time {
+	var n atomic.Int64
+	return func() time.Time {
+		return start.Add(time.Duration(n.Add(1)) * time.Millisecond)
+	}
 }
 
 // headerEntry is the default header-sourced AgentEntry used by most cases.
@@ -95,26 +122,58 @@ func TestDispatcher_ExistingSessionIsReused(t *testing.T) {
 	assert.EqualValues(t, 2, got.Stats.Turns, "the second turn must accumulate onto the same record")
 }
 
-func TestDispatcher_YieldWaitingFlipsSessionIdle(t *testing.T) {
+// TestDispatcher_YieldWaitingFlipsSessionIdleAndRefreshesLastActive pins R6:
+// LastActiveAt must be refreshed by the step-5 write on BOTH branches, not
+// just the "stay active" one. It isolates step-3's write (captured at the
+// gate, before the upstream handler is released) from step-5's write
+// (captured after) using a gate — like the flush test — plus a
+// strictly-monotonic fake clock, so the two timestamps can never tie: if
+// step 5 skips the LastActiveAt refresh on the waiting branch, "got" equals
+// "mid" exactly and the After() assertion fails.
+func TestDispatcher_YieldWaitingFlipsSessionIdleAndRefreshesLastActive(t *testing.T) {
 	t.Parallel()
+	release := make(chan struct{})
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
+	reachedUpstream := make(chan struct{})
+
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(reachedUpstream)
+		<-release
 		w.Header().Set(HeaderYield, YieldWaiting)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("done"))
 	}))
 	t.Cleanup(upstream.Close)
-	d, view, store := newTestDispatcher(t, upstream.URL)
+
+	clock := stepClock(time.Now())
+	d, view, store := newTestDispatcherWithClock(t, upstream.URL, clock)
 	view.Upsert(headerEntry("ns", "fn", 0))
 
 	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
 	req.Header.Set(HeaderSession, "sess-yield")
-	rec := httptest.NewRecorder()
-	d.Handler().ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
+	respRec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		d.Handler().ServeHTTP(respRec, req)
+		close(done)
+	}()
+
+	<-reachedUpstream // step 3's Get/Create/Update has already committed by now
+	mid, _, err := store.Get(t.Context(), "ns", "fn", "sess-yield")
+	require.NoError(t, err)
+
+	releaseOnce()
+	<-done
+
+	require.Equal(t, http.StatusOK, respRec.Code)
+	assert.Equal(t, YieldWaiting, respRec.Header().Get(HeaderYield), "the yield outcome must be surfaced on the response")
 
 	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-yield")
 	require.NoError(t, err)
 	assert.Equal(t, StatusIdle, got.Status)
+	assert.True(t, got.LastActiveAt.After(mid.LastActiveAt), "LastActiveAt must be refreshed by the post-response write on BOTH branches, including waiting->idle (R6)")
 }
 
 func TestDispatcher_Upstream500IncrementsErrorsAndPassesThrough(t *testing.T) {
@@ -141,6 +200,60 @@ func TestDispatcher_Upstream500IncrementsErrorsAndPassesThrough(t *testing.T) {
 	assert.EqualValues(t, 1, got.Stats.Turns)
 }
 
+func TestDispatcher_TransportFailureRecordsTurnAndError(t *testing.T) {
+	t.Parallel()
+	// Bind then immediately close, giving a URL nothing listens on so Do
+	// fails with a connection-refused error rather than hanging.
+	dead := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	d, view, store := newTestDispatcher(t, deadURL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req.Header.Set(HeaderSession, "sess-transport")
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadGateway, rec.Code)
+
+	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-transport")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, got.Stats.Turns, "a transport failure still counts as a turn")
+	assert.EqualValues(t, 1, got.Stats.Errors, "a transport failure must be metered as an error")
+	assert.Equal(t, StatusActive, got.Status)
+}
+
+func TestDispatcher_ConcurrentCreateRaceActivatesInsteadOfDropping(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	var wg sync.WaitGroup
+	codes := make([]int, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+			req.Header.Set(HeaderSession, "sess-race")
+			rec := httptest.NewRecorder()
+			d.Handler().ServeHTTP(rec, req)
+			codes[i] = rec.Code
+		}(i)
+	}
+	wg.Wait()
+
+	for _, code := range codes {
+		assert.Equal(t, http.StatusOK, code, "a racing Create must never surface as a client-visible error")
+	}
+	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-race")
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, got.Stats.Turns, "both racing turns must still be counted, not silently dropped")
+}
+
 func TestDispatcher_SessionQuotaExceeded(t *testing.T) {
 	t.Parallel()
 	upstream := okUpstream(t)
@@ -165,7 +278,7 @@ func TestDispatcher_SessionQuotaExceeded(t *testing.T) {
 func TestDispatcher_RequestBodyTooLarge(t *testing.T) {
 	t.Parallel()
 	upstream := okUpstream(t)
-	d, view, _ := newTestDispatcher(t, upstream.URL)
+	d, view, store := newTestDispatcher(t, upstream.URL)
 	view.Upsert(headerEntry("ns", "fn", 0))
 
 	huge := strings.NewReader(strings.Repeat("a", maxTurnBodyBytes+1))
@@ -174,6 +287,11 @@ func TestDispatcher_RequestBodyTooLarge(t *testing.T) {
 	d.Handler().ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+
+	sessionID := rec.Header().Get(HeaderSession)
+	require.NotEmpty(t, sessionID, "the session id still resolves (and is reported) even though the turn is rejected")
+	_, _, err := store.Get(t.Context(), "ns", "fn", sessionID)
+	assert.ErrorIs(t, err, statestore.ErrNotFound, "an oversized request must never create a session record (R5)")
 }
 
 func TestDispatcher_NonAgentFunctionNotFound(t *testing.T) {
@@ -278,15 +396,23 @@ func TestDispatcher_StreamsIncrementallyWithPerWriteFlush(t *testing.T) {
 	chunk1 := []byte("first-chunk-payload")
 	chunk2 := []byte("second-chunk-payload")
 	release := make(chan struct{})
+	// releaseOnce is shared between the test body's deliberate release and a
+	// t.Cleanup safety net for a failed/timed-out run — sync.OnceFunc makes
+	// closing twice safe instead of panicking.
+	releaseOnce := sync.OnceFunc(func() { close(release) })
+	t.Cleanup(releaseOnce)
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// This handler runs on the httptest server's own goroutine, not the
+		// test goroutine: require's t.FailNow is documented as unsafe there,
+		// so use assert (t.Errorf), which is goroutine-safe.
 		rc := http.NewResponseController(w)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(chunk1)
-		require.NoError(t, rc.Flush())
+		assert.NoError(t, rc.Flush())
 		<-release
 		_, _ = w.Write(chunk2)
-		require.NoError(t, rc.Flush())
+		assert.NoError(t, rc.Flush())
 	}))
 	t.Cleanup(upstream.Close)
 
@@ -317,7 +443,7 @@ func TestDispatcher_StreamsIncrementallyWithPerWriteFlush(t *testing.T) {
 	}
 	assert.Equal(t, chunk1, got)
 
-	close(release)
+	releaseOnce()
 
 	rest, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -8,7 +8,10 @@
 // (Spec.Agent != nil), resolves an inbound "/agents/{namespace}/{name}" turn
 // to the matching Function, forwards it to the router internal listener with
 // the same ServiceRouterInternal HMAC signing the other publishers use, and
-// meters the result into a per-session record.
+// meters the result into a per-session record. In v1, only Content-Type and
+// session headers are forwarded upstream, and only Content-Type plus
+// X-Fission-Agent-Yield are returned; custom caller headers are intentionally
+// not proxied in v1 (revisit with the SDK slice).
 //
 // Sessions are statestore records, never CRDs — there is no AgentSession CRD
 // and no reconcile loop over session state. The sweeper that ages sessions

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package agentruntime implements the fission-bundle --agentPort subsystem:
+// session dispatch, a per-replica registry of agent-enabled Functions, and
+// an idle/archive sweeper for their sessions. It watches Function CRDs
+// (Spec.Agent != nil), resolves an inbound "/agents/{namespace}/{name}" turn
+// to the matching Function, forwards it to the router internal listener with
+// the same ServiceRouterInternal HMAC signing the other publishers use, and
+// meters the result into a per-session record.
+//
+// Sessions are statestore records, never CRDs — there is no AgentSession CRD
+// and no reconcile loop over session state. The sweeper that ages sessions
+// active -> idle -> archived runs on every replica with no leader election:
+// every transition is a CAS write at the version the sweeper (or the request
+// dispatcher) just read, so two replicas racing the same record simply have
+// one CAS win and one CAS lose silently — that idempotence is the substitute
+// for leader election, the same way the router-admitted request path never
+// needed one.
+//
+// Known follow-ups (not in v1): no status condition is written back to the
+// Function (unlike mcp's ToolExposed) — once the agent runtime has an
+// observable signal worth surfacing, add an AgentReady/AgentExposed
+// condition the same way pkg/mcp/reconciler.go's controller.SetConditions
+// calls do. authz.go is a hand-mirrored duplicate of pkg/mcp/authz.go rather
+// than a shared package; extracting the common bearer-token verifier into
+// one place both subsystems import is deferred cleanup, not a design choice
+// worth blocking this slice on.
+package agentruntime
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"golang.org/x/sync/errgroup"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	"github.com/fission/fission/pkg/controller"
+	"github.com/fission/fission/pkg/crd"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
+	"github.com/fission/fission/pkg/statestore"
+	_ "github.com/fission/fission/pkg/statestore/client"   // embedded-mode driver
+	_ "github.com/fission/fission/pkg/statestore/memory"   // dev/test driver
+	_ "github.com/fission/fission/pkg/statestore/postgres" // external-mode driver
+	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
+	"github.com/fission/fission/pkg/utils/crmanager"
+	"github.com/fission/fission/pkg/utils/httpserver"
+	"github.com/fission/fission/pkg/utils/httpx"
+)
+
+const (
+	// envAllowInsecure, when "true", permits the agent runtime to start
+	// without a signing key (every caller gets a wildcard namespace scope).
+	// Without it, an empty JWT_SIGNING_KEY is a hard startup error so the
+	// endpoint fails closed rather than silently dispatching every caller's
+	// turns unauthenticated.
+	envAllowInsecure = "AGENT_ALLOW_INSECURE"
+
+	// envSweepInterval / envArchiveRetention configure the Sweeper. Both are
+	// read once here (never in a library constructor) per the deterministic-
+	// constructor convention.
+	envSweepInterval    = "AGENT_SWEEP_INTERVAL"
+	envArchiveRetention = "AGENT_ARCHIVE_RETENTION"
+
+	// defaultSweepInterval / defaultArchiveRetention are applied when the
+	// corresponding env var is unset.
+	defaultSweepInterval    = 30 * time.Second
+	defaultArchiveRetention = 168 * time.Hour // 7 days
+
+	// dispatcherMaxIdleConnsPerHost bounds the dispatcher's outbound
+	// connection pool to the single router-internal host (see
+	// httpx.PooledTransport) — sized like the workflow invoker's worker pool,
+	// since both are internal clients driving one hot upstream.
+	dispatcherMaxIdleConnsPerHost = 64
+)
+
+// Options configures Start. The listener is either pre-bound by the caller
+// (Listener — e.g. a test harness binding 127.0.0.1:0) or bound here from
+// Port.
+type Options struct {
+	// Port is the agent runtime's port. Ignored when Listener is set.
+	Port int
+	// Listener optionally pre-binds the listener.
+	Listener net.Listener
+	// RouterInternalURL is the resolved ROUTER_INTERNAL_URL passed down from
+	// fission-bundle (the same value kubewatcher/timer/mqt/mcp receive), so
+	// library constructors stay deterministic for unit tests.
+	RouterInternalURL string
+}
+
+// Start runs the agent runtime subsystem. It builds a non-leader-elected,
+// namespace-scoped cache manager over Functions (every replica serves its own
+// AgentView, so reconcile must run on each), registers the agent reconciler,
+// and serves the dispatch endpoint on Port until ctx is cancelled.
+func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger logr.Logger,
+	mgr *errgroup.Group, opts Options) error {
+	logger = logger.WithName("agentruntime")
+
+	fissionClient, err := clientGen.GetFissionClient()
+	if err != nil {
+		return fmt.Errorf("failed to get fission client: %w", err)
+	}
+	restConfig, err := clientGen.GetRestConfig()
+	if err != nil {
+		return fmt.Errorf("failed to get rest config: %w", err)
+	}
+	if err := crd.WaitForFunctionCRDs(ctx, logger, fissionClient); err != nil {
+		return fmt.Errorf("error waiting for CRDs: %w", err)
+	}
+
+	// Env reads live here, never in constructors (deterministic-constructor
+	// convention): the statestore DSN, the sweep/retention policy, and the
+	// internal-auth master secret.
+	opened, err := statestore.Open(ctx, statestore.FromEnv())
+	if err != nil {
+		return fmt.Errorf("opening statestore: %w", err)
+	}
+	caps := statestore.NewScoped(opened, nil)
+	defer func() { _ = caps.Close() }()
+
+	kv, err := caps.KV()
+	if err != nil {
+		return fmt.Errorf("statestore KV capability: %w", err)
+	}
+
+	sweepInterval, err := envDuration(envSweepInterval, defaultSweepInterval)
+	if err != nil {
+		return err
+	}
+	retention, err := envDuration(envArchiveRetention, defaultArchiveRetention)
+	if err != nil {
+		return err
+	}
+
+	// Fail closed: refuse to serve unauthenticated unless explicitly opted
+	// in. Pass-through grants every caller a wildcard namespace scope and can
+	// dispatch a turn to any agent-enabled Function via the internal
+	// listener, so it must be a deliberate choice, not the consequence of a
+	// missing key.
+	authz := NewAuthorizer([]byte(os.Getenv("JWT_SIGNING_KEY")))
+	allowInsecure, _ := strconv.ParseBool(os.Getenv(envAllowInsecure))
+	if !authz.Enabled() && !allowInsecure {
+		return fmt.Errorf("refusing to start agent runtime without authentication: set JWT_SIGNING_KEY to scope agent access, or %s=true to explicitly run the endpoint unauthenticated (dev only)", envAllowInsecure)
+	}
+
+	// Invocations go to the router internal listener, signed exactly like the
+	// other publishers (timer/mqtrigger/workflow/mcp).
+	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(dispatcherMaxIdleConnsPerHost))
+	if master := storagesvcClient.HMACSecretFromEnv(); len(master) > 0 {
+		rt = hmacauth.ServiceSigner(master, hmacauth.ServiceRouterInternal, rt, time.Now)
+	}
+
+	view := NewAgentView()
+	store := NewSessionStore(kv, time.Now)
+	dispatcher := NewDispatcher(logger.WithName("dispatcher"), view, store, &http.Client{Transport: rt}, opts.RouterInternalURL, retention, time.Now)
+	sweeper := NewSweeper(logger.WithName("sweeper"), view, store, sweepInterval, retention, time.Now)
+
+	// No leader election: each replica maintains its own in-memory view and
+	// serves dispatch from it, so each must run the reconciler. The cache is
+	// scoped to the Fission-watched namespaces (per-namespace RBAC Roles
+	// forbid a cluster-wide watch), mirroring the mcp/router managers.
+	crMgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+		Scheme:                 scheme.Scheme,
+		Cache:                  crmanager.FissionCacheOptions(),
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+		LeaderElection:         false,
+		Logger:                 logger,
+	})
+	if err != nil {
+		return fmt.Errorf("unable to set up agentruntime manager: %w", err)
+	}
+
+	r := NewAgentReconciler(logger.WithName("agent_reconciler"), crMgr.GetClient(), view)
+	if err := controller.RegisterTenantScoped(crMgr, &fv1.Function{}, r, "agentruntime-function"); err != nil {
+		return fmt.Errorf("error registering agentruntime function reconciler: %w", err)
+	}
+
+	// The sweeper runs as a manager runnable so it starts after cache sync
+	// (a replica's view is empty until then anyway) and stops with the
+	// manager.
+	if err := crMgr.Add(manager.RunnableFunc(func(rctx context.Context) error {
+		sweeper.Run(rctx)
+		return nil
+	})); err != nil {
+		return fmt.Errorf("adding agentruntime sweeper: %w", err)
+	}
+
+	// ready flips true once the Function cache has synced (the manager starts
+	// added runnables only after cache sync), so a replica reports ready only
+	// after its view is being populated. /readyz additionally requires the
+	// statestore to answer at probe time — a replica that cannot reach it
+	// must not be serviced.
+	var ready atomic.Bool
+	if err := crMgr.Add(manager.RunnableFunc(func(rctx context.Context) error {
+		ready.Store(true)
+		logger.Info("agentruntime function cache synced; dispatching turns")
+		<-rctx.Done()
+		return nil
+	})); err != nil {
+		return fmt.Errorf("adding agentruntime readiness runnable: %w", err)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if !ready.Load() {
+			http.Error(w, "caches not yet synced", http.StatusServiceUnavailable)
+			return
+		}
+		if err := caps.Ping(r.Context()); err != nil {
+			// The body says WHY: an opaque 503 turns into a rollout-timeout
+			// mystery in CI.
+			http.Error(w, "statestore unreachable: "+err.Error(), http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+	// The pattern here matches Dispatcher.Handler()'s own registration
+	// exactly: the outer mux performs the {namespace}/{name} match (and sets
+	// the path values authz.Middleware reads) before calling into the
+	// auth-wrapped dispatcher, which then matches the same pattern again.
+	mux.Handle("POST /agents/{namespace}/{name}", authz.Middleware(dispatcher.Handler()))
+
+	mgr.Go(func() error {
+		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{
+			Name: "agentruntime", Addr: strconv.Itoa(opts.Port), Listener: opts.Listener, Handler: mux,
+		})
+		return nil
+	})
+
+	if authz.Enabled() {
+		logger.Info("starting agentruntime server", "port", opts.Port, "authEnabled", true)
+	} else {
+		// Pass-through mode grants every caller a wildcard namespace scope.
+		// Explicitly opted in via AGENT_ALLOW_INSECURE; loud so it is never
+		// mistaken for a scoped deployment.
+		logger.Info("WARNING: starting agentruntime server with authentication DISABLED — every caller can dispatch turns to any agent-enabled function (set JWT_SIGNING_KEY to scope access)", "port", opts.Port)
+	}
+	return crMgr.Start(ctx)
+}
+
+// envDuration reads key as a time.Duration, returning def when it is unset.
+// A set-but-unparseable value is a startup error, not a silent fallback to
+// def — a typo'd AGENT_SWEEP_INTERVAL should fail loudly, not run the
+// sweeper on a default cadence nobody chose.
+func envDuration(key string, def time.Duration) (time.Duration, error) {
+	v := os.Getenv(key)
+	if v == "" {
+		return def, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, fmt.Errorf("parsing %s=%q: %w", key, v, err)
+	}
+	return d, nil
+}

--- a/pkg/agentruntime/reconciler.go
+++ b/pkg/agentruntime/reconciler.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// reconciler.go implements AgentReconciler, which keeps AgentView in sync
+// with Function CRDs. It mirrors pkg/mcp's FunctionToolReconciler shape:
+// cache-backed client.Get, IsNotFound -> remove, Spec.Agent == nil -> remove,
+// otherwise build the defaults-applied entry and Upsert it into the view.
+//
+// Follow-up (not in v1): no status condition is written back to the Function
+// (unlike mcp's ToolExposed). Once the agent runtime has an observable
+// signal worth surfacing (e.g. an AgentReady/AgentExposed condition), add it
+// here the same way pkg/mcp/reconciler.go's controller.SetConditions calls
+// do.
+package agentruntime
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// AgentReconciler keeps AgentView in sync with Function CRDs. It runs on
+// every replica (no leader election, mirroring pkg/mcp): each replica serves
+// requests from its own view, and the work is idempotent map mutation so
+// concurrent replicas do not conflict.
+type AgentReconciler struct {
+	logger logr.Logger
+	client client.Client
+	view   *AgentView
+}
+
+// NewAgentReconciler returns an AgentReconciler that maintains view from c.
+func NewAgentReconciler(logger logr.Logger, c client.Client, view *AgentView) *AgentReconciler {
+	return &AgentReconciler{logger: logger, client: c, view: view}
+}
+
+func (r *AgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	fn := &fv1.Function{}
+	if err := r.client.Get(ctx, req.NamespacedName, fn); err != nil {
+		if apierrors.IsNotFound(err) {
+			r.view.Remove(req.NamespacedName)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if fn.Spec.Agent == nil {
+		r.view.Remove(req.NamespacedName)
+		return ctrl.Result{}, nil
+	}
+
+	entry := entryFromAgentConfig(fn.Namespace, fn.Name, fn.Spec.Agent)
+	r.view.Upsert(entry)
+	return ctrl.Result{}, nil
+}

--- a/pkg/agentruntime/reconciler_test.go
+++ b/pkg/agentruntime/reconciler_test.go
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agentruntime
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/generated/clientset/versioned/scheme"
+)
+
+func newTestReconciler(t *testing.T, objs ...client.Object) (*AgentReconciler, *AgentView, client.Client) {
+	t.Helper()
+	c := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(objs...).
+		Build()
+	view := NewAgentView()
+	r := NewAgentReconciler(logr.Discard(), c, view)
+	return r, view, c
+}
+
+func agentFn(name string, agent *fv1.AgentConfig) *fv1.Function {
+	return &fv1.Function{
+		Name: name, Namespace: "default", Generation: 1,
+		Spec: fv1.FunctionSpec{Agent: agent},
+	}
+}
+
+func TestAgentReconcilerBuildsEntry(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		agent *fv1.AgentConfig
+		want  AgentEntry
+	}{
+		{
+			name:  "all nil/zero applies platform defaults",
+			agent: &fv1.AgentConfig{},
+			want: AgentEntry{
+				SessionSource: fv1.SessionSourceHeader,
+				SessionName:   fv1.DefaultAgentSessionHeader,
+				IdleAfter:     DefaultIdleAfter,
+				ArchiveAfter:  DefaultArchiveAfter,
+				MaxSessions:   0,
+			},
+		},
+		{
+			name: "explicit values carry through",
+			agent: &fv1.AgentConfig{
+				Session:      &fv1.AgentSessionConfig{Source: fv1.SessionSourceQueryParam, Name: "session"},
+				IdleAfter:    &metav1.Duration{Duration: 10 * time.Minute},
+				ArchiveAfter: &metav1.Duration{Duration: 48 * time.Hour},
+				MaxSessions:  42,
+			},
+			want: AgentEntry{
+				SessionSource: fv1.SessionSourceQueryParam,
+				SessionName:   "session",
+				IdleAfter:     10 * time.Minute,
+				ArchiveAfter:  48 * time.Hour,
+				MaxSessions:   42,
+			},
+		},
+		{
+			name: "explicit zero durations also apply platform defaults",
+			agent: &fv1.AgentConfig{
+				IdleAfter:    &metav1.Duration{Duration: 0},
+				ArchiveAfter: &metav1.Duration{Duration: 0},
+			},
+			want: AgentEntry{
+				SessionSource: fv1.SessionSourceHeader,
+				SessionName:   fv1.DefaultAgentSessionHeader,
+				IdleAfter:     DefaultIdleAfter,
+				ArchiveAfter:  DefaultArchiveAfter,
+				MaxSessions:   0,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fn := agentFn("agent-fn", tt.agent)
+			r, view, _ := newTestReconciler(t, fn)
+			key := types.NamespacedName{Namespace: "default", Name: "agent-fn"}
+
+			_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+			require.NoError(t, err)
+
+			e, ok := view.Lookup("default", "agent-fn")
+			require.True(t, ok, "entry should be in the view")
+			tt.want.Namespace = "default"
+			tt.want.Name = "agent-fn"
+			assert.Equal(t, tt.want, e)
+		})
+	}
+}
+
+func TestAgentReconcilerAgentNilRemoves(t *testing.T) {
+	t.Parallel()
+	fn := agentFn("no-agent", nil)
+	r, view, _ := newTestReconciler(t, fn)
+	key := types.NamespacedName{Namespace: "default", Name: "no-agent"}
+
+	// Seed the view as if a prior reconcile had exposed it, to prove Agent==nil
+	// removes an existing entry rather than just skipping insertion.
+	view.Upsert(AgentEntry{Namespace: "default", Name: "no-agent"})
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	_, ok := view.Lookup("default", "no-agent")
+	assert.False(t, ok, "a function without Agent must not be in the view")
+}
+
+func TestAgentReconcilerNotFoundRemoves(t *testing.T) {
+	t.Parallel()
+	r, view, _ := newTestReconciler(t)
+	key := types.NamespacedName{Namespace: "default", Name: "missing"}
+
+	view.Upsert(AgentEntry{Namespace: "default", Name: "missing"})
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	_, ok := view.Lookup("default", "missing")
+	assert.False(t, ok, "a deleted function must be removed from the view")
+}
+
+func TestAgentReconcilerIdempotent(t *testing.T) {
+	t.Parallel()
+	fn := agentFn("steady", &fv1.AgentConfig{MaxSessions: 5})
+	r, view, _ := newTestReconciler(t, fn)
+	key := types.NamespacedName{Namespace: "default", Name: "steady"}
+
+	_, err := r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	first, ok := view.Lookup("default", "steady")
+	require.True(t, ok)
+
+	_, err = r.Reconcile(t.Context(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	second, ok := view.Lookup("default", "steady")
+	require.True(t, ok)
+
+	assert.Equal(t, first, second, "re-reconciling an unchanged function must be a no-op on the entry")
+	assert.Len(t, view.List(), 1)
+}

--- a/pkg/agentruntime/reconciler_test.go
+++ b/pkg/agentruntime/reconciler_test.go
@@ -140,6 +140,35 @@ func TestAgentReconcilerNotFoundRemoves(t *testing.T) {
 	assert.False(t, ok, "a deleted function must be removed from the view")
 }
 
+func TestAgentReconcilerUpdatesExistingEntry(t *testing.T) {
+	t.Parallel()
+	fn := agentFn("updatable", &fv1.AgentConfig{MaxSessions: 5})
+	r, view, c := newTestReconciler(t, fn)
+	key := types.NamespacedName{Namespace: "default", Name: "updatable"}
+	ctx := t.Context()
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	before, ok := view.Lookup("default", "updatable")
+	require.True(t, ok)
+	require.Equal(t, DefaultIdleAfter, before.IdleAfter)
+	require.EqualValues(t, 5, before.MaxSessions)
+
+	got := &fv1.Function{}
+	require.NoError(t, c.Get(ctx, key, got))
+	got.Spec.Agent.IdleAfter = &metav1.Duration{Duration: 30 * time.Minute}
+	got.Spec.Agent.MaxSessions = 99
+	require.NoError(t, c.Update(ctx, got))
+
+	_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	after, ok := view.Lookup("default", "updatable")
+	require.True(t, ok)
+	assert.Equal(t, 30*time.Minute, after.IdleAfter, "reconcile must pick up the updated spec, not keep serving the stale entry")
+	assert.EqualValues(t, 99, after.MaxSessions)
+}
+
 func TestAgentReconcilerIdempotent(t *testing.T) {
 	t.Parallel()
 	fn := agentFn("steady", &fv1.AgentConfig{MaxSessions: 5})

--- a/pkg/agentruntime/session.go
+++ b/pkg/agentruntime/session.go
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// session.go implements the statestore-backed session record store used by
+// the agent runtime's request dispatcher and idle/archive sweeper.
+
+package agentruntime
+
+import (
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"time"
+
+	"github.com/fission/fission/pkg/statestore"
+)
+
+// SessionStatus is the lifecycle state of a session record.
+type SessionStatus string
+
+const (
+	// StatusActive is a session with recent turn activity.
+	StatusActive SessionStatus = "active"
+	// StatusIdle is a session past its agent's IdleAfter with no activity.
+	StatusIdle SessionStatus = "idle"
+	// StatusArchived is a session moved out of the live keyspace into the
+	// archived keyspace, retained for inspection until its retention TTL.
+	StatusArchived SessionStatus = "archived"
+)
+
+var (
+	// ErrSessionExists is returned by Create when a record with the same ID
+	// already exists (the create-only IfVersion=0 write clashed).
+	ErrSessionExists = errors.New("agentruntime: session already exists")
+	// ErrSessionQuota is returned by Create when the agent's MaxSessions
+	// live-key budget is already spent (mapped from statestore.ErrQuotaExceeded).
+	ErrSessionQuota = errors.New("agentruntime: session quota exceeded")
+)
+
+// SessionStats is the per-session meter set (G19: full meter schema from day
+// one; Tokens/Cost reserved for the gateway integration, always 0 for now).
+type SessionStats struct {
+	Turns        int64 `json:"turns"`
+	Errors       int64 `json:"errors"`
+	ToolCalls    int64 `json:"toolCalls"`
+	ActiveMillis int64 `json:"activeMillis"`
+	TokensIn     int64 `json:"tokensIn"`
+	TokensOut    int64 `json:"tokensOut"`
+	CostMicroUSD int64 `json:"costMicroUSD"`
+}
+
+// SessionRecord is the persisted state of one agent session.
+type SessionRecord struct {
+	ID           string        `json:"id"`
+	Agent        string        `json:"agent"`
+	Namespace    string        `json:"namespace"`
+	Status       SessionStatus `json:"status"`
+	CreatedAt    time.Time     `json:"createdAt"`
+	LastActiveAt time.Time     `json:"lastActiveAt"`
+	CurrentPod   string        `json:"currentPod,omitempty"` // best-effort UI truth, never routing truth
+	Stats        SessionStats  `json:"stats"`
+}
+
+// SessionStore persists SessionRecords in a statestore KVStore. Live records
+// live in one keyspace and archived records in a sibling keyspace, so the
+// CountedKV live-key budget meters only live sessions.
+type SessionStore struct {
+	kv  statestore.KVStore
+	now func() time.Time
+}
+
+// NewSessionStore returns a SessionStore backed by kv. now is the store's
+// injected clock.
+func NewSessionStore(kv statestore.KVStore, now func() time.Time) *SessionStore {
+	return &SessionStore{kv: kv, now: now}
+}
+
+// sessionScope is the live keyspace for one agent's sessions.
+func sessionScope(ns, agent string) statestore.Scope {
+	return statestore.Scope{Namespace: ns, Owner: "agent/" + agent, Keyspace: "sessions"}
+}
+
+// archivedScope is the sibling keyspace holding archived records. It is
+// separate from sessionScope so an archived record's retention TTL never
+// counts against the live CountedKV MaxSessions budget.
+func archivedScope(ns, agent string) statestore.Scope {
+	return statestore.Scope{Namespace: ns, Owner: "agent/" + agent, Keyspace: "sessions-archived"}
+}
+
+// Get returns the live record for id and its KV version, for CAS-back via
+// Update or Archive.
+func (s *SessionStore) Get(ctx context.Context, ns, agent, id string) (SessionRecord, int64, error) {
+	v, err := s.kv.Get(ctx, sessionScope(ns, agent), id)
+	if err != nil {
+		return SessionRecord{}, 0, err
+	}
+	var rec SessionRecord
+	if err := json.Unmarshal(v.Data, &rec); err != nil {
+		return SessionRecord{}, 0, err
+	}
+	return rec, v.Version, nil
+}
+
+// Create writes a new active record create-only (IfVersion=0) with liveTTL
+// (orphan self-expiry: if the agent Function is deleted, records vanish
+// without a sweeper). maxSessions>0 routes through CountedKV.SetCounted so
+// the budget check and the write are one atomic step.
+//
+// Returns ErrSessionQuota on statestore.ErrQuotaExceeded, ErrSessionExists on
+// an IfVersion=0 clash.
+func (s *SessionStore) Create(ctx context.Context, rec SessionRecord, maxSessions int64, liveTTL time.Duration) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	scope := sessionScope(rec.Namespace, rec.Agent)
+	opts := statestore.SetOptions{IfVersion: new(int64), TTL: liveTTL}
+
+	if ck, ok := s.kv.(statestore.CountedKV); ok && maxSessions > 0 {
+		err = ck.SetCounted(ctx, scope, rec.ID, data, opts, maxSessions)
+	} else {
+		err = s.kv.Set(ctx, scope, rec.ID, data, opts)
+	}
+	switch {
+	case errors.Is(err, statestore.ErrQuotaExceeded):
+		return ErrSessionQuota
+	case errors.Is(err, statestore.ErrVersionConflict):
+		return ErrSessionExists
+	default:
+		return err
+	}
+}
+
+// Update CAS-writes rec at version with liveTTL (refreshing the orphan
+// expiry). statestore.ErrVersionConflict passes through unmapped.
+func (s *SessionStore) Update(ctx context.Context, rec SessionRecord, version int64, liveTTL time.Duration) error {
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	scope := sessionScope(rec.Namespace, rec.Agent)
+	opts := statestore.SetOptions{IfVersion: new(version), TTL: liveTTL}
+	return s.kv.Set(ctx, scope, rec.ID, data, opts)
+}
+
+// Archive moves the record to the archived keyspace: it writes the archived
+// copy (Status=archived, TTL=retention, unconditional set) FIRST, then
+// CAS-deletes the live key at version. A delete conflict means a concurrent
+// turn revived the session — the archived copy is removed and Archive
+// aborts, leaving the live record as-is; the next sweep retries.
+func (s *SessionStore) Archive(ctx context.Context, rec SessionRecord, version int64, retention time.Duration) error {
+	archived := rec
+	archived.Status = StatusArchived
+
+	data, err := json.Marshal(archived)
+	if err != nil {
+		return err
+	}
+	aScope := archivedScope(rec.Namespace, rec.Agent)
+	if err := s.kv.Set(ctx, aScope, rec.ID, data, statestore.SetOptions{TTL: retention}); err != nil {
+		return err
+	}
+
+	lScope := sessionScope(rec.Namespace, rec.Agent)
+	if err := s.kv.Delete(ctx, lScope, rec.ID, version); err != nil {
+		// Concurrent revive: undo the speculative archived write and abort.
+		_ = s.kv.Delete(ctx, aScope, rec.ID, 0)
+		return err
+	}
+	return nil
+}
+
+// List pages LIVE records for one agent (prefix "" = all keys in the scope).
+// Page keys come from KVStore.List; each key is decoded via Get. A key that
+// expires between List and Get (an orphan TTL race) is skipped rather than
+// failing the page.
+func (s *SessionStore) List(ctx context.Context, ns, agent, pageToken string, limit int) ([]SessionRecord, string, error) {
+	scope := sessionScope(ns, agent)
+	kp, err := s.kv.List(ctx, scope, "", statestore.Page{Token: pageToken, Limit: limit})
+	if err != nil {
+		return nil, "", err
+	}
+	recs := make([]SessionRecord, 0, len(kp.Keys))
+	for _, key := range kp.Keys {
+		rec, _, err := s.Get(ctx, ns, agent, key)
+		if errors.Is(err, statestore.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return nil, "", err
+		}
+		recs = append(recs, rec)
+	}
+	return recs, kp.Next, nil
+}

--- a/pkg/agentruntime/session.go
+++ b/pkg/agentruntime/session.go
@@ -146,9 +146,19 @@ func (s *SessionStore) Update(ctx context.Context, rec SessionRecord, version in
 
 // Archive moves the record to the archived keyspace: it writes the archived
 // copy (Status=archived, TTL=retention, unconditional set) FIRST, then
-// CAS-deletes the live key at version. A delete conflict means a concurrent
-// turn revived the session — the archived copy is removed and Archive
-// aborts, leaving the live record as-is; the next sweep retries.
+// CAS-deletes the live key at version.
+//
+// A delete conflict has two distinct causes that must be told apart: a
+// concurrent turn revived the session (the live key still exists, at a
+// newer version), or a peer replica's own Archive call already won the same
+// race (the live key is now absent). Only the revive case may undo the
+// archived copy — undoing it unconditionally would, on the peer-won case,
+// delete the archived record the peer just committed, destroying the
+// session from both keyspaces even though it was correctly archived. So on
+// conflict we re-Get the live key: present means revived (undo and abort,
+// leaving the live record as-is for the next sweep to retry); absent means
+// a peer already archived it (leave the archived copy alone and return nil
+// — this call is then a no-op success, not a failure).
 func (s *SessionStore) Archive(ctx context.Context, rec SessionRecord, version int64, retention time.Duration) error {
 	archived := rec
 	archived.Status = StatusArchived
@@ -164,7 +174,17 @@ func (s *SessionStore) Archive(ctx context.Context, rec SessionRecord, version i
 
 	lScope := sessionScope(rec.Namespace, rec.Agent)
 	if err := s.kv.Delete(ctx, lScope, rec.ID, version); err != nil {
-		// Concurrent revive: undo the speculative archived write and abort.
+		if errors.Is(err, statestore.ErrVersionConflict) {
+			if _, getErr := s.kv.Get(ctx, lScope, rec.ID); errors.Is(getErr, statestore.ErrNotFound) {
+				// A peer replica's Archive already won: the archived copy
+				// we (re)wrote above is the committed record. Leave it.
+				return nil
+			}
+			// Concurrent revive: undo the speculative archived write and abort.
+			_ = s.kv.Delete(ctx, aScope, rec.ID, 0)
+			return err
+		}
+		// Unexpected error: undo the speculative archived write and abort.
 		_ = s.kv.Delete(ctx, aScope, rec.ID, 0)
 		return err
 	}

--- a/pkg/agentruntime/session_test.go
+++ b/pkg/agentruntime/session_test.go
@@ -205,6 +205,45 @@ func TestSessionStoreArchiveVsReviveRaceAborts(t *testing.T) {
 	require.ErrorIs(t, err, statestore.ErrNotFound)
 }
 
+// TestSessionStoreArchiveRaceBetweenTwoArchiversLeavesOneRecord covers the
+// other CAS-delete-conflict cause: not a revive, but a second Archive call
+// (a second replica's sweeper) racing the same pre-read version. Both calls
+// write the archived copy unconditionally before their CAS-delete, so the
+// second call's Set overwrites the first's archived copy with identical
+// content — benign. The dangerous part is what happens on its CAS-delete
+// conflict: the live key is now genuinely absent (the first Archive call
+// already deleted it), not revived. Blindly deleting the archived copy on
+// any delete conflict destroys the just-committed archived record from BOTH
+// keyspaces, losing the session entirely.
+func TestSessionStoreArchiveRaceBetweenTwoArchiversLeavesOneRecord(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusIdle}
+	require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+	_, version, err := store.Get(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+
+	// Two replicas both read version and independently decide to archive.
+	err1 := store.Archive(ctx, rec, version, 7*24*time.Hour)
+	err2 := store.Archive(ctx, rec, version, 7*24*time.Hour)
+
+	require.NoError(t, err1, "the first Archive call must win outright")
+	require.NoError(t, err2, "the second Archive call must treat 'already archived by a peer' as a no-op success, not an error")
+
+	// The archived record must have survived both racing calls.
+	v, err := kv.Get(ctx, archivedScope("ns", "a"), "s1")
+	require.NoError(t, err, "archived record must survive two racing Archive calls at the same version")
+	assert.NotEmpty(t, v.Data)
+
+	// The live key must be gone (both agree the session is archived).
+	_, _, err = store.Get(ctx, "ns", "a", "s1")
+	assert.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
 func TestSessionStoreListPagination(t *testing.T) {
 	t.Parallel()
 	kv := newTestKV(t)

--- a/pkg/agentruntime/session_test.go
+++ b/pkg/agentruntime/session_test.go
@@ -1,0 +1,237 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agentruntime
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/statestore"
+	_ "github.com/fission/fission/pkg/statestore/memory"
+)
+
+// newTestKV opens a fresh in-memory statestore KVStore for one test.
+func newTestKV(t *testing.T) statestore.KVStore {
+	t.Helper()
+	caps, err := statestore.Open(t.Context(), statestore.Config{Driver: "memory"})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = caps.Close() })
+	kv, err := caps.KV()
+	require.NoError(t, err)
+	return kv
+}
+
+func fixedClock(ts time.Time) func() time.Time {
+	return func() time.Time { return ts }
+}
+
+func TestSessionStoreCreateGetRoundtrip(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	ts := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	store := NewSessionStore(kv, fixedClock(ts))
+	ctx := t.Context()
+
+	rec := SessionRecord{
+		ID:           "sess-1",
+		Agent:        "myagent",
+		Namespace:    "ns1",
+		Status:       StatusActive,
+		CreatedAt:    ts,
+		LastActiveAt: ts,
+	}
+	require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+	got, version, err := store.Get(ctx, "ns1", "myagent", "sess-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, version)
+	assert.Equal(t, StatusActive, got.Status)
+	assert.True(t, ts.Equal(got.CreatedAt), "CreatedAt should roundtrip through the injected clock")
+	assert.True(t, ts.Equal(got.LastActiveAt), "LastActiveAt should roundtrip through the injected clock")
+	assert.Equal(t, rec.ID, got.ID)
+	assert.Equal(t, rec.Agent, got.Agent)
+	assert.Equal(t, rec.Namespace, got.Namespace)
+}
+
+func TestSessionStoreCreateDuplicateExists(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	rec := SessionRecord{ID: "sess-1", Agent: "a", Namespace: "ns", Status: StatusActive}
+	require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+	err := store.Create(ctx, rec, 0, time.Hour)
+	require.ErrorIs(t, err, ErrSessionExists)
+}
+
+func TestSessionStoreCreateQuotaExceeded(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	rec1 := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+	rec2 := SessionRecord{ID: "s2", Agent: "a", Namespace: "ns", Status: StatusActive}
+	require.NoError(t, store.Create(ctx, rec1, 1, time.Hour))
+
+	err := store.Create(ctx, rec2, 1, time.Hour)
+	require.ErrorIs(t, err, ErrSessionQuota)
+}
+
+func TestSessionStoreArchiveFreesQuota(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	rec1 := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+	require.NoError(t, store.Create(ctx, rec1, 1, time.Hour))
+
+	_, version, err := store.Get(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+	require.NoError(t, store.Archive(ctx, rec1, version, 7*24*time.Hour))
+
+	// The live keyspace no longer holds s1, so a second create against the
+	// same MaxSessions=1 budget must succeed — the sibling-keyspace property.
+	rec2 := SessionRecord{ID: "s2", Agent: "a", Namespace: "ns", Status: StatusActive}
+	require.NoError(t, store.Create(ctx, rec2, 1, time.Hour))
+}
+
+func TestSessionStoreUpdateStaleVersionConflict(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+	require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+	_, version, err := store.Get(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+
+	rec.Status = StatusIdle
+	require.NoError(t, store.Update(ctx, rec, version, time.Hour))
+
+	// version is now stale (the successful Update above bumped it).
+	err = store.Update(ctx, rec, version, time.Hour)
+	require.ErrorIs(t, err, statestore.ErrVersionConflict)
+}
+
+func TestSessionStoreArchiveRemovesFromListAndExpiresAfterRetention(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		ctx := t.Context()
+
+		rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+		require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+		_, version, err := store.Get(ctx, "ns", "a", "s1")
+		require.NoError(t, err)
+		require.NoError(t, store.Archive(ctx, rec, version, time.Hour))
+
+		list, _, err := store.List(ctx, "ns", "a", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, list, "archived record must not appear in List")
+
+		// The archived copy is present before its retention TTL fires.
+		v, err := kv.Get(ctx, archivedScope("ns", "a"), "s1")
+		require.NoError(t, err)
+		assert.NotEmpty(t, v.Data)
+
+		time.Sleep(2 * time.Hour)
+
+		_, err = kv.Get(ctx, archivedScope("ns", "a"), "s1")
+		require.ErrorIs(t, err, statestore.ErrNotFound, "archived copy must expire after retention")
+	})
+}
+
+func TestSessionStoreOrphanLiveTTLWithNoSweeper(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		ctx := t.Context()
+
+		rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+		require.NoError(t, store.Create(ctx, rec, 0, time.Minute))
+
+		_, _, err := store.Get(ctx, "ns", "a", "s1")
+		require.NoError(t, err)
+
+		time.Sleep(2 * time.Minute)
+
+		_, _, err = store.Get(ctx, "ns", "a", "s1")
+		require.ErrorIs(t, err, statestore.ErrNotFound, "an orphaned record must self-expire on its liveTTL with no sweeper")
+	})
+}
+
+func TestSessionStoreArchiveVsReviveRaceAborts(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+	require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+	_, version, err := store.Get(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+
+	// A concurrent turn revives (updates) the session between the sweeper's
+	// Get and its Archive call, bumping the version out from under it.
+	revived := rec
+	revived.Status = StatusActive
+	revived.LastActiveAt = time.Now()
+	require.NoError(t, store.Update(ctx, revived, version, time.Hour))
+
+	err = store.Archive(ctx, rec, version, 24*time.Hour)
+	require.ErrorIs(t, err, statestore.ErrVersionConflict)
+
+	// The live record must remain intact — Archive aborted, did not delete it.
+	got, _, err := store.Get(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+	assert.Equal(t, StatusActive, got.Status)
+
+	// The archived copy Archive wrote speculatively must have been cleaned up.
+	_, err = kv.Get(ctx, archivedScope("ns", "a"), "s1")
+	require.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+func TestSessionStoreListPagination(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	for _, id := range []string{"a", "b", "c"} {
+		rec := SessionRecord{ID: id, Agent: "agent1", Namespace: "ns", Status: StatusActive}
+		require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+	}
+
+	page1, next1, err := store.List(ctx, "ns", "agent1", "", 2)
+	require.NoError(t, err)
+	require.Len(t, page1, 2)
+	require.NotEmpty(t, next1)
+
+	page2, next2, err := store.List(ctx, "ns", "agent1", next1, 2)
+	require.NoError(t, err)
+	require.Len(t, page2, 1)
+	assert.Empty(t, next2)
+
+	var ids []string
+	for _, r := range page1 {
+		ids = append(ids, r.ID)
+	}
+	for _, r := range page2 {
+		ids = append(ids, r.ID)
+	}
+	assert.ElementsMatch(t, []string{"a", "b", "c"}, ids)
+}

--- a/pkg/agentruntime/sweeper.go
+++ b/pkg/agentruntime/sweeper.go
@@ -86,6 +86,17 @@ func (s *Sweeper) sweepOnce(ctx context.Context) {
 	}
 }
 
+// logSweepErr logs a sweep-path error, unless it is context.Canceled — a
+// canceled context is the expected shape of Run's ctx.Done() shutdown
+// racing an in-flight store call, not a failure worth an Error-level log.
+func (s *Sweeper) logSweepErr(err error, msg string, keysAndValues ...any) {
+	if errors.Is(err, context.Canceled) {
+		s.logger.V(1).Info("sweeper: context canceled, stopping", append(keysAndValues, "cause", msg)...)
+		return
+	}
+	s.logger.Error(err, msg, keysAndValues...)
+}
+
 // sweepAgent pages through one agent's live sessions, applying the idle and
 // archive transitions where due. liveTTL (entry.IdleAfter + entry.ArchiveAfter
 // + s.retention, per the controller's Update signature) is passed to every
@@ -100,10 +111,13 @@ func (s *Sweeper) sweepAgent(ctx context.Context, entry AgentEntry) {
 		}
 		recs, next, err := s.store.List(ctx, entry.Namespace, entry.Name, pageToken, sweepPageLimit)
 		if err != nil {
-			s.logger.Error(err, "sweeper: list failed", "namespace", entry.Namespace, "agent", entry.Name)
+			s.logSweepErr(err, "sweeper: list failed", "namespace", entry.Namespace, "agent", entry.Name)
 			return
 		}
 		for _, rec := range recs {
+			if ctx.Err() != nil {
+				return
+			}
 			s.sweepRecord(ctx, entry, rec, liveTTL)
 		}
 		if next == "" {
@@ -133,7 +147,7 @@ func (s *Sweeper) idle(ctx context.Context, entry AgentEntry, rec SessionRecord,
 	fresh, version, err := s.store.Get(ctx, entry.Namespace, entry.Name, rec.ID)
 	if err != nil {
 		if !errors.Is(err, statestore.ErrNotFound) {
-			s.logger.Error(err, "sweeper: get before idle transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+			s.logSweepErr(err, "sweeper: get before idle transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 		}
 		return
 	}
@@ -152,7 +166,7 @@ func (s *Sweeper) idle(ctx context.Context, entry AgentEntry, rec SessionRecord,
 			s.logger.V(1).Info("sweeper: idle transition skipped, CAS conflict", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 			return
 		}
-		s.logger.Error(err, "sweeper: idle transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+		s.logSweepErr(err, "sweeper: idle transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 	}
 }
 
@@ -165,7 +179,7 @@ func (s *Sweeper) archive(ctx context.Context, entry AgentEntry, rec SessionReco
 	fresh, version, err := s.store.Get(ctx, entry.Namespace, entry.Name, rec.ID)
 	if err != nil {
 		if !errors.Is(err, statestore.ErrNotFound) {
-			s.logger.Error(err, "sweeper: get before archive transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+			s.logSweepErr(err, "sweeper: get before archive transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 		}
 		return
 	}
@@ -184,6 +198,6 @@ func (s *Sweeper) archive(ctx context.Context, entry AgentEntry, rec SessionReco
 			s.logger.V(1).Info("sweeper: archive skipped, CAS conflict (revived)", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 			return
 		}
-		s.logger.Error(err, "sweeper: archive failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+		s.logSweepErr(err, "sweeper: archive failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 	}
 }

--- a/pkg/agentruntime/sweeper.go
+++ b/pkg/agentruntime/sweeper.go
@@ -1,0 +1,189 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// sweeper.go implements Sweeper, the lifecycle sweeper that ages active
+// sessions to idle and idle sessions to archived.
+//
+// The sweeper runs on every replica with no leader election. Each replica
+// pages through every agent's live sessions on its own timer and drives the
+// same two transitions the request dispatcher would drive on a turn:
+// active -> idle (Update) and idle -> archived (Archive). Both writes are
+// CAS at the version the sweeper just read. When two replicas race the same
+// record, or a live turn touches it between the sweeper's read and its
+// write, the loser's CAS fails with statestore.ErrVersionConflict and the
+// sweeper skips that record silently — it never retries within the same
+// sweep, and it never deletes anything (archived and orphaned-live records
+// expire on their own TTLs). That CAS idempotence is what lets every
+// replica sweep independently and correctly: whichever write lands first
+// wins, and the loser's no-op is indistinguishable from "nothing to do
+// here" from the sweeper's point of view. This is the substitute for leader
+// election in v1.
+package agentruntime
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/fission/fission/pkg/statestore"
+)
+
+// sweepPageLimit is the per-agent List page size.
+const sweepPageLimit = 500
+
+// Sweeper ages active sessions to idle and idle sessions to archived, per
+// the IdleAfter/ArchiveAfter policy resolved on each AgentEntry.
+type Sweeper struct {
+	logger    logr.Logger
+	view      *AgentView
+	store     *SessionStore
+	interval  time.Duration // AGENT_SWEEP_INTERVAL, default 30s (read in Start, injected here)
+	retention time.Duration // AGENT_ARCHIVE_RETENTION, default 168h (7d)
+	now       func() time.Time
+
+	// beforeCAS, when non-nil, runs immediately after the sweeper re-reads a
+	// record's authoritative version and before it issues the CAS write. It
+	// is a test-only seam for landing a race in that window (another writer
+	// mutating the record) that would otherwise require real concurrency to
+	// exercise deterministically. Production code never sets this.
+	beforeCAS func()
+}
+
+// NewSweeper returns a Sweeper that ages sessions in store per the policy on
+// each entry in view, using now as its clock.
+func NewSweeper(logger logr.Logger, view *AgentView, store *SessionStore, interval, retention time.Duration, now func() time.Time) *Sweeper {
+	return &Sweeper{
+		logger:    logger,
+		view:      view,
+		store:     store,
+		interval:  interval,
+		retention: retention,
+		now:       now,
+	}
+}
+
+// Run loops sweepOnce every s.interval until ctx is done.
+func (s *Sweeper) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.sweepOnce(ctx)
+		}
+	}
+}
+
+// sweepOnce sweeps every agent in the view once.
+func (s *Sweeper) sweepOnce(ctx context.Context) {
+	for _, entry := range s.view.List() {
+		s.sweepAgent(ctx, entry)
+	}
+}
+
+// sweepAgent pages through one agent's live sessions, applying the idle and
+// archive transitions where due. liveTTL (entry.IdleAfter + entry.ArchiveAfter
+// + s.retention, per the controller's Update signature) is passed to every
+// idle transition so an orphaned record still self-expires with no sweeper
+// running.
+func (s *Sweeper) sweepAgent(ctx context.Context, entry AgentEntry) {
+	liveTTL := entry.IdleAfter + entry.ArchiveAfter + s.retention
+	pageToken := ""
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		recs, next, err := s.store.List(ctx, entry.Namespace, entry.Name, pageToken, sweepPageLimit)
+		if err != nil {
+			s.logger.Error(err, "sweeper: list failed", "namespace", entry.Namespace, "agent", entry.Name)
+			return
+		}
+		for _, rec := range recs {
+			s.sweepRecord(ctx, entry, rec, liveTTL)
+		}
+		if next == "" {
+			return
+		}
+		pageToken = next
+	}
+}
+
+// sweepRecord applies the one transition, if any, that rec's listed snapshot
+// is due for. The actual CAS re-reads the record immediately beforehand (the
+// re-Get discipline: use the version from that read, not the List page's
+// snapshot) so the write always targets the current data.
+func (s *Sweeper) sweepRecord(ctx context.Context, entry AgentEntry, rec SessionRecord, liveTTL time.Duration) {
+	idleFor := s.now().Sub(rec.LastActiveAt)
+	switch {
+	case rec.Status == StatusActive && idleFor >= entry.IdleAfter:
+		s.idle(ctx, entry, rec, liveTTL)
+	case rec.Status == StatusIdle && idleFor >= entry.ArchiveAfter:
+		s.archive(ctx, entry, rec)
+	}
+}
+
+// idle CAS-transitions rec to StatusIdle. A version conflict means another
+// replica or a live turn already moved it — skip silently, no retry.
+func (s *Sweeper) idle(ctx context.Context, entry AgentEntry, rec SessionRecord, liveTTL time.Duration) {
+	fresh, version, err := s.store.Get(ctx, entry.Namespace, entry.Name, rec.ID)
+	if err != nil {
+		if !errors.Is(err, statestore.ErrNotFound) {
+			s.logger.Error(err, "sweeper: get before idle transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+		}
+		return
+	}
+	// Re-validate against the fresh read: a turn may have touched the
+	// record between the List page's snapshot and this Get (the CAS below
+	// only guards the Get-to-write window, not this one).
+	if fresh.Status != StatusActive || s.now().Sub(fresh.LastActiveAt) < entry.IdleAfter {
+		return
+	}
+	if s.beforeCAS != nil {
+		s.beforeCAS()
+	}
+	fresh.Status = StatusIdle
+	if err := s.store.Update(ctx, fresh, version, liveTTL); err != nil {
+		if errors.Is(err, statestore.ErrVersionConflict) {
+			s.logger.V(1).Info("sweeper: idle transition skipped, CAS conflict", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+			return
+		}
+		s.logger.Error(err, "sweeper: idle transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+	}
+}
+
+// archive CAS-transitions rec to the archived keyspace. A version conflict
+// means a concurrent turn revived the session (SessionStore.Archive aborts
+// on its CAS-delete conflict, cleaning up its speculative archived write) —
+// skip silently, no retry; the live record is left exactly as the reviver
+// left it.
+func (s *Sweeper) archive(ctx context.Context, entry AgentEntry, rec SessionRecord) {
+	fresh, version, err := s.store.Get(ctx, entry.Namespace, entry.Name, rec.ID)
+	if err != nil {
+		if !errors.Is(err, statestore.ErrNotFound) {
+			s.logger.Error(err, "sweeper: get before archive transition failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+		}
+		return
+	}
+	// Re-validate against the fresh read: a turn may have revived the
+	// record between the List page's snapshot and this Get (the CAS below
+	// only guards the Get-to-write window, not this one) — without this
+	// check a just-revived session would be archived out from under it.
+	if fresh.Status != StatusIdle || s.now().Sub(fresh.LastActiveAt) < entry.ArchiveAfter {
+		return
+	}
+	if s.beforeCAS != nil {
+		s.beforeCAS()
+	}
+	if err := s.store.Archive(ctx, fresh, version, s.retention); err != nil {
+		if errors.Is(err, statestore.ErrVersionConflict) {
+			s.logger.V(1).Info("sweeper: archive skipped, CAS conflict (revived)", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+			return
+		}
+		s.logger.Error(err, "sweeper: archive failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+	}
+}

--- a/pkg/agentruntime/sweeper_test.go
+++ b/pkg/agentruntime/sweeper_test.go
@@ -242,6 +242,52 @@ func TestSweeperArchiveSkipsOnListToGetStalenessWindow(t *testing.T) {
 	})
 }
 
+// TestSweeperIdleSkipsOnListToGetStalenessWindow is the idle-side analogue
+// of TestSweeperArchiveSkipsOnListToGetStalenessWindow: a new turn touches
+// an active session (refreshing LastActiveAt) between the sweeper's List
+// page snapshot and its own re-Get. The Get observes the fresh, still-active
+// record — no CAS conflict occurs — so only a re-validation of the fresh
+// read (not just the CAS) prevents the sweeper from idling a session a turn
+// just touched.
+func TestSweeperIdleSkipsOnListToGetStalenessWindow(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		longAgo := time.Now()
+		staleSnapshot := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusActive, LastActiveAt: longAgo}
+		require.NoError(t, store.Create(ctx, staleSnapshot, 0, time.Hour))
+
+		time.Sleep(entry.IdleAfter + time.Second)
+
+		// A new turn touches the session after the (simulated) List page
+		// was captured, but before the sweeper processes this record.
+		_, version, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err)
+		touchedAt := time.Now()
+		touched := staleSnapshot
+		touched.LastActiveAt = touchedAt
+		touched.Stats.Turns = 1
+		require.NoError(t, store.Update(ctx, touched, version, time.Hour))
+
+		sweeper := NewSweeper(logr.Discard(), view, store, time.Second, 7*24*time.Hour, time.Now)
+		// staleSnapshot is what the sweeper's List call would have returned
+		// before the turn landed; sweepRecord must re-validate against a
+		// fresh Get rather than trusting it.
+		sweeper.sweepRecord(ctx, entry, staleSnapshot, time.Hour)
+
+		got, _, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err)
+		assert.Equal(t, StatusActive, got.Status, "must not idle a session a turn just touched")
+		assert.True(t, touchedAt.Equal(got.LastActiveAt))
+		assert.EqualValues(t, 1, got.Stats.Turns, "the turn's data must survive intact")
+	})
+}
+
 func TestSweeperRunRespectsContextCancel(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		kv := newTestKV(t)

--- a/pkg/agentruntime/sweeper_test.go
+++ b/pkg/agentruntime/sweeper_test.go
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agentruntime
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/statestore"
+)
+
+// sweeperTestEntry returns an AgentEntry with short, distinct lifecycle
+// windows so IdleAfter and ArchiveAfter thresholds are easy to straddle in a
+// synctest bubble.
+func sweeperTestEntry(ns, agent string) AgentEntry {
+	return AgentEntry{
+		Namespace:    ns,
+		Name:         agent,
+		IdleAfter:    5 * time.Minute,
+		ArchiveAfter: time.Hour,
+		MaxSessions:  0,
+	}
+}
+
+func TestSweeperActiveToIdleAfterIdleAfter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusActive, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+		sweeper := NewSweeper(logr.Discard(), view, store, time.Second, 7*24*time.Hour, time.Now)
+
+		// Not yet due: less than IdleAfter has elapsed.
+		time.Sleep(entry.IdleAfter - time.Second)
+		sweeper.sweepOnce(ctx)
+		got, _, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err)
+		assert.Equal(t, StatusActive, got.Status, "must not idle before IdleAfter elapses")
+
+		// Now past IdleAfter.
+		time.Sleep(2 * time.Second)
+		sweeper.sweepOnce(ctx)
+		got, _, err = store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err)
+		assert.Equal(t, StatusIdle, got.Status, "must idle once IdleAfter elapses")
+	})
+}
+
+func TestSweeperIdleToArchivedAfterArchiveAfter(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
+
+		sweeper := NewSweeper(logr.Discard(), view, store, time.Second, retention, time.Now)
+
+		// Not yet due.
+		time.Sleep(entry.ArchiveAfter - time.Second)
+		sweeper.sweepOnce(ctx)
+		list, _, err := store.List(ctx, "ns", "agent1", "", 10)
+		require.NoError(t, err)
+		require.Len(t, list, 1, "must not archive before ArchiveAfter elapses")
+
+		// Now past ArchiveAfter.
+		time.Sleep(2 * time.Second)
+		sweeper.sweepOnce(ctx)
+		list, _, err = store.List(ctx, "ns", "agent1", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, list, "archived record must leave the live List")
+
+		// Present in the archived keyspace, before its retention TTL.
+		v, err := kv.Get(ctx, archivedScope("ns", "agent1"), "s1")
+		require.NoError(t, err)
+		assert.NotEmpty(t, v.Data)
+
+		// Gone after retention.
+		time.Sleep(retention + time.Second)
+		_, err = kv.Get(ctx, archivedScope("ns", "agent1"), "s1")
+		require.ErrorIs(t, err, statestore.ErrNotFound, "archived copy must expire after retention")
+	})
+}
+
+// TestSweeperIdleTransitionSkipsOnCASConflict drives the sweeper's beforeCAS
+// test seam to land a write in the window between the sweeper's re-Get and
+// its Update call: another writer (standing in for a second replica) bumps
+// the record's version first. The sweeper's own CAS must then fail with
+// ErrVersionConflict and be skipped silently, without touching the record
+// the other writer just wrote.
+func TestSweeperIdleTransitionSkipsOnCASConflict(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusActive, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+		time.Sleep(entry.IdleAfter + time.Second)
+
+		sweeper := NewSweeper(logr.Discard(), view, store, time.Second, 7*24*time.Hour, time.Now)
+		sweeper.beforeCAS = func() {
+			// Simulate a second replica winning the race: it idles the
+			// record first, landing between this sweeper's Get and Update.
+			winner, version, err := store.Get(ctx, "ns", "agent1", "s1")
+			require.NoError(t, err)
+			winner.Status = StatusIdle
+			winner.CurrentPod = "winner-replica"
+			require.NoError(t, store.Update(ctx, winner, version, time.Hour))
+		}
+
+		sweeper.sweepOnce(ctx)
+
+		got, _, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err)
+		assert.Equal(t, StatusIdle, got.Status)
+		assert.Equal(t, "winner-replica", got.CurrentPod, "the sweeper's own CAS must have been skipped, not overwritten the winner's write")
+	})
+}
+
+// TestSweeperArchiveSkipsOnReviveRace covers the specific race carried from
+// Task 9's review: a turn revives (re-activates) a session between the
+// sweeper's re-Get and its Archive call. SessionStore.Archive's CAS-delete
+// then conflicts and aborts, undoing its speculative archived-copy write.
+// The sweeper must treat that as a silent skip, and the live record must
+// survive with the reviver's data intact — never archived.
+func TestSweeperArchiveSkipsOnReviveRace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
+		time.Sleep(entry.ArchiveAfter + time.Second)
+
+		sweeper := NewSweeper(logr.Discard(), view, store, time.Second, retention, time.Now)
+		var revivedAt time.Time
+		sweeper.beforeCAS = func() {
+			// A live turn revives the session, landing between this
+			// sweeper's Get and Archive.
+			live, version, err := store.Get(ctx, "ns", "agent1", "s1")
+			require.NoError(t, err)
+			revivedAt = time.Now()
+			live.Status = StatusActive
+			live.LastActiveAt = revivedAt
+			live.Stats.Turns = 1
+			require.NoError(t, store.Update(ctx, live, version, time.Hour))
+		}
+
+		sweeper.sweepOnce(ctx)
+
+		got, _, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err, "the revived record must still be live, not archived")
+		assert.Equal(t, StatusActive, got.Status)
+		assert.True(t, revivedAt.Equal(got.LastActiveAt))
+		assert.EqualValues(t, 1, got.Stats.Turns, "the reviver's data must survive intact")
+
+		_, err = kv.Get(ctx, archivedScope("ns", "agent1"), "s1")
+		assert.ErrorIs(t, err, statestore.ErrNotFound, "Archive's speculative archived-copy write must have been undone")
+	})
+}
+
+// TestSweeperArchiveSkipsOnListToGetStalenessWindow covers the other race
+// window: a turn revives the record between the sweeper's List page
+// snapshot and its own re-Get (not between the Get and the CAS write, which
+// TestSweeperArchiveSkipsOnReviveRace already covers). The Get itself would
+// observe the revived, active record — no CAS conflict occurs at all — so
+// only a re-validation of the fresh read (not just the CAS) can catch this.
+// It drives sweepRecord directly with a hand-built stale snapshot, per the
+// brief's "driving sweepOnce directly with a pre-staleness setup".
+func TestSweeperArchiveSkipsOnListToGetStalenessWindow(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		longAgo := time.Now()
+		staleSnapshot := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: longAgo}
+		require.NoError(t, store.Create(ctx, staleSnapshot, 0, liveTTL))
+
+		time.Sleep(entry.ArchiveAfter + time.Second)
+
+		// A turn revives the session after the (simulated) List page was
+		// captured, but before the sweeper processes this record.
+		_, version, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err)
+		revivedAt := time.Now()
+		revived := staleSnapshot
+		revived.Status = StatusActive
+		revived.LastActiveAt = revivedAt
+		revived.Stats.Turns = 1
+		require.NoError(t, store.Update(ctx, revived, version, time.Hour))
+
+		sweeper := NewSweeper(logr.Discard(), view, store, time.Second, retention, time.Now)
+		// staleSnapshot is what the sweeper's List call would have returned
+		// before the revive landed; sweepRecord must re-validate against a
+		// fresh Get rather than trusting it.
+		sweeper.sweepRecord(ctx, entry, staleSnapshot, liveTTL)
+
+		got, _, err := store.Get(ctx, "ns", "agent1", "s1")
+		require.NoError(t, err, "the revived record must still be live, not archived")
+		assert.Equal(t, StatusActive, got.Status)
+		assert.True(t, revivedAt.Equal(got.LastActiveAt))
+		assert.EqualValues(t, 1, got.Stats.Turns, "the reviver's data must survive intact")
+
+		_, err = kv.Get(ctx, archivedScope("ns", "agent1"), "s1")
+		assert.ErrorIs(t, err, statestore.ErrNotFound, "must never have written a speculative archived copy")
+	})
+}
+
+func TestSweeperRunRespectsContextCancel(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		sweeper := NewSweeper(logr.Discard(), view, store, 10*time.Millisecond, time.Hour, time.Now)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		done := make(chan struct{})
+		go func() {
+			sweeper.Run(ctx)
+			close(done)
+		}()
+
+		// Let a few ticks fire (no-op: the view is empty), then cancel.
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		synctest.Wait()
+		select {
+		case <-done:
+		default:
+			t.Fatal("Run did not return promptly after ctx cancel")
+		}
+	})
+}

--- a/pkg/agentruntime/view.go
+++ b/pkg/agentruntime/view.go
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// view.go implements AgentView, the per-replica in-memory read model of
+// Functions with Spec.Agent != nil. It follows the pkg/mcp Registry pattern:
+// reconcile-maintained, RWMutex-guarded, and safe for concurrent
+// reconcile/serve.
+
+package agentruntime
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+const (
+	// DefaultIdleAfter is the platform default for AgentConfig.IdleAfter when
+	// it is nil or zero.
+	DefaultIdleAfter = 5 * time.Minute
+	// DefaultArchiveAfter is the platform default for AgentConfig.ArchiveAfter
+	// when it is nil or zero.
+	DefaultArchiveAfter = 24 * time.Hour
+)
+
+// AgentEntry is the resolved, defaults-applied view of one agent-enabled
+// Function.
+type AgentEntry struct {
+	Namespace, Name string
+
+	// SessionSource and SessionName are where the dispatcher extracts the
+	// session id from an incoming request. Defaults (when Spec.Agent.Session
+	// is nil): fv1.SessionSourceHeader / fv1.DefaultAgentSessionHeader.
+	SessionSource fv1.SessionSource
+	SessionName   string
+
+	// IdleAfter and ArchiveAfter are the resolved lifecycle policy. Defaults
+	// (when nil or zero on the spec): DefaultIdleAfter / DefaultArchiveAfter.
+	IdleAfter    time.Duration
+	ArchiveAfter time.Duration
+
+	// MaxSessions is the live-session quota, unchanged from the spec (0 means
+	// unbounded).
+	MaxSessions int64
+}
+
+// AgentView is the per-replica in-memory read model of Functions with
+// Agent != nil, maintained by AgentReconciler and read by the request
+// dispatcher and idle/archive sweeper. Each replica keeps its own copy (no
+// leader election), so the reconcile is idempotent map mutation.
+type AgentView struct {
+	mu   sync.RWMutex
+	byFn map[types.NamespacedName]AgentEntry
+}
+
+// NewAgentView returns an empty AgentView.
+func NewAgentView() *AgentView {
+	return &AgentView{byFn: map[types.NamespacedName]AgentEntry{}}
+}
+
+// Upsert inserts or replaces the entry for e.Namespace/e.Name.
+func (v *AgentView) Upsert(e AgentEntry) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.byFn[types.NamespacedName{Namespace: e.Namespace, Name: e.Name}] = e
+}
+
+// Remove drops the entry for nn, if present.
+func (v *AgentView) Remove(nn types.NamespacedName) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	delete(v.byFn, nn)
+}
+
+// Lookup returns the entry for ns/name, if present.
+func (v *AgentView) Lookup(ns, name string) (AgentEntry, bool) {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	e, ok := v.byFn[types.NamespacedName{Namespace: ns, Name: name}]
+	return e, ok
+}
+
+// List returns a snapshot of all entries, in no particular order.
+func (v *AgentView) List() []AgentEntry {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	out := make([]AgentEntry, 0, len(v.byFn))
+	for _, e := range v.byFn {
+		out = append(out, e)
+	}
+	return out
+}
+
+// entryFromAgentConfig builds the defaults-applied AgentEntry for a Function
+// whose Spec.Agent is non-nil.
+func entryFromAgentConfig(ns, name string, ac *fv1.AgentConfig) AgentEntry {
+	e := AgentEntry{
+		Namespace:     ns,
+		Name:          name,
+		SessionSource: fv1.SessionSourceHeader,
+		SessionName:   fv1.DefaultAgentSessionHeader,
+		IdleAfter:     DefaultIdleAfter,
+		ArchiveAfter:  DefaultArchiveAfter,
+		MaxSessions:   ac.MaxSessions,
+	}
+	if ac.Session != nil {
+		e.SessionSource = ac.Session.Source
+		e.SessionName = ac.Session.Name
+	}
+	if ac.IdleAfter != nil && ac.IdleAfter.Duration != 0 {
+		e.IdleAfter = ac.IdleAfter.Duration
+	}
+	if ac.ArchiveAfter != nil && ac.ArchiveAfter.Duration != 0 {
+		e.ArchiveAfter = ac.ArchiveAfter.Duration
+	}
+	return e
+}

--- a/pkg/fission-cli/cmd/support/dump.go
+++ b/pkg/fission-cli/cmd/support/dump.go
@@ -31,7 +31,7 @@ const (
 	// componentSelector matches the control-plane Deployments. Keep in sync
 	// with the svc: labels in charts/fission-all/templates/*/deployment.yaml —
 	// a component absent here has no spec and no logs in the bundle at all.
-	componentSelector = "svc in (buildermgr, canaryconfig, executor, kubewatcher, mcp, mqtrigger, " +
+	componentSelector = "svc in (agentruntime, buildermgr, canaryconfig, executor, kubewatcher, mcp, mqtrigger, " +
 		"mqtrigger-keda, router, router-internal, statestore, statesvc, storagesvc, tenantcontroller, timer, " +
 		"webhook-service, workflow)"
 

--- a/pkg/svcinfo/svcinfo.go
+++ b/pkg/svcinfo/svcinfo.go
@@ -54,6 +54,9 @@ const (
 	// (RFC-0023). Scoped surface only — the raw statestore stays on
 	// PortStatestore, unreachable from function pods.
 	PortStateSvc = 8893
+	// PortAgentRuntime is the agent runtime's session-dispatch port: health
+	// probes plus POST /agents/{namespace}/{name}.
+	PortAgentRuntime = 8894
 	// PortMetrics is the default Prometheus metrics port every component
 	// serves when METRICS_ADDR is unset; chart ServiceMonitors scrape it.
 	PortMetrics = 8080
@@ -76,6 +79,7 @@ const (
 	SvcStatestore     = "statestore"
 	SvcWorkflow       = "workflow"
 	SvcStateSvc       = "statesvc"
+	SvcAgentRuntime   = "agentruntime"
 )
 
 // RouterURL returns the in-cluster URL of the router's public listener

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -61,6 +61,10 @@ manifests:
           # Dev/CI clusters run without authentication, so opt into the
           # unauthenticated MCP endpoint explicitly (the chart fails closed otherwise).
           mcp.allowInsecure: "true"
+          agentRuntime.enabled: "true"
+          # Same dev/CI posture as mcp.allowInsecure above: the agent runtime
+          # also fails closed without a signing key.
+          agentRuntime.allowInsecure: "true"
           namespace: fission
           networkPolicy.enabled: "false"
           router.displayAccessLog: "false"

--- a/test/helm/networkpolicy_test.go
+++ b/test/helm/networkpolicy_test.go
@@ -33,8 +33,9 @@ func TestNetworkPolicySvcLabelsResolveToRealWorkloads(t *testing.T) {
 		"--set", "mcp.enabled=true", "--set", "mcp.allowInsecure=true",
 		"--set", "canaryDeployment.enabled=true",
 		"--set", "workflows.enabled=true",
-		// workflows depends on the statestore; the chart refuses to render
-		// otherwise (statestore/validate.yaml).
+		"--set", "agentRuntime.enabled=true", "--set", "agentRuntime.allowInsecure=true",
+		// workflows and the agent runtime depend on the statestore; the chart
+		// refuses to render otherwise (statestore/validate.yaml).
 		"--set", "statestore.enabled=true", "--set", "statestore.mode=embedded",
 		"--set", "functionState.enabled=true",
 	)

--- a/test/helm/serviceaccount_test.go
+++ b/test/helm/serviceaccount_test.go
@@ -21,6 +21,9 @@ import (
 // allComponentsValues enables every optional component, so a render sees every
 // ServiceAccount the chart can produce rather than the default subset.
 const allComponentsValues = `
+agentRuntime:
+  enabled: true
+  allowInsecure: true
 statestore:
   enabled: true
   mode: embedded
@@ -71,7 +74,7 @@ func serviceAccounts(t *testing.T, ms manifests) []corev1.ServiceAccount {
 // proves this list and the rendered accounts agree, and a copy the test owns is
 // what makes that a real assertion rather than a tautology against the helper.
 var saComponents = []string{
-	"builder", "buildermgr", "canaryconfig", "executor", "fetcher", "kafka",
+	"agentruntime", "builder", "buildermgr", "canaryconfig", "executor", "fetcher", "kafka",
 	"kubewatcher", "mcp", "mqtKeda", "preupgrade", "router", "statestore",
 	"statestoreMqt", "statesvc", "storagesvc", "tenantController", "timer",
 	"webhook", "workflow",

--- a/test/integration/framework/framework.go
+++ b/test/integration/framework/framework.go
@@ -51,6 +51,10 @@ const (
 	// MCPName resolves to svc/mcp (RFC-0011). MCP tests skip when it is
 	// unreachable (MCP disabled in this install).
 	MCPName = "mcp.fission"
+	// AgentRuntimeName resolves to svc/agentruntime (agent-runtime session
+	// dispatch, slices 1-2). Agent tests skip when it is unreachable (the
+	// agent runtime disabled in this install).
+	AgentRuntimeName = "agentruntime.fission"
 	// StateSvcName resolves to svc/statesvc (RFC-0023 keyed state). State
 	// tests skip when it is unreachable (functionState disabled).
 	StateSvcName = "statesvc.fission"
@@ -207,6 +211,7 @@ func newRegistry(restConfig *rest.Config) (*portless.Registry, error) {
 		{MCPName, "FISSION_MCP_BASE_URL", "mcp", []portless.RouteOption{portless.RouteWithHostRewrite("127.0.0.1")}},
 		{StateSvcName, "FISSION_STATESVC", "statesvc", nil},
 		{ExecutorName, "FISSION_EXECUTOR", "executor", nil},
+		{AgentRuntimeName, "FISSION_AGENTRUNTIME_BASE_URL", "agentruntime", nil},
 	} {
 		var b portless.Backend
 		var err error
@@ -294,6 +299,13 @@ func (f *Framework) InternalAuthSecret() []byte { return f.internalAuthSecret }
 // unreachable (the MCP subsystem is enabled in the kind/kind-ci skaffold
 // profiles but may be off in other installs).
 func (f *Framework) MCPBaseURL() string { return portless.URL(MCPName, 0, "") }
+
+// AgentRuntimeBaseURL returns the URL of the agent runtime dispatch endpoint
+// (svc/agentruntime). Agent integration tests POST turns to
+// "<base>/agents/<namespace>/<name>" via HTTPClient; they should skip when
+// the endpoint is unreachable (the agent runtime is enabled in the
+// kind/kind-ci skaffold profiles but may be off in other installs).
+func (f *Framework) AgentRuntimeBaseURL() string { return portless.URL(AgentRuntimeName, 0, "") }
 
 // ExecutorBaseURL returns the framework's URL for the executor's HTTP API
 // (svc/executor). Direct-specialize tests (RFC-0025 phase 2) POST versioned

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -111,15 +111,24 @@ func TestAgentRuntimeSessionDispatch(t *testing.T) {
 
 	// Second turn: supply the minted session id explicitly. The dispatcher
 	// must resolve (not mint a new) session and echo the same id back.
-	attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
-	defer cancel()
-	resp, err := postTurn(attemptCtx, f, turnURL, sessionID)
-	require.NoErrorf(t, err, "POST %s", turnURL)
-	defer resp.Body.Close()
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, sessionID, resp.Header.Get(agentruntime.HeaderSession),
-		"second turn must echo the caller-supplied session id, not mint a new one")
-	assert.Empty(t, resp.Header.Get(agentruntime.HeaderYield))
+	// Wrapped in the same EventuallyWithT/attempt-timeout shape as the first
+	// turn (symmetric with TestMCPToolsListAndCall's tools/list + tools/call
+	// subtests, both of which poll) rather than a single direct call.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postTurn(attemptCtx, f, turnURL, sessionID)
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "second turn to %s", turnURL) {
+			return
+		}
+		assert.Equal(c, sessionID, resp.Header.Get(agentruntime.HeaderSession),
+			"second turn must echo the caller-supplied session id, not mint a new one")
+		assert.Empty(c, resp.Header.Get(agentruntime.HeaderYield))
+	}, 180*time.Second, 2*time.Second)
 }
 
 // postTurn POSTs one turn to turnURL, carrying sessionID on

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/agentruntime"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// turnAttemptTimeout bounds a single POST /agents/... attempt.
+// f.HTTPClient() sets no client-wide timeout (per its own doc: dials block
+// until the backend accepts), so an unbounded per-request context would let
+// one hung attempt (a stuck dial, a pathological cold start) consume the
+// entire require.EventuallyWithT budget below as a single try, turning
+// "retry until it converges" into "one shot, then fail". 60s leaves ~3 real
+// attempts inside the 180s polling budget.
+const turnAttemptTimeout = 60 * time.Second
+
+// TestAgentRuntimeSessionDispatch exercises the agent-runtime session
+// dispatch path end-to-end against a real Node.js runtime: a function
+// created with `--agent` (default header session source, X-Fission-Session)
+// is (1) reachable at POST /agents/<ns>/<fn>, (2) mints a session id on a
+// turn with no session header and returns it via X-Fission-Session, and (3)
+// echoes the SAME id back when the caller supplies it on a follow-up turn.
+// It also asserts the plain (non-yielding) fixture leaves
+// X-Fission-Agent-Yield unset on the response, since the dispatcher only
+// surfaces that header when the function itself sets it.
+//
+// The agent runtime is enabled in the kind/kind-ci skaffold profiles
+// (agentRuntime.enabled/allowInsecure, mirroring mcp.enabled/allowInsecure);
+// the framework reaches it through the agentruntime.fission route
+// (in-process port-forward, or the FISSION_AGENTRUNTIME_BASE_URL override).
+// The test skips when the endpoint is unreachable — same shape as
+// TestMCPToolsListAndCall's requireMCPReachable. In CI the server runs in
+// pass-through auth mode (AGENT_ALLOW_INSECURE=true), so no bearer token is
+// needed here; JWT namespace scoping is covered by the pkg/agentruntime unit
+// tests (authz_test.go).
+func TestAgentRuntimeSessionDispatch(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "nodejs-agent-" + ns.ID
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	fnName := "agent-hello-" + ns.ID
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{
+		Name: fnName,
+		Env:  envName,
+		Code: framework.WriteTestData(t, "nodejs/hello/hello.js"),
+	})
+	ns.WaitForFunction(t, ctx, fnName)
+
+	// FunctionOptions has no Agent field yet (RFC agent-runtime slices 1-2
+	// added the CLI flag but this framework helper predates it); attach the
+	// Agent config with a follow-up `fn update --agent`. The bare flag (no
+	// --agent-session-*/--agent-idle-after/etc.) leaves Session/IdleAfter/
+	// ArchiveAfter/MaxSessions nil, which the agent runtime's AgentView
+	// resolves to its documented defaults: header source
+	// X-Fission-Session, 5m idle, 24h archive, unlimited sessions (see
+	// pkg/agentruntime/view.go's entryFromAgentConfig).
+	ns.CLI(t, ctx, "fn", "update", "--name", fnName, "--agent")
+
+	turnURL := f.AgentRuntimeBaseURL() + "/agents/" + ns.Name + "/" + fnName
+
+	// First turn: no session header. The dispatcher mints one, and by the
+	// time this returns 200 the agentruntime replica's reconciler has also
+	// caught up with the Function admission — poll until 200 to absorb both
+	// that convergence and the function's cold start.
+	var sessionID string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postTurn(attemptCtx, f, turnURL, "")
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "first turn to %s", turnURL) {
+			return
+		}
+		sid := resp.Header.Get(agentruntime.HeaderSession)
+		if !assert.NotEmpty(c, sid, "first turn must mint a session id via %s", agentruntime.HeaderSession) {
+			return
+		}
+		assert.Empty(c, resp.Header.Get(agentruntime.HeaderYield),
+			"a plain function that never sets %s must not surface it on the response", agentruntime.HeaderYield)
+		sessionID = sid
+	}, 180*time.Second, 2*time.Second)
+	require.NotEmpty(t, sessionID, "first turn never minted a session id")
+
+	// Second turn: supply the minted session id explicitly. The dispatcher
+	// must resolve (not mint a new) session and echo the same id back.
+	attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+	defer cancel()
+	resp, err := postTurn(attemptCtx, f, turnURL, sessionID)
+	require.NoErrorf(t, err, "POST %s", turnURL)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, sessionID, resp.Header.Get(agentruntime.HeaderSession),
+		"second turn must echo the caller-supplied session id, not mint a new one")
+	assert.Empty(t, resp.Header.Get(agentruntime.HeaderYield))
+}
+
+// postTurn POSTs one turn to turnURL, carrying sessionID on
+// agentruntime.HeaderSession when non-empty. The caller is responsible for
+// closing the response body on a nil error.
+func postTurn(ctx context.Context, f *framework.Framework, turnURL, sessionID string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, turnURL, strings.NewReader(`{}`))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set(agentruntime.HeaderSession, sessionID)
+	}
+	return f.HTTPClient().Do(req)
+}
+
+// requireAgentRuntimeReachable skips the test when the agent runtime endpoint
+// isn't serving (agent runtime disabled in this install). Mirrors
+// requireMCPReachable in mcp_test.go: a short first probe distinguishes "not
+// installed" (typed target-not-found — skip fast) from "warming" (earns the
+// generous deadline a cold in-process port-forward needs).
+func requireAgentRuntimeReachable(t *testing.T, ctx context.Context, f *framework.Framework) {
+	t.Helper()
+	base := f.AgentRuntimeBaseURL()
+	probe := func(timeout time.Duration) (int, error) {
+		reqCtx, cancel := context.WithTimeout(ctx, timeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, base+"/healthz", nil)
+		require.NoError(t, err)
+		resp, err := f.HTTPClient().Do(req)
+		if err != nil {
+			return 0, err
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode, nil
+	}
+	status, err := probe(5 * time.Second)
+	if framework.IsTargetMissing(err) {
+		t.Skipf("agent runtime not installed (svc/agentruntime absent); skipping: %v", err)
+	}
+	if err != nil {
+		status, err = probe(30 * time.Second)
+	}
+	if err != nil {
+		t.Skipf("agent runtime endpoint %s not reachable (%v); skipping", base, err)
+	}
+	if status != http.StatusOK {
+		t.Skipf("agent runtime endpoint %s returned %d; skipping", base, status)
+	}
+}


### PR DESCRIPTION
This PR ships slice 2 of the distributed agent runtime:
the `pkg/agentruntime` subsystem (`fission-bundle --agentPort`, port 8894).
Builds on #3699 (`FunctionSpec.Agent`).

It dispatches session-scoped turns at `POST /agents/{namespace}/{name}`
to agent-enabled Functions over the router internal listener,
with the same ServiceRouterInternal HMAC signing the other publishers use,
streaming responses with per-write flush.

Session records are statestore KV entries, never CRDs:
create-only CAS writes with an atomic `SetCounted` MaxSessions quota,
a sibling archived keyspace so retention never consumes quota,
and orphan self-expiry TTLs.
A CAS-idempotent sweeper ages sessions active → idle → archived on every replica
with no leader election —
a lost CAS means another replica already applied the transition.

AuthZ mirrors the MCP server's fail-closed JWT contract
(`allowed_namespaces`, 403 on out-of-scope namespaces;
chart render fails unless authentication is enabled or `agentRuntime.allowInsecure` is explicit).
The Helm chart adds the deployment/service/SA/RBAC
plus both NetworkPolicy allowlists (router-internal 8889 and statestore 8891),
and an integration test covers mint-and-reuse session dispatch end-to-end,
gated in CI by an explicit `deploy/agentruntime` rollout wait
so a profile regression can never turn the coverage into a green skip.

Per-session meters (turns, errors, active-millis, token/cost placeholders)
are recorded in the session stats block from day one;
metrics export is deliberately deferred to the metering slice,
matching how the MCP subsystem shipped.

In v1 only Content-Type and the session headers cross the dispatcher in either direction
(plus `X-Fission-Agent-Yield` on the way back) —
custom caller headers are intentionally not proxied yet.
