### PR TITLE
agentruntime: per-agent identity — HKDF bearer for spawn auth (G16 phase 1)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -29,6 +29,7 @@ linters:
             - "!**/pkg/executor/executortype/poolmgr/gp_pod.go"
             - "!**/pkg/executor/client/client.go"
             - "!**/pkg/executor/executortype/poolmgr/oci_specialize.go"
+            - "!**/pkg/fetcher/agenttoken.go"
             - "!**/pkg/fetcher/config/config.go"
             - "!**/pkg/fetcher/fetcher.go"
             - "!**/pkg/fetcher/statetoken.go"

--- a/charts/fission-all/templates/executor/deployment.yaml
+++ b/charts/fission-all/templates/executor/deployment.yaml
@@ -77,6 +77,13 @@ spec:
         - name: STATESVC_URL
           value: "http://statesvc.{{ .Release.Namespace }}:{{ include "fission.statesvcPort" . }}"
         {{- end }}
+        {{- if .Values.agentRuntime.enabled }}
+        # The executor stamps this URL into agent-identity-bearing function
+        # pods as AGENT_RUNTIME_URL (the dispatch endpoint spawned agents
+        # call home to); unset (feature off) keeps pods byte-identical.
+        - name: AGENT_RUNTIME_URL
+          value: "http://agentruntime.{{ .Release.Namespace }}:{{ include "fission.agentRuntimePort" . }}"
+        {{- end }}
         - name: FETCHER_MINCPU
           value: {{ .Values.fetcher.resource.cpu.requests | quote }}
         - name: FETCHER_MINMEM

--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -148,8 +148,13 @@ What to watch on the `/ui/` board:
   on a `kind`/dev deployment (`AGENT_ALLOW_INSECURE=true`, the default per the Kind quickstart above)
   no token is needed for `architect` to spawn children.
   On an `authentication.enabled` install,
-  set `AGENT_RUNTIME_TOKEN` on the `architect` Function's pod env to a dispatch-scoped bearer token —
-  there is no automatic credential handoff from the architect's own inbound call today.
+  `architect` spawns children with its own injected identity —
+  the fetcher writes a per-agent credential to the pod at specialize time,
+  and `architect.js` sends it automatically on every spawn dispatch.
+  No manual token provisioning is needed;
+  `AGENT_RUNTIME_TOKEN` remains a fallback for the one non-default install shape
+  (`authentication.enabled` with `internalAuth.enabled=false`)
+  where the injected credential is a placeholder.
 
 ## Demo beats checklist
 

--- a/demo/agent-boardroom/fixtures/architect.js
+++ b/demo/agent-boardroom/fixtures/architect.js
@@ -109,7 +109,10 @@ if (STATE_URL && TOKEN_PATH) {
   try {
     stateCreds = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
   } catch (err) {
-    console.error(`architect: could not read state token file ${TOKEN_PATH}: ${err}`);
+    // err.code/err.name only: a raw JSON.parse SyntaxError embeds a source
+    // snippet, and the token is the last field in the file (same leak class
+    // the agent-credentials read below guards against).
+    console.error(`architect: could not read state token file ${TOKEN_PATH}: ${err.code || err.name}`);
   }
 }
 

--- a/demo/agent-boardroom/fixtures/architect.js
+++ b/demo/agent-boardroom/fixtures/architect.js
@@ -28,16 +28,18 @@
 //   parent = {namespace:"ns", agent:"a", id:"sess-1"}, stepKey = "step-1"
 //   => "c-27304abfe9308ae9849ace27841bc098"
 //
-// Auth (G16 gate): the dispatch route this fixture calls is the SAME
+// Auth (G16 gate LIFTED): the dispatch route this fixture calls is the SAME
 // full-privilege POST /agents/{ns}/{name} route any external caller uses,
 // gated by JWT_SIGNING_KEY / AGENT_ALLOW_INSECURE (pkg/agentruntime/main.go).
-// A running function pod holds no per-agent identity of its own today (that
-// is the still-open G16 gap the RFC tracks) -- it can only spawn children if
-// EITHER the cluster runs the agent runtime with AGENT_ALLOW_INSECURE=true
-// (the kind/demo default, see ../README.md's Kind quickstart) OR the
-// deployer threads a real dispatch-scoped bearer token into this pod via
-// AGENT_RUNTIME_TOKEN. There is no automatic credential handoff from the
-// architect's OWN inbound call to its outbound spawn calls.
+// This pod now carries its OWN per-agent identity: the fetcher writes a
+// {namespace, agent, token} credential to the file FISSION_AGENT_TOKEN_PATH
+// points at (pkg/fetcher/agenttoken.go) at specialize time, and this fixture
+// sends it on every spawn dispatch as Authorization: Bearer <token> plus the
+// X-Fission-Agent-Auth-Namespace / X-Fission-Agent-Auth-Name claims headers
+// (pkg/agentruntime/identity.go) -- an automatic credential handoff from the
+// architect's OWN inbound specialization to its outbound spawn calls, no
+// manual provisioning required. See readAgentCredentials()/authHeaders()
+// below for the fallback order and the dev-placeholder edge case.
 //
 // Spawn failures are best-effort and never fail the architect's own turn: a
 // child dispatch returning 4xx/5xx (or a network error) is logged to
@@ -70,16 +72,29 @@ const K_EXPERTS = 3;
 // "agentruntime" in the fission namespace, port from
 // `fission.agentRuntimePort`, 8894 by default) -- reachable from this pod
 // because the agentruntime NetworkPolicy is deliberately permissive on that
-// port for any in-cluster caller (see that chart's networkpolicy.yaml).
+// port for any in-cluster caller (see that chart's networkpolicy.yaml). It
+// is correct only for install-namespace "fission", which is why the executor
+// now injects the real URL as FISSION_AGENT_RUNTIME_URL
+// (pkg/executor/util/agentenv.go) -- prefer that; the legacy AGENT_RUNTIME_URL
+// manual override and this hardcoded default remain as fallbacks.
 const DEFAULT_AGENT_RUNTIME_URL = 'http://agentruntime.fission:8894';
-const AGENT_RUNTIME_URL = process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
-// AGENT_RUNTIME_TOKEN is optional (see the G16 auth note above): absent
-// means this fixture relies on the cluster's AGENT_ALLOW_INSECURE dev-mode
-// pass-through rather than sending an Authorization header at all.
+const AGENT_RUNTIME_URL =
+  process.env.FISSION_AGENT_RUNTIME_URL || process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
+// AGENT_RUNTIME_TOKEN is the pre-G16 manual-provisioning fallback (see
+// authHeaders() below): a plain bearer with no claims headers, used only
+// when the fetcher-written identity file is absent or carries the dev
+// placeholder.
 const AGENT_RUNTIME_TOKEN = process.env.AGENT_RUNTIME_TOKEN || '';
 
 const STATE_URL = process.env.FISSION_STATE_URL || '';
 const TOKEN_PATH = process.env.FISSION_STATE_TOKEN_PATH || '';
+
+// AGENT_TOKEN_PATH is the G16 identity file the executor points at via
+// FISSION_AGENT_TOKEN_PATH (pkg/executor/util/agentenv.go), written by the
+// fetcher at specialize time (pkg/fetcher/agenttoken.go). Deliberately a
+// SEPARATE env var and file from the state-token pair above: agent identity
+// must not require State to be enabled.
+const AGENT_TOKEN_PATH = process.env.FISSION_AGENT_TOKEN_PATH || '';
 
 // stateCreds is read the same way support-desk.js reads it (RFC-0023's
 // fetcher-written token file at specialize time), used ONLY to learn this
@@ -99,8 +114,42 @@ if (STATE_URL && TOKEN_PATH) {
 }
 
 function ownNamespace() {
-  return (stateCreds && stateCreds.namespace) || 'default';
+  // agentCreds.namespace is a valid fallback here even when its token is the
+  // dev placeholder (authHeaders() skips the placeholder for AUTH purposes
+  // only) -- the namespace claim itself is always the real one the fetcher
+  // wrote, and identity.go's verify() requires the spawn URL's {namespace}
+  // to equal the claims header, so falling back to 'default' here on a
+  // non-default-namespace secured install would 403 every spawn even with a
+  // perfectly valid token.
+  return (stateCreds && stateCreds.namespace) || (agentCreds && agentCreds.namespace) || 'default';
 }
+
+// DEV_PLACEHOLDER_TOKEN is the fetcher's un-derived stand-in
+// (pkg/fetcher/agenttoken.go writeAgentTokenFile): written when the fetcher
+// itself has no FISSION_INTERNAL_AUTH_SECRET, so it never verifies as a real
+// identity token. Preferring it anyway would matter on one non-default
+// install shape: authentication.enabled but internalAuth.enabled=false, where
+// the file carries the placeholder and file-first-always would 401 where a
+// manually-provisioned AGENT_RUNTIME_TOKEN JWT would have worked -- so
+// authHeaders() below falls through to the env token in that case instead.
+const DEV_PLACEHOLDER_TOKEN = 'dev-unauthenticated';
+
+// readAgentCredentials mirrors the stateCreds read above (a fetcher-written
+// JSON file at specialize time), read once at module load -- not per spawn
+// call -- and cached in agentCreds below.
+function readAgentCredentials(path) {
+  if (!path) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch (err) {
+    console.error(`architect: could not read agent identity token file ${path}: ${err}`);
+    return null;
+  }
+}
+
+const agentCreds = readAgentCredentials(AGENT_TOKEN_PATH);
 
 // spawnSessionID is the JS twin of pkg/agentruntime/session.go's
 // SpawnSessionID: 'c-' + the first 32 lowercase hex characters of
@@ -111,7 +160,22 @@ function spawnSessionID(parentRef, stepKey) {
   return 'c-' + digest.slice(0, 32);
 }
 
+// authHeaders picks the spawn-call credential in preference order:
+//  1. The fetcher-written identity file (agentCreds), sent as
+//     Authorization: Bearer <token> plus the two claims headers -- but ONLY
+//     when its token is not DEV_PLACEHOLDER_TOKEN (see that constant's
+//     comment for the install shape this guards).
+//  2. AGENT_RUNTIME_TOKEN, sent as a plain bearer with no claims headers
+//     (the pre-G16 manual-provisioning fallback).
+//  3. No auth -- relies on the cluster's AGENT_ALLOW_INSECURE pass-through.
 function authHeaders() {
+  if (agentCreds && agentCreds.token && agentCreds.token !== DEV_PLACEHOLDER_TOKEN) {
+    return {
+      Authorization: `Bearer ${agentCreds.token}`,
+      'X-Fission-Agent-Auth-Namespace': agentCreds.namespace,
+      'X-Fission-Agent-Auth-Name': agentCreds.agent,
+    };
+  }
   return AGENT_RUNTIME_TOKEN ? { Authorization: `Bearer ${AGENT_RUNTIME_TOKEN}` } : {};
 }
 

--- a/demo/agent-boardroom/fixtures/architect.js
+++ b/demo/agent-boardroom/fixtures/architect.js
@@ -144,7 +144,11 @@ function readAgentCredentials(path) {
   try {
     return JSON.parse(fs.readFileSync(path, 'utf8'));
   } catch (err) {
-    console.error(`architect: could not read agent identity token file ${path}: ${err}`);
+    // Log err.code/err.name only: a mid-token corrupt-file parse failure
+    // embeds a source snippet in err.message (V8 JSON.parse SyntaxError),
+    // and the token is the last field of this JSON -- stringifying err
+    // could leak token bytes into pod logs.
+    console.error(`architect: could not read agent identity token file ${path}: ${err.code || err.name}`);
     return null;
   }
 }

--- a/demo/agent-boardroom/fixtures/support-desk.js
+++ b/demo/agent-boardroom/fixtures/support-desk.js
@@ -97,7 +97,9 @@ if (STATE_URL && TOKEN_PATH) {
   try {
     stateCreds = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
   } catch (err) {
-    console.error(`support-desk: could not read state token file ${TOKEN_PATH}: ${err}`);
+    // err.code/err.name only: a raw JSON.parse SyntaxError embeds a source
+    // snippet, and the token is the last field in the file.
+    console.error(`support-desk: could not read state token file ${TOKEN_PATH}: ${err.code || err.name}`);
   }
 }
 

--- a/pkg/agentruntime/identity.go
+++ b/pkg/agentruntime/identity.go
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// identity.go implements the G16 agent-identity bearer verification on the
+// dispatch route ONLY (POST /agents/{namespace}/{name}) — a second,
+// exclusive auth path alongside authz.go's JWT verification, for a pod's own
+// spawn/dispatch calls carrying the HKDF-derived token Task 1
+// (DeriveAgentIdentityKey, pkg/auth/hmac/keys.go) and Task 2 (the fetcher's
+// .fission-agent-token file) produced. It never reaches the registry/SSE
+// routes: IdentityOrJWT is wired onto the dispatch mount only (main.go).
+package agentruntime
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+const (
+	// HeaderIdentityNamespace and HeaderIdentityName carry the CLAIMED
+	// (namespace, agent) identity of a pod-side bearer token: the
+	// Authorization header carries the derived token itself, and verification
+	// recomputes DeriveAgentIdentityKey from exactly these claims and
+	// compares — the same claims-ride-beside-the-token shape as statesvc's
+	// bearer channel (pkg/statesvc/auth.go, stateapi.HeaderNamespace/
+	// HeaderKeyspace). The presence of either header (not the Authorization
+	// scheme) selects the identity verification path on the dispatch route
+	// EXCLUSIVELY — see IdentityOrJWT. Named alongside the dispatcher's own
+	// X-Fission-Agent-* header family (dispatcher.go:37-74) but distinct in
+	// kind: those are turn-protocol headers forwarded to/from the function;
+	// these two are AUTHENTICATION claims consumed here and never proxied
+	// upstream.
+	HeaderIdentityNamespace = "X-Fission-Agent-Auth-Namespace"
+	HeaderIdentityName      = "X-Fission-Agent-Auth-Name"
+)
+
+// IdentityVerifier verifies the G16 agent-identity bearer against BOTH the
+// active and rotation-old FISSION_INTERNAL_AUTH_SECRET masters. master and
+// masterOld are RAW — read as []byte(os.Getenv(...)) exactly like every
+// other master-secret consumer (hmacauth.ServiceSigner/ServiceVerifier,
+// fetcher/statetoken.go, fetcher/agenttoken.go) — never
+// hmacauth.DecodeKeyFromEnv, which reverses EncodeKeyForEnv for an
+// already-DERIVED key read back from an env var; applying it to the raw
+// master here would silently re-hex-decode a secret that was never
+// hex-encoded in the first place and change what every derivation produces.
+//
+// view is the live AgentView (Task-independent, view.go): Lookup is the
+// revocation check — a token that derives correctly for a deleted or
+// never-existing agent is still rejected, because the view holds only
+// Agent-enabled Functions the reconciler currently knows about.
+type IdentityVerifier struct {
+	master, masterOld []byte
+	view              *AgentView
+}
+
+// NewIdentityVerifier returns a verifier over the given masters and view.
+func NewIdentityVerifier(master, masterOld []byte, view *AgentView) *IdentityVerifier {
+	return &IdentityVerifier{master: master, masterOld: masterOld, view: view}
+}
+
+// verify implements the identity path's five checks, in order, writing the
+// HTTP error response itself and returning false on the first one that
+// fails; true means the caller is authorized to proceed straight to next.
+//
+//  1. Parse the bearer token. Empty (missing header, non-Bearer scheme, or
+//     an empty token) -> 401.
+//  2. Both masters unset -> 401 with an operator-actionable message: this is
+//     the misconfig row of the truth table (JWT auth is on but the internal
+//     secret the identity channel depends on never got wired in), distinct
+//     from "identity is not in use here" (that case never reaches verify —
+//     see IdentityOrJWT).
+//  3. Constant-time compare against BOTH masters' derivations, mirroring
+//     statesvc's verifyKeyspaceToken (pkg/statesvc/auth.go:65-77): both
+//     comparisons always run (ok |=, never short-circuited) so which master
+//     matched is not observable via timing. Failure -> 401.
+//  4. Revocation check AFTER the compare, not before: view.Lookup so an
+//     invalid-token holder never learns whether the claimed agent exists.
+//     Missing -> 401.
+//  5. Inline authorization — the plan-review blocker this file exists for:
+//     the claimed namespace must equal the dispatch path's {namespace} (set
+//     by the outer mux before this wrapper runs). The claimed AGENT
+//     identifies the CALLER, not the target: dispatch to a different agent
+//     in the SAME namespace is the spawn shape (architect -> support-desk)
+//     and is allowed. Mismatch -> 403.
+func (v *IdentityVerifier) verify(w http.ResponseWriter, r *http.Request) bool {
+	claimedNS := r.Header.Get(HeaderIdentityNamespace)
+	claimedAgent := r.Header.Get(HeaderIdentityName)
+
+	token, isBearer := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if !isBearer || token == "" {
+		http.Error(w, "missing agent identity bearer token", http.StatusUnauthorized)
+		return false
+	}
+
+	if len(v.master) == 0 && len(v.masterOld) == 0 {
+		http.Error(w, "agent identity requires FISSION_INTERNAL_AUTH_SECRET on the agent runtime", http.StatusUnauthorized)
+		return false
+	}
+
+	ok := 0
+	for _, master := range [][]byte{v.master, v.masterOld} {
+		if len(master) == 0 {
+			continue
+		}
+		want := hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, claimedNS, claimedAgent))
+		ok |= subtle.ConstantTimeCompare([]byte(token), []byte(want))
+	}
+	if ok != 1 {
+		http.Error(w, "invalid agent identity token", http.StatusUnauthorized)
+		return false
+	}
+
+	if _, live := v.view.Lookup(claimedNS, claimedAgent); !live {
+		http.Error(w, "invalid agent identity token", http.StatusUnauthorized)
+		return false
+	}
+
+	if claimedNS != r.PathValue("namespace") {
+		http.Error(w, "forbidden: agent identity token not authorized for this namespace", http.StatusForbidden)
+		return false
+	}
+
+	return true
+}
+
+// IdentityOrJWT wraps next with the dispatch route's dual auth: the identity
+// path when identity is non-nil and the request carries either identity
+// claim header, otherwise the existing jwt middleware unchanged.
+//
+// identity is nil exactly when the JWT signing key is unset (allowInsecure
+// dev mode) — main.go only constructs an IdentityVerifier when
+// authz.Enabled(). That is what makes the allowInsecure row of the truth
+// table hold without IdentityOrJWT needing any other signal of its own: with
+// identity == nil the returned handler is jwt(next) and nothing else, so it
+// is a bytewise no-op passthrough exactly as today (authz.HTTPMiddleware
+// returns next unwrapped when the key is empty, authz.go:85-90) — a request
+// carrying identity headers with the fetcher's "dev-unauthenticated"
+// placeholder token (agenttoken.go) never reaches identity verification at
+// all, and so cannot be 401'd by the "no master secret configured" check.
+//
+// When identity is non-nil, the two credential channels are mutually
+// exclusive by construction: identity headers present selects verify()
+// EXCLUSIVELY — success calls next.ServeHTTP directly (bypassing jwt
+// entirely, even when the request also carries an Authorization: Bearer JWT
+// — identity wins), and failure returns the identity path's own error
+// response with NO fallback to jwt (falling back would let an attacker
+// downgrade a rejected identity token to a JWT check by also supplying a
+// stolen or forged bearer). Identity headers absent delegates unchanged to
+// jwt(next), built once here rather than per-request.
+func IdentityOrJWT(identity *IdentityVerifier, jwt func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		jwtHandler := jwt(next)
+		if identity == nil {
+			return jwtHandler
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get(HeaderIdentityNamespace) == "" && r.Header.Get(HeaderIdentityName) == "" {
+				jwtHandler.ServeHTTP(w, r)
+				return
+			}
+			if identity.verify(w, r) {
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}

--- a/pkg/agentruntime/identity_test.go
+++ b/pkg/agentruntime/identity_test.go
@@ -1,0 +1,357 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// identity_test.go drives every row of the design spec's auth truth table
+// through IdentityOrJWT wrapping the real Authorizer.Middleware, with real
+// HKDF-derived tokens (hmacauth.DeriveAgentIdentityKey) — the same shape
+// main_route_test.go uses for the JWT-only route, extended to the identity
+// channel.
+package agentruntime
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// identityToken derives and hex-encodes the G16 agent-identity bearer for
+// (ns, agent) under master — exactly what the fetcher's agenttoken.go writes
+// to the pod-side credential file.
+func identityToken(master []byte, ns, agent string) string {
+	return hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, ns, agent))
+}
+
+// newIdentityRequest builds a POST /agents/{pathNS}/{pathName} request with
+// the {namespace}/{name} path values set as the outer mux would, carrying
+// the identity claim headers (claimedNS, claimedAgent) and an
+// Authorization: Bearer <bearer> header. An empty claimedNS/claimedAgent
+// (both) omits the identity headers entirely.
+func newIdentityRequest(pathNS, pathName, claimedNS, claimedAgent, bearer string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/agents/"+pathNS+"/"+pathName, nil)
+	r.SetPathValue("namespace", pathNS)
+	r.SetPathValue("name", pathName)
+	if claimedNS != "" {
+		r.Header.Set(HeaderIdentityNamespace, claimedNS)
+	}
+	if claimedAgent != "" {
+		r.Header.Set(HeaderIdentityName, claimedAgent)
+	}
+	if bearer != "" {
+		r.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	return r
+}
+
+// TestIdentityOrJWT_AllowInsecurePassthrough covers truth-table row 1: JWT
+// key unset -> the whole wrapper is a no-op passthrough, including a request
+// carrying identity headers with the fetcher's "dev-unauthenticated"
+// placeholder token (agenttoken.go) — it must NOT 401.
+func TestIdentityOrJWT_AllowInsecurePassthrough(t *testing.T) {
+	t.Parallel()
+	authz := NewAuthorizer(nil) // JWT key unset
+	require.False(t, authz.Enabled())
+
+	// main.go's own rule: identity is nil exactly when authz is disabled.
+	handler := IdentityOrJWT(nil, authz.Middleware)(okHandler())
+
+	t.Run("no headers at all", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "", "", ""))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("dev-unauthenticated placeholder with identity headers", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "ns-a", "caller-agent", "dev-unauthenticated"))
+		assert.Equal(t, http.StatusOK, w.Code, "allowInsecure must pass through even with identity headers present")
+	})
+
+	t.Run("identity headers with a real-looking but bogus token", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "ns-a", "caller-agent", "deadbeef"))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+}
+
+// TestIdentityOrJWT_HeadersAbsentDelegatesToJWT covers truth-table row 5:
+// identity headers absent -> the existing JWT path, byte-identical to
+// authz.Middleware alone (TestMiddleware in authz_test.go already proves
+// Middleware's own behavior; this proves IdentityOrJWT doesn't change it).
+func TestIdentityOrJWT_HeadersAbsentDelegatesToJWT(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	validTok := mintToken(t, key, jwt.MapClaims{
+		"sub": "caller-1", "allowed_namespaces": []any{"ns-a"},
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	t.Run("valid JWT, no identity headers, passes", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "", "", validTok))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("missing bearer, no identity headers, 401", func(t *testing.T) {
+		t.Parallel()
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "", "", ""))
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
+	})
+}
+
+// TestIdentityOrJWT_MissingOrMalformedBearerRejected covers the identity
+// path's own step 1 (verify's doc comment): identity headers present but no
+// usable bearer token — no Authorization header at all, a non-Bearer scheme,
+// or an empty token after the prefix — is 401, and never reaches the
+// constant-time compare (there is nothing to compare). Also pins the
+// deliberate either-header-present fail-closed choice: a request with only
+// ONE of the two claim headers set still takes the identity path (and is
+// rejected, rather than silently falling back to JWT).
+func TestIdentityOrJWT_MissingOrMalformedBearerRejected(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "caller-agent", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	tests := []struct {
+		name string
+		req  *http.Request
+	}{
+		{
+			name: "identity headers present, no Authorization header at all",
+			req:  newIdentityRequest("ns-a", "fn", "ns-a", "caller-agent", ""),
+		},
+		{
+			name: "identity headers present, non-Bearer scheme",
+			req: func() *http.Request {
+				r := newIdentityRequest("ns-a", "fn", "ns-a", "caller-agent", "")
+				r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+				return r
+			}(),
+		},
+		{
+			name: "only the namespace claim header set",
+			req: func() *http.Request {
+				r := httptest.NewRequest(http.MethodPost, "/agents/ns-a/fn", nil)
+				r.SetPathValue("namespace", "ns-a")
+				r.SetPathValue("name", "fn")
+				r.Header.Set(HeaderIdentityNamespace, "ns-a")
+				return r
+			}(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, tt.req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}
+
+// TestIdentityOrJWT_ValidIdentityDispatches covers truth-table row 2: a
+// valid, live-agent identity token scoped to the path's namespace dispatches
+// straight through — identity headers present is sufficient; no
+// Authorization: Bearer JWT is needed at all.
+func TestIdentityOrJWT_ValidIdentityDispatches(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	// The revocation check looks up the CALLER's claimed identity
+	// (caller-agent), not the dispatch target (target-fn) — the two are
+	// deliberately different names here to make that distinction obvious.
+	view.Upsert(headerEntry("ns-a", "caller-agent", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	tok := identityToken(master, "ns-a", "caller-agent")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newIdentityRequest("ns-a", "target-fn", "ns-a", "caller-agent", tok))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// TestIdentityOrJWT_OldMasterAcceptance: a token derived from masterOld
+// (rotation) still verifies, mirroring statesvc's dual-master acceptance.
+func TestIdentityOrJWT_OldMasterAcceptance(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("new-master")
+	masterOld := []byte("old-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "caller-agent", 0))
+	identity := NewIdentityVerifier(master, masterOld, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	tok := identityToken(masterOld, "ns-a", "caller-agent")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newIdentityRequest("ns-a", "target-fn", "ns-a", "caller-agent", tok))
+	assert.Equal(t, http.StatusOK, w.Code, "a token derived from the OLD (rotation) master must still verify")
+}
+
+// TestIdentityOrJWT_DeadAgentRejected: the token derives correctly (a valid
+// signature over the claimed namespace/agent) but the agent is absent from
+// the live view (deleted, or never existed) -> 401, not 200.
+func TestIdentityOrJWT_DeadAgentRejected(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView() // empty: no agent registered
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	tok := identityToken(master, "ns-a", "ghost-agent")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newIdentityRequest("ns-a", "target-fn", "ns-a", "ghost-agent", tok))
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "a correctly-derived token for a dead/nonexistent agent must be rejected")
+}
+
+// TestIdentityOrJWT_MismatchedClaimsRejected: the claim headers name one
+// (namespace, agent) but the presented token was derived for a different
+// one — the constant-time compare fails, 401, no fallback.
+func TestIdentityOrJWT_MismatchedClaimsRejected(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "target-fn", 0))
+	view.Upsert(headerEntry("ns-a", "other-agent", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	// Token is actually derived for "other-agent", but the claim headers say
+	// "caller-agent".
+	tok := identityToken(master, "ns-a", "other-agent")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newIdentityRequest("ns-a", "target-fn", "ns-a", "caller-agent", tok))
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestIdentityOrJWT_CrossNamespaceForbidden is the plan-review blocker: a
+// valid token for (nsA, agentX) must not authorize dispatch into a different
+// namespace's path, even though the token verifies and the agent is live.
+func TestIdentityOrJWT_CrossNamespaceForbidden(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	w := httptest.NewRecorder()
+	// Path namespace is ns-b; the token/claims are for ns-a.
+	handler.ServeHTTP(w, newIdentityRequest("ns-b", "some-fn", "ns-a", "agent-x", tok))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// TestIdentityOrJWT_SameNamespaceCrossAgentAllowed is the spawn shape: a
+// valid token identifying the CALLER (nsA, agentX) dispatching to a
+// DIFFERENT agent in the same namespace (nsA, agentY) must be allowed — the
+// claimed agent name identifies who is calling, not who may be dispatched
+// to.
+func TestIdentityOrJWT_SameNamespaceCrossAgentAllowed(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	view.Upsert(headerEntry("ns-a", "agent-y", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	w := httptest.NewRecorder()
+	// Dispatch path targets agent-y; the caller's identity is agent-x.
+	handler.ServeHTTP(w, newIdentityRequest("ns-a", "agent-y", "ns-a", "agent-x", tok))
+	assert.Equal(t, http.StatusOK, w.Code, "dispatch to a different agent in the same namespace is the spawn shape and must be allowed")
+}
+
+// TestIdentityOrJWT_MasterUnsetMisconfig covers truth-table row 4: JWT is
+// enabled but no internal master secret is configured on either the active
+// or rotation slot -> 401 with an operator-actionable message, regardless of
+// what token/claims the request carries.
+func TestIdentityOrJWT_MasterUnsetMisconfig(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "caller-agent", 0))
+	identity := NewIdentityVerifier(nil, nil, view) // both masters unset
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "ns-a", "caller-agent", "anything"))
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.Contains(t, w.Body.String(), "FISSION_INTERNAL_AUTH_SECRET", "the misconfig response must name the env var an operator needs to set")
+}
+
+// TestIdentityOrJWT_BothCredentialsPresentIdentityWins covers the design
+// spec's explicit both-present case: identity headers select the identity
+// path exclusively, so a valid identity token dispatches successfully even
+// though the same Authorization value is not a valid JWT (proving no JWT
+// verification ever ran) — and conversely, an otherwise-valid JWT bearer is
+// never consulted once identity headers are present, even when the identity
+// token itself is invalid (proving no fallback).
+func TestIdentityOrJWT_BothCredentialsPresentIdentityWins(t *testing.T) {
+	t.Parallel()
+	key := []byte("test-signing-key")
+	master := []byte("test-internal-master")
+	authz := NewAuthorizer(key)
+	view := NewAgentView()
+	view.Upsert(headerEntry("ns-a", "caller-agent", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	handler := IdentityOrJWT(identity, authz.Middleware)(okHandler())
+
+	t.Run("valid identity token (not a valid JWT) dispatches", func(t *testing.T) {
+		t.Parallel()
+		tok := identityToken(master, "ns-a", "caller-agent")
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "target-fn", "ns-a", "caller-agent", tok))
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("valid JWT bearer ignored when identity headers present and identity invalid", func(t *testing.T) {
+		t.Parallel()
+		validJWT := mintToken(t, key, jwt.MapClaims{
+			"sub": "caller-1", "allowed_namespaces": []any{"ns-a"},
+			"exp": time.Now().Add(time.Hour).Unix(),
+		})
+		w := httptest.NewRecorder()
+		// The Authorization header carries a well-formed, validly-signed JWT
+		// scoped to ns-a — if IdentityOrJWT fell back to jwt(next) on identity
+		// failure, this would be admitted (200). It must not be.
+		handler.ServeHTTP(w, newIdentityRequest("ns-a", "target-fn", "ns-a", "caller-agent", validJWT))
+		assert.Equal(t, http.StatusUnauthorized, w.Code, "a valid JWT must never rescue a failed identity check")
+	})
+}

--- a/pkg/agentruntime/identity_test.go
+++ b/pkg/agentruntime/identity_test.go
@@ -115,6 +115,22 @@ func TestIdentityOrJWT_HeadersAbsentDelegatesToJWT(t *testing.T) {
 		handler.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "", "", ""))
 		assert.Equal(t, http.StatusUnauthorized, w.Code)
 	})
+
+	// Row 5 also covers the masters-empty case: the headers-absent branch
+	// must short-circuit to the JWT path before it ever looks at the master
+	// secret(s), so a misconfigured (mastersless) install still serves plain
+	// JWT-authenticated traffic that never presents identity headers — only
+	// a request that DOES present identity headers hits the row-4 misconfig
+	// 401 (TestIdentityOrJWT_MasterUnsetMisconfig).
+	t.Run("both masters unset, no identity headers, valid JWT still passes", func(t *testing.T) {
+		t.Parallel()
+		identityNoMasters := NewIdentityVerifier(nil, nil, view) // both masters unset
+		handlerNoMasters := IdentityOrJWT(identityNoMasters, authz.Middleware)(okHandler())
+
+		w := httptest.NewRecorder()
+		handlerNoMasters.ServeHTTP(w, newIdentityRequest("ns-a", "fn", "", "", validTok))
+		assert.Equal(t, http.StatusOK, w.Code, "the headers-absent branch must never consult the masters")
+	})
 }
 
 // TestIdentityOrJWT_MissingOrMalformedBearerRejected covers the identity

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -446,6 +446,15 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		return fmt.Errorf("refusing to start agent runtime without authentication: set JWT_SIGNING_KEY to scope agent access, or %s=true to explicitly run the endpoint unauthenticated (dev only)", envAllowInsecure)
 	}
 
+	// The G16 agent-identity bearer (IdentityOrJWT, identity.go) is the
+	// dispatch route's second, exclusive auth path for a pod's own spawn/
+	// dispatch calls. Read RAW here (never hmacauth.DecodeKeyFromEnv, which
+	// is for already-derived keys) — see IdentityVerifier's doc comment.
+	// identityMaster/identityMasterOld are only ever consulted when authz is
+	// Enabled(): see identityVerifier below.
+	identityMaster := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET"))
+	identityMasterOld := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET_OLD"))
+
 	// Invocations go to the router internal listener, signed exactly like the
 	// other publishers (timer/mqtrigger/workflow/mcp).
 	var rt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(dispatcherMaxIdleConnsPerHost))
@@ -618,11 +627,25 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		}
 		w.WriteHeader(http.StatusOK)
 	})
+	// identityVerifier is constructed only when authz.Enabled(): a nil
+	// IdentityVerifier is what makes IdentityOrJWT's allowInsecure row a
+	// bytewise no-op passthrough (see IdentityOrJWT's doc comment) —
+	// identity headers must never be consulted, let alone 401 a caller over
+	// a missing internal secret, when the whole endpoint is running
+	// unauthenticated.
+	var identityVerifier *IdentityVerifier
+	if authz.Enabled() {
+		identityVerifier = NewIdentityVerifier(identityMaster, identityMasterOld, view)
+	}
+
 	// The pattern here matches Dispatcher.Handler()'s own registration
 	// exactly: the outer mux performs the {namespace}/{name} match (and sets
-	// the path values authz.Middleware reads) before calling into the
-	// auth-wrapped dispatcher, which then matches the same pattern again.
-	mux.Handle("POST /agents/{namespace}/{name}", authz.Middleware(dispatcher.Handler()))
+	// the path values authz.Middleware / IdentityOrJWT's identity path read)
+	// before calling into the auth-wrapped dispatcher, which then matches the
+	// same pattern again. IdentityOrJWT is the dispatch route's ONLY mount —
+	// registry/SSE routes below stay on authz.Middleware/HTTPMiddleware
+	// directly, so the identity bearer never reaches them.
+	mux.Handle("POST /agents/{namespace}/{name}", IdentityOrJWT(identityVerifier, authz.Middleware)(dispatcher.Handler()))
 
 	// Registry read API: GET /registry/agents carries no
 	// {namespace} path value, so it is mounted behind authz.HTTPMiddleware

--- a/pkg/agentruntime/main_route_test.go
+++ b/pkg/agentruntime/main_route_test.go
@@ -25,6 +25,78 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// TestDispatchRouteIdentityComposition mounts the dispatch route exactly as
+// main.go wires it post-Task-3 — IdentityOrJWT(identity, authz.Middleware)
+// (dispatcher.Handler()), not authz.Middleware alone — and proves a valid
+// G16 identity bearer reaches the upstream function through the real mux,
+// the same falsifiable upstream-hit-counter signal
+// TestDispatchRouteAuthComposition uses for the JWT path.
+func TestDispatchRouteIdentityComposition(t *testing.T) {
+	t.Parallel()
+	key := []byte("route-composition-identity-key")
+	master := []byte("route-composition-identity-master")
+
+	var upstreamHits atomic.Int64
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamHits.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(upstream.Close)
+
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	// "fn" is both the dispatch target (the {name} path value) and the
+	// caller's own claimed identity here: the dispatcher's own path lookup
+	// and the identity revocation check both need a live view entry, and
+	// self-dispatch (an agent turn-chaining into itself) is a real shape, so
+	// one registered agent covers both.
+	view.Upsert(headerEntry("ns-a", "fn", 0))
+	authz := NewAuthorizer(key)
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mux.Handle("POST /agents/{namespace}/{name}", IdentityOrJWT(identity, authz.Middleware)(d.Handler()))
+
+	tok := identityToken(master, "ns-a", "fn")
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns-a/fn", strings.NewReader("hello"))
+	req.Header.Set(HeaderIdentityNamespace, "ns-a")
+	req.Header.Set(HeaderIdentityName, "fn")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.EqualValues(t, 1, upstreamHits.Load())
+}
+
+// TestRegistryRouteRejectsIdentityBearer proves identity never reaches a
+// registry route: GET /registry/agents is mounted (as main.go does) behind
+// plain authz.HTTPMiddleware, never IdentityOrJWT — so a request carrying
+// the identity claim headers plus a validly-derived G16 bearer is still
+// 401'd, because that bearer is not a JWT and the registry route only ever
+// verifies JWTs.
+func TestRegistryRouteRejectsIdentityBearer(t *testing.T) {
+	t.Parallel()
+	key := []byte("registry-route-key")
+	master := []byte("registry-route-master")
+	authz := NewAuthorizer(key)
+
+	mux := http.NewServeMux()
+	mux.Handle("GET /registry/agents", authz.HTTPMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})))
+
+	tok := identityToken(master, "ns-a", "caller-agent")
+	req := httptest.NewRequest(http.MethodGet, "/registry/agents", nil)
+	req.Header.Set(HeaderIdentityNamespace, "ns-a")
+	req.Header.Set(HeaderIdentityName, "caller-agent")
+	req.Header.Set("Authorization", "Bearer "+tok)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code, "a G16 identity bearer must never authenticate a registry route")
+}
+
 // TestDispatchRouteAuthComposition asserts the triple the brief calls the
 // highest-value coverage for the dispatch route: a correctly-scoped token
 // reaches the upstream function (200), a wrong-namespace token is rejected

--- a/pkg/auth/hmac/keys.go
+++ b/pkg/auth/hmac/keys.go
@@ -194,6 +194,28 @@ func DeriveStateKeyspaceKey(master []byte, namespace, keyspace string) []byte {
 	return deriveKey(master, KeyVersion+":"+string(ServiceStateAPI)+":"+namespace+":"+keyspace)
 }
 
+// DeriveAgentIdentityKey derives the per-agent identity bearer credential (G16):
+// a bespoke chain — NOT an extension of DeriveStateKeyspaceKey or any
+// ServiceXxx channel — with info string "<KeyVersion>:agentident:<namespace>:<agent>".
+// The distinct "agentident" tag makes collision with every other channel
+// structural rather than incidental: DeriveServiceKey/DeriveServiceKeyNS stop
+// after "<service>"/"<service>:<ns>" and never contain "agentident", and
+// DeriveStateKeyspaceKey's info string carries "stateapi" in the same
+// position this one carries "agentident" — so even the same (namespace, agent)
+// pair fed to both chains derives unrelated keys, by construction, not by
+// coincidence of field values. Within the chain, namespace and agent are both
+// Kubernetes DNS labels, which cannot contain ':', so the two-colon-joined
+// tail cannot be re-split ambiguously (no "a:b" vs "a", "b" splice).
+//
+// Verification is stateless: agentruntime re-derives from the claimed
+// (namespace, agent) and the master(s) it holds and compares — the same
+// pattern as DeriveStateKeyspaceKey/statesvc. Transport to a pod must go
+// through EncodeKeyForEnv. Returns nil for an empty master, like every other
+// derivation in this file.
+func DeriveAgentIdentityKey(master []byte, namespace, agent string) []byte {
+	return deriveKey(master, KeyVersion+":agentident:"+namespace+":"+agent)
+}
+
 // EncodeKeyForEnv encodes a derived key for transport through a Kubernetes Secret
 // that a pod consumes as an ENVIRONMENT VARIABLE. Raw HKDF output is binary and is
 // not valid UTF-8, and env-var values must be — the kubelet/containerd reject the

--- a/pkg/auth/hmac/keys_test.go
+++ b/pkg/auth/hmac/keys_test.go
@@ -119,6 +119,59 @@ func TestServiceVerifierEmptyMasterPasses(t *testing.T) {
 	assert.Equal(t, 200, rr.Code, "empty master must disable enforcement")
 }
 
+// TestDeriveAgentIdentityKeyDeterministic pins the basic HKDF contract for the
+// per-agent identity chain: same master + namespace + agent always derives the
+// same key, at the standard 32-byte length.
+func TestDeriveAgentIdentityKeyDeterministic(t *testing.T) {
+	master := []byte(testMaster)
+	a := DeriveAgentIdentityKey(master, "ns", "architect")
+	b := DeriveAgentIdentityKey(master, "ns", "architect")
+	require.Len(t, a, derivedKeyLength)
+	assert.Equal(t, a, b, "same master + namespace + agent must produce the same key")
+}
+
+// TestDeriveAgentIdentityKeyIsolation is the distinctness matrix for the
+// agentident chain: a token derived for one (namespace, agent) can never
+// collide with another scope, with a different master, or with the
+// DeriveStateKeyspaceKey chain fed the identical (namespace, agent) inputs —
+// the "agentident" tag alone must be what keeps the two channels apart.
+func TestDeriveAgentIdentityKeyIsolation(t *testing.T) {
+	master := []byte(testMaster)
+	base := DeriveAgentIdentityKey(master, "ns-a", "architect")
+
+	distinct := [][]byte{
+		DeriveAgentIdentityKey(master, "ns-b", "architect"),                 // other namespace
+		DeriveAgentIdentityKey(master, "ns-a", "support-desk"),              // other agent
+		DeriveAgentIdentityKey([]byte("other-master"), "ns-a", "architect"), // other master
+		DeriveStateKeyspaceKey(master, "ns-a", "architect"),                 // sibling chain, same inputs
+	}
+	for i, k := range distinct {
+		assert.NotEqual(t, base, k, "candidate %d must not collide with the base key", i)
+	}
+}
+
+func TestDeriveAgentIdentityKeyNoFieldSplice(t *testing.T) {
+	master := []byte(testMaster)
+	// DNS-label namespace/agent names cannot contain ':', so swapped fields
+	// spliced across the info-string boundary must not derive equal keys.
+	assert.NotEqual(t,
+		DeriveAgentIdentityKey(master, "a", "b"),
+		DeriveAgentIdentityKey(master, "b", "a"))
+}
+
+func TestDeriveAgentIdentityKeyEmptyMaster(t *testing.T) {
+	assert.Nil(t, DeriveAgentIdentityKey(nil, "ns", "architect"),
+		"empty master must return nil so callers can short-circuit")
+	assert.Nil(t, DeriveAgentIdentityKey([]byte{}, "ns", "architect"))
+}
+
+func TestDeriveAgentIdentityKeyEncodeDecodeRoundTrip(t *testing.T) {
+	key := DeriveAgentIdentityKey([]byte(testMaster), "ns", "architect")
+	require.NotEmpty(t, key)
+	enc := EncodeKeyForEnv(key)
+	assert.Equal(t, key, DecodeKeyFromEnv(enc), "encode->decode must round-trip the derived identity key")
+}
+
 // recordingTransport captures the signed request without dialing
 // over the network so we can replay it through the verifier.
 type recordingTransport struct {

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -179,10 +179,13 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 			Name:  fv1.ResourceVersionCount,
 			Value: fmt.Sprintf("%d", rvCount),
 		},
-		// RFC-0023 state API env (nil when functionState is off). The token
-		// itself arrives via the specialize-on-startup fetcher, which writes
-		// it to the shared mount (see fetcher.StateTokenFileName).
-	}, util.StateAPIEnvVars(deploy.fetcherConfig.SharedMountPath())...)
+		// RFC-0023 state API env (nil when functionState is off) and G16
+		// agent runtime env (nil when agentRuntime is off). The tokens
+		// themselves arrive via the specialize-on-startup fetcher, which
+		// writes them to the shared mount (see fetcher.StateTokenFileName,
+		// fetcher.AgentTokenFileName).
+	}, append(util.StateAPIEnvVars(deploy.fetcherConfig.SharedMountPath()),
+		util.AgentAPIEnvVars(deploy.fetcherConfig.SharedMountPath())...)...)
 
 	container, err := util.MergeContainer(&apiv1.Container{
 		Name:                   env.Name,

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -127,11 +127,14 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 		ImagePullPolicy:        gp.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
 		Resources:              env.Spec.Resources,
-		// RFC-0023: the function-agnostic state API location. The per-function
-		// token is NOT an env var here — a generic pod's user container starts
-		// before its function is known; the fetcher writes the token file at
-		// specialize time (FISSION_STATE_TOKEN_PATH points the SDK at it).
-		Env: util.StateAPIEnvVars(gp.fetcherConfig.SharedMountPath()),
+		// RFC-0023 + G16: the function-agnostic state/agent-runtime API
+		// locations. The per-function/per-agent tokens are NOT env vars here —
+		// a generic pod's user container starts before its function is known;
+		// the fetcher writes the token files at specialize time
+		// (FISSION_STATE_TOKEN_PATH / FISSION_AGENT_TOKEN_PATH point the SDK
+		// at them).
+		Env: append(util.StateAPIEnvVars(gp.fetcherConfig.SharedMountPath()),
+			util.AgentAPIEnvVars(gp.fetcherConfig.SharedMountPath())...),
 		// Connection-draining preStop hook; see utils.DrainLifecycle.
 		Lifecycle: utils.DrainLifecycle(gracePeriodSeconds),
 		// https://istio.io/docs/setup/kubernetes/additional-setup/requirements/

--- a/pkg/executor/util/agentenv.go
+++ b/pkg/executor/util/agentenv.go
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/fission/fission/pkg/fetcher"
+)
+
+// AgentAPIEnvVars returns the env vars a function's USER container needs to
+// reach the G16 agent runtime, or nil when the feature is off. The split is
+// deliberate (mirrors StateAPIEnvVars's pre-implementation review pin): the
+// agent runtime URL is function-agnostic so it CAN be a plain env var even
+// on a poolmgr generic pod (whose user container starts before its function
+// identity is known); the per-agent token cannot — the fetcher writes it to
+// the shared mount at specialize time, and FISSION_AGENT_TOKEN_PATH just
+// tells the SDK where.
+//
+// agentRuntimeURL comes from the executor's own AGENT_RUNTIME_URL env
+// (chart-set only when agentRuntime.enabled); empty means the feature is not
+// deployed and no vars are injected, keeping pods byte-identical to today.
+//
+// Boundary: the container executortype has no fetcher sidecar and therefore
+// no call site for this function — a container-executor agent gets no
+// identity file in phase 1.
+func AgentAPIEnvVars(sharedMountPath string) []apiv1.EnvVar {
+	agentRuntimeURL := os.Getenv("AGENT_RUNTIME_URL")
+	if agentRuntimeURL == "" {
+		return nil
+	}
+	return []apiv1.EnvVar{
+		{Name: "FISSION_AGENT_RUNTIME_URL", Value: agentRuntimeURL},
+		{Name: "FISSION_AGENT_TOKEN_PATH", Value: filepath.Join(sharedMountPath, fetcher.AgentTokenFileName)},
+	}
+}

--- a/pkg/executor/util/agentenv_test.go
+++ b/pkg/executor/util/agentenv_test.go
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentAPIEnvVars(t *testing.T) {
+	t.Run("feature off: nil, pods stay byte-identical", func(t *testing.T) {
+		t.Setenv("AGENT_RUNTIME_URL", "")
+		assert.Nil(t, AgentAPIEnvVars("/userfunc"))
+	})
+
+	t.Run("feature on: url and token path", func(t *testing.T) {
+		t.Setenv("AGENT_RUNTIME_URL", "http://agentruntime.fission:8894")
+		vars := AgentAPIEnvVars("/userfunc")
+		require.Len(t, vars, 2)
+		assert.Equal(t, "FISSION_AGENT_RUNTIME_URL", vars[0].Name)
+		assert.Equal(t, "http://agentruntime.fission:8894", vars[0].Value)
+		assert.Equal(t, "FISSION_AGENT_TOKEN_PATH", vars[1].Name)
+		assert.Equal(t, "/userfunc/.fission-agent-token", vars[1].Value)
+	})
+}

--- a/pkg/fetcher/agenttoken.go
+++ b/pkg/fetcher/agenttoken.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher
+
+import (
+	jsonv1 "encoding/json"
+	"encoding/json/v2"
+	"errors"
+	"os"
+	"path/filepath"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// AgentTokenFileName is the file under the shared mount (/userfunc) where
+// the fetcher writes the function's per-agent identity token at specialize
+// time (G16). It is a file, not an env var, because a poolmgr generic pod's
+// user container is already running before its function identity is known —
+// env vars cannot be added to a running container. The executor points the
+// SDK at it via FISSION_AGENT_TOKEN_PATH.
+const AgentTokenFileName = ".fission-agent-token"
+
+// AgentCredentials is the JSON document the fetcher writes to
+// AgentTokenFileName: everything a token-carrying client must present —
+// agentruntime's stateless verification re-derives from the claimed
+// (namespace, agent), so the claims travel WITH the token.
+type AgentCredentials struct {
+	Namespace string `json:"namespace"`
+	Agent     string `json:"agent"`
+	Token     string `json:"token"`
+}
+
+// agenttokenWireOpts pins the on-disk agenttoken file to exact v1 emission;
+// see statetokenWireOpts for why this matters even though AgentCredentials
+// is three plain strings that v2 defaults would emit identically today.
+var agenttokenWireOpts = jsonv1.DefaultOptionsV1()
+
+// writeAgentTokenFile derives the G16 agent identity token from the
+// fetcher's master secret and writes the AgentCredentials JSON to
+// AgentTokenFileName under the shared mount (0444: the env container runs
+// as a different user and only ever reads it). Without a master secret (dev
+// clusters) it writes a placeholder token — agentruntime's pass-through mode
+// accepts any bearer, and the SDK contract stays uniform.
+func (fetcher *Fetcher) writeAgentTokenFile(loadReq FunctionLoadRequest) error {
+	if loadReq.FunctionMetadata == nil {
+		return errors.New("specialize request with an agent name but no function metadata")
+	}
+	creds := AgentCredentials{
+		Namespace: loadReq.FunctionMetadata.Namespace,
+		Agent:     loadReq.AgentName,
+		Token:     "dev-unauthenticated",
+	}
+	if master := []byte(os.Getenv("FISSION_INTERNAL_AUTH_SECRET")); len(master) > 0 {
+		creds.Token = hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master,
+			creds.Namespace, creds.Agent))
+	}
+	// cross-language SDK file contract: exact v1 emission
+	blob, err := json.Marshal(creds, agenttokenWireOpts)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(fetcher.sharedVolumePath, AgentTokenFileName)
+	// The file is read-only, so a re-specialize (infinite-functions pools,
+	// retried specialization) cannot overwrite in place — replace it.
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return os.WriteFile(path, blob, 0444)
+}

--- a/pkg/fetcher/agenttoken_test.go
+++ b/pkg/fetcher/agenttoken_test.go
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package fetcher
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+func TestWriteAgentTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	f := &Fetcher{sharedVolumePath: dir}
+	loadReq := FunctionLoadRequest{
+		FunctionMetadata: &metav1.ObjectMeta{Name: "support-desk", Namespace: "user-ns"},
+		AgentName:        "support-desk",
+	}
+
+	readCreds := func(t *testing.T) AgentCredentials {
+		t.Helper()
+		got, err := os.ReadFile(filepath.Join(dir, AgentTokenFileName))
+		require.NoError(t, err)
+		var creds AgentCredentials
+		require.NoError(t, json.Unmarshal(got, &creds))
+		return creds
+	}
+
+	t.Run("derives the exact agent identity token with its claims", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "test-master")
+		require.NoError(t, f.writeAgentTokenFile(loadReq))
+
+		creds := readCreds(t)
+		assert.Equal(t, "user-ns", creds.Namespace)
+		assert.Equal(t, "support-desk", creds.Agent)
+		want := hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey([]byte("test-master"), "user-ns", "support-desk"))
+		assert.Equal(t, want, creds.Token)
+	})
+
+	t.Run("no master secret: dev placeholder (overwrites read-only file)", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "")
+		require.NoError(t, f.writeAgentTokenFile(loadReq))
+		assert.Equal(t, "dev-unauthenticated", readCreds(t).Token)
+	})
+
+	t.Run("re-specialize overwrites the read-only file", func(t *testing.T) {
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "first-master")
+		require.NoError(t, f.writeAgentTokenFile(loadReq))
+		first := readCreds(t).Token
+
+		t.Setenv("FISSION_INTERNAL_AUTH_SECRET", "second-master")
+		require.NoError(t, f.writeAgentTokenFile(loadReq))
+		second := readCreds(t).Token
+
+		assert.NotEqual(t, first, second)
+	})
+
+	t.Run("missing metadata is an error", func(t *testing.T) {
+		assert.Error(t, f.writeAgentTokenFile(FunctionLoadRequest{AgentName: "support-desk"}))
+	})
+}

--- a/pkg/fetcher/config/agent_test.go
+++ b/pkg/fetcher/config/agent_test.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package container
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+func agentTestFn(agent *fv1.AgentConfig) *fv1.Function {
+	return &fv1.Function{
+		Name: "support-desk", Namespace: "user-ns",
+		Spec: fv1.FunctionSpec{
+			Package: fv1.FunctionPackageRef{PackageRef: fv1.PackageRef{Name: "pkg", Namespace: "user-ns"}},
+			Agent:   agent,
+		},
+	}
+}
+
+func agentTestEnv() *fv1.Environment {
+	return &fv1.Environment{
+		Name: "node", Namespace: "user-ns",
+		Spec: fv1.EnvironmentSpec{Version: 2},
+	}
+}
+
+func TestNewSpecializeRequestAgentName(t *testing.T) {
+	t.Parallel()
+	cfg, err := MakeFetcherConfig("/userfunc")
+	require.NoError(t, err)
+
+	t.Run("not an agent: empty name", func(t *testing.T) {
+		t.Parallel()
+		req := cfg.NewSpecializeRequest(agentTestFn(nil), agentTestEnv())
+		assert.Empty(t, req.LoadReq.AgentName)
+	})
+
+	t.Run("agent function on a finite env: name is the function name", func(t *testing.T) {
+		t.Parallel()
+		req := cfg.NewSpecializeRequest(agentTestFn(&fv1.AgentConfig{}), agentTestEnv())
+		assert.Equal(t, "support-desk", req.LoadReq.AgentName)
+	})
+
+	t.Run("infinite env: no token minted (specialize-time S1 backstop)", func(t *testing.T) {
+		t.Parallel()
+		env := agentTestEnv()
+		env.Spec.AllowedFunctionsPerContainer = fv1.AllowedFunctionsPerContainerInfinite
+		req := cfg.NewSpecializeRequest(agentTestFn(&fv1.AgentConfig{}), env)
+		assert.Empty(t, req.LoadReq.AgentName, "an infinite env must not receive a scoped agent identity token")
+	})
+}

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -221,6 +221,7 @@ func (cfg *Config) NewSpecializeRequest(fn *fv1.Function, env *fv1.Environment) 
 			FunctionMetadata: &fn.ObjectMeta,
 			EnvVersion:       env.Spec.Version,
 			StateKeyspace:    stateKeyspace(fn, env),
+			AgentName:        agentName(fn, env),
 		},
 	}
 }
@@ -245,6 +246,26 @@ func stateKeyspace(fn *fv1.Function, env *fv1.Environment) string {
 		return ""
 	}
 	return fn.Spec.State.EffectiveKeyspace(fn.Name)
+}
+
+// agentName resolves the G16 agent identity name for a function that is an
+// agent ("" = not an agent, no token is delivered). Only this non-secret
+// name travels in the specialize request; the fetcher derives the actual
+// token pod-locally.
+//
+// Drop-in sibling of stateKeyspace: the same specialize-time enforcement of
+// the "no per-function credentials on an allowedFunctionsPerContainer:
+// infinite environment" invariant (S1) applies here for the identical
+// reason — such pods serve many functions from one shared mount, so a
+// single per-pod token file cannot isolate them.
+func agentName(fn *fv1.Function, env *fv1.Environment) string {
+	if fn.Spec.Agent == nil {
+		return ""
+	}
+	if env.Spec.AllowedFunctionsPerContainer == fv1.AllowedFunctionsPerContainerInfinite {
+		return ""
+	}
+	return fn.Name
 }
 
 // AddFetcherToPodSpec adds the fetcher sidecar to podSpec. namespace is where the

--- a/pkg/fetcher/config/state_test.go
+++ b/pkg/fetcher/config/state_test.go
@@ -65,18 +65,12 @@ func TestNewSpecializeRequestStateKeyspace(t *testing.T) {
 	})
 }
 
-// TestSpecializePayloadCarriesNoToken pins the security property the
-// pre-implementation review demanded: the -specialize-request CLI arg is
-// visible to anyone who can read pods, so it must carry only the NON-SECRET
-// keyspace name — never a token or the master secret.
-func TestSpecializePayloadCarriesNoToken(t *testing.T) {
-	t.Parallel()
-	cfg, err := MakeFetcherConfig("/userfunc")
-	require.NoError(t, err)
-
+// specializePayload builds fn's specialize pod spec and returns the raw
+// -specialize-request JSON arg the fetcher sidecar's command line carries.
+func specializePayload(t *testing.T, cfg *Config, fn *fv1.Function, env *fv1.Environment) string {
+	t.Helper()
 	podSpec := apiv1.PodSpec{Containers: []apiv1.Container{{Name: "node"}}}
-	require.NoError(t, cfg.AddSpecializingFetcherToPodSpec(&podSpec, "node", "user-ns",
-		stateTestFn(&fv1.StateConfig{Keyspace: "carts"}), stateTestEnv()))
+	require.NoError(t, cfg.AddSpecializingFetcherToPodSpec(&podSpec, "node", "user-ns", fn, env))
 
 	var fetcherContainer *apiv1.Container
 	for i := range podSpec.Containers {
@@ -93,12 +87,49 @@ func TestSpecializePayloadCarriesNoToken(t *testing.T) {
 		}
 	}
 	require.NotEmpty(t, payload, "specialize request rides the command line")
-	assert.Contains(t, payload, `"stateKeyspace":"carts"`)
-	assert.NotContains(t, strings.ToLower(payload), "token")
-	assert.NotContains(t, strings.ToLower(payload), "secret\":")
+	return payload
+}
 
-	// The payload must be a well-formed JSON object; json.Valid plus the
-	// object check is the whole assertion, no fields are read back.
-	require.True(t, json.Valid([]byte(payload)), "payload must be valid JSON")
-	assert.True(t, strings.HasPrefix(strings.TrimSpace(payload), "{"), "payload must be a JSON object")
+// TestSpecializePayloadCarriesNoToken pins the security property the
+// pre-implementation review demanded: the -specialize-request CLI arg is
+// visible to anyone who can read pods, so it must carry only NON-SECRET
+// fields (state keyspace, agent name) — never a token or the master secret.
+func TestSpecializePayloadCarriesNoToken(t *testing.T) {
+	t.Parallel()
+	cfg, err := MakeFetcherConfig("/userfunc")
+	require.NoError(t, err)
+
+	t.Run("state keyspace", func(t *testing.T) {
+		t.Parallel()
+		payload := specializePayload(t, cfg, stateTestFn(&fv1.StateConfig{Keyspace: "carts"}), stateTestEnv())
+
+		assert.Contains(t, payload, `"stateKeyspace":"carts"`)
+		assert.NotContains(t, strings.ToLower(payload), "token")
+		assert.NotContains(t, strings.ToLower(payload), "secret\":")
+
+		// The payload must be a well-formed JSON object; json.Valid plus the
+		// object check is the whole assertion, no fields are read back.
+		require.True(t, json.Valid([]byte(payload)), "payload must be valid JSON")
+		assert.True(t, strings.HasPrefix(strings.TrimSpace(payload), "{"), "payload must be a JSON object")
+	})
+
+	// Agent identity (G16): an agent-enabled function's specialize payload
+	// carries the non-secret AgentName, and still no token-like field — the
+	// scoped identity token derives pod-locally from the fetcher's own
+	// master secret and never rides this pod-visible command-line arg.
+	t.Run("agent name", func(t *testing.T) {
+		t.Parallel()
+		fn := stateTestFn(nil)
+		fn.Spec.Agent = &fv1.AgentConfig{}
+		payload := specializePayload(t, cfg, fn, stateTestEnv())
+
+		assert.Contains(t, payload, `"agentName":"counter"`)
+		assert.NotContains(t, strings.ToLower(payload), "token")
+		assert.NotContains(t, strings.ToLower(payload), "secret\":")
+
+		// The payload must be a well-formed JSON object; json.Valid plus the
+		// object check is the whole assertion, no fields are read back.
+		require.True(t, json.Valid([]byte(payload)), "payload must be valid JSON")
+		assert.True(t, strings.HasPrefix(strings.TrimSpace(payload), "{"), "payload must be a JSON object")
+	})
 }

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -876,6 +876,17 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		}
 	}
 
+	// G16: materialize the per-agent identity token BEFORE specializing, for
+	// the same reason and on the same shared-mount mechanism as the state
+	// token above. Derived pod-locally from the fetcher's own master secret —
+	// the secret and the token never ride the (pod-visible) specialize
+	// request.
+	if loadReq.AgentName != "" {
+		if err := fetcher.writeAgentTokenFile(loadReq); err != nil {
+			return http.StatusInternalServerError, fmt.Errorf("error writing agent token file: %w", err)
+		}
+	}
+
 	// Specialize the pod
 
 	var contentType string

--- a/pkg/fetcher/types.go
+++ b/pkg/fetcher/types.go
@@ -61,6 +61,15 @@ type (
 		// (it appears in the pod-visible -specialize-request arg); the token
 		// itself never does.
 		StateKeyspace string `json:"stateKeyspace,omitempty"`
+
+		// AgentName, when non-empty, is this function's agent identity name
+		// (G16): before specializing, the fetcher derives the scoped agent
+		// identity token from its own master secret and writes it to
+		// AgentTokenFileName under the shared mount for the user container's
+		// SDK to read. Only the NON-SECRET agent name rides this request (it
+		// appears in the pod-visible -specialize-request arg); the token
+		// itself never does — it derives pod-locally.
+		AgentName string `json:"agentName,omitempty"`
 	}
 
 	// ArchiveUploadRequest send from builder manager describes which

--- a/test/helm/agentruntime_chart_test.go
+++ b/test/helm/agentruntime_chart_test.go
@@ -220,3 +220,53 @@ func TestAgentRuntimeChartAuthGates(t *testing.T) {
 			"the failure must name the statestore gate, not some other refusal")
 	})
 }
+
+// TestAgentRuntimeChartExecutorURL checks Task 4's chart wiring: the executor
+// Deployment carries AGENT_RUNTIME_URL, pointing at the agentruntime
+// ClusterIP Service, when agentRuntime.enabled — and carries no such env var
+// when the feature is off, so an executor pod is never handed a URL for a
+// dispatcher that isn't deployed.
+func TestAgentRuntimeChartExecutorURL(t *testing.T) {
+	t.Run("present when agentRuntime.enabled", func(t *testing.T) {
+		docs := render(t,
+			"--set", "agentRuntime.enabled=true", "--set", "agentRuntime.allowInsecure=true",
+			"--set", "statestore.enabled=true", "--set", "statestore.mode=embedded")
+		env := containerEnv(t, deployment(t, docs, svcinfo.SvcExecutor))
+		assert.Equal(t, "http://agentruntime.fission:8894", env["AGENT_RUNTIME_URL"],
+			"executor must be handed the agentruntime dispatcher's ClusterIP Service URL")
+	})
+
+	t.Run("absent when agentRuntime disabled", func(t *testing.T) {
+		docs := render(t)
+		env := containerEnv(t, deployment(t, docs, svcinfo.SvcExecutor))
+		_, ok := env["AGENT_RUNTIME_URL"]
+		assert.False(t, ok, "AGENT_RUNTIME_URL must not render when agentRuntime.enabled is false")
+	})
+}
+
+// TestAgentRuntimeChartInternalAuthEnvs is a verify-only assertion (no chart
+// change needed): the agentruntime Deployment already carries
+// FISSION_INTERNAL_AUTH_SECRET under default values, wired via
+// internalAuth.envs (deployment.yaml:88) and gated on internalAuth.enabled
+// (default true), not on agentRuntime.enabled.
+func TestAgentRuntimeChartInternalAuthEnvs(t *testing.T) {
+	docs := render(t,
+		"--set", "agentRuntime.enabled=true", "--set", "agentRuntime.allowInsecure=true",
+		"--set", "statestore.enabled=true", "--set", "statestore.mode=embedded")
+	c := firstContainer(t, deployment(t, docs, svcinfo.SvcAgentRuntime))
+
+	var secretEnv *corev1.EnvVar
+	for i := range c.Env {
+		if c.Env[i].Name == "FISSION_INTERNAL_AUTH_SECRET" {
+			secretEnv = &c.Env[i]
+			break
+		}
+	}
+	// FISSION_INTERNAL_AUTH_SECRET is a valueFrom secretKeyRef, not a literal
+	// value — containerEnv deliberately skips valueFrom entries, so this
+	// walks Env directly rather than going through it.
+	require.NotNil(t, secretEnv, "FISSION_INTERNAL_AUTH_SECRET must be rendered under default values (internalAuth.enabled defaults true)")
+	require.NotNil(t, secretEnv.ValueFrom, "FISSION_INTERNAL_AUTH_SECRET must be sourced from a secret, not a literal value")
+	require.NotNil(t, secretEnv.ValueFrom.SecretKeyRef)
+	assert.Equal(t, "secret", secretEnv.ValueFrom.SecretKeyRef.Key)
+}

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -953,7 +953,11 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		}
 		if !assert.Equalf(c, expectedTokenSha256, payload.AgentTokenSha256,
 			"derived-token sha256 mismatch for agent %s/%s: the fetcher's injected credential does not match "+
-				"hmacauth.DeriveAgentIdentityKey(master, ns, agent) computed by this test", ns.Name, fnName) {
+				"hmacauth.DeriveAgentIdentityKey(master, ns, agent) computed by this test -- either a real "+
+				"derivation drift between the fetcher and this test, OR (on a secured cluster) this test "+
+				"runner's own env is missing FISSION_INTERNAL_AUTH_SECRET while the fetcher's is set, so the "+
+				"two sides compared a derived token against the wrong expectation (env mismatch, not a code "+
+				"bug -- see the expectedToken comment above)", ns.Name, fnName) {
 			return
 		}
 

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -9,6 +9,8 @@ package common_test
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -20,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/fission/fission/pkg/agentruntime"
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
 	"github.com/fission/fission/test/integration/framework"
 )
 
@@ -744,7 +747,7 @@ func postAgentTurn(ctx context.Context, f *framework.Framework, turnURL, session
 // ITSELF for stepKey "expert-1", using a byte-identical JS twin of
 // SpawnSessionID.
 //
-// Four things are asserted, in order:
+// Five things are asserted, in order:
 //
 //  1. Cross-language id agreement (the load-bearing assertion): this test
 //     computes expected := agentruntime.SpawnSessionID(parentRef, "expert-1")
@@ -753,6 +756,21 @@ func postAgentTurn(ctx context.Context, f *framework.Framework, turnURL, session
 //     against the fixture's own reported "spawned" id, so a derivation drift
 //     on either side (hash, prefix, truncation length) fails with a message
 //     naming which side disagreed, not just a registry 404.
+//  1b. Token injection (Task 6 of the parent-graph plan, G16), checked
+//     INSIDE the spawn-turn retry loop (a pod specialized off a stale
+//     pre-`--agent` view of the Function never gets a credential file at
+//     all, so this needs the same retry runway as 1's cross-language
+//     check): the fixture's pod carries a per-agent identity credential the
+//     fetcher wrote at specialize time (pkg/fetcher/agenttoken.go). The
+//     fixture echoes the credential file's claimed (namespace, agent) and
+//     the SHA-256 hex of its token — never the raw token — and this test
+//     asserts the claims equal the function's own (namespace, name) and
+//     independently re-derives the expected token via
+//     hmacauth.DeriveAgentIdentityKey/EncodeKeyForEnv from
+//     Framework.InternalAuthSecret(), comparing by hash. This is the
+//     injection-chain half of the identity proof (derivation agreement
+//     without a secured install); the verify half lives in
+//     pkg/agentruntime/identity_test.go's truth table.
 //  2. Idempotent spawn: re-dispatching the parent's spawn turn a second time
 //     must not mint a second child — ListSessions must still show exactly one
 //     session whose parent.id is the parent session.
@@ -833,6 +851,45 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 	expectedChildID := agentruntime.SpawnSessionID(parentRef, "expert-1")
 	childURL := base + "/registry/agents/" + ns.Name + "/" + fnName + "/sessions/" + expectedChildID
 
+	// expectedTokenSha256 is the Task 6 injection-chain proof's expected
+	// value, computed once (deterministic — it depends only on the master
+	// secret and this function's own (namespace, name), not on anything the
+	// fixture reports). Checked INSIDE the spawn-turn loop below, not after
+	// it: WaitForFunction only confirms the Function CR is visible, and the
+	// CLI's `fn update --agent` a few lines above returns before every
+	// watcher has necessarily observed Spec.Agent — a pod specialized off a
+	// stale pre-agent view never gets a credential file at all (the fetcher
+	// gates writeAgentTokenFile on the specialize request carrying an agent
+	// name) and the fixture reports "absent" forever for that pod's
+	// lifetime. Asserting outside the loop would capture whatever a single
+	// (possibly stale) success left behind with no further retries; asserting
+	// on `c` inside it gives the same generation-bump retry runway the
+	// cross-language check below already relies on.
+	master := f.InternalAuthSecret()
+	var expectedToken string
+	if len(master) == 0 {
+		// Pass-through install (internalAuth disabled): the fetcher had no
+		// FISSION_INTERNAL_AUTH_SECRET either (the chart wires the SAME
+		// secret to both the framework's signing client and the fetcher),
+		// so it wrote the placeholder token instead of a derived one. Assert
+		// against that placeholder explicitly (stronger than skipping the
+		// sha check outright) — it still pins the placeholder path, it only
+		// changes what "expected" means. Caveat: this equates "the test
+		// runner's own env has no FISSION_INTERNAL_AUTH_SECRET" with "the
+		// fetcher had none" — true whenever the chart wires both from the
+		// same secret (CI's case), but if a secured cluster's test runner
+		// simply didn't export the var, the fixture would report a REAL
+		// derived sha and this assertion would fail on an environment
+		// mismatch, not a code bug.
+		t.Log("FISSION_INTERNAL_AUTH_SECRET is empty on the framework (pass-through install); " +
+			"asserting the fetcher's dev-unauthenticated placeholder token instead of a derived one")
+		expectedToken = "dev-unauthenticated"
+	} else {
+		expectedToken = hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, ns.Name, fnName))
+	}
+	expectedTokenSha256Sum := sha256.Sum256([]byte(expectedToken))
+	expectedTokenSha256 := hex.EncodeToString(expectedTokenSha256Sum[:])
+
 	// Turn 2 on the parent session: {"spawn":true} asks the fixture to spawn
 	// its one child. The fixture's inner dispatch to the child is a separate,
 	// best-effort network hop from inside the pod (spawn.js's spawnChild doc
@@ -862,11 +919,43 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 			Spawned     string `json:"spawned"`
 			SpawnStatus int    `json:"spawnStatus"`
 			SpawnBody   string `json:"spawnBody"`
+			// AgentTokenSha256/AgentTokenNamespace/AgentTokenAgent are the
+			// Task 6 injection-chain proof: spawn.js reads its own
+			// fetcher-written credential file
+			// (pkg/fetcher/agenttoken.go) once at module load and echoes
+			// its sha256 hex plus claimed namespace/agent on every turn --
+			// never the raw token itself (see the in-loop assertions below
+			// for why they're checked here and not after the loop).
+			AgentTokenSha256    string `json:"agentTokenSha256"`
+			AgentTokenNamespace string `json:"agentTokenNamespace"`
+			AgentTokenAgent     string `json:"agentTokenAgent"`
 		}
 		if !assert.NoErrorf(c, json.Unmarshal(turnBody, &payload), "decoding spawn turn response body %q", turnBody) {
 			return
 		}
 		reportedSpawnID = payload.Spawned
+
+		// TOKEN INJECTION, checked HERE (not after the loop): a pod
+		// specialized off a stale pre-`--agent` view of the Function never
+		// gets a credential file at all (see expectedTokenSha256's doc
+		// comment above), so asserting only after the loop exits would
+		// capture a possibly-stale single success with no further retries.
+		// Asserting on `c` here lets a generation bump (which routes a
+		// fresh specialize once the update propagates) actually resolve
+		// the staleness within this loop's normal retry budget.
+		if !assert.Equalf(c, ns.Name, payload.AgentTokenNamespace,
+			"credential file claimed namespace %q, want %q", payload.AgentTokenNamespace, ns.Name) {
+			return
+		}
+		if !assert.Equalf(c, fnName, payload.AgentTokenAgent,
+			"credential file claimed agent %q, want %q", payload.AgentTokenAgent, fnName) {
+			return
+		}
+		if !assert.Equalf(c, expectedTokenSha256, payload.AgentTokenSha256,
+			"derived-token sha256 mismatch for agent %s/%s: the fetcher's injected credential does not match "+
+				"hmacauth.DeriveAgentIdentityKey(master, ns, agent) computed by this test", ns.Name, fnName) {
+			return
+		}
 
 		// CROSS-LANGUAGE AGREEMENT, checked HERE (not just after the loop):
 		// if the JS twin ever derived a DIFFERENT id than Go's
@@ -920,6 +1009,16 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		assert.Equalf(t, parentRef, *childRec.Parent, "child session %s parent mismatch", expectedChildID)
 	}
 	assert.Equalf(t, 1, childRec.Depth, "child session %s must be depth 1, got %d", expectedChildID, childRec.Depth)
+
+	// 1b. TOKEN INJECTION: already asserted INSIDE the spawn-turn loop above
+	// (checked on `c` before the cross-language id check, for the staleness
+	// reason documented at expectedTokenSha256's declaration). By this
+	// point the fixture's credential file is known to claim exactly this
+	// function's (namespace, name), and its sha256 is known to equal what
+	// this test independently re-derives via
+	// hmacauth.DeriveAgentIdentityKey/EncodeKeyForEnv from
+	// Framework.InternalAuthSecret() — the injection-chain proof, without a
+	// secured install and without a raw token ever touching test output.
 
 	// 2. IDEMPOTENT SPAWN: re-dispatch the parent's spawn turn. The fixture
 	// derives the SAME childID (same parent session, same stepKey) and

--- a/test/integration/testdata/nodejs/agenthistory/history.js
+++ b/test/integration/testdata/nodejs/agenthistory/history.js
@@ -65,7 +65,9 @@ if (STATE_URL && TOKEN_PATH) {
   try {
     stateCreds = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
   } catch (err) {
-    console.error(`agenthistory: could not read state token file ${TOKEN_PATH}: ${err}`);
+    // err.code/err.name only: a raw JSON.parse SyntaxError embeds a source
+    // snippet, and the token is the last field in the file.
+    console.error(`agenthistory: could not read state token file ${TOKEN_PATH}: ${err.code || err.name}`);
   }
 }
 

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -29,12 +29,22 @@
 // SELF_AGENT_NAME=...) instead.
 //
 // Spawn failures are best-effort and never fail this turn's own reply — see
-// architect.js's header comment for the same auth/G16 caveat, which applies
+// architect.js's header comment for the same auth/G16 writeup, which applies
 // identically here (this fixture calls the same full-privilege dispatch
 // route architect.js does).
+//
+// Auth (G16 gate LIFTED): this pod carries its own per-agent identity, a
+// {namespace, agent, token} credential the fetcher writes to the file
+// FISSION_AGENT_TOKEN_PATH points at (pkg/fetcher/agenttoken.go) at
+// specialize time. This fixture reads it once at module load and sends it on
+// the spawn dispatch as Authorization: Bearer <token> plus the
+// X-Fission-Agent-Auth-Namespace / X-Fission-Agent-Auth-Name claims headers
+// (pkg/agentruntime/identity.go) -- see readAgentCredentials()/authHeaders()
+// below for the fallback order and the dev-placeholder edge case.
 
 'use strict';
 
+const fs = require('fs');
 const crypto = require('crypto');
 
 const SESSION_HEADER = 'x-fission-session'; // express lower-cases header names
@@ -45,10 +55,50 @@ const SELF_NAMESPACE = process.env.SELF_NAMESPACE || 'default';
 const SELF_AGENT_NAME = process.env.SELF_AGENT_NAME || '';
 
 // DEFAULT_AGENT_RUNTIME_URL mirrors architect.js's constant of the same
-// name: the agentruntime Service's in-cluster DNS name.
+// name: the agentruntime Service's in-cluster DNS name, correct only for
+// install-namespace "fission". Prefer FISSION_AGENT_RUNTIME_URL (injected by
+// the executor, pkg/executor/util/agentenv.go); the legacy AGENT_RUNTIME_URL
+// manual override and this hardcoded default remain as fallbacks.
 const DEFAULT_AGENT_RUNTIME_URL = 'http://agentruntime.fission:8894';
-const AGENT_RUNTIME_URL = process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
+const AGENT_RUNTIME_URL =
+  process.env.FISSION_AGENT_RUNTIME_URL || process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
+// AGENT_RUNTIME_TOKEN is the pre-G16 manual-provisioning fallback (see
+// authHeaders() below): a plain bearer with no claims headers, used only
+// when the fetcher-written identity file is absent or carries the dev
+// placeholder.
 const AGENT_RUNTIME_TOKEN = process.env.AGENT_RUNTIME_TOKEN || '';
+
+// AGENT_TOKEN_PATH is the G16 identity file the executor points at via
+// FISSION_AGENT_TOKEN_PATH (pkg/executor/util/agentenv.go), written by the
+// fetcher at specialize time (pkg/fetcher/agenttoken.go).
+const AGENT_TOKEN_PATH = process.env.FISSION_AGENT_TOKEN_PATH || '';
+
+// DEV_PLACEHOLDER_TOKEN is the fetcher's un-derived stand-in
+// (pkg/fetcher/agenttoken.go writeAgentTokenFile): written when the fetcher
+// itself has no FISSION_INTERNAL_AUTH_SECRET, so it never verifies as a real
+// identity token. Preferring it anyway would matter on one non-default
+// install shape: authentication.enabled but internalAuth.enabled=false, where
+// the file carries the placeholder and file-first-always would 401 where a
+// manually-provisioned AGENT_RUNTIME_TOKEN JWT would have worked -- so
+// authHeaders() below falls through to the env token in that case instead.
+const DEV_PLACEHOLDER_TOKEN = 'dev-unauthenticated';
+
+// readAgentCredentials reads the fetcher-written AgentCredentials JSON
+// ({namespace, agent, token}) once at module load -- not per spawn call --
+// and caches it in agentCreds below.
+function readAgentCredentials(path) {
+  if (!path) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch (err) {
+    console.error(`agentspawn: could not read agent identity token file ${path}: ${err}`);
+    return null;
+  }
+}
+
+const agentCreds = readAgentCredentials(AGENT_TOKEN_PATH);
 
 // spawnSessionID is the JS twin of pkg/agentruntime/session.go's
 // SpawnSessionID: 'c-' + the first 32 lowercase hex characters of
@@ -58,7 +108,22 @@ function spawnSessionID(parentRef, stepKey) {
   return 'c-' + digest.slice(0, 32);
 }
 
+// authHeaders picks the spawn-call credential in preference order:
+//  1. The fetcher-written identity file (agentCreds), sent as
+//     Authorization: Bearer <token> plus the two claims headers -- but ONLY
+//     when its token is not DEV_PLACEHOLDER_TOKEN (see that constant's
+//     comment for the install shape this guards).
+//  2. AGENT_RUNTIME_TOKEN, sent as a plain bearer with no claims headers
+//     (the pre-G16 manual-provisioning fallback).
+//  3. No auth -- relies on the cluster's AGENT_ALLOW_INSECURE pass-through.
 function authHeaders() {
+  if (agentCreds && agentCreds.token && agentCreds.token !== DEV_PLACEHOLDER_TOKEN) {
+    return {
+      Authorization: `Bearer ${agentCreds.token}`,
+      'X-Fission-Agent-Auth-Namespace': agentCreds.namespace,
+      'X-Fission-Agent-Auth-Name': agentCreds.agent,
+    };
+  }
   return AGENT_RUNTIME_TOKEN ? { Authorization: `Bearer ${AGENT_RUNTIME_TOKEN}` } : {};
 }
 

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -100,7 +100,11 @@ function readAgentCredentials(path) {
   try {
     return JSON.parse(fs.readFileSync(path, 'utf8'));
   } catch (err) {
-    console.error(`agentspawn: could not read agent identity token file ${path}: ${err}`);
+    // Log err.code/err.name only: a mid-token corrupt-file parse failure
+    // embeds a source snippet in err.message (V8 JSON.parse SyntaxError),
+    // and the token is the last field of this JSON -- stringifying err
+    // could leak token bytes into pod logs.
+    console.error(`agentspawn: could not read agent identity token file ${path}: ${err.code || err.name}`);
     return null;
   }
 }

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -6,12 +6,19 @@
 // namespace, same function) with X-Fission-Session set to the derived id and
 // X-Fission-Agent-Parent set to this session's own ParentRef. Every turn
 // (spawn or not) replies 200 with {"session","parent","spawned","spawnStatus",
-// "spawnBody"}, where "spawned" is the derived child id (or null when this
-// turn did not spawn) and spawnStatus/spawnBody are the inner dispatch's own
+// "spawnBody","agentTokenSha256","agentTokenNamespace","agentTokenAgent"},
+// where "spawned" is the derived child id (or null when this turn did not
+// spawn) and spawnStatus/spawnBody are the inner dispatch's own
 // last-observed HTTP status and response body (0/"" when no spawn was
 // attempted, or on a network error before any response arrived) -- present
 // specifically so a caller-side test can name what the inner dispatch
-// actually saw instead of just timing out on a registry 404.
+// actually saw instead of just timing out on a registry 404. The
+// agentToken* fields are the Task 6 injection-chain proof (see the "Auth"
+// paragraph below): they NEVER carry the raw token, only its sha256 hex (or
+// the literal "absent") plus the file's claimed namespace/agent, so a
+// caller-side test can independently re-derive the expected token and
+// compare hashes without a live bearer credential ever touching test
+// output/logs.
 //
 // spawnSessionID below is the same byte-identical JS twin of
 // pkg/agentruntime/session.go's SpawnSessionID that architect.js carries
@@ -99,6 +106,25 @@ function readAgentCredentials(path) {
 }
 
 const agentCreds = readAgentCredentials(AGENT_TOKEN_PATH);
+
+// agentTokenSha256/agentTokenNamespace/agentTokenAgent are computed once at
+// module load (agentCreds is read once, not per turn) and echoed on EVERY
+// turn's response so TestAgentRuntimeSpawnParentage
+// (agentruntime_test.go, Task 6 of the parent-graph plan) can prove the
+// injection chain end-to-end: the fetcher wrote this pod a credential file
+// (pkg/fetcher/agenttoken.go) whose token the Go test independently
+// re-derives via hmacauth.DeriveAgentIdentityKey and compares by sha256 --
+// NEVER by echoing the raw token itself, which would leak a live bearer
+// credential into test output/logs. agentTokenSha256 is the literal string
+// "absent" when the credentials file is missing or unreadable (see
+// readAgentCredentials's catch above); the namespace/agent claims are empty
+// strings in that same case.
+const agentTokenSha256 =
+  agentCreds && agentCreds.token
+    ? crypto.createHash('sha256').update(agentCreds.token).digest('hex')
+    : 'absent';
+const agentTokenNamespace = agentCreds ? agentCreds.namespace || '' : '';
+const agentTokenAgent = agentCreds ? agentCreds.agent || '' : '';
 
 // spawnSessionID is the JS twin of pkg/agentruntime/session.go's
 // SpawnSessionID: 'c-' + the first 32 lowercase hex characters of
@@ -217,6 +243,9 @@ module.exports = async function (context) {
       spawned: spawned,
       spawnStatus: spawnStatus,
       spawnBody: spawnBody,
+      agentTokenSha256: agentTokenSha256,
+      agentTokenNamespace: agentTokenNamespace,
+      agentTokenAgent: agentTokenAgent,
     }),
     headers: { 'Content-Type': 'application/json' },
   };


### PR DESCRIPTION
Stack position 5 (#3701 ← #3703 ← #3704 ← this). Gives agent function pods a real per-agent credential so handler-driven spawns authenticate on secured installs — the G16 gate on spawning is lifted.

## Design (amended from the gap sketch: HKDF, not JWT)

No `allowed_namespaces`-JWT minting infrastructure exists in-repo (those tokens are operator-provisioned), so the credential mirrors the shipped statesvc bearer end to end — no minting service, no key distribution, stateless verification, rotation via the existing active/old masters:

- **Derivation**: `DeriveAgentIdentityKey(master, ns, agent)` — new `agentident` link in the HKDF chain, collision-free by tag.
- **Injection**: the fetcher writes `.fission-agent-token` (`{namespace, agent, token}`) at specialize time, sibling of the state token (same `os.Remove`/0444 dance, same `dev-unauthenticated` placeholder without a master; deliberately NOT the state file — identity must not require `State`). The executor injects `FISSION_AGENT_TOKEN_PATH` + `FISSION_AGENT_RUNTIME_URL` (chart adds `AGENT_RUNTIME_URL` on the executor, fixing the fixtures' hardcoded install-namespace URL). Container executortype: no fetcher → no file (documented boundary).
- **Verification (dispatch route ONLY, fail-closed)**: identity claims headers select the identity path exclusively — no JWT fallback. Constant-time compare against both masters → live-view revocation check (the `requireKnownKeyspace` mirror: a deleted agent's token dies with it) → **inline authorization: claimed namespace must equal the dispatched path namespace** (403 otherwise; the claimed agent names the caller, not the target — same-namespace cross-agent dispatch is the spawn shape). Full truth table unit-tested through the real middleware stack; allowInsecure remains a bytewise pass-through.
- **Boundaries**: per-AGENT, not per-session (Q9 open); tool grants stay server-side from the live view, never in the token; scope composes with the same-namespace parentage rule below this PR — a spawning agent can never reach further than parentage already allows.

## Verification

- Task 3's middleware survived a dedicated adversarial review (timing, oracles, header-predicate abuse, mount scope) with zero blockers/majors.
- Integration proves the injection chain end to end without a secured install: the fixture echoes sha256(token), the test re-derives from `FISSION_INTERNAL_AUTH_SECRET` and asserts equality (placeholder path pinned too). Secured-mode e2e (env-flip serial test) is a named follow-up.
- Final whole-branch review: SHIP (1 minor — a JSON.parse-snippet token-leak-to-logs class in fixture error paths, fixed across all token-file reads).

## Follow-ups (named, not in this PR)
mcp `ctx.tools` scoping (rides tool consumption); mcp/agentruntime authz shared-package extraction; cross-namespace parentage relaxation via `Scope.Allows`; per-session tokens (Q9); secured-mode serial e2e.

CI note: workflows are main-base-scoped; full battery runs when the stack retargets main.

Process: reviewed plan (REVISE→fixed: 1 blocker — the identity path bypasses the JWT middleware's inline namespace check, so the wrapper enforces it itself), 6 SDD tasks all PASS/PASS, adversarial authz review, final SHIP, fix round + re-review (which itself caught an incomplete fix, closed inline).