### PR TITLE
agentruntime: session parentage + graph-over-sessions (slice 5)

### DIFF
--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -26,10 +26,19 @@ sub-second resume, live UI.**
   a real agent would call it mid-conversation,
   but the load generator below drives `support-desk` directly,
   so this stays decoupled from the density/teleport story.
+- `fixtures/architect.js` —
+  the swarm-beat agent function.
+  On every turn it spawns 3 deterministically-derived "expert" child sessions on `support-desk`
+  (see `pkg/agentruntime/session.go`'s `SpawnSessionID` / `ParentRef`),
+  carrying `X-Fission-Agent-Parent` on each spawn so the platform records real parentage —
+  the boardroom UI's family tree (below) renders the result.
+  Workers ARE `support-desk` sessions;
+  no separate worker function exists.
 - `specs/` —
   `fission spec`-format YAML: one shared `node` Environment plus a Package + Function per fixture.
   `support-desk`'s Function carries `spec.agent` (session lifecycle) and `spec.state` (keyed-state keyspace, with `sticky` routing on the session header so the router's real request routing lands on the same pod the dispatcher's `CurrentPod` prediction shows in the UI);
-  `order-lookup`'s Function carries `spec.tool`.
+  `order-lookup`'s Function carries `spec.tool`;
+  `architect`'s Function carries `spec.agent` (its own session lifecycle) and a minimal `spec.state` (used only so the fetcher writes the state token file `architect.js` reads its own namespace from).
 - `loadgen/main.go` —
   a stdlib-only Go CLI that drives sessions against the dispatcher and
   prints the demo's success metrics at the end.
@@ -99,6 +108,49 @@ It stays here for now so the whole stack (fixtures, specs, load driver) is self-
    list (`--agents-url`, `--namespace`, `--agent`, `--environment`,
    `--concurrency`, `--timeout`).
 
+## Swarm beat
+
+`architect` (`fixtures/architect.js` / `specs/architect.yaml`) is a second agent function:
+every turn it spawns 3 deterministically-derived "expert" child sessions on `support-desk`,
+carrying real parentage (`X-Fission-Agent-Parent`) end to end.
+This is manual, not part of `loadgen` —
+start one turn by hand and watch the board:
+
+```sh
+# Port-forward as in step 3 above, then:
+curl -i -X POST http://127.0.0.1:8894/agents/default/architect \
+  -H 'Content-Type: application/json' \
+  -H 'X-Fission-Session: architect-demo-1' \
+  -d '{"message":"kick off the swarm"}'
+```
+
+What to watch on the `/ui/` board:
+
+- The response carries `X-Fission-Session: architect-demo-1`
+  (echoed back — the dispatcher minted or resumed that exact id)
+  and a JSON body listing 3 `experts`, each with its derived `childID` and dispatch status.
+- The SESSIONS panel gets a new **root** card for `architect-demo-1`
+  (`default/architect`, no depth badge — a root session has none),
+  with 3 **child** cards indented underneath it, tree-connected,
+  each carrying a `d1` depth badge (`default/support-desk`,
+  same as any other support-desk session in every other respect —
+  same status chip, same click-to-transcript panel).
+- Re-run the exact same `curl` (same `X-Fission-Session: architect-demo-1`):
+  the same 3 child ids reappear —
+  `SpawnSessionID` derives them from `("default/architect/architect-demo-1", "expert-<k>")`,
+  so the SAME turn keeps resuming the SAME 3 children rather than minting new ones each time.
+  Watch their `turns` counter climb instead of the child count growing.
+- If a child session is later archived (or its agent isn't the one this page fetched)
+  while the architect session is still listed,
+  its card would show as a root under an `(unknown parent: ...)` group header instead of disappearing —
+  the family tree never silently drops a card just because its parent fell out of view.
+- Auth note (see `fixtures/architect.js`'s header comment for the full G16 gate writeup):
+  on a `kind`/dev deployment (`AGENT_ALLOW_INSECURE=true`, the default per the Kind quickstart above)
+  no token is needed for `architect` to spawn children.
+  On an `authentication.enabled` install,
+  set `AGENT_RUNTIME_TOKEN` on the `architect` Function's pod env to a dispatch-scoped bearer token —
+  there is no automatic credential handoff from the architect's own inbound call today.
+
 ## Demo beats checklist
 
 Mapped from the boardroom demo script; check these off live against the
@@ -126,8 +178,9 @@ Mapped from the boardroom demo script; check these off live against the
       `support-desk` sessions keep resuming, with 429s visible only past
       the function's `Concurrency` limit (honest backpressure, not
       failure).
-- [ ] **Swarm** (not built by this task) — a planner agent fanning out to
-      expert sub-agents via async-invoke; tracked separately.
+- [ ] **Swarm** — start an `architect` session (see "Swarm beat" below) and
+      watch its 3 expert children appear indented underneath it in the
+      SESSIONS panel, with a `d1` depth badge.
 - [ ] **Burst counter** — `loadgen`'s final report line
       (`density (sessions:pods): NNx`) climbs as `--sessions` grows for a
       fixed pool size.

--- a/demo/agent-boardroom/fixtures/architect.js
+++ b/demo/agent-boardroom/fixtures/architect.js
@@ -1,0 +1,197 @@
+'use strict';
+
+// architect is the boardroom demo's "swarm beat" agent function (see
+// ../specs/architect.yaml, spec.agent). Like fixtures/support-desk.js it is
+// dispatched by fission-bundle --agentPort (pkg/agentruntime/dispatcher.go):
+// every call carries the session id in the X-Fission-Session request header,
+// and the reply sets X-Fission-Agent-Yield: waiting so the session flips
+// back to idle immediately.
+//
+// What makes this fixture different: on EVERY turn it spawns K_EXPERTS child
+// sessions on the support-desk agent, demonstrating session parentage
+// end-to-end (RFC-0031 slice 5 / Task 4 of the parent-graph plan) --
+// pkg/agentruntime/session.go's ParentRef + SpawnSessionID, dispatcher.go's
+// HeaderParent, and the boardroom UI's family tree (Task 4's other half,
+// pkg/agentruntime/ui/boardroom.html) all meet here.
+//
+// Child-id derivation (spawnSessionID below) is a byte-identical JS twin of
+// SpawnSessionID (pkg/agentruntime/session.go): same parent + same stepKey
+// always derives the same child id, which is what makes re-spawning
+// "expert-1".."expert-3" on a LATER turn resume the SAME three child
+// sessions rather than minting new ones -- the exactly-once admission row
+// the plan calls "demonstrated". The derivation is pinned against Go's own
+// fixed-vector test (pkg/agentruntime/session_test.go
+// TestSpawnSessionIDFixedVector), reproduced here as a comment so a change
+// to the hash, prefix, or truncation length on either side is caught by
+// eyeballing this file, not just by CI:
+//
+//   parent = {namespace:"ns", agent:"a", id:"sess-1"}, stepKey = "step-1"
+//   => "c-27304abfe9308ae9849ace27841bc098"
+//
+// Auth (G16 gate): the dispatch route this fixture calls is the SAME
+// full-privilege POST /agents/{ns}/{name} route any external caller uses,
+// gated by JWT_SIGNING_KEY / AGENT_ALLOW_INSECURE (pkg/agentruntime/main.go).
+// A running function pod holds no per-agent identity of its own today (that
+// is the still-open G16 gap the RFC tracks) -- it can only spawn children if
+// EITHER the cluster runs the agent runtime with AGENT_ALLOW_INSECURE=true
+// (the kind/demo default, see ../README.md's Kind quickstart) OR the
+// deployer threads a real dispatch-scoped bearer token into this pod via
+// AGENT_RUNTIME_TOKEN. There is no automatic credential handoff from the
+// architect's OWN inbound call to its outbound spawn calls.
+//
+// Spawn failures are best-effort and never fail the architect's own turn: a
+// child dispatch returning 4xx/5xx (or a network error) is logged to
+// console.error and recorded in the reply body, but the turn still answers
+// 200 -- this is a demo fixture illustrating the wire contract, not a
+// production supervisor with retry/backoff semantics.
+
+const fs = require('fs');
+const crypto = require('crypto');
+
+const SESSION_HEADER = 'x-fission-session'; // express lower-cases header names
+const YIELD_HEADER = 'X-Fission-Agent-Yield';
+
+// OWN_AGENT_NAME must match this fixture's own Function name in
+// ../specs/architect.yaml -- it is the middle segment of the ParentRef this
+// fixture stamps on every child it spawns ("<ns>/architect/<own-session-id>"),
+// and the platform has no way to tell this pod its own function name at
+// runtime (see the header comment on ownNamespace below for the analogous
+// namespace problem).
+const OWN_AGENT_NAME = 'architect';
+// WORKER_AGENT is the agent every spawned child session runs on -- the
+// existing support-desk fixture, unmodified: the brief for this task is
+// explicit that workers ARE support-desk sessions, no separate worker
+// function needed.
+const WORKER_AGENT = 'support-desk';
+const K_EXPERTS = 3;
+
+// DEFAULT_AGENT_RUNTIME_URL is the agentruntime Service's in-cluster DNS
+// name (charts/fission-all/templates/agentruntime/service.yaml: ClusterIP
+// "agentruntime" in the fission namespace, port from
+// `fission.agentRuntimePort`, 8894 by default) -- reachable from this pod
+// because the agentruntime NetworkPolicy is deliberately permissive on that
+// port for any in-cluster caller (see that chart's networkpolicy.yaml).
+const DEFAULT_AGENT_RUNTIME_URL = 'http://agentruntime.fission:8894';
+const AGENT_RUNTIME_URL = process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
+// AGENT_RUNTIME_TOKEN is optional (see the G16 auth note above): absent
+// means this fixture relies on the cluster's AGENT_ALLOW_INSECURE dev-mode
+// pass-through rather than sending an Authorization header at all.
+const AGENT_RUNTIME_TOKEN = process.env.AGENT_RUNTIME_TOKEN || '';
+
+const STATE_URL = process.env.FISSION_STATE_URL || '';
+const TOKEN_PATH = process.env.FISSION_STATE_TOKEN_PATH || '';
+
+// stateCreds is read the same way support-desk.js reads it (RFC-0023's
+// fetcher-written token file at specialize time), used ONLY to learn this
+// pod's own namespace for building the ParentRef below -- a function pod has
+// no other reliable way to learn which namespace it was deployed into. See
+// ../specs/architect.yaml's spec.state block, which is what makes the
+// fetcher actually write this file; without it (or with functionState
+// disabled cluster-wide) ownNamespace() falls back to "default", which is
+// also where this whole demo's specs deploy everything.
+let stateCreds = null;
+if (STATE_URL && TOKEN_PATH) {
+  try {
+    stateCreds = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`architect: could not read state token file ${TOKEN_PATH}: ${err}`);
+  }
+}
+
+function ownNamespace() {
+  return (stateCreds && stateCreds.namespace) || 'default';
+}
+
+// spawnSessionID is the JS twin of pkg/agentruntime/session.go's
+// SpawnSessionID: 'c-' + the first 32 lowercase hex characters of
+// sha256(parentRef + "/" + stepKey). See the file header comment for the
+// cross-language fixed-vector pin this must keep matching.
+function spawnSessionID(parentRef, stepKey) {
+  const digest = crypto.createHash('sha256').update(parentRef + '/' + stepKey).digest('hex');
+  return 'c-' + digest.slice(0, 32);
+}
+
+function authHeaders() {
+  return AGENT_RUNTIME_TOKEN ? { Authorization: `Bearer ${AGENT_RUNTIME_TOKEN}` } : {};
+}
+
+// spawnOneExpert dispatches one child turn on support-desk for stepKey
+// "expert-<k>", carrying X-Fission-Session (the derived child id) and
+// X-Fission-Agent-Parent (this architect session's ParentRef). Per
+// dispatcher.go's HeaderParent contract, the parent header is consulted ONLY
+// the first time this childID is dispatched (session creation); on every
+// later turn -- including the identical spawn on the architect's NEXT turn
+// -- the same call simply resumes the existing child session.
+async function spawnOneExpert(ns, parentRef, ownSessionID, k) {
+  const stepKey = `expert-${k}`;
+  const childID = spawnSessionID(parentRef, stepKey);
+  const url = `${AGENT_RUNTIME_URL}/agents/${encodeURIComponent(ns)}/${encodeURIComponent(WORKER_AGENT)}`;
+  const body = JSON.stringify({
+    message: `architect ${ownSessionID} dispatching ${stepKey}: triage the current support queue from the ${stepKey} angle.`,
+  });
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: Object.assign(
+        {
+          'Content-Type': 'application/json',
+          'X-Fission-Session': childID,
+          'X-Fission-Agent-Parent': parentRef,
+        },
+        authHeaders(),
+      ),
+      body: body,
+    });
+    if (!res.ok) {
+      // Best-effort: a 4xx/5xx spawning one child never fails the
+      // architect's own turn (see the file header comment).
+      console.error(`architect: spawn ${stepKey} (${childID}) failed: HTTP ${res.status}`);
+      return { stepKey: stepKey, childID: childID, ok: false, status: res.status };
+    }
+    return { stepKey: stepKey, childID: childID, ok: true, status: res.status };
+  } catch (err) {
+    console.error(`architect: spawn ${stepKey} (${childID}) failed: ${err}`);
+    return { stepKey: stepKey, childID: childID, ok: false, status: 0, error: String(err) };
+  }
+}
+
+// spawnExperts fans out all K_EXPERTS spawn calls concurrently -- they are
+// independent dispatch calls to independent (deterministically-derived)
+// child sessions, so there is no ordering requirement between them, and
+// running them in parallel keeps one slow/cold child from serializing the
+// architect's own turn latency behind the others.
+async function spawnExperts(ns, parentRef, ownSessionID) {
+  const tasks = [];
+  for (let k = 1; k <= K_EXPERTS; k++) {
+    tasks.push(spawnOneExpert(ns, parentRef, ownSessionID, k));
+  }
+  return Promise.all(tasks);
+}
+
+module.exports = async function (context) {
+  const req = context.request;
+  const sessionID = req.headers[SESSION_HEADER] || 'unknown';
+  const ns = ownNamespace();
+  // The canonical ParentRef form (session.go's ParentRef.String()):
+  // "<namespace>/<agent>/<id>" -- every spawned child's X-Fission-Agent-Parent
+  // header carries exactly this string.
+  const parentRef = `${ns}/${OWN_AGENT_NAME}/${sessionID}`;
+
+  const experts = await spawnExperts(ns, parentRef, sessionID);
+
+  const reply = {
+    session: sessionID,
+    parent: parentRef,
+    experts: experts,
+  };
+
+  return {
+    status: 200,
+    body: JSON.stringify(reply),
+    headers: {
+      'Content-Type': 'application/json',
+      [YIELD_HEADER]: 'waiting',
+    },
+  };
+};

--- a/demo/agent-boardroom/specs/architect.yaml
+++ b/demo/agent-boardroom/specs/architect.yaml
@@ -1,0 +1,69 @@
+include:
+  - fixtures/architect.js
+kind: ArchiveUploadSpec
+name: architect-src
+
+---
+apiVersion: fission.io/v1
+kind: Package
+metadata:
+  name: architect
+  namespace: default
+spec:
+  environment:
+    name: node
+    namespace: default
+  # A single JS file needs no build: the deployment archive IS the source,
+  # buildstatus none skips the env's builder entirely (mirrors
+  # support-desk.yaml / order-lookup.yaml).
+  deployment:
+    type: url
+    url: archive://architect-src
+    checksum: {}
+  source:
+    checksum: {}
+status:
+  buildstatus: none
+
+---
+apiVersion: fission.io/v1
+kind: Function
+metadata:
+  name: architect
+  namespace: default
+spec:
+  environment:
+    name: node
+    namespace: default
+  package:
+    packageref:
+      name: architect
+      namespace: default
+  InvokeStrategy:
+    ExecutionStrategy:
+      ExecutorType: poolmgr
+      MaxScale: 0
+      MinScale: 0
+      SpecializationTimeout: 0
+      TargetCPUPercent: 0
+    StrategyType: execution
+  # 3 concurrent spawn POSTs to support-desk (each a possible cold
+  # specialization) plus the architect's own turn -- generous relative to
+  # support-desk's 60s, but still bounded.
+  functionTimeout: 90
+  resources: {}
+  # RFC-0023 keyed state: architect.js reads only the fetcher-written state
+  # token file's `namespace` field (ownNamespace() in the fixture) to build
+  # the ParentRef it stamps on spawned children -- it keeps no KV blob of its
+  # own, unlike support-desk. The keyspace still has to be set for the
+  # fetcher to write that token file at all (pkg/fetcher/fetcher.go).
+  state:
+    keyspace: architect
+  # Agent dispatch (fission-bundle --agentPort): the swarm beat -- every turn
+  # spawns 3 expert child sessions on support-desk (see fixtures/architect.js).
+  # maxSessions is smaller than support-desk's 500: this demo drives a
+  # handful of architect sessions, each fanning out to its own 3 children.
+  agent:
+    idleAfter: 2m
+    archiveAfter: 30m
+    maxSessions: 50

--- a/pkg/agentruntime/dispatcher.go
+++ b/pkg/agentruntime/dispatcher.go
@@ -645,17 +645,33 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 // claimed parent's OWN stored record, so a forged or stale header can at
 // worst misattribute lineage, never fabricate a depth that skips the cap.
 //
+// Cross-AGENT parentage within one namespace is the supported shape
+// (Handoff/multi-agent-orchestration). Cross-NAMESPACE parentage is
+// rejected: the dispatcher's store handle is unscoped, so resolving a
+// foreign-namespace ref would Get another tenant's record on the strength
+// of a caller-supplied header alone, and the minted child's depth (readable
+// back by the caller in its own namespace) plus the depth-cap's 400-vs-200
+// split would together leak that tenant's session existence and exact spawn
+// depth — a cross-tenant oracle. This is a security ruling (RFC amendment
+// recorded separately), not a functional gap: nothing on this branch uses
+// cross-namespace parentage.
+//
 // Resolution:
 //   - header == "": root (nil parent, depth 0) — the common case (no spawn).
 //   - unparseable header: root, logged at V(1) (the header is caller input,
 //     not a store-health signal, so this is not worth Error level).
-//   - parseable header: Get the claimed parent from the LIVE keyspace; on
-//     ANY error (not just ErrNotFound — see the note below) fall back to
-//     GetArchived. Found in either: depth = parent.Depth + 1. If
-//     int64(depth) > maxSpawnDepth, returns ErrSpawnDepthExceeded — the
-//     caller MUST NOT proceed to Create; no record is minted for a rejected
-//     spawn. Unreadable in BOTH keyspaces: logged "parent claim dropped",
-//     admitted as root.
+//   - parseable header naming a DIFFERENT namespace than ns: root, logged at
+//     V(1) — treated identically to an unparseable header (same fields,
+//     same level) so the response is byte-indistinguishable regardless of
+//     whether the foreign session exists.
+//   - parseable, same-namespace header: Get the claimed parent from the
+//     LIVE keyspace; on ANY error (not just ErrNotFound — see the note
+//     below) fall back to GetArchived. Found in either: depth =
+//     parent.Depth + 1. If int64(depth) > maxSpawnDepth, returns
+//     ErrSpawnDepthExceeded — the caller MUST NOT proceed to Create; no
+//     record is minted for a rejected spawn. Unreadable in BOTH keyspaces:
+//     logged "parent claim dropped" (with both Get errors), admitted as
+//     root.
 //
 // Depth-cap nuance: falling back to root on ANY parent-Get error — not just
 // ErrNotFound — means a transient store hiccup fragments what should have
@@ -676,13 +692,30 @@ func (d *Dispatcher) resolveParentage(ctx context.Context, ns, agent, header str
 		d.logger.V(1).Info("unparseable parent header, admitting as root", "namespace", ns, "agent", agent, "headerLen", len(header))
 		return nil, 0, nil
 	}
+	if parent.Namespace != ns {
+		// Tenant isolation: never Get a foreign namespace's record on the
+		// strength of a caller-supplied header. Logged and admitted exactly
+		// like the unparseable-header case above, on purpose — a foreign-ns
+		// claim must be indistinguishable from an unparseable one to the
+		// caller (see the doc comment above).
+		d.logger.V(1).Info("cross-namespace parent header, admitting as root", "namespace", ns, "agent", agent, "headerLen", len(header))
+		return nil, 0, nil
+	}
 
-	rec, _, err := d.store.Get(ctx, parent.Namespace, parent.Agent, parent.ID)
+	rec, _, liveErr := d.store.Get(ctx, parent.Namespace, parent.Agent, parent.ID)
+	err := liveErr
 	if err != nil {
 		rec, _, err = d.store.GetArchived(ctx, parent.Namespace, parent.Agent, parent.ID)
 	}
 	if err != nil {
-		d.logger.V(1).Info("parent claim dropped, admitting as root", "namespace", ns, "agent", agent, "parent", parent.String())
+		// Both Get errors are attached (when they differ) so a store outage
+		// that silently fragments a legitimate lineage is diagnosable after
+		// the fact, instead of looking identical to a plain not-found.
+		if errors.Is(liveErr, err) {
+			d.logger.V(1).Info("parent claim dropped, admitting as root", "namespace", ns, "agent", agent, "parent", parent.String(), "err", err)
+		} else {
+			d.logger.V(1).Info("parent claim dropped, admitting as root", "namespace", ns, "agent", agent, "parent", parent.String(), "liveErr", liveErr, "archivedErr", err)
+		}
 		return nil, 0, nil
 	}
 

--- a/pkg/agentruntime/dispatcher.go
+++ b/pkg/agentruntime/dispatcher.go
@@ -62,6 +62,17 @@ const (
 	HeaderWakeID      = "X-Fission-Agent-Wake-Id"
 	HeaderWakeAttempt = "X-Fission-Agent-Wake-Attempt"
 
+	// HeaderParent is the request header a caller may set on a turn that
+	// creates a session, naming the spawning parent session in ParentRef's
+	// canonical "<namespace>/<agent>/<id>" form. It is consulted ONLY when
+	// this turn is the one that creates the session record (DispatchTurn's
+	// ErrNotFound branch, via resolveParentage) — Parent/Depth are
+	// immutable after Create (session.go), so on resume or on a
+	// create-race loss the header is only ever compared against the
+	// already-stored value, never applied; a mismatch there is dropped
+	// with a V(1) log, never an error, never a write.
+	HeaderParent = "X-Fission-Agent-Parent"
+
 	// maxTurnBodyBytes caps a buffered turn request body. The HMAC
 	// ServiceSigner binds the signature to a body hash (pkg/auth/hmac/hmac.go),
 	// so the request body MUST be fully buffered (and replayable via GetBody)
@@ -89,6 +100,14 @@ type TurnRequest struct {
 	ContentType                 string
 	WakeID                      string // non-empty only for wake-delivered turns
 	WakeAttempt                 int    // 1-based, wake-delivered turns only
+	// ParentHeader is the raw HeaderParent value from the inbound HTTP
+	// request, copied in by dispatch() — the only place that sees
+	// *http.Request. The wake consumer (wake.go) builds its TurnRequest
+	// with no such header, so ParentHeader is always "" there; that zero
+	// value is exactly what makes a wake-recreated session fall back to
+	// root (no Parent, Depth 0) with NO change to wake.go — see
+	// resolveParentage.
+	ParentHeader string
 }
 
 // TurnResult is the outcome of one DispatchTurn call: the HTTP handler
@@ -138,6 +157,15 @@ var ErrNotAgent = errors.New("agentruntime: not an agent function")
 // there is no budget to protect, so the long-standing "bookkeeping never gates
 // a turn" rule still applies there.
 var ErrStoreUnavailable = errors.New("agentruntime: session store unavailable")
+
+// ErrSpawnDepthExceeded is returned by DispatchTurn when a turn that would
+// CREATE a new session names a parent (HeaderParent) whose resolved chain
+// depth (parent.Depth+1) exceeds maxSpawnDepth. It is returned by
+// resolveParentage BEFORE Create runs — no record is minted for a rejected
+// spawn. The HTTP handler (dispatch) maps it to 400; it can never be
+// produced by the wake consumer's re-dispatch (TurnRequest.ParentHeader is
+// always "" there, so resolveParentage never reaches the cap check).
+var ErrSpawnDepthExceeded = errors.New("agentruntime: spawn depth exceeded")
 
 // enqueuer is the continue-chain seam DispatchTurn calls into on
 // yield=continue (implemented by WakeService). A Dispatcher's zero
@@ -206,6 +234,17 @@ type Dispatcher struct {
 	// unlimited). See DispatchTurn's step-5 bookkeeping closure.
 	maxContinuations int64
 
+	// maxSpawnDepth caps the depth resolveParentage will admit a spawned
+	// session to: parent.Depth+1 <= maxSpawnDepth, checked BEFORE Create.
+	// Unlike maxContinuations, 0 is NOT "unlimited" here — 0 means "no
+	// spawning", rejecting every parented create. That divergence is
+	// deliberate: this cap exists to bound resource exhaustion from an
+	// unbounded spawn tree, and "unlimited" is never a safe default for
+	// that guard. A root session (no claimed parent, or an unreadable/
+	// unparseable claim) is never subject to this cap regardless of its
+	// value — see resolveParentage.
+	maxSpawnDepth int64
+
 	// wake is the continue-chain seam. It is injected AFTER construction via
 	// SetWakeEnqueuer — see that method's doc comment for the
 	// construction-cycle rationale and the pre-serve contract. nil disables
@@ -223,9 +262,10 @@ type Dispatcher struct {
 // IdleAfter+ArchiveAfter to compute the live-key TTL passed to
 // SessionStore.Create/Update (orphan self-expiry covers idle + archive-wait +
 // archived-copy retention in one live-key lease). maxContinuations caps
-// yield=continue self-chaining per session (0 = unlimited); the wake
-// enqueuer itself is wired separately via SetWakeEnqueuer.
-func NewDispatcher(logger logr.Logger, view *AgentView, store *SessionStore, client *http.Client, routerURL string, retention time.Duration, now func() time.Time, maxContinuations int64) *Dispatcher {
+// yield=continue self-chaining per session (0 = unlimited); maxSpawnDepth
+// caps spawn-chain depth (0 = no spawning, see the field's doc comment); the
+// wake enqueuer itself is wired separately via SetWakeEnqueuer.
+func NewDispatcher(logger logr.Logger, view *AgentView, store *SessionStore, client *http.Client, routerURL string, retention time.Duration, now func() time.Time, maxContinuations int64, maxSpawnDepth int64) *Dispatcher {
 	return &Dispatcher{
 		logger:           logger,
 		view:             view,
@@ -235,6 +275,7 @@ func NewDispatcher(logger logr.Logger, view *AgentView, store *SessionStore, cli
 		retention:        retention,
 		now:              now,
 		maxContinuations: maxContinuations,
+		maxSpawnDepth:    maxSpawnDepth,
 	}
 }
 
@@ -320,11 +361,12 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tr := TurnRequest{
-		Namespace:   ns,
-		Agent:       name,
-		SessionID:   sessionID,
-		Body:        body,
-		ContentType: r.Header.Get("Content-Type"),
+		Namespace:    ns,
+		Agent:        name,
+		SessionID:    sessionID,
+		Body:         body,
+		ContentType:  r.Header.Get("Content-Type"),
+		ParentHeader: r.Header.Get(HeaderParent),
 	}
 	sink := &httpSink{w: w, rc: http.NewResponseController(w)}
 	// DispatchTurn's errors arrive BEFORE sink.Begin (no status has been
@@ -337,6 +379,8 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 			writeErr(w, http.StatusServiceUnavailable, "session store unavailable")
 		case errors.Is(err, ErrNotAgent):
 			writeErr(w, http.StatusNotFound, "not an agent function")
+		case errors.Is(err, ErrSpawnDepthExceeded):
+			writeErr(w, http.StatusBadRequest, "spawn depth exceeded")
 		default:
 			writeErr(w, http.StatusBadGateway, "calling upstream function")
 		}
@@ -375,6 +419,10 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 	rec, version, err := d.store.Get(ctx, tr.Namespace, tr.Agent, tr.SessionID)
 	switch {
 	case errors.Is(err, statestore.ErrNotFound):
+		parent, depth, perr := d.resolveParentage(ctx, tr.Namespace, tr.Agent, tr.ParentHeader)
+		if perr != nil {
+			return TurnResult{}, perr
+		}
 		newRec := SessionRecord{
 			ID:           tr.SessionID,
 			Agent:        tr.Agent,
@@ -382,6 +430,8 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 			Status:       StatusActive,
 			CreatedAt:    now,
 			LastActiveAt: now,
+			Parent:       parent,
+			Depth:        depth,
 		}
 		switch cerr := d.store.Create(ctx, newRec, entry.MaxSessions, liveTTL); {
 		case cerr == nil:
@@ -396,6 +446,11 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 			d.logger.Info("session created concurrently, activating existing record", "namespace", tr.Namespace, "agent", tr.Agent, "session", tr.SessionID)
 			d.casUpdateFresh(ctx, tr.Namespace, tr.Agent, tr.SessionID, liveTTL, func(rec *SessionRecord) {
 				turnsAtStart = rec.Stats.Turns
+				// This turn lost the create race: the winner's Create already
+				// fixed Parent/Depth immutably. Our own ParentHeader (if any)
+				// names a claim that was never applied — only compared, for
+				// diagnostics.
+				d.checkParentHeaderIgnored(tr.Namespace, tr.Agent, tr.SessionID, tr.ParentHeader, rec)
 				rec.Status = StatusActive
 				rec.LastActiveAt = now
 			})
@@ -420,6 +475,10 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 		}
 	default:
 		turnsAtStart = rec.Stats.Turns
+		// A resumed session's Parent/Depth are already fixed at Create; a
+		// ParentHeader on THIS turn (if any) is only ever compared against
+		// them, never applied.
+		d.checkParentHeaderIgnored(tr.Namespace, tr.Agent, tr.SessionID, tr.ParentHeader, &rec)
 		d.casUpdate(ctx, tr.Namespace, tr.Agent, tr.SessionID, rec, version, liveTTL, func(rec *SessionRecord) {
 			rec.Status = StatusActive
 			rec.LastActiveAt = now
@@ -576,6 +635,84 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 	}
 
 	return TurnResult{StatusCode: resp.StatusCode, Yield: yield, WakeEnqueueAttempted: doEnqueue}, nil
+}
+
+// resolveParentage resolves the Parent/Depth to mint for a session-CREATING
+// turn from its raw ParentHeader. It is called ONLY from DispatchTurn's
+// ErrNotFound (create) branch — see HeaderParent's doc comment for why every
+// other branch only ever compares, via checkParentHeaderIgnored. Depth is
+// NEVER taken off the wire: it is always parent.Depth+1, read from the
+// claimed parent's OWN stored record, so a forged or stale header can at
+// worst misattribute lineage, never fabricate a depth that skips the cap.
+//
+// Resolution:
+//   - header == "": root (nil parent, depth 0) — the common case (no spawn).
+//   - unparseable header: root, logged at V(1) (the header is caller input,
+//     not a store-health signal, so this is not worth Error level).
+//   - parseable header: Get the claimed parent from the LIVE keyspace; on
+//     ANY error (not just ErrNotFound — see the note below) fall back to
+//     GetArchived. Found in either: depth = parent.Depth + 1. If
+//     int64(depth) > maxSpawnDepth, returns ErrSpawnDepthExceeded — the
+//     caller MUST NOT proceed to Create; no record is minted for a rejected
+//     spawn. Unreadable in BOTH keyspaces: logged "parent claim dropped",
+//     admitted as root.
+//
+// Depth-cap nuance: falling back to root on ANY parent-Get error — not just
+// ErrNotFound — means a transient store hiccup fragments what should have
+// been one long lineage into a fresh, separately-capped chain rather than
+// extending the existing one. That is benign for the resource-exhaustion
+// case this cap actually guards: a live runaway spawn loop is, by
+// construction, still actively reading and writing its own parent chain, so
+// its records stay readable and the cap still bites it. The fragmentation
+// risk only lands on the rare, already-cold case of a legitimate deep chain
+// whose parent record was transiently unreadable at exactly the wrong
+// moment — annoying, never a resource-exhaustion hole.
+func (d *Dispatcher) resolveParentage(ctx context.Context, ns, agent, header string) (*ParentRef, int, error) {
+	if header == "" {
+		return nil, 0, nil
+	}
+	parent, ok := ParseParentRef(header)
+	if !ok {
+		d.logger.V(1).Info("unparseable parent header, admitting as root", "namespace", ns, "agent", agent, "headerLen", len(header))
+		return nil, 0, nil
+	}
+
+	rec, _, err := d.store.Get(ctx, parent.Namespace, parent.Agent, parent.ID)
+	if err != nil {
+		rec, _, err = d.store.GetArchived(ctx, parent.Namespace, parent.Agent, parent.ID)
+	}
+	if err != nil {
+		d.logger.V(1).Info("parent claim dropped, admitting as root", "namespace", ns, "agent", agent, "parent", parent.String())
+		return nil, 0, nil
+	}
+
+	depth := rec.Depth + 1
+	if int64(depth) > d.maxSpawnDepth {
+		return nil, 0, ErrSpawnDepthExceeded
+	}
+	return &parent, depth, nil
+}
+
+// checkParentHeaderIgnored logs (V(1), never an error, never a write) when
+// header is present and disagrees with rec's already-stored parentage. It is
+// called from every DispatchTurn branch EXCEPT the creation path: the record
+// already exists there, so Parent/Depth (immutable after Create) can only be
+// compared against a claim on this turn, never applied. Comparing the raw
+// header string against ParentRef.String() (rather than parsing header
+// first) is deliberate and still correct: ParentRef.String() is exactly
+// ParseParentRef's canonical form, so it also catches an unparseable header
+// as a mismatch, with no separate parse-and-branch needed here.
+func (d *Dispatcher) checkParentHeaderIgnored(ns, agent, session, header string, rec *SessionRecord) {
+	if header == "" {
+		return
+	}
+	stored := ""
+	if rec.Parent != nil {
+		stored = rec.Parent.String()
+	}
+	if header != stored {
+		d.logger.V(1).Info("parent header ignored: turn did not create this session", "namespace", ns, "agent", agent, "session", session, "stored", stored)
+	}
 }
 
 // resolveSessionID extracts the session id from r per entry's configured

--- a/pkg/agentruntime/dispatcher_test.go
+++ b/pkg/agentruntime/dispatcher_test.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -36,7 +37,7 @@ func newTestDispatcher(t *testing.T, upstreamURL string) (*Dispatcher, *AgentVie
 	kv := newTestKV(t)
 	store := NewSessionStore(kv, time.Now)
 	view := NewAgentView()
-	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, time.Now, 0)
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
 	return d, view, store
 }
 
@@ -48,7 +49,7 @@ func newTestDispatcherWithClock(t *testing.T, upstreamURL string, now func() tim
 	kv := newTestKV(t)
 	store := NewSessionStore(kv, now)
 	view := NewAgentView()
-	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, now, 0)
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstreamURL, time.Hour, now, 0, defaultMaxSpawnDepth)
 	return d, view, store
 }
 
@@ -312,7 +313,7 @@ func TestDispatcher_PhantomEnqueueSuppressedWhenWriteLost(t *testing.T) {
 	store := NewSessionStore(kv, time.Now)
 	view := NewAgentView()
 	view.Upsert(headerEntry("ns", "fn", 0))
-	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0)
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
 	fe := &fakeEnqueuer{}
 	d.SetWakeEnqueuer(fe)
 
@@ -347,7 +348,7 @@ func TestDispatcher_StoreDownFailsClosedWhenQuotaBearing(t *testing.T) {
 		store := NewSessionStore(kv, time.Now)
 		view := NewAgentView()
 		view.Upsert(headerEntry("ns", "fn", 5)) // MaxSessions=5: quota-bearing
-		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0)
+		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
 
 		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
 		req.Header.Set(HeaderSession, "sess-x")
@@ -372,7 +373,7 @@ func TestDispatcher_StoreDownFailsClosedWhenQuotaBearing(t *testing.T) {
 		store := NewSessionStore(kv, time.Now)
 		view := NewAgentView()
 		view.Upsert(headerEntry("ns", "fn", 0)) // MaxSessions=0: no quota to protect
-		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0)
+		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
 
 		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
 		req.Header.Set(HeaderSession, "sess-y")
@@ -412,7 +413,7 @@ func TestDispatcher_CreateWriteFailureFailsClosedWhenQuotaBearing(t *testing.T) 
 		store := NewSessionStore(kv, time.Now)
 		view := NewAgentView()
 		view.Upsert(headerEntry("ns", "fn", 5)) // MaxSessions=5: quota-bearing
-		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0)
+		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
 
 		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
 		req.Header.Set(HeaderSession, "sess-create-fail")
@@ -437,7 +438,7 @@ func TestDispatcher_CreateWriteFailureFailsClosedWhenQuotaBearing(t *testing.T) 
 		store := NewSessionStore(kv, time.Now)
 		view := NewAgentView()
 		view.Upsert(headerEntry("ns", "fn", 0)) // MaxSessions=0: no quota to protect
-		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0)
+		d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
 
 		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
 		req.Header.Set(HeaderSession, "sess-create-fail-ok")
@@ -738,7 +739,7 @@ func TestDispatcher_ContinuationCapStopsEnqueueing(t *testing.T) {
 	store := NewSessionStore(kv, time.Now)
 	view := NewAgentView()
 	view.Upsert(headerEntry("ns", "fn", 0))
-	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 1)
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 1, defaultMaxSpawnDepth)
 	fe := &fakeEnqueuer{}
 	d.SetWakeEnqueuer(fe)
 
@@ -1029,4 +1030,299 @@ func TestResolveSessionIDRejectsCheckpointPrefix(t *testing.T) {
 	got, ok2 := resolveSessionID(req2, entry)
 	assert.True(t, ok2)
 	assert.Equal(t, "s2", got)
+}
+
+// --- spawn parentage (Task 2): parent header, record-derived depth, cap ---
+
+// TestDispatcher_CreateWithLiveParentInheritsDepth pins the base case: a
+// turn that CREATES a session with a HeaderParent naming a live parent
+// stores that parent and depth = parent.Depth + 1.
+func TestDispatcher_CreateWithLiveParentInheritsDepth(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	require.NoError(t, store.Create(t.Context(), SessionRecord{
+		ID: "parent-1", Agent: "fn", Namespace: "ns", Status: StatusActive,
+		CreatedAt: time.Now(), LastActiveAt: time.Now(),
+	}, 0, time.Hour))
+	parent := ParentRef{Namespace: "ns", Agent: "fn", ID: "parent-1"}
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req.Header.Set(HeaderSession, "child-1")
+	req.Header.Set(HeaderParent, parent.String())
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	got, _, err := store.Get(t.Context(), "ns", "fn", "child-1")
+	require.NoError(t, err)
+	require.NotNil(t, got.Parent)
+	assert.Equal(t, parent, *got.Parent)
+	assert.Equal(t, 1, got.Depth)
+}
+
+// TestDispatcher_CreateWithArchivedParentInheritsDepth pins that depth
+// resolution falls through to the archived keyspace when the claimed parent
+// has already aged out of live — resolveParentage's Get(live) miss ->
+// GetArchived path.
+func TestDispatcher_CreateWithArchivedParentInheritsDepth(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	require.NoError(t, store.Create(t.Context(), SessionRecord{
+		ID: "parent-arch", Agent: "fn", Namespace: "ns", Status: StatusActive,
+		CreatedAt: time.Now(), LastActiveAt: time.Now(), Depth: 2,
+	}, 0, time.Hour))
+	live, version, err := store.Get(t.Context(), "ns", "fn", "parent-arch")
+	require.NoError(t, err)
+	require.NoError(t, store.Archive(t.Context(), live, version, time.Hour))
+	_, _, err = store.Get(t.Context(), "ns", "fn", "parent-arch")
+	require.ErrorIs(t, err, statestore.ErrNotFound, "the parent must actually be gone from live for this test to mean anything")
+
+	parent := ParentRef{Namespace: "ns", Agent: "fn", ID: "parent-arch"}
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req.Header.Set(HeaderSession, "child-arch")
+	req.Header.Set(HeaderParent, parent.String())
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	got, _, err := store.Get(t.Context(), "ns", "fn", "child-arch")
+	require.NoError(t, err)
+	require.NotNil(t, got.Parent)
+	assert.Equal(t, parent, *got.Parent)
+	assert.Equal(t, 3, got.Depth, "depth inherits from the archived parent's own depth (2) + 1")
+}
+
+// TestDispatcher_CreateWithUnreadableParentAdmitsAsRoot pins the
+// "parent claim dropped" fallback: a HeaderParent naming a session absent
+// from BOTH keyspaces must never fail the turn, only drop the claim.
+func TestDispatcher_CreateWithUnreadableParentAdmitsAsRoot(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	parent := ParentRef{Namespace: "ns", Agent: "fn", ID: "ghost-parent"}
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req.Header.Set(HeaderSession, "child-ghost")
+	req.Header.Set(HeaderParent, parent.String())
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "an unreadable parent claim must admit the turn as root, not fail it")
+	got, _, err := store.Get(t.Context(), "ns", "fn", "child-ghost")
+	require.NoError(t, err)
+	assert.Nil(t, got.Parent)
+	assert.Equal(t, 0, got.Depth)
+}
+
+// TestDispatcher_SpawnDepthCapRejectsBeyondLimit chains real creates out to
+// the default cap (3) and pins that the NEXT spawn (depth 4) is rejected
+// with 400 and, critically, mints NO record at all.
+func TestDispatcher_SpawnDepthCapRejectsBeyondLimit(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL) // maxSpawnDepth = defaultMaxSpawnDepth (3)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	create := func(id, parentHeader string) int {
+		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+		req.Header.Set(HeaderSession, id)
+		if parentHeader != "" {
+			req.Header.Set(HeaderParent, parentHeader)
+		}
+		rec := httptest.NewRecorder()
+		d.Handler().ServeHTTP(rec, req)
+		return rec.Code
+	}
+	depthOf := func(id string) int {
+		got, _, err := store.Get(t.Context(), "ns", "fn", id)
+		require.NoError(t, err)
+		return got.Depth
+	}
+
+	require.Equal(t, http.StatusOK, create("s0", ""))
+	require.Equal(t, 0, depthOf("s0"))
+
+	require.Equal(t, http.StatusOK, create("s1", ParentRef{Namespace: "ns", Agent: "fn", ID: "s0"}.String()))
+	require.Equal(t, 1, depthOf("s1"))
+
+	require.Equal(t, http.StatusOK, create("s2", ParentRef{Namespace: "ns", Agent: "fn", ID: "s1"}.String()))
+	require.Equal(t, 2, depthOf("s2"))
+
+	require.Equal(t, http.StatusOK, create("s3", ParentRef{Namespace: "ns", Agent: "fn", ID: "s2"}.String()))
+	require.Equal(t, 3, depthOf("s3"), "depth 3 is within the default cap of 3")
+
+	code := create("s4", ParentRef{Namespace: "ns", Agent: "fn", ID: "s3"}.String())
+	assert.Equal(t, http.StatusBadRequest, code, "depth 4 exceeds the cap and must be rejected")
+	_, _, err := store.Get(t.Context(), "ns", "fn", "s4")
+	assert.ErrorIs(t, err, statestore.ErrNotFound, "a rejected spawn must not mint any record")
+}
+
+// TestDispatcher_ResumeIgnoresMismatchingParentHeader pins the
+// creation-only rule from the resume side: a HeaderParent sent on a turn
+// that does NOT create the session (the record already exists) is compared
+// against the stored value and, on a mismatch, dropped — never applied,
+// never a failure.
+func TestDispatcher_ResumeIgnoresMismatchingParentHeader(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req.Header.Set(HeaderSession, "sess-resume")
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	before, _, err := store.Get(t.Context(), "ns", "fn", "sess-resume")
+	require.NoError(t, err)
+	assert.Nil(t, before.Parent)
+
+	req2 := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req2.Header.Set(HeaderSession, "sess-resume")
+	req2.Header.Set(HeaderParent, "ns/fn/some-other-parent")
+	rec2 := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec2, req2)
+	require.Equal(t, http.StatusOK, rec2.Code, "a mismatching header on resume must never fail the turn")
+
+	after, _, err := store.Get(t.Context(), "ns", "fn", "sess-resume")
+	require.NoError(t, err)
+	assert.Nil(t, after.Parent, "stored parentage must be unchanged by a resume-time header")
+	assert.Equal(t, 0, after.Depth)
+}
+
+// TestDispatcher_UnparseableParentHeaderAdmitsAsRoot pins that a header
+// which fails ParseParentRef (wrong segment count, or an invalid charset in
+// a segment) is treated exactly like an absent one on the creation path.
+func TestDispatcher_UnparseableParentHeaderAdmitsAsRoot(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	for i, header := range []string{"a/b", "a/b/c/d", "BAD_NS/agent/id"} {
+		t.Run(header, func(t *testing.T) {
+			t.Parallel()
+			d, view, store := newTestDispatcher(t, upstream.URL)
+			view.Upsert(headerEntry("ns", "fn", 0))
+
+			id := "sess-unparse-" + strconv.Itoa(i)
+			req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+			req.Header.Set(HeaderSession, id)
+			req.Header.Set(HeaderParent, header)
+			rec := httptest.NewRecorder()
+			d.Handler().ServeHTTP(rec, req)
+
+			require.Equal(t, http.StatusOK, rec.Code)
+			got, _, err := store.Get(t.Context(), "ns", "fn", id)
+			require.NoError(t, err)
+			assert.Nil(t, got.Parent)
+			assert.Equal(t, 0, got.Depth)
+		})
+	}
+}
+
+// raceOnceNotFoundKV wraps a KVStore and forces exactly ONE Get on one
+// specific (scope, key) to fail with statestore.ErrNotFound, regardless of
+// what is actually stored there — a deterministic stand-in for
+// DispatchTurn's initial Get racing a concurrent Create, used by
+// TestDispatcher_CreateRaceIgnoresParentHeader (a real two-goroutine race,
+// like TestDispatcher_ConcurrentCreateRaceActivatesInsteadOfDropping uses
+// elsewhere, cannot pin which turn's header "wins" — this can). Every other
+// (scope, key) — notably a claimed parent's own record, read from inside
+// resolveParentage — passes through untouched.
+type raceOnceNotFoundKV struct {
+	statestore.KVStore
+	scope statestore.Scope
+	key   string
+	fired bool
+}
+
+func (k *raceOnceNotFoundKV) Get(ctx context.Context, s statestore.Scope, key string) (statestore.Value, error) {
+	if !k.fired && s == k.scope && key == k.key {
+		k.fired = true
+		return statestore.Value{}, statestore.ErrNotFound
+	}
+	return k.KVStore.Get(ctx, s, key)
+}
+
+// TestDispatcher_CreateRaceIgnoresParentHeader pins the create-race branch
+// of the creation-only rule: when this turn's own Get misses (ErrNotFound)
+// but another turn already won the Create — carrying its OWN parentage —
+// this turn's HeaderParent must never be applied, only compared. The
+// pre-seeded record's parentage (parent-a) must survive untouched even
+// though this turn claims a DIFFERENT, independently-resolvable parent
+// (parent-b).
+func TestDispatcher_CreateRaceIgnoresParentHeader(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	inner := newTestKV(t)
+
+	seed := NewSessionStore(inner, time.Now)
+	parentA := ParentRef{Namespace: "ns", Agent: "fn", ID: "parent-a"}
+	require.NoError(t, seed.Create(t.Context(), SessionRecord{
+		ID: "sess-race-parent", Agent: "fn", Namespace: "ns", Status: StatusActive,
+		CreatedAt: time.Now(), LastActiveAt: time.Now(),
+		Parent: &parentA, Depth: 1,
+	}, 0, time.Hour))
+	require.NoError(t, seed.Create(t.Context(), SessionRecord{
+		ID: "parent-b", Agent: "fn", Namespace: "ns", Status: StatusActive,
+		CreatedAt: time.Now(), LastActiveAt: time.Now(),
+	}, 0, time.Hour))
+
+	kv := &raceOnceNotFoundKV{KVStore: inner, scope: sessionScope("ns", "fn"), key: "sess-race-parent"}
+	store := NewSessionStore(kv, time.Now)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns", "fn", 0))
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
+
+	parentB := ParentRef{Namespace: "ns", Agent: "fn", ID: "parent-b"}
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req.Header.Set(HeaderSession, "sess-race-parent")
+	req.Header.Set(HeaderParent, parentB.String())
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, "a create-race loss must never surface as a client-visible error")
+	got, _, err := store.Get(t.Context(), "ns", "fn", "sess-race-parent")
+	require.NoError(t, err)
+	require.NotNil(t, got.Parent)
+	assert.Equal(t, parentA, *got.Parent, "the winning create's parentage must survive — this turn's own header must be ignored")
+	assert.Equal(t, 1, got.Depth)
+}
+
+// TestDispatcher_ExplicitZeroSpawnDepthRejectsAnySpawn pins the
+// AGENT_MAX_SPAWN_DEPTH=0 decision documented on envMaxSpawnDepth: unlike
+// maxContinuations, an explicit 0 means "no spawning" (every parented
+// create rejected), not "unlimited". A root turn (no claimed parent) is
+// unaffected by the cap at any value.
+func TestDispatcher_ExplicitZeroSpawnDepthRejectsAnySpawn(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns", "fn", 0))
+	d := NewDispatcher(logr.Discard(), view, store, http.DefaultClient, upstream.URL, time.Hour, time.Now, 0, 0)
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req.Header.Set(HeaderSession, "root-under-zero-cap")
+	rec := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, "a root turn is not a spawn and must be unaffected by maxSpawnDepth=0")
+
+	parent := ParentRef{Namespace: "ns", Agent: "fn", ID: "root-under-zero-cap"}
+	req2 := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+	req2.Header.Set(HeaderSession, "child-under-zero-cap")
+	req2.Header.Set(HeaderParent, parent.String())
+	rec2 := httptest.NewRecorder()
+	d.Handler().ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusBadRequest, rec2.Code, "AGENT_MAX_SPAWN_DEPTH=0 must reject every parented create")
+
+	_, _, err := store.Get(t.Context(), "ns", "fn", "child-under-zero-cap")
+	assert.ErrorIs(t, err, statestore.ErrNotFound, "a rejected spawn must not mint any record")
 }

--- a/pkg/agentruntime/dispatcher_test.go
+++ b/pkg/agentruntime/dispatcher_test.go
@@ -1226,6 +1226,63 @@ func TestDispatcher_UnparseableParentHeaderAdmitsAsRoot(t *testing.T) {
 	}
 }
 
+// TestDispatcher_CrossNamespaceParentHeaderAdmitsAsRootIndistinguishably
+// pins the security fix: a HeaderParent naming a DIFFERENT namespace than
+// the dispatched one must never be resolved (never Get another tenant's
+// record), and the outcome must be byte-indistinguishable regardless of
+// whether the foreign session exists — otherwise a caller scoped to one
+// namespace could probe another tenant's session existence and exact spawn
+// depth via the minted child's parent/depth fields and the depth-cap
+// 400-vs-200 split. The existing-parent case is planted at depth ==
+// defaultMaxSpawnDepth specifically so that, were cross-namespace
+// resolution allowed, the child would hit the cap (400) instead of the 200
+// both cases must produce here.
+func TestDispatcher_CrossNamespaceParentHeaderAdmitsAsRootIndistinguishably(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	d, view, store := newTestDispatcher(t, upstream.URL)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	// Plant a real, live session in a FOREIGN namespace, at exactly the
+	// depth that would blow the cap for a same-namespace child.
+	require.NoError(t, store.Create(t.Context(), SessionRecord{
+		ID: "foreign-parent", Agent: "fn", Namespace: "other", Status: StatusActive,
+		CreatedAt: time.Now(), LastActiveAt: time.Now(), Depth: defaultMaxSpawnDepth,
+	}, 0, time.Hour))
+
+	existingParent := ParentRef{Namespace: "other", Agent: "fn", ID: "foreign-parent"}
+	ghostParent := ParentRef{Namespace: "other", Agent: "fn", ID: "no-such-session"}
+
+	dispatch := func(sessionID string, parent ParentRef) (int, SessionRecord) {
+		req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hi"))
+		req.Header.Set(HeaderSession, sessionID)
+		req.Header.Set(HeaderParent, parent.String())
+		rec := httptest.NewRecorder()
+		d.Handler().ServeHTTP(rec, req)
+
+		got, _, err := store.Get(t.Context(), "ns", "fn", sessionID)
+		require.NoError(t, err)
+		return rec.Code, got
+	}
+
+	existingCode, existingRec := dispatch("child-cross-existing", existingParent)
+	ghostCode, ghostRec := dispatch("child-cross-ghost", ghostParent)
+
+	require.Equal(t, http.StatusOK, existingCode, "an existing foreign-namespace parent must never surface as anything but root-degraded 200")
+	require.Equal(t, http.StatusOK, ghostCode)
+	assert.Nil(t, existingRec.Parent, "a foreign-namespace ref must never be resolved into Parent, existing or not")
+	assert.Nil(t, ghostRec.Parent)
+	assert.Equal(t, 0, existingRec.Depth)
+	assert.Equal(t, 0, ghostRec.Depth)
+
+	// The two outcomes must be identical in every parentage-relevant
+	// respect: this is the actual security property (a foreign namespace's
+	// session existence must not be observable).
+	assert.Equal(t, existingCode, ghostCode)
+	assert.Equal(t, existingRec.Parent, ghostRec.Parent)
+	assert.Equal(t, existingRec.Depth, ghostRec.Depth)
+}
+
 // raceOnceNotFoundKV wraps a KVStore and forces exactly ONE Get on one
 // specific (scope, key) to fail with statestore.ErrNotFound, regardless of
 // what is actually stored there — a deterministic stand-in for

--- a/pkg/agentruntime/events.go
+++ b/pkg/agentruntime/events.go
@@ -398,9 +398,9 @@ func diffSessions(prev, current map[sessionKey]SessionRecord) []SessionRecord {
 // sessionUnchanged reports whether old and cur are identical on the fields
 // the poller diffs: Status, LastActiveAt, Stats.Turns, CurrentPod. Every
 // other field the poller ignores is either immutable after Create
-// (Namespace, Agent, ID, CreatedAt) or not yet meaningful for the feed
-// (the rest of Stats). LastActiveAt is compared with Equal, not ==: both
-// values here round-tripped through JSON, but Equal is the correct
+// (Namespace, Agent, ID, CreatedAt, Parent, Depth) or not yet meaningful for
+// the feed (the rest of Stats). LastActiveAt is compared with Equal, not ==:
+// both values here round-tripped through JSON, but Equal is the correct
 // time.Time comparison regardless.
 func sessionUnchanged(old, cur SessionRecord) bool {
 	return old.Status == cur.Status &&

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -287,6 +287,19 @@ const (
 	// self-chaining cap. 0 means unlimited (see Dispatcher.maxContinuations).
 	envMaxContinuations = "AGENT_MAX_CONTINUATIONS"
 
+	// envMaxSpawnDepth configures the Dispatcher's spawn-chain depth cap
+	// (see Dispatcher.maxSpawnDepth / resolveParentage / ErrSpawnDepthExceeded).
+	// Unset uses defaultMaxSpawnDepth (3). This is a DELIBERATE divergence
+	// from envMaxContinuations: there, 0 means unlimited; here, an explicit
+	// 0 means "no spawning" — every parented create is rejected. The cap
+	// guards spawn-tree resource exhaustion, so "unlimited" is never the
+	// right unset-equivalent default for this particular knob. What makes
+	// "unset -> 3" and "explicit 0 -> 0 (none)" distinguishable at all is
+	// envInt64's own contract: it substitutes the default only when the env
+	// var is EMPTY, and parses an explicit "0" as the int64 0, not as a
+	// signal to fall back.
+	envMaxSpawnDepth = "AGENT_MAX_SPAWN_DEPTH"
+
 	// envMaxSessionsDefault is the platform-wide live-session ceiling applied
 	// to an agent whose spec sets no MaxSessions of its own. 0 means no default
 	// (unbounded). Read once here, like envMaxContinuations.
@@ -306,6 +319,11 @@ const (
 
 	// defaultMaxContinuations is applied when envMaxContinuations is unset.
 	defaultMaxContinuations = 1000
+
+	// defaultMaxSpawnDepth is applied when envMaxSpawnDepth is unset. See
+	// envMaxSpawnDepth's doc comment for why an explicit 0 is NOT the same
+	// as unset.
+	defaultMaxSpawnDepth = 3
 
 	// defaultMaxSessionsDefault is applied when envMaxSessionsDefault is unset:
 	// a conservative platform ceiling that bounds unqualified session creation
@@ -404,6 +422,10 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	if err != nil {
 		return err
 	}
+	maxSpawnDepth, err := envInt64(envMaxSpawnDepth, defaultMaxSpawnDepth)
+	if err != nil {
+		return err
+	}
 	registryPollInterval, err := envDuration(envRegistryPoll, defaultRegistryPollInterval)
 	if err != nil {
 		return err
@@ -438,7 +460,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// history/checkpoint HTTP surface; it has no append path, so it is not a
 	// dispatcher dependency.
 	hist := NewHistoryStore(eventLog, kv)
-	dispatcher := NewDispatcher(logger.WithName("dispatcher"), view, store, &http.Client{Transport: rt}, opts.RouterInternalURL, retention, time.Now, maxContinuations)
+	dispatcher := NewDispatcher(logger.WithName("dispatcher"), view, store, &http.Client{Transport: rt}, opts.RouterInternalURL, retention, time.Now, maxContinuations, maxSpawnDepth)
 	sweeper := NewSweeper(logger.WithName("sweeper"), view, store, hist, sweepInterval, retention, time.Now)
 
 	// SSE registry feed: a single background Poller diffs

--- a/pkg/agentruntime/registry_api_test.go
+++ b/pkg/agentruntime/registry_api_test.go
@@ -401,6 +401,32 @@ func TestGetSessionFound(t *testing.T) {
 	got := decodeJSON[SessionRecord](t, w)
 	assert.Equal(t, "sess-1", got.ID)
 	assert.Equal(t, StatusActive, got.Status)
+
+	// Registry passthrough (Task 3): GetSession marshals the SessionRecord
+	// directly, so a child's Parent/Depth need no handler change to reach the
+	// wire — verify-only, on the raw wire keys the same way
+	// TestListSessionsPaginationWalksNextToken pins "sessions"/"next" (decoding
+	// through SessionRecord's own tags wouldn't prove the wire shape). Depth
+	// must be >0: it is tagged omitzero, so a depth-0 root would omit the
+	// field entirely and this assertion would prove nothing.
+	child := SessionRecord{
+		ID: "sess-2", Agent: "fn", Namespace: "ns", Status: StatusActive,
+		Parent: &ParentRef{Namespace: "ns", Agent: "fn", ID: "sess-1"},
+		Depth:  1,
+	}
+	require.NoError(t, store.Create(t.Context(), child, 0, time.Hour))
+
+	w2 := httptest.NewRecorder()
+	mux.ServeHTTP(w2, bearerRequest(http.MethodGet, "/registry/agents/ns/fn/sessions/sess-2", ""))
+	require.Equal(t, http.StatusOK, w2.Code)
+	rawChild := decodeJSON[map[string]jsontext.Value](t, w2)
+	require.Contains(t, rawChild, "parent")
+	require.Contains(t, rawChild, "depth")
+	var parent map[string]jsontext.Value
+	require.NoError(t, json.Unmarshal(rawChild["parent"], &parent))
+	assert.Contains(t, parent, "namespace")
+	assert.Contains(t, parent, "agent")
+	assert.Contains(t, parent, "id")
 }
 
 func TestGetSessionNotFound(t *testing.T) {

--- a/pkg/agentruntime/session.go
+++ b/pkg/agentruntime/session.go
@@ -9,9 +9,14 @@ package agentruntime
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json/v2"
 	"errors"
+	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/fission/fission/pkg/statestore"
 )
@@ -45,6 +50,54 @@ var (
 	ErrUpdateArchived = errors.New("agentruntime: refusing to Update an archived session record into the live keyspace")
 )
 
+// ParentRef is the qualified reference to a spawning session. A bare session
+// id cannot identify a parent: ids are unique only within one
+// (namespace, agent) scope (see sessionKey in events.go), and cross-agent
+// parentage is the Handoff/multi-agent-orchestration extension point.
+type ParentRef struct {
+	Namespace string `json:"namespace"`
+	Agent     string `json:"agent"`
+	ID        string `json:"id"`
+}
+
+// String is the canonical wire/display form "<ns>/<agent>/<id>". All three
+// components are charset-constrained and cannot contain '/', so the form is
+// unambiguous and ParseParentRef can split on '/'.
+func (p ParentRef) String() string {
+	return p.Namespace + "/" + p.Agent + "/" + p.ID
+}
+
+// ParseParentRef parses the canonical form; ok=false on anything but three
+// non-empty charset-valid segments (validate id against sessionIDPattern and
+// ns/agent against DNS-label shape the way the dispatcher's route values are).
+func ParseParentRef(s string) (ParentRef, bool) {
+	parts := strings.Split(s, "/")
+	if len(parts) != 3 {
+		return ParentRef{}, false
+	}
+	ns, agent, id := parts[0], parts[1], parts[2]
+	if ns == "" || agent == "" || id == "" {
+		return ParentRef{}, false
+	}
+	if len(validation.IsDNS1123Label(ns)) != 0 || len(validation.IsDNS1123Label(agent)) != 0 {
+		return ParentRef{}, false
+	}
+	if !sessionIDPattern.MatchString(id) {
+		return ParentRef{}, false
+	}
+	return ParentRef{Namespace: ns, Agent: agent, ID: id}, true
+}
+
+// SpawnSessionID derives the deterministic child session id for one logical
+// spawn: same parent + same stepKey => same id, always — which makes the
+// shipped Create(IfVersion=0) the exactly-once admission row (ErrSessionExists
+// = already admitted = the dispatch proceeds as a resume).
+// Lowercase hex (spec amendment): "c-" + hex(sha256(parent.String()+"/"+stepKey))[:32].
+func SpawnSessionID(parent ParentRef, stepKey string) string {
+	sum := sha256.Sum256([]byte(parent.String() + "/" + stepKey))
+	return "c-" + hex.EncodeToString(sum[:])[:32]
+}
+
 // SessionStats is the per-session meter set (G19: full meter schema from day
 // one; Tokens/Cost reserved for the gateway integration, always 0 for now).
 type SessionStats struct {
@@ -68,6 +121,18 @@ type SessionRecord struct {
 	LastActiveAt time.Time     `json:"lastActiveAt"`
 	CurrentPod   string        `json:"currentPod,omitempty"` // best-effort UI truth, never routing truth
 	Stats        SessionStats  `json:"stats"`
+
+	// Parent is the spawning session, if this session was created by a spawn
+	// admission rather than a direct inbound turn. IMMUTABLE after Create: set
+	// only by the dispatcher's creation path (Task 2), never touched by Update.
+	Parent *ParentRef `json:"parent,omitempty"`
+	// Depth is the spawn-chain depth: 0 for a root session, parent.Depth+1 for
+	// a spawned child. IMMUTABLE after Create, for the same reason as Parent.
+	//
+	// Tagged omitzero, not omitempty: encoding/json/v2's omitempty omits only
+	// a JSON null/""/{}/[] and does NOT drop a zero int, so the root-session
+	// value (0) would otherwise appear on the wire as an explicit "depth":0.
+	Depth int `json:"depth,omitzero"`
 }
 
 // SessionStore persists SessionRecords in a statestore KVStore. Live records
@@ -100,6 +165,22 @@ func archivedScope(ns, agent string) statestore.Scope {
 // Update or Archive.
 func (s *SessionStore) Get(ctx context.Context, ns, agent, id string) (SessionRecord, int64, error) {
 	v, err := s.kv.Get(ctx, sessionScope(ns, agent), id)
+	if err != nil {
+		return SessionRecord{}, 0, err
+	}
+	var rec SessionRecord
+	if err := json.Unmarshal(v.Data, &rec); err != nil {
+		return SessionRecord{}, 0, err
+	}
+	return rec, v.Version, nil
+}
+
+// GetArchived returns the archived record for id and its KV version, reading
+// from archivedScope. Same decode and ErrNotFound-passthrough contract as
+// Get; used as depth resolution's second look when a parent has already left
+// the live keyspace.
+func (s *SessionStore) GetArchived(ctx context.Context, ns, agent, id string) (SessionRecord, int64, error) {
+	v, err := s.kv.Get(ctx, archivedScope(ns, agent), id)
 	if err != nil {
 		return SessionRecord{}, 0, err
 	}

--- a/pkg/agentruntime/session_test.go
+++ b/pkg/agentruntime/session_test.go
@@ -5,6 +5,8 @@
 package agentruntime
 
 import (
+	"encoding/json/v2"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -297,4 +299,160 @@ func TestSessionStoreListPagination(t *testing.T) {
 		ids = append(ids, r.ID)
 	}
 	assert.ElementsMatch(t, []string{"a", "b", "c"}, ids)
+}
+
+func TestParentRefStringParseRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	p := ParentRef{Namespace: "ns1", Agent: "myagent", ID: "sess-1"}
+	s := p.String()
+	assert.Equal(t, "ns1/myagent/sess-1", s)
+
+	got, ok := ParseParentRef(s)
+	require.True(t, ok)
+	assert.Equal(t, p, got)
+}
+
+func TestParentRefParseRejectsMalformed(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"two segments":          "ns1/myagent",
+		"four segments":         "ns1/myagent/sess-1/extra",
+		"empty namespace":       "/myagent/sess-1",
+		"empty agent":           "ns1//sess-1",
+		"empty id":              "ns1/myagent/",
+		"empty string":          "",
+		"bad charset namespace": "NS_1/myagent/sess-1",
+		"bad charset agent":     "ns1/My_Agent/sess-1",
+		"bad charset id":        "ns1/myagent/sess!1",
+		"id has slash":          "ns1/myagent/sess/1/x",
+	}
+	for name, s := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			_, ok := ParseParentRef(s)
+			assert.False(t, ok, "expected ParseParentRef(%q) to fail", s)
+		})
+	}
+}
+
+// TestSpawnSessionIDFixedVector pins the derivation to one exact input/output
+// pair so a future change to the hash, prefix, or truncation length is caught
+// as a test failure rather than silently reshaping every derived child id.
+func TestSpawnSessionIDFixedVector(t *testing.T) {
+	t.Parallel()
+
+	parent := ParentRef{Namespace: "ns", Agent: "a", ID: "sess-1"}
+	id := SpawnSessionID(parent, "step-1")
+
+	const want = "c-27304abfe9308ae9849ace27841bc098"
+	assert.Equal(t, want, id)
+	assert.Len(t, id, 34)
+}
+
+func TestSpawnSessionIDDeterministicAndDistinct(t *testing.T) {
+	t.Parallel()
+
+	parent := ParentRef{Namespace: "ns", Agent: "a", ID: "sess-1"}
+
+	a1 := SpawnSessionID(parent, "step-1")
+	a2 := SpawnSessionID(parent, "step-1")
+	assert.Equal(t, a1, a2, "same parent + same stepKey must derive the same id every time")
+
+	b := SpawnSessionID(parent, "step-2")
+	assert.NotEqual(t, a1, b, "distinct stepKeys must derive distinct ids")
+
+	otherParent := ParentRef{Namespace: "ns", Agent: "a", ID: "sess-2"}
+	c := SpawnSessionID(otherParent, "step-1")
+	assert.NotEqual(t, a1, c, "distinct parents must derive distinct ids")
+}
+
+func TestSpawnSessionIDMatchesSessionIDPatternAndAvoidsReservedPrefix(t *testing.T) {
+	t.Parallel()
+
+	parent := ParentRef{Namespace: "ns", Agent: "a", ID: "sess-1"}
+	id := SpawnSessionID(parent, "step-1")
+
+	assert.True(t, sessionIDPattern.MatchString(id), "derived id must satisfy the dispatcher's sessionIDPattern")
+	assert.False(t, strings.HasPrefix(id, CheckpointKeyPrefix), "derived id must not collide with the reserved checkpoint-key prefix")
+}
+
+func TestSessionStoreGetArchivedReadsWhatArchiveWrote(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	parent := ParentRef{Namespace: "ns", Agent: "a", ID: "root-1"}
+	rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive, Parent: &parent, Depth: 3}
+	require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
+
+	_, version, err := store.Get(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+	require.NoError(t, store.Archive(ctx, rec, version, 7*24*time.Hour))
+
+	got, aVersion, err := store.GetArchived(ctx, "ns", "a", "s1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, aVersion)
+	assert.Equal(t, StatusArchived, got.Status)
+	assert.Equal(t, "s1", got.ID)
+	require.NotNil(t, got.Parent, "Parent must survive the archive round-trip — depth resolution's second look depends on it")
+	assert.Equal(t, parent, *got.Parent)
+	assert.Equal(t, 3, got.Depth, "Depth must survive the archive round-trip")
+}
+
+func TestSessionStoreGetArchivedNotFound(t *testing.T) {
+	t.Parallel()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	ctx := t.Context()
+
+	_, _, err := store.GetArchived(ctx, "ns", "a", "does-not-exist")
+	require.ErrorIs(t, err, statestore.ErrNotFound)
+}
+
+// TestSessionRecordParentDepthJSONRoundtrip pins the wire contract: Parent
+// and Depth roundtrip through JSON, and both are omitted (not present as
+// null/0 keys) when zero-valued, matching every other omitempty field on
+// SessionRecord.
+func TestSessionRecordParentDepthJSONRoundtrip(t *testing.T) {
+	t.Parallel()
+
+	parent := ParentRef{Namespace: "ns", Agent: "a", ID: "sess-1"}
+	rec := SessionRecord{
+		ID:        "child-1",
+		Agent:     "a",
+		Namespace: "ns",
+		Status:    StatusActive,
+		Parent:    &parent,
+		Depth:     2,
+	}
+
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"parent":`)
+	assert.Contains(t, string(data), `"depth":2`)
+
+	var got SessionRecord
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.NotNil(t, got.Parent)
+	assert.Equal(t, parent, *got.Parent)
+	assert.Equal(t, 2, got.Depth)
+}
+
+func TestSessionRecordParentDepthOmittedWhenZero(t *testing.T) {
+	t.Parallel()
+
+	rec := SessionRecord{ID: "s1", Agent: "a", Namespace: "ns", Status: StatusActive}
+
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), `"parent"`)
+	assert.NotContains(t, string(data), `"depth"`)
+
+	var got SessionRecord
+	require.NoError(t, json.Unmarshal(data, &got))
+	assert.Nil(t, got.Parent)
+	assert.Zero(t, got.Depth)
 }

--- a/pkg/agentruntime/ui/boardroom.html
+++ b/pkg/agentruntime/ui/boardroom.html
@@ -251,6 +251,12 @@
 var STATUS_COLOR = { active: "#3ddc84", idle: "#f2b705", archived: "#5a6472" };
 var STATUS_ORDER = { active: 0, idle: 1, archived: 2 };
 
+// MAX_SESSION_PAGES bounds pollAgentSessions's page-cursor loop (500 sessions
+// per page => 50,000 sessions for one agent). Without a ceiling, a buggy
+// server -- or a registry bug that returns a repeating cursor -- wedges this
+// agent's poll tick forever, looping on `next` with no forward progress.
+var MAX_SESSION_PAGES = 100;
+
 // TOKEN is read once from the page's URL fragment (#token=...), never the
 // query string: a fragment is never sent to the server or logged by a
 // fronting proxy, unlike EventsHandler's own ?token= transport (which exists
@@ -425,11 +431,23 @@ function buildFamilyForest() {
 
 // renderSubtree renders `entry` plus every descendant reachable through
 // childrenOf, each level indented one step deeper than its parent.
-function renderSubtree(entry, childrenOf, level) {
+//
+// `printed` guards against a parent cycle: a record whose ancestor chain
+// revisits a node it already produced (self-parent, or two-or-more records
+// naming each other as parent) would otherwise recurse forever. Once a
+// session's key is in `printed`, this returns immediately instead of
+// descending into it again -- the same guard printSessionTree (the CLI's
+// `--tree` printer, pkg/fission-cli/cmd/agent/sessions.go) uses, and for the
+// same reason: it is the smallest change that guarantees every member is
+// rendered exactly once, cycle or not.
+function renderSubtree(entry, childrenOf, level, printed) {
+  var key = sessionKey(entry.record);
+  if (printed.has(key)) return "";
+  printed.add(key);
   var html = sessionCardHTML(entry, level);
-  var kids = (childrenOf.get(sessionKey(entry.record)) || []).slice().sort(compareEntries);
+  var kids = (childrenOf.get(key) || []).slice().sort(compareEntries);
   kids.forEach(function (child) {
-    html += renderSubtree(child, childrenOf, level + 1);
+    html += renderSubtree(child, childrenOf, level + 1, printed);
   });
   return html;
 }
@@ -441,9 +459,10 @@ function groupHeaderHTML(parentRef) {
 function renderSessions() {
   var forest = buildFamilyForest();
   var html = "";
+  var printed = new Set();
 
   forest.roots.slice().sort(compareEntries).forEach(function (entry) {
-    html += renderSubtree(entry, forest.childrenOf, 0);
+    html += renderSubtree(entry, forest.childrenOf, 0, printed);
   });
 
   // Deterministic group order: sort by the parent ref string itself, not
@@ -452,8 +471,22 @@ function renderSessions() {
   Array.from(forest.unknownGroups.keys()).sort().forEach(function (parentKey) {
     html += groupHeaderHTML(parentKey);
     forest.unknownGroups.get(parentKey).slice().sort(compareEntries).forEach(function (entry) {
-      html += renderSubtree(entry, forest.childrenOf, 0);
+      html += renderSubtree(entry, forest.childrenOf, 0, printed);
     });
+  });
+
+  // Leftover pass: a parent cycle (every member has a parent field set AND
+  // that parent is present in the current session set, so none of them ever
+  // lands in `roots` or `unknownGroups`, and nothing outside the cycle
+  // points into it) would otherwise vanish from the board entirely instead
+  // of rendering. Anything still unprinted after the two passes above gets
+  // its own top-level card -- mirrors the CLI tree printer's group 3.
+  var leftover = [];
+  sessions.forEach(function (entry) {
+    if (!printed.has(sessionKey(entry.record))) leftover.push(entry);
+  });
+  leftover.sort(compareEntries).forEach(function (entry) {
+    html += renderSubtree(entry, forest.childrenOf, 0, printed);
   });
 
   qs("#sessions-list").innerHTML = html || emptyState("no sessions yet");
@@ -570,10 +603,17 @@ async function loadPool() {
 // pages fetched before the failure still land (freshened), matching
 // collectAgentSessions's own "a page fetched before the error already landed
 // in out" comment. The next 5s tick retries this agent from the top.
+//
+// Hitting MAX_SESSION_PAGES is treated the same way as a fetch error: the
+// accumulated `seen` set is partial by construction, so running the
+// delete-on-absence pass against it would delete live cards past the
+// ceiling -- same rule as the partial-failure path above, just a different
+// reason the set is incomplete. Sessions upserted from pages fetched before
+// the ceiling still land.
 async function pollAgentSessions(a) {
   var seen = new Set();
   var pageToken = "";
-  for (;;) {
+  for (var page = 0; page < MAX_SESSION_PAGES; page++) {
     var path = "/registry/agents/" + encodeURIComponent(a.namespace) + "/" +
       encodeURIComponent(a.name) + "/sessions?limit=500" +
       (pageToken ? "&page=" + encodeURIComponent(pageToken) : "");
@@ -584,14 +624,19 @@ async function pollAgentSessions(a) {
       upsertSession(rec);
       seen.add(sessionKey(rec));
     });
-    if (!data.next) break;
+    if (!data.next) {
+      sessions.forEach(function (entry, key) {
+        if (entry.record.namespace === a.namespace && entry.record.agent === a.name && !seen.has(key)) {
+          sessions.delete(key);
+        }
+      });
+      return;
+    }
     pageToken = data.next;
   }
-  sessions.forEach(function (entry, key) {
-    if (entry.record.namespace === a.namespace && entry.record.agent === a.name && !seen.has(key)) {
-      sessions.delete(key);
-    }
-  });
+  // Ceiling hit with a cursor still outstanding: proceed with the partial
+  // set already upserted above, but skip the delete pass -- see the doc
+  // comment.
 }
 
 // pollSessionsTick is the SSE-unavailable fallback: it walks every known

--- a/pkg/agentruntime/ui/boardroom.html
+++ b/pkg/agentruntime/ui/boardroom.html
@@ -85,8 +85,33 @@
   .badge.warm { color: var(--muted); margin-left: 0; }
   .badge.provisioned { color: var(--accent); border-color: var(--accent); }
   .badge.ready { color: var(--active); border-color: var(--active); margin-left: auto; }
+  /* Family-tree badge: depth sits right after the card id, not pushed to the
+     far right the way the trailing status badge is (its margin-left stays
+     the general .badge auto, since it renders LAST in .card-top). */
+  .badge.depth { color: var(--accent); border-color: var(--accent); margin-left: 0; }
   .teleport { color: var(--accent); }
   .empty { color: var(--muted); font-style: italic; padding: 8px 0; }
+  /* Family tree: one row per session card, indented by nesting level
+     (inline style, computed from the parent chain -- see renderSubtree).
+     The connector glyph marks a child row; a root row has none. */
+  .card-row { display: flex; align-items: flex-start; gap: 4px; }
+  .card-row > .card { flex: 1 1 auto; min-width: 0; }
+  .tree-connector {
+    flex: none;
+    color: var(--muted);
+    font-family: ui-monospace, Menlo, monospace;
+    line-height: 1;
+    padding-top: 10px;
+  }
+  .group-header {
+    font-size: 11px;
+    font-style: italic;
+    color: var(--muted);
+    margin: 12px 0 4px;
+    padding-top: 8px;
+    border-top: 1px dashed var(--border);
+  }
+  .card-list > .group-header:first-child { border-top: none; padding-top: 0; margin-top: 0; }
   #anchor-svg { position: absolute; top: 0; left: 0; pointer-events: none; z-index: 5; }
   .card[data-key] { cursor: pointer; }
   .card[data-key]:hover { border-color: var(--accent); }
@@ -313,7 +338,36 @@ function renderStats() {
 
 function emptyState(msg) { return '<div class="empty">' + esc(msg) + "</div>"; }
 
-function sessionCardHTML(entry) {
+// compareEntries is the deterministic sibling order shared by every level of
+// the family tree (and, before the tree existed, the flat list): active
+// before idle before archived, most-recently-active first within a status.
+function compareEntries(a, b) {
+  var oa = STATUS_ORDER[a.record.status], ob = STATUS_ORDER[b.record.status];
+  if (oa !== ob) return oa - ob;
+  var byActive = (b.record.lastActiveAt || "").localeCompare(a.record.lastActiveAt || "");
+  if (byActive !== 0) return byActive;
+  // Final tiebreak for full determinism: siblings spawned by parallel
+  // requests (e.g. architect.js's 3 concurrent expert POSTs) can share both
+  // status and lastActiveAt, which would otherwise fall back to Map
+  // insertion order -- i.e. arrival order, not deterministic across renders.
+  return sessionKey(a.record).localeCompare(sessionKey(b.record));
+}
+
+// parentKeyOf returns the sessionKey-shaped "<ns>/<agent>/<id>" string for a
+// record's parent field (session.go's ParentRef, carried on the wire as
+// {namespace,agent,id} -- see SessionRecord.Parent), or "" for a root
+// session (parent omitted/omitzero on the wire).
+function parentKeyOf(r) {
+  return r.parent ? r.parent.namespace + "/" + r.parent.agent + "/" + r.parent.id : "";
+}
+
+// sessionCardHTML renders one card. `level` is this card's DEPTH IN THE
+// RENDERED TREE (0 = no indent), which drives the connector/indent and is
+// distinct from SessionRecord.Depth (the platform's absolute spawn-chain
+// depth, shown as the "dN" badge) -- a child under an "(unknown parent)"
+// group header is drawn at tree level 0 even though its own record.depth may
+// be >0.
+function sessionCardHTML(entry, level) {
   var r = entry.record;
   var color = STATUS_COLOR[r.status] || STATUS_COLOR.archived;
   var shortId = r.id.slice(0, 8);
@@ -321,23 +375,88 @@ function sessionCardHTML(entry) {
   if (entry.teleports > 0) {
     meta += ' · <span class="teleport">teleports ' + entry.teleports + "</span>";
   }
+  var depthBadge = r.depth ? '<span class="badge depth">d' + esc(r.depth) + "</span>" : "";
   // data-key carries the exact sessions Map key (not the sanitized DOM id,
   // which is lossy) so the click handler below can look the record back up.
-  return '<div class="card" id="' + cardId(r) + '" data-key="' + esc(sessionKey(r)) + '" style="border-left-color:' + color + '">' +
+  var card = '<div class="card" id="' + cardId(r) + '" data-key="' + esc(sessionKey(r)) + '" style="border-left-color:' + color + '">' +
     '<div class="card-top"><span class="dot" style="background:' + color + '"></span>' +
-    '<span class="card-id">' + esc(shortId) + "</span>" +
+    '<span class="card-id">' + esc(shortId) + "</span>" + depthBadge +
     '<span class="badge status-' + esc(r.status) + '">' + esc(r.status) + "</span></div>" +
     '<div class="card-agent">' + esc(r.namespace) + "/" + esc(r.agent) + "</div>" +
     '<div class="card-meta">' + meta + "</div></div>";
+  if (level === 0) {
+    return '<div class="card-row">' + card + "</div>";
+  }
+  return '<div class="card-row" style="margin-left:' + (level * 18) +
+    'px"><span class="tree-connector">└</span>' + card + "</div>";
+}
+
+// buildFamilyForest partitions the current session set into a forest: `roots`
+// (no parent field at all), `childrenOf` (keyed by the PARENT's sessionKey,
+// for children whose parent is itself in the current card set), and
+// `unknownGroups` (keyed by the raw, unresolvable parent ref string, for
+// children whose parent is NOT in the current card set -- e.g. the parent
+// session already archived off the list, or belongs to an agent this page
+// never fetched). Every live entry lands in exactly one of the three
+// buckets, so the render pass below is a complete, non-duplicating walk.
+function buildFamilyForest() {
+  var childrenOf = new Map();
+  var roots = [];
+  var unknownGroups = new Map();
+
+  sessions.forEach(function (entry) {
+    var r = entry.record;
+    if (!r.parent) {
+      roots.push(entry);
+      return;
+    }
+    var pKey = parentKeyOf(r);
+    if (sessions.has(pKey)) {
+      if (!childrenOf.has(pKey)) childrenOf.set(pKey, []);
+      childrenOf.get(pKey).push(entry);
+      return;
+    }
+    if (!unknownGroups.has(pKey)) unknownGroups.set(pKey, []);
+    unknownGroups.get(pKey).push(entry);
+  });
+
+  return { childrenOf: childrenOf, roots: roots, unknownGroups: unknownGroups };
+}
+
+// renderSubtree renders `entry` plus every descendant reachable through
+// childrenOf, each level indented one step deeper than its parent.
+function renderSubtree(entry, childrenOf, level) {
+  var html = sessionCardHTML(entry, level);
+  var kids = (childrenOf.get(sessionKey(entry.record)) || []).slice().sort(compareEntries);
+  kids.forEach(function (child) {
+    html += renderSubtree(child, childrenOf, level + 1);
+  });
+  return html;
+}
+
+function groupHeaderHTML(parentRef) {
+  return '<div class="group-header">(unknown parent: ' + esc(parentRef) + ")</div>";
 }
 
 function renderSessions() {
-  var items = Array.from(sessions.values()).sort(function (a, b) {
-    var oa = STATUS_ORDER[a.record.status], ob = STATUS_ORDER[b.record.status];
-    if (oa !== ob) return oa - ob;
-    return (b.record.lastActiveAt || "").localeCompare(a.record.lastActiveAt || "");
+  var forest = buildFamilyForest();
+  var html = "";
+
+  forest.roots.slice().sort(compareEntries).forEach(function (entry) {
+    html += renderSubtree(entry, forest.childrenOf, 0);
   });
-  qs("#sessions-list").innerHTML = items.map(sessionCardHTML).join("") || emptyState("no sessions yet");
+
+  // Deterministic group order: sort by the parent ref string itself, not
+  // insertion order (a Map iterates in insertion order, which would jitter
+  // across renders as different children arrive first).
+  Array.from(forest.unknownGroups.keys()).sort().forEach(function (parentKey) {
+    html += groupHeaderHTML(parentKey);
+    forest.unknownGroups.get(parentKey).slice().sort(compareEntries).forEach(function (entry) {
+      html += renderSubtree(entry, forest.childrenOf, 0);
+    });
+  });
+
+  qs("#sessions-list").innerHTML = html || emptyState("no sessions yet");
 }
 
 function podCardHTML(p) {
@@ -430,33 +549,58 @@ async function loadPool() {
   scheduleRender();
 }
 
-// pollSessionsTick is the SSE-unavailable fallback: it re-lists every known
-// agent's sessions and treats each agent's page as ground truth, dropping
-// any previously-seen session for that agent that no longer appears (the
-// SSE feed never sends deletions either -- see events.go's package doc --
-// so this is the same reconciliation the feed's own fallback advice
-// prescribes). limit=500 (maxSessionListLimit) covers the demo's session
-// counts in one page; a production poller would walk `next`.
+// pollAgentSessions re-lists ONE agent's ENTIRE live-session set, paging the
+// `page` cursor to exhaustion (mirroring events.go's collectAgentSessions,
+// the SSE path's own server-side poller), then treats the full accumulated
+// set as ground truth: any previously-seen session for this agent that does
+// not appear in it is dropped (the SSE feed never sends deletions either --
+// see events.go's package doc -- so this is the same reconciliation the
+// feed's own fallback advice prescribes).
+//
+// Bug fixed here: this used to fetch exactly ONE ?limit=500 page and delete
+// every session absent from THAT page -- past 500 live sessions for one
+// agent, a truncated first page deleted LIVE cards, not just orphans. Paging
+// to exhaustion before running the delete pass is the actual fix; limit=500
+// per page is just a page size now, not an assumed ceiling.
+//
+// On a page-fetch error partway through, this agent's walk is abandoned for
+// the tick with NO delete pass run at all: an incomplete `seen` set would
+// otherwise delete every live session past the point of failure, which is
+// the same class of bug this function exists to fix. Sessions upserted from
+// pages fetched before the failure still land (freshened), matching
+// collectAgentSessions's own "a page fetched before the error already landed
+// in out" comment. The next 5s tick retries this agent from the top.
+async function pollAgentSessions(a) {
+  var seen = new Set();
+  var pageToken = "";
+  for (;;) {
+    var path = "/registry/agents/" + encodeURIComponent(a.namespace) + "/" +
+      encodeURIComponent(a.name) + "/sessions?limit=500" +
+      (pageToken ? "&page=" + encodeURIComponent(pageToken) : "");
+    var res = await apiGet(path);
+    if (!res.ok) return; // abort this agent's walk; no deletion this tick
+    var data = await res.json();
+    (data.sessions || []).forEach(function (rec) {
+      upsertSession(rec);
+      seen.add(sessionKey(rec));
+    });
+    if (!data.next) break;
+    pageToken = data.next;
+  }
+  sessions.forEach(function (entry, key) {
+    if (entry.record.namespace === a.namespace && entry.record.agent === a.name && !seen.has(key)) {
+      sessions.delete(key);
+    }
+  });
+}
+
+// pollSessionsTick is the SSE-unavailable fallback: it walks every known
+// agent via pollAgentSessions (see its doc comment for the pagination fix).
 async function pollSessionsTick() {
   await loadAgents();
   for (var i = 0; i < agents.length; i++) {
-    var a = agents[i];
     try {
-      var path = "/registry/agents/" + encodeURIComponent(a.namespace) + "/" +
-        encodeURIComponent(a.name) + "/sessions?limit=500";
-      var res = await apiGet(path);
-      if (!res.ok) continue;
-      var data = await res.json();
-      var seen = new Set();
-      (data.sessions || []).forEach(function (rec) {
-        upsertSession(rec);
-        seen.add(sessionKey(rec));
-      });
-      sessions.forEach(function (entry, key) {
-        if (entry.record.namespace === a.namespace && entry.record.agent === a.name && !seen.has(key)) {
-          sessions.delete(key);
-        }
-      });
+      await pollAgentSessions(agents[i]);
     } catch (e) { /* leave this agent's sessions stale for one tick */ }
   }
   scheduleRender();

--- a/pkg/agentruntime/wake_test.go
+++ b/pkg/agentruntime/wake_test.go
@@ -63,7 +63,7 @@ func newTestWakeServiceFull(t *testing.T, client *http.Client, upstreamURL strin
 
 	store := NewSessionStore(kv, now)
 	view := NewAgentView()
-	d := NewDispatcher(logr.Discard(), view, store, client, upstreamURL, time.Hour, now, maxContinuations)
+	d := NewDispatcher(logr.Discard(), view, store, client, upstreamURL, time.Hour, now, maxContinuations, defaultMaxSpawnDepth)
 	w := NewWakeService(logr.Discard(), q, d, now)
 	if wireEnqueuer {
 		d.SetWakeEnqueuer(w)

--- a/pkg/fission-cli/cmd/agent/sessions.go
+++ b/pkg/fission-cli/cmd/agent/sessions.go
@@ -123,8 +123,10 @@ func (s sessionRecord) key() string {
 
 // sessionsResponse mirrors ListSessions's response envelope
 // (pkg/agentruntime/registry_api.go sessionsResponse). Next (a pagination
-// cursor) is not surfaced by this CLI yet — `sessions list` always fetches a
-// single page, at maxSessionListLimit (below).
+// cursor) is not surfaced directly to the caller: the plain (non-`--tree`)
+// `sessions list` fetches a single page, at maxSessionListLimit (below), and
+// `--tree` instead consumes Next itself, via fetchAllSessionPages, to walk
+// every page to exhaustion before rendering the family tree.
 type sessionsResponse struct {
 	Sessions []sessionRecord `json:"sessions"`
 	Next     string          `json:"next,omitempty"`
@@ -135,6 +137,13 @@ type sessionsResponse struct {
 // this back down to it, so asking for it directly is the largest single
 // page this CLI can ever get.
 const maxSessionListLimit = 500
+
+// maxSessionPages bounds fetchAllSessionPages's page-cursor loop (500
+// sessions per page => 50,000 sessions for one agent). Without a ceiling, a
+// buggy server -- or a registry bug that returns a repeating cursor -- hangs
+// `sessions list --tree` forever, looping on `next` with no forward
+// progress.
+const maxSessionPages = 100
 
 type SessionsListSubCommand struct {
 	cmd.CommandActioner
@@ -239,11 +248,15 @@ func listSessionsTree(input cli.Input, format util.OutputFormat, base, namespace
 
 // fetchAllSessionPages GETs every page of an agent's sessions, following the
 // server's "next" cursor (the "page" query param, mirroring registry_api.go)
-// until it comes back empty.
+// until it comes back empty, or until maxSessionPages is reached — whichever
+// comes first. Hitting the ceiling returns what was fetched so far (never an
+// error: a partial family tree is more useful than none) with a warning on
+// stderr; the caller gets a possibly-incomplete set, exactly the same shape
+// a page-fetch error would have left it in.
 func fetchAllSessionPages(input cli.Input, base, namespace, agentName string) ([]sessionRecord, error) {
 	var all []sessionRecord
 	page := ""
-	for {
+	for i := 0; i < maxSessionPages; i++ {
 		reqURL := fmt.Sprintf("%s/registry/agents/%s/%s/sessions?limit=%d", base,
 			url.PathEscape(namespace), url.PathEscape(agentName), maxSessionListLimit)
 		if page != "" {
@@ -264,6 +277,8 @@ func fetchAllSessionPages(input cli.Input, base, namespace, agentName string) ([
 		}
 		page = resp.Next
 	}
+	console.Warn(fmt.Sprintf("sessions list --tree: stopped after %d pages with more sessions remaining (server keeps returning a cursor); showing a partial, possibly-incomplete family tree", maxSessionPages))
+	return all, nil
 }
 
 // printSessionTree renders sessions as an indented parent/child tree to w.

--- a/pkg/fission-cli/cmd/agent/sessions.go
+++ b/pkg/fission-cli/cmd/agent/sessions.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -40,7 +41,7 @@ func SessionCommands() *cobra.Command {
 		Short: "List an agent function's sessions",
 	}, SessionsList, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
-		Optional: []flag.Flag{flag.Namespace, flag.Output, flag.AgentToken},
+		Optional: []flag.Flag{flag.Namespace, flag.Output, flag.AgentToken, flag.AgentSessionsTree},
 	})
 	getCmd := wrapper.SubCommand(&cobra.Command{
 		Use:   "get",
@@ -73,6 +74,23 @@ type sessionStats struct {
 	Continuations int64 `json:"continuations"`
 }
 
+// parentRef mirrors agentruntime.ParentRef's wire shape (pkg/agentruntime/
+// session.go) — the qualified <namespace>/<agent>/<id> reference to a
+// spawning session. Kept as its own small mirror rather than importing
+// ParentRef, for the same no-import reason sessionRecord below documents.
+type parentRef struct {
+	Namespace string `json:"namespace"`
+	Agent     string `json:"agent"`
+	ID        string `json:"id"`
+}
+
+// key returns p's canonical "<namespace>/<agent>/<id>" form — the same
+// string agentruntime.ParentRef.String() produces, and the form --tree
+// groups children by (a bare id is ambiguous across agents).
+func (p parentRef) key() string {
+	return p.Namespace + "/" + p.Agent + "/" + p.ID
+}
+
 // sessionRecord mirrors agentruntime.SessionRecord's wire shape. The CLI
 // decodes its own copy rather than importing pkg/agentruntime, the same
 // reasoning history.go gives for historyEvent: the server package pulls in
@@ -88,6 +106,19 @@ type sessionRecord struct {
 	LastActiveAt time.Time    `json:"lastActiveAt"`
 	CurrentPod   string       `json:"currentPod,omitempty"`
 	Stats        sessionStats `json:"stats"`
+	// Parent and Depth mirror SessionRecord's spawn-parentage fields
+	// (pkg/agentruntime/session.go). Depth is tagged omitzero, matching the
+	// server: json/v2's omitempty only drops null/""/{}/[], not a zero int,
+	// so a root session's Depth (0) would otherwise appear on the wire (and
+	// re-marshal, under --tree -o json) as an explicit "depth":0.
+	Parent *parentRef `json:"parent,omitempty"`
+	Depth  int        `json:"depth,omitzero"`
+}
+
+// key returns s's canonical "<namespace>/<agent>/<id>" form, the same shape
+// parentRef.key() produces, so a child's Parent.key() looks it up directly.
+func (s sessionRecord) key() string {
+	return s.Namespace + "/" + s.Agent + "/" + s.ID
 }
 
 // sessionsResponse mirrors ListSessions's response envelope
@@ -135,6 +166,11 @@ func (opts *SessionsListSubCommand) do(input cli.Input) error {
 	if err != nil {
 		return err
 	}
+
+	if input.Bool(flagkey.AgentSessionsTree) {
+		return listSessionsTree(input, format, base, namespace, agentName)
+	}
+
 	// limit=maxSessionListLimit (the server's cap, pkg/agentruntime/registry_api.go):
 	// this CLI fetches a single page and does not follow Next, so asking for
 	// the server's cap rather than its lower default raises the truncation
@@ -173,6 +209,164 @@ func (opts *SessionsListSubCommand) do(input cli.Input) error {
 	wideRow := func(s sessionRecord) []string { return []string{timeOrDash(s.CreatedAt)} }
 
 	return util.PrintObjects(format, resp.Sessions, headers, row, wideExtra, wideRow)
+}
+
+// listSessionsTree implements `sessions list --tree`: unlike the plain list
+// above, it loops the server's page cursor to exhaustion first — a
+// truncated page would show orphaned children (a child whose parent landed
+// on an earlier, un-fetched page looks parentless) and hide parents (a
+// parent past the fetched page never appears at all) — then renders the
+// spawn family as an indented tree.
+func listSessionsTree(input cli.Input, format util.OutputFormat, base, namespace, agentName string) error {
+	sessions, err := fetchAllSessionPages(input, base, namespace, agentName)
+	if err != nil {
+		return sessionsFriendlyError(err, namespace, agentName)
+	}
+
+	// --tree's only effect on a structured format is the exhaustive fetch
+	// above: json/yaml already render the full flat array PrintStructured
+	// produces for the plain list, just complete instead of one page, and
+	// carry no console.Warn (there is nothing left un-fetched to warn about).
+	if handled, err := util.PrintStructured(format, sessions); err != nil || handled {
+		return err
+	}
+
+	// OutputWide has no extra tree-specific column; it renders identically
+	// to the default table.
+	printSessionTree(os.Stdout, sessions)
+	return nil
+}
+
+// fetchAllSessionPages GETs every page of an agent's sessions, following the
+// server's "next" cursor (the "page" query param, mirroring registry_api.go)
+// until it comes back empty.
+func fetchAllSessionPages(input cli.Input, base, namespace, agentName string) ([]sessionRecord, error) {
+	var all []sessionRecord
+	page := ""
+	for {
+		reqURL := fmt.Sprintf("%s/registry/agents/%s/%s/sessions?limit=%d", base,
+			url.PathEscape(namespace), url.PathEscape(agentName), maxSessionListLimit)
+		if page != "" {
+			reqURL += "&page=" + url.QueryEscape(page)
+		}
+
+		body, err := agentRuntimeGet(input, reqURL)
+		if err != nil {
+			return nil, err
+		}
+		var resp sessionsResponse
+		if err := json.Unmarshal(body, &resp); err != nil {
+			return nil, fmt.Errorf("decoding sessions response: %w", err)
+		}
+		all = append(all, resp.Sessions...)
+		if resp.Next == "" {
+			return all, nil
+		}
+		page = resp.Next
+	}
+}
+
+// printSessionTree renders sessions as an indented parent/child tree to w.
+// Children are keyed by their parent's full <namespace>/<agent>/<id> triple
+// (parentRef.key(); a bare id is ambiguous across agents) rather than by
+// object identity, so the walk below is a pure lookup over that map.
+//
+// Three groups, all guaranteed visible (never silently dropped):
+//  1. roots (Parent == nil), printed with their reachable descendants;
+//  2. a child whose parent triple was not among the fetched records renders
+//     under an explicit "(unknown: <ref>)" node instead of vanishing;
+//  3. anything still unprinted after (1) and (2) has a parent that IS among
+//     the fetched records but is unreachable from any root — a self-parent
+//     or a cycle in a buggy/hostile server response — and is rendered as its
+//     own top-level entry rather than dropped or looped over forever.
+//
+// Every row's indent is the record's own Depth field (already the absolute
+// spawn-chain depth the server computed at creation time), not a depth
+// recomputed from how much of the tree this walk could reconstruct — so an
+// orphan under an "(unknown: ...)" node still indents at its true depth.
+func printSessionTree(w io.Writer, sessions []sessionRecord) {
+	tw := util.NewTabWriter(w)
+	fmt.Fprintln(tw, strings.Join([]string{"ID", "STATUS", "DEPTH", "TURNS", "CONTINUATIONS", "LAST-ACTIVE", "POD"}, "\t"))
+
+	byKey := make(map[string]sessionRecord, len(sessions))
+	childrenOf := make(map[string][]sessionRecord)
+	var roots []sessionRecord
+	for _, s := range sessions {
+		byKey[s.key()] = s
+		if s.Parent == nil {
+			roots = append(roots, s)
+		} else {
+			pk := s.Parent.key()
+			childrenOf[pk] = append(childrenOf[pk], s)
+		}
+	}
+
+	byID := func(recs []sessionRecord) {
+		sort.Slice(recs, func(i, j int) bool { return recs[i].ID < recs[j].ID })
+	}
+	byID(roots)
+	for k := range childrenOf {
+		byID(childrenOf[k])
+	}
+
+	printed := make(map[string]bool, len(sessions))
+	var printSubtree func(s sessionRecord)
+	printSubtree = func(s sessionRecord) {
+		key := s.key()
+		if printed[key] {
+			return // already printed via another path (e.g. a cycle) — never twice.
+		}
+		printed[key] = true
+		writeSessionTreeRow(tw, s)
+		for _, child := range childrenOf[key] {
+			printSubtree(child)
+		}
+	}
+
+	for _, root := range roots {
+		printSubtree(root)
+	}
+
+	var unknownParents []string
+	for pk := range childrenOf {
+		if _, ok := byKey[pk]; !ok {
+			unknownParents = append(unknownParents, pk)
+		}
+	}
+	sort.Strings(unknownParents)
+	for _, pk := range unknownParents {
+		fmt.Fprintf(tw, "(unknown: %s)\t-\t-\t-\t-\t-\t-\n", pk)
+		for _, child := range childrenOf[pk] {
+			printSubtree(child)
+		}
+	}
+
+	var leftover []sessionRecord
+	for _, s := range sessions {
+		if !printed[s.key()] {
+			leftover = append(leftover, s)
+		}
+	}
+	byID(leftover)
+	for _, s := range leftover {
+		printSubtree(s)
+	}
+
+	tw.Flush()
+}
+
+// writeSessionTreeRow writes one session's row, indenting its ID cell two
+// spaces per level of s.Depth.
+func writeSessionTreeRow(w io.Writer, s sessionRecord) {
+	fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%d\t%s\t%s\n",
+		strings.Repeat("  ", s.Depth)+s.ID,
+		s.Status,
+		s.Depth,
+		s.Stats.Turns,
+		s.Stats.Continuations,
+		timeOrDash(s.LastActiveAt),
+		stringOrDash(s.CurrentPod),
+	)
 }
 
 func (opts *SessionsGetSubCommand) do(input cli.Input) error {

--- a/pkg/fission-cli/cmd/agent/sessions_test.go
+++ b/pkg/fission-cli/cmd/agent/sessions_test.go
@@ -129,6 +129,129 @@ func TestSessionsListJSONStaysParseableWithMorePages(t *testing.T) {
 	assert.Equal(t, "sess-1", decoded[0].ID)
 }
 
+// familyTreeFixture is a single page (no "next") carrying a 3-node spawn
+// family (root-1 -> child-1 -> grand-1) plus orphan-1, whose parent ref
+// ("missing-parent") is not among the fetched records — the case the
+// "(unknown: ...)" node exists to make visible instead of silently dropping.
+const familyTreeFixture = `{"sessions":[
+	{"id":"root-1","agent":"agentfn","namespace":"testns","status":"active",
+	 "createdAt":"2026-08-20T09:00:00Z","stats":{"turns":1}},
+	{"id":"child-1","agent":"agentfn","namespace":"testns","status":"active",
+	 "createdAt":"2026-08-20T09:05:00Z","stats":{"turns":2},
+	 "parent":{"namespace":"testns","agent":"agentfn","id":"root-1"},"depth":1},
+	{"id":"grand-1","agent":"agentfn","namespace":"testns","status":"active",
+	 "createdAt":"2026-08-20T09:10:00Z","stats":{"turns":3},
+	 "parent":{"namespace":"testns","agent":"agentfn","id":"child-1"},"depth":2},
+	{"id":"orphan-1","agent":"agentfn","namespace":"testns","status":"idle",
+	 "createdAt":"2026-08-20T09:15:00Z","stats":{"turns":0},
+	 "parent":{"namespace":"testns","agent":"agentfn","id":"missing-parent"},"depth":1}
+]}`
+
+// TestSessionsListTreeRendersFamily exercises `fission agent sessions list
+// --tree` against a fabricated 3-generation family plus one orphan, checking
+// the indentation nests children under their parent, in parent-before-child
+// order, and that the orphan renders under an explicit "(unknown: ...)" node
+// (naming the missing parent's full <ns>/<agent>/<id> triple) rather than
+// being silently dropped.
+func TestSessionsListTreeRendersFamily(t *testing.T) {
+	mockAgentRuntime(t, http.StatusOK, familyTreeFixture)
+
+	in := dummy.TestFlagSetWith(
+		dummy.String(flagkey.FnName, "agentfn"),
+		dummy.String(flagkey.Namespace, "testns"),
+	)
+	in.SetBool(flagkey.AgentSessionsTree, true)
+	out := captureStdout(t, func() error { return SessionsList(in) })
+
+	lines := splitNonEmptyLines(out)
+	require.Len(t, lines, 6, "header + root-1 + child-1 + grand-1 + (unknown: ...) + orphan-1:\n%s", out)
+
+	rootLine := findLine(t, lines, "root-1")
+	childLine := findLine(t, lines, "child-1")
+	grandLine := findLine(t, lines, "grand-1")
+	unknownLine := findLine(t, lines, "(unknown:")
+	orphanLine := findLine(t, lines, "orphan-1")
+
+	assert.True(t, strings.HasPrefix(rootLine, "root-1"), "root has no indent: %q", rootLine)
+	assert.True(t, strings.HasPrefix(childLine, "  child-1"), "child indented 2 spaces under its parent: %q", childLine)
+	assert.True(t, strings.HasPrefix(grandLine, "    grand-1"), "grandchild indented 4 spaces: %q", grandLine)
+	assert.Contains(t, unknownLine, "(unknown: testns/agentfn/missing-parent)")
+	assert.True(t, strings.HasPrefix(orphanLine, "  orphan-1"), "orphan rendered at its own depth under the unknown node: %q", orphanLine)
+
+	// Parent-before-child ordering, and the unknown group after the real
+	// family tree.
+	assert.Less(t, indexOf(lines, rootLine), indexOf(lines, childLine))
+	assert.Less(t, indexOf(lines, childLine), indexOf(lines, grandLine))
+	assert.Less(t, indexOf(lines, grandLine), indexOf(lines, unknownLine))
+	assert.Less(t, indexOf(lines, unknownLine), indexOf(lines, orphanLine))
+}
+
+// TestSessionsListTreePaginatesToExhaustion checks that --tree loops the
+// server's page cursor to exhaustion before building the tree: a fake server
+// answers the first request with one session and a "next" cursor, and the
+// second (carrying that cursor) with a final session and no cursor. Both
+// pages' sessions must appear in the rendered output, and the plain
+// (non-tree) single-page behavior this regresses against is covered by
+// TestSessionsListRendersColumns.
+func TestSessionsListTreePaginatesToExhaustion(t *testing.T) {
+	var reqs []recordedSessionReq
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs = append(reqs, recordedSessionReq{
+			Method: r.Method,
+			Path:   r.URL.Path,
+			Query:  r.URL.RawQuery,
+			Auth:   r.Header.Get("Authorization"),
+		})
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("page") == "" {
+			_, _ = w.Write([]byte(`{"sessions":[{"id":"page1-a","agent":"agentfn","namespace":"testns","status":"active",
+				"createdAt":"2026-08-20T09:00:00Z","stats":{"turns":1}}],"next":"cursor-1"}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"sessions":[{"id":"page2-a","agent":"agentfn","namespace":"testns","status":"active",
+			"createdAt":"2026-08-20T09:05:00Z","stats":{"turns":2}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("FISSION_AGENTRUNTIME_URL", srv.URL)
+
+	in := dummy.TestFlagSetWith(
+		dummy.String(flagkey.FnName, "agentfn"),
+		dummy.String(flagkey.Namespace, "testns"),
+	)
+	in.SetBool(flagkey.AgentSessionsTree, true)
+	out := captureStdout(t, func() error { return SessionsList(in) })
+
+	require.Len(t, reqs, 2, "must loop the page cursor until the server reports no next page")
+	assert.Equal(t, "limit=500", reqs[0].Query)
+	assert.Equal(t, "limit=500&page=cursor-1", reqs[1].Query)
+
+	assert.Contains(t, out, "page1-a")
+	assert.Contains(t, out, "page2-a")
+}
+
+// findLine returns the first line in lines containing substr, failing the
+// test if none does.
+func findLine(t *testing.T, lines []string, substr string) string {
+	t.Helper()
+	for _, line := range lines {
+		if strings.Contains(line, substr) {
+			return line
+		}
+	}
+	t.Fatalf("no output line contains %q:\n%s", substr, strings.Join(lines, "\n"))
+	return ""
+}
+
+// indexOf returns s's index in lines (exact match).
+func indexOf(lines []string, s string) int {
+	for i, line := range lines {
+		if line == s {
+			return i
+		}
+	}
+	return -1
+}
+
 // TestSessionsGetRendersDetail exercises `fission agent sessions get`
 // against a single-record fixture and checks the request hits the
 // {namespace}/{name}/sessions/{id} route with every stat rendered.

--- a/pkg/fission-cli/cmd/agent/sessions_test.go
+++ b/pkg/fission-cli/cmd/agent/sessions_test.go
@@ -229,6 +229,45 @@ func TestSessionsListTreePaginatesToExhaustion(t *testing.T) {
 	assert.Contains(t, out, "page2-a")
 }
 
+// twoNodeCycleFixture fabricates a parent cycle: cyc-a claims cyc-b as its
+// parent, and cyc-b claims cyc-a right back. Both records are present in the
+// single fetched page (so neither lands under the "(unknown: ...)" bucket),
+// and neither has Parent == nil (so neither is a root either) -- the exact
+// shape the tree printer's group-3 leftover fallback exists for.
+const twoNodeCycleFixture = `{"sessions":[
+	{"id":"cyc-a","agent":"agentfn","namespace":"testns","status":"active",
+	 "createdAt":"2026-08-20T09:00:00Z","stats":{"turns":1},
+	 "parent":{"namespace":"testns","agent":"agentfn","id":"cyc-b"},"depth":1},
+	{"id":"cyc-b","agent":"agentfn","namespace":"testns","status":"active",
+	 "createdAt":"2026-08-20T09:05:00Z","stats":{"turns":1},
+	 "parent":{"namespace":"testns","agent":"agentfn","id":"cyc-a"},"depth":1}
+]}`
+
+// TestSessionsListTreeHandlesTwoNodeCycle pins printSessionTree's cycle
+// safety: a fabricated 2-node parent cycle (each record names the other as
+// its parent) must render BOTH members exactly once, with no hang, instead
+// of looping forever or silently vanishing from the output. The tree
+// printer is already safe against this (the `printed` guard in
+// printSubtree); this test is the pin the final review asked for.
+func TestSessionsListTreeHandlesTwoNodeCycle(t *testing.T) {
+	mockAgentRuntime(t, http.StatusOK, twoNodeCycleFixture)
+
+	in := dummy.TestFlagSetWith(
+		dummy.String(flagkey.FnName, "agentfn"),
+		dummy.String(flagkey.Namespace, "testns"),
+	)
+	in.SetBool(flagkey.AgentSessionsTree, true)
+	// If printSubtree's `printed` guard regressed, this call would hang on
+	// the cycle forever; the test binary's own -timeout is the backstop that
+	// turns that into a failure rather than a silent CI wedge.
+	out := captureStdout(t, func() error { return SessionsList(in) })
+
+	lines := splitNonEmptyLines(out)
+	require.Len(t, lines, 3, "header + cyc-a + cyc-b, each exactly once:\n%s", out)
+	assert.Equal(t, 1, strings.Count(out, "cyc-a"))
+	assert.Equal(t, 1, strings.Count(out, "cyc-b"))
+}
+
 // findLine returns the first line in lines containing substr, failing the
 // test if none does.
 func findLine(t *testing.T, lines []string, substr string) string {

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -275,7 +275,7 @@ var (
 	// `fission agent sessions` introspection CLI (slice 4).
 	AgentSession      = Flag{Type: String, Name: flagkey.AgentSession, Usage: "Session id"}
 	AgentToken        = Flag{Type: String, Name: flagkey.AgentToken, Usage: "Bearer token for the agent runtime (defaults to FISSION_AGENT_TOKEN; unset works only when agentRuntime.allowInsecure is set)"}
-	AgentSessionsTree = Flag{Type: Bool, Name: flagkey.AgentSessionsTree, Usage: "Render sessions as a parent/child spawn tree, paging through every session first (ignores the single-page truncation the plain list applies)"}
+	AgentSessionsTree = Flag{Type: Bool, Name: flagkey.AgentSessionsTree, Usage: "Render sessions as a parent/child spawn tree, paging through every session first (ignores the single-page truncation the plain list applies); with -o json/yaml the output stays a flat, fully-paginated array rather than a nested tree"}
 
 	// RFC-0023 `fission fn state` admin flags.
 	StateKey       = Flag{Type: String, Name: flagkey.StateKey, Usage: "State key to operate on"}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -273,8 +273,9 @@ var (
 	FnAgentHistoryTrim   = Flag{Type: Bool, Name: flagkey.FnAgentHistoryTrim, Usage: "Let the agent runtime's sweeper trim this agent's session fact logs below each session's committed checkpoint (requires --state)"}
 
 	// `fission agent sessions` introspection CLI (slice 4).
-	AgentSession = Flag{Type: String, Name: flagkey.AgentSession, Usage: "Session id"}
-	AgentToken   = Flag{Type: String, Name: flagkey.AgentToken, Usage: "Bearer token for the agent runtime (defaults to FISSION_AGENT_TOKEN; unset works only when agentRuntime.allowInsecure is set)"}
+	AgentSession      = Flag{Type: String, Name: flagkey.AgentSession, Usage: "Session id"}
+	AgentToken        = Flag{Type: String, Name: flagkey.AgentToken, Usage: "Bearer token for the agent runtime (defaults to FISSION_AGENT_TOKEN; unset works only when agentRuntime.allowInsecure is set)"}
+	AgentSessionsTree = Flag{Type: Bool, Name: flagkey.AgentSessionsTree, Usage: "Render sessions as a parent/child spawn tree, paging through every session first (ignores the single-page truncation the plain list applies)"}
 
 	// RFC-0023 `fission fn state` admin flags.
 	StateKey       = Flag{Type: String, Name: flagkey.StateKey, Usage: "State key to operate on"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -165,8 +165,9 @@ const (
 	FnAgentHistoryTrim   = "agent-history-trim"
 
 	// `fission agent sessions` introspection CLI (slice 4).
-	AgentSession = "session"
-	AgentToken   = "agent-token"
+	AgentSession      = "session"
+	AgentToken        = "agent-token"
+	AgentSessionsTree = "tree"
 
 	HtName              = resourceName
 	HtMethod            = "method"

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -698,6 +698,321 @@ func TestAgentRuntimeHistory(t *testing.T) {
 	}, 60*time.Second, 2*time.Second)
 }
 
+// sessionsListDTO decodes ListSessions's response
+// (pkg/agentruntime/registry_api.go's unexported sessionsResponse) — Sessions
+// is typed as the real agentruntime.SessionRecord (exported, same package
+// this test already imports) rather than a hand-duplicated DTO, since its
+// wire shape (including the Parent/Depth fields this test asserts on) is
+// exactly what GetSession/ListSessions marshal.
+type sessionsListDTO struct {
+	Sessions []agentruntime.SessionRecord `json:"sessions"`
+	Next     string                       `json:"next,omitempty"`
+}
+
+// postAgentTurn POSTs one turn to turnURL carrying sessionID on
+// agentruntime.HeaderSession when non-empty, parentHeader on
+// agentruntime.HeaderParent when non-empty, and body as the raw JSON
+// request body. Generalizes postTurn (fixed "{}" body, no parent header) for
+// TestAgentRuntimeSpawnParentage's needs: turns that ask the fixture to spawn
+// ({"spawn":true}) and depth-chain turns dispatched directly by this test
+// with only a parent header, no fixture-side spawning involved at all.
+func postAgentTurn(ctx context.Context, f *framework.Framework, turnURL, sessionID, parentHeader, body string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, turnURL, strings.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set(agentruntime.HeaderSession, sessionID)
+	}
+	if parentHeader != "" {
+		req.Header.Set(agentruntime.HeaderParent, parentHeader)
+	}
+	return f.HTTPClient().Do(req)
+}
+
+// TestAgentRuntimeSpawnParentage exercises RFC-0031 slice 5's session
+// parentage wire path end-to-end against a real cluster (Task 5 of the
+// parent-graph plan): pkg/agentruntime/dispatcher.go's X-Fission-Agent-Parent
+// creation-only header handling and session.go's ParentRef/SpawnSessionID
+// derivation, GetSession's parent/depth wire shape, and the live 400 the
+// spawn-depth cap returns.
+//
+// The fixture (test/integration/testdata/nodejs/agentspawn/spawn.js) is a
+// minimal cousin of demo/agent-boardroom/fixtures/architect.js: on a turn
+// whose body carries {"spawn":true} it spawns exactly ONE child session on
+// ITSELF for stepKey "expert-1", using a byte-identical JS twin of
+// SpawnSessionID.
+//
+// Four things are asserted, in order:
+//
+//  1. Cross-language id agreement (the load-bearing assertion): this test
+//     computes expected := agentruntime.SpawnSessionID(parentRef, "expert-1")
+//     in Go and GETs EXACTLY that id from the registry — 200, with parent
+//     equal to the parent's triple and depth == 1. It also compares expected
+//     against the fixture's own reported "spawned" id, so a derivation drift
+//     on either side (hash, prefix, truncation length) fails with a message
+//     naming which side disagreed, not just a registry 404.
+//  2. Idempotent spawn: re-dispatching the parent's spawn turn a second time
+//     must not mint a second child — ListSessions must still show exactly one
+//     session whose parent.id is the parent session.
+//  3. Root-degrade: a fresh session dispatched with a parent header naming a
+//     NONEXISTENT session must still succeed (200, root-admitted per
+//     resolveParentage's "parent claim dropped" fallback) and its registry
+//     record must carry no parent and depth 0.
+//  4. Depth cap: chaining sessions directly (this test dispatches turns to
+//     each derived id itself, carrying only a parent header — no fixture-side
+//     spawning needed, since resolveParentage runs entirely off the STORED
+//     parent record before the function is ever invoked) from the depth-0
+//     parent through depth 1, 2, 3 succeeds; the depth-4 attempt must return
+//     HTTP 400 (AGENT_MAX_SPAWN_DEPTH is unset in CI, so the default cap of 3
+//     makes depth 4 the first rejection).
+func TestAgentRuntimeSpawnParentage(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "nodejs-agent-spawn-" + ns.ID
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	fnName := "agent-spawn-" + ns.ID
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{
+		Name: fnName,
+		Env:  envName,
+		Code: framework.WriteTestData(t, "nodejs/agentspawn/spawn.js"),
+		// The fixture spawns children on ITSELF: it needs to know its own
+		// namespace and function name to build both the outbound dispatch
+		// URL and the ParentRef header it stamps on the child. This test
+		// already knows both before creating the function, so it passes
+		// them as plain env vars rather than making the fixture depend on
+		// the (unrelated) RFC-0023 state-token file the way architect.js
+		// does.
+		EnvVars: []string{
+			"SELF_NAMESPACE=" + ns.Name,
+			"SELF_AGENT_NAME=" + fnName,
+		},
+	})
+	ns.WaitForFunction(t, ctx, fnName)
+	// Same CLI-update workaround as the other tests in this file
+	// (FunctionOptions has no Agent field yet).
+	ns.CLI(t, ctx, "fn", "update", "--name", fnName, "--agent")
+
+	base := f.AgentRuntimeBaseURL()
+	turnURL := base + "/agents/" + ns.Name + "/" + fnName
+
+	// Turn 1: no session header, no spawn. Mints the parent (root, depth 0)
+	// session this whole test hangs off of.
+	var parentSessionID string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, "", "", `{}`)
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "root turn to %s", turnURL) {
+			return
+		}
+		sid := resp.Header.Get(agentruntime.HeaderSession)
+		if !assert.NotEmpty(c, sid, "root turn must mint a session id via %s", agentruntime.HeaderSession) {
+			return
+		}
+		parentSessionID = sid
+	}, 180*time.Second, 2*time.Second)
+	require.NotEmpty(t, parentSessionID, "root turn never minted a session id")
+
+	parentRef := agentruntime.ParentRef{Namespace: ns.Name, Agent: fnName, ID: parentSessionID}
+	expectedChildID := agentruntime.SpawnSessionID(parentRef, "expert-1")
+
+	// Turn 2 on the parent session: {"spawn":true} asks the fixture to spawn
+	// its one child. The fixture reports the derived id back as "spawned" —
+	// compared against expectedChildID below.
+	var reportedSpawnID string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, parentSessionID, "", `{"spawn":true}`)
+		if !assert.NoErrorf(c, err, "POST %s (spawn turn)", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "spawn turn to %s", turnURL) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoErrorf(c, err, "reading spawn turn response body") {
+			return
+		}
+		var payload struct {
+			Spawned string `json:"spawned"`
+		}
+		if !assert.NoErrorf(c, json.Unmarshal(body, &payload), "decoding spawn turn response body %q", body) {
+			return
+		}
+		reportedSpawnID = payload.Spawned
+	}, 180*time.Second, 2*time.Second)
+	require.NotEmptyf(t, reportedSpawnID, "spawn turn on session %s never reported a spawned id", parentSessionID)
+
+	// 1. CROSS-LANGUAGE AGREEMENT: Go's agentruntime.SpawnSessionID and the
+	// fixture's JS twin must derive the SAME id from the SAME parent+stepKey.
+	assert.Equalf(t, expectedChildID, reportedSpawnID,
+		"cross-language derivation mismatch: Go agentruntime.SpawnSessionID(%+v, %q) = %s, fixture spawnSessionID reported %s",
+		parentRef, "expert-1", expectedChildID, reportedSpawnID)
+
+	// And the registry must show a session record living at EXACTLY that id,
+	// admitted with the parent's triple and depth 1 — this is what actually
+	// proves the two independent derivations converged on a real admission
+	// row, not just matching strings.
+	childURL := base + "/registry/agents/" + ns.Name + "/" + fnName + "/sessions/" + expectedChildID
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+		defer cancel()
+		body, status, err := getRegistry(attemptCtx, f, childURL)
+		if !assert.NoErrorf(c, err, "GET %s", childURL) {
+			return
+		}
+		if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", childURL, body) {
+			return
+		}
+		var rec agentruntime.SessionRecord
+		if !assert.NoErrorf(c, json.Unmarshal(body, &rec), "decoding %s body %q", childURL, body) {
+			return
+		}
+		if !assert.NotNilf(c, rec.Parent, "child session %s must carry a parent, got nil (body=%s)", expectedChildID, body) {
+			return
+		}
+		assert.Equalf(c, parentRef, *rec.Parent, "child session %s parent mismatch", expectedChildID)
+		assert.Equalf(c, 1, rec.Depth, "child session %s must be depth 1, got %d", expectedChildID, rec.Depth)
+	}, 60*time.Second, 2*time.Second)
+
+	// 2. IDEMPOTENT SPAWN: re-dispatch the parent's spawn turn. The fixture
+	// derives the SAME childID (same parent session, same stepKey) and
+	// spawns again — the dispatcher's Create(IfVersion=0) semantics on the
+	// child mean this resumes the existing child record rather than minting
+	// a second one. List the function's sessions and confirm exactly ONE
+	// carries this parent.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, parentSessionID, "", `{"spawn":true}`)
+		if !assert.NoErrorf(c, err, "POST %s (second spawn turn)", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equalf(c, http.StatusOK, resp.StatusCode, "second spawn turn to %s", turnURL)
+	}, 180*time.Second, 2*time.Second)
+
+	sessionsURL := base + "/registry/agents/" + ns.Name + "/" + fnName + "/sessions"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+		defer cancel()
+		body, status, err := getRegistry(attemptCtx, f, sessionsURL)
+		if !assert.NoErrorf(c, err, "GET %s", sessionsURL) {
+			return
+		}
+		if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", sessionsURL, body) {
+			return
+		}
+		var payload sessionsListDTO
+		if !assert.NoErrorf(c, json.Unmarshal(body, &payload), "decoding %s body %q", sessionsURL, body) {
+			return
+		}
+		children := 0
+		for _, s := range payload.Sessions {
+			if s.Parent != nil && s.Parent.ID == parentSessionID {
+				children++
+			}
+		}
+		assert.Equalf(c, 1, children,
+			"session %s must have exactly one child after re-dispatching the spawn turn (idempotent spawn), got %d (sessions=%+v)",
+			parentSessionID, children, payload.Sessions)
+	}, 60*time.Second, 2*time.Second)
+
+	// 3. ROOT-DEGRADE: a fresh session dispatched with a parent header naming
+	// a session that does not exist must still be admitted (200), as a root
+	// (no parent, depth 0) — resolveParentage's "parent claim dropped,
+	// admitting as root" fallback, not an error surfaced to the caller.
+	rootDegradeSessionID := "root-degrade-" + ns.ID
+	fakeParentHeader := ns.Name + "/" + fnName + "/does-not-exist-xyz"
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, rootDegradeSessionID, fakeParentHeader, `{}`)
+		if !assert.NoErrorf(c, err, "POST %s (root-degrade turn)", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equalf(c, http.StatusOK, resp.StatusCode,
+			"a turn naming a nonexistent parent must still be admitted as root (200), not rejected")
+	}, 180*time.Second, 2*time.Second)
+
+	rootDegradeURL := base + "/registry/agents/" + ns.Name + "/" + fnName + "/sessions/" + rootDegradeSessionID
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+		defer cancel()
+		body, status, err := getRegistry(attemptCtx, f, rootDegradeURL)
+		if !assert.NoErrorf(c, err, "GET %s", rootDegradeURL) {
+			return
+		}
+		if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", rootDegradeURL, body) {
+			return
+		}
+		var rec agentruntime.SessionRecord
+		if !assert.NoErrorf(c, json.Unmarshal(body, &rec), "decoding %s body %q", rootDegradeURL, body) {
+			return
+		}
+		assert.Nilf(c, rec.Parent, "session %s named a nonexistent parent, so it must carry NO parent, got %+v", rootDegradeSessionID, rec.Parent)
+		assert.Equalf(c, 0, rec.Depth, "session %s named a nonexistent parent, so it must be depth 0, got %d", rootDegradeSessionID, rec.Depth)
+	}, 60*time.Second, 2*time.Second)
+
+	// 4. DEPTH CAP: chain sessions directly from the depth-0 parent —
+	// resolveParentage computes depth from the STORED parent record alone,
+	// before the function is ever invoked, so this test can dispatch each
+	// hop itself with just a parent header; no fixture-side spawning is
+	// needed for this part at all. AGENT_MAX_SPAWN_DEPTH is unset in CI, so
+	// the default cap (3) makes a would-be depth-4 session the first
+	// rejection.
+	chainStepKey := "chain"
+	chainParent := parentRef // depth 0
+	for depth := 1; depth <= 3; depth++ {
+		childID := agentruntime.SpawnSessionID(chainParent, chainStepKey)
+		parentHeader := chainParent.String()
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+			defer cancel()
+			resp, err := postAgentTurn(attemptCtx, f, turnURL, childID, parentHeader, `{}`)
+			if !assert.NoErrorf(c, err, "POST %s (depth-%d chain turn)", turnURL, depth) {
+				return
+			}
+			defer resp.Body.Close()
+			assert.Equalf(c, http.StatusOK, resp.StatusCode, "depth-%d chain turn (session %s, parent %s) must be admitted", depth, childID, parentHeader)
+		}, 180*time.Second, 2*time.Second)
+		chainParent = agentruntime.ParentRef{Namespace: ns.Name, Agent: fnName, ID: childID}
+	}
+
+	depth4ParentHeader := chainParent.String() // chainParent is now the depth-3 session
+	depth4ChildID := agentruntime.SpawnSessionID(chainParent, chainStepKey)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, depth4ChildID, depth4ParentHeader, `{}`)
+		if !assert.NoErrorf(c, err, "POST %s (depth-4 chain turn)", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equalf(c, http.StatusBadRequest, resp.StatusCode,
+			"depth-4 spawn (session %s, parent %s) must be rejected — AGENT_MAX_SPAWN_DEPTH defaults to 3 in CI", depth4ChildID, depth4ParentHeader)
+	}, 60*time.Second, 2*time.Second)
+}
+
 // nextSSEFrame reads one SSE message from r: comment lines (starting with
 // ':', e.g. the ": keepalive" lines events.go's ServeHTTP writes) are
 // skipped entirely, then an "event:" line and a "data:" line are read up to

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -831,11 +831,18 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 
 	parentRef := agentruntime.ParentRef{Namespace: ns.Name, Agent: fnName, ID: parentSessionID}
 	expectedChildID := agentruntime.SpawnSessionID(parentRef, "expert-1")
+	childURL := base + "/registry/agents/" + ns.Name + "/" + fnName + "/sessions/" + expectedChildID
 
 	// Turn 2 on the parent session: {"spawn":true} asks the fixture to spawn
-	// its one child. The fixture reports the derived id back as "spawned" —
-	// compared against expectedChildID below.
+	// its one child. The fixture's inner dispatch to the child is a separate,
+	// best-effort network hop from inside the pod (spawn.js's spawnChild doc
+	// comment) that this outer turn's own 200 does not reflect the success
+	// of — so a transient failure there would otherwise strand a
+	// registry-only retry loop polling for a record that never arrives. This
+	// loop instead re-issues the WHOLE spawn turn on every attempt, giving a
+	// flaky inner dispatch further attempts to actually land.
 	var reportedSpawnID string
+	var childRec agentruntime.SessionRecord
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
 		defer cancel()
@@ -847,18 +854,31 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "spawn turn to %s", turnURL) {
 			return
 		}
-		body, err := io.ReadAll(resp.Body)
+		turnBody, err := io.ReadAll(resp.Body)
 		if !assert.NoErrorf(c, err, "reading spawn turn response body") {
 			return
 		}
 		var payload struct {
 			Spawned string `json:"spawned"`
 		}
-		if !assert.NoErrorf(c, json.Unmarshal(body, &payload), "decoding spawn turn response body %q", body) {
+		if !assert.NoErrorf(c, json.Unmarshal(turnBody, &payload), "decoding spawn turn response body %q", turnBody) {
 			return
 		}
 		reportedSpawnID = payload.Spawned
-	}, 180*time.Second, 2*time.Second)
+
+		registryCtx, registryCancel := context.WithTimeout(ctx, registryAttemptTimeout)
+		defer registryCancel()
+		regBody, status, err := getRegistry(registryCtx, f, childURL)
+		if !assert.NoErrorf(c, err, "GET %s", childURL) {
+			return
+		}
+		if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", childURL, regBody) {
+			return
+		}
+		if !assert.NoErrorf(c, json.Unmarshal(regBody, &childRec), "decoding %s body %q", childURL, regBody) {
+			return
+		}
+	}, 180*time.Second, 3*time.Second)
 	require.NotEmptyf(t, reportedSpawnID, "spawn turn on session %s never reported a spawned id", parentSessionID)
 
 	// 1. CROSS-LANGUAGE AGREEMENT: Go's agentruntime.SpawnSessionID and the
@@ -867,31 +887,14 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		"cross-language derivation mismatch: Go agentruntime.SpawnSessionID(%+v, %q) = %s, fixture spawnSessionID reported %s",
 		parentRef, "expert-1", expectedChildID, reportedSpawnID)
 
-	// And the registry must show a session record living at EXACTLY that id,
+	// And the registry shows a session record living at EXACTLY that id,
 	// admitted with the parent's triple and depth 1 — this is what actually
 	// proves the two independent derivations converged on a real admission
 	// row, not just matching strings.
-	childURL := base + "/registry/agents/" + ns.Name + "/" + fnName + "/sessions/" + expectedChildID
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
-		defer cancel()
-		body, status, err := getRegistry(attemptCtx, f, childURL)
-		if !assert.NoErrorf(c, err, "GET %s", childURL) {
-			return
-		}
-		if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", childURL, body) {
-			return
-		}
-		var rec agentruntime.SessionRecord
-		if !assert.NoErrorf(c, json.Unmarshal(body, &rec), "decoding %s body %q", childURL, body) {
-			return
-		}
-		if !assert.NotNilf(c, rec.Parent, "child session %s must carry a parent, got nil (body=%s)", expectedChildID, body) {
-			return
-		}
-		assert.Equalf(c, parentRef, *rec.Parent, "child session %s parent mismatch", expectedChildID)
-		assert.Equalf(c, 1, rec.Depth, "child session %s must be depth 1, got %d", expectedChildID, rec.Depth)
-	}, 60*time.Second, 2*time.Second)
+	if assert.NotNilf(t, childRec.Parent, "child session %s must carry a parent, got nil", expectedChildID) {
+		assert.Equalf(t, parentRef, *childRec.Parent, "child session %s parent mismatch", expectedChildID)
+	}
+	assert.Equalf(t, 1, childRec.Depth, "child session %s must be depth 1, got %d", expectedChildID, childRec.Depth)
 
 	// 2. IDEMPOTENT SPAWN: re-dispatch the parent's spawn turn. The fixture
 	// derives the SAME childID (same parent session, same stepKey) and
@@ -899,6 +902,12 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 	// child mean this resumes the existing child record rather than minting
 	// a second one. List the function's sessions and confirm exactly ONE
 	// carries this parent.
+	//
+	// This MUST run before part 4's depth chain: that chain's first hop
+	// (chainParent = parentRef, depth 0) is ALSO a direct child of
+	// parentSessionID, so counting "children of parentSessionID" after the
+	// chain exists would no longer isolate this assertion to the fixture's
+	// own spawn.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
 		defer cancel()

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -859,7 +859,9 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 			return
 		}
 		var payload struct {
-			Spawned string `json:"spawned"`
+			Spawned     string `json:"spawned"`
+			SpawnStatus int    `json:"spawnStatus"`
+			SpawnBody   string `json:"spawnBody"`
 		}
 		if !assert.NoErrorf(c, json.Unmarshal(turnBody, &payload), "decoding spawn turn response body %q", turnBody) {
 			return
@@ -886,7 +888,17 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		if !assert.NoErrorf(c, err, "GET %s", childURL) {
 			return
 		}
-		if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", childURL, regBody) {
+		// If the fixture's INNER dispatch (spawn.js's spawnChild, a separate
+		// best-effort network hop from inside the pod) keeps failing
+		// deterministically, the child record never gets created and this
+		// GET 404s on every attempt for the full 180s. Naming the inner
+		// dispatch's own last-observed status/body here (payload.SpawnStatus/
+		// SpawnBody, reported by the fixture on every turn -- see spawn.js's
+		// header comment) turns that into a pinpointed failure instead of an
+		// opaque registry 404.
+		if !assert.Equalf(c, http.StatusOK, status,
+			"GET %s (body=%s); the fixture's inner dispatch to the child last reported HTTP status=%d body=%q",
+			childURL, regBody, payload.SpawnStatus, payload.SpawnBody) {
 			return
 		}
 		if !assert.NoErrorf(c, json.Unmarshal(regBody, &childRec), "decoding %s body %q", childURL, regBody) {

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -866,6 +866,20 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		}
 		reportedSpawnID = payload.Spawned
 
+		// CROSS-LANGUAGE AGREEMENT, checked HERE (not just after the loop):
+		// if the JS twin ever derived a DIFFERENT id than Go's
+		// agentruntime.SpawnSessionID, the child would be created at that
+		// other id and the registry GET below for expectedChildID would
+		// 404 on every attempt — timing this whole loop out after 180s with
+		// an opaque 404 instead of pinpointing the actual mismatch. Failing
+		// (and returning) here on a real drift instead prints the mismatch
+		// on the very first attempt.
+		if !assert.Equalf(c, expectedChildID, reportedSpawnID,
+			"cross-language derivation mismatch: Go agentruntime.SpawnSessionID(%+v, %q) = %s, fixture spawnSessionID reported %s",
+			parentRef, "expert-1", expectedChildID, reportedSpawnID) {
+			return
+		}
+
 		registryCtx, registryCancel := context.WithTimeout(ctx, registryAttemptTimeout)
 		defer registryCancel()
 		regBody, status, err := getRegistry(registryCtx, f, childURL)
@@ -881,13 +895,12 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 	}, 180*time.Second, 3*time.Second)
 	require.NotEmptyf(t, reportedSpawnID, "spawn turn on session %s never reported a spawned id", parentSessionID)
 
-	// 1. CROSS-LANGUAGE AGREEMENT: Go's agentruntime.SpawnSessionID and the
-	// fixture's JS twin must derive the SAME id from the SAME parent+stepKey.
-	assert.Equalf(t, expectedChildID, reportedSpawnID,
-		"cross-language derivation mismatch: Go agentruntime.SpawnSessionID(%+v, %q) = %s, fixture spawnSessionID reported %s",
-		parentRef, "expert-1", expectedChildID, reportedSpawnID)
-
-	// And the registry shows a session record living at EXACTLY that id,
+	// 1. CROSS-LANGUAGE AGREEMENT: already asserted inside the loop above
+	// (checked before the registry GET, so a real mismatch is pinpointed on
+	// the first attempt instead of surfacing as a 180s registry-404
+	// timeout). By this point Go's agentruntime.SpawnSessionID and the
+	// fixture's JS twin are known to agree on expectedChildID, and the
+	// registry shows a session record living at EXACTLY that id,
 	// admitted with the parent's triple and depth 1 — this is what actually
 	// proves the two independent derivations converged on a real admission
 	// row, not just matching strings.

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -97,7 +97,18 @@ module.exports = async function (context) {
   // "<namespace>/<agent>/<id>".
   const parentRef = `${SELF_NAMESPACE}/${SELF_AGENT_NAME}/${sessionID}`;
 
-  const body = req.body;
+  // req.body arrives pre-parsed as an object for a JSON content type in the
+  // common case, but support-desk.js (this same testdata family) defends
+  // against a raw-string body too -- mirror that defensiveness here rather
+  // than assume the parsed-object case always holds.
+  let body = req.body;
+  if (typeof body === 'string') {
+    try {
+      body = body.trim() === '' ? {} : JSON.parse(body);
+    } catch (err) {
+      body = {};
+    }
+  }
   const shouldSpawn = !!(body && typeof body === 'object' && body.spawn === true);
 
   // spawned is reported whenever this turn spawned, REGARDLESS of whether

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -5,8 +5,13 @@
 // "expert-1" and dispatches ONE turn to that child on ITSELF (same
 // namespace, same function) with X-Fission-Session set to the derived id and
 // X-Fission-Agent-Parent set to this session's own ParentRef. Every turn
-// (spawn or not) replies 200 with {"session","parent","spawned"}, where
-// "spawned" is the derived child id (or null when this turn did not spawn).
+// (spawn or not) replies 200 with {"session","parent","spawned","spawnStatus",
+// "spawnBody"}, where "spawned" is the derived child id (or null when this
+// turn did not spawn) and spawnStatus/spawnBody are the inner dispatch's own
+// last-observed HTTP status and response body (0/"" when no spawn was
+// attempted, or on a network error before any response arrived) -- present
+// specifically so a caller-side test can name what the inner dispatch
+// actually saw instead of just timing out on a registry 404.
 //
 // spawnSessionID below is the same byte-identical JS twin of
 // pkg/agentruntime/session.go's SpawnSessionID that architect.js carries
@@ -80,13 +85,23 @@ async function spawnChild(parentRef, stepKey) {
       body: JSON.stringify({}),
     });
     if (!res.ok) {
-      console.error(`agentspawn: spawn ${stepKey} (${childID}) failed: HTTP ${res.status}`);
-      return { childID: childID, ok: false, status: res.status };
+      // Best-effort body read for diagnostics -- res.text() itself should
+      // not throw here (the response already completed with a status), but
+      // this is a test fixture's failure-reporting path, not the happy
+      // path, so it stays defensive anyway.
+      let bodyText = '';
+      try {
+        bodyText = await res.text();
+      } catch (err) {
+        bodyText = `<failed to read body: ${err}>`;
+      }
+      console.error(`agentspawn: spawn ${stepKey} (${childID}) failed: HTTP ${res.status} body=${bodyText}`);
+      return { childID: childID, ok: false, status: res.status, body: bodyText };
     }
-    return { childID: childID, ok: true, status: res.status };
+    return { childID: childID, ok: true, status: res.status, body: '' };
   } catch (err) {
     console.error(`agentspawn: spawn ${stepKey} (${childID}) failed: ${err}`);
-    return { childID: childID, ok: false, status: 0, error: String(err) };
+    return { childID: childID, ok: false, status: 0, body: '', error: String(err) };
   }
 }
 
@@ -98,9 +113,10 @@ module.exports = async function (context) {
   const parentRef = `${SELF_NAMESPACE}/${SELF_AGENT_NAME}/${sessionID}`;
 
   // req.body arrives pre-parsed as an object for a JSON content type in the
-  // common case, but support-desk.js (this same testdata family) defends
-  // against a raw-string body too -- mirror that defensiveness here rather
-  // than assume the parsed-object case always holds.
+  // common case, but support-desk.js (demo/agent-boardroom/fixtures/, not
+  // this testdata family) defends against a raw-string body too -- mirror
+  // that defensiveness here rather than assume the parsed-object case always
+  // holds.
   let body = req.body;
   if (typeof body === 'string') {
     try {
@@ -114,15 +130,29 @@ module.exports = async function (context) {
   // spawned is reported whenever this turn spawned, REGARDLESS of whether
   // the inner dispatch call itself succeeded -- the derivation never fails,
   // only the network call can (see spawnChild's best-effort doc comment).
+  // spawnStatus/spawnBody carry that inner dispatch's own last-observed
+  // outcome (0/"" when nothing was attempted) so a caller-side test failure
+  // can name what actually happened inside the pod, instead of surfacing
+  // only as a generic registry-side 404 after its own timeout.
   let spawned = null;
+  let spawnStatus = 0;
+  let spawnBody = '';
   if (shouldSpawn) {
     const result = await spawnChild(parentRef, STEP_KEY);
     spawned = result.childID;
+    spawnStatus = result.status;
+    spawnBody = result.error ? `<network error: ${result.error}>` : result.body;
   }
 
   return {
     status: 200,
-    body: JSON.stringify({ session: sessionID, parent: parentRef, spawned: spawned }),
+    body: JSON.stringify({
+      session: sessionID,
+      parent: parentRef,
+      spawned: spawned,
+      spawnStatus: spawnStatus,
+      spawnBody: spawnBody,
+    }),
     headers: { 'Content-Type': 'application/json' },
   };
 };

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -1,0 +1,117 @@
+// Agent-runtime spawn-parentage fixture (RFC-0031 slice 5 / parent-graph
+// plan, Task 5). A minimal cousin of
+// demo/agent-boardroom/fixtures/architect.js: on a turn whose JSON body
+// carries {"spawn":true}, it derives ONE child session id for stepKey
+// "expert-1" and dispatches ONE turn to that child on ITSELF (same
+// namespace, same function) with X-Fission-Session set to the derived id and
+// X-Fission-Agent-Parent set to this session's own ParentRef. Every turn
+// (spawn or not) replies 200 with {"session","parent","spawned"}, where
+// "spawned" is the derived child id (or null when this turn did not spawn).
+//
+// spawnSessionID below is the same byte-identical JS twin of
+// pkg/agentruntime/session.go's SpawnSessionID that architect.js carries
+// (see that file's header comment for the pinned fixed-vector this must keep
+// matching: byte-identical derivation is what TestAgentRuntimeSpawnParentage,
+// agentruntime_test.go, actually proves against a real cluster — the Go test
+// computes the SAME id via agentruntime.SpawnSessionID and asserts it equals
+// both the registry record's key AND this fixture's reported "spawned"
+// value).
+//
+// Unlike architect.js, this fixture never reads a state-token file to learn
+// its own namespace: TestAgentRuntimeSpawnParentage already knows its own
+// namespace and function name before creating the function, so it passes
+// both as plain function env vars (--env-var SELF_NAMESPACE=... --env-var
+// SELF_AGENT_NAME=...) instead.
+//
+// Spawn failures are best-effort and never fail this turn's own reply — see
+// architect.js's header comment for the same auth/G16 caveat, which applies
+// identically here (this fixture calls the same full-privilege dispatch
+// route architect.js does).
+
+'use strict';
+
+const crypto = require('crypto');
+
+const SESSION_HEADER = 'x-fission-session'; // express lower-cases header names
+const PARENT_HEADER = 'X-Fission-Agent-Parent';
+const STEP_KEY = 'expert-1';
+
+const SELF_NAMESPACE = process.env.SELF_NAMESPACE || 'default';
+const SELF_AGENT_NAME = process.env.SELF_AGENT_NAME || '';
+
+// DEFAULT_AGENT_RUNTIME_URL mirrors architect.js's constant of the same
+// name: the agentruntime Service's in-cluster DNS name.
+const DEFAULT_AGENT_RUNTIME_URL = 'http://agentruntime.fission:8894';
+const AGENT_RUNTIME_URL = process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
+const AGENT_RUNTIME_TOKEN = process.env.AGENT_RUNTIME_TOKEN || '';
+
+// spawnSessionID is the JS twin of pkg/agentruntime/session.go's
+// SpawnSessionID: 'c-' + the first 32 lowercase hex characters of
+// sha256(parentRef + "/" + stepKey).
+function spawnSessionID(parentRef, stepKey) {
+  const digest = crypto.createHash('sha256').update(parentRef + '/' + stepKey).digest('hex');
+  return 'c-' + digest.slice(0, 32);
+}
+
+function authHeaders() {
+  return AGENT_RUNTIME_TOKEN ? { Authorization: `Bearer ${AGENT_RUNTIME_TOKEN}` } : {};
+}
+
+// spawnChild dispatches ONE turn to the derived child id on this SAME
+// function/namespace, carrying X-Fission-Session (the derived child id) and
+// X-Fission-Agent-Parent (parentRef). Best-effort: a 4xx/5xx or network
+// error is logged to console.error and reflected in the returned status but
+// never thrown -- this turn's own reply is always 200.
+async function spawnChild(parentRef, stepKey) {
+  const childID = spawnSessionID(parentRef, stepKey);
+  const url = `${AGENT_RUNTIME_URL}/agents/${encodeURIComponent(SELF_NAMESPACE)}/${encodeURIComponent(SELF_AGENT_NAME)}`;
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: Object.assign(
+        {
+          'Content-Type': 'application/json',
+          'X-Fission-Session': childID,
+          [PARENT_HEADER]: parentRef,
+        },
+        authHeaders(),
+      ),
+      body: JSON.stringify({}),
+    });
+    if (!res.ok) {
+      console.error(`agentspawn: spawn ${stepKey} (${childID}) failed: HTTP ${res.status}`);
+      return { childID: childID, ok: false, status: res.status };
+    }
+    return { childID: childID, ok: true, status: res.status };
+  } catch (err) {
+    console.error(`agentspawn: spawn ${stepKey} (${childID}) failed: ${err}`);
+    return { childID: childID, ok: false, status: 0, error: String(err) };
+  }
+}
+
+module.exports = async function (context) {
+  const req = context.request;
+  const sessionID = req.headers[SESSION_HEADER] || 'unknown';
+  // Canonical ParentRef form (session.go's ParentRef.String()):
+  // "<namespace>/<agent>/<id>".
+  const parentRef = `${SELF_NAMESPACE}/${SELF_AGENT_NAME}/${sessionID}`;
+
+  const body = req.body;
+  const shouldSpawn = !!(body && typeof body === 'object' && body.spawn === true);
+
+  // spawned is reported whenever this turn spawned, REGARDLESS of whether
+  // the inner dispatch call itself succeeded -- the derivation never fails,
+  // only the network call can (see spawnChild's best-effort doc comment).
+  let spawned = null;
+  if (shouldSpawn) {
+    const result = await spawnChild(parentRef, STEP_KEY);
+    spawned = result.childID;
+  }
+
+  return {
+    status: 200,
+    body: JSON.stringify({ session: sessionID, parent: parentRef, spawned: spawned }),
+    headers: { 'Content-Type': 'application/json' },
+  };
+};


### PR DESCRIPTION
Stacked on the G13 branch (#3703 ← #3701). Implements qualified session parentage and the multi-agent graph substrate: Workflow = the schedule, sessions-with-parent = the operators, statestore CAS admission = the exactly-once identity.

## What

- **Record**: sessions gain an immutable qualified `parent {namespace, agent, id}` + `depth` (set only at creation; SSE/sweeper/diff untouched by construction — immutable fields can't be why a record differs).
- **Dispatcher**: `X-Fission-Agent-Parent` applies only when a turn creates a session. Depth is **never wire-supplied** — it derives from the claimed parent's own persisted record (live keyspace, then archived), capped by `AGENT_MAX_SPAWN_DEPTH` (default 3; explicit 0 = no spawning; 400 past the cap, rejected before any record/quota is minted). A parent unreadable in both keyspaces degrades to root admission (lineage is descriptive, not referential — no dangling-ref policing, no archive cascade).
- **Security (final-review finding, fixed)**: parentage is **same-namespace-only**. The dispatcher resolves depth with its privileged store handle, so honoring a foreign-namespace ref would have made root-degrade-vs-inheritance a cross-tenant session-existence + depth oracle. A foreign ref is now byte-indistinguishable from an unparseable one (guard before any store read; pinned by a pairwise-equality test). Cross-agent parentage within a namespace — the Handoff/Magentic shape — is unaffected.
- **Exactly-once spawn**: `SpawnSessionID(parentRef, stepKey)` = `"c-" + hex(sha256(ref+"/"+stepKey))[:32]` — same parent + stepKey ⇒ same id, so the shipped `Create(IfVersion=0)` is the admission row (`ErrSessionExists` = already admitted = resume). Byte-identical JS twin in the fixtures; the integration test computes the id in Go and fetches exactly that session spawned by the node fixture — cross-language agreement is asserted, not assumed.
- **Surfaces**: `fission agent sessions list --tree` (paginates to exhaustion, explicit `(unknown: <ref>)` nodes, deterministic order); boardroom family tree (children indent under parents, depth badges) + a real bug fixed en route: the polling fallback fetched one page and deleted absent sessions — past 500 sessions it deleted live cards; it now pages to exhaustion with a ceiling, and never runs the delete pass on a partial set. Cycle rendering hardened in both renderers (printed-exactly-once).
- **Demo**: `architect` fixture spawns 3 expert child sessions per turn (best-effort, never fails its own turn); README swarm-beat walkthrough.
- **Integration**: spawn parentage end to end — cross-language id agreement, idempotent re-spawn, root-degrade, live depth-cap 400.

## Notes

- Wake-recreate loses lineage by design (wake carries no parent; recreated session is a root) — the RFC's wake-envelope open item closes as "no". Transient parent-read failures fragment lineage into fresh capped chains rather than extending one; benign for the exhaustion case the cap guards.
- Handler-driven spawn presents the dispatch credential: works under `AGENT_ALLOW_INSECURE` (dev/demo); G16 (per-agent identity) is the gate for secured installs.
- CI note: workflows are main-base-scoped, so this stacked PR gets meta-checks only; the full battery runs when the stack retargets main.

Process: reviewed plan (APPROVE + 3 folded warnings), 5 SDD tasks all PASS/PASS, whole-branch final review (FIX-FIRST: 1 major security + 3 minors), fix round + CLEAN scoped re-review.