### PR TITLE
agentruntime,mcp: OTel GenAI spans — invoke_agent turns, wake-stitched traces, MCP _meta (G15)

### DIFF
--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -190,6 +190,80 @@ Mapped from the boardroom demo script; check these off live against the
       (`density (sessions:pods): NNx`) climbs as `--sessions` grows for a
       fixed pool size.
 
+## Observability
+
+The agent runtime and `pkg/mcp` emit OTel traces for the boardroom demo's
+request paths — no meters yet (that stays a follow-up; see the observability
+plan's Global Constraints).
+This section is a reference, not a walkthrough:
+the spans exist whether or not a collector is running,
+so nothing here is required to run the demo itself.
+
+### What spans exist
+
+- **`invoke_agent <agent>`** —
+  one span per agent turn, started in `pkg/agentruntime/dispatcher.go`'s `DispatchTurn`,
+  a child of the inbound HTTP request's server span.
+  Attributes: `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name`,
+  plus `fission.agent.namespace`, `fission.session.id`, `fission.turn`, `fission.turn.source` (`http` or `wake`),
+  and on completion `fission.yield` + a span status (`Error` on transport failure, `Ok` otherwise).
+  **Wake-stitched:** when a turn yields `continue`, the dispatcher injects its span's trace context
+  into the wake envelope it enqueues (`pkg/agentruntime/wake.go`),
+  and the woken continuation's `invoke_agent` span is started as a child of THAT context —
+  so a whole self-continuation chain (turn, yield, wake, turn, yield, wake, ...)
+  is ONE trace end to end, not a new root span per turn.
+  A wake delivered without the trace field (e.g. from a pre-upgrade envelope) degrades gracefully
+  to a fresh root span, never an error.
+- **`execute_tool <tool>`** —
+  one span per MCP tool call, started in `pkg/mcp/server.go`'s `callTool`.
+  Attributes: `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `fission.agent.namespace` of the target function.
+  When the caller's `_meta` carries a valid W3C `traceparent` (MCP 2026-07-28's reserved trace-context keys —
+  `traceparent`/`tracestate`/`baggage`), the span parents to that extracted context instead of a fresh one,
+  so a caller-supplied trace also stitches through a tool call.
+  `_meta` is untrusted input handled additive-only: absent or malformed values never error and never log above `V(1)`.
+- **Server spans** on both muxes —
+  `fission-agentruntime` (the agent runtime's mux, `/registry/events`, `/ui`, `/healthz`, `/readyz` excluded so SSE and the UI never get spans)
+  and `fission-mcp` (the `/mcp` mux, no filter needed).
+  These are what `invoke_agent` and `execute_tool` parent to on the inbound side.
+
+Span names and attribute keys follow the OTel **GenAI semantic conventions,
+pinned at `go.opentelemetry.io/otel/semconv/v1.37.0`**
+(pre-stable/experimental — the spec has moved these keys before; re-verify on any future semconv bump,
+see the doc comments next to `pkg/agentruntime/dispatcher.go`'s `tracer()` and `pkg/mcp/tracing.go`).
+
+### Seeing traces locally
+
+Fission bundles no collector or backend — `fission-bundle` only installs the TracerProvider and W3C propagator
+(`pkg/utils/otel/provider.go`) and points them at whatever OTLP endpoint you configure.
+With no collector reachable, the SDK falls back to `NeverSample`:
+trace-ids still propagate end to end (see Task 3's integration test, `TestAgentRuntimeTraceContextPropagation`),
+but nothing is exported anywhere, so there's nothing to look at.
+
+The `kind-opentelemetry` skaffold profile points `openTelemetry.otlpCollectorEndpoint` at
+`otel-collector.opentelemetry-operator-system.svc:4317`,
+but it deploys no collector itself — bring your own via the OpenTelemetry Operator, roughly:
+
+```sh
+# 1. Install the operator (cert-manager is its own prerequisite; see the
+#    operator's own install docs for that step).
+helm upgrade --install opentelemetry-operator open-telemetry/opentelemetry-operator \
+  -n opentelemetry-operator-system --create-namespace
+
+# 2. Apply a Collector CR named "otel-collector" in that same namespace, with
+#    an otlp receiver on :4317 and whatever exporter you want traces to land
+#    on (a "debug" exporter to start, or a real backend's OTLP exporter).
+kubectl apply -n opentelemetry-operator-system -f your-otelcollector-cr.yaml
+```
+
+Then redeploy with `SKAFFOLD_PROFILE=kind-opentelemetry make skaffold-deploy`
+so the agent runtime and mcp pick up the endpoint.
+
+**Reference OTLP backends:**
+[Langfuse](https://langfuse.com) and [Arize Phoenix](https://phoenix.arize.com) both accept OTLP directly
+and understand the GenAI semconv attributes above out of the box — either is a reasonable target
+for the Collector CR's exporter if you want to actually look at the `invoke_agent`/`execute_tool` traces
+this demo produces (docs mention only; neither ships with Fission).
+
 ## Success metrics `loadgen` prints
 
 At the end of a run (the boardroom demo script's "Success metrics" section

--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -235,7 +235,7 @@ see the doc comments next to `pkg/agentruntime/dispatcher.go`'s `tracer()` and `
 
 Fission bundles no collector or backend — `fission-bundle` only installs the TracerProvider and W3C propagator
 (`pkg/utils/otel/provider.go`) and points them at whatever OTLP endpoint you configure.
-With no collector reachable, the SDK falls back to `NeverSample`:
+With no OTLP endpoint configured, the SDK falls back to `NeverSample`:
 trace-ids still propagate end to end (see Task 3's integration test, `TestAgentRuntimeTraceContextPropagation`),
 but nothing is exported anywhere, so there's nothing to look at.
 

--- a/hack/antislop-baseline.txt
+++ b/hack/antislop-baseline.txt
@@ -6,6 +6,7 @@
 # The gate fails when a file/analyzer pair is missing from this list or its
 # count grows; a pair that shrinks passes. Every line is a claim that the
 # pattern is right for that file — justify new ones in review.
+1 pkg/mcp/tracing_test.go noanycontainers
 1 pkg/workflow/decide_test.go noanycontainers
 1 pkg/workflow/decide_test.go nountypedunmarshal
 3 pkg/workflow/engine_branch_test.go noanycontainers

--- a/pkg/agentruntime/dispatcher.go
+++ b/pkg/agentruntime/dispatcher.go
@@ -25,6 +25,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"go.opentelemetry.io/otel/trace"
 
 	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/router/endpointcache"
@@ -32,6 +37,9 @@ import (
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/uuid"
 )
+
+// agentTracerName scopes the invoke_agent span's Tracer (see Dispatcher.tracer).
+const agentTracerName = "fission/agentruntime"
 
 const (
 	// HeaderSession is the response header carrying the resolved session id —
@@ -256,6 +264,17 @@ type Dispatcher struct {
 	// doc comment. nil disables prediction: DispatchTurn leaves
 	// SessionRecord.CurrentPod untouched rather than clearing it.
 	index *endpointcache.Index
+
+	// tracerProvider is the invoke_agent span's TracerProvider seam,
+	// injected AFTER construction via SetTracerProvider (mirroring
+	// SetWakeEnqueuer/SetEndpointIndex's construction-cycle rationale) —
+	// see that method's doc comment. nil means "use the process-wide
+	// otel.GetTracerProvider()", which is what fission-bundle's main
+	// installs in production (pkg/utils/otel/provider.go); tests thread an
+	// explicit sdktrace.NewTracerProvider + tracetest.SpanRecorder instead,
+	// since the global default propagator/provider in tests is a no-op that
+	// would make span assertions pass vacuously.
+	tracerProvider trace.TracerProvider
 }
 
 // NewDispatcher returns a Dispatcher. retention is added to an entry's
@@ -305,6 +324,33 @@ func (d *Dispatcher) SetWakeEnqueuer(w enqueuer) {
 // identically: CurrentPod is left untouched, never cleared.
 func (d *Dispatcher) SetEndpointIndex(ix *endpointcache.Index) {
 	d.index = ix
+}
+
+// SetTracerProvider wires the invoke_agent span's TracerProvider seam
+// post-construction, mirroring SetWakeEnqueuer/SetEndpointIndex's plain,
+// unsynchronized pre-serve field-write contract — call it before the
+// dispatcher serves any turn. Production leaves it unset (nil), which makes
+// tracer() fall back to the process-wide otel.GetTracerProvider(); unit
+// tests set an explicit provider (e.g. sdktrace.NewTracerProvider with a
+// tracetest.SpanRecorder syncer) so span assertions are hermetic and do not
+// depend on — or pollute — global otel state.
+func (d *Dispatcher) SetTracerProvider(tp trace.TracerProvider) {
+	d.tracerProvider = tp
+}
+
+// tracer returns the Tracer DispatchTurn starts its invoke_agent span from.
+//
+// GenAI semantic conventions are PRE-STABLE (experimental) as of this pin:
+// go.opentelemetry.io/otel/semconv/v1.37.0 supplies the gen_ai.* attribute
+// keys used below (GenAIOperationNameInvokeAgent = "invoke_agent",
+// GenAIAgentName = "gen_ai.agent.name"). Re-verify attribute names against
+// the semconv package on any future bump — the spec has moved these before.
+func (d *Dispatcher) tracer() trace.Tracer {
+	tp := d.tracerProvider
+	if tp == nil {
+		tp = otel.GetTracerProvider()
+	}
+	return tp.Tracer(agentTracerName)
 }
 
 // Handler serves POST /agents/{namespace}/{name}; other methods get 405 (the
@@ -393,6 +439,42 @@ func (d *Dispatcher) dispatch(w http.ResponseWriter, r *http.Request) {
 // yield, LastActiveAt, and continue-enqueue). The HTTP handler and the wake
 // consumer both call this — chaining lives HERE so both turn kinds chain.
 func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink TurnSink) (TurnResult, error) {
+	turnSource := "http"
+	if tr.WakeID != "" {
+		turnSource = "wake"
+	}
+	// The invoke_agent span MUST start here — before EVERY early return in
+	// this function (including the entry-lookup miss immediately below) and,
+	// above all, before bgCtx is derived a few lines down: context.
+	// WithoutCancel preserves context VALUES (just not cancellation), and
+	// EnqueueWake is later called with bgCtx (step 5, below) — a span
+	// started any later would silently degrade every yield=continue
+	// continuation to a root span, masked by the wake envelope's
+	// backward-compat Trace-absent fallback (wake.go). `defer span.End()`
+	// immediately after Start covers every return in this function by
+	// construction, and — since it runs as part of a normal function
+	// return — always fires AFTER the step-5 settle below, satisfying "end
+	// after settle" with no separate End() call anywhere else. Never end or
+	// re-parent this span from a bgCtx-derived code path: carrying its
+	// values there via bgCtx is exactly what the wake stitch needs.
+	//
+	// An HTTP turn starts from the caller's ctx, which for the dispatch mux
+	// is already a child of the "fission-agentruntime" server span
+	// (main.go's otelUtils.GetHandlerWithOTEL wrap). A wake-delivered turn
+	// starts from the delivery ctx wake.go's process() extracted from the
+	// wake envelope's optional Trace field, making the continuation's span
+	// a child in the SAME trace as the turn that originally enqueued it —
+	// or, when Trace is absent (no propagator injected anything, or a
+	// pre-observability envelope), a fresh root span, never an error.
+	ctx, span := d.tracer().Start(ctx, "invoke_agent "+tr.Agent, trace.WithAttributes(
+		semconv.GenAIOperationNameInvokeAgent,
+		semconv.GenAIAgentName(tr.Agent),
+		attribute.String("fission.agent.namespace", tr.Namespace),
+		attribute.String("fission.session.id", tr.SessionID),
+		attribute.String("fission.turn.source", turnSource),
+	))
+	defer span.End()
+
 	entry, ok := d.view.Lookup(tr.Namespace, tr.Agent)
 	if !ok {
 		return TurnResult{}, ErrNotAgent
@@ -401,7 +483,10 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 	// bgCtx carries no cancellation from the caller: the post-response
 	// bookkeeping (and the transport-failure bookkeeping below) must still
 	// land even if the caller has already gone away, since it is what keeps
-	// Stats/Status honest and self-heals nothing on its own.
+	// Stats/Status honest and self-heals nothing on its own. It DOES carry
+	// every value on ctx — including the invoke_agent span started above —
+	// which is exactly what lets EnqueueWake (step 5) inject this turn's
+	// trace into a continuation's wake envelope.
 	bgCtx := context.WithoutCancel(ctx)
 	liveTTL := entry.IdleAfter + entry.ArchiveAfter + d.retention
 	now := d.now()
@@ -484,6 +569,7 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 			rec.LastActiveAt = now
 		})
 	}
+	span.SetAttributes(attribute.Int64("fission.turn", turnsAtStart))
 
 	// Step 4: forward the turn.
 	upstream := d.routerURL + utils.UrlForFunction(tr.Agent, tr.Namespace)
@@ -533,6 +619,14 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 			rec.Status = StatusActive
 			rec.LastActiveAt = d.now()
 		})
+		// Span status: Error on a transport failure (this branch), Ok on a
+		// normal completion (the final return below) — the two outcomes the
+		// plan pins explicitly. A caller-disconnect (context.Canceled) is
+		// still a span-level Error: that distinction only matters for
+		// Stats.Errors metering above, not for whether this span's own
+		// operation completed successfully.
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return TurnResult{}, fmt.Errorf("calling upstream function: %w", err)
 	}
 	defer resp.Body.Close()
@@ -634,6 +728,8 @@ func (d *Dispatcher) DispatchTurn(ctx context.Context, tr TurnRequest, sink Turn
 		}
 	}
 
+	span.SetAttributes(attribute.String("fission.yield", yield))
+	span.SetStatus(codes.Ok, "")
 	return TurnResult{StatusCode: resp.StatusCode, Yield: yield, WakeEnqueueAttempted: doEnqueue}, nil
 }
 

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -718,15 +718,20 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// to hide its span.
 	//
 	// Filtered: /registry/events (the SSE registry feed — a span living for
-	// the lifetime of an open stream is not useful) and /ui (the boardroom
+	// the lifetime of an open stream is not useful), /ui (the boardroom
 	// UI, both the bare GET /ui route and everything under GET /ui/ — the
 	// otelUtils.UrlsToIgnore filter is HasPrefix, so the single "/ui" entry
-	// covers both routes registered above). otelhttp v0.70.0's middleware
+	// covers both routes registered above), and /healthz + /readyz (kubelet
+	// liveness/readiness probes, registered above as the exact paths
+	// "/healthz" / "/readyz" with no trailing-slash variant — a span on
+	// every probe poll is pure noise, and the router's own public listener
+	// filters its healthz endpoint the same way, otelUtils.UrlsToIgnore
+	// ("/router-healthz"), router.go). otelhttp v0.70.0's middleware
 	// short-circuits to next.ServeHTTP BEFORE span creation AND before
 	// propagator extraction whenever a filter returns false (handler.go
 	// :90-98) — a filtered request is not merely un-spanned, it never even
 	// sees an extracted trace context, which is the behavior wanted here.
-	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui"))
+	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui", "/healthz", "/readyz"))
 
 	capsClosed = true
 	serveCtx, stopServe := context.WithCancel(ctx)

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -81,6 +81,7 @@ import (
 	"github.com/fission/fission/pkg/utils/crmanager"
 	"github.com/fission/fission/pkg/utils/httpserver"
 	"github.com/fission/fission/pkg/utils/httpx"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 // agentruntimeScheme is the agent runtime Manager's scheme: the Fission CRD
@@ -707,13 +708,33 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// so without stopServe() below, <-serveDone would block forever on that
 	// error path and wedge this whole function (and caps.Close with it) even
 	// though the process is still live and should report the error.
+	// Server spans on the whole mux, mirroring the router's public-listener
+	// precedent (router.go's otelUtils.GetHandlerWithOTEL(publicMR, "fission-
+	// router", ...) wrap): otel wraps OUTSIDE every per-route auth wrapper
+	// (IdentityOrJWT above, authz.Middleware/HTTPMiddleware below) so an
+	// unauthenticated 401/403 still gets a span — deliberately inverting the
+	// router-INTERNAL listener's verifier-outside ordering, which exists
+	// there to keep an unsigned request from reaching the proxy at all, not
+	// to hide its span.
+	//
+	// Filtered: /registry/events (the SSE registry feed — a span living for
+	// the lifetime of an open stream is not useful) and /ui (the boardroom
+	// UI, both the bare GET /ui route and everything under GET /ui/ — the
+	// otelUtils.UrlsToIgnore filter is HasPrefix, so the single "/ui" entry
+	// covers both routes registered above). otelhttp v0.70.0's middleware
+	// short-circuits to next.ServeHTTP BEFORE span creation AND before
+	// propagator extraction whenever a filter returns false (handler.go
+	// :90-98) — a filtered request is not merely un-spanned, it never even
+	// sees an extracted trace context, which is the behavior wanted here.
+	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui"))
+
 	capsClosed = true
 	serveCtx, stopServe := context.WithCancel(ctx)
 	serveDone := make(chan struct{})
 	mgr.Go(func() error {
 		defer close(serveDone)
 		httpserver.Serve(serveCtx, logger, mgr, httpserver.ServerOptions{
-			Name: "agentruntime", Addr: strconv.Itoa(opts.Port), Listener: opts.Listener, Handler: mux,
+			Name: "agentruntime", Addr: strconv.Itoa(opts.Port), Listener: opts.Listener, Handler: handler,
 		})
 		return nil
 	})

--- a/pkg/agentruntime/tracing_test.go
+++ b/pkg/agentruntime/tracing_test.go
@@ -466,10 +466,11 @@ func TestDispatchTurn_OutboundRequestCarriesTraceparent(t *testing.T) {
 }
 
 // TestAgentruntimeMux_FiltersSSEAndUIFromServerSpans pins the mux-wrap
-// filter (main.go): /registry/events and /ui (both the bare route and
-// everything under /ui/, since otelUtils.UrlsToIgnore is HasPrefix) must
-// produce NO server span, while an ordinary route still does — proving the
-// filter engaged rather than the whole pipeline being silently dead.
+// filter (main.go): /registry/events, /ui (both the bare route and
+// everything under /ui/, since otelUtils.UrlsToIgnore is HasPrefix), and the
+// kubelet probe routes /healthz + /readyz must all produce NO server span,
+// while an ordinary route still does — proving the filter engaged rather
+// than the whole pipeline being silently dead.
 func TestAgentruntimeMux_FiltersSSEAndUIFromServerSpans(t *testing.T) {
 	// Not t.Parallel(): withGlobalTracerProvider mutates global otel state.
 	tp, rec := newTestTracerProvider(t)
@@ -481,17 +482,22 @@ func TestAgentruntimeMux_FiltersSSEAndUIFromServerSpans(t *testing.T) {
 	mux.HandleFunc("GET /ui", ok)
 	mux.HandleFunc("GET /ui/", ok)
 	mux.HandleFunc("GET /healthz", ok)
-	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui"))
+	mux.HandleFunc("GET /readyz", ok)
+	// A control route NOT in the filter list, mirroring another route
+	// main.go actually registers unfiltered — proves the filter mechanism
+	// itself is what suppressed the others, not a dead otel pipeline.
+	mux.HandleFunc("GET /registry/agents", ok)
+	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui", "/healthz", "/readyz"))
 
-	for _, path := range []string{"/registry/events", "/ui", "/ui/console"} {
+	for _, path := range []string{"/registry/events", "/ui", "/ui/console", "/healthz", "/readyz"} {
 		req := httptest.NewRequest(http.MethodGet, path, nil)
 		w := httptest.NewRecorder()
 		handler.ServeHTTP(w, req)
 		require.Equal(t, http.StatusOK, w.Code, path)
 	}
-	assert.Empty(t, rec.Ended(), "filtered routes must produce NO server span")
+	assert.Empty(t, rec.Ended(), "filtered routes (including the kubelet probes) must produce NO server span")
 
-	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	req := httptest.NewRequest(http.MethodGet, "/registry/agents", nil)
 	w := httptest.NewRecorder()
 	handler.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)

--- a/pkg/agentruntime/tracing_test.go
+++ b/pkg/agentruntime/tracing_test.go
@@ -1,0 +1,499 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// tracing_test.go covers the invoke_agent span (dispatcher.go), the
+// wake-envelope trace stitching (wake.go), and the agentruntime mux's server
+// spans (main.go's otelUtils.GetHandlerWithOTEL wrap, exercised here directly
+// against a hand-built mux mirroring that wiring).
+//
+// Test seams (Global Constraints): the package-wide W3C composite propagator
+// is installed EXACTLY ONCE in TestMain below — the process default is a
+// no-op TextMapPropagator, so any test relying on it would pass vacuously
+// (Extract/Inject would silently no-op). Per-test span assertions thread an
+// explicit sdktrace.NewTracerProvider + tracetest.SpanRecorder through
+// Dispatcher.SetTracerProvider (mirrors SetWakeEnqueuer's construction-cycle
+// seam) rather than touching the global TracerProvider — safe under
+// t.Parallel(). The two tests that exercise the SERVER span (otelhttp has no
+// GetHandlerWithOTEL provider option) are the deliberate exception: they
+// swap otel.SetTracerProvider for their duration (restored via t.Cleanup)
+// and are NOT t.Parallel() for that reason — see withGlobalTracerProvider.
+package agentruntime
+
+import (
+	"context"
+	"encoding/json/v2"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
+)
+
+// TestMain installs the W3C composite propagator (tracecontext + baggage)
+// ONCE for the whole package's test binary. Without this the process default
+// is otel's no-op propagator: Inject writes nothing and Extract reads
+// nothing, so any stitch/inject assertion below would pass vacuously
+// regardless of whether dispatcher.go/wake.go's carriage logic is even
+// wired correctly. The same propagator value is used by every test — safe
+// under t.Parallel() since nothing here mutates it again.
+func TestMain(m *testing.M) {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	os.Exit(m.Run())
+}
+
+// newTestTracerProvider returns an SDK TracerProvider recording every
+// started/ended span into rec, with AlwaysSample so a span parented on an
+// extracted remote SpanContext is recorded regardless of that context's
+// carried sampled-flag.
+func newTestTracerProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+// withGlobalTracerProvider temporarily swaps the GLOBAL otel TracerProvider
+// to tp, restoring the previous one on cleanup. Only the two server-span
+// tests need this: otelUtils.GetHandlerWithOTEL (main.go's precedent) has no
+// per-call TracerProvider option, so otelhttp's middleware always resolves
+// the server span's tracer from otel.GetTracerProvider() at request time
+// (see otelhttp's handler.go serveHTTP — h.tracer is nil, and the incoming
+// request carries no live span object on its own context, so it falls back
+// to the global). Callers of this helper must NOT call t.Parallel().
+func withGlobalTracerProvider(t *testing.T, tp trace.TracerProvider) {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+}
+
+// findSpan returns the first ended span whose name starts with prefix.
+func findSpan(spans []sdktrace.ReadOnlySpan, prefix string) (sdktrace.ReadOnlySpan, bool) {
+	for _, s := range spans {
+		if strings.HasPrefix(s.Name(), prefix) {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+// attrValue returns the value of key among attrs, if present.
+func attrValue(attrs []attribute.KeyValue, key attribute.Key) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// TestDispatchTurn_ServerSpanAndInvokeAgentChild drives one HTTP turn
+// through the REAL mux shape main.go wires (dispatcher.Handler() wrapped in
+// otelUtils.GetHandlerWithOTEL, the router-public precedent) and asserts: a
+// "fission-agentruntime"-scoped server span exists, an "invoke_agent fn"
+// span exists as ITS CHILD (same trace-id, Parent().SpanID() equals the
+// server span's SpanID), the invoke_agent span carries the pinned
+// gen_ai.*/fission.* attributes plus fission.yield on completion, ends
+// with an Ok status, and — critically — is ended EXACTLY ONCE.
+func TestDispatchTurn_ServerSpanAndInvokeAgentChild(t *testing.T) {
+	// Not t.Parallel(): withGlobalTracerProvider mutates global otel state.
+	tp, rec := newTestTracerProvider(t)
+	withGlobalTracerProvider(t, tp)
+
+	upstream := okUpstream(t)
+	d, view, _ := newTestDispatcher(t, upstream.URL)
+	d.SetTracerProvider(tp)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	mux := http.NewServeMux()
+	mux.Handle("POST /agents/{namespace}/{name}", d.Handler())
+	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui"))
+
+	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
+	req.Header.Set(HeaderSession, "sess-span")
+	rec2 := httptest.NewRecorder()
+	handler.ServeHTTP(rec2, req)
+	require.Equal(t, http.StatusOK, rec2.Code)
+
+	ended := rec.Ended()
+	serverSpan, ok := findSpan(ended, "POST ")
+	require.True(t, ok, "expected an otelhttp server span, got spans: %v", spanNames(ended))
+	invokeSpan, ok := findSpan(ended, "invoke_agent ")
+	require.True(t, ok, "expected an invoke_agent span, got spans: %v", spanNames(ended))
+
+	assert.Equal(t, "invoke_agent fn", invokeSpan.Name())
+	assert.Equal(t, serverSpan.SpanContext().TraceID(), invokeSpan.SpanContext().TraceID(), "invoke_agent must share the server span's trace")
+	assert.Equal(t, serverSpan.SpanContext().SpanID(), invokeSpan.Parent().SpanID(), "invoke_agent must be a CHILD of the server span")
+
+	attrs := invokeSpan.Attributes()
+	if v, ok := attrValue(attrs, "gen_ai.operation.name"); assert.True(t, ok) {
+		assert.Equal(t, "invoke_agent", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "gen_ai.agent.name"); assert.True(t, ok) {
+		assert.Equal(t, "fn", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "fission.agent.namespace"); assert.True(t, ok) {
+		assert.Equal(t, "ns", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "fission.session.id"); assert.True(t, ok) {
+		assert.Equal(t, "sess-span", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "fission.turn.source"); assert.True(t, ok) {
+		assert.Equal(t, "http", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "fission.turn"); assert.True(t, ok) {
+		assert.EqualValues(t, 0, v.AsInt64(), "turnsAtStart for a freshly-minted session is 0")
+	}
+	if v, ok := attrValue(attrs, "fission.yield"); assert.True(t, ok) {
+		assert.Equal(t, "", v.AsString(), "okUpstream sets no X-Fission-Agent-Yield header")
+	}
+	assert.Equal(t, codes.Ok, invokeSpan.Status().Code)
+
+	// Ended exactly once: exactly one span named "invoke_agent fn" in the
+	// whole recording, not two (a double-End, or a re-parented duplicate).
+	count := 0
+	for _, s := range ended {
+		if s.Name() == "invoke_agent fn" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "invoke_agent span must be ended exactly once")
+}
+
+func spanNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name()
+	}
+	return names
+}
+
+// TestDispatchTurn_SpanEndsExactlyOnceOnEarlyReturn drives the ErrNotAgent
+// early-return path (DispatchTurn's very first branch, entry lookup miss) —
+// the earliest possible return, before bgCtx is even derived — and asserts
+// the invoke_agent span is STILL ended exactly once (the `defer span.End()`
+// placed before that branch covers it) with core identity attributes set,
+// even though the turn never reached the session-record or upstream-call
+// stages. Uses the Dispatcher-local tracer-provider seam only, so this is
+// safe under t.Parallel().
+func TestDispatchTurn_SpanEndsExactlyOnceOnEarlyReturn(t *testing.T) {
+	t.Parallel()
+	tp, rec := newTestTracerProvider(t)
+	d, _, _ := newTestDispatcher(t, "http://unused.invalid")
+	d.SetTracerProvider(tp)
+	// Deliberately no view.Upsert: (ns, fn) is not a registered agent.
+
+	tr := TurnRequest{Namespace: "ns", Agent: "fn", SessionID: "sess-notfound"}
+	_, err := d.DispatchTurn(t.Context(), tr, &wakeSink{})
+	require.ErrorIs(t, err, ErrNotAgent)
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1, "exactly one span must be ended on the earliest possible return")
+	span := ended[0]
+	assert.Equal(t, "invoke_agent fn", span.Name())
+	if v, ok := attrValue(span.Attributes(), "fission.session.id"); assert.True(t, ok) {
+		assert.Equal(t, "sess-notfound", v.AsString())
+	}
+	if v, ok := attrValue(span.Attributes(), "fission.turn.source"); assert.True(t, ok) {
+		assert.Equal(t, "http", v.AsString())
+	}
+	// No fission.turn/fission.yield/explicit status: the turn never reached
+	// the bookkeeping or upstream-call stages that set those (see
+	// DispatchTurn's doc comment on status placement).
+	assert.Equal(t, codes.Unset, span.Status().Code)
+}
+
+// TestDispatchTurn_TransportFailureSetsErrorStatus pins the status split the
+// plan calls out explicitly: Error on a transport failure, Ok otherwise.
+func TestDispatchTurn_TransportFailureSetsErrorStatus(t *testing.T) {
+	t.Parallel()
+	dead := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := dead.URL
+	dead.Close()
+
+	tp, rec := newTestTracerProvider(t)
+	d, view, _ := newTestDispatcher(t, deadURL)
+	d.SetTracerProvider(tp)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	tr := TurnRequest{Namespace: "ns", Agent: "fn", SessionID: "sess-transport"}
+	_, err := d.DispatchTurn(t.Context(), tr, &wakeSink{})
+	require.Error(t, err)
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, codes.Error, ended[0].Status().Code)
+}
+
+// TestWakeStitching_ContinuationSharesEnqueuingTrace drives yield=continue
+// END-TO-END: DispatchTurn's own shared-path enqueue (SetWakeEnqueuer wired,
+// production shape) produces the wake envelope actually sitting in the
+// queue — never a hand-built one — and delivering it must produce a SECOND
+// invoke_agent span sharing the FIRST span's trace-id (a different span-id:
+// children re-span, they never pass through unchanged).
+func TestWakeStitching_ContinuationSharesEnqueuingTrace(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(HeaderYield, YieldContinue)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	tp, rec := newTestTracerProvider(t)
+	w, view, _, q := newTestWakeServiceFull(t, http.DefaultClient, upstream.URL, time.Now, 0, true)
+	w.d.SetTracerProvider(tp)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	tr := TurnRequest{Namespace: "ns", Agent: "fn", SessionID: "sess-stitch"}
+	res, err := w.d.DispatchTurn(t.Context(), tr, &wakeSink{})
+	require.NoError(t, err)
+	require.Equal(t, YieldContinue, res.Yield)
+	require.True(t, res.WakeEnqueueAttempted)
+
+	enqueuing, ok := findSpan(rec.Ended(), "invoke_agent ")
+	require.True(t, ok)
+	enqueuingTraceID := enqueuing.SpanContext().TraceID()
+	enqueuingSpanID := enqueuing.SpanContext().SpanID()
+
+	msgs, err := q.Lease(t.Context(), wakeQueue, 10, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1, "the shared path must have enqueued the continuation")
+
+	var env wakeEnvelope
+	require.NoError(t, json.Unmarshal(msgs[0].Body, &env))
+	require.NotEmpty(t, env.Trace, "EnqueueWake must have injected the enqueuing turn's trace context")
+
+	w.process(t.Context(), msgs[0])
+
+	ended := rec.Ended()
+	require.Len(t, ended, 2, "the delivered continuation must produce a second invoke_agent span")
+	var continuation sdktrace.ReadOnlySpan
+	for _, s := range ended {
+		if s.SpanContext().SpanID() != enqueuingSpanID && strings.HasPrefix(s.Name(), "invoke_agent ") {
+			continuation = s
+		}
+	}
+	require.NotNil(t, continuation, "expected a distinct second invoke_agent span")
+	assert.Equal(t, enqueuingTraceID, continuation.SpanContext().TraceID(), "the continuation must share the enqueuing turn's trace id")
+	assert.NotEqual(t, enqueuingSpanID, continuation.SpanContext().SpanID(), "children re-span — the span-id must differ")
+	assert.Equal(t, enqueuingSpanID, continuation.Parent().SpanID(), "the continuation must be a DIRECT CHILD of the enqueuing turn's still-open invoke_agent span (bgCtx carries it live into EnqueueWake), not just trace-id-adjacent")
+	if v, ok := attrValue(continuation.Attributes(), "fission.turn.source"); assert.True(t, ok) {
+		assert.Equal(t, "wake", v.AsString())
+	}
+}
+
+// TestWakeStitching_AbsentTraceFieldIsRootSpan pins the backward-compat
+// fallback: a wake envelope with no Trace field (the zero value — a
+// pre-observability envelope, or an EnqueueWake call whose ctx carried no
+// span) must still deliver correctly, producing a fresh ROOT span rather
+// than an error or a silently-broken delivery.
+func TestWakeStitching_AbsentTraceFieldIsRootSpan(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	tp, rec := newTestTracerProvider(t)
+	w, view, _, q := newTestWakeService(t, upstream.URL, time.Now)
+	w.d.SetTracerProvider(tp)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	// EnqueueWake called with a context carrying no span: the injected
+	// carrier is empty, so env.Trace stays nil — exactly the pre-
+	// observability shape.
+	require.NoError(t, w.EnqueueWake(t.Context(), "ns", "fn", "sess-root", 0))
+	msgs, err := q.Lease(t.Context(), wakeQueue, 10, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	var env wakeEnvelope
+	require.NoError(t, json.Unmarshal(msgs[0].Body, &env))
+	require.Empty(t, env.Trace, "a context with no active span must inject nothing")
+
+	w.process(t.Context(), msgs[0])
+
+	ended := rec.Ended()
+	require.Len(t, ended, 1)
+	span := ended[0]
+	assert.False(t, span.Parent().IsValid(), "no Trace field on the envelope must produce a ROOT span, not an error")
+	if v, ok := attrValue(span.Attributes(), "fission.turn.source"); assert.True(t, ok) {
+		assert.Equal(t, "wake", v.AsString())
+	}
+}
+
+// TestWakeRevival_CarriesDeliveryTrace forces the chain-death race
+// reviveChain exists to close (SetWakeEnqueuer deliberately never wired, so
+// the shared path CANNOT enqueue — see
+// TestWakeService_AckedContinueRevivesChainWithoutSharedPathEnqueuer for the
+// non-tracing version of this shape) and asserts the revival's own enqueue
+// (wake.go's reviveChain, via withDeliveryTrace) carries the SAME trace-id
+// as the delivery's extracted trace — the plan-review pin that a
+// poll-loop-derived settle ctx must not silently drop it.
+func TestWakeRevival_CarriesDeliveryTrace(t *testing.T) {
+	t.Parallel()
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(HeaderYield, YieldContinue)
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	tp, _ := newTestTracerProvider(t)
+	w, view, _, q := newTestWakeService(t, upstream.URL, time.Now) // wireEnqueuer=false
+	w.d.SetTracerProvider(tp)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	// Seed a trace context to inject into the parent envelope, standing in
+	// for whatever turn originally enqueued it.
+	seedCtx, seedSpan := tp.Tracer("seed").Start(t.Context(), "seed")
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(seedCtx, carrier)
+	seedSpan.End()
+	wantTraceID := seedSpan.SpanContext().TraceID()
+	require.NotEmpty(t, carrier)
+
+	enqueueWakeEnvelope(t, q, wakeEnvelope{
+		Version: wakeEnvelopeVersion, Namespace: "ns", Agent: "fn", Session: "sess-revive",
+		Turns: 0, EnqueueTime: time.Now(), Trace: map[string]string(carrier),
+	})
+
+	msgs, err := q.Lease(t.Context(), wakeQueue, 10, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	w.process(t.Context(), msgs[0])
+
+	// The shared path could not enqueue (wireEnqueuer=false), so any
+	// successor found here came from reviveChain alone.
+	successors, err := q.Lease(t.Context(), wakeQueue, 10, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, successors, 1, "reviveChain must have enqueued a successor")
+
+	var succ wakeEnvelope
+	require.NoError(t, json.Unmarshal(successors[0].Body, &succ))
+	require.NotEmpty(t, succ.Trace, "the revival enqueue must carry the delivery's extracted trace")
+
+	gotCtx := otel.GetTextMapPropagator().Extract(t.Context(), propagation.MapCarrier(succ.Trace))
+	sc := trace.SpanContextFromContext(gotCtx)
+	require.True(t, sc.IsValid())
+	assert.Equal(t, wantTraceID, sc.TraceID(), "the revival enqueue must carry the SAME trace-id as the delivery's extracted trace")
+}
+
+// TestWakeDedup_TraceFieldExcludedFromKey pins wakeDedupKey's exclusion of
+// Trace: two enqueues of the identical logical continuation, injected from
+// DIFFERENT active spans, must still collapse to one unsettled message (the
+// dedup key is ns/agent/session/turns only) — and the FIRST enqueue's trace
+// must be the one that survives, since a deduped EnqueueWake call never
+// rewrites an existing message body.
+func TestWakeDedup_TraceFieldExcludedFromKey(t *testing.T) {
+	t.Parallel()
+	tp, _ := newTestTracerProvider(t)
+	w, _, _, q := newTestWakeService(t, "http://unused.invalid", time.Now)
+
+	ctx1, span1 := tp.Tracer("t1").Start(t.Context(), "first")
+	require.NoError(t, w.EnqueueWake(ctx1, "ns", "fn", "sess", 3))
+	span1.End()
+
+	ctx2, span2 := tp.Tracer("t2").Start(t.Context(), "second")
+	require.NoError(t, w.EnqueueWake(ctx2, "ns", "fn", "sess", 3))
+	span2.End()
+
+	st, err := q.Stats(t.Context(), wakeQueue)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, st.Visible, "the trace field must not affect the dedup key")
+
+	msgs, err := q.Lease(t.Context(), wakeQueue, 10, time.Minute)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	var env wakeEnvelope
+	require.NoError(t, json.Unmarshal(msgs[0].Body, &env))
+	gotCtx := otel.GetTextMapPropagator().Extract(t.Context(), propagation.MapCarrier(env.Trace))
+	sc := trace.SpanContextFromContext(gotCtx)
+	require.True(t, sc.IsValid())
+	assert.Equal(t, span1.SpanContext().TraceID(), sc.TraceID(), "the FIRST enqueue's trace must win the dedup collapse")
+}
+
+// TestDispatchTurn_OutboundRequestCarriesTraceparent proves the whole point
+// of starting the span before the outbound call: the router-internal
+// request's traceparent header must carry the SAME trace-id as the inbound
+// turn, via the otelhttp transport that main.go wires onto the dispatcher's
+// client (main.go:460).
+func TestDispatchTurn_OutboundRequestCarriesTraceparent(t *testing.T) {
+	t.Parallel()
+	var gotTraceparent string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	tp, rec := newTestTracerProvider(t)
+	client := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport, otelhttp.WithTracerProvider(tp))}
+	view := NewAgentView()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	d := NewDispatcher(logr.Discard(), view, store, client, upstream.URL, time.Hour, time.Now, 0, defaultMaxSpawnDepth)
+	d.SetTracerProvider(tp)
+	view.Upsert(headerEntry("ns", "fn", 0))
+
+	tr := TurnRequest{Namespace: "ns", Agent: "fn", SessionID: "sess-outbound"}
+	_, err := d.DispatchTurn(t.Context(), tr, &wakeSink{})
+	require.NoError(t, err)
+
+	require.NotEmpty(t, gotTraceparent, "the outbound request must carry a traceparent header")
+	parts := strings.Split(gotTraceparent, "-")
+	require.Len(t, parts, 4, "traceparent must be 00-<trace-id>-<span-id>-<flags>")
+
+	invokeSpan, ok := findSpan(rec.Ended(), "invoke_agent ")
+	require.True(t, ok)
+	assert.Equal(t, invokeSpan.SpanContext().TraceID().String(), parts[1], "outbound traceparent trace-id must match the invoke_agent span's")
+	assert.NotEqual(t, invokeSpan.SpanContext().SpanID().String(), parts[2], "the outbound request re-spans under otelhttp's own client span, not the server span's id")
+}
+
+// TestAgentruntimeMux_FiltersSSEAndUIFromServerSpans pins the mux-wrap
+// filter (main.go): /registry/events and /ui (both the bare route and
+// everything under /ui/, since otelUtils.UrlsToIgnore is HasPrefix) must
+// produce NO server span, while an ordinary route still does — proving the
+// filter engaged rather than the whole pipeline being silently dead.
+func TestAgentruntimeMux_FiltersSSEAndUIFromServerSpans(t *testing.T) {
+	// Not t.Parallel(): withGlobalTracerProvider mutates global otel state.
+	tp, rec := newTestTracerProvider(t)
+	withGlobalTracerProvider(t, tp)
+
+	mux := http.NewServeMux()
+	ok := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+	mux.HandleFunc("GET /registry/events", ok)
+	mux.HandleFunc("GET /ui", ok)
+	mux.HandleFunc("GET /ui/", ok)
+	mux.HandleFunc("GET /healthz", ok)
+	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui"))
+
+	for _, path := range []string{"/registry/events", "/ui", "/ui/console"} {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code, path)
+	}
+	assert.Empty(t, rec.Ended(), "filtered routes must produce NO server span")
+
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Len(t, rec.Ended(), 1, "an un-filtered route must still produce a server span — proves the filter, not the pipeline, is what suppressed the others")
+}

--- a/pkg/agentruntime/tracing_test.go
+++ b/pkg/agentruntime/tracing_test.go
@@ -125,7 +125,9 @@ func TestDispatchTurn_ServerSpanAndInvokeAgentChild(t *testing.T) {
 
 	mux := http.NewServeMux()
 	mux.Handle("POST /agents/{namespace}/{name}", d.Handler())
-	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui"))
+	// Filter list kept in sync with main.go's (4 entries); this test only
+	// exercises the dispatch route, but drift here masked a real gap once.
+	handler := otelUtils.GetHandlerWithOTEL(mux, "fission-agentruntime", otelUtils.UrlsToIgnore("/registry/events", "/ui", "/healthz", "/readyz"))
 
 	req := httptest.NewRequest(http.MethodPost, "/agents/ns/fn", strings.NewReader("hello"))
 	req.Header.Set(HeaderSession, "sess-span")

--- a/pkg/agentruntime/wake.go
+++ b/pkg/agentruntime/wake.go
@@ -62,6 +62,9 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/fission/fission/pkg/statestore"
 	"github.com/fission/fission/pkg/utils/backoff"
@@ -134,6 +137,23 @@ type wakeEnvelope struct {
 	Session     string    `json:"session"`
 	Turns       int64     `json:"turns"` // dedup basis: turn count at enqueue
 	EnqueueTime time.Time `json:"enqueueTime"`
+	// Trace carries the enqueuing invoke_agent span's W3C trace context
+	// (tracecontext + baggage, via propagation.MapCarrier), injected by
+	// EnqueueWake and extracted by process() into the delivery ctx BEFORE
+	// DispatchTurn runs — this is the wake-stitching mechanism: a
+	// continuation's invoke_agent span becomes a child in the SAME trace as
+	// the turn that enqueued it. Optional and additive: a nil/empty map
+	// (pre-observability envelopes, or an EnqueueWake call whose ctx carried
+	// no span/context) decodes and processes identically to today —
+	// decodeWakeEnvelope's json.Unmarshal is lenient about unknown/missing
+	// fields, so this needed NO wakeEnvelopeVersion bump. Deliberately
+	// EXCLUDED from wakeDedupKey (see that function's doc comment): two
+	// enqueues of the same logical continuation (same ns/agent/session/
+	// turns) must still collapse to one message even when their trace
+	// contexts differ — the FIRST enqueue's Trace is the one that survives,
+	// since a deduped EnqueueWake call never overwrites the existing
+	// message body.
+	Trace map[string]string `json:"trace,omitempty"`
 }
 
 // decodeWakeEnvelope parses a leased message body. Deliberately lenient about
@@ -225,6 +245,13 @@ func (w *WakeService) SetRand(rand func() float64) {
 // Acks, Kills, or dead-letters, a later EnqueueWake with the identical key
 // enqueues a fresh message — the overall guarantee is at-least-once, not
 // exactly-once.
+//
+// Deliberately excludes wakeEnvelope.Trace: two enqueues of the same logical
+// continuation must still collapse to one message even when their trace
+// contexts differ (e.g. the shared path's own enqueue and reviveChain's
+// post-Ack revival, which can carry different — but same-trace-id — spans).
+// A deduped EnqueueWake call never rewrites an existing message body, so
+// whichever enqueue reaches the queue FIRST is the one whose Trace wins.
 func wakeDedupKey(ns, agent, session string, turns int64) string {
 	return fmt.Sprintf("%s/%s/%s/%d", ns, agent, session, turns)
 }
@@ -241,6 +268,22 @@ func (w *WakeService) EnqueueWake(ctx context.Context, ns, agent, session string
 		Session:     session,
 		Turns:       turns,
 		EnqueueTime: w.now(),
+	}
+	// Inject whatever trace context ctx carries (the shared path in
+	// DispatchTurn passes bgCtx, which — because the invoke_agent span
+	// starts BEFORE bgCtx is derived, see dispatcher.go — still carries that
+	// turn's own open span; reviveChain passes a ctx carrying the just-
+	// completed delivery's extracted trace, see process()) into the
+	// envelope's Trace field. otel.GetTextMapPropagator() is the PROCESS-
+	// WIDE propagator fission-bundle's main installs (W3C tracecontext +
+	// baggage); ctx carrying no span/extracted context, or the default
+	// no-op propagator (unconfigured tests), yields an empty carrier — left
+	// as env.Trace's zero value (nil), which decodeWakeEnvelope treats
+	// exactly like an absent field.
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(ctx, carrier)
+	if len(carrier) > 0 {
+		env.Trace = map[string]string(carrier)
 	}
 	body, err := json.Marshal(env)
 	if err != nil {
@@ -357,6 +400,19 @@ func (w *WakeService) process(ctx context.Context, msg statestore.LeasedMessage)
 		return
 	}
 
+	// deliveryCtx extracts env.Trace (if present) into ctx — this is the
+	// stitching half of the wake-trace mechanism (see wakeEnvelope.Trace's
+	// doc comment for the injecting half): DispatchTurn starts its
+	// invoke_agent span from dctx below, so a continuation's span becomes a
+	// child in the SAME trace as the turn that enqueued it. An envelope with
+	// no Trace field (nil/empty map) leaves ctx unchanged — DispatchTurn's
+	// span then starts a fresh root trace, which is correct, not degraded:
+	// there was nothing to stitch onto.
+	deliveryCtx := ctx
+	if len(env.Trace) > 0 {
+		deliveryCtx = otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier(env.Trace))
+	}
+
 	tr := TurnRequest{
 		Namespace:   env.Namespace,
 		Agent:       env.Agent,
@@ -367,7 +423,7 @@ func (w *WakeService) process(ctx context.Context, msg statestore.LeasedMessage)
 		WakeAttempt: msg.Attempts,
 	}
 	sink := &wakeSink{}
-	dctx, dcancel := context.WithTimeout(ctx, wakeDeliveryTimeout)
+	dctx, dcancel := context.WithTimeout(deliveryCtx, wakeDeliveryTimeout)
 	res, derr := w.d.DispatchTurn(dctx, tr, sink)
 	dcancel()
 	w.logger.V(1).Info("wake turn dispatched", "id", msg.ID, "attempt", msg.Attempts, "bytesDrained", sink.counted)
@@ -381,7 +437,15 @@ func (w *WakeService) process(ctx context.Context, msg statestore.LeasedMessage)
 	switch classifyWakeResult(res, derr) {
 	case wakeActionAck:
 		if w.ack(sctx, msg) && res.ShouldReviveChain() {
-			w.reviveChain(sctx, env)
+			// Thread the DELIVERY's extracted trace context into the
+			// revival enqueue (plan-review pin): sctx alone is rebuilt from
+			// the POLL LOOP's ctx (context.WithoutCancel(ctx) above, on
+			// this method's own `ctx` param) and never carries the trace
+			// this delivery ran under — reviveChain's EnqueueWake call would
+			// otherwise inject nothing, silently breaking the stitch on
+			// exactly the chain-death race reviveChain exists to close. See
+			// withDeliveryTrace's doc comment.
+			w.reviveChain(withDeliveryTrace(sctx, deliveryCtx), env)
 		}
 	case wakeActionKillNotAgent:
 		w.logger.V(1).Info("wake dead-lettered: not an agent function", "id", msg.ID, "namespace", env.Namespace, "agent", env.Agent, "session", env.Session, "attempts", msg.Attempts)
@@ -465,6 +529,22 @@ func (w *WakeService) ack(ctx context.Context, msg statestore.LeasedMessage) boo
 		return false
 	}
 	return true
+}
+
+// withDeliveryTrace returns base with deliveryCtx's SpanContext attached (if
+// valid), and base unchanged otherwise. It exists so process's post-Ack
+// revival enqueue can carry the just-completed delivery's trace even though
+// its settle ctx (sctx) is independently derived from the POLL LOOP's ctx
+// (never from deliveryCtx) — see process's reviveChain call site. Only the
+// SpanContext VALUE is copied; base's own cancellation/deadline (sctx's
+// settle-scoped timeout) is left untouched, since trace.ContextWithSpanContext
+// only ever sets a context value, never a deadline.
+func withDeliveryTrace(base, deliveryCtx context.Context) context.Context {
+	sc := trace.SpanContextFromContext(deliveryCtx)
+	if !sc.IsValid() {
+		return base
+	}
+	return trace.ContextWithSpanContext(base, sc)
 }
 
 // reviveChain closes the self-dedup chain-death window documented on

--- a/pkg/mcp/main.go
+++ b/pkg/mcp/main.go
@@ -34,6 +34,7 @@ import (
 	storagesvcClient "github.com/fission/fission/pkg/storagesvc/client"
 	"github.com/fission/fission/pkg/utils/crmanager"
 	"github.com/fission/fission/pkg/utils/httpserver"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
 )
 
 // envAllowInsecure, when "true", permits the MCP server to start without a
@@ -172,7 +173,18 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)
 	})
-	mux.Handle("/mcp", server.HTTPHandler())
+	// Server spans on the /mcp mount only -- NOT the whole mux (/healthz and
+	// /readyz stay unspanned, kubelet-probe-noise-free, by simply never being
+	// wrapped, no filter list needed). otel wraps OUTSIDE authz.HTTPMiddleware
+	// (already inside server.HTTPHandler()), matching the router-public /
+	// agentruntime precedent (otelUtils.GetHandlerWithOTEL wraps outside the
+	// per-route auth wrapper so an unauthenticated 401/403 still gets a
+	// span). No filter is needed here: the MCP transport has no
+	// infinite-lifetime SSE route -- streaming tool calls ride the POST
+	// request's own SSE response (progress notifications), which completes
+	// when the buffered CallToolResult returns, so its server span has the
+	// same bounded lifetime as any other POST /mcp request.
+	mux.Handle("/mcp", otelUtils.GetHandlerWithOTEL(server.HTTPHandler(), "fission-mcp"))
 	mgr.Go(func() error {
 		httpserver.Serve(ctx, logger, mgr, httpserver.ServerOptions{
 			Name: "mcp", Addr: strconv.Itoa(opts.Port), Listener: opts.Listener, Handler: mux,

--- a/pkg/mcp/proxy.go
+++ b/pkg/mcp/proxy.go
@@ -164,6 +164,17 @@ func (p *Proxy) Invoke(ctx context.Context, e ToolEntry, args []byte) (*mcp.Call
 // ":<alias>" suffix so the call is proxied through the alias's
 // currently-resolved version rather than straight to the live function --
 // resolution of what that routes to stays entirely router-side.
+//
+// No explicit propagation.Inject here: VERIFIED (TestCallTool_
+// OutboundProxyRequestCarriesExtractedTraceparent, tracing_test.go) that
+// http.NewRequestWithContext(ctx, ...) below is sufficient by itself -- the
+// client's transport (NewProxy) is otelhttp.NewTransport(...), which reads
+// the span off ctx and injects via the process-wide otel.GetTextMapPropagator()
+// on every RoundTrip automatically. callTool (server.go) starts the
+// execute_tool span (parented on the _meta-extracted context, when present)
+// BEFORE calling Invoke/InvokeStreaming, so by the time ctx reaches here it
+// already carries that span -- an explicit Inject would be redundant with
+// what the transport already does.
 func (p *Proxy) buildRequest(ctx context.Context, e ToolEntry, args []byte) (*http.Request, error) {
 	url := p.baseURL + utils.UrlForFunctionRef(e.FnName, e.Namespace, e.Alias)
 	if len(args) == 0 {

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -12,6 +12,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/modelcontextprotocol/go-sdk/auth"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel/attribute"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/fission/fission/pkg/info"
 )
@@ -54,6 +57,12 @@ type Server struct {
 	proxy  *Proxy
 	authz  *Authorizer
 	logger logr.Logger
+
+	// tracerProvider is the execute_tool span's TracerProvider seam,
+	// injected AFTER construction via SetTracerProvider (tracing.go) --
+	// nil (production's default) falls back to the process-wide
+	// otel.GetTracerProvider() in tracer().
+	tracerProvider trace.TracerProvider
 }
 
 // NewServer constructs the MCP server over the given registry, proxy, and
@@ -182,6 +191,37 @@ func (s *Server) callTool(ctx context.Context, req *mcp.CallToolRequest) (*mcp.C
 	if !found || !scope.Allows(entry.Namespace) {
 		return nil, errToolNotFound
 	}
+
+	// execute_tool span (GenAI semconv, pre-stable; see tracing.go). _meta's
+	// reserved traceparent/tracestate/baggage keys (MCP spec 2026-07-28,
+	// verified against the spec itself -- see traceContextFromMeta's doc
+	// comment), when present and well-formed, make this span a CHILD OF THE
+	// EXTRACTED CONTEXT -- the caller's own trace is the causally-correct
+	// parent for its own tool call, not this transport's per-request server
+	// span. Absent or malformed _meta leaves ctx unchanged, so the span
+	// parents on whatever ctx already carries: for an HTTP tools/call that is
+	// a child of the "fission-mcp" server span (main.go's
+	// otelUtils.GetHandlerWithOTEL wrap on the /mcp mount) -- VERIFIED (plan
+	// review Step 1b): the go-sdk's streamable transport passes req.Context()
+	// into connectStreamable "to allow middleware to add context values"
+	// (streamable.go:701-703) and jsonrpc2.NewConnection wraps it in notDone
+	// (internal/jsonrpc2/conn.go), whose Value() delegates unchanged to the
+	// wrapped context -- so every context VALUE, including a live server
+	// span, survives into the tool handler's ctx for BOTH legacy and
+	// >=2026-07-28 callers. Only cancellation semantics differ by protocol
+	// version (PropagateRequestCancellation / shouldPropagateCancellation);
+	// values are never dropped either way, so there is no root-span fallback
+	// to special-case here -- absent _meta simply means "parent on whatever
+	// is already there," same as any other child span.
+	tCtx := traceContextFromMeta(ctx, req.Params.Meta)
+	tCtx, span := s.tracer().Start(tCtx, "execute_tool "+entry.ToolName, trace.WithAttributes(
+		semconv.GenAIOperationNameExecuteTool,
+		semconv.GenAIToolName(entry.ToolName),
+		attribute.String("fission.agent.namespace", entry.Namespace),
+	))
+	defer span.End()
+	ctx = tCtx
+
 	// Streaming needs BOTH sides opted in: the function declares Streaming,
 	// and the caller sent a progress token (the MCP spec permits progress
 	// notifications only for requests that carried one). Everything else
@@ -212,9 +252,11 @@ func (s *Server) callTool(ctx context.Context, req *mcp.CallToolRequest) (*mcp.C
 			}
 			return err
 		}
-		return s.proxy.InvokeStreaming(ctx, entry, req.Params.Arguments, notify)
+		res, err := s.proxy.InvokeStreaming(ctx, entry, req.Params.Arguments, notify)
+		return endToolSpan(span, res, err)
 	}
-	return s.proxy.Invoke(ctx, entry, req.Params.Arguments)
+	res, err := s.proxy.Invoke(ctx, entry, req.Params.Arguments)
+	return endToolSpan(span, res, err)
 }
 
 // scopeFor derives the caller's namespace scope from the request's token info.

--- a/pkg/mcp/tracing.go
+++ b/pkg/mcp/tracing.go
@@ -1,0 +1,130 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// tracing.go implements the execute_tool span (GenAI semantic conventions,
+// pre-stable) and _meta trace-context extraction for callTool (server.go).
+//
+// Blast-radius note (see the plan's Global Constraints): pkg/mcp ships
+// independently of agentRuntime.enabled and serves non-agent MCP clients, so
+// everything here is ADDITIVE-ONLY. _meta is UNTRUSTED caller input: a
+// missing or malformed traceparent/tracestate/baggage never errors and never
+// logs above V(1) -- the call proceeds exactly as it would if _meta were
+// absent. _meta present but empty of the reserved keys, or absent entirely,
+// must be byte-identical in observable behavior to today (pre-this-slice).
+package mcp
+
+import (
+	"context"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// mcpTracerName scopes the execute_tool span's Tracer (see Server.tracer).
+const mcpTracerName = "fission/mcp"
+
+// traceContextKeys are the exact top-level _meta keys the MCP spec (revision
+// 2026-07-28, "General fields > _meta > OpenTelemetry trace context")
+// reserves for W3C trace-context propagation -- verified against the spec
+// itself (modelcontextprotocol.io/specification/2026-07-28/basic/index#_meta),
+// not assumed: the vendored go-sdk v1.7.0 module cache contains ZERO
+// traceparent/otel material of its own (plan-review verified), so the SDK
+// gave no signal either way. The spec text: "the keys traceparent,
+// tracestate, and baggage are reserved for OpenTelemetry trace context
+// propagation. When present, their values MUST follow W3C Trace Context and
+// W3C Baggage formats respectively" -- an explicit exception to the
+// otherwise-mandatory `<prefix>/<name>` _meta key format, so these three
+// keys sit at the top level with no reverse-DNS prefix, matching
+// propagation.TraceContext{} + propagation.Baggage{}'s own header names.
+var traceContextKeys = [...]string{"traceparent", "tracestate", "baggage"}
+
+// traceContextFromMeta extracts W3C trace context + baggage from the
+// caller-supplied _meta fields, if present, and returns the resulting
+// context; ctx unchanged when there is nothing to extract.
+//
+// _meta is UNTRUSTED caller input (any MCP client can set it to anything):
+// only STRING-typed values under the three reserved keys are honored -- a
+// non-string value (an object, a number, a bool) is silently ignored, never
+// an error, matching the "malformed extracts to nothing, call proceeds"
+// constraint. A present-but-malformed traceparent string (bad format, bad
+// trace-id) is likewise not an error at this layer: propagation.TraceContext
+// .Extract validates the W3C format internally and simply returns ctx
+// unchanged when parsing fails (see go.opentelemetry.io/otel/propagation's
+// TraceContext.Extract), so an attacker sending garbage cannot inject a
+// spoofed parent span -- worst case is the call proceeds as if _meta carried
+// no trace context at all, which is the additive-only, fail-open contract
+// this function exists to guarantee.
+func traceContextFromMeta(ctx context.Context, meta mcp.Meta) context.Context {
+	if len(meta) == 0 {
+		return ctx
+	}
+	carrier := propagation.MapCarrier{}
+	for _, key := range traceContextKeys {
+		v, ok := meta[key]
+		if !ok {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			continue // untrusted input: ignore silently, never error
+		}
+		carrier[key] = s
+	}
+	if len(carrier) == 0 {
+		return ctx
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, carrier)
+}
+
+// SetTracerProvider wires the execute_tool span's TracerProvider seam
+// post-construction, mirroring agentruntime's Dispatcher.SetTracerProvider
+// (pkg/agentruntime/dispatcher.go) -- same construction-cycle rationale:
+// NewServer's signature is the stable production wiring call sites use, and
+// unit tests need a hermetic sdktrace.NewTracerProvider + tracetest.
+// SpanRecorder instead of process-wide global state. nil (the zero value,
+// production's default) makes tracer() fall back to otel.GetTracerProvider()
+// -- what fission-bundle's main installs in production
+// (pkg/utils/otel/provider.go).
+func (s *Server) SetTracerProvider(tp trace.TracerProvider) {
+	s.tracerProvider = tp
+}
+
+// tracer returns the Tracer callTool starts its execute_tool span from.
+//
+// GenAI semantic conventions are PRE-STABLE (experimental) as of this pin:
+// go.opentelemetry.io/otel/semconv/v1.37.0 supplies the gen_ai.* attribute
+// keys used in callTool (GenAIOperationNameExecuteTool = "execute_tool",
+// GenAIToolName = "gen_ai.tool.name") -- the same version pin
+// pkg/agentruntime/dispatcher.go uses for invoke_agent. Re-verify attribute
+// names against the semconv package on any future bump; the spec has moved
+// these before.
+func (s *Server) tracer() trace.Tracer {
+	tp := s.tracerProvider
+	if tp == nil {
+		tp = otel.GetTracerProvider()
+	}
+	return tp.Tracer(mcpTracerName)
+}
+
+// endToolSpan records the outcome on span -- Error status (+ RecordError)
+// for a protocol-level error, Ok otherwise -- mirroring the invoke_agent
+// span's status discipline (pkg/agentruntime/dispatcher.go's DispatchTurn).
+// A tool-level failure (function 4xx/5xx, timeout, oversized body) is NOT a
+// protocol-level error here: Proxy.Invoke/InvokeStreaming map those into a
+// CallToolResult with IsError set and a nil error (see proxy.go's doc
+// comment), so this span's status reflects whether the MCP call itself
+// completed, not whether the tool's own output was an error the agent can
+// see and self-correct on.
+func endToolSpan(span trace.Span, res *mcp.CallToolResult, err error) (*mcp.CallToolResult, error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+	return res, err
+}

--- a/pkg/mcp/tracing_test.go
+++ b/pkg/mcp/tracing_test.go
@@ -1,0 +1,364 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// tracing_test.go covers _meta trace-context extraction (tracing.go) and the
+// execute_tool span (server.go's callTool), plus the /mcp mount's server span
+// (main.go's otelUtils.GetHandlerWithOTEL wrap, exercised here directly
+// against a hand-built handler mirroring that wiring).
+//
+// Test seams (Global Constraints, mirroring pkg/agentruntime/tracing_test.go):
+// the package-wide W3C composite propagator is installed EXACTLY ONCE in
+// TestMain below -- the process default is a no-op TextMapPropagator, so any
+// test relying on it would pass vacuously (Extract/Inject would silently
+// no-op). Per-test span assertions thread an explicit
+// sdktrace.NewTracerProvider + tracetest.SpanRecorder through
+// Server.SetTracerProvider rather than touching the global TracerProvider --
+// safe under t.Parallel(). The tests that exercise the SERVER span or the
+// outbound proxy's otelhttp auto-inject are the deliberate exception: they
+// swap otel.SetTracerProvider for their duration (restored via t.Cleanup)
+// and are NOT t.Parallel() for that reason -- see withGlobalTracerProvider.
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
+)
+
+// TestMain installs the W3C composite propagator (tracecontext + baggage)
+// ONCE for the whole package's test binary -- without this the process
+// default is otel's no-op propagator: Inject writes nothing and Extract
+// reads nothing, so every extraction/inject assertion below would pass
+// vacuously regardless of whether tracing.go's carriage logic is wired
+// correctly at all. The same propagator value is used by every test -- safe
+// under t.Parallel() since nothing here mutates it again.
+func TestMain(m *testing.M) {
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
+	os.Exit(m.Run())
+}
+
+// newTestTracerProvider returns an SDK TracerProvider recording every
+// started/ended span into rec, with AlwaysSample so a span parented on an
+// extracted remote SpanContext is recorded regardless of that context's
+// carried sampled-flag.
+func newTestTracerProvider(t *testing.T) (*sdktrace.TracerProvider, *tracetest.SpanRecorder) {
+	t.Helper()
+	rec := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(rec), sdktrace.WithSampler(sdktrace.AlwaysSample()))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	return tp, rec
+}
+
+// withGlobalTracerProvider temporarily swaps the GLOBAL otel TracerProvider
+// to tp, restoring the previous one on cleanup. Needed by the tests that
+// exercise otelhttp's own span creation (the /mcp server span via
+// otelUtils.GetHandlerWithOTEL, and the outbound proxy client span via
+// otelhttp.NewTransport as wired in proxy.go's NewProxy) -- neither call site
+// takes a per-call TracerProvider option, so both always resolve their
+// tracer from otel.GetTracerProvider() at request time. Callers of this
+// helper must NOT call t.Parallel().
+func withGlobalTracerProvider(t *testing.T, tp trace.TracerProvider) {
+	t.Helper()
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+}
+
+// findSpan returns the first ended span whose name starts with prefix.
+func findSpan(spans []sdktrace.ReadOnlySpan, prefix string) (sdktrace.ReadOnlySpan, bool) {
+	for _, s := range spans {
+		if strings.HasPrefix(s.Name(), prefix) {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+func attrValue(attrs []attribute.KeyValue, key attribute.Key) (attribute.Value, bool) {
+	for _, a := range attrs {
+		if a.Key == key {
+			return a.Value, true
+		}
+	}
+	return attribute.Value{}, false
+}
+
+// okToolServer returns a Server wired to upstream, with tp threaded via
+// SetTracerProvider, one tool ("tool-a" in "ns-a") registered, and a
+// pass-through authorizer (authz is not what tracing tests exercise).
+func okToolServer(t *testing.T, tp trace.TracerProvider, upstreamURL string) *Server {
+	t.Helper()
+	reg := NewRegistry()
+	e := entry("ns-a", "fn1", "tool-a")
+	reg.Upsert(e)
+	s := NewServer(reg, NewProxy(upstreamURL, nil, logr.Discard(), 0), NewAuthorizer(nil), logr.Discard())
+	s.SetTracerProvider(tp)
+	s.ApplyToolDelta([]ToolEntry{e}, nil) // what the reconciler does on upsert; needed so tools/call resolves over the wire
+	return s
+}
+
+func okUpstream(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// callToolReq builds a *mcp.CallToolRequest with the given raw _meta map
+// (nil for "no _meta at all"), bypassing the scopeMiddleware/HTTP transport
+// so callTool's extraction+span logic is exercised directly (mirrors
+// pkg/agentruntime/tracing_test.go's direct DispatchTurn calls).
+func callToolReq(tool string, meta mcp.Meta) *mcp.CallToolRequest {
+	return &mcp.CallToolRequest{
+		Params: &mcp.CallToolParamsRaw{Name: tool, Meta: meta},
+	}
+}
+
+// TestCallTool_MetaTraceparent_ChildOfExtractedTrace pins the spec'd
+// extraction: a valid traceparent under _meta makes execute_tool a CHILD of
+// the extracted (caller's own) trace, not of whatever ctx already carried --
+// proving the "parents on the extracted context" half of callTool's design.
+func TestCallTool_MetaTraceparent_ChildOfExtractedTrace(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	tp, rec := newTestTracerProvider(t)
+	s := okToolServer(t, tp, upstream.URL)
+
+	seedCtx, seedSpan := tp.Tracer("seed").Start(t.Context(), "seed")
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(seedCtx, carrier)
+	seedSpan.End()
+	require.NotEmpty(t, carrier["traceparent"])
+
+	meta := mcp.Meta{"traceparent": carrier["traceparent"]}
+	res, err := s.callTool(context.Background(), callToolReq("tool-a", meta))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, res.IsError)
+
+	toolSpan, ok := findSpan(rec.Ended(), "execute_tool ")
+	require.True(t, ok, "expected an execute_tool span")
+	assert.Equal(t, "execute_tool tool-a", toolSpan.Name())
+	assert.Equal(t, seedSpan.SpanContext().TraceID(), toolSpan.SpanContext().TraceID(), "execute_tool must share the extracted _meta trace")
+	assert.Equal(t, seedSpan.SpanContext().SpanID(), toolSpan.Parent().SpanID(), "execute_tool must be a CHILD of the extracted span, not a root")
+	assert.Equal(t, codes.Ok, toolSpan.Status().Code)
+
+	attrs := toolSpan.Attributes()
+	if v, ok := attrValue(attrs, "gen_ai.operation.name"); assert.True(t, ok) {
+		assert.Equal(t, "execute_tool", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "gen_ai.tool.name"); assert.True(t, ok) {
+		assert.Equal(t, "tool-a", v.AsString())
+	}
+	if v, ok := attrValue(attrs, "fission.agent.namespace"); assert.True(t, ok) {
+		assert.Equal(t, "ns-a", v.AsString())
+	}
+}
+
+// TestCallTool_MetaMalformed_NewRootSpanCallSucceeds pins the additive-only,
+// fail-open contract: a syntactically invalid traceparent must not error the
+// call, must not panic, and must not log above V(1) (log level is not
+// observable from this test, but the call succeeding with a fresh ROOT span
+// is the behavioral proof that extraction failed closed rather than open).
+func TestCallTool_MetaMalformed_NewRootSpanCallSucceeds(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	tp, rec := newTestTracerProvider(t)
+	s := okToolServer(t, tp, upstream.URL)
+
+	meta := mcp.Meta{"traceparent": "not-a-valid-traceparent-at-all"}
+	res, err := s.callTool(context.Background(), callToolReq("tool-a", meta))
+	require.NoError(t, err, "a malformed traceparent must never error the call")
+	require.NotNil(t, res)
+	assert.False(t, res.IsError)
+
+	toolSpan, ok := findSpan(rec.Ended(), "execute_tool ")
+	require.True(t, ok)
+	assert.False(t, toolSpan.Parent().IsValid(), "a malformed traceparent must produce a ROOT span, not a spoofed/broken parent")
+}
+
+// TestCallTool_MetaAbsent_ServerSpanChild drives the byte-identical-behavior
+// pin from the other direction: with NO _meta at all, an HTTP tools/call must
+// still produce an execute_tool span, parented on the "fission-mcp" server
+// span from main.go's otelUtils.GetHandlerWithOTEL wrap -- proving Step 1b's
+// finding empirically (the go-sdk's ctx detach preserves context VALUES, so
+// the server span survives into callTool) rather than merely asserting it
+// from source reading.
+func TestCallTool_MetaAbsent_ServerSpanChild(t *testing.T) {
+	// Not t.Parallel(): withGlobalTracerProvider mutates global otel state.
+	tp, rec := newTestTracerProvider(t)
+	withGlobalTracerProvider(t, tp)
+
+	upstream := okUpstream(t)
+	s := okToolServer(t, tp, upstream.URL)
+	handler := otelUtils.GetHandlerWithOTEL(s.HTTPHandler(), "fission-mcp")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+	sess, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: srv.URL}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	res, err := sess.CallTool(t.Context(), &mcp.CallToolParams{Name: "tool-a"})
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	// client.Connect() issues its own "initialize" POST first, producing an
+	// UNRELATED server span in a different trace before the tools/call one --
+	// so the server span under test must be found by matching
+	// toolSpan.Parent(), not by taking the first "POST "-prefixed span.
+	ended := rec.Ended()
+	toolSpan, ok := findSpan(ended, "execute_tool ")
+	require.True(t, ok, "expected an execute_tool span, got spans: %v", spanNames(ended))
+
+	var serverSpan sdktrace.ReadOnlySpan
+	for _, sp := range ended {
+		if sp.SpanContext().SpanID() == toolSpan.Parent().SpanID() {
+			serverSpan = sp
+		}
+	}
+	require.NotNil(t, serverSpan, "expected to find execute_tool's parent span among the ended spans: %v", spanNames(ended))
+	assert.True(t, strings.HasPrefix(serverSpan.Name(), "POST"), "execute_tool's parent must be the otelhttp server span, got %q", serverSpan.Name())
+	assert.Equal(t, serverSpan.SpanContext().TraceID(), toolSpan.SpanContext().TraceID(), "execute_tool must share the server span's trace when _meta carries no trace context")
+	assert.Equal(t, serverSpan.SpanContext().SpanID(), toolSpan.Parent().SpanID(), "execute_tool must be a CHILD of the server span -- proving context VALUES survive the SDK's ctx detach")
+}
+
+func spanNames(spans []sdktrace.ReadOnlySpan) []string {
+	names := make([]string, len(spans))
+	for i, s := range spans {
+		names[i] = s.Name()
+	}
+	return names
+}
+
+// TestCallTool_MetaTraceparentOverWire_ChildOfExtractedTrace is the real-SDK-
+// client twin of TestCallTool_MetaTraceparent_ChildOfExtractedTrace: the
+// direct-callTool test above proves the SERVER's extraction contract, but
+// says nothing about whether a real go-sdk client's params.SetMeta actually
+// puts traceparent on the wire under the bare _meta key the server expects,
+// rather than the client silently reshaping or namespacing it. If the go-sdk
+// client ever stopped round-tripping caller-set _meta verbatim, every other
+// test in this file would keep passing while the feature went dead for every
+// real go-sdk caller -- this is the test that would catch that.
+func TestCallTool_MetaTraceparentOverWire_ChildOfExtractedTrace(t *testing.T) {
+	// Not t.Parallel(): withGlobalTracerProvider mutates global otel state.
+	tp, rec := newTestTracerProvider(t)
+	withGlobalTracerProvider(t, tp)
+
+	upstream := okUpstream(t)
+	s := okToolServer(t, tp, upstream.URL)
+	handler := otelUtils.GetHandlerWithOTEL(s.HTTPHandler(), "fission-mcp")
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "t", Version: "0"}, nil)
+	sess, err := client.Connect(t.Context(), &mcp.StreamableClientTransport{Endpoint: srv.URL}, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sess.Close() })
+
+	seedCtx, seedSpan := tp.Tracer("seed").Start(t.Context(), "seed")
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(seedCtx, carrier)
+	seedSpan.End()
+	require.NotEmpty(t, carrier["traceparent"])
+
+	params := &mcp.CallToolParams{Name: "tool-a"}
+	params.SetMeta(map[string]any{"traceparent": carrier["traceparent"]})
+	res, err := sess.CallTool(t.Context(), params)
+	require.NoError(t, err)
+	require.False(t, res.IsError)
+
+	toolSpan, ok := findSpan(rec.Ended(), "execute_tool ")
+	require.True(t, ok, "expected an execute_tool span")
+	assert.Equal(t, seedSpan.SpanContext().TraceID(), toolSpan.SpanContext().TraceID(),
+		"a real go-sdk client's params.SetMeta traceparent must survive the wire and be extracted server-side")
+	assert.Equal(t, seedSpan.SpanContext().SpanID(), toolSpan.Parent().SpanID(),
+		"execute_tool must be a CHILD of the client-set traceparent's span, not the fission-mcp server span")
+}
+
+// TestCallTool_MetaNonStringValuesIgnored pins the untrusted-input handling:
+// a non-string value under a reserved trace-context key must be ignored
+// silently (not type-asserted into a panic, not an error), and the call must
+// still succeed.
+func TestCallTool_MetaNonStringValuesIgnored(t *testing.T) {
+	t.Parallel()
+	upstream := okUpstream(t)
+	tp, rec := newTestTracerProvider(t)
+	s := okToolServer(t, tp, upstream.URL)
+
+	meta := mcp.Meta{
+		"traceparent": 12345,              // wrong type: must be ignored, not asserted
+		"tracestate":  []string{"a", "b"}, // wrong type
+		"baggage":     true,               // wrong type
+	}
+	res, err := s.callTool(context.Background(), callToolReq("tool-a", meta))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.False(t, res.IsError)
+
+	toolSpan, ok := findSpan(rec.Ended(), "execute_tool ")
+	require.True(t, ok)
+	assert.False(t, toolSpan.Parent().IsValid(), "non-string _meta trace values must be ignored, producing a root span")
+}
+
+// TestCallTool_OutboundProxyRequestCarriesExtractedTraceparent proves the
+// whole point of starting the span before the proxy call: the router-internal
+// request otelhttp injects into must carry the SAME trace-id as the _meta
+// traceparent that was extracted -- end to end through callTool, the real
+// Proxy, and the real otelhttp transport wired in proxy.go's NewProxy (no
+// explicit propagator.Inject added to buildRequest: this test is what proves
+// the transport's own auto-inject already suffices once a span is on ctx --
+// see tracing.go's doc comment on why no such explicit Inject was added).
+func TestCallTool_OutboundProxyRequestCarriesExtractedTraceparent(t *testing.T) {
+	// Not t.Parallel(): withGlobalTracerProvider mutates global otel state
+	// (proxy.go's otelhttp.NewTransport takes no TracerProvider option, so it
+	// always resolves from the global at request time).
+	tp, _ := newTestTracerProvider(t)
+	withGlobalTracerProvider(t, tp)
+
+	var gotTraceparent string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotTraceparent = r.Header.Get("traceparent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(upstream.Close)
+
+	s := okToolServer(t, tp, upstream.URL)
+
+	seedCtx, seedSpan := tp.Tracer("seed").Start(t.Context(), "seed")
+	carrier := propagation.MapCarrier{}
+	otel.GetTextMapPropagator().Inject(seedCtx, carrier)
+	seedSpan.End()
+
+	meta := mcp.Meta{"traceparent": carrier["traceparent"]}
+	_, err := s.callTool(context.Background(), callToolReq("tool-a", meta))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, gotTraceparent, "the outbound request must carry a traceparent header")
+	parts := strings.Split(gotTraceparent, "-")
+	require.Len(t, parts, 4, "traceparent must be 00-<trace-id>-<span-id>-<flags>")
+	assert.Equal(t, seedSpan.SpanContext().TraceID().String(), parts[1], "outbound traceparent trace-id must match the _meta-extracted trace")
+}

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -1242,7 +1242,13 @@ func parseTraceparent(v string) (traceID, spanID string, ok bool) {
 func TestAgentRuntimeTraceContextPropagation(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	// 6 minutes, matching TestAgentRuntimeSpawnParentage's sibling budget:
+	// setup (CreateEnv/CreateFunction/WaitForFunction/CLI update, cold
+	// specialize) runs before the EventuallyWithT loop below, whose own
+	// budget is turnAttemptTimeout*3 (180s) -- a tighter overall ctx would
+	// let CI setup eat most of that polling budget before the first attempt
+	// even starts.
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
 	defer cancel()
 
 	f := framework.Connect(t)

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -9,6 +9,7 @@ package common_test
 import (
 	"bufio"
 	"context"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -20,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/fission/fission/pkg/agentruntime"
 	hmacauth "github.com/fission/fission/pkg/auth/hmac"
@@ -1148,6 +1151,175 @@ func TestAgentRuntimeSpawnParentage(t *testing.T) {
 		assert.Equalf(c, http.StatusBadRequest, resp.StatusCode,
 			"depth-4 spawn (session %s, parent %s) must be rejected — AGENT_MAX_SPAWN_DEPTH defaults to 3 in CI", depth4ChildID, depth4ParentHeader)
 	}, 60*time.Second, 2*time.Second)
+}
+
+// syntheticTraceparent mints a fresh, valid, REMOTE W3C trace-context
+// SpanContext (random trace-id and span-id, sampled flag set — the flag is
+// irrelevant to what this test asserts, see TestAgentRuntimeTraceContextPropagation's
+// doc comment) and returns its wire-encoded `traceparent` header value
+// alongside the trace-id/span-id strings the test sent, so the caller can
+// compare them against what the fixture echoes back. It goes through
+// go.opentelemetry.io/otel/propagation's own TraceContext.Inject rather than
+// hand-formatting the "00-<trace-id>-<span-id>-<flags>" string, so the
+// header this test sends is guaranteed well-formed by the same code the
+// production propagator uses.
+func syntheticTraceparent(t *testing.T) (header, traceID, spanID string) {
+	t.Helper()
+	var tid trace.TraceID
+	_, err := rand.Read(tid[:])
+	require.NoError(t, err, "generating synthetic trace-id")
+	var sid trace.SpanID
+	_, err = rand.Read(sid[:])
+	require.NoError(t, err, "generating synthetic span-id")
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    tid,
+		SpanID:     sid,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	carrier := propagation.MapCarrier{}
+	propagation.TraceContext{}.Inject(trace.ContextWithRemoteSpanContext(context.Background(), sc), carrier)
+	return carrier.Get("traceparent"), tid.String(), sid.String()
+}
+
+// parseTraceparent decodes v as a W3C traceparent header value using
+// go.opentelemetry.io/otel/propagation's own extraction path — the same
+// parser the production TracerProvider uses on the inbound side — and
+// returns its trace-id/span-id as lowercase hex, plus whether v parsed as a
+// valid (non-zero) SpanContext at all.
+func parseTraceparent(v string) (traceID, spanID string, ok bool) {
+	carrier := propagation.MapCarrier{"traceparent": v}
+	sc := trace.SpanContextFromContext(propagation.TraceContext{}.Extract(context.Background(), carrier))
+	if !sc.IsValid() {
+		return "", "", false
+	}
+	return sc.TraceID().String(), sc.SpanID().String(), true
+}
+
+// TestAgentRuntimeTraceContextPropagation is Task 3 of the agent-runtime
+// observability plan
+// (docs/superpowers/plans/2026-08-25-agent-runtime-observability.md, in the
+// sibling `fission` checkout): the collectorless end-to-end propagation
+// proof for the invoke_agent spans + wake-envelope trace carriage Task 1
+// added to pkg/agentruntime/dispatcher.go.
+//
+// It reuses the agentspawn fixture (test/integration/testdata/nodejs/agentspawn/spawn.js),
+// which now echoes the raw `traceparent` request header it saw as
+// "traceparentSeen" on every turn's JSON response (or the literal "absent"
+// when none arrived — see that fixture's header comment). This test sends
+// ONE turn carrying a SYNTHETIC, valid traceparent header
+// (00-<random 32 hex>-<random 16 hex>-01, minted via syntheticTraceparent
+// above) and asserts:
+//
+//  1. traceparentSeen parses as a well-formed W3C traceparent at all (proves
+//     SOME traceparent — not just any header — reached the pod).
+//  2. Its trace-id EQUALS the one this test sent. This is the load-bearing
+//     assertion: it proves the header survived POST /agents/<ns>/<fn> -> the
+//     dispatcher's invoke_agent span (started from the inbound request ctx,
+//     dispatcher.go) -> the outbound otelhttp-instrumented client -> the
+//     router-internal hop -> this specialized pod, all with ZERO OTLP
+//     collector anywhere in the loop.
+//  3. Its span-id DIFFERS from the one this test sent — children re-span at
+//     every hop; an EQUAL span-id would mean the header passed through
+//     verbatim with no span ever created, which is not what this proves.
+//
+// It deliberately does NOT assert the sampled (01) flag on the echoed
+// value. With no collector configured, the installed TracerProvider samples
+// with an always-off sampler: trace-id is preserved and fresh span-ids are
+// minted at each hop, but the 01 flag is stripped on the way out (see
+// go.opentelemetry.io/otel/sdk/trace's Tracer.newSpan SpanContext
+// construction, roughly tracer.go:103-106 and :126 in the SDK version this
+// module pins — cited in the observability plan's Task 3, not re-verified
+// line-for-line here since the module is vendor-external and line numbers
+// drift across patch releases). Asserting the flag would fail in every CI
+// run, since CI runs this suite with no collector deployed either.
+//
+// If a future run of this test finds the trace-id does NOT survive the hop,
+// that is a REAL finding about the router-internal leg of the dispatch
+// chain (dispatcher -> router-internal -> pod) — the right response is to
+// investigate that leg, not to loosen or delete this assertion.
+func TestAgentRuntimeTraceContextPropagation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "nodejs-agent-trace-" + ns.ID
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	fnName := "agent-trace-" + ns.ID
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{
+		Name: fnName,
+		Env:  envName,
+		Code: framework.WriteTestData(t, "nodejs/agentspawn/spawn.js"),
+		// spawn.js requires these even for a plain (non-spawning) turn: it
+		// builds parentRef from them unconditionally before deciding
+		// whether to spawn.
+		EnvVars: []string{
+			"SELF_NAMESPACE=" + ns.Name,
+			"SELF_AGENT_NAME=" + fnName,
+		},
+	})
+	ns.WaitForFunction(t, ctx, fnName)
+	// Same CLI-update workaround as the other tests in this file
+	// (FunctionOptions has no Agent field yet).
+	ns.CLI(t, ctx, "fn", "update", "--name", fnName, "--agent")
+
+	base := f.AgentRuntimeBaseURL()
+	turnURL := base + "/agents/" + ns.Name + "/" + fnName
+
+	sentTraceparent, sentTraceID, sentSpanID := syntheticTraceparent(t)
+
+	var payload struct {
+		TraceparentSeen string `json:"traceparentSeen"`
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(attemptCtx, http.MethodPost, turnURL, strings.NewReader(`{}`))
+		if !assert.NoErrorf(c, err, "building trace-context turn request") {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("traceparent", sentTraceparent)
+		resp, err := f.HTTPClient().Do(req)
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "trace-context turn to %s", turnURL) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoErrorf(c, err, "reading trace-context turn response body") {
+			return
+		}
+		if !assert.NoErrorf(c, json.Unmarshal(body, &payload), "decoding trace-context turn response body %q", body) {
+			return
+		}
+	}, turnAttemptTimeout*3, 2*time.Second)
+
+	require.NotEqualf(t, "absent", payload.TraceparentSeen,
+		"fixture pod saw no traceparent header at all (sent %s on %s)", sentTraceparent, turnURL)
+
+	seenTraceID, seenSpanID, ok := parseTraceparent(payload.TraceparentSeen)
+	require.Truef(t, ok, "echoed traceparentSeen %q does not parse as a well-formed W3C traceparent", payload.TraceparentSeen)
+
+	assert.Equalf(t, sentTraceID, seenTraceID,
+		"trace-id did not survive the dispatch chain (sent %s, pod saw %s on echoed value %q) — "+
+			"this is a real finding about the router-internal hop, not a flaky assertion",
+		sentTraceID, seenTraceID, payload.TraceparentSeen)
+	assert.NotEqualf(t, sentSpanID, seenSpanID,
+		"span-id must differ from what this test sent (both %s) — an equal span-id would mean the "+
+			"request passed through with no invoke_agent span ever created, not that propagation works",
+		sentSpanID)
 }
 
 // nextSSEFrame reads one SSE message from r: comment lines (starting with

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -6,7 +6,8 @@
 // namespace, same function) with X-Fission-Session set to the derived id and
 // X-Fission-Agent-Parent set to this session's own ParentRef. Every turn
 // (spawn or not) replies 200 with {"session","parent","spawned","spawnStatus",
-// "spawnBody","agentTokenSha256","agentTokenNamespace","agentTokenAgent"},
+// "spawnBody","agentTokenSha256","agentTokenNamespace","agentTokenAgent",
+// "traceparentSeen"},
 // where "spawned" is the derived child id (or null when this turn did not
 // spawn) and spawnStatus/spawnBody are the inner dispatch's own
 // last-observed HTTP status and response body (0/"" when no spawn was
@@ -207,6 +208,20 @@ module.exports = async function (context) {
   // "<namespace>/<agent>/<id>".
   const parentRef = `${SELF_NAMESPACE}/${SELF_AGENT_NAME}/${sessionID}`;
 
+  // traceparentSeen is Task 3 of the agent-runtime observability plan's
+  // end-to-end propagation proof: the raw `traceparent` request header this
+  // pod saw (or the literal "absent" when none arrived), echoed on EVERY
+  // turn's response. traceparent is NOT a secret (it is a public W3C
+  // trace-context header, not a credential), so unlike agentTokenSha256
+  // above this is safe to echo verbatim rather than hash -- a caller-side
+  // test parses it and compares its trace-id against one it sent, proving
+  // the header survived POST /agents/... -> the dispatcher's invoke_agent
+  // span -> the otelhttp-instrumented outbound call -> the router-internal
+  // hop -> this pod, with no collector anywhere in the loop. Express lowers
+  // header names (see SESSION_HEADER above), so the plain lowercase key is
+  // enough.
+  const traceparentSeen = req.headers['traceparent'] || 'absent';
+
   // req.body arrives pre-parsed as an object for a JSON content type in the
   // common case, but support-desk.js (demo/agent-boardroom/fixtures/, not
   // this testdata family) defends against a raw-string body too -- mirror
@@ -250,6 +265,7 @@ module.exports = async function (context) {
       agentTokenSha256: agentTokenSha256,
       agentTokenNamespace: agentTokenNamespace,
       agentTokenAgent: agentTokenAgent,
+      traceparentSeen: traceparentSeen,
     }),
     headers: { 'Content-Type': 'application/json' },
   };


### PR DESCRIPTION
Stack position 6 (#3701 ← #3703 ← #3704 ← #3705 ← this). Agent-native tracing on infrastructure that already existed — the branch adds spans and context carriage, zero new dependencies (go.mod untouched).

## What

- **`invoke_agent` spans** (GenAI semconv v1.37.0, pre-stable, version-pinned): one span per agent turn in the dispatcher — started before the background-context derivation (load-bearing: that's what lets the wake enqueue inherit it), defer-ended across every return path, `gen_ai.*` + `fission.*` attrs, yield + status on completions.
- **Wake-stitched traces**: the wake envelope carries an optional `trace` field (injected at enqueue, extracted at delivery; lenient decode = no version bump, dedup key untouched, rolling-deploy safe in both directions) — so a whole `yield: continue` self-continuation chain renders as ONE trace, including the post-Ack revival enqueue (threaded from the delivery's context). The stitch test drives yield=continue end-to-end and captures the real enqueued envelope; its non-vacuity was verified by deleting the propagator install and watching four tests fail.
- **Server spans**: agentruntime mux wrapped (filters: `/registry/events`, `/ui`, `/healthz`, `/readyz` — no hour-long SSE spans, no kubelet-probe noise; otel outside auth so 401s get spans, router-public precedent) and the `/mcp` handler.
- **MCP `_meta` trace-context** (2026-07-28 spec, keys verified against the spec text): `traceparent`/`tracestate`/`baggage` extracted from `tools/call` `_meta` into an `execute_tool` span. **Additive-only**: `_meta` absent → byte-identical behavior; malformed values extract to nothing and the call proceeds (untrusted input); the SDK's ctx-detach was verified value-preserving (empirically) so parenting claims are tested against reality.
- **Collectorless propagation proof** (integration): a synthetic traceparent sent on dispatch must reach the function pod with the SAME trace-id and a DIFFERENT span-id (no sampled-flag assertion — NeverSample strips it by design).
- **Docs**: boardroom README observability appendix (span inventory, kind-opentelemetry BYO-collector steps, Langfuse/Phoenix as reference backends).

## Visible behavior note (final-review corrected framing)

Function pods already received a `traceparent` header on every proxied call before this branch (otelhttp injects even parentless). The actual delta: that header's trace-id is now **continuous with the caller's trace**, and caller-supplied `tracestate`/`baggage` now flow through to pods and wake envelopes — standard W3C propagation, HMAC-safe (the canonical signs method+URI+body only).

## Boundaries
- **No meters** — `fission_agent_*` metrics remain the parked G19-export follow-up.
- SDK-side `execute_tool` children from inside function code are the env-SDK track, not this PR.

Process: reviewed plan (REVISE→fixed: 1 blocker — span placement vs the background-context derivation would have silently broken every stitch), 4 SDD tasks all PASS/PASS (one implementer recovered mid-task from an API error), final review SHIP with an empirical framing correction, fix round inline.