### PR TITLE
agentruntime,storagesvc: session artifact workspace (G12/G18a)

### DIFF
--- a/charts/fission-all/templates/agentruntime/deployment.yaml
+++ b/charts/fission-all/templates/agentruntime/deployment.yaml
@@ -82,6 +82,22 @@ spec:
           value: {{ .Values.agentRuntime.maxContinuations | quote }}
         - name: AGENT_MAX_SESSIONS_DEFAULT
           value: {{ .Values.agentRuntime.maxSessions | quote }}
+        # Upstream for the session workspace routes (pkg/agentruntime/
+        # workspace.go): mirrors buildermgr's own --storageSvcUrl VALUE
+        # (charts/fission-all/templates/buildermgr/deployment.yaml) as an ENV
+        # instead of a container arg. Unset means the workspace routes answer
+        # 503 "workspace disabled" rather than agentruntime guessing a URL —
+        # here it is always set, since storagesvc is a core, always-deployed
+        # component (no storagesvc.enabled gate exists to condition on).
+        - name: STORAGESVC_URL
+          value: "http://storagesvc.{{ .Release.Namespace }}"
+        # AGENT_MAX_ARTIFACT_BYTES / AGENT_MAX_SESSION_ARTIFACT_BYTES /
+        # AGENT_MAX_SESSION_ARTIFACTS are deliberately left unset here: the
+        # code's own defaults (32MiB per artifact, 256MiB and 1000 artifacts
+        # per session — pkg/agentruntime/main.go's defaultMaxArtifactBytes/
+        # defaultMaxSessionArtifactBytes/defaultMaxSessionArtifacts) apply.
+        # Promote these to values.yaml-backed envs (like AGENT_MAX_CONTINUATIONS
+        # above) only once an operator actually needs to override them.
         {{- include "fission-resource-namespace.envs" . | indent 8 }}
         {{- include "kube_client.envs" . | indent 8 }}
         {{- include "opentelemtry.envs" . | indent 8 }}

--- a/charts/fission-all/templates/storagesvc/networkpolicy.yaml
+++ b/charts/fission-all/templates/storagesvc/networkpolicy.yaml
@@ -63,6 +63,18 @@ spec:
       ports:
         - port: 8000
           protocol: TCP
+    # The agent runtime dispatcher proxies the session artifact workspace API
+    # (PUT/GET/DELETE/LIST under /v1/workspace) and the sweeper's archive-time
+    # prefix purge to storagesvc. agentruntime and storagesvc share the chart
+    # release namespace (no namespaceSelector needed), mirroring the router
+    # netpol's own `svc: agentruntime` entry (router/networkpolicy.yaml).
+    - from:
+        - podSelector:
+            matchLabels:
+              svc: agentruntime
+      ports:
+        - port: 8000
+          protocol: TCP
     # Allow the metrics endpoint from any source so Prometheus / podMonitor
     # scraping works regardless of where the operator is deployed. Metrics
     # contain no archive content, only counts.

--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -207,6 +207,11 @@ it can reach any agent's workspace within its scoped namespace.
 - **256MiB per session** (`AGENT_MAX_SESSION_ARTIFACT_BYTES`) and **1000 artifacts per session** (`AGENT_MAX_SESSION_ARTIFACTS`) —
   a PUT past either budget is rejected with 429.
   The count budget closes the byte budget's zero-byte-artifact bypass and structurally bounds how large a single LIST response can ever get.
+- **DELETE-side settle is the one accepted fail-open exception.** Two concurrent DELETEs of the same path can both decrement the tracked meters
+  for a single real shrink (storagesvc's DELETE is idempotent-200, so the race is self-inflicted, not exploitable cross-session) —
+  bounded at defaults by `maxSessionArtifacts * maxArtifactBytes` (~31GiB), not the 256MiB byte budget. See `probeExisting`'s doc comment in `pkg/agentruntime/workspace.go`.
+- **Operators: `STORAGE_MAX_ARCHIVE_SIZE_MIB` interacts with `AGENT_MAX_ARTIFACT_BYTES`.** storagesvc's own upload cap applies to workspace PUTs too;
+  lowering it below the artifact cap makes an agentruntime-accepted PUT fail at storagesvc (a 502 here, not the expected 413).
 
 ### Lifecycle
 

--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -20,6 +20,8 @@ sub-second resume, live UI.**
   Session-scoped (dispatched by `fission-bundle --agentPort`, see `pkg/agentruntime/dispatcher.go`);
   keeps a per-session turn count and running summary via the RFC-0023 keyed-state API (`FISSION_STATE_URL` + the fetcher-written state token file);
   sets `X-Fission-Agent-Yield: waiting` after every reply so the session flips back to idle immediately.
+  On a turn carrying `{"artifact":true}` it also round-trips a generated artifact through its own G12 session workspace
+  (see "Session workspace" below).
 - `fixtures/order-lookup.js` —
   a trivial MCP tool function (static order data by id).
   Independent of `support-desk` on purpose:
@@ -156,6 +158,67 @@ What to watch on the `/ui/` board:
   (`authentication.enabled` with `internalAuth.enabled=false`)
   where the injected credential is a placeholder.
 
+## Session workspace
+
+`support-desk` (`fixtures/support-desk.js`) also demonstrates the G12 session workspace API on request:
+send `{"artifact":true}` in a turn's body and it PUTs a generated few-KiB text artifact to its own session workspace at `notes/summary.txt`,
+GETs it straight back,
+and lists the session,
+reporting both sha256 digests plus the list response in its reply.
+This is manual, like the swarm beat above — not part of `loadgen`.
+
+```sh
+# Port-forward as in the Kind quickstart's step 3, then run one turn with
+# the artifact flag set:
+curl -s -X POST http://127.0.0.1:8894/agents/default/support-desk \
+  -H 'Content-Type: application/json' \
+  -H 'X-Fission-Session: workspace-demo-1' \
+  -d '{"artifact":true}' | jq .
+```
+
+The reply's `artifactSha256Put` and `artifactSha256Got` should match,
+and `artifactList` should carry one entry for `notes/summary.txt`.
+`fixtures/support-desk.js` authenticates these calls the same way `architect.js` authenticates its spawn dispatches
+(the fetcher-written per-agent identity credential) —
+see the "Swarm beat" auth note above, which applies identically here.
+
+### SDK-visible surface
+
+Four routes on the agent runtime mux (`pkg/agentruntime/workspace.go`), all scoped to `<namespace>/<agent>/<session>`:
+
+- `PUT /workspace/{ns}/{agent}/{session}/{path...}` — write (or overwrite) an artifact.
+- `GET /workspace/{ns}/{agent}/{session}/{path...}` — read an artifact back; 404 if it does not exist.
+- `DELETE /workspace/{ns}/{agent}/{session}/{path...}` — remove an artifact; idempotent (a missing artifact still answers 200).
+- `GET /workspace/{ns}/{agent}/{session}` — list every artifact currently stored under the session, with sizes.
+
+Every route requires a **live session record** at `{ns}/{agent}/{session}` before it does anything else — the workspace is scoped to a session dispatch actually minted, never a caller-chosen id with no session behind it,
+and every route 404s otherwise.
+Authorization depends on which credential the caller sends:
+the per-agent identity bearer (the normal pod-to-workspace path) is **own-workspace only** —
+the claimed namespace AND agent must both match the path,
+so a pod can read/write/list/delete only its own session's artifacts, never another agent's, even one in the same namespace.
+A namespace-scoped JWT (the debugging-parity path) is checked on namespace alone,
+same as every other JWT-authenticated route on this mux —
+it can reach any agent's workspace within its scoped namespace.
+
+### Caps (code defaults)
+
+- **32MiB per artifact** (`AGENT_MAX_ARTIFACT_BYTES`) — a PUT over the cap is rejected with 413 before anything is stored.
+- **256MiB per session** (`AGENT_MAX_SESSION_ARTIFACT_BYTES`) and **1000 artifacts per session** (`AGENT_MAX_SESSION_ARTIFACTS`) —
+  a PUT past either budget is rejected with 429.
+  The count budget closes the byte budget's zero-byte-artifact bypass and structurally bounds how large a single LIST response can ever get.
+
+### Lifecycle
+
+- **Purged at archive.** The sweeper deletes every object under a session's workspace prefix when its record archives (`pkg/agentruntime/sweeper.go`) —
+  best-effort and log-don't-retry, the same posture as the rest of the sweeper.
+- **Scratch, not truth.** The workspace has no head-capture analog and no recovery story of its own:
+  treat it as a working area for the current session, not a system of record.
+  A purge racing a session recreated at the same id is accepted, documented residue, not a bug.
+- **Shrink-reclaim is delete+PUT, not overwrite.** Overwriting a path with a SMALLER file never credits the freed bytes back to the session's byte budget
+  (a same-path shrink is deliberately fail-closed against a quota-bypass race) —
+  to actually reclaim budget, DELETE the path first, then PUT the smaller replacement.
+
 ## Demo beats checklist
 
 Mapped from the boardroom demo script; check these off live against the
@@ -186,6 +249,10 @@ Mapped from the boardroom demo script; check these off live against the
 - [ ] **Swarm** — start an `architect` session (see "Swarm beat" below) and
       watch its 3 expert children appear indented underneath it in the
       SESSIONS panel, with a `d1` depth badge.
+- [ ] **Session workspace** — send one turn with `{"artifact":true}` (see
+      "Session workspace" below) and confirm the reply's
+      `artifactSha256Put`/`artifactSha256Got` match and `artifactList`
+      carries `notes/summary.txt`.
 - [ ] **Burst counter** — `loadgen`'s final report line
       (`density (sessions:pods): NNx`) climbs as `--sessions` grows for a
       fixed pool size.

--- a/demo/agent-boardroom/fixtures/support-desk.js
+++ b/demo/agent-boardroom/fixtures/support-desk.js
@@ -42,8 +42,24 @@
 // an in-process Map for the KV blob, and skips history/checkpoint writes
 // entirely — that memory does not survive a pod recycle, unlike the real
 // state-backed path.
+//
+// Session workspace beat (G12, see ../README.md's "Session workspace"
+// section): on a turn whose body carries {"artifact":true} this fixture
+// PUTs a generated few-KiB text artifact to its OWN session workspace at
+// "notes/summary.txt" (pkg/agentruntime/workspace.go), GETs it straight
+// back, and lists the session, replying with both sha256 hex digests plus
+// the list response's items. It authenticates these calls with the SAME
+// per-agent identity credential ../fixtures/architect.js's spawn calls use
+// (readAgentCredentials()/authHeaders() below, ported from that file
+// verbatim) — workspace.go's own-workspace check requires the identical
+// (namespace, agent) claims a spawn dispatch already carries, just checked
+// more strictly (ns AND agent equality, not ns-only). Best-effort like
+// architect.js's spawnOneExpert: a failed PUT/GET/LIST never fails this
+// turn's own 200, it only reports "error:<code>" in the corresponding
+// field(s) — see artifactBeat's doc comment below.
 
 const fs = require('fs');
+const crypto = require('crypto');
 
 const SESSION_HEADER = 'x-fission-session'; // express lower-cases header names
 // TURNS_HEADER carries the session's turn count from BEFORE this turn
@@ -107,6 +123,189 @@ if (STATE_URL && TOKEN_PATH) {
 // pod-local and lost on every recycle, so it must never be mistaken for the
 // real RFC-0023 keyspace.
 const memoryFallback = new Map();
+
+// OWN_AGENT_NAME must match this fixture's own Function name in
+// ../specs/support-desk.yaml -- mirrors architect.js's constant of the same
+// name; a function pod has no other reliable way to learn its own name at
+// runtime.
+const OWN_AGENT_NAME = 'support-desk';
+
+// DEFAULT_AGENT_RUNTIME_URL / AGENT_RUNTIME_URL / AGENT_RUNTIME_TOKEN /
+// AGENT_TOKEN_PATH / DEV_PLACEHOLDER_TOKEN / readAgentCredentials /
+// authHeaders are ported verbatim from ../fixtures/architect.js -- see that
+// file's header comment for the full G16 auth writeup this applies
+// identically to (the workspace routes are the identity bearer's SECOND
+// mount, see pkg/agentruntime/identity.go's package doc).
+const DEFAULT_AGENT_RUNTIME_URL = 'http://agentruntime.fission:8894';
+const AGENT_RUNTIME_URL =
+  process.env.FISSION_AGENT_RUNTIME_URL || process.env.AGENT_RUNTIME_URL || DEFAULT_AGENT_RUNTIME_URL;
+// AGENT_RUNTIME_TOKEN is the pre-G16 manual-provisioning fallback (see
+// authHeaders() below): a plain bearer with no claims headers, used only
+// when the fetcher-written identity file is absent or carries the dev
+// placeholder.
+const AGENT_RUNTIME_TOKEN = process.env.AGENT_RUNTIME_TOKEN || '';
+// AGENT_TOKEN_PATH is the G16 identity file the executor points at via
+// FISSION_AGENT_TOKEN_PATH (pkg/executor/util/agentenv.go), written by the
+// fetcher at specialize time (pkg/fetcher/agenttoken.go). Deliberately a
+// SEPARATE env var and file from the state-token pair above: agent identity
+// must not require State to be enabled.
+const AGENT_TOKEN_PATH = process.env.FISSION_AGENT_TOKEN_PATH || '';
+// DEV_PLACEHOLDER_TOKEN is the fetcher's un-derived stand-in
+// (pkg/fetcher/agenttoken.go writeAgentTokenFile): written when the fetcher
+// itself has no FISSION_INTERNAL_AUTH_SECRET, so it never verifies as a real
+// identity token.
+const DEV_PLACEHOLDER_TOKEN = 'dev-unauthenticated';
+
+// readAgentCredentials reads the fetcher-written AgentCredentials JSON
+// ({namespace, agent, token}) once at module load, cached in agentCreds
+// below.
+function readAgentCredentials(path) {
+  if (!path) {
+    return null;
+  }
+  try {
+    return JSON.parse(fs.readFileSync(path, 'utf8'));
+  } catch (err) {
+    // Log err.code/err.name only: a mid-token corrupt-file parse failure
+    // embeds a source snippet in err.message (V8 JSON.parse SyntaxError),
+    // and the token is the last field of this JSON -- stringifying err
+    // could leak token bytes into pod logs.
+    console.error(`support-desk: could not read agent identity token file ${path}: ${err.code || err.name}`);
+    return null;
+  }
+}
+
+const agentCreds = readAgentCredentials(AGENT_TOKEN_PATH);
+
+// ownNamespace mirrors architect.js's helper of the same name: a function
+// pod has no other reliable way to learn which namespace it was deployed
+// into. agentCreds.namespace is a valid fallback even when its token is the
+// dev placeholder (authHeaders() below skips the placeholder for AUTH
+// purposes only) -- the namespace claim itself is always the real one the
+// fetcher wrote.
+function ownNamespace() {
+  return (stateCreds && stateCreds.namespace) || (agentCreds && agentCreds.namespace) || 'default';
+}
+
+// authHeaders picks the workspace-call credential in preference order (see
+// architect.js's identical helper for the full writeup):
+//  1. The fetcher-written identity file (agentCreds) -- but ONLY when its
+//     token is not DEV_PLACEHOLDER_TOKEN.
+//  2. AGENT_RUNTIME_TOKEN, a plain bearer with no claims headers.
+//  3. No auth -- relies on the cluster's AGENT_ALLOW_INSECURE pass-through.
+function authHeaders() {
+  if (agentCreds && agentCreds.token && agentCreds.token !== DEV_PLACEHOLDER_TOKEN) {
+    return {
+      Authorization: `Bearer ${agentCreds.token}`,
+      'X-Fission-Agent-Auth-Namespace': agentCreds.namespace,
+      'X-Fission-Agent-Auth-Name': agentCreds.agent,
+    };
+  }
+  return AGENT_RUNTIME_TOKEN ? { Authorization: `Bearer ${AGENT_RUNTIME_TOKEN}` } : {};
+}
+
+// ARTIFACT_PATH is the fixed within-session path the artifact beat
+// round-trips (matches the integration test's fixture and assertion, see
+// test/integration/testdata/nodejs/agentspawn/spawn.js and
+// test/integration/suites/common/agentruntime_test.go's
+// TestAgentRuntimeWorkspace).
+const ARTIFACT_PATH = 'notes/summary.txt';
+// ARTIFACT_MIN_BYTES bounds the generated content to "a few KiB" -- well
+// under AGENT_MAX_ARTIFACT_BYTES' 32MiB default.
+const ARTIFACT_MIN_BYTES = 3072;
+
+function workspaceURL(ns, agent, sessionID, path) {
+  const base = `${AGENT_RUNTIME_URL}/workspace/${encodeURIComponent(ns)}/${encodeURIComponent(agent)}/${encodeURIComponent(sessionID)}`;
+  return path ? `${base}/${path}` : base;
+}
+
+// buildArtifactContent deterministically generates a few-KiB text artifact
+// from the session id and turn number -- no randomness, so a re-run against
+// the SAME session/turn produces byte-identical content.
+function buildArtifactContent(sessionID, turn) {
+  const line = `session ${sessionID} turn ${turn}: session workspace (G12) artifact demo beat -- PUT/GET/LIST round-trip through pkg/agentruntime/workspace.go.\n`;
+  let out = '';
+  while (out.length < ARTIFACT_MIN_BYTES) {
+    out += line;
+  }
+  return out;
+}
+
+// errTag extracts a short, loggable tag from an artifact-beat error: the
+// HTTP status code when the call threw a "status:<code>" Error, otherwise
+// the error's own code/name -- never its full message.
+function errTag(err) {
+  const m = /^status:(\d+)$/.exec(err && err.message);
+  return m ? m[1] : (err && (err.code || err.name)) || 'network';
+}
+
+async function putArtifact(ns, agent, sessionID, content) {
+  const res = await fetch(workspaceURL(ns, agent, sessionID, ARTIFACT_PATH), {
+    method: 'PUT',
+    headers: Object.assign({ 'Content-Type': 'text/plain' }, authHeaders()),
+    body: content,
+  });
+  if (!res.ok) {
+    throw new Error(`status:${res.status}`);
+  }
+  await res.json(); // drain/validate the {path,size} body.
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+async function getArtifact(ns, agent, sessionID) {
+  const res = await fetch(workspaceURL(ns, agent, sessionID, ARTIFACT_PATH), { headers: authHeaders() });
+  if (!res.ok) {
+    throw new Error(`status:${res.status}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+async function listArtifacts(ns, agent, sessionID) {
+  const res = await fetch(workspaceURL(ns, agent, sessionID, ''), { headers: authHeaders() });
+  if (!res.ok) {
+    throw new Error(`status:${res.status}`);
+  }
+  const data = await res.json();
+  return Array.isArray(data.items) ? data.items : [];
+}
+
+// artifactBeat runs the PUT -> GET -> LIST sequence and returns the wire
+// shape the turn's response echoes: artifactSha256Put/artifactSha256Got are
+// the literal string "error:<code>" on failure (never thrown), and
+// artifactList is always an array; a LIST failure reports as a single
+// sentinel item {path:"error:<code>",size:0} rather than changing the
+// field's type.
+async function artifactBeat(sessionID, turn) {
+  const ns = ownNamespace();
+  const content = buildArtifactContent(sessionID, turn);
+
+  let put = 'error:unknown';
+  try {
+    put = await putArtifact(ns, OWN_AGENT_NAME, sessionID, content);
+  } catch (err) {
+    console.error(`support-desk: artifact PUT (session ${sessionID}) failed: ${err}`);
+    put = `error:${errTag(err)}`;
+  }
+
+  let got = 'error:unknown';
+  try {
+    got = await getArtifact(ns, OWN_AGENT_NAME, sessionID);
+  } catch (err) {
+    console.error(`support-desk: artifact GET (session ${sessionID}) failed: ${err}`);
+    got = `error:${errTag(err)}`;
+  }
+
+  let list = [{ path: 'error:unknown', size: 0 }];
+  try {
+    list = await listArtifacts(ns, OWN_AGENT_NAME, sessionID);
+  } catch (err) {
+    console.error(`support-desk: artifact LIST (session ${sessionID}) failed: ${err}`);
+    list = [{ path: `error:${errTag(err)}`, size: 0 }];
+  }
+
+  return { artifactSha256Put: put, artifactSha256Got: got, artifactList: list };
+}
 
 function stateHeaders(extra) {
   return Object.assign(
@@ -429,6 +628,14 @@ function extractMessage(body) {
   return '(empty turn)';
 }
 
+// artifactRequested reports whether body carries {"artifact":true} -- a
+// string body (extractMessage's plain-message shape) never requests the
+// beat, matching spawn.js's identical parsing of its own {"spawn":true}
+// flag.
+function artifactRequested(body) {
+  return !!(body && typeof body === 'object' && body.artifact === true);
+}
+
 module.exports = async function (context) {
   const req = context.request;
   const sessionID = req.headers[SESSION_HEADER] || 'unknown';
@@ -479,6 +686,16 @@ module.exports = async function (context) {
     summary: session.summary,
     reply: replyText,
   };
+
+  // artifact* fields are only added when this turn's body asked for the
+  // beat -- omitted entirely on every other turn, rather than running it
+  // unconditionally on every turn.
+  if (artifactRequested(req.body)) {
+    const artifact = await artifactBeat(sessionID, turn);
+    reply.artifactSha256Put = artifact.artifactSha256Put;
+    reply.artifactSha256Got = artifact.artifactSha256Got;
+    reply.artifactList = artifact.artifactList;
+  }
 
   return {
     status: 200,

--- a/pkg/agentruntime/dispatcher.go
+++ b/pkg/agentruntime/dispatcher.go
@@ -898,25 +898,31 @@ func streamToSink(sink TurnSink, src io.Reader) {
 // actually landed, so a caller whose post-write action depends on the mutated
 // state having been persisted (the step-5 continue-enqueue) can tell a real
 // persist from a phantom one that never reached the store.
-func (d *Dispatcher) casUpdate(ctx context.Context, ns, agent, id string, rec SessionRecord, version int64, liveTTL time.Duration, mutate func(*SessionRecord)) bool {
+//
+// Package-level (not a Dispatcher method) so the session workspace routes
+// (workspace.go, a later slice) can settle their ArtifactCount/ArtifactBytes
+// counters through the exact same retry-once-on-conflict logic without a
+// second, drifting copy — Dispatcher's own casUpdate/casUpdateFresh methods
+// below are thin delegates to these, byte-identical in behavior.
+func casUpdate(ctx context.Context, logger logr.Logger, store *SessionStore, ns, agent, id string, rec SessionRecord, version int64, liveTTL time.Duration, mutate func(*SessionRecord)) bool {
 	mutate(&rec)
-	err := d.store.Update(ctx, rec, version, liveTTL)
+	err := store.Update(ctx, rec, version, liveTTL)
 	if err == nil {
 		return true
 	}
 	if !errors.Is(err, statestore.ErrVersionConflict) {
-		d.logger.Error(err, "updating session record", "namespace", ns, "agent", agent, "session", id)
+		logger.Error(err, "updating session record", "namespace", ns, "agent", agent, "session", id)
 		return false
 	}
 
-	fresh, freshVersion, gerr := d.store.Get(ctx, ns, agent, id)
+	fresh, freshVersion, gerr := store.Get(ctx, ns, agent, id)
 	if gerr != nil {
-		d.logger.Error(gerr, "re-getting session record after conflict", "namespace", ns, "agent", agent, "session", id)
+		logger.Error(gerr, "re-getting session record after conflict", "namespace", ns, "agent", agent, "session", id)
 		return false
 	}
 	mutate(&fresh)
-	if uerr := d.store.Update(ctx, fresh, freshVersion, liveTTL); uerr != nil {
-		d.logger.Error(uerr, "updating session record after retry", "namespace", ns, "agent", agent, "session", id)
+	if uerr := store.Update(ctx, fresh, freshVersion, liveTTL); uerr != nil {
+		logger.Error(uerr, "updating session record after retry", "namespace", ns, "agent", agent, "session", id)
 		return false
 	}
 	return true
@@ -926,14 +932,27 @@ func (d *Dispatcher) casUpdate(ctx context.Context, ns, agent, id string, rec Se
 // delegates to casUpdate. Used whenever an unbounded amount of work (an
 // upstream call) may have happened since any previously held version was
 // read. It returns casUpdate's persisted flag (false also when the fresh Get
-// itself fails).
-func (d *Dispatcher) casUpdateFresh(ctx context.Context, ns, agent, id string, liveTTL time.Duration, mutate func(*SessionRecord)) bool {
-	rec, version, err := d.store.Get(ctx, ns, agent, id)
+// itself fails). Package-level for the same reason casUpdate is — see its
+// doc comment.
+func casUpdateFresh(ctx context.Context, logger logr.Logger, store *SessionStore, ns, agent, id string, liveTTL time.Duration, mutate func(*SessionRecord)) bool {
+	rec, version, err := store.Get(ctx, ns, agent, id)
 	if err != nil {
-		d.logger.Error(err, "getting session record for update", "namespace", ns, "agent", agent, "session", id)
+		logger.Error(err, "getting session record for update", "namespace", ns, "agent", agent, "session", id)
 		return false
 	}
-	return d.casUpdate(ctx, ns, agent, id, rec, version, liveTTL, mutate)
+	return casUpdate(ctx, logger, store, ns, agent, id, rec, version, liveTTL, mutate)
+}
+
+// casUpdate is Dispatcher's delegate to the package-level casUpdate, over
+// this Dispatcher's own logger and store.
+func (d *Dispatcher) casUpdate(ctx context.Context, ns, agent, id string, rec SessionRecord, version int64, liveTTL time.Duration, mutate func(*SessionRecord)) bool {
+	return casUpdate(ctx, d.logger, d.store, ns, agent, id, rec, version, liveTTL, mutate)
+}
+
+// casUpdateFresh is Dispatcher's delegate to the package-level
+// casUpdateFresh, over this Dispatcher's own logger and store.
+func (d *Dispatcher) casUpdateFresh(ctx context.Context, ns, agent, id string, liveTTL time.Duration, mutate func(*SessionRecord)) bool {
+	return casUpdateFresh(ctx, d.logger, d.store, ns, agent, id, liveTTL, mutate)
 }
 
 // writeErr answers with a small {"error": msg} JSON object at status.

--- a/pkg/agentruntime/events.go
+++ b/pkg/agentruntime/events.go
@@ -399,9 +399,14 @@ func diffSessions(prev, current map[sessionKey]SessionRecord) []SessionRecord {
 // the poller diffs: Status, LastActiveAt, Stats.Turns, CurrentPod. Every
 // other field the poller ignores is either immutable after Create
 // (Namespace, Agent, ID, CreatedAt, Parent, Depth) or not yet meaningful for
-// the feed (the rest of Stats). LastActiveAt is compared with Equal, not ==:
-// both values here round-tripped through JSON, but Equal is the correct
-// time.Time comparison regardless.
+// the feed (the rest of Stats). This deliberately includes
+// Stats.ArtifactCount/ArtifactBytes (G12 session workspace, a later slice):
+// a workspace PUT/DELETE settles those counters via its own CAS write, and
+// that write must NOT be treated as an SSE-worthy session change — the feed
+// exists for turn/status activity, not storage bookkeeping, and diffing them
+// here would churn the feed on every artifact write. LastActiveAt is
+// compared with Equal, not ==: both values here round-tripped through JSON,
+// but Equal is the correct time.Time comparison regardless.
 func sessionUnchanged(old, cur SessionRecord) bool {
 	return old.Status == cur.Status &&
 		old.LastActiveAt.Equal(cur.LastActiveAt) &&

--- a/pkg/agentruntime/identity.go
+++ b/pkg/agentruntime/identity.go
@@ -2,13 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// identity.go implements the G16 agent-identity bearer verification on the
-// dispatch route ONLY (POST /agents/{namespace}/{name}) — a second,
-// exclusive auth path alongside authz.go's JWT verification, for a pod's own
-// spawn/dispatch calls carrying the HKDF-derived token Task 1
+// identity.go implements the G16 agent-identity bearer verification,
+// originally on the dispatch route ONLY (POST /agents/{namespace}/{name}) —
+// a second, exclusive auth path alongside authz.go's JWT verification, for a
+// pod's own spawn/dispatch calls carrying the HKDF-derived token Task 1
 // (DeriveAgentIdentityKey, pkg/auth/hmac/keys.go) and Task 2 (the fetcher's
-// .fission-agent-token file) produced. It never reaches the registry/SSE
-// routes: IdentityOrJWT is wired onto the dispatch mount only (main.go).
+// .fission-agent-token file) produced.
+//
+// AMENDED (G12 session workspace, a later slice): the identity bearer now
+// also authenticates the session workspace routes
+// (PUT/GET/DELETE /workspace/{namespace}/{name}/{session}/{path...} and the
+// list route, workspace.go) — a SECOND surface, with a STRICTER
+// authorization rule than dispatch's. The shared verification steps (1-4
+// below) are factored into verifyClaims; each surface then applies its own
+// step-5 authorization closure: dispatch's verify keeps ns-only equality
+// (cross-agent dispatch in the same namespace is the spawn shape), while
+// workspace's verifyOwnWorkspace additionally requires agent equality
+// (own-workspace only in v1 — see verifyOwnWorkspace's doc for the future
+// cross-agent-sharing relaxation this parallels). It still never reaches the
+// registry/SSE routes: IdentityOrJWT/IdentityOrJWTOwnWorkspace are wired onto
+// the dispatch and workspace mounts only (main.go).
 package agentruntime
 
 import (
@@ -27,9 +40,11 @@ const (
 	// compares — the same claims-ride-beside-the-token shape as statesvc's
 	// bearer channel (pkg/statesvc/auth.go, stateapi.HeaderNamespace/
 	// HeaderKeyspace). The presence of either header (not the Authorization
-	// scheme) selects the identity verification path on the dispatch route
-	// EXCLUSIVELY — see IdentityOrJWT. Named alongside the dispatcher's own
-	// X-Fission-Agent-* header family (dispatcher.go:37-74) but distinct in
+	// scheme) selects the identity verification path EXCLUSIVELY on either of
+	// the two mounts that consult it — the dispatch route (IdentityOrJWT) and
+	// the session workspace routes (IdentityOrJWTOwnWorkspace, workspace.go).
+	// Named alongside the dispatcher's own X-Fission-Agent-* header family
+	// (dispatcher.go:37-74) but distinct in
 	// kind: those are turn-protocol headers forwarded to/from the function;
 	// these two are AUTHENTICATION claims consumed here and never proxied
 	// upstream.
@@ -61,9 +76,12 @@ func NewIdentityVerifier(master, masterOld []byte, view *AgentView) *IdentityVer
 	return &IdentityVerifier{master: master, masterOld: masterOld, view: view}
 }
 
-// verify implements the identity path's five checks, in order, writing the
-// HTTP error response itself and returning false on the first one that
-// fails; true means the caller is authorized to proceed straight to next.
+// verifyClaims implements the identity path's shared checks 1-4, in order,
+// writing the HTTP error response itself and returning ok=false on the first
+// one that fails. It is the extracted "verify core" both surfaces
+// (dispatch's verify and workspace's verifyOwnWorkspace) build on — each
+// composes its own step-5 authorization closure on top of the returned,
+// now-authenticated claims.
 //
 //  1. Parse the bearer token. Empty (missing header, non-Bearer scheme, or
 //     an empty token) -> 401.
@@ -79,61 +97,92 @@ func NewIdentityVerifier(master, masterOld []byte, view *AgentView) *IdentityVer
 //  4. Revocation check AFTER the compare, not before: view.Lookup so an
 //     invalid-token holder never learns whether the claimed agent exists.
 //     Missing -> 401.
-//  5. Inline authorization — the plan-review blocker this file exists for:
-//     the claimed namespace must equal the dispatch path's {namespace} (set
-//     by the outer mux before this wrapper runs). The claimed AGENT
-//     identifies the CALLER, not the target: dispatch to a different agent
-//     in the SAME namespace is the spawn shape (architect -> support-desk)
-//     and is allowed. Mismatch -> 403.
-func (v *IdentityVerifier) verify(w http.ResponseWriter, r *http.Request) bool {
-	claimedNS := r.Header.Get(HeaderIdentityNamespace)
-	claimedAgent := r.Header.Get(HeaderIdentityName)
+func (v *IdentityVerifier) verifyClaims(w http.ResponseWriter, r *http.Request) (claimedNS, claimedAgent string, ok bool) {
+	claimedNS = r.Header.Get(HeaderIdentityNamespace)
+	claimedAgent = r.Header.Get(HeaderIdentityName)
 
 	token, isBearer := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
 	if !isBearer || token == "" {
 		http.Error(w, "missing agent identity bearer token", http.StatusUnauthorized)
-		return false
+		return "", "", false
 	}
 
 	if len(v.master) == 0 && len(v.masterOld) == 0 {
 		http.Error(w, "agent identity requires FISSION_INTERNAL_AUTH_SECRET on the agent runtime", http.StatusUnauthorized)
-		return false
+		return "", "", false
 	}
 
-	ok := 0
+	match := 0
 	for _, master := range [][]byte{v.master, v.masterOld} {
 		if len(master) == 0 {
 			continue
 		}
 		want := hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, claimedNS, claimedAgent))
-		ok |= subtle.ConstantTimeCompare([]byte(token), []byte(want))
+		match |= subtle.ConstantTimeCompare([]byte(token), []byte(want))
 	}
-	if ok != 1 {
+	if match != 1 {
 		http.Error(w, "invalid agent identity token", http.StatusUnauthorized)
-		return false
+		return "", "", false
 	}
 
 	if _, live := v.view.Lookup(claimedNS, claimedAgent); !live {
 		http.Error(w, "invalid agent identity token", http.StatusUnauthorized)
-		return false
+		return "", "", false
 	}
 
+	return claimedNS, claimedAgent, true
+}
+
+// verify is the dispatch route's step-5 authorization on top of
+// verifyClaims: the claimed namespace must equal the dispatch path's
+// {namespace} (set by the outer mux before this wrapper runs). The claimed
+// AGENT identifies the CALLER, not the target: dispatch to a different agent
+// in the SAME namespace is the spawn shape (architect -> support-desk) and
+// is allowed. Mismatch -> 403.
+func (v *IdentityVerifier) verify(w http.ResponseWriter, r *http.Request) bool {
+	claimedNS, _, ok := v.verifyClaims(w, r)
+	if !ok {
+		return false
+	}
 	if claimedNS != r.PathValue("namespace") {
 		http.Error(w, "forbidden: agent identity token not authorized for this namespace", http.StatusForbidden)
 		return false
 	}
-
 	return true
 }
 
-// IdentityOrJWT wraps next with the dispatch route's dual auth: the identity
-// path when identity is non-nil and the request carries either identity
-// claim header, otherwise the existing jwt middleware unchanged.
+// verifyOwnWorkspace is the session workspace routes' step-5 authorization
+// on top of verifyClaims — the G16 surface amendment (see this file's
+// package doc): STRICTER than dispatch's verify, requiring BOTH the claimed
+// namespace AND the claimed agent to equal the workspace path's
+// {namespace}/{name}. Own-workspace only in v1: a pod may read/write/list/
+// delete only its own session's artifacts, never another agent's — even one
+// in the same namespace, which verify's dispatch-side check would allow.
+// Cross-agent workspace sharing (parallel to dispatch's cross-agent spawn
+// allowance) is a later relaxation, deliberately not built here. Mismatch on
+// either claim -> 403.
+func (v *IdentityVerifier) verifyOwnWorkspace(w http.ResponseWriter, r *http.Request) bool {
+	claimedNS, claimedAgent, ok := v.verifyClaims(w, r)
+	if !ok {
+		return false
+	}
+	if claimedNS != r.PathValue("namespace") || claimedAgent != r.PathValue("name") {
+		http.Error(w, "forbidden: agent identity token not authorized for this workspace", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+// identityOrJWT is the shared combinator behind IdentityOrJWT and
+// IdentityOrJWTOwnWorkspace: identity path when identity is non-nil and the
+// request carries either identity claim header (verified by check, the
+// surface-specific step-5 closure — (*IdentityVerifier).verify or
+// verifyOwnWorkspace), otherwise the existing jwt middleware unchanged.
 //
 // identity is nil exactly when the JWT signing key is unset (allowInsecure
 // dev mode) — main.go only constructs an IdentityVerifier when
 // authz.Enabled(). That is what makes the allowInsecure row of the truth
-// table hold without IdentityOrJWT needing any other signal of its own: with
+// table hold without this needing any other signal of its own: with
 // identity == nil the returned handler is jwt(next) and nothing else, so it
 // is a bytewise no-op passthrough exactly as today (authz.HTTPMiddleware
 // returns next unwrapped when the key is empty, authz.go:85-90) — a request
@@ -142,7 +191,7 @@ func (v *IdentityVerifier) verify(w http.ResponseWriter, r *http.Request) bool {
 // all, and so cannot be 401'd by the "no master secret configured" check.
 //
 // When identity is non-nil, the two credential channels are mutually
-// exclusive by construction: identity headers present selects verify()
+// exclusive by construction: identity headers present selects check
 // EXCLUSIVELY — success calls next.ServeHTTP directly (bypassing jwt
 // entirely, even when the request also carries an Authorization: Bearer JWT
 // — identity wins), and failure returns the identity path's own error
@@ -150,7 +199,7 @@ func (v *IdentityVerifier) verify(w http.ResponseWriter, r *http.Request) bool {
 // downgrade a rejected identity token to a JWT check by also supplying a
 // stolen or forged bearer). Identity headers absent delegates unchanged to
 // jwt(next), built once here rather than per-request.
-func IdentityOrJWT(identity *IdentityVerifier, jwt func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+func identityOrJWT(identity *IdentityVerifier, jwt func(http.Handler) http.Handler, check func(*IdentityVerifier, http.ResponseWriter, *http.Request) bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		jwtHandler := jwt(next)
 		if identity == nil {
@@ -161,9 +210,22 @@ func IdentityOrJWT(identity *IdentityVerifier, jwt func(http.Handler) http.Handl
 				jwtHandler.ServeHTTP(w, r)
 				return
 			}
-			if identity.verify(w, r) {
+			if check(identity, w, r) {
 				next.ServeHTTP(w, r)
 			}
 		})
 	}
+}
+
+// IdentityOrJWT wraps next with the dispatch route's dual auth: see
+// identityOrJWT. Uses (*IdentityVerifier).verify (ns-only equality).
+func IdentityOrJWT(identity *IdentityVerifier, jwt func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return identityOrJWT(identity, jwt, (*IdentityVerifier).verify)
+}
+
+// IdentityOrJWTOwnWorkspace wraps next with the session workspace routes'
+// dual auth: see identityOrJWT. Uses (*IdentityVerifier).verifyOwnWorkspace
+// (ns AND agent equality — own-workspace only, the G16 surface amendment).
+func IdentityOrJWTOwnWorkspace(identity *IdentityVerifier, jwt func(http.Handler) http.Handler) func(http.Handler) http.Handler {
+	return identityOrJWT(identity, jwt, (*IdentityVerifier).verifyOwnWorkspace)
 }

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -339,7 +339,11 @@ const (
 	// is unset. 0 for either session budget means unlimited (see
 	// WorkspaceHandler.maxSessionArtifactBytes/maxSessionArtifacts); the
 	// per-artifact cap has no such "0 means unlimited" escape hatch — it
-	// always bounds a single PUT.
+	// always bounds a single PUT. This cap is agentruntime's own, independent
+	// of storagesvc's STORAGE_MAX_ARCHIVE_SIZE_MIB — an operator who lowers
+	// that below AGENT_MAX_ARTIFACT_BYTES makes a PUT agentruntime accepted
+	// here fail at storagesvc instead (see WorkspaceHandler.maxArtifactBytes
+	// in workspace.go for the full interplay note).
 	defaultMaxArtifactBytes        int64 = 32 << 20
 	defaultMaxSessionArtifactBytes int64 = 256 << 20
 	defaultMaxSessionArtifacts     int64 = 1000

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -310,10 +310,34 @@ const (
 	// (see events.go). Read once here, like envSweepInterval.
 	envRegistryPoll = "AGENT_REGISTRY_POLL"
 
+	// envStoragesvcURL configures the session workspace routes' (workspace.go)
+	// upstream storagesvc base URL. Confirmed ABSENT from the agentruntime
+	// deployment as of this slice (chart wiring is a later slice) — empty
+	// means the workspace routes are DISABLED (503 "workspace disabled"),
+	// deliberately never guessed from a convention like
+	// "http://storagesvc.<namespace>": a wrong guess would silently point
+	// artifact traffic at the wrong service rather than failing loudly.
+	envStoragesvcURL = "STORAGESVC_URL"
+
+	// envMaxArtifactBytes / envMaxSessionArtifactBytes configure
+	// WorkspaceHandler's per-artifact cap and per-session budget
+	// (workspace.go's handlePut doc). Read once here, like the other agent
+	// runtime knobs.
+	envMaxArtifactBytes        = "AGENT_MAX_ARTIFACT_BYTES"
+	envMaxSessionArtifactBytes = "AGENT_MAX_SESSION_ARTIFACT_BYTES"
+
 	// defaultSweepInterval / defaultArchiveRetention are applied when the
 	// corresponding env var is unset.
 	defaultSweepInterval    = 30 * time.Second
 	defaultArchiveRetention = 168 * time.Hour // 7 days
+
+	// defaultMaxArtifactBytes / defaultMaxSessionArtifactBytes are applied
+	// when the corresponding env var is unset. 0 for the session budget
+	// means unlimited (see WorkspaceHandler.maxSessionArtifactBytes); the
+	// per-artifact cap has no such "0 means unlimited" escape hatch — it
+	// always bounds a single PUT.
+	defaultMaxArtifactBytes        int64 = 32 << 20
+	defaultMaxSessionArtifactBytes int64 = 256 << 20
 
 	// defaultRegistryPollInterval is applied when envRegistryPoll is unset.
 	defaultRegistryPollInterval = 2 * time.Second
@@ -435,6 +459,14 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	if err != nil {
 		return err
 	}
+	maxArtifactBytes, err := envInt64(envMaxArtifactBytes, defaultMaxArtifactBytes)
+	if err != nil {
+		return err
+	}
+	maxSessionArtifactBytes, err := envInt64(envMaxSessionArtifactBytes, defaultMaxSessionArtifactBytes)
+	if err != nil {
+		return err
+	}
 
 	// Fail closed: refuse to serve unauthenticated unless explicitly opted
 	// in. Pass-through grants every caller a wildcard namespace scope and can
@@ -472,6 +504,24 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	hist := NewHistoryStore(eventLog, kv)
 	dispatcher := NewDispatcher(logger.WithName("dispatcher"), view, store, &http.Client{Transport: rt}, opts.RouterInternalURL, retention, time.Now, maxContinuations, maxSpawnDepth)
 	sweeper := NewSweeper(logger.WithName("sweeper"), view, store, hist, sweepInterval, retention, time.Now)
+
+	// Session workspace routes (workspace.go): a SMALL internal client to
+	// storagesvc's /v1/workspace surface, built the same way the dispatcher's
+	// own router-internal client is above (otelhttp transport, master-signed
+	// hmacauth.ServiceSigner) rather than extending pkg/storagesvc/client
+	// (whose ClientInterface targets the archive upload/download contract).
+	// wsClient stays nil when STORAGESVC_URL is unset — see envStoragesvcURL's
+	// doc comment — which is what makes every workspace route answer 503
+	// "workspace disabled" instead of agentruntime guessing a URL.
+	var wsClient *workspaceClient
+	if storagesvcURL := os.Getenv(envStoragesvcURL); storagesvcURL != "" {
+		var wsrt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(workspaceIdleConnsPerHost))
+		if master := storagesvcClient.HMACSecretFromEnv(); len(master) > 0 {
+			wsrt = hmacauth.ServiceSigner(master, hmacauth.ServiceStoragesvc, wsrt, time.Now)
+		}
+		wsClient = newWorkspaceClient(storagesvcURL, wsrt)
+	}
+	wsHandler := NewWorkspaceHandler(logger.WithName("workspace"), view, store, wsClient, retention, maxArtifactBytes, maxSessionArtifactBytes)
 
 	// SSE registry feed: a single background Poller diffs
 	// SessionStore.List across view.List() agents and publishes changes to a
@@ -643,10 +693,21 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// exactly: the outer mux performs the {namespace}/{name} match (and sets
 	// the path values authz.Middleware / IdentityOrJWT's identity path read)
 	// before calling into the auth-wrapped dispatcher, which then matches the
-	// same pattern again. IdentityOrJWT is the dispatch route's ONLY mount —
-	// registry/SSE routes below stay on authz.Middleware/HTTPMiddleware
-	// directly, so the identity bearer never reaches them.
+	// same pattern again. IdentityOrJWT is the dispatch route's mount; the
+	// session workspace routes below are the identity bearer's ONLY other
+	// mount (via IdentityOrJWTOwnWorkspace, a STRICTER own-workspace-only
+	// closure — see identity.go's verifyOwnWorkspace) — registry/SSE routes
+	// stay on authz.Middleware/HTTPMiddleware directly, so the identity
+	// bearer never reaches them.
 	mux.Handle("POST /agents/{namespace}/{name}", IdentityOrJWT(identityVerifier, authz.Middleware)(dispatcher.Handler()))
+
+	// Session workspace routes (workspace.go): PUT/GET/DELETE artifacts plus
+	// a list route, mounted inside the SAME otel wrap as everything else
+	// (handler := otelUtils.GetHandlerWithOTEL(mux, ...) below wraps the
+	// whole mux, so registering here rather than separately is what keeps
+	// these routes spanned). wsHandler itself answers 503 on every route when
+	// wsClient is nil (STORAGESVC_URL unset).
+	mountWorkspaceRoutes(mux, wsHandler, IdentityOrJWTOwnWorkspace(identityVerifier, authz.Middleware))
 
 	// Registry read API: GET /registry/agents carries no
 	// {namespace} path value, so it is mounted behind authz.HTTPMiddleware

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -512,7 +512,6 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// dispatcher dependency.
 	hist := NewHistoryStore(eventLog, kv)
 	dispatcher := NewDispatcher(logger.WithName("dispatcher"), view, store, &http.Client{Transport: rt}, opts.RouterInternalURL, retention, time.Now, maxContinuations, maxSpawnDepth)
-	sweeper := NewSweeper(logger.WithName("sweeper"), view, store, hist, sweepInterval, retention, time.Now)
 
 	// Session workspace routes (workspace.go): a SMALL internal client to
 	// storagesvc's /v1/workspace surface, built the same way the dispatcher's
@@ -521,7 +520,9 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	// (whose ClientInterface targets the archive upload/download contract).
 	// wsClient stays nil when STORAGESVC_URL is unset — see envStoragesvcURL's
 	// doc comment — which is what makes every workspace route answer 503
-	// "workspace disabled" instead of agentruntime guessing a URL.
+	// "workspace disabled" instead of agentruntime guessing a URL. Constructed
+	// BEFORE the sweeper below so the same client doubles as the sweeper's
+	// archive-time workspace-purge dependency (sweeper.go's workspacePurger).
 	var wsClient *workspaceClient
 	if storagesvcURL := os.Getenv(envStoragesvcURL); storagesvcURL != "" {
 		var wsrt http.RoundTripper = otelhttp.NewTransport(httpx.PooledTransport(workspaceIdleConnsPerHost))
@@ -531,6 +532,19 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		wsClient = newWorkspaceClient(storagesvcURL, wsrt)
 	}
 	wsHandler := NewWorkspaceHandler(logger.WithName("workspace"), view, store, wsClient, retention, maxArtifactBytes, maxSessionArtifactBytes, maxSessionArtifacts)
+
+	// wsPurger is a workspacePurger interface value, NOT the *workspaceClient
+	// pointer directly: passing a typed-nil *workspaceClient through the
+	// interface parameter would make the sweeper's `s.wsPurger == nil` check
+	// (sweeper.go) false even when wsClient is nil, since a non-nil interface
+	// type wrapping a nil pointer is itself a non-nil interface value. This
+	// explicit nil-to-nil-interface conversion is what actually disables the
+	// sweeper's purge when STORAGESVC_URL is unset.
+	var wsPurger workspacePurger
+	if wsClient != nil {
+		wsPurger = wsClient
+	}
+	sweeper := NewSweeper(logger.WithName("sweeper"), view, store, hist, wsPurger, sweepInterval, retention, time.Now)
 
 	// SSE registry feed: a single background Poller diffs
 	// SessionStore.List across view.List() agents and publishes changes to a

--- a/pkg/agentruntime/main.go
+++ b/pkg/agentruntime/main.go
@@ -319,25 +319,30 @@ const (
 	// artifact traffic at the wrong service rather than failing loudly.
 	envStoragesvcURL = "STORAGESVC_URL"
 
-	// envMaxArtifactBytes / envMaxSessionArtifactBytes configure
-	// WorkspaceHandler's per-artifact cap and per-session budget
-	// (workspace.go's handlePut doc). Read once here, like the other agent
-	// runtime knobs.
+	// envMaxArtifactBytes / envMaxSessionArtifactBytes / envMaxSessionArtifacts
+	// configure WorkspaceHandler's per-artifact byte cap, per-session byte
+	// budget, and per-session artifact-COUNT budget (workspace.go's handlePut
+	// doc — the count budget is what closes the zero-byte-artifact bypass a
+	// bytes-only budget leaves open, and what structurally bounds a session's
+	// LIST response size). Read once here, like the other agent runtime knobs.
 	envMaxArtifactBytes        = "AGENT_MAX_ARTIFACT_BYTES"
 	envMaxSessionArtifactBytes = "AGENT_MAX_SESSION_ARTIFACT_BYTES"
+	envMaxSessionArtifacts     = "AGENT_MAX_SESSION_ARTIFACTS"
 
 	// defaultSweepInterval / defaultArchiveRetention are applied when the
 	// corresponding env var is unset.
 	defaultSweepInterval    = 30 * time.Second
 	defaultArchiveRetention = 168 * time.Hour // 7 days
 
-	// defaultMaxArtifactBytes / defaultMaxSessionArtifactBytes are applied
-	// when the corresponding env var is unset. 0 for the session budget
-	// means unlimited (see WorkspaceHandler.maxSessionArtifactBytes); the
+	// defaultMaxArtifactBytes / defaultMaxSessionArtifactBytes /
+	// defaultMaxSessionArtifacts are applied when the corresponding env var
+	// is unset. 0 for either session budget means unlimited (see
+	// WorkspaceHandler.maxSessionArtifactBytes/maxSessionArtifacts); the
 	// per-artifact cap has no such "0 means unlimited" escape hatch — it
 	// always bounds a single PUT.
 	defaultMaxArtifactBytes        int64 = 32 << 20
 	defaultMaxSessionArtifactBytes int64 = 256 << 20
+	defaultMaxSessionArtifacts     int64 = 1000
 
 	// defaultRegistryPollInterval is applied when envRegistryPoll is unset.
 	defaultRegistryPollInterval = 2 * time.Second
@@ -467,6 +472,10 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 	if err != nil {
 		return err
 	}
+	maxSessionArtifacts, err := envInt64(envMaxSessionArtifacts, defaultMaxSessionArtifacts)
+	if err != nil {
+		return err
+	}
 
 	// Fail closed: refuse to serve unauthenticated unless explicitly opted
 	// in. Pass-through grants every caller a wildcard namespace scope and can
@@ -521,7 +530,7 @@ func Start(ctx context.Context, clientGen crd.ClientGeneratorInterface, logger l
 		}
 		wsClient = newWorkspaceClient(storagesvcURL, wsrt)
 	}
-	wsHandler := NewWorkspaceHandler(logger.WithName("workspace"), view, store, wsClient, retention, maxArtifactBytes, maxSessionArtifactBytes)
+	wsHandler := NewWorkspaceHandler(logger.WithName("workspace"), view, store, wsClient, retention, maxArtifactBytes, maxSessionArtifactBytes, maxSessionArtifacts)
 
 	// SSE registry feed: a single background Poller diffs
 	// SessionStore.List across view.List() agents and publishes changes to a

--- a/pkg/agentruntime/session.go
+++ b/pkg/agentruntime/session.go
@@ -100,6 +100,14 @@ func SpawnSessionID(parent ParentRef, stepKey string) string {
 
 // SessionStats is the per-session meter set (G19: full meter schema from day
 // one; Tokens/Cost reserved for the gateway integration, always 0 for now).
+//
+// ArtifactCount/ArtifactBytes (G12 session workspace, a later slice) meter
+// the session's storagesvc workspace usage: bumped on a successful PUT,
+// decremented (clamped at 0) on a successful DELETE — see workspace.go's
+// quota pre-check/settle ordering. They are deliberately excluded from
+// sessionUnchanged's diffed field set (events.go): an artifact write/delete
+// must not churn the SSE registry feed, which exists for turn/status
+// activity, not storage bookkeeping.
 type SessionStats struct {
 	Turns         int64 `json:"turns"`
 	Errors        int64 `json:"errors"`
@@ -109,6 +117,8 @@ type SessionStats struct {
 	TokensOut     int64 `json:"tokensOut"`
 	CostMicroUSD  int64 `json:"costMicroUSD"`
 	Continuations int64 `json:"continuations"`
+	ArtifactCount int64 `json:"artifactCount,omitzero"`
+	ArtifactBytes int64 `json:"artifactBytes,omitzero"`
 }
 
 // SessionRecord is the persisted state of one agent session.

--- a/pkg/agentruntime/sweeper.go
+++ b/pkg/agentruntime/sweeper.go
@@ -34,6 +34,17 @@ import (
 // sweepPageLimit is the per-agent List page size.
 const sweepPageLimit = 500
 
+// workspacePurger is the sweeper's dependency for purging a session's
+// workspace at archive time (deletePrefix on pkg/agentruntime's own
+// workspaceClient in production; a counting fake in tests). A nil
+// workspacePurger means the workspace feature is disabled (STORAGESVC_URL
+// unset — main.go passes a nil interface, never a typed-nil *workspaceClient,
+// so this comparison is safe) and the sweeper skips the purge silently,
+// exactly like every other workspace route's 503-vs-disabled stance.
+type workspacePurger interface {
+	deletePrefix(ctx context.Context, prefix string) (int, error)
+}
+
 // Sweeper ages active sessions to idle and idle sessions to archived, per
 // the IdleAfter/ArchiveAfter policy resolved on each AgentEntry.
 type Sweeper struct {
@@ -41,8 +52,9 @@ type Sweeper struct {
 	view      *AgentView
 	store     *SessionStore
 	hist      *HistoryStore
-	interval  time.Duration // AGENT_SWEEP_INTERVAL, default 30s (read in Start, injected here)
-	retention time.Duration // AGENT_ARCHIVE_RETENTION, default 168h (7d)
+	wsPurger  workspacePurger // nil when the workspace feature is disabled; see workspacePurger's doc.
+	interval  time.Duration   // AGENT_SWEEP_INTERVAL, default 30s (read in Start, injected here)
+	retention time.Duration   // AGENT_ARCHIVE_RETENTION, default 168h (7d)
 	now       func() time.Time
 
 	// beforeCAS, when non-nil, runs immediately after the sweeper re-reads a
@@ -58,13 +70,18 @@ type Sweeper struct {
 // to session history/checkpoint cleanup (archive-time trim + the
 // HistoryTrim-knob live-session trim); every call into it is guarded by
 // entry.StateKeyspace != "" (history is disabled for an agent with no state
-// keyspace), so hist is never dereferenced for such an agent.
-func NewSweeper(logger logr.Logger, view *AgentView, store *SessionStore, hist *HistoryStore, interval, retention time.Duration, now func() time.Time) *Sweeper {
+// keyspace), so hist is never dereferenced for such an agent. wsPurger is the
+// sweeper's path to the archive-time workspace purge (see workspacePurger's
+// doc for the nil-disables contract); unlike hist it is called unconditionally
+// of StateKeyspace — a workspace artifact has nothing to do with whether the
+// agent opted into history.
+func NewSweeper(logger logr.Logger, view *AgentView, store *SessionStore, hist *HistoryStore, wsPurger workspacePurger, interval, retention time.Duration, now func() time.Time) *Sweeper {
 	return &Sweeper{
 		logger:    logger,
 		view:      view,
 		store:     store,
 		hist:      hist,
+		wsPurger:  wsPurger,
 		interval:  interval,
 		retention: retention,
 		now:       now,
@@ -282,6 +299,15 @@ func (s *Sweeper) archive(ctx context.Context, entry AgentEntry, rec SessionReco
 		return
 	}
 
+	// Workspace purge: fires on every successful archive CAS, BEFORE the
+	// entry.StateKeyspace=="" early return below — deliberately, not merely
+	// placed early. A workspace artifact is independent of whether the agent
+	// opted into history/state (StateKeyspace); putting this purge beside the
+	// history/checkpoint cleanup further down would nest it inside that early
+	// return and it would never run for a state-less agent (plan-review
+	// finding on this slice).
+	s.purgeWorkspace(ctx, entry, rec)
+
 	if entry.StateKeyspace == "" {
 		return
 	}
@@ -313,4 +339,46 @@ func (s *Sweeper) archive(ctx context.Context, entry AgentEntry, rec SessionReco
 			s.logSweepErr(err, "sweeper: deleting archived session checkpoint failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
 		}
 	}
+}
+
+// purgeWorkspace deletes every workspace artifact under rec's session prefix,
+// called once per successful archive CAS (see the call site in archive above
+// for why this must run BEFORE the StateKeyspace=="" early return). A nil
+// wsPurger means the workspace feature is disabled (STORAGESVC_URL unset) —
+// skipped silently, not an error: an install that never turned workspace on
+// has nothing to purge.
+//
+// Discipline mirrors this sweeper's own stated stance exactly (package doc):
+// idempotent (storagesvc's prefix-delete is itself an idempotent bulk delete,
+// so two replicas racing the same purge, or a retry on a later sweep pass
+// that never happens because this is fire-once, both land safely), log-don't-
+// retry on error, and orphan residue accepted. Two residue classes are
+// therefore accepted here, not just one:
+//   - a per-item delete failure inside storagesvc's own prefix-delete (its
+//     own log-don't-retry stance, see pkg/storagesvc/workspace.go); and
+//   - the GC-anchor residual class named in this feature's Global
+//     Constraints: a session record that TTLs out unswept (its agent
+//     Function deleted before the sweeper ever archived it) never reaches
+//     this call at all, and the archive pruner excludes the workspace root
+//     entirely, so that record's workspace objects are orphaned permanently.
+//     That class joins the already-named orphan-sweep follow-up (RFC-0027's
+//     deferred orphan-stream age sweep, referenced above for history/
+//     checkpoint residue) — not solved here.
+//
+// The purge-vs-recreated-session race (a new session minted under the same
+// id in the window between this archive and the purge landing) is also
+// accepted: workspace is scratch, not truth, and unlike a checkpoint/history
+// delete there is no version to CAS a prefix-delete against, so no head-
+// capture analog is possible here.
+func (s *Sweeper) purgeWorkspace(ctx context.Context, entry AgentEntry, rec SessionRecord) {
+	if s.wsPurger == nil {
+		return
+	}
+	prefix := workspaceSessionPrefix(entry.Namespace, entry.Name, rec.ID)
+	deleted, err := s.wsPurger.deletePrefix(ctx, prefix)
+	if err != nil {
+		s.logSweepErr(err, "sweeper: workspace purge failed", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID)
+		return
+	}
+	s.logger.V(1).Info("sweeper: workspace purged", "namespace", entry.Namespace, "agent", entry.Name, "session", rec.ID, "deleted", deleted)
 }

--- a/pkg/agentruntime/sweeper_test.go
+++ b/pkg/agentruntime/sweeper_test.go
@@ -7,6 +7,7 @@ package agentruntime
 import (
 	"context"
 	"encoding/json/v2"
+	"errors"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -150,7 +151,7 @@ func TestSweeperActiveToIdleAfterIdleAfter(t *testing.T) {
 		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusActive, LastActiveAt: time.Now()}
 		require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
 
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, time.Second, 7*24*time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, 7*24*time.Hour, time.Now)
 
 		// Not yet due: less than IdleAfter has elapsed.
 		time.Sleep(entry.IdleAfter - time.Second)
@@ -182,7 +183,7 @@ func TestSweeperIdleToArchivedAfterArchiveAfter(t *testing.T) {
 		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
 		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
 
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, retention, time.Now)
 
 		// Not yet due.
 		time.Sleep(entry.ArchiveAfter - time.Second)
@@ -229,7 +230,7 @@ func TestSweeperIdleTransitionSkipsOnCASConflict(t *testing.T) {
 		require.NoError(t, store.Create(ctx, rec, 0, time.Hour))
 		time.Sleep(entry.IdleAfter + time.Second)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, time.Second, 7*24*time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, 7*24*time.Hour, time.Now)
 		sweeper.beforeCAS = func() {
 			// Simulate a second replica winning the race: it idles the
 			// record first, landing between this sweeper's Get and Update.
@@ -270,7 +271,7 @@ func TestSweeperArchiveSkipsOnReviveRace(t *testing.T) {
 		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
 		time.Sleep(entry.ArchiveAfter + time.Second)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, retention, time.Now)
 		var revivedAt time.Time
 		sweeper.beforeCAS = func() {
 			// A live turn revives the session, landing between this
@@ -333,7 +334,7 @@ func TestSweeperArchiveSkipsOnListToGetStalenessWindow(t *testing.T) {
 		revived.Stats.Turns = 1
 		require.NoError(t, store.Update(ctx, revived, version, time.Hour))
 
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, retention, time.Now)
 		// staleSnapshot is what the sweeper's List call would have returned
 		// before the revive landed; sweepRecord must re-validate against a
 		// fresh Get rather than trusting it.
@@ -382,7 +383,7 @@ func TestSweeperIdleSkipsOnListToGetStalenessWindow(t *testing.T) {
 		touched.Stats.Turns = 1
 		require.NoError(t, store.Update(ctx, touched, version, time.Hour))
 
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, time.Second, 7*24*time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, 7*24*time.Hour, time.Now)
 		// staleSnapshot is what the sweeper's List call would have returned
 		// before the turn landed; sweepRecord must re-validate against a
 		// fresh Get rather than trusting it.
@@ -401,7 +402,7 @@ func TestSweeperRunRespectsContextCancel(t *testing.T) {
 		kv := newTestKV(t)
 		store := NewSessionStore(kv, time.Now)
 		view := NewAgentView()
-		sweeper := NewSweeper(logr.Discard(), view, store, nil, 10*time.Millisecond, time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, 10*time.Millisecond, time.Hour, time.Now)
 
 		ctx, cancel := context.WithCancel(t.Context())
 		done := make(chan struct{})
@@ -446,7 +447,7 @@ func TestSweeperArchiveTrimsHistoryToPreArchiveHeadAndDeletesCheckpoint(t *testi
 		setTestCheckpoint(t, ctx, hkv, "ns", "ks1", "s1", 4)
 		hist := NewHistoryStore(el, hkv)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, retention, time.Now)
 		time.Sleep(entry.ArchiveAfter + time.Second)
 		sweeper.sweepOnce(ctx)
 
@@ -484,7 +485,7 @@ func TestSweeperArchiveDeletesCheckpointDespiteZeroHead(t *testing.T) {
 		setTestCheckpoint(t, ctx, hkv, "ns", "ks1", "s1", 0)
 		hist := NewHistoryStore(el, hkv)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, retention, time.Now)
 		time.Sleep(entry.ArchiveAfter + time.Second)
 		sweeper.sweepOnce(ctx)
 
@@ -524,7 +525,7 @@ func TestSweeperArchiveCheckpointDeleteSurvivesFreshCheckpointWrite(t *testing.T
 		}
 		hist := NewHistoryStore(el, wrapped)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, retention, time.Now)
 		time.Sleep(entry.ArchiveAfter + time.Second)
 		sweeper.sweepOnce(ctx)
 
@@ -564,7 +565,7 @@ func TestSweeperArchiveTrimSurvivesLateAppendedEvents(t *testing.T) {
 		}
 		hist := NewHistoryStore(wrapped, hkv)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, retention, time.Now)
 		time.Sleep(entry.ArchiveAfter + time.Second)
 		sweeper.sweepOnce(ctx)
 
@@ -599,7 +600,7 @@ func TestSweeperArchiveCASConflictLeavesHistoryUntouched(t *testing.T) {
 
 		time.Sleep(entry.ArchiveAfter + time.Second)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, retention, time.Now)
 		sweeper.beforeCAS = func() {
 			// A live turn revives the session, landing between the
 			// sweeper's Get and its Archive CAS.
@@ -646,7 +647,7 @@ func TestSweeperKnobTrimsLiveSessionToCheckpointBoundary(t *testing.T) {
 		setTestCheckpoint(t, ctx, hkv, "ns", "ks1", "s1", 3)
 		hist := NewHistoryStore(el, hkv)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, 7*24*time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, 7*24*time.Hour, time.Now)
 		sweeper.sweepOnce(ctx)
 
 		events, err := hist.Read(ctx, "ns", "ks1", "s1", 0, 100)
@@ -683,7 +684,7 @@ func TestSweeperKnobTrimClampsForgedCoveredThroughSeqToHead(t *testing.T) {
 		setTestCheckpoint(t, ctx, hkv, "ns", "ks1", "s1", 1<<60) // forged
 		hist := NewHistoryStore(el, hkv)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, 7*24*time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, 7*24*time.Hour, time.Now)
 		sweeper.sweepOnce(ctx)
 
 		events, err := hist.Read(ctx, "ns", "ks1", "s1", 0, 100)
@@ -716,7 +717,7 @@ func TestSweeperKnobFalseLeavesLiveSessionHistoryUntouched(t *testing.T) {
 		setTestCheckpoint(t, ctx, hkv, "ns", "ks1", "s1", 3)
 		hist := NewHistoryStore(el, hkv)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, 7*24*time.Hour, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, 7*24*time.Hour, time.Now)
 		sweeper.sweepOnce(ctx)
 
 		events, err := hist.Read(ctx, "ns", "ks1", "s1", 0, 100)
@@ -748,7 +749,7 @@ func TestSweeperNoKeyspaceAgentNeverTouchesHistoryStore(t *testing.T) {
 		countedKV := &countingKV{KVStore: hkv}
 		hist := NewHistoryStore(countedEl, countedKV)
 
-		sweeper := NewSweeper(logr.Discard(), view, store, hist, time.Second, retention, time.Now)
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, nil, time.Second, retention, time.Now)
 		// Drive it past archive due, so the only reason history stays
 		// untouched is the StateKeyspace=="" guard, not "never reached the
 		// archive path".
@@ -763,5 +764,177 @@ func TestSweeperNoKeyspaceAgentNeverTouchesHistoryStore(t *testing.T) {
 		list, _, err := store.List(ctx, "ns", "agent1", "", 10)
 		require.NoError(t, err)
 		assert.Empty(t, list, "the archive transition itself must still have happened")
+	})
+}
+
+// countingWorkspacePurger is a counting fake workspacePurger (sweeper.go)
+// for testing the sweeper's archive-time workspace purge without a real
+// storagesvc. err, when non-nil, is returned by every call (after still
+// recording it in calls) — used to pin the log-don't-retry stance.
+type countingWorkspacePurger struct {
+	calls []string // prefixes passed to deletePrefix, in call order.
+	err   error
+}
+
+func (p *countingWorkspacePurger) deletePrefix(_ context.Context, prefix string) (int, error) {
+	p.calls = append(p.calls, prefix)
+	if p.err != nil {
+		return 0, p.err
+	}
+	return 1, nil
+}
+
+// TestSweeperArchivePurgesWorkspace pins the happy path: a successful archive
+// CAS purges the session's workspace prefix exactly once, with the canonical
+// trailing-slash "_workspace_/<ns>/<agent>/<session>/" prefix.
+func TestSweeperArchivePurgesWorkspace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		el, hkv := newTestStores(t)
+		hist := NewHistoryStore(el, hkv)
+		entry := sweeperTestEntryWithHistory("ns", "agent1", "ks1", false)
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
+
+		purger := &countingWorkspacePurger{}
+		sweeper := NewSweeper(logr.Discard(), view, store, hist, purger, time.Second, retention, time.Now)
+		time.Sleep(entry.ArchiveAfter + time.Second)
+		sweeper.sweepOnce(ctx)
+
+		require.Len(t, purger.calls, 1)
+		assert.Equal(t, "_workspace_/ns/agent1/s1/", purger.calls[0])
+	})
+}
+
+// TestSweeperArchivePurgesWorkspaceNoStateKeyspace pins the early-return
+// trap named in this feature's plan review: the workspace purge must fire
+// for a STATE-LESS agent (StateKeyspace == "") too, because it is inserted
+// BEFORE the entry.StateKeyspace=="" early return in archive, not beside the
+// history/checkpoint cleanup that return guards.
+func TestSweeperArchivePurgesWorkspaceNoStateKeyspace(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1") // StateKeyspace == ""
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
+
+		purger := &countingWorkspacePurger{}
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, purger, time.Second, retention, time.Now)
+		time.Sleep(entry.ArchiveAfter + time.Second)
+		sweeper.sweepOnce(ctx)
+
+		require.Len(t, purger.calls, 1, "a no-StateKeyspace agent must still get its workspace purged")
+		assert.Equal(t, "_workspace_/ns/agent1/s1/", purger.calls[0])
+	})
+}
+
+// TestSweeperArchiveCASConflictSkipsWorkspacePurge covers the CAS-conflict/
+// revive race: when store.Archive's CAS fails (a live turn revived the
+// session between the sweeper's Get and its Archive call), the workspace
+// purge must never fire — the session is still live.
+func TestSweeperArchiveCASConflictSkipsWorkspacePurge(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
+		time.Sleep(entry.ArchiveAfter + time.Second)
+
+		purger := &countingWorkspacePurger{}
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, purger, time.Second, retention, time.Now)
+		sweeper.beforeCAS = func() {
+			// A live turn revives the session, landing between this
+			// sweeper's Get and Archive — see TestSweeperArchiveSkipsOnReviveRace.
+			live, version, err := store.Get(ctx, "ns", "agent1", "s1")
+			require.NoError(t, err)
+			live.Status = StatusActive
+			live.LastActiveAt = time.Now()
+			require.NoError(t, store.Update(ctx, live, version, liveTTL))
+		}
+
+		sweeper.sweepOnce(ctx)
+
+		assert.Empty(t, purger.calls, "a revived session must never have its workspace purged")
+	})
+}
+
+// TestSweeperArchivePurgeErrorLoggedNotRetried pins the log-don't-retry
+// stance: a workspace-purge failure must not abort the sweep, must not be
+// retried within the same pass, and must not block any other record in the
+// same sweep from being processed.
+func TestSweeperArchivePurgeErrorLoggedNotRetried(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec1 := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		rec2 := SessionRecord{ID: "s2", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec1, 0, liveTTL))
+		require.NoError(t, store.Create(ctx, rec2, 0, liveTTL))
+		time.Sleep(entry.ArchiveAfter + time.Second)
+
+		purger := &countingWorkspacePurger{err: errors.New("storagesvc unreachable")}
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, purger, time.Second, retention, time.Now)
+		sweeper.sweepOnce(ctx)
+
+		assert.Len(t, purger.calls, 2, "a purge error must not be retried within the sweep, and must not block the other record's archive")
+		list, _, err := store.List(ctx, "ns", "agent1", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, list, "both records must still have archived despite the purge failure")
+	})
+}
+
+// TestSweeperNilWorkspacePurgerSkipsSilently pins the "workspace disabled"
+// contract: with a nil workspacePurger (STORAGESVC_URL unset in production —
+// see main.go's wsPurger construction) the archive transition must still
+// succeed, with no error and nothing purged.
+func TestSweeperNilWorkspacePurgerSkipsSilently(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		kv := newTestKV(t)
+		store := NewSessionStore(kv, time.Now)
+		view := NewAgentView()
+		entry := sweeperTestEntry("ns", "agent1")
+		view.Upsert(entry)
+
+		ctx := t.Context()
+		retention := 7 * 24 * time.Hour
+		liveTTL := entry.IdleAfter + entry.ArchiveAfter + retention
+		rec := SessionRecord{ID: "s1", Agent: "agent1", Namespace: "ns", Status: StatusIdle, LastActiveAt: time.Now()}
+		require.NoError(t, store.Create(ctx, rec, 0, liveTTL))
+		time.Sleep(entry.ArchiveAfter + time.Second)
+
+		sweeper := NewSweeper(logr.Discard(), view, store, nil, nil, time.Second, retention, time.Now)
+		sweeper.sweepOnce(ctx)
+
+		list, _, err := store.List(ctx, "ns", "agent1", "", 10)
+		require.NoError(t, err)
+		assert.Empty(t, list, "archive must succeed even with no workspace purger configured")
 	})
 }

--- a/pkg/agentruntime/workspace.go
+++ b/pkg/agentruntime/workspace.go
@@ -1,0 +1,753 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// workspace.go implements the session artifact workspace API (G12/G18a):
+// PUT/GET/DELETE/LIST routes mounted on the agent runtime mux that proxy to
+// storagesvc's internal-only /v1/workspace surface (pkg/storagesvc/
+// workspace.go). This is the ONLY path pods use to reach that surface — see
+// pkg/storagesvc/workspace.go's package doc for why agentruntime, not
+// storagesvc, is where the identity bearer is verified (it is the only place
+// that can verify it WITH revocation, via the live AgentView).
+//
+// Security model, in the order every handler applies it:
+//
+//  1. Auth (outer middleware, main.go): IdentityOrJWTOwnWorkspace — the G16
+//     identity bearer under a STRICTER own-workspace-only closure than
+//     dispatch's (see identity.go's verifyOwnWorkspace), or the existing JWT
+//     namespace-scoped middleware for debugging parity.
+//  2. Disabled check: STORAGESVC_URL unset means client is nil and every
+//     route answers 503 rather than agentruntime guessing a URL.
+//  3. Path validation (this layer's own defense in depth, mirroring
+//     pkg/storagesvc/workspace.go's rules exactly): namespace/name are
+//     DNS-1123 labels, session matches sessionIDPattern and does not
+//     collide with the checkpoint keyspace, and {path...} segments are
+//     charset/length-bounded and reject ".", "..", empty, and a leading "_"
+//     (reserved for the "_workspace_" root marker).
+//  4. Existence anchor: store.Get(ns, agent, session) must find a LIVE
+//     session record BEFORE any storagesvc call. This is the GC anchor, not
+//     tidiness — the session-archive purge (sweeper.go, a later slice) fires
+//     at record archive, and the archive pruner excludes the workspace root
+//     entirely, so a workspace object under a session id that was never
+//     recorded here would be deleted by NOTHING, ever: a permanent orphan
+//     any identity/JWT holder could otherwise mint by PUTting to an
+//     arbitrary session id. It doubles as the authorization anchor (the
+//     record only exists under the (ns, agent) SessionStore itself scoped
+//     it to) and keeps the dispatcher the sole session-minting authority
+//     (Q32). Residual orphans from records that TTL out unswept (e.g. a
+//     deleted agent Function) join the already-named orphan-sweep
+//     follow-up, not solved here.
+//  5. Quota (PUT only): a per-artifact cap (AGENT_MAX_ARTIFACT_BYTES) and a
+//     per-session budget (AGENT_MAX_SESSION_ARTIFACT_BYTES) — see
+//     handlePut's doc for the pre-check/write/settle ordering.
+//
+// Streaming: the request body is spooled (spoolWorkspaceBody) rather than
+// buffered whole — bounded in-memory up to workspaceSpoolThresholdBytes,
+// spilled to a temp file above it — so hmacauth.Signer's streaming-hash path
+// (it reads a fresh copy via GetBody to hash, while the transport streams
+// the original Body) never requires holding an artifact up to the full
+// AGENT_MAX_ARTIFACT_BYTES cap in RAM at once. GET is a plain io.Copy
+// passthrough with Content-Length set from storagesvc's own stream.
+package agentruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/fission/fission/pkg/statestore"
+)
+
+const (
+	// workspaceMarker is the reserved root segment of every workspace object
+	// id/prefix, matching pkg/storagesvc/authz.go's workspaceMarker exactly
+	// (the wire contract the two packages share). Kept as a local copy
+	// rather than an import: storagesvc's constant is unexported, and this
+	// is the only string this package needs from it.
+	workspaceMarker = "_workspace_"
+
+	// maxWorkspaceSegmentBytes / maxWorkspacePathBytes bound a single
+	// {path...} segment and the full path, mirroring
+	// pkg/storagesvc/workspace.go's maxWorkspaceSegmentBytes/
+	// maxWorkspaceIDBytes (that bound is on the FULL id, marker+ns+agent+
+	// session+path; this bound is on the path portion alone, so it is
+	// intentionally smaller — well within storagesvc's own ceiling once the
+	// marker/ns/agent/session prefix is added back).
+	maxWorkspaceSegmentBytes = 128
+	maxWorkspacePathBytes    = 1024
+
+	// workspaceSpoolThresholdBytes bounds how much of a PUT body this
+	// handler keeps in memory before spilling to a temp file, mirroring
+	// storagesvc's own uploadSpoolThresholdBytes (storagesvc.go) and the
+	// HMAC verifier's SpoolThresholdBytes spill pattern (pkg/auth/hmac/
+	// spool.go) — on the SIGNING side here instead of the verifying side.
+	workspaceSpoolThresholdBytes int64 = 4 << 20
+
+	// workspaceIdleConnsPerHost sizes the internal storagesvc client's idle
+	// connection pool, matching pkg/storagesvc/client's own
+	// storagesvcIdleConnsPerHost sizing for the same single upstream.
+	workspaceIdleConnsPerHost = 16
+)
+
+// workspaceSegmentCharset is the allowed charset for a non-marker workspace
+// path segment, identical to pkg/storagesvc/workspace.go's
+// workspaceSegmentCharset.
+var workspaceSegmentCharset = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// validateWorkspaceSegment validates one "/"-split segment of a caller
+// {path...} value: not empty, not "." or "..", not leading with "_"
+// (reserved for the workspaceMarker root and any future marker), within the
+// length bound, and drawn from workspaceSegmentCharset. Mirrors
+// pkg/storagesvc/workspace.go's validateWorkspaceSegment exactly — this
+// layer's defense in depth does not rely on storagesvc's own validation
+// (Global Constraints: "never rely on localstorage's os.Root — S3 has no
+// such net").
+func validateWorkspaceSegment(s string) error {
+	switch {
+	case s == "":
+		return errors.New("workspace path contains an empty segment")
+	case s == "." || s == "..":
+		return fmt.Errorf("workspace path contains an invalid segment %q", s)
+	case strings.HasPrefix(s, "_"):
+		return fmt.Errorf("workspace path segment %q must not start with '_'", s)
+	case len(s) > maxWorkspaceSegmentBytes:
+		return fmt.Errorf("workspace path segment exceeds %d bytes", maxWorkspaceSegmentBytes)
+	case !workspaceSegmentCharset.MatchString(s):
+		return fmt.Errorf("workspace path segment %q has invalid characters", s)
+	}
+	return nil
+}
+
+// validateWorkspacePath validates a full {path...} value: bounded length,
+// every "/"-split segment individually valid. An EMPTY path — which is what
+// Go's ServeMux hands {path...} for a trailing-slash request against the
+// file route (".../session/") — is rejected here too: strings.Split("", "/")
+// yields one empty-string segment, and validateWorkspaceSegment rejects
+// that, so a trailing-slash PUT/GET/DELETE 400s rather than being silently
+// treated as the list route (which is a DIFFERENT, shorter pattern with no
+// trailing slash at all — see mountWorkspaceRoutes).
+func validateWorkspacePath(p string) error {
+	if len(p) > maxWorkspacePathBytes {
+		return fmt.Errorf("workspace path exceeds %d bytes", maxWorkspacePathBytes)
+	}
+	for _, s := range strings.Split(p, "/") {
+		if err := validateWorkspaceSegment(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateWorkspaceRouteIdentity validates the namespace/name/session path
+// values common to every workspace route, writing a 400 and returning false
+// on the first failure. namespace/name are validated as DNS-1123 labels
+// (ParseParentRef, session.go, is this package's existing precedent for that
+// rule) — this also closes the encoded-segment traversal surface Go's
+// ServeMux otherwise opens: {namespace}/{name} are decoded by the mux before
+// PathValue returns them, so a request built with "%2F" or "%2E" segments
+// arrives here already decoded, and DNS-1123 rejects '/' and a bare "."/".."
+// outright. session is validated with the dispatcher's own sessionIDPattern
+// plus the same CheckpointKeyPrefix collision rule resolveSessionID applies
+// (dispatcher.go) — a workspace session id is never minted here, only
+// checked against what dispatch already validated when it created the
+// record.
+func validateWorkspaceRouteIdentity(w http.ResponseWriter, ns, name, session string) bool {
+	if len(validation.IsDNS1123Label(ns)) != 0 {
+		writeErr(w, http.StatusBadRequest, "invalid namespace")
+		return false
+	}
+	if len(validation.IsDNS1123Label(name)) != 0 {
+		writeErr(w, http.StatusBadRequest, "invalid agent name")
+		return false
+	}
+	if !sessionIDPattern.MatchString(session) || strings.HasPrefix(session, CheckpointKeyPrefix) {
+		writeErr(w, http.StatusBadRequest, "invalid session id")
+		return false
+	}
+	return true
+}
+
+// workspaceSessionPrefix is the canonical "_workspace_/<ns>/<agent>/<session>/"
+// root every object/prefix under one session shares.
+func workspaceSessionPrefix(ns, agent, session string) string {
+	return workspaceMarker + "/" + ns + "/" + agent + "/" + session + "/"
+}
+
+// workspaceID is the full wire id for one artifact path within a session.
+func workspaceID(ns, agent, session, path string) string {
+	return workspaceSessionPrefix(ns, agent, session) + path
+}
+
+// stripWorkspacePrefix converts a storagesvc-returned list item id back into
+// the caller-facing relative path within the (ns, agent, session) scope
+// requested. ok is false if id is not actually under that session's prefix
+// (defensive: should be unreachable given the list call itself was scoped to
+// the prefix, but a caller must not surface a raw "_workspace_/..." id to
+// the client if it somehow were).
+func stripWorkspacePrefix(id, ns, agent, session string) (path string, ok bool) {
+	return strings.CutPrefix(id, workspaceSessionPrefix(ns, agent, session))
+}
+
+// workspaceSpool holds a PUT request body drained once: in memory when it
+// fits within workspaceSpoolThresholdBytes, spilled to a temp file above
+// that. Mirrors pkg/auth/hmac/spool.go's bodySpool, but on the signing
+// (client) side instead of the verifying (server) side, and without a hash
+// — hmacauth.Signer computes its own hash from a fresh reader() call via
+// GetBody; this spool only needs to hand out that fresh copy on demand.
+type workspaceSpool struct {
+	mem      []byte
+	fileName string // "" when mem holds the body.
+	size     int64
+}
+
+// spoolWorkspaceBody drains src (already wrapped by the caller in
+// io.LimitReader(body, cap+1) for over-read detection — see handlePut) into
+// a workspaceSpool. Reading exactly threshold bytes with more remaining
+// spills the rest (plus the already-buffered prefix) to a temp file, so
+// caller memory stays bounded by threshold regardless of how large the
+// (LimitReader-capped) body is.
+func spoolWorkspaceBody(src io.Reader, threshold int64) (*workspaceSpool, error) {
+	var buf bytes.Buffer
+	// A body of EXACTLY threshold bytes takes the file-spill branch below
+	// (io.CopyN's LimitReader synthesizes its own EOF once it has copied
+	// threshold bytes, without needing the underlying src to report EOF —
+	// so err is nil, not io.EOF, even though there is nothing left to read).
+	// Harmless: the object is still correct, just spilled to disk one byte
+	// earlier than strictly necessary at that exact boundary.
+	n1, err := io.CopyN(&buf, src, threshold)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if errors.Is(err, io.EOF) {
+		// Fewer than `threshold` bytes total: fits entirely in memory.
+		return &workspaceSpool{mem: buf.Bytes(), size: n1}, nil
+	}
+
+	f, ferr := os.CreateTemp("", "fission-agentruntime-workspace-*")
+	if ferr != nil {
+		return nil, ferr
+	}
+	defer f.Close()
+	if _, werr := f.Write(buf.Bytes()); werr != nil {
+		_ = os.Remove(f.Name())
+		return nil, werr
+	}
+	n2, cerr := io.Copy(f, src)
+	if cerr != nil {
+		_ = os.Remove(f.Name())
+		return nil, cerr
+	}
+	return &workspaceSpool{fileName: f.Name(), size: n1 + n2}, nil
+}
+
+// reader returns a FRESH, independent reader over the spooled bytes — safe
+// to call more than once (once for the outgoing request's Body, again from
+// its GetBody closure for hmacauth.Signer's streaming-hash pass). The
+// file-backed case opens its OWN *os.File per call (os.Open, not a shared
+// handle rewound with Seek): sharing one handle would let the hash pass's
+// read consume the same file position the transport later streams from,
+// silently truncating the wire body to empty after the hash was computed.
+func (s *workspaceSpool) reader() (io.ReadCloser, error) {
+	if s.fileName == "" {
+		return io.NopCloser(bytes.NewReader(s.mem)), nil
+	}
+	return os.Open(s.fileName)
+}
+
+// cleanup removes the spool's temp file, if any. Idempotent; safe to defer
+// immediately after a successful spoolWorkspaceBody call.
+func (s *workspaceSpool) cleanup() {
+	if s.fileName == "" {
+		return
+	}
+	_ = os.Remove(s.fileName)
+	s.fileName = ""
+}
+
+// errWorkspaceNotFound is returned by workspaceClient.get for a storagesvc
+// 404.
+var errWorkspaceNotFound = errors.New("agentruntime: workspace artifact not found")
+
+// workspaceClient is a SMALL internal HTTP client to storagesvc's
+// /v1/workspace surface, built here rather than extending
+// pkg/storagesvc/client (whose ClientInterface targets /v1/archive's
+// multipart-upload, server-minted-id shape — a poor fit for a raw-body,
+// caller-chosen-id, machine-to-machine PUT/GET/DELETE/LIST). It mirrors the
+// dispatcher's own internal-client construction pattern (main.go: otelhttp
+// transport, hmacauth.ServiceSigner over the master secret) rather than
+// reusing storagesvc/client's exported constructors, which are shaped for
+// the archive upload/download contract.
+type workspaceClient struct {
+	baseURL string
+	http    *http.Client
+}
+
+// newWorkspaceClient returns a workspaceClient posting to baseURL (e.g.
+// "http://storagesvc.fission") over rt.
+func newWorkspaceClient(baseURL string, rt http.RoundTripper) *workspaceClient {
+	return &workspaceClient{baseURL: strings.TrimSuffix(baseURL, "/"), http: &http.Client{Transport: rt}}
+}
+
+// readLimitedBody reads up to 4KiB of r for an error message — bounded so a
+// misbehaving or hostile upstream can't inflate an error log entry
+// unboundedly.
+func readLimitedBody(r io.Reader) string {
+	b, _ := io.ReadAll(io.LimitReader(r, 4<<10))
+	return strings.TrimSpace(string(b))
+}
+
+// workspacePutStoragesvcResp mirrors storagesvc's workspacePutResponse wire
+// shape ({"size": N}) — a local decode target rather than an import, since
+// storagesvc's type is unexported.
+type workspacePutStoragesvcResp struct {
+	Size int64 `json:"size"`
+}
+
+// put streams sp's spooled body to storagesvc's PUT /v1/workspace?id=<id>,
+// returning the size storagesvc reports it actually received (the ground
+// truth of what got persisted, rather than trusting the caller's own count
+// unconditionally — see handlePut).
+func (c *workspaceClient) put(ctx context.Context, id string, sp *workspaceSpool) (int64, error) {
+	first, err := sp.reader()
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+"/v1/workspace?id="+url.QueryEscape(id), nil)
+	if err != nil {
+		_ = first.Close()
+		return 0, err
+	}
+	req.Body = first
+	req.ContentLength = sp.size
+	// GetBody, not the request constructor's body argument: hmacauth.Signer
+	// streams its hash from a FRESH GetBody() reader while the transport
+	// streams the original req.Body — see this file's package doc and
+	// workspaceSpool.reader's doc for why a shared handle would break this.
+	req.GetBody = func() (io.ReadCloser, error) { return sp.reader() }
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("storagesvc PUT %s: status %d: %s", id, resp.StatusCode, readLimitedBody(resp.Body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, err
+	}
+	var out workspacePutStoragesvcResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, fmt.Errorf("decoding storagesvc PUT response: %w", err)
+	}
+	return out.Size, nil
+}
+
+// get issues GET /v1/workspace?id=<id>. The caller must Close the returned
+// body. Returns errWorkspaceNotFound on a storagesvc 404.
+func (c *workspaceClient) get(ctx context.Context, id string) (io.ReadCloser, int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/workspace?id="+url.QueryEscape(id), nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		_ = resp.Body.Close()
+		return nil, 0, errWorkspaceNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		defer resp.Body.Close()
+		return nil, 0, fmt.Errorf("storagesvc GET %s: status %d: %s", id, resp.StatusCode, readLimitedBody(resp.Body))
+	}
+	size, _ := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	return resp.Body, size, nil
+}
+
+// del issues DELETE /v1/workspace?id=<id>. Idempotent on the storagesvc
+// side (a missing object is a 200, not a 404 — see pkg/storagesvc/
+// workspace.go's workspaceDeleteHandler).
+func (c *workspaceClient) del(ctx context.Context, id string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/workspace?id="+url.QueryEscape(id), nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("storagesvc DELETE %s: status %d: %s", id, resp.StatusCode, readLimitedBody(resp.Body))
+	}
+	return nil
+}
+
+// workspaceListStoragesvcItem/Resp mirror storagesvc's workspaceItem/
+// workspaceListResponse wire shapes.
+type workspaceListStoragesvcItem struct {
+	ID   string `json:"id"`
+	Size int64  `json:"size"`
+}
+type workspaceListStoragesvcResp struct {
+	Items []workspaceListStoragesvcItem `json:"items"`
+}
+
+// list issues GET /v1/workspace/list?prefix=<prefix>.
+func (c *workspaceClient) list(ctx context.Context, prefix string) ([]workspaceListStoragesvcItem, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/workspace/list?prefix="+url.QueryEscape(prefix), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("storagesvc LIST %s: status %d: %s", prefix, resp.StatusCode, readLimitedBody(resp.Body))
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	var out workspaceListStoragesvcResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("decoding storagesvc LIST response: %w", err)
+	}
+	return out.Items, nil
+}
+
+// WorkspaceHandler serves the session workspace routes. See this file's
+// package doc for the full security model.
+type WorkspaceHandler struct {
+	logger    logr.Logger
+	view      *AgentView
+	store     *SessionStore
+	client    *workspaceClient // nil when STORAGESVC_URL is unset: every route answers 503.
+	retention time.Duration
+
+	maxArtifactBytes        int64
+	maxSessionArtifactBytes int64 // 0 means unlimited.
+}
+
+// NewWorkspaceHandler returns a WorkspaceHandler. client nil disables the
+// feature (every route answers 503 rather than agentruntime guessing a
+// storagesvc URL — see main.go's STORAGESVC_URL handling). retention is the
+// same archive-retention duration NewDispatcher receives, used identically
+// to compute a settled record's refreshed live-key TTL (see liveTTL).
+func NewWorkspaceHandler(logger logr.Logger, view *AgentView, store *SessionStore, client *workspaceClient, retention time.Duration, maxArtifactBytes, maxSessionArtifactBytes int64) *WorkspaceHandler {
+	return &WorkspaceHandler{
+		logger: logger, view: view, store: store, client: client, retention: retention,
+		maxArtifactBytes: maxArtifactBytes, maxSessionArtifactBytes: maxSessionArtifactBytes,
+	}
+}
+
+// liveTTL computes the same live-key TTL Dispatcher's own handler uses
+// (entry.IdleAfter + entry.ArchiveAfter + retention — dispatcher.go:491),
+// so a workspace-triggered counter settle refreshes the record's orphan
+// self-expiry by the SAME lease every turn does, rather than shortening it.
+// Falls back to the platform defaults when the AgentEntry is no longer in
+// the view (the Function was deleted after the session was created but
+// before its record was archived/swept) — TTL=0 would mean "no expiry" to
+// statestore.KVStore.Set, which would strip the orphan-expiry safety net
+// entirely, so a conservative non-zero fallback is required, never zero.
+func (wh *WorkspaceHandler) liveTTL(ns, agent string) time.Duration {
+	if e, ok := wh.view.Lookup(ns, agent); ok {
+		return e.IdleAfter + e.ArchiveAfter + wh.retention
+	}
+	return DefaultIdleAfter + DefaultArchiveAfter + wh.retention
+}
+
+// requireSession is the existence anchor every handler runs BEFORE any
+// storagesvc call — see this file's package doc, point 4.
+func (wh *WorkspaceHandler) requireSession(w http.ResponseWriter, r *http.Request, ns, agent, session string) (SessionRecord, bool) {
+	rec, _, err := wh.store.Get(r.Context(), ns, agent, session)
+	if err != nil {
+		if errors.Is(err, statestore.ErrNotFound) {
+			writeErr(w, http.StatusNotFound, "session not found")
+			return SessionRecord{}, false
+		}
+		wh.logger.Error(err, "getting session record", "namespace", ns, "agent", agent, "session", session)
+		writeErr(w, http.StatusInternalServerError, "getting session")
+		return SessionRecord{}, false
+	}
+	return rec, true
+}
+
+// workspaceDisabledMsg is the 503 body every route answers with when
+// STORAGESVC_URL is unset — see main.go's envStoragesvcURL handling.
+const workspaceDisabledMsg = "workspace disabled: STORAGESVC_URL not configured"
+
+// workspacePutResp is the wire shape of a successful PUT.
+type workspacePutResp struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// handlePut serves PUT /workspace/{namespace}/{name}/{session}/{path...}.
+//
+// Quota ordering (Global Constraints): pre-check the per-session budget
+// (using the fresh record's ArtifactBytes read by requireSession) -> write
+// to storagesvc -> CAS-settle the counters via casUpdateFresh. The settle
+// closure is func(*SessionRecord) with no error return, so the budget check
+// CANNOT live inside it — it must happen before the write, as a pre-check.
+// That ordering leaves a small accepted overshoot window: two PUTs racing
+// right at the budget can both pass the pre-check (each reads the budget as
+// not-yet-exceeded) and both write, overshooting by up to one artifact's
+// worth of bytes before the next pre-check observes the settled total.
+// Mirrors the G19 honesty notes on other best-effort session meters.
+func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
+	if wh.client == nil {
+		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
+		return
+	}
+	ns, agent, session := r.PathValue("namespace"), r.PathValue("name"), r.PathValue("session")
+	if !validateWorkspaceRouteIdentity(w, ns, agent, session) {
+		return
+	}
+	path := r.PathValue("path")
+	if err := validateWorkspacePath(path); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	rec, ok := wh.requireSession(w, r, ns, agent, session)
+	if !ok {
+		return
+	}
+
+	body := r.Body
+	if body == nil {
+		body = http.NoBody
+	}
+	defer body.Close()
+
+	// LimitReader(cap+1): reading exactly cap+1 bytes means the body
+	// exceeded the cap. A plain LimitReader(cap) would silently accept and
+	// spool a TRUNCATED artifact instead of rejecting the request outright
+	// — that silent-truncation shape is exactly the bug this over-read
+	// detection exists to prevent (Global Constraints).
+	sp, err := spoolWorkspaceBody(io.LimitReader(body, wh.maxArtifactBytes+1), workspaceSpoolThresholdBytes)
+	if err != nil {
+		wh.logger.Error(err, "spooling workspace PUT body", "namespace", ns, "agent", agent, "session", session, "path", path)
+		writeErr(w, http.StatusInternalServerError, "reading request body")
+		return
+	}
+	defer sp.cleanup()
+
+	if sp.size > wh.maxArtifactBytes {
+		writeErr(w, http.StatusRequestEntityTooLarge, fmt.Sprintf("artifact exceeds the %d byte cap", wh.maxArtifactBytes))
+		return
+	}
+
+	if wh.maxSessionArtifactBytes > 0 && rec.Stats.ArtifactBytes+sp.size > wh.maxSessionArtifactBytes {
+		writeErr(w, http.StatusTooManyRequests, "session artifact budget exceeded")
+		return
+	}
+
+	id := workspaceID(ns, agent, session, path)
+	size, err := wh.client.put(r.Context(), id, sp)
+	if err != nil {
+		wh.logger.Error(err, "writing workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)
+		writeErr(w, http.StatusBadGateway, "writing workspace object")
+		return
+	}
+
+	casUpdateFresh(r.Context(), wh.logger, wh.store, ns, agent, session, wh.liveTTL(ns, agent), func(rec *SessionRecord) {
+		rec.Stats.ArtifactCount++
+		rec.Stats.ArtifactBytes += size
+	})
+
+	writeJSON(w, http.StatusOK, workspacePutResp{Path: path, Size: size})
+}
+
+// handleGet serves GET /workspace/{namespace}/{name}/{session}/{path...}: an
+// io.Copy passthrough stream with Content-Length set from storagesvc's own
+// response — no buffering, no signing needed on this hop (GET carries no
+// body to sign).
+func (wh *WorkspaceHandler) handleGet(w http.ResponseWriter, r *http.Request) {
+	if wh.client == nil {
+		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
+		return
+	}
+	ns, agent, session := r.PathValue("namespace"), r.PathValue("name"), r.PathValue("session")
+	if !validateWorkspaceRouteIdentity(w, ns, agent, session) {
+		return
+	}
+	path := r.PathValue("path")
+	if err := validateWorkspacePath(path); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, ok := wh.requireSession(w, r, ns, agent, session); !ok {
+		return
+	}
+
+	id := workspaceID(ns, agent, session, path)
+	body, size, err := wh.client.get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, errWorkspaceNotFound) {
+			writeErr(w, http.StatusNotFound, "artifact not found")
+			return
+		}
+		wh.logger.Error(err, "reading workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)
+		writeErr(w, http.StatusBadGateway, "reading workspace object")
+		return
+	}
+	defer body.Close()
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	if _, err := io.Copy(w, body); err != nil {
+		wh.logger.Error(err, "streaming workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)
+	}
+}
+
+// workspaceDeleteResp is the wire shape of a successful DELETE.
+type workspaceDeleteResp struct {
+	Path string `json:"path"`
+}
+
+// handleDelete serves DELETE /workspace/{namespace}/{name}/{session}/{path...}.
+// Idempotent (a missing artifact is still a 200, matching storagesvc's own
+// DELETE contract). The frozen storagesvc wire contract has no HEAD/info
+// route, so the byte size needed to decrement Stats.ArtifactBytes is looked
+// up via a LIST scoped to the session prefix, filtered to the exact id —
+// the cheapest primitive the contract offers (an alternative GET-then-
+// discard would transfer the whole artifact just to read a header). A
+// failed list is logged and treated as "size unknown": the delete itself
+// still proceeds and still returns 200 (idempotent-delete is the contract),
+// it only means the counter settle below is skipped — accepted drift, the
+// same "residue accepted" stance the purge/prefix-delete paths take
+// elsewhere in this feature.
+func (wh *WorkspaceHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
+	if wh.client == nil {
+		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
+		return
+	}
+	ns, agent, session := r.PathValue("namespace"), r.PathValue("name"), r.PathValue("session")
+	if !validateWorkspaceRouteIdentity(w, ns, agent, session) {
+		return
+	}
+	path := r.PathValue("path")
+	if err := validateWorkspacePath(path); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if _, ok := wh.requireSession(w, r, ns, agent, session); !ok {
+		return
+	}
+
+	id := workspaceID(ns, agent, session, path)
+	prefix := workspaceSessionPrefix(ns, agent, session)
+
+	var size int64
+	found := false
+	if items, err := wh.client.list(r.Context(), prefix); err != nil {
+		wh.logger.Error(err, "listing workspace session for delete-size lookup", "namespace", ns, "agent", agent, "session", session, "path", path)
+	} else {
+		for _, it := range items {
+			if it.ID == id {
+				size, found = it.Size, true
+				break
+			}
+		}
+	}
+
+	if err := wh.client.del(r.Context(), id); err != nil {
+		wh.logger.Error(err, "deleting workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)
+		writeErr(w, http.StatusBadGateway, "deleting workspace object")
+		return
+	}
+
+	if found {
+		// Clamped at 0: a settle racing a concurrent delete of the same
+		// path, or drift from a prior failed-list skip, must never drive
+		// the counters negative.
+		casUpdateFresh(r.Context(), wh.logger, wh.store, ns, agent, session, wh.liveTTL(ns, agent), func(rec *SessionRecord) {
+			rec.Stats.ArtifactCount = max(0, rec.Stats.ArtifactCount-1)
+			rec.Stats.ArtifactBytes = max(0, rec.Stats.ArtifactBytes-size)
+		})
+	}
+
+	writeJSON(w, http.StatusOK, workspaceDeleteResp{Path: path})
+}
+
+// workspaceListItemResp is one entry in handleList's response.
+type workspaceListItemResp struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// workspaceListResp is the wire shape of handleList's response.
+type workspaceListResp struct {
+	Items []workspaceListItemResp `json:"items"`
+}
+
+// handleList serves GET /workspace/{namespace}/{name}/{session} — every
+// artifact currently stored under the session, with sizes.
+func (wh *WorkspaceHandler) handleList(w http.ResponseWriter, r *http.Request) {
+	if wh.client == nil {
+		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
+		return
+	}
+	ns, agent, session := r.PathValue("namespace"), r.PathValue("name"), r.PathValue("session")
+	if !validateWorkspaceRouteIdentity(w, ns, agent, session) {
+		return
+	}
+	if _, ok := wh.requireSession(w, r, ns, agent, session); !ok {
+		return
+	}
+
+	prefix := workspaceSessionPrefix(ns, agent, session)
+	items, err := wh.client.list(r.Context(), prefix)
+	if err != nil {
+		wh.logger.Error(err, "listing workspace session", "namespace", ns, "agent", agent, "session", session)
+		writeErr(w, http.StatusBadGateway, "listing workspace")
+		return
+	}
+
+	out := make([]workspaceListItemResp, 0, len(items))
+	for _, it := range items {
+		path, ok := stripWorkspacePrefix(it.ID, ns, agent, session)
+		if !ok || path == "" {
+			wh.logger.Error(nil, "workspace list item outside expected session prefix; skipping", "id", it.ID, "namespace", ns, "agent", agent, "session", session)
+			continue
+		}
+		out = append(out, workspaceListItemResp{Path: path, Size: it.Size})
+	}
+	writeJSON(w, http.StatusOK, workspaceListResp{Items: out})
+}
+
+// mountWorkspaceRoutes registers the four session workspace routes on mux,
+// each wrapped by auth (main.go passes
+// IdentityOrJWTOwnWorkspace(identityVerifier, authz.Middleware)).
+//
+// Factored out of main.go so workspace_test.go exercises the EXACT same
+// pattern registration production uses on a real *http.ServeMux — the
+// trailing-slash-is-400/encoded-segment/list-vs-file behavior these routes
+// pin depends on Go's actual ServeMux pattern-matching semantics, which a
+// hand-built request with r.SetPathValue set directly would bypass.
+func mountWorkspaceRoutes(mux *http.ServeMux, wh *WorkspaceHandler, auth func(http.Handler) http.Handler) {
+	mux.Handle("PUT /workspace/{namespace}/{name}/{session}/{path...}", auth(http.HandlerFunc(wh.handlePut)))
+	mux.Handle("GET /workspace/{namespace}/{name}/{session}/{path...}", auth(http.HandlerFunc(wh.handleGet)))
+	mux.Handle("DELETE /workspace/{namespace}/{name}/{session}/{path...}", auth(http.HandlerFunc(wh.handleDelete)))
+	mux.Handle("GET /workspace/{namespace}/{name}/{session}", auth(http.HandlerFunc(wh.handleList)))
+}

--- a/pkg/agentruntime/workspace.go
+++ b/pkg/agentruntime/workspace.go
@@ -444,6 +444,51 @@ func (c *workspaceClient) del(ctx context.Context, id string) error {
 	return nil
 }
 
+// workspaceDeletePrefixStoragesvcResp mirrors storagesvc's
+// workspaceDeletePrefixResponse wire shape ({"deleted": N}).
+type workspaceDeletePrefixStoragesvcResp struct {
+	Deleted int `json:"deleted"`
+}
+
+// deletePrefix issues DELETE /v1/workspace/prefix?prefix=<prefix> — the
+// idempotent bulk-delete primitive the sweeper's archive-time workspace
+// purge (sweeper.go, via the workspacePurger interface) is built on. Same
+// signer/transport as every other workspaceClient method (constructed once in
+// newWorkspaceClient); nothing route-specific here. The returned count is
+// storagesvc's own report of how many objects it actually removed — logged by
+// the caller at V(1), not used for any correctness decision: storagesvc's own
+// per-item delete failures are already log-don't-retry on its side (see
+// pkg/storagesvc/workspace.go's workspaceDeletePrefixHandler doc), so
+// `deleted == N` here is informational, never a completeness guarantee.
+func (c *workspaceClient) deletePrefix(ctx context.Context, prefix string) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, c.baseURL+"/v1/workspace/prefix?prefix="+url.QueryEscape(prefix), nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("storagesvc DELETE prefix %s: status %d: %s", prefix, resp.StatusCode, readLimitedBody(resp.Body))
+	}
+	// Same over-read-detection shape as workspaceClient.list: a response past
+	// the cap is treated as an error, not silently truncated-and-parsed.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, workspaceListMaxResponseBytes+1))
+	if err != nil {
+		return 0, err
+	}
+	if int64(len(body)) > workspaceListMaxResponseBytes {
+		return 0, fmt.Errorf("storagesvc DELETE prefix %s: response exceeds the %d byte cap", prefix, workspaceListMaxResponseBytes)
+	}
+	var out workspaceDeletePrefixStoragesvcResp
+	if err := json.Unmarshal(body, &out); err != nil {
+		return 0, fmt.Errorf("decoding storagesvc DELETE prefix response: %w", err)
+	}
+	return out.Deleted, nil
+}
+
 // workspaceListStoragesvcItem/Resp mirror storagesvc's workspaceItem/
 // workspaceListResponse wire shapes.
 type workspaceListStoragesvcItem struct {

--- a/pkg/agentruntime/workspace.go
+++ b/pkg/agentruntime/workspace.go
@@ -37,9 +37,12 @@
 //     (Q32). Residual orphans from records that TTL out unswept (e.g. a
 //     deleted agent Function) join the already-named orphan-sweep
 //     follow-up, not solved here.
-//  5. Quota (PUT only): a per-artifact cap (AGENT_MAX_ARTIFACT_BYTES) and a
-//     per-session budget (AGENT_MAX_SESSION_ARTIFACT_BYTES) — see
-//     handlePut's doc for the pre-check/write/settle ordering.
+//  5. Quota (PUT only): a per-artifact byte cap (AGENT_MAX_ARTIFACT_BYTES), a
+//     per-session byte budget (AGENT_MAX_SESSION_ARTIFACT_BYTES), and a
+//     per-session artifact-COUNT budget (AGENT_MAX_SESSION_ARTIFACTS — the
+//     bytes-only budget's zero-byte-artifact bypass, and what structurally
+//     bounds a session's LIST response size) — see handlePut's doc for the
+//     delta-accounting and pre-check/write/settle ordering.
 //
 // Streaming: the request body is spooled (spoolWorkspaceBody) rather than
 // buffered whole — bounded in-memory up to workspaceSpoolThresholdBytes,
@@ -100,6 +103,22 @@ const (
 	// connection pool, matching pkg/storagesvc/client's own
 	// storagesvcIdleConnsPerHost sizing for the same single upstream.
 	workspaceIdleConnsPerHost = 16
+
+	// workspaceListMaxResponseBytes bounds how much of a storagesvc LIST
+	// response workspaceClient.list will buffer. Tied to the artifact-COUNT
+	// budget (AGENT_MAX_SESSION_ARTIFACTS, defaultMaxSessionArtifacts items
+	// in main.go): a session's list JSON is at most roughly
+	// defaultMaxSessionArtifacts items * (workspaceMarker + ns + agent +
+	// session + a maxWorkspacePathBytes path + a size field + JSON
+	// punctuation), which comfortably fits well under this cap at the
+	// default count budget — a legitimate list never truncates. A caller
+	// that somehow produced a bigger response already violated the count
+	// budget upstream (or storagesvc/agentruntime disagree on it); either
+	// way this is defense in depth, not the primary bound: without it an
+	// unbounded io.ReadAll of a hostile or corrupted upstream response would
+	// be a shared-control-plane memory amplification (one LIST call turning
+	// into an unbounded allocation), not merely a slow one.
+	workspaceListMaxResponseBytes int64 = 8 << 20
 )
 
 // workspaceSegmentCharset is the allowed charset for a non-marker workspace
@@ -175,6 +194,22 @@ func validateWorkspaceRouteIdentity(w http.ResponseWriter, ns, name, session str
 	}
 	if !sessionIDPattern.MatchString(session) || strings.HasPrefix(session, CheckpointKeyPrefix) {
 		writeErr(w, http.StatusBadRequest, "invalid session id")
+		return false
+	}
+	// sessionIDPattern's charset (identical to workspaceSegmentCharset) still
+	// admits ".", "..", and a leading "_" — none of which resolveSessionID
+	// itself ever mints, but a caller can still SUPPLY a session id matching
+	// one, and this route treats {session} as a wire path segment.
+	// validateWorkspaceSegment closes exactly that gap: without it, such a
+	// session id sails through this check and only fails downstream at
+	// storagesvc's own validateWorkspaceID (pkg/storagesvc/workspace.go),
+	// surfacing as an opaque 502 here instead of this layer's own 400 —
+	// contradicting this function's "mirrors storagesvc's rules exactly"
+	// defense-in-depth claim. Every session id this check newly rejects was
+	// already guaranteed to fail at storagesvc, so this only replaces a 502
+	// with a 400 — no previously-working id is affected.
+	if err := validateWorkspaceSegment(session); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid session id: "+err.Error())
 		return false
 	}
 	return true
@@ -358,7 +393,14 @@ func (c *workspaceClient) put(ctx context.Context, id string, sp *workspaceSpool
 }
 
 // get issues GET /v1/workspace?id=<id>. The caller must Close the returned
-// body. Returns errWorkspaceNotFound on a storagesvc 404.
+// body. Returns errWorkspaceNotFound on a storagesvc 404. size is -1 when
+// storagesvc's Content-Length header was absent or unparsable — the caller
+// (handleGet) must treat that as "unknown", NOT as an actual 0-byte body:
+// blindly parsing with ", _" and defaulting to 0 would make handleGet
+// declare "Content-Length: 0" while still copying a non-empty stream, which
+// Go's server enforces by silently truncating the response to empty. In
+// contract storagesvc always sets the header (workspaceGetHandler stats
+// before streaming), so -1 is a robustness path, not a live one.
 func (c *workspaceClient) get(ctx context.Context, id string) (io.ReadCloser, int64, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/workspace?id="+url.QueryEscape(id), nil)
 	if err != nil {
@@ -376,7 +418,10 @@ func (c *workspaceClient) get(ctx context.Context, id string) (io.ReadCloser, in
 		defer resp.Body.Close()
 		return nil, 0, fmt.Errorf("storagesvc GET %s: status %d: %s", id, resp.StatusCode, readLimitedBody(resp.Body))
 	}
-	size, _ := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	size, err := strconv.ParseInt(resp.Header.Get("Content-Length"), 10, 64)
+	if err != nil {
+		size = -1
+	}
 	return resp.Body, size, nil
 }
 
@@ -409,7 +454,10 @@ type workspaceListStoragesvcResp struct {
 	Items []workspaceListStoragesvcItem `json:"items"`
 }
 
-// list issues GET /v1/workspace/list?prefix=<prefix>.
+// list issues GET /v1/workspace/list?prefix=<prefix>. The response body is
+// read through workspaceListMaxResponseBytes — see that constant's doc for
+// why an unbounded io.ReadAll here would be a memory-amplification vector,
+// not merely a slow one.
 func (c *workspaceClient) list(ctx context.Context, prefix string) ([]workspaceListStoragesvcItem, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/workspace/list?prefix="+url.QueryEscape(prefix), nil)
 	if err != nil {
@@ -423,9 +471,18 @@ func (c *workspaceClient) list(ctx context.Context, prefix string) ([]workspaceL
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("storagesvc LIST %s: status %d: %s", prefix, resp.StatusCode, readLimitedBody(resp.Body))
 	}
-	body, err := io.ReadAll(resp.Body)
+	// Read one byte past the cap: landing exactly at cap+1 (rather than a
+	// silently truncated cap bytes that json.Unmarshal might still happen to
+	// parse as valid-but-wrong JSON) means the response really did exceed
+	// the bound, mirroring the PUT-side over-read-detection shape
+	// (spoolWorkspaceBody's LimitReader(cap+1)) rather than the truncate-
+	// and-hope alternative.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, workspaceListMaxResponseBytes+1))
 	if err != nil {
 		return nil, err
+	}
+	if int64(len(body)) > workspaceListMaxResponseBytes {
+		return nil, fmt.Errorf("storagesvc LIST %s: response exceeds the %d byte cap", prefix, workspaceListMaxResponseBytes)
 	}
 	var out workspaceListStoragesvcResp
 	if err := json.Unmarshal(body, &out); err != nil {
@@ -445,6 +502,7 @@ type WorkspaceHandler struct {
 
 	maxArtifactBytes        int64
 	maxSessionArtifactBytes int64 // 0 means unlimited.
+	maxSessionArtifacts     int64 // 0 means unlimited.
 }
 
 // NewWorkspaceHandler returns a WorkspaceHandler. client nil disables the
@@ -452,10 +510,17 @@ type WorkspaceHandler struct {
 // storagesvc URL — see main.go's STORAGESVC_URL handling). retention is the
 // same archive-retention duration NewDispatcher receives, used identically
 // to compute a settled record's refreshed live-key TTL (see liveTTL).
-func NewWorkspaceHandler(logger logr.Logger, view *AgentView, store *SessionStore, client *workspaceClient, retention time.Duration, maxArtifactBytes, maxSessionArtifactBytes int64) *WorkspaceHandler {
+// maxSessionArtifacts bounds the number of DISTINCT artifact paths a session
+// may hold (0 = unlimited) — the count-side counterpart to
+// maxSessionArtifactBytes, closing the zero-byte-artifact bypass a
+// bytes-only budget leaves open (an unbounded number of 0-byte PUTs always
+// passes a bytes check) and structurally bounding how large a single LIST
+// response for the session can ever legitimately be.
+func NewWorkspaceHandler(logger logr.Logger, view *AgentView, store *SessionStore, client *workspaceClient, retention time.Duration, maxArtifactBytes, maxSessionArtifactBytes, maxSessionArtifacts int64) *WorkspaceHandler {
 	return &WorkspaceHandler{
 		logger: logger, view: view, store: store, client: client, retention: retention,
 		maxArtifactBytes: maxArtifactBytes, maxSessionArtifactBytes: maxSessionArtifactBytes,
+		maxSessionArtifacts: maxSessionArtifacts,
 	}
 }
 
@@ -491,6 +556,34 @@ func (wh *WorkspaceHandler) requireSession(w http.ResponseWriter, r *http.Reques
 	return rec, true
 }
 
+// probeExisting looks up id's CURRENT size (and whether it exists at all)
+// via a LIST scoped to the session prefix, filtered to the exact id — the
+// only sizing primitive the frozen storagesvc wire contract offers (no
+// HEAD/info route). Both handlePut (to settle an overwrite by DELTA rather
+// than double-counting the write) and handleDelete (to know how much to
+// decrement) share this lookup.
+//
+// A LIST failure is logged at V(1) and treated as "does not exist"
+// (size 0, found false) — the accepted-drift fallback: handlePut then
+// settles as a plain create (the honest worst case being a slightly
+// over-counted budget, never an under-counted one that could bypass it) and
+// handleDelete simply skips its counter decrement (documented at its own
+// call site). Neither caller-visible outcome (the PUT/DELETE still
+// succeeds) depends on the probe succeeding — only the bookkeeping does.
+func (wh *WorkspaceHandler) probeExisting(ctx context.Context, ns, agent, session, id string) (size int64, found bool) {
+	items, err := wh.client.list(ctx, workspaceSessionPrefix(ns, agent, session))
+	if err != nil {
+		wh.logger.V(1).Info("probing existing workspace object failed; treating as not-yet-existing", "id", id, "namespace", ns, "agent", agent, "session", session, "error", err.Error())
+		return 0, false
+	}
+	for _, it := range items {
+		if it.ID == id {
+			return it.Size, true
+		}
+	}
+	return 0, false
+}
+
 // workspaceDisabledMsg is the 503 body every route answers with when
 // STORAGESVC_URL is unset — see main.go's envStoragesvcURL handling.
 const workspaceDisabledMsg = "workspace disabled: STORAGESVC_URL not configured"
@@ -503,16 +596,32 @@ type workspacePutResp struct {
 
 // handlePut serves PUT /workspace/{namespace}/{name}/{session}/{path...}.
 //
-// Quota ordering (Global Constraints): pre-check the per-session budget
-// (using the fresh record's ArtifactBytes read by requireSession) -> write
-// to storagesvc -> CAS-settle the counters via casUpdateFresh. The settle
-// closure is func(*SessionRecord) with no error return, so the budget check
-// CANNOT live inside it — it must happen before the write, as a pre-check.
-// That ordering leaves a small accepted overshoot window: two PUTs racing
-// right at the budget can both pass the pre-check (each reads the budget as
-// not-yet-exceeded) and both write, overshooting by up to one artifact's
-// worth of bytes before the next pre-check observes the settled total.
-// Mirrors the G19 honesty notes on other best-effort session meters.
+// Delta accounting: storagesvc's PUT is an OVERWRITE-in-place (Task 1's
+// wire contract has no separate create/replace verb), so unconditionally
+// adding the new size on every PUT would turn the per-session byte budget
+// into a cumulative-WRITE budget rather than a stored-bytes one — a session
+// that legitimately rewrites one 32MiB file 8 times would hit the default
+// 256MiB budget and 429-lock, and a later DELETE would only decrement by the
+// object's CURRENT size, leaving permanent phantom residue (a nonzero
+// counter backed by zero live objects). probeExisting looks up the prior
+// size (and whether the path existed at all) BEFORE the write; both the
+// pre-check and the post-write settle use that delta — oldSize subtracted,
+// newSize added, ArtifactCount incremented only when the path did not
+// already exist. A rewrite of an unchanged-size file nets to a zero-byte
+// delta, exactly matching what actually changed on storagesvc.
+//
+// Quota ordering (Global Constraints): pre-check the per-session budgets
+// (bytes AND count — see maxSessionArtifacts) -> write to storagesvc ->
+// CAS-settle the counters via casUpdateFresh. The settle closure is
+// func(*SessionRecord) with no error return, so the budget checks CANNOT
+// live inside it — they must happen before the write, as a pre-check. That
+// ordering leaves an accepted overshoot window, and it is NOT bounded to
+// "one artifact's worth": with N PUTs racing concurrently, every one of them
+// can read the pre-settle (not-yet-exceeded) budget and all N write before
+// any settle lands, so the real worst case is (N-1)*maxArtifactBytes — there
+// is no per-session in-flight-write semaphore bounding N itself. Mirrors the
+// G19 honesty notes on other best-effort session meters; a per-session
+// in-flight cap is a follow-up, not built here.
 func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 	if wh.client == nil {
 		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
@@ -557,12 +666,22 @@ func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if wh.maxSessionArtifactBytes > 0 && rec.Stats.ArtifactBytes+sp.size > wh.maxSessionArtifactBytes {
-		writeErr(w, http.StatusTooManyRequests, "session artifact budget exceeded")
+	id := workspaceID(ns, agent, session, path)
+	oldSize, existed := wh.probeExisting(r.Context(), ns, agent, session, id)
+
+	if wh.maxSessionArtifactBytes > 0 && rec.Stats.ArtifactBytes+(sp.size-oldSize) > wh.maxSessionArtifactBytes {
+		writeErr(w, http.StatusTooManyRequests, "session artifact byte budget exceeded")
+		return
+	}
+	// Zero-byte artifacts (and any artifact that shrinks the byte delta to
+	// ~0) still consume ONE slot of this budget when the path is new — the
+	// count check is what closes the bypass a bytes-only budget leaves open
+	// (an unbounded number of 0-byte PUTs always satisfies a bytes check).
+	if !existed && wh.maxSessionArtifacts > 0 && rec.Stats.ArtifactCount+1 > wh.maxSessionArtifacts {
+		writeErr(w, http.StatusTooManyRequests, "session artifact count budget exceeded")
 		return
 	}
 
-	id := workspaceID(ns, agent, session, path)
 	size, err := wh.client.put(r.Context(), id, sp)
 	if err != nil {
 		wh.logger.Error(err, "writing workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)
@@ -571,8 +690,14 @@ func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 	}
 
 	casUpdateFresh(r.Context(), wh.logger, wh.store, ns, agent, session, wh.liveTTL(ns, agent), func(rec *SessionRecord) {
-		rec.Stats.ArtifactCount++
-		rec.Stats.ArtifactBytes += size
+		if !existed {
+			rec.Stats.ArtifactCount++
+		}
+		// Clamped at 0: a probe that raced a concurrent delete/rewrite of
+		// the SAME path (oldSize stale by the time this settles) must never
+		// drive the counter negative — the same defensive clamp DELETE's
+		// own settle applies.
+		rec.Stats.ArtifactBytes = max(0, rec.Stats.ArtifactBytes+(size-oldSize))
 	})
 
 	writeJSON(w, http.StatusOK, workspacePutResp{Path: path, Size: size})
@@ -614,7 +739,15 @@ func (wh *WorkspaceHandler) handleGet(w http.ResponseWriter, r *http.Request) {
 	defer body.Close()
 
 	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	// size == -1 means storagesvc's Content-Length was absent/unparsable
+	// (workspaceClient.get's doc) — omit the header rather than declaring a
+	// wrong length: Go's server enforces whatever Content-Length it is told,
+	// so writing "0" here while still copying a non-empty body would
+	// silently truncate the response to empty. Omitting it instead falls
+	// back to chunked transfer encoding, which is always correct.
+	if size >= 0 {
+		w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	}
 	if _, err := io.Copy(w, body); err != nil {
 		wh.logger.Error(err, "streaming workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)
 	}
@@ -627,16 +760,21 @@ type workspaceDeleteResp struct {
 
 // handleDelete serves DELETE /workspace/{namespace}/{name}/{session}/{path...}.
 // Idempotent (a missing artifact is still a 200, matching storagesvc's own
-// DELETE contract). The frozen storagesvc wire contract has no HEAD/info
-// route, so the byte size needed to decrement Stats.ArtifactBytes is looked
-// up via a LIST scoped to the session prefix, filtered to the exact id —
-// the cheapest primitive the contract offers (an alternative GET-then-
-// discard would transfer the whole artifact just to read a header). A
-// failed list is logged and treated as "size unknown": the delete itself
-// still proceeds and still returns 200 (idempotent-delete is the contract),
-// it only means the counter settle below is skipped — accepted drift, the
-// same "residue accepted" stance the purge/prefix-delete paths take
-// elsewhere in this feature.
+// DELETE contract). The byte size needed to decrement Stats.ArtifactBytes
+// comes from probeExisting — the frozen storagesvc wire contract has no
+// HEAD/info route, so this is a LIST scoped to the session prefix, filtered
+// to the exact id (the cheapest primitive the contract offers; a GET-then-
+// discard would transfer the whole artifact just to read a header). That
+// list is O(N) in the session's live artifact count per delete — O(N^2) for
+// a client tearing a session down file-by-file — but N is now structurally
+// bounded by maxSessionArtifacts (handlePut's count budget), and this same
+// call is bounded in RESPONSE SIZE by workspaceListMaxResponseBytes, so
+// neither the per-call cost nor the memory it buffers is unbounded. A probe
+// failure is treated as "does not exist" (see probeExisting's doc): the
+// delete itself still proceeds and still returns 200 (idempotent-delete is
+// the contract), it only means the counter settle below is skipped —
+// accepted drift, the same "residue accepted" stance the purge/prefix-delete
+// paths take elsewhere in this feature.
 func (wh *WorkspaceHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 	if wh.client == nil {
 		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
@@ -656,20 +794,7 @@ func (wh *WorkspaceHandler) handleDelete(w http.ResponseWriter, r *http.Request)
 	}
 
 	id := workspaceID(ns, agent, session, path)
-	prefix := workspaceSessionPrefix(ns, agent, session)
-
-	var size int64
-	found := false
-	if items, err := wh.client.list(r.Context(), prefix); err != nil {
-		wh.logger.Error(err, "listing workspace session for delete-size lookup", "namespace", ns, "agent", agent, "session", session, "path", path)
-	} else {
-		for _, it := range items {
-			if it.ID == id {
-				size, found = it.Size, true
-				break
-			}
-		}
-	}
+	size, found := wh.probeExisting(r.Context(), ns, agent, session, id)
 
 	if err := wh.client.del(r.Context(), id); err != nil {
 		wh.logger.Error(err, "deleting workspace object", "namespace", ns, "agent", agent, "session", session, "path", path)

--- a/pkg/agentruntime/workspace.go
+++ b/pkg/agentruntime/workspace.go
@@ -85,12 +85,22 @@ const (
 	// maxWorkspaceSegmentBytes / maxWorkspacePathBytes bound a single
 	// {path...} segment and the full path, mirroring
 	// pkg/storagesvc/workspace.go's maxWorkspaceSegmentBytes/
-	// maxWorkspaceIDBytes (that bound is on the FULL id, marker+ns+agent+
-	// session+path; this bound is on the path portion alone, so it is
-	// intentionally smaller — well within storagesvc's own ceiling once the
-	// marker/ns/agent/session prefix is added back).
+	// maxWorkspaceIDBytes (that bound is on the FULL id,
+	// marker+ns+agent+session+path; this bound is on the path portion
+	// alone, so it must be smaller by at least the worst-case prefix, not
+	// merely smaller).
+	//
+	// The full id is `_workspace_` (11 bytes) + "/" + ns (<=63, DNS-1123) +
+	// "/" + agent (<=63, DNS-1123) + "/" + session (<=128,
+	// sessionIDPattern) + "/" + path. At the worst case (ns/agent/session
+	// all maxed) the fixed prefix alone is 11+1+63+1+63+1+128+1 = 269
+	// bytes, leaving at most 1024-269 = 755 bytes of storagesvc's
+	// maxWorkspaceIDBytes budget for path. 1024 here would let a valid
+	// path pass this layer and still be 400'd by storagesvc (surfaced to
+	// the caller as an opaque 502) — so this bound must be <=755. 700 is
+	// used for a safety margin against future prefix growth.
 	maxWorkspaceSegmentBytes = 128
-	maxWorkspacePathBytes    = 1024
+	maxWorkspacePathBytes    = 700
 
 	// workspaceSpoolThresholdBytes bounds how much of a PUT body this
 	// handler keeps in memory before spilling to a temp file, mirroring
@@ -545,6 +555,14 @@ type WorkspaceHandler struct {
 	client    *workspaceClient // nil when STORAGESVC_URL is unset: every route answers 503.
 	retention time.Duration
 
+	// maxArtifactBytes bounds a single PUT (413 over the cap, handlePut).
+	// This is agentruntime's OWN cap, checked before the write; it does not
+	// widen storagesvc's own upload ceiling. An operator who lowers
+	// storagesvc's STORAGE_MAX_ARCHIVE_SIZE_MIB below this value makes a
+	// PUT that agentruntime accepted at this layer fail at storagesvc
+	// instead (surfaced here as a 502 "writing workspace object", not the
+	// 413 a caller would expect) — the two caps are independent knobs an
+	// operator must keep coherent, not one deriving from the other.
 	maxArtifactBytes        int64
 	maxSessionArtifactBytes int64 // 0 means unlimited.
 	maxSessionArtifacts     int64 // 0 means unlimited.
@@ -615,17 +633,31 @@ func (wh *WorkspaceHandler) requireSession(w http.ResponseWriter, r *http.Reques
 // outcome (the PUT/DELETE still succeeds) depends on the probe succeeding —
 // only the bookkeeping does.
 //
-// Every caller-visible fallback of a stale or failed probe — a LIST outage
-// read as "does not exist", or a raced probe whose oldSize is stale by
-// settle time — is engineered to be fail-CLOSED: it only ever OVER-counts
-// the tracked budget relative to true storage, never under-counts it. That
-// is enforced at the CALL sites, not by this function alone: handlePut
-// clamps its byte delta to a non-negative contribution (max(0, new-old)) so
-// a stale/negative delta from a same-path shrink race can never credit
-// budget back, and a spuriously "not found" probe only ever causes an
-// extra ArtifactCount++ (a permanent but bounded phantom), never a missed
-// decrement that would let real usage outrun the tracked total. See
-// handlePut's doc comment for the specific race shapes this closes.
+// On the PUT side, every caller-visible fallback of a stale or failed probe
+// — a LIST outage read as "does not exist", or a raced probe whose oldSize
+// is stale by settle time — is engineered to be fail-CLOSED: it only ever
+// OVER-counts the tracked budget relative to true storage, never
+// under-counts it. That is enforced at the CALL sites, not by this function
+// alone: handlePut clamps its byte delta to a non-negative contribution
+// (max(0, new-old)) so a stale/negative delta from a same-path shrink race
+// can never credit budget back, and a spuriously "not found" probe only
+// ever causes an extra ArtifactCount++ (a permanent but bounded phantom),
+// never a missed decrement that would let real usage outrun the tracked
+// total. See handlePut's doc comment for the specific race shapes this
+// closes.
+//
+// The DELETE side is the one ACCEPTED exception to that fail-closed
+// guarantee: two concurrent DELETEs of the same path both probe and both
+// observe found=true, size=S (storagesvc's own DELETE is idempotent-200, so
+// neither request sees "already gone"), so both settle
+// ArtifactCount/ArtifactBytes down by 1/S even though real storage only
+// shrank once — a fail-OPEN, self-inflicted double-decrement. This is a
+// ruled residue, not an oversight: exact settle would need per-path
+// serialization, which is disproportionate for a race only the session's
+// own credential holder can trigger against itself, and
+// the resulting headroom is bounded — at defaults, at most
+// maxSessionArtifacts * maxArtifactBytes (~31GiB) of daylight between
+// tracked and true usage, not unbounded. See handleDelete's doc comment.
 func (wh *WorkspaceHandler) probeExisting(ctx context.Context, ns, agent, session, id string) (size int64, found bool) {
 	items, err := wh.client.list(ctx, workspaceSessionPrefix(ns, agent, session))
 	if err != nil {
@@ -781,6 +813,15 @@ func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// The persisted bool casUpdateFresh returns is deliberately discarded
+	// here: a false means the settle never landed (the fresh Get or the
+	// retried Update failed, already logged inside casUpdate) after the
+	// storagesvc write already succeeded — an ACCEPTED, fail-OPEN
+	// under-count of the same "drift from failed puts is accepted residue"
+	// family as the DELETE-side double-decrement (handleDelete's doc
+	// comment), not a new failure mode: the write itself is not rolled
+	// back, and retrying the settle from here would need its own
+	// idempotency story this handler does not have.
 	casUpdateFresh(r.Context(), wh.logger, wh.store, ns, agent, session, wh.liveTTL(ns, agent), func(rec *SessionRecord) {
 		if !existed {
 			rec.Stats.ArtifactCount++
@@ -872,6 +913,19 @@ type workspaceDeleteResp struct {
 // the contract), it only means the counter settle below is skipped —
 // accepted drift, the same "residue accepted" stance the purge/prefix-delete
 // paths take elsewhere in this feature.
+//
+// ACCEPTED RESIDUE, fail-OPEN: two concurrent DELETEs of the same path both
+// probe before either's del() lands, both observe found=true with the SAME
+// size, and both settle the decrement below — real storage shrinks once,
+// the tracked meters shrink twice. This is the one place in the workspace
+// quota system that is not fail-closed;
+// it is accepted rather than fixed because storagesvc's DELETE is
+// idempotent-200 (a "removed" and an "already gone" response are
+// indistinguishable to this handler), and closing it exactly would need
+// per-path settle serialization — disproportionate for a race a session can
+// only mount against its own budget. The resulting headroom is bounded, not
+// unbounded: at defaults, at most maxSessionArtifacts * maxArtifactBytes
+// (~31GiB) of daylight between tracked and true usage.
 func (wh *WorkspaceHandler) handleDelete(w http.ResponseWriter, r *http.Request) {
 	if wh.client == nil {
 		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
@@ -902,7 +956,11 @@ func (wh *WorkspaceHandler) handleDelete(w http.ResponseWriter, r *http.Request)
 	if found {
 		// Clamped at 0: a settle racing a concurrent delete of the same
 		// path, or drift from a prior failed-list skip, must never drive
-		// the counters negative.
+		// the counters negative. The clamp bounds the double-decrement
+		// race documented on handleDelete's doc comment (ACCEPTED RESIDUE)
+		// at 0 per counter — it does not prevent the race itself, which
+		// still under-counts relative to true storage when the session
+		// holds other artifacts.
 		casUpdateFresh(r.Context(), wh.logger, wh.store, ns, agent, session, wh.liveTTL(ns, agent), func(rec *SessionRecord) {
 			rec.Stats.ArtifactCount = max(0, rec.Stats.ArtifactCount-1)
 			rec.Stats.ArtifactBytes = max(0, rec.Stats.ArtifactBytes-size)

--- a/pkg/agentruntime/workspace.go
+++ b/pkg/agentruntime/workspace.go
@@ -565,11 +565,22 @@ func (wh *WorkspaceHandler) requireSession(w http.ResponseWriter, r *http.Reques
 //
 // A LIST failure is logged at V(1) and treated as "does not exist"
 // (size 0, found false) — the accepted-drift fallback: handlePut then
-// settles as a plain create (the honest worst case being a slightly
-// over-counted budget, never an under-counted one that could bypass it) and
-// handleDelete simply skips its counter decrement (documented at its own
-// call site). Neither caller-visible outcome (the PUT/DELETE still
-// succeeds) depends on the probe succeeding — only the bookkeeping does.
+// settles as a plain create and handleDelete simply skips its counter
+// decrement (documented at its own call site). Neither caller-visible
+// outcome (the PUT/DELETE still succeeds) depends on the probe succeeding —
+// only the bookkeeping does.
+//
+// Every caller-visible fallback of a stale or failed probe — a LIST outage
+// read as "does not exist", or a raced probe whose oldSize is stale by
+// settle time — is engineered to be fail-CLOSED: it only ever OVER-counts
+// the tracked budget relative to true storage, never under-counts it. That
+// is enforced at the CALL sites, not by this function alone: handlePut
+// clamps its byte delta to a non-negative contribution (max(0, new-old)) so
+// a stale/negative delta from a same-path shrink race can never credit
+// budget back, and a spuriously "not found" probe only ever causes an
+// extra ArtifactCount++ (a permanent but bounded phantom), never a missed
+// decrement that would let real usage outrun the tracked total. See
+// handlePut's doc comment for the specific race shapes this closes.
 func (wh *WorkspaceHandler) probeExisting(ctx context.Context, ns, agent, session, id string) (size int64, found bool) {
 	items, err := wh.client.list(ctx, workspaceSessionPrefix(ns, agent, session))
 	if err != nil {
@@ -610,18 +621,48 @@ type workspacePutResp struct {
 // already exist. A rewrite of an unchanged-size file nets to a zero-byte
 // delta, exactly matching what actually changed on storagesvc.
 //
+// The delta is CLAMPED to a minimum of zero (max(0, newSize-oldSize)), both
+// in the pre-check and the settle — a shrinking overwrite of the SAME path
+// (newSize < oldSize) contributes NO byte-budget credit, ever, rather than
+// crediting the difference back. This is deliberately fail-CLOSED, not an
+// oversight: crediting a negative delta is exactly what let a fix-round
+// review (R2) turn a race into a genuine quota-bypass shape — two PUTs
+// racing the SAME shrinking path both probe the SAME stale oldSize and both
+// settle a negative delta against a fresh read, so the tracked total drops
+// by (N-1)x(oldSize-newSize) more than the real storage did; repeated
+// shrink/regrow cycles could otherwise manufacture unbounded byte-budget
+// headroom bounded only by maxSessionArtifacts*maxArtifactBytes rather than
+// maxSessionArtifactBytes. Clamping to zero makes every settle either exact
+// or an OVER-count relative to true storage, never an under-count — the
+// safe direction for a resource-exhaustion backstop, at the cost that a
+// same-path shrink alone never reclaims budget. A caller that needs the
+// budget back must actually DELETE the path (which decrements by the real
+// stored size, see handleDelete) rather than overwriting it smaller.
+//
 // Quota ordering (Global Constraints): pre-check the per-session budgets
 // (bytes AND count — see maxSessionArtifacts) -> write to storagesvc ->
 // CAS-settle the counters via casUpdateFresh. The settle closure is
 // func(*SessionRecord) with no error return, so the budget checks CANNOT
 // live inside it — they must happen before the write, as a pre-check. That
-// ordering leaves an accepted overshoot window, and it is NOT bounded to
-// "one artifact's worth": with N PUTs racing concurrently, every one of them
-// can read the pre-settle (not-yet-exceeded) budget and all N write before
-// any settle lands, so the real worst case is (N-1)*maxArtifactBytes — there
-// is no per-session in-flight-write semaphore bounding N itself. Mirrors the
-// G19 honesty notes on other best-effort session meters; a per-session
-// in-flight cap is a follow-up, not built here.
+// ordering leaves two accepted, fail-closed overshoot races, neither bounded
+// to "one artifact's worth":
+//   - N PUTs racing a NEW path can all read the pre-settle (not-yet-exceeded)
+//     budget and all write before any settle lands, overshooting BYTES by up
+//     to (N-1)*maxArtifactBytes — there is no per-session in-flight-write
+//     semaphore bounding N itself.
+//   - N PUTs racing to CREATE the SAME not-yet-existing path can all
+//     probeExisting before any of their writes land, all observe
+//     existed=false, and all settle ArtifactCount++ — the final COUNT is
+//     permanently inflated by (N-1) with no self-correction (one subsequent
+//     DELETE only decrements by 1). This is the same failure family the
+//     probe-failure fallback already accepts elsewhere (a LIST outage on an
+//     existing path also yields existed=false and an identical permanent,
+//     fail-closed phantom +1) — a stale "does not exist yet" read, whatever
+//     its cause, always over-counts, never under-counts.
+//
+// Both mirror the G19 honesty notes on other best-effort session meters; a
+// per-session in-flight cap or per-path settle serialization is a follow-up,
+// not built here.
 func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 	if wh.client == nil {
 		writeErr(w, http.StatusServiceUnavailable, workspaceDisabledMsg)
@@ -669,7 +710,13 @@ func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 	id := workspaceID(ns, agent, session, path)
 	oldSize, existed := wh.probeExisting(r.Context(), ns, agent, session, id)
 
-	if wh.maxSessionArtifactBytes > 0 && rec.Stats.ArtifactBytes+(sp.size-oldSize) > wh.maxSessionArtifactBytes {
+	// Clamped to zero — see this function's doc comment: a shrinking
+	// overwrite must never be credited as freed budget, only an actual
+	// DELETE does that. The pre-check uses the SAME clamped estimate the
+	// settle below will apply, so a request that will not actually reduce
+	// the tracked total is never pre-approved on the assumption that it will.
+	estimatedDelta := max(0, sp.size-oldSize)
+	if wh.maxSessionArtifactBytes > 0 && rec.Stats.ArtifactBytes+estimatedDelta > wh.maxSessionArtifactBytes {
 		writeErr(w, http.StatusTooManyRequests, "session artifact byte budget exceeded")
 		return
 	}
@@ -693,11 +740,16 @@ func (wh *WorkspaceHandler) handlePut(w http.ResponseWriter, r *http.Request) {
 		if !existed {
 			rec.Stats.ArtifactCount++
 		}
-		// Clamped at 0: a probe that raced a concurrent delete/rewrite of
-		// the SAME path (oldSize stale by the time this settles) must never
-		// drive the counter negative — the same defensive clamp DELETE's
-		// own settle applies.
-		rec.Stats.ArtifactBytes = max(0, rec.Stats.ArtifactBytes+(size-oldSize))
+		// max(0, size-oldSize), NOT size-oldSize: the delta itself is
+		// clamped to a non-negative contribution BEFORE it is added — see
+		// this function's doc comment for why a raw (possibly negative)
+		// delta here is a genuine quota-bypass shape under a same-path
+		// shrink race, not merely a cosmetic accounting choice. The
+		// outer max(0, ...) around the whole addition is a second,
+		// independent safety net against the total itself ever going
+		// negative (e.g. from otherwise-unanticipated drift) — both clamps
+		// are load-bearing, neither subsumes the other.
+		rec.Stats.ArtifactBytes = max(0, rec.Stats.ArtifactBytes+max(0, size-oldSize))
 	})
 
 	writeJSON(w, http.StatusOK, workspacePutResp{Path: path, Size: size})

--- a/pkg/agentruntime/workspace_test.go
+++ b/pkg/agentruntime/workspace_test.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -40,6 +41,15 @@ type fakeStoragesvc struct {
 	mu    sync.Mutex
 	objs  map[string][]byte
 	calls int
+
+	// failList, when set, makes GET /v1/workspace/list answer 500 — for
+	// TestWorkspacePut_ProbeFailureTreatedAsCreate's probe-failure pin.
+	failList atomic.Bool
+	// listPadBytes, when nonzero, pads the LIST response with an extra JSON
+	// field of that many bytes — for TestWorkspaceClientList_BoundedRead,
+	// which needs a response that legitimately exceeds
+	// workspaceListMaxResponseBytes without needing that many real objects.
+	listPadBytes atomic.Int64
 }
 
 func newFakeStoragesvc(t *testing.T, master []byte) (*httptest.Server, *fakeStoragesvc) {
@@ -84,10 +94,21 @@ func newFakeStoragesvc(t *testing.T, master []byte) (*httptest.Server, *fakeStor
 	mux.HandleFunc("GET /v1/workspace/list", func(w http.ResponseWriter, r *http.Request) {
 		f.mu.Lock()
 		f.calls++
+		if f.failList.Load() {
+			f.mu.Unlock()
+			http.Error(w, "simulated list failure", http.StatusInternalServerError)
+			return
+		}
 		prefix := r.URL.Query().Get("prefix")
 		type item struct {
 			ID   string `json:"id"`
 			Size int64  `json:"size"`
+		}
+		type listResp struct {
+			Items []item `json:"items"`
+			// Pad is TestWorkspaceClientList_BoundedRead's oversized-response
+			// simulator (see listPadBytes) — never set outside that test.
+			Pad string `json:"_pad,omitempty"`
 		}
 		var items []item
 		for id, body := range f.objs {
@@ -95,8 +116,13 @@ func newFakeStoragesvc(t *testing.T, master []byte) (*httptest.Server, *fakeStor
 				items = append(items, item{ID: id, Size: int64(len(body))})
 			}
 		}
+		pad := f.listPadBytes.Load()
 		f.mu.Unlock()
-		resp, _ := json.Marshal(map[string]any{"items": items})
+		out := listResp{Items: items}
+		if pad > 0 {
+			out.Pad = strings.Repeat("p", int(pad))
+		}
+		resp, _ := json.Marshal(out)
 		_, _ = w.Write(resp)
 	})
 
@@ -125,6 +151,14 @@ func (f *fakeStoragesvc) has(id string) bool {
 // hmacauth.ServiceSigner exactly as main.go's Start does.
 func newTestWorkspaceHandler(t *testing.T, master []byte, storagesvcURL string, maxArtifactBytes, maxSessionArtifactBytes int64) (*WorkspaceHandler, *AgentView, *SessionStore) {
 	t.Helper()
+	return newTestWorkspaceHandlerWithCountBudget(t, master, storagesvcURL, maxArtifactBytes, maxSessionArtifactBytes, 0)
+}
+
+// newTestWorkspaceHandlerWithCountBudget is newTestWorkspaceHandler with an
+// explicit maxSessionArtifacts (the count budget), for tests exercising it
+// directly.
+func newTestWorkspaceHandlerWithCountBudget(t *testing.T, master []byte, storagesvcURL string, maxArtifactBytes, maxSessionArtifactBytes, maxSessionArtifacts int64) (*WorkspaceHandler, *AgentView, *SessionStore) {
+	t.Helper()
 	kv := newTestKV(t)
 	store := NewSessionStore(kv, time.Now)
 	view := NewAgentView()
@@ -133,7 +167,7 @@ func newTestWorkspaceHandler(t *testing.T, master []byte, storagesvcURL string, 
 		rt := hmacauth.ServiceSigner(master, hmacauth.ServiceStoragesvc, http.DefaultTransport, time.Now)
 		client = newWorkspaceClient(storagesvcURL, rt)
 	}
-	wh := NewWorkspaceHandler(logr.Discard(), view, store, client, time.Hour, maxArtifactBytes, maxSessionArtifactBytes)
+	wh := NewWorkspaceHandler(logr.Discard(), view, store, client, time.Hour, maxArtifactBytes, maxSessionArtifactBytes, maxSessionArtifacts)
 	return wh, view, store
 }
 
@@ -371,7 +405,9 @@ func TestWorkspacePut_OverCap413_NothingStored(t *testing.T) {
 
 // TestWorkspacePut_OverBudget429 is the quota pre-check pin: a session
 // already near AGENT_MAX_SESSION_ARTIFACT_BYTES rejects a PUT that would
-// push it over, BEFORE the storagesvc write.
+// push it over, BEFORE the storagesvc WRITE. It costs exactly ONE upstream
+// call — the probeExisting LIST that delta-accounting needs to tell an
+// overwrite from a create (M1's fix) — never the PUT itself.
 func TestWorkspacePut_OverBudget429(t *testing.T) {
 	t.Parallel()
 	master := []byte("ws-429-master")
@@ -393,7 +429,130 @@ func TestWorkspacePut_OverBudget429(t *testing.T) {
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
-	assert.Zero(t, fake.callCount(), "an over-budget PUT must never reach storagesvc")
+	assert.EqualValues(t, 1, fake.callCount(), "an over-budget PUT must reach storagesvc only for the delta-accounting probe (LIST), never the PUT itself")
+	assert.False(t, fake.has("_workspace_/ns-a/agent-x/sess-1/more.txt"), "nothing must be stored on a 429")
+}
+
+// TestWorkspacePut_OverwriteDeltaAccounting is finding M1's core pin:
+// rewriting the SAME path multiple times (with different sizes) must settle
+// ArtifactBytes to the CURRENT stored size, not the cumulative sum of every
+// write, and ArtifactCount must stay at 1 — never re-incrementing for a path
+// that already existed. A budget sized to fit only ONE of the larger bodies
+// (not N of them) proves the settle is delta-based, not additive: a naive
+// additive implementation would 429 on the second or third rewrite.
+func TestWorkspacePut_OverwriteDeltaAccounting(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-delta-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	// Budget fits exactly one 40-byte body plus slack, never two.
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 50)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	sizes := []int{10, 40, 20, 40} // grows, shrinks, grows again — all under budget only if delta-settled
+	for i, sz := range sizes {
+		body := strings.Repeat("z", sz)
+		req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/same.txt", "ns-a", "agent-x", tok, body)
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equalf(t, http.StatusOK, w.Code, "rewrite #%d (size %d) must succeed under a budget sized for ONE body, not the cumulative sum: %s", i, sz, w.Body.String())
+
+		rec, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+		require.NoError(t, err)
+		assert.EqualValuesf(t, sz, rec.Stats.ArtifactBytes, "after rewrite #%d, ArtifactBytes must equal the CURRENT stored size, not a cumulative sum", i)
+		assert.EqualValuesf(t, 1, rec.Stats.ArtifactCount, "rewrite #%d must not re-increment ArtifactCount for a path that already existed", i)
+	}
+	assert.True(t, fake.has("_workspace_/ns-a/agent-x/sess-1/same.txt"))
+
+	// DELETE must restore the budget to exactly 0, not leave phantom residue
+	// from the (now-irrelevant) earlier write sizes.
+	delReq := identityWorkspaceRequest(http.MethodDelete, "/workspace/ns-a/agent-x/sess-1/same.txt", "ns-a", "agent-x", tok, "")
+	delRec := httptest.NewRecorder()
+	mux.ServeHTTP(delRec, delReq)
+	require.Equal(t, http.StatusOK, delRec.Code)
+
+	rec, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.Zero(t, rec.Stats.ArtifactBytes, "delete must restore the byte budget fully")
+	assert.Zero(t, rec.Stats.ArtifactCount)
+}
+
+// TestWorkspacePut_ProbeFailureTreatedAsCreate is M1's accepted-drift pin:
+// when probeExisting's LIST call fails, handlePut must treat the path as
+// not-yet-existing (oldSize=0, count bumped) rather than blocking the write
+// — a probe outage degrades bookkeeping accuracy, never availability.
+func TestWorkspacePut_ProbeFailureTreatedAsCreate(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-probefail-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	fake.failList.Store(true)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	const artifact = "twelve bytes"
+	req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/a.txt", "ns-a", "agent-x", tok, artifact)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "a probe failure must not block the PUT")
+
+	rec, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, rec.Stats.ArtifactCount, "probe failure must fall back to treating the path as new")
+	assert.EqualValues(t, len(artifact), rec.Stats.ArtifactBytes)
+}
+
+// TestWorkspacePut_CountBudget429 is finding M2(a)/(c)'s pin: a session at
+// its AGENT_MAX_SESSION_ARTIFACTS ceiling rejects a NEW-path PUT even when
+// the body is 0 bytes (closing the bytes-budget bypass), while a rewrite of
+// an ALREADY-EXISTING path (which does not consume a new count slot) still
+// succeeds.
+func TestWorkspacePut_CountBudget429(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-countbudget-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandlerWithCountBudget(t, master, upstream.URL, 1<<20, 0, 1) // count budget of 1
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	firstReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/first.txt", "ns-a", "agent-x", tok, "")
+	firstRec := httptest.NewRecorder()
+	mux.ServeHTTP(firstRec, firstReq)
+	require.Equal(t, http.StatusOK, firstRec.Code, "the first (zero-byte) artifact must consume the one available count slot")
+
+	t.Run("a second distinct zero-byte path is rejected — the count budget, not the byte budget, catches it", func(t *testing.T) {
+		secondReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/second.txt", "ns-a", "agent-x", tok, "")
+		secondRec := httptest.NewRecorder()
+		mux.ServeHTTP(secondRec, secondReq)
+		assert.Equal(t, http.StatusTooManyRequests, secondRec.Code)
+		assert.False(t, fake.has("_workspace_/ns-a/agent-x/sess-1/second.txt"))
+	})
+
+	t.Run("rewriting the SAME existing path is still allowed — it consumes no new count slot", func(t *testing.T) {
+		rewriteReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/first.txt", "ns-a", "agent-x", tok, "updated")
+		rewriteRec := httptest.NewRecorder()
+		mux.ServeHTTP(rewriteRec, rewriteReq)
+		assert.Equal(t, http.StatusOK, rewriteRec.Code)
+	})
+
+	rec, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, rec.Stats.ArtifactCount)
 }
 
 // TestWorkspacePathValidation_400 exercises the four path-traversal/encoding
@@ -427,6 +586,66 @@ func TestWorkspacePathValidation_400(t *testing.T) {
 		})
 	}
 	assert.Zero(t, fake.callCount(), "every case here must be rejected before any storagesvc call")
+}
+
+// TestWorkspaceSessionValidation_400 is finding 4's pin: sessionIDPattern
+// alone admits ".", "..", and a leading "_" as a session id (its charset is
+// permissive), and only storagesvc's own validateWorkspaceID rejects those
+// as a path segment — surfacing as an opaque 502 rather than this layer's
+// own 400, contradicting the "mirrors storagesvc's rules exactly" defense-
+// in-depth claim. validateWorkspaceRouteIdentity now additionally runs
+// validateWorkspaceSegment(session), closing the gap: these ids must 400
+// here, before any storagesvc call.
+func TestWorkspaceSessionValidation_400(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-session400-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, _, _ := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, passthroughAuth)
+
+	tests := []struct {
+		name    string
+		session string
+	}{
+		// "." and ".." are given ENCODED (%2E): a literal "/workspace/.../."
+		// or "/workspace/.../.." is redirected (307) by net/http's own path
+		// cleaning before ever reaching the mux pattern match — the encoded
+		// form is what actually exercises this layer's validation, exactly
+		// like the {path...} traversal case in TestWorkspacePathValidation_400.
+		{"single dot (encoded)", "%2E"},
+		{"double dot (encoded)", "%2E%2E"},
+		{"leading underscore", "_hidden"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/workspace/ns-a/agent-x/"+tt.session, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+	assert.Zero(t, fake.callCount(), "a malformed session id must never reach storagesvc")
+}
+
+// TestWorkspaceClientList_BoundedRead is finding M2(b)'s pin: a storagesvc
+// LIST response larger than workspaceListMaxResponseBytes must error out
+// (never be fully buffered) — the fake pads its response with an oversized
+// filler field to simulate a hostile/corrupted upstream without needing
+// thousands of real objects.
+func TestWorkspaceClientList_BoundedRead(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-listbound-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	fake.listPadBytes.Store(workspaceListMaxResponseBytes + 1024)
+
+	rt := hmacauth.ServiceSigner(master, hmacauth.ServiceStoragesvc, http.DefaultTransport, time.Now)
+	client := newWorkspaceClient(upstream.URL, rt)
+
+	_, err := client.list(t.Context(), "_workspace_/ns-a/agent-x/sess-1/")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds")
 }
 
 // TestWorkspaceMeters_BumpAndDecrement is the settle-ordering pin: a

--- a/pkg/agentruntime/workspace_test.go
+++ b/pkg/agentruntime/workspace_test.go
@@ -1,0 +1,632 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// workspace_test.go drives the session workspace routes through the REAL
+// production mux wiring (mountWorkspaceRoutes, the exact function main.go
+// calls) against a fake storagesvc upstream wrapped in the REAL
+// hmacauth.ServiceVerifier — so "the request is signed" means the signature
+// actually verifies, not merely that some header is present — and a REAL
+// http.ServeMux for path-pattern matching, so the trailing-slash/encoded-
+// segment/list-vs-file behavior these tests pin depends on Go's actual
+// pattern-matching semantics rather than a hand-set r.SetPathValue shortcut.
+package agentruntime
+
+import (
+	"encoding/json/v2"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+)
+
+// fakeStoragesvc is a minimal in-memory stand-in for pkg/storagesvc's
+// /v1/workspace surface, wired behind the REAL hmacauth.ServiceVerifier so a
+// test asserting "the request is signed" is asserting a verified signature,
+// not merely a present header.
+type fakeStoragesvc struct {
+	mu    sync.Mutex
+	objs  map[string][]byte
+	calls int
+}
+
+func newFakeStoragesvc(t *testing.T, master []byte) (*httptest.Server, *fakeStoragesvc) {
+	t.Helper()
+	f := &fakeStoragesvc{objs: map[string][]byte{}}
+	mux := http.NewServeMux()
+	mux.HandleFunc("PUT /v1/workspace", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.calls++
+		f.mu.Unlock()
+		id := r.URL.Query().Get("id")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		f.mu.Lock()
+		f.objs[id] = body
+		f.mu.Unlock()
+		resp, _ := json.Marshal(map[string]int64{"size": int64(len(body))})
+		_, _ = w.Write(resp)
+	})
+	mux.HandleFunc("GET /v1/workspace", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.calls++
+		body, ok := f.objs[r.URL.Query().Get("id")]
+		f.mu.Unlock()
+		if !ok {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Length", strconv.Itoa(len(body)))
+		_, _ = w.Write(body)
+	})
+	mux.HandleFunc("DELETE /v1/workspace", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.calls++
+		delete(f.objs, r.URL.Query().Get("id"))
+		f.mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("GET /v1/workspace/list", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.calls++
+		prefix := r.URL.Query().Get("prefix")
+		type item struct {
+			ID   string `json:"id"`
+			Size int64  `json:"size"`
+		}
+		var items []item
+		for id, body := range f.objs {
+			if strings.HasPrefix(id, prefix) {
+				items = append(items, item{ID: id, Size: int64(len(body))})
+			}
+		}
+		f.mu.Unlock()
+		resp, _ := json.Marshal(map[string]any{"items": items})
+		_, _ = w.Write(resp)
+	})
+
+	verified := hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{})(mux)
+	srv := httptest.NewServer(verified)
+	t.Cleanup(srv.Close)
+	return srv, f
+}
+
+func (f *fakeStoragesvc) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+func (f *fakeStoragesvc) has(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.objs[id]
+	return ok
+}
+
+// newTestWorkspaceHandler returns a WorkspaceHandler wired to a fresh
+// in-memory SessionStore/AgentView. storagesvcURL == "" gives a nil client
+// (the disabled-feature case); otherwise it signs with master over
+// hmacauth.ServiceSigner exactly as main.go's Start does.
+func newTestWorkspaceHandler(t *testing.T, master []byte, storagesvcURL string, maxArtifactBytes, maxSessionArtifactBytes int64) (*WorkspaceHandler, *AgentView, *SessionStore) {
+	t.Helper()
+	kv := newTestKV(t)
+	store := NewSessionStore(kv, time.Now)
+	view := NewAgentView()
+	var client *workspaceClient
+	if storagesvcURL != "" {
+		rt := hmacauth.ServiceSigner(master, hmacauth.ServiceStoragesvc, http.DefaultTransport, time.Now)
+		client = newWorkspaceClient(storagesvcURL, rt)
+	}
+	wh := NewWorkspaceHandler(logr.Discard(), view, store, client, time.Hour, maxArtifactBytes, maxSessionArtifactBytes)
+	return wh, view, store
+}
+
+// passthroughAuth is a no-op middleware used for the routing/validation
+// tests below that are not exercising the auth layer at all (identity_test.go
+// and the composition tests in this file already cover auth).
+func passthroughAuth(h http.Handler) http.Handler { return h }
+
+// identityWorkspaceRequest builds a request against the workspace mux
+// carrying identity claim headers, mirroring newIdentityRequest
+// (identity_test.go) for the workspace path shape.
+func identityWorkspaceRequest(method, path, claimedNS, claimedAgent, bearer string, body string) *http.Request {
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	if claimedNS != "" {
+		r.Header.Set(HeaderIdentityNamespace, claimedNS)
+	}
+	if claimedAgent != "" {
+		r.Header.Set(HeaderIdentityName, claimedAgent)
+	}
+	if bearer != "" {
+		r.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	return r
+}
+
+func newActiveSessionRecord(ns, agent, id string, now time.Time) SessionRecord {
+	return SessionRecord{ID: id, Agent: agent, Namespace: ns, Status: StatusActive, CreatedAt: now, LastActiveAt: now}
+}
+
+// TestWorkspaceRoutes_IdentityHappyPath drives PUT -> GET -> LIST -> DELETE
+// through the real mux with a valid G16 identity bearer, asserting the fake
+// storagesvc actually received the signed, translated ?id= at each step.
+func TestWorkspaceRoutes_IdentityHappyPath(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-happy-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+	const artifact = "hello artifact bytes"
+
+	putReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/notes/todo.txt", "ns-a", "agent-x", tok, artifact)
+	putRec := httptest.NewRecorder()
+	mux.ServeHTTP(putRec, putReq)
+	require.Equal(t, http.StatusOK, putRec.Code, putRec.Body.String())
+	var putResp workspacePutResp
+	require.NoError(t, json.Unmarshal(putRec.Body.Bytes(), &putResp))
+	assert.Equal(t, "notes/todo.txt", putResp.Path)
+	assert.EqualValues(t, len(artifact), putResp.Size)
+	assert.True(t, fake.has("_workspace_/ns-a/agent-x/sess-1/notes/todo.txt"), "the fake must have received the translated ?id=")
+
+	getReq := identityWorkspaceRequest(http.MethodGet, "/workspace/ns-a/agent-x/sess-1/notes/todo.txt", "ns-a", "agent-x", tok, "")
+	getRec := httptest.NewRecorder()
+	mux.ServeHTTP(getRec, getReq)
+	require.Equal(t, http.StatusOK, getRec.Code)
+	assert.Equal(t, artifact, getRec.Body.String())
+	assert.Equal(t, strconv.Itoa(len(artifact)), getRec.Header().Get("Content-Length"))
+
+	listReq := identityWorkspaceRequest(http.MethodGet, "/workspace/ns-a/agent-x/sess-1", "ns-a", "agent-x", tok, "")
+	listRec := httptest.NewRecorder()
+	mux.ServeHTTP(listRec, listReq)
+	require.Equal(t, http.StatusOK, listRec.Code)
+	var listResp workspaceListResp
+	require.NoError(t, json.Unmarshal(listRec.Body.Bytes(), &listResp))
+	require.Len(t, listResp.Items, 1)
+	assert.Equal(t, "notes/todo.txt", listResp.Items[0].Path)
+	assert.EqualValues(t, len(artifact), listResp.Items[0].Size)
+
+	delReq := identityWorkspaceRequest(http.MethodDelete, "/workspace/ns-a/agent-x/sess-1/notes/todo.txt", "ns-a", "agent-x", tok, "")
+	delRec := httptest.NewRecorder()
+	mux.ServeHTTP(delRec, delReq)
+	require.Equal(t, http.StatusOK, delRec.Code)
+	assert.False(t, fake.has("_workspace_/ns-a/agent-x/sess-1/notes/todo.txt"))
+}
+
+// TestWorkspaceRoutes_CrossAgentForbidden is the G16 surface amendment's own
+// test: a valid identity bearer for (ns-a, agent-x) must not reach agent-y's
+// workspace in the SAME namespace — stricter than dispatch's cross-agent
+// spawn allowance (identity_test.go's
+// TestIdentityOrJWT_SameNamespaceCrossAgentAllowed).
+func TestWorkspaceRoutes_CrossAgentForbidden(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-crossagent-master")
+	wh, view, _ := newTestWorkspaceHandler(t, master, "", 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	view.Upsert(headerEntry("ns-a", "agent-y", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	req := identityWorkspaceRequest(http.MethodGet, "/workspace/ns-a/agent-y/sess-1", "ns-a", "agent-x", tok, "")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestWorkspaceRoutes_CrossNamespaceForbidden mirrors dispatch's own
+// cross-namespace pin (identity_test.go's
+// TestIdentityOrJWT_CrossNamespaceForbidden) on the workspace surface.
+func TestWorkspaceRoutes_CrossNamespaceForbidden(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-crossns-master")
+	wh, view, _ := newTestWorkspaceHandler(t, master, "", 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	req := identityWorkspaceRequest(http.MethodGet, "/workspace/ns-b/agent-x/sess-1", "ns-a", "agent-x", tok, "")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code)
+}
+
+// TestWorkspaceRoutes_JWTScopeDebuggingParity: a namespace-scoped JWT (no
+// identity headers) may reach ANY agent's workspace within its scoped
+// namespace — deliberately LESS strict than the identity path's
+// own-workspace-only rule (debugging parity, per the plan).
+func TestWorkspaceRoutes_JWTScopeDebuggingParity(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-jwt-master")
+	key := []byte("ws-jwt-signing-key")
+	upstream, _ := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+	authz := NewAuthorizer(key)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, authz.Middleware))
+
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+
+	scopedTok := mintToken(t, key, jwt.MapClaims{
+		"sub": "debug-operator", "allowed_namespaces": []any{"ns-a"},
+		"exp": time.Now().Add(time.Hour).Unix(),
+	})
+
+	t.Run("scoped JWT reaches an agent's workspace with no identity claim at all", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/workspace/ns-a/agent-x/sess-1", nil)
+		req.Header.Set("Authorization", "Bearer "+scopedTok)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	})
+
+	t.Run("out-of-scope namespace is still forbidden via JWT", func(t *testing.T) {
+		t.Parallel()
+		req := httptest.NewRequest(http.MethodGet, "/workspace/ns-b/agent-x/sess-1", nil)
+		req.Header.Set("Authorization", "Bearer "+scopedTok)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+}
+
+// TestWorkspaceRoutes_NoSessionRecord404_NoUpstreamCalls is the GC-anchor
+// pin: a session id with no live record 404s BEFORE any storagesvc call —
+// the counting fake proves zero upstream hits.
+func TestWorkspaceRoutes_NoSessionRecord404_NoUpstreamCalls(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-404-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, view, _ := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"GET file", http.MethodGet, "/workspace/ns-a/agent-x/no-such-session/foo.txt"},
+		{"PUT file", http.MethodPut, "/workspace/ns-a/agent-x/no-such-session/foo.txt"},
+		{"DELETE file", http.MethodDelete, "/workspace/ns-a/agent-x/no-such-session/foo.txt"},
+		{"LIST", http.MethodGet, "/workspace/ns-a/agent-x/no-such-session"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := identityWorkspaceRequest(tc.method, tc.path, "ns-a", "agent-x", tok, "")
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+		})
+	}
+	assert.Zero(t, fake.callCount(), "a 404 on the existence anchor must never reach storagesvc")
+}
+
+// TestWorkspacePut_OverCap413_NothingStored is the over-read-detection pin:
+// LimitReader(cap+1) rejects a body over AGENT_MAX_ARTIFACT_BYTES with 413
+// and ZERO upstream calls — never silently stores a truncated artifact.
+func TestWorkspacePut_OverCap413_NothingStored(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-413-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 10, 0) // 10-byte cap
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/big.txt", "ns-a", "agent-x", tok, strings.Repeat("x", 25))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	assert.Zero(t, fake.callCount(), "an over-cap PUT must never reach storagesvc")
+
+	rec2, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.Zero(t, rec2.Stats.ArtifactCount, "a rejected PUT must not bump the meter")
+}
+
+// TestWorkspacePut_OverBudget429 is the quota pre-check pin: a session
+// already near AGENT_MAX_SESSION_ARTIFACT_BYTES rejects a PUT that would
+// push it over, BEFORE the storagesvc write.
+func TestWorkspacePut_OverBudget429(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-429-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 100) // 100-byte session budget
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+
+	rec := newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now())
+	rec.Stats.ArtifactBytes = 90
+	require.NoError(t, store.Create(t.Context(), rec, 0, time.Hour))
+
+	tok := identityToken(master, "ns-a", "agent-x")
+	req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/more.txt", "ns-a", "agent-x", tok, strings.Repeat("y", 20))
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Zero(t, fake.callCount(), "an over-budget PUT must never reach storagesvc")
+}
+
+// TestWorkspacePathValidation_400 exercises the four path-traversal/encoding
+// pins through the REAL ServeMux (auth deliberately bypassed via
+// passthroughAuth — these are pure routing/validation assertions).
+func TestWorkspacePathValidation_400(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-400-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	wh, _, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, passthroughAuth)
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"encoded traversal segment (%2E%2E decoded by ServeMux before PathValue)", "/workspace/ns-a/agent-x/sess-1/%2E%2E%2Fetc%2Fpasswd"},
+		{"trailing slash yields an empty {path...} on the file route", "/workspace/ns-a/agent-x/sess-1/"},
+		{"leading underscore path segment collides with the reserved marker", "/workspace/ns-a/agent-x/sess-1/_secret"},
+		{"empty inner segment via doubled encoded slash", "/workspace/ns-a/agent-x/sess-1/foo%2F%2Fbar"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPut, tt.path, strings.NewReader("x"))
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusBadRequest, rec.Code, "body: %s", rec.Body.String())
+		})
+	}
+	assert.Zero(t, fake.callCount(), "every case here must be rejected before any storagesvc call")
+}
+
+// TestWorkspaceMeters_BumpAndDecrement is the settle-ordering pin: a
+// successful PUT bumps Stats.ArtifactCount/ArtifactBytes, a successful
+// DELETE decrements them, and a second DELETE of the same (now-gone) path
+// leaves the counters clamped at 0 rather than going negative.
+func TestWorkspaceMeters_BumpAndDecrement(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-meters-master")
+	upstream, _ := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	const artifact = "twelve bytes"
+	putReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/a.txt", "ns-a", "agent-x", tok, artifact)
+	putRec := httptest.NewRecorder()
+	mux.ServeHTTP(putRec, putReq)
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, rec.Stats.ArtifactCount)
+	assert.EqualValues(t, len(artifact), rec.Stats.ArtifactBytes)
+
+	delReq := identityWorkspaceRequest(http.MethodDelete, "/workspace/ns-a/agent-x/sess-1/a.txt", "ns-a", "agent-x", tok, "")
+	delRec := httptest.NewRecorder()
+	mux.ServeHTTP(delRec, delReq)
+	require.Equal(t, http.StatusOK, delRec.Code)
+
+	rec, _, err = store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.Zero(t, rec.Stats.ArtifactCount)
+	assert.Zero(t, rec.Stats.ArtifactBytes)
+
+	// Second delete of the already-gone path: idempotent 200, and the
+	// counters must stay clamped at 0, never go negative.
+	delRec2 := httptest.NewRecorder()
+	mux.ServeHTTP(delRec2, identityWorkspaceRequest(http.MethodDelete, "/workspace/ns-a/agent-x/sess-1/a.txt", "ns-a", "agent-x", tok, ""))
+	assert.Equal(t, http.StatusOK, delRec2.Code)
+
+	rec, _, err = store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.Zero(t, rec.Stats.ArtifactCount)
+	assert.Zero(t, rec.Stats.ArtifactBytes)
+}
+
+// TestWorkspacePut_SSEFeedUntouched is the sessionUnchanged pin: an artifact
+// write settles Stats.ArtifactCount/ArtifactBytes but must not be
+// SSE-worthy — sessionUnchanged (events.go) must still report the before/
+// after records as unchanged even though those two fields differ.
+func TestWorkspacePut_SSEFeedUntouched(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-sse-master")
+	upstream, _ := newFakeStoragesvc(t, master)
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	before, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+
+	req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/a.txt", "ns-a", "agent-x", tok, "some bytes")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	after, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	require.NotEqualValues(t, before.Stats.ArtifactBytes, after.Stats.ArtifactBytes, "the PUT must have actually settled the counter")
+	assert.True(t, sessionUnchanged(before, after), "an artifact write must not be SSE-diff-worthy")
+}
+
+// TestSpoolWorkspaceBody_FileBranchIndependentReaders is the load-bearing
+// spool test: a body larger than threshold spills to a temp file, and
+// reader() called TWICE must each return the FULL body independently — the
+// invariant workspaceClient.put relies on (one reader for the outgoing
+// req.Body, a second FRESH one from req.GetBody for hmacauth.Signer's
+// streaming-hash pass). A shared *os.File handle rewound with Seek would
+// pass a single-reader test but fail this one: the second reader would see
+// whatever position the first read left behind.
+func TestSpoolWorkspaceBody_FileBranchIndependentReaders(t *testing.T) {
+	t.Parallel()
+	const body = "0123456789" // 10 bytes
+	sp, err := spoolWorkspaceBody(strings.NewReader(body), 4)
+	require.NoError(t, err)
+	t.Cleanup(sp.cleanup)
+
+	require.NotEmpty(t, sp.fileName, "a body larger than threshold must spill to a temp file")
+	assert.EqualValues(t, len(body), sp.size)
+
+	r1, err := sp.reader()
+	require.NoError(t, err)
+	got1, err := io.ReadAll(r1)
+	require.NoError(t, err)
+	require.NoError(t, r1.Close())
+	assert.Equal(t, body, string(got1), "first reader must see the full spooled body")
+
+	r2, err := sp.reader()
+	require.NoError(t, err)
+	got2, err := io.ReadAll(r2)
+	require.NoError(t, err)
+	require.NoError(t, r2.Close())
+	assert.Equal(t, body, string(got2), "a SECOND, independent reader must ALSO see the full body — a shared file handle would see EOF here instead")
+
+	fileName := sp.fileName
+	sp.cleanup()
+	_, statErr := os.Stat(fileName)
+	assert.True(t, os.IsNotExist(statErr), "cleanup must remove the spool temp file")
+}
+
+// TestSpoolWorkspaceBody_MemBranch covers the in-memory path: a body at or
+// under threshold never touches disk.
+func TestSpoolWorkspaceBody_MemBranch(t *testing.T) {
+	t.Parallel()
+	const body = "small"
+	sp, err := spoolWorkspaceBody(strings.NewReader(body), int64(len(body)+10))
+	require.NoError(t, err)
+	t.Cleanup(sp.cleanup)
+
+	assert.Empty(t, sp.fileName, "a body under threshold must stay in memory")
+	assert.EqualValues(t, len(body), sp.size)
+
+	r, err := sp.reader()
+	require.NoError(t, err)
+	got, err := io.ReadAll(r)
+	require.NoError(t, err)
+	assert.Equal(t, body, string(got))
+}
+
+// TestWorkspacePut_OverThresholdViaRealSignerVerifier is the end-to-end
+// proof that the spilled-to-disk branch round-trips through the REAL
+// hmacauth.Signer/Verifier pair, not just spoolWorkspaceBody in isolation: a
+// body larger than workspaceSpoolThresholdBytes must still produce a
+// signature that verifies, and the bytes that arrive at storagesvc must
+// match exactly.
+func TestWorkspacePut_OverThresholdViaRealSignerVerifier(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-spill-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	artifactCap := workspaceSpoolThresholdBytes + 1024 // forces the file-spill branch
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, artifactCap, 0)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	artifact := strings.Repeat("A", int(workspaceSpoolThresholdBytes)+512)
+	req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/big.bin", "ns-a", "agent-x", tok, artifact)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+
+	getReq := identityWorkspaceRequest(http.MethodGet, "/workspace/ns-a/agent-x/sess-1/big.bin", "ns-a", "agent-x", tok, "")
+	getRec := httptest.NewRecorder()
+	mux.ServeHTTP(getRec, getReq)
+	require.Equal(t, http.StatusOK, getRec.Code)
+	assert.Equal(t, len(artifact), getRec.Body.Len())
+	assert.Equal(t, artifact, getRec.Body.String())
+	assert.GreaterOrEqual(t, fake.callCount(), 2)
+}
+
+// TestWorkspaceRoutes_Disabled503 covers every route answering 503 when
+// STORAGESVC_URL was unset at startup (client == nil) — agentruntime must
+// never guess a storagesvc URL.
+func TestWorkspaceRoutes_Disabled503(t *testing.T) {
+	t.Parallel()
+	wh, _, store := newTestWorkspaceHandler(t, nil, "", 1<<20, 0)
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, passthroughAuth)
+
+	for _, tc := range []struct {
+		method, path string
+	}{
+		{http.MethodPut, "/workspace/ns-a/agent-x/sess-1/a.txt"},
+		{http.MethodGet, "/workspace/ns-a/agent-x/sess-1/a.txt"},
+		{http.MethodDelete, "/workspace/ns-a/agent-x/sess-1/a.txt"},
+		{http.MethodGet, "/workspace/ns-a/agent-x/sess-1"},
+	} {
+		t.Run(tc.method+" "+tc.path, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader("x"))
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			assert.Equal(t, http.StatusServiceUnavailable, rec.Code)
+			assert.Contains(t, rec.Body.String(), "STORAGESVC_URL")
+		})
+	}
+}

--- a/pkg/agentruntime/workspace_test.go
+++ b/pkg/agentruntime/workspace_test.go
@@ -125,6 +125,21 @@ func newFakeStoragesvc(t *testing.T, master []byte) (*httptest.Server, *fakeStor
 		resp, _ := json.Marshal(out)
 		_, _ = w.Write(resp)
 	})
+	mux.HandleFunc("DELETE /v1/workspace/prefix", func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.calls++
+		prefix := r.URL.Query().Get("prefix")
+		deleted := 0
+		for id := range f.objs {
+			if strings.HasPrefix(id, prefix) {
+				delete(f.objs, id)
+				deleted++
+			}
+		}
+		f.mu.Unlock()
+		resp, _ := json.Marshal(map[string]int{"deleted": deleted})
+		_, _ = w.Write(resp)
+	})
 
 	verified := hmacauth.ServiceVerifier(master, nil, hmacauth.ServiceStoragesvc, hmacauth.VerifierOpts{})(mux)
 	srv := httptest.NewServer(verified)
@@ -730,6 +745,46 @@ func TestWorkspaceClientList_BoundedRead(t *testing.T) {
 	_, err := client.list(t.Context(), "_workspace_/ns-a/agent-x/sess-1/")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds")
+}
+
+// TestWorkspaceClientDeletePrefix is workspaceClient.deletePrefix's own
+// wire-level test (the sweeper's archive-time purge primitive): it issues a
+// signed DELETE /v1/workspace/prefix, removes exactly the objects under the
+// given prefix (leaving a sibling session's object untouched), and reports
+// the storagesvc-side deleted count. Same signer/transport construction as
+// every other workspaceClient method — this test exercises it through the
+// REAL hmacauth.ServiceVerifier on the fake upstream, not a hand-signed
+// request.
+func TestWorkspaceClientDeletePrefix(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-delprefix-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+
+	rt := hmacauth.ServiceSigner(master, hmacauth.ServiceStoragesvc, http.DefaultTransport, time.Now)
+	client := newWorkspaceClient(upstream.URL, rt)
+
+	const target = "_workspace_/ns-a/agent-x/sess-1/"
+	sibling := "_workspace_/ns-a/agent-x/sess-2/b.txt"
+	putSp, err := spoolWorkspaceBody(strings.NewReader("a"), workspaceSpoolThresholdBytes)
+	require.NoError(t, err)
+	_, err = client.put(t.Context(), target+"a.txt", putSp)
+	require.NoError(t, err)
+	putSp2, err := spoolWorkspaceBody(strings.NewReader("b"), workspaceSpoolThresholdBytes)
+	require.NoError(t, err)
+	_, err = client.put(t.Context(), sibling, putSp2)
+	require.NoError(t, err)
+
+	deleted, err := client.deletePrefix(t.Context(), target)
+	require.NoError(t, err)
+	assert.Equal(t, 1, deleted)
+	assert.False(t, fake.has(target+"a.txt"), "the target session's object must be gone")
+	assert.True(t, fake.has(sibling), "a sibling session's object must survive an unrelated prefix delete")
+
+	// Idempotent: a second delete of the now-empty prefix is still a
+	// successful 200 with deleted == 0, not an error.
+	deleted, err = client.deletePrefix(t.Context(), target)
+	require.NoError(t, err)
+	assert.Zero(t, deleted)
 }
 
 // TestWorkspaceMeters_BumpAndDecrement is the settle-ordering pin: a

--- a/pkg/agentruntime/workspace_test.go
+++ b/pkg/agentruntime/workspace_test.go
@@ -434,12 +434,15 @@ func TestWorkspacePut_OverBudget429(t *testing.T) {
 }
 
 // TestWorkspacePut_OverwriteDeltaAccounting is finding M1's core pin:
-// rewriting the SAME path multiple times (with different sizes) must settle
+// rewriting the SAME path multiple times (each GROWING it) must settle
 // ArtifactBytes to the CURRENT stored size, not the cumulative sum of every
 // write, and ArtifactCount must stay at 1 — never re-incrementing for a path
 // that already existed. A budget sized to fit only ONE of the larger bodies
 // (not N of them) proves the settle is delta-based, not additive: a naive
-// additive implementation would 429 on the second or third rewrite.
+// additive implementation would 429 on the second or third rewrite. The
+// SHRINKING-overwrite case (which the delta clamp treats differently — see
+// handlePut's doc — and does NOT credit budget back) is covered separately
+// by TestWorkspacePut_ShrinkDoesNotCreditBudget.
 func TestWorkspacePut_OverwriteDeltaAccounting(t *testing.T) {
 	t.Parallel()
 	master := []byte("ws-delta-master")
@@ -454,7 +457,7 @@ func TestWorkspacePut_OverwriteDeltaAccounting(t *testing.T) {
 	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
 	tok := identityToken(master, "ns-a", "agent-x")
 
-	sizes := []int{10, 40, 20, 40} // grows, shrinks, grows again — all under budget only if delta-settled
+	sizes := []int{10, 25, 40} // monotonically grows — only under budget if delta-settled, not additive
 	for i, sz := range sizes {
 		body := strings.Repeat("z", sz)
 		req := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/same.txt", "ns-a", "agent-x", tok, body)
@@ -480,6 +483,87 @@ func TestWorkspacePut_OverwriteDeltaAccounting(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, rec.Stats.ArtifactBytes, "delete must restore the byte budget fully")
 	assert.Zero(t, rec.Stats.ArtifactCount)
+}
+
+// TestWorkspacePut_ShrinkDoesNotCreditBudget is the round-2 fix's core pin
+// (R2 from the fix-round review): a same-path SHRINK settles a CLAMPED delta
+// (max(0, new-old)) — ArtifactBytes must stay at the PRE-shrink value, never
+// drop to the smaller post-shrink size, because crediting a negative delta
+// back is exactly the shape a concurrent shrink race could exploit to
+// manufacture unbounded byte-budget headroom. A real DELETE only decrements
+// by the artifact's TRUE current size (its own probeExisting call, at
+// delete time) — NOT by the full pre-shrink phantom amount — so a
+// shrink-then-delete leaves permanent, accepted residue; what it DOES do is
+// reclaim enough headroom for a subsequent PUT that was blocked to now fit.
+func TestWorkspacePut_ShrinkDoesNotCreditBudget(t *testing.T) {
+	t.Parallel()
+	master := []byte("ws-shrink-master")
+	upstream, fake := newFakeStoragesvc(t, master)
+	// Budget fits one 100-byte body plus a little slack, never 100+60.
+	wh, view, store := newTestWorkspaceHandler(t, master, upstream.URL, 1<<20, 150)
+	view.Upsert(headerEntry("ns-a", "agent-x", 0))
+	identity := NewIdentityVerifier(master, nil, view)
+
+	mux := http.NewServeMux()
+	mountWorkspaceRoutes(mux, wh, IdentityOrJWTOwnWorkspace(identity, NewAuthorizer(nil).Middleware))
+	require.NoError(t, store.Create(t.Context(), newActiveSessionRecord("ns-a", "agent-x", "sess-1", time.Now()), 0, time.Hour))
+	tok := identityToken(master, "ns-a", "agent-x")
+
+	// Establish the path at 100 bytes.
+	putReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/f.bin", "ns-a", "agent-x", tok, strings.Repeat("a", 100))
+	putRec := httptest.NewRecorder()
+	mux.ServeHTTP(putRec, putReq)
+	require.Equal(t, http.StatusOK, putRec.Code)
+
+	rec, _, err := store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	require.EqualValues(t, 100, rec.Stats.ArtifactBytes)
+
+	// Shrink the SAME path to 10 bytes.
+	shrinkReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/f.bin", "ns-a", "agent-x", tok, strings.Repeat("b", 10))
+	shrinkRec := httptest.NewRecorder()
+	mux.ServeHTTP(shrinkRec, shrinkReq)
+	require.Equal(t, http.StatusOK, shrinkRec.Code)
+
+	rec, _, err = store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 100, rec.Stats.ArtifactBytes, "a same-path shrink must NOT credit budget back — ArtifactBytes must stay at the pre-shrink value")
+	assert.EqualValues(t, 1, rec.Stats.ArtifactCount)
+	assert.True(t, fake.has("_workspace_/ns-a/agent-x/sess-1/f.bin"))
+
+	// A second, distinct path that would fit under the REAL 10-byte current
+	// usage but not under the phantom 100-byte tracked total is correctly
+	// rejected — proving the budget really is still holding the pre-shrink
+	// size, not silently reconciled to the smaller real size.
+	tightReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/other.bin", "ns-a", "agent-x", tok, strings.Repeat("c", 60))
+	tightRec := httptest.NewRecorder()
+	mux.ServeHTTP(tightRec, tightReq)
+	assert.Equal(t, http.StatusTooManyRequests, tightRec.Code, "the phantom pre-shrink bytes still count against the budget until an actual DELETE")
+
+	// DELETE-then-PUT reclaims: deleting the shrunk path decrements by its
+	// REAL current size (10, via probeExisting's own LIST at delete time) —
+	// tracked total goes from 100 to 90, NOT to 0. The 90 bytes of phantom
+	// residue from the earlier un-credited shrink (real usage dropped by 90
+	// when the file shrank from 100 to 10, but the clamp never credited
+	// that) is permanent, accepted drift — the same "residue accepted"
+	// stance this feature already takes elsewhere (probe-failure over-
+	// counts, DELETE decrements are best-effort). What DELETE DOES reclaim
+	// is enough for the previously-429'd PUT (90+60=150, exactly at budget)
+	// to now succeed.
+	delReq := identityWorkspaceRequest(http.MethodDelete, "/workspace/ns-a/agent-x/sess-1/f.bin", "ns-a", "agent-x", tok, "")
+	delRec := httptest.NewRecorder()
+	mux.ServeHTTP(delRec, delReq)
+	require.Equal(t, http.StatusOK, delRec.Code)
+
+	rec, _, err = store.Get(t.Context(), "ns-a", "agent-x", "sess-1")
+	require.NoError(t, err)
+	assert.EqualValues(t, 90, rec.Stats.ArtifactBytes, "DELETE decrements by the REAL current size (10), leaving the 90-byte phantom residue from the un-credited shrink — accepted drift, not a bug")
+	assert.Zero(t, rec.Stats.ArtifactCount)
+
+	reclaimedReq := identityWorkspaceRequest(http.MethodPut, "/workspace/ns-a/agent-x/sess-1/other.bin", "ns-a", "agent-x", tok, strings.Repeat("c", 60))
+	reclaimedRec := httptest.NewRecorder()
+	mux.ServeHTTP(reclaimedRec, reclaimedReq)
+	assert.Equal(t, http.StatusOK, reclaimedRec.Code, "after DELETE reclaims the budget, the previously-429'd PUT now succeeds")
 }
 
 // TestWorkspacePut_ProbeFailureTreatedAsCreate is M1's accepted-drift pin:

--- a/pkg/storagesvc/authz.go
+++ b/pkg/storagesvc/authz.go
@@ -23,6 +23,38 @@ import (
 // used as a storage sub-directory (SUBDIR / STORAGE_S3_SUB_DIR).
 const archiveTenantMarker = "_tenant_"
 
+// workspaceMarker is the fixed path segment that roots the reserved session
+// artifact workspace object space (".../_workspace_/<ns>/<agent>/<session>/...",
+// see workspace.go). Reserved exactly like archiveTenantMarker: an underscore
+// makes it impossible for an RFC-1123 namespace label to collide with it, and
+// it must never be used as a storage sub-directory (SUBDIR / STORAGE_S3_SUB_DIR).
+// The archive pruner and the /v1/archive routes must never treat an id
+// containing this marker as an archive — see isWorkspaceID and its call sites.
+const workspaceMarker = "_workspace_"
+
+// isWorkspaceID reports whether id contains the reserved workspaceMarker as a
+// path segment, independent of any backend-added prefix — the local backend's
+// id is the ABSOLUTE container path, and an S3 id may carry a
+// STORAGE_S3_SUB_DIR prefix — so a naive strings.HasPrefix(id, workspaceMarker)
+// would miss both. Same segment-based approach as archiveNamespace (path.Clean
+// first so a crafted ".."-bearing id is judged on what the backend will
+// actually resolve, not the literal string).
+//
+// This is the seal between the workspace object space and the archive routes:
+// the archive handlers (download/delete/info) and the archive/orphan-pruner
+// candidate listing (getItemIDsWithFilter) all reject/exclude on this check so
+// a workspace object is never reachable as if it were an archive — including
+// for the master principal, which authorizedFor's legacy-id grandfather would
+// otherwise wave through unconditionally.
+func isWorkspaceID(id string) bool {
+	for _, s := range strings.Split(path.Clean(filepath.ToSlash(id)), "/") {
+		if s == workspaceMarker {
+			return true
+		}
+	}
+	return false
+}
+
 // archiveNamespace returns the namespace that owns the archive id, or "" for a
 // legacy/unscoped id (one with no marker). It locates the marker segment and
 // returns the following segment when it is a valid namespace label and is itself

--- a/pkg/storagesvc/client.go
+++ b/pkg/storagesvc/client.go
@@ -146,6 +146,16 @@ type filter func(objectInfo) bool
 
 // getItemIDsWithFilter returns the IDs of all items in the container that the
 // filter does not exclude.
+//
+// Workspace objects (under the reserved workspaceMarker root, see
+// pkg/storagesvc/workspace.go) are excluded UNCONDITIONALLY here, before the
+// caller-supplied filter runs — not composed into individual filter values —
+// so both call sites are sealed by construction: the archive list
+// (StorageService.listItems) never surfaces one, and the orphan pruner
+// (ArchivePruner.getOrphanArchives) never treats one as an orphaned archive
+// (it has its own lifecycle: session-archive purge). isWorkspaceID is
+// segment-based, so this is correct regardless of backend id shape — the
+// local backend's absolute container path or an S3 STORAGE_S3_SUB_DIR prefix.
 func (client *StorageClient) getItemIDsWithFilter(exclude filter) ([]string, error) {
 	items, err := client.backend.list(client.config.storage.getSubDir())
 	if err != nil {
@@ -154,6 +164,9 @@ func (client *StorageClient) getItemIDsWithFilter(exclude filter) ([]string, err
 
 	archiveIDList := make([]string, 0)
 	for _, item := range items {
+		if isWorkspaceID(item.id) {
+			continue
+		}
 		if exclude(item) {
 			continue
 		}

--- a/pkg/storagesvc/objectstore.go
+++ b/pkg/storagesvc/objectstore.go
@@ -21,6 +21,10 @@ type objectInfo struct {
 	// lastMod is the object's last-modified time, used by the archive pruner
 	// to skip recently created (not-yet-referenced) archives.
 	lastMod time.Time
+	// size is the object's byte size, used by the workspace list route
+	// (pkg/storagesvc/workspace.go) to report artifact sizes without an extra
+	// per-item stat call.
+	size int64
 }
 
 // objectStore is an internal abstraction over the two supported storage

--- a/pkg/storagesvc/objectstore_local.go
+++ b/pkg/storagesvc/objectstore_local.go
@@ -186,7 +186,7 @@ func (s *localObjectStore) list(prefix string) ([]objectInfo, error) {
 		if infoErr != nil {
 			return infoErr
 		}
-		infos = append(infos, objectInfo{id: path, lastMod: fi.ModTime()})
+		infos = append(infos, objectInfo{id: path, lastMod: fi.ModTime(), size: fi.Size()})
 		return nil
 	})
 	if err != nil {

--- a/pkg/storagesvc/objectstore_s3.go
+++ b/pkg/storagesvc/objectstore_s3.go
@@ -134,7 +134,7 @@ func (s *s3ObjectStore) list(prefix string) ([]objectInfo, error) {
 		if obj.Err != nil {
 			return nil, obj.Err
 		}
-		infos = append(infos, objectInfo{id: obj.Key, lastMod: obj.LastModified})
+		infos = append(infos, objectInfo{id: obj.Key, lastMod: obj.LastModified, size: obj.Size})
 	}
 	return infos, nil
 }

--- a/pkg/storagesvc/storagesvc.go
+++ b/pkg/storagesvc/storagesvc.go
@@ -234,6 +234,15 @@ func (ss *StorageService) deleteHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// A workspace object is never an archive, for ANY principal including
+	// master — see isWorkspaceID. Checked before authorizedFor because the
+	// legacy-id grandfather in authorizedFor would otherwise wave a
+	// _workspace_-marked id through as an unscoped legacy archive.
+	if isWorkspaceID(fileId) {
+		http.Error(w, "Error deleting item: not found", http.StatusNotFound)
+		return
+	}
+
 	// A namespace-scoped caller may only delete its own (or legacy) archives.
 	// 404, not 403, so it cannot probe whether another tenant's archive exists.
 	if !ss.authorizedFor(r, fileId) {
@@ -269,6 +278,15 @@ func (ss *StorageService) downloadHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	// A workspace object is never an archive, for ANY principal including
+	// master — see isWorkspaceID. Checked before authorizedFor because the
+	// legacy-id grandfather in authorizedFor would otherwise wave a
+	// _workspace_-marked id through as an unscoped legacy archive.
+	if isWorkspaceID(fileId) {
+		http.Error(w, "Error retrieving item: not found", http.StatusNotFound)
+		return
+	}
+
 	// A namespace-scoped caller may only download its own (or legacy) archives.
 	// 404, not 403, so it cannot probe whether another tenant's archive exists.
 	if !ss.authorizedFor(r, fileId) {
@@ -297,6 +315,15 @@ func (ss *StorageService) infoHandler(w http.ResponseWriter, r *http.Request) {
 	fileID, err := ss.getIdFromRequest(r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// A workspace object is never an archive, for ANY principal including
+	// master — see isWorkspaceID. Checked before authorizedFor because the
+	// legacy-id grandfather in authorizedFor would otherwise wave a
+	// _workspace_-marked id through as an unscoped legacy archive.
+	if isWorkspaceID(fileID) {
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 
@@ -390,6 +417,19 @@ func (ss *StorageService) makeHandler() http.Handler {
 	m.HandleFunc("/v1/archive", ss.deleteHandler).Methods("DELETE")
 	m.HandleFunc("/v1/archive", ss.infoHandler).Methods("HEAD")
 	m.HandleFunc("/healthz", ss.healthHandler).Methods("GET")
+
+	// Internal-only session artifact workspace API (see workspace.go): mounted
+	// on the SAME mux, so it inherits the HMAC verifier (when configured) and
+	// its spool machinery exactly like every archive route above — no separate
+	// wiring. It is additionally master-signer-only (workspace.go rejects a
+	// non-empty AuthenticatedNamespace itself, on every route) because
+	// agentruntime — not any tenant fetcher/builder — is the sole legitimate
+	// caller.
+	m.HandleFunc("/v1/workspace", ss.workspacePutHandler).Methods("PUT")
+	m.HandleFunc("/v1/workspace", ss.workspaceGetHandler).Methods("GET")
+	m.HandleFunc("/v1/workspace", ss.workspaceDeleteHandler).Methods("DELETE")
+	m.HandleFunc("/v1/workspace/list", ss.workspaceListHandler).Methods("GET")
+	m.HandleFunc("/v1/workspace/prefix", ss.workspaceDeletePrefixHandler).Methods("DELETE")
 
 	// Storagesvc is router/builder/function-pod internal per
 	// charts/fission-all/templates/storagesvc/networkpolicy.yaml.

--- a/pkg/storagesvc/workspace.go
+++ b/pkg/storagesvc/workspace.go
@@ -1,0 +1,476 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package storagesvc: this file implements the internal-only session artifact
+// workspace object API (G12/G18a) under the reserved workspaceMarker root.
+//
+// Unlike /v1/archive (server-minted UUID ids), a workspace object id is
+// CALLER-CHOSEN — "_workspace_/<namespace>/<agent>/<session>/<path...>" — which
+// is a path-traversal surface the archive API never had. Every route validates
+// the full id/prefix server-side (validateWorkspaceID / validateWorkspacePrefix)
+// before it ever reaches the objectStore backend; the local backend's os.Root
+// is defense in depth, not the primary guard (S3 has no such net).
+//
+// These routes build directly on the objectStore interface (put/open/size/
+// remove/list/exists) rather than StorageClient.putFile/getFile — putFile
+// takes a multipart.File and mints its own uuid id server-side, neither of
+// which fits a machine-to-machine raw-body PUT at a caller-chosen path. The
+// local backend's put() returns an ABSOLUTE container path as its id (kept for
+// archive in-place-upgrade compatibility); workspace handlers never use that
+// return value as the object's id — they key every subsequent GET/DELETE/LIST
+// on the REQUEST id (or, for list results, the id normalized back from
+// whatever the backend's list() returned — see normalizeWorkspaceID), so the
+// id space is uniform across both backends and matches what the caller PUT.
+//
+// Authorization: every route is master-signer-only — a request whose
+// hmacauth.AuthenticatedNamespace is non-empty (a tenant-scoped storage key,
+// e.g. a fetcher/builder sidecar's derived key) is rejected with 403.
+// agentruntime (holding the master-derived ServiceStoragesvc key) is the sole
+// legitimate caller; it is itself what authorizes the identity-bearer/JWT
+// caller against its own (namespace, agent) workspace one layer up
+// (pkg/agentruntime/workspace.go, a later slice of this feature) before
+// signing through here. This mirrors every archive route's posture: when
+// FISSION_INTERNAL_AUTH_SECRET is unset the HMAC verifier middleware is not
+// registered AT ALL (see makeHandler), so these routes are then as open as
+// every archive route already is — that is an accepted, pre-existing
+// dev/no-internal-auth trust posture (the same level as the pass-through
+// statesvc/agentruntime posture in that install shape), not a gap introduced
+// here; it is intentionally NOT special-cased into a workspace-only refusal
+// the archive routes don't also have.
+//
+// The archive routes and the archive/orphan-pruner candidate listing exclude
+// every workspace-marked id (see isWorkspaceID in authz.go and its call
+// sites) so a workspace object is never reachable through /v1/archive and
+// never pruned as an orphaned archive; workspace objects instead live and die
+// by their own lifecycle (a session record's archive triggers a prefix purge
+// — a later slice of this feature).
+package storagesvc
+
+import (
+	"encoding/json/v2"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	otelUtils "github.com/fission/fission/pkg/utils/otel"
+)
+
+const (
+	// maxWorkspaceSegmentBytes bounds any single path segment of a workspace
+	// id or prefix (namespace, agent, session, or a path component).
+	maxWorkspaceSegmentBytes = 128
+	// maxWorkspaceIDBytes bounds the full id/prefix string.
+	maxWorkspaceIDBytes = 1024
+)
+
+// workspaceSegmentCharset is the allowed charset for a non-marker workspace
+// path segment: RFC-1123-ish but permissive enough for a session-generated
+// filename (dots and underscores allowed mid-segment; a leading underscore is
+// rejected separately so a segment can never collide with a reserved marker).
+var workspaceSegmentCharset = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+
+// validateWorkspaceSegment validates a single path segment of a workspace
+// id/prefix (everything after the leading workspaceMarker segment): not
+// empty, not "." or "..", not leading with "_" (reserved for markers like
+// workspaceMarker/archiveTenantMarker), within the length bound, and drawn
+// from workspaceSegmentCharset.
+func validateWorkspaceSegment(s string) error {
+	switch {
+	case s == "":
+		return errors.New("workspace id contains an empty path segment")
+	case s == "." || s == "..":
+		return fmt.Errorf("workspace id contains an invalid path segment %q", s)
+	case strings.HasPrefix(s, "_"):
+		return fmt.Errorf("workspace id path segment %q must not start with '_'", s)
+	case len(s) > maxWorkspaceSegmentBytes:
+		return fmt.Errorf("workspace id path segment exceeds %d bytes", maxWorkspaceSegmentBytes)
+	case !workspaceSegmentCharset.MatchString(s):
+		return fmt.Errorf("workspace id path segment %q has invalid characters", s)
+	}
+	return nil
+}
+
+// validateWorkspaceID validates a full workspace object id:
+// "_workspace_/<namespace>/<agent>/<session>[/<path...>]". Segments are
+// checked literally (no path.Clean first) so a raw ".." segment anywhere —
+// including one crafted to walk back out of the workspace root entirely, e.g.
+// "_workspace_/ns/agent/sess/../../../_tenant_/x" — is rejected outright by
+// validateWorkspaceSegment before any cleaning could resolve it to something
+// that looks legitimate.
+func validateWorkspaceID(id string) error {
+	if len(id) > maxWorkspaceIDBytes {
+		return fmt.Errorf("workspace id exceeds %d bytes", maxWorkspaceIDBytes)
+	}
+	segs := strings.Split(id, "/")
+	if len(segs) == 0 || segs[0] != workspaceMarker {
+		return fmt.Errorf("workspace id must start with %q", workspaceMarker)
+	}
+	rest := segs[1:]
+	if len(rest) < 3 {
+		return errors.New("workspace id must include namespace/agent/session")
+	}
+	for _, s := range rest {
+		if err := validateWorkspaceSegment(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// canonicalWorkspacePrefix appends a trailing "/" if prefix doesn't already
+// end with one. Both backends' list() do a plain string-prefix match, so an
+// un-slashed prefix like "_workspace_/ns/agent/sess1" would also match a
+// sibling session named "sess12" — a cross-session bulk match/delete the
+// caller never named. validateWorkspacePrefix deliberately accepts the
+// un-slashed form (a caller-friendly convenience matching the plan's route
+// doc, which shows the prefix WITH a trailing slash); every handler must
+// canonicalize with this before calling backend.list so matching is always
+// segment-safe.
+func canonicalWorkspacePrefix(prefix string) string {
+	if strings.HasSuffix(prefix, "/") {
+		return prefix
+	}
+	return prefix + "/"
+}
+
+// validateWorkspacePrefix validates a workspace list/prefix-delete prefix:
+// "_workspace_/<namespace>/<agent>/<session>/" (a trailing slash is optional;
+// stripped before splitting). Same per-segment rules as validateWorkspaceID,
+// requiring at least the namespace/agent/session segments — a prefix may not
+// stop short at the namespace or agent level, which would otherwise let a
+// single prefix-delete reach every session of an agent (or every agent of a
+// namespace) at once. Callers MUST run the validated prefix through
+// canonicalWorkspacePrefix before using it for backend.list — see that
+// function's doc.
+func validateWorkspacePrefix(prefix string) error {
+	if len(prefix) > maxWorkspaceIDBytes {
+		return fmt.Errorf("workspace prefix exceeds %d bytes", maxWorkspaceIDBytes)
+	}
+	trimmed := strings.TrimSuffix(prefix, "/")
+	segs := strings.Split(trimmed, "/")
+	if len(segs) == 0 || segs[0] != workspaceMarker {
+		return fmt.Errorf("workspace prefix must start with %q", workspaceMarker)
+	}
+	rest := segs[1:]
+	if len(rest) < 3 {
+		return errors.New("workspace prefix must include namespace/agent/session")
+	}
+	for _, s := range rest {
+		if err := validateWorkspaceSegment(s); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// normalizeWorkspaceID converts a backend-native object id — for the local
+// backend an ABSOLUTE container path, for S3 already the bare key — from
+// objectStore.list back into the canonical request-style workspace id
+// ("_workspace_/..."), by locating the workspaceMarker segment and rejoining
+// from there. Same segment-based approach as archiveNamespace/isWorkspaceID,
+// so it needs no backend-specific knowledge (no container path threading into
+// this file). ok is false if the marker is not present as a segment — it
+// should always be, since callers only apply this to items already returned
+// by a list(prefix) call whose prefix itself starts with the marker.
+func normalizeWorkspaceID(nativeID string) (id string, ok bool) {
+	segs := strings.Split(filepath.ToSlash(nativeID), "/")
+	for i, s := range segs {
+		if s == workspaceMarker {
+			return strings.Join(segs[i:], "/"), true
+		}
+	}
+	return "", false
+}
+
+// rejectNamespaceScoped writes 403 and returns true if the request's
+// authenticated principal is namespace-scoped (a tenant-derived storagesvc
+// key). Every workspace route calls this first: agentruntime (holding the
+// master-derived key) is the sole legitimate caller, so a tenant fetcher/
+// builder key — which legitimately reaches /v1/archive — must never reach a
+// workspace object. An empty/absent principal (master, or the verifier not
+// registered at all) is unrestricted, matching every other handler's
+// AuthenticatedNamespace convention in this package.
+func rejectNamespaceScoped(w http.ResponseWriter, r *http.Request) bool {
+	if ns, _ := hmacauth.AuthenticatedNamespace(r.Context()); ns != "" {
+		http.Error(w, "workspace routes are master-signer-only", http.StatusForbidden)
+		return true
+	}
+	return false
+}
+
+func (ss *StorageService) getPrefixFromRequest(r *http.Request) (string, error) {
+	values := r.URL.Query()
+	prefixes, ok := values["prefix"]
+	if !ok || len(prefixes) == 0 {
+		return "", errors.New("missing `prefix' query param")
+	}
+	return prefixes[0], nil
+}
+
+type workspacePutResponse struct {
+	Size int64 `json:"size"`
+}
+
+type workspaceItem struct {
+	ID   string `json:"id"`
+	Size int64  `json:"size"`
+}
+
+type workspaceListResponse struct {
+	Items []workspaceItem `json:"items"`
+}
+
+type workspaceDeletePrefixResponse struct {
+	Deleted int `json:"deleted"`
+}
+
+// countingReader wraps an io.Reader and counts the bytes it yields, so the PUT
+// handler can report the actual number of bytes streamed to the backend
+// without a second stat() round-trip (and without trusting a caller-supplied
+// Content-Length, which S3 also receives but which the local backend ignores
+// entirely).
+type countingReader struct {
+	r io.Reader
+	n int64
+}
+
+func (c *countingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.n += int64(n)
+	return n, err
+}
+
+// workspacePutHandler handles PUT /v1/workspace?id=<id>: a raw-body,
+// streamed write. Unlike archive uploads (multipart, buffered) this is a
+// machine-to-machine hop — no multipart, no StorageClient.putFile (which
+// would mint its own id) — straight to the objectStore backend, keyed on the
+// caller's (validated) id.
+func (ss *StorageService) workspacePutHandler(w http.ResponseWriter, r *http.Request) {
+	logger := otelUtils.LoggerWithTraceID(r.Context(), ss.logger)
+
+	if rejectNamespaceScoped(w, r) {
+		return
+	}
+
+	id, err := ss.getIdFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateWorkspaceID(id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	body := r.Body
+	if body == nil {
+		body = http.NoBody
+	}
+	defer body.Close()
+
+	cr := &countingReader{r: body}
+	// The local backend ignores the size hint entirely; the S3 backend passes
+	// it through to minio's PutObject, which accepts -1 for an unknown-length
+	// streamed upload (chunked transfer, no Content-Length header) — so
+	// r.ContentLength (0, a real length, or -1) is always a valid hint here.
+	if _, err := ss.storageClient.backend.put(id, cr, r.ContentLength); err != nil {
+		logger.Error(err, "error writing workspace object", "id", id)
+		http.Error(w, "error writing workspace object", http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := json.Marshal(workspacePutResponse{Size: cr.n})
+	if err != nil {
+		logger.Error(err, "error marshaling workspace put response", "id", id)
+		http.Error(w, "error marshaling response", http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(resp); err != nil {
+		logger.Error(err, "error writing HTTP response", "id", id)
+	}
+}
+
+// workspaceGetHandler handles GET /v1/workspace?id=<id>: an io.Copy
+// passthrough stream with Content-Length set from a size() stat — no
+// multipart, no buffering.
+func (ss *StorageService) workspaceGetHandler(w http.ResponseWriter, r *http.Request) {
+	logger := otelUtils.LoggerWithTraceID(r.Context(), ss.logger)
+
+	if rejectNamespaceScoped(w, r) {
+		return
+	}
+
+	id, err := ss.getIdFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateWorkspaceID(id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	size, err := ss.storageClient.backend.size(id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		logger.Error(err, "error stat-ing workspace object", "id", id)
+		http.Error(w, "error retrieving workspace object", http.StatusInternalServerError)
+		return
+	}
+
+	f, err := ss.storageClient.backend.open(id)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		logger.Error(err, "error opening workspace object", "id", id)
+		http.Error(w, "error retrieving workspace object", http.StatusInternalServerError)
+		return
+	}
+	defer f.Close()
+
+	w.Header().Set("Content-Length", strconv.FormatInt(size, 10))
+	if _, err := io.Copy(w, f); err != nil {
+		logger.Error(err, "error streaming workspace object", "id", id)
+	}
+}
+
+// workspaceDeleteHandler handles DELETE /v1/workspace?id=<id>. Idempotent: a
+// missing object is a 200, not a 404 — the caller (agentruntime, and the
+// session-archive purge behind it) may retry or race a concurrent delete.
+func (ss *StorageService) workspaceDeleteHandler(w http.ResponseWriter, r *http.Request) {
+	logger := otelUtils.LoggerWithTraceID(r.Context(), ss.logger)
+
+	if rejectNamespaceScoped(w, r) {
+		return
+	}
+
+	id, err := ss.getIdFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateWorkspaceID(id); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if err := ss.storageClient.backend.remove(id); err != nil && !errors.Is(err, ErrNotFound) {
+		logger.Error(err, "error deleting workspace object", "id", id)
+		http.Error(w, "error deleting workspace object", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// workspaceListHandler handles GET /v1/workspace/list?prefix=<prefix>: every
+// object under prefix, with sizes, ids normalized back to the canonical
+// request-style form (see normalizeWorkspaceID).
+func (ss *StorageService) workspaceListHandler(w http.ResponseWriter, r *http.Request) {
+	logger := otelUtils.LoggerWithTraceID(r.Context(), ss.logger)
+
+	if rejectNamespaceScoped(w, r) {
+		return
+	}
+
+	prefix, err := ss.getPrefixFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateWorkspacePrefix(prefix); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	infos, err := ss.storageClient.backend.list(canonicalWorkspacePrefix(prefix))
+	if err != nil {
+		logger.Error(err, "error listing workspace objects", "prefix", prefix)
+		http.Error(w, "error listing workspace objects", http.StatusInternalServerError)
+		return
+	}
+
+	items := make([]workspaceItem, 0, len(infos))
+	for _, info := range infos {
+		id, ok := normalizeWorkspaceID(info.id)
+		if !ok {
+			// Cannot happen for an id this store itself returned from a
+			// prefix search whose prefix already starts with workspaceMarker;
+			// skip defensively rather than surface a native (backend-shaped)
+			// id to the caller.
+			logger.Error(nil, "workspace list item has no marker segment; skipping", "id", info.id)
+			continue
+		}
+		items = append(items, workspaceItem{ID: id, Size: info.size})
+	}
+
+	resp, err := json.Marshal(workspaceListResponse{Items: items})
+	if err != nil {
+		logger.Error(err, "error marshaling workspace list response", "prefix", prefix)
+		http.Error(w, "error marshaling response", http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(resp); err != nil {
+		logger.Error(err, "error writing HTTP response", "prefix", prefix)
+	}
+}
+
+// workspaceDeletePrefixHandler handles DELETE /v1/workspace/prefix?prefix=<prefix>:
+// idempotent bulk delete of every object under prefix — the session-archive
+// purge's primitive (a later slice of this feature). A per-item removal error
+// is logged and the item is not counted as deleted; it does not abort the
+// rest of the sweep (log-don't-retry, matching the purge's own stance).
+func (ss *StorageService) workspaceDeletePrefixHandler(w http.ResponseWriter, r *http.Request) {
+	logger := otelUtils.LoggerWithTraceID(r.Context(), ss.logger)
+
+	if rejectNamespaceScoped(w, r) {
+		return
+	}
+
+	prefix, err := ss.getPrefixFromRequest(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateWorkspacePrefix(prefix); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	infos, err := ss.storageClient.backend.list(canonicalWorkspacePrefix(prefix))
+	if err != nil {
+		logger.Error(err, "error listing workspace objects for prefix delete", "prefix", prefix)
+		http.Error(w, "error deleting workspace objects", http.StatusInternalServerError)
+		return
+	}
+
+	deleted := 0
+	for _, info := range infos {
+		if err := ss.storageClient.backend.remove(info.id); err != nil && !errors.Is(err, ErrNotFound) {
+			logger.Error(err, "error deleting workspace object during prefix delete", "id", info.id)
+			continue
+		}
+		deleted++
+	}
+
+	resp, err := json.Marshal(workspaceDeletePrefixResponse{Deleted: deleted})
+	if err != nil {
+		logger.Error(err, "error marshaling workspace prefix delete response", "prefix", prefix)
+		http.Error(w, "error marshaling response", http.StatusInternalServerError)
+		return
+	}
+	if _, err := w.Write(resp); err != nil {
+		logger.Error(err, "error writing HTTP response", "prefix", prefix)
+	}
+}

--- a/pkg/storagesvc/workspace.go
+++ b/pkg/storagesvc/workspace.go
@@ -53,6 +53,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -189,6 +190,42 @@ func normalizeWorkspaceID(nativeID string) (id string, ok bool) {
 	return "", false
 }
 
+// workspaceBackendKey translates a wire-shape workspace id/prefix (already
+// validated by validateWorkspaceID/validateWorkspacePrefix) into the actual
+// objectStore key: the same STORAGE_S3_SUB_DIR the archive path folds in via
+// Storage.getUploadFileName (s3storage.go: path.Join(ss.subDir, ...)) — the
+// mechanism an operator uses to let several Fission installs (or several
+// environments) share one S3 bucket without colliding. Every workspace
+// backend call (put/open/size/remove/list/prefix-delete) MUST go through this
+// — skipping it writes/reads at the bucket root, outside the operator's
+// install-isolation prefix, so two installs sharing a bucket could collide on
+// an identical namespace/agent/session name.
+//
+// The local backend's getSubDir() always returns "" (mirroring
+// localStorage.getUploadFileName, which never joins a subDir either), so
+// path.Join is then a no-op and every existing local-backend id/behavior —
+// including every test in this package — is unchanged.
+//
+// This is purely a storage-layout detail: the wire id/prefix shape callers
+// see (PUT/GET/DELETE query params, list response ids via normalizeWorkspaceID,
+// which is already prefix-agnostic and needs no change) never carries the
+// subDir. isWorkspaceID/normalizeWorkspaceID already tolerate an arbitrary
+// prefix in front of the marker, so this introduces no new sealing/pruner gap.
+func (ss *StorageService) workspaceBackendKey(wireID string) string {
+	key := path.Join(ss.storageClient.config.storage.getSubDir(), wireID)
+	// path.Join runs path.Clean, which strips a trailing "/" — load-bearing
+	// for a canonicalWorkspacePrefix'd prefix (list/prefix-delete): losing it
+	// here would reopen the exact sess1-vs-sess12 string-prefix bleed
+	// canonicalWorkspacePrefix exists to close, only now via the subDir join
+	// instead of a missing trailing slash. Restore it whenever the input had
+	// one; plain object ids (put/get/delete) never end in "/", so this is a
+	// no-op for them.
+	if strings.HasSuffix(wireID, "/") && !strings.HasSuffix(key, "/") {
+		key += "/"
+	}
+	return key
+}
+
 // rejectNamespaceScoped writes 403 and returns true if the request's
 // authenticated principal is namespace-scoped (a tenant-derived storagesvc
 // key). Every workspace route calls this first: agentruntime (holding the
@@ -280,7 +317,7 @@ func (ss *StorageService) workspacePutHandler(w http.ResponseWriter, r *http.Req
 	// it through to minio's PutObject, which accepts -1 for an unknown-length
 	// streamed upload (chunked transfer, no Content-Length header) — so
 	// r.ContentLength (0, a real length, or -1) is always a valid hint here.
-	if _, err := ss.storageClient.backend.put(id, cr, r.ContentLength); err != nil {
+	if _, err := ss.storageClient.backend.put(ss.workspaceBackendKey(id), cr, r.ContentLength); err != nil {
 		logger.Error(err, "error writing workspace object", "id", id)
 		http.Error(w, "error writing workspace object", http.StatusInternalServerError)
 		return
@@ -317,7 +354,7 @@ func (ss *StorageService) workspaceGetHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	size, err := ss.storageClient.backend.size(id)
+	size, err := ss.storageClient.backend.size(ss.workspaceBackendKey(id))
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -328,7 +365,7 @@ func (ss *StorageService) workspaceGetHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	f, err := ss.storageClient.backend.open(id)
+	f, err := ss.storageClient.backend.open(ss.workspaceBackendKey(id))
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			http.Error(w, "not found", http.StatusNotFound)
@@ -366,7 +403,7 @@ func (ss *StorageService) workspaceDeleteHandler(w http.ResponseWriter, r *http.
 		return
 	}
 
-	if err := ss.storageClient.backend.remove(id); err != nil && !errors.Is(err, ErrNotFound) {
+	if err := ss.storageClient.backend.remove(ss.workspaceBackendKey(id)); err != nil && !errors.Is(err, ErrNotFound) {
 		logger.Error(err, "error deleting workspace object", "id", id)
 		http.Error(w, "error deleting workspace object", http.StatusInternalServerError)
 		return
@@ -394,7 +431,7 @@ func (ss *StorageService) workspaceListHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	infos, err := ss.storageClient.backend.list(canonicalWorkspacePrefix(prefix))
+	infos, err := ss.storageClient.backend.list(ss.workspaceBackendKey(canonicalWorkspacePrefix(prefix)))
 	if err != nil {
 		logger.Error(err, "error listing workspace objects", "prefix", prefix)
 		http.Error(w, "error listing workspace objects", http.StatusInternalServerError)
@@ -430,7 +467,10 @@ func (ss *StorageService) workspaceListHandler(w http.ResponseWriter, r *http.Re
 // idempotent bulk delete of every object under prefix — the session-archive
 // purge's primitive (a later slice of this feature). A per-item removal error
 // is logged and the item is not counted as deleted; it does not abort the
-// rest of the sweep (log-don't-retry, matching the purge's own stance).
+// rest of the sweep (log-don't-retry, matching the purge's own stance). This
+// means `deleted == N` is NOT a guarantee that every matched object was
+// removed — a caller that needs "fully cleared" must not infer it from the
+// count; log-don't-retry accepts silently-undercounted residue by design.
 func (ss *StorageService) workspaceDeletePrefixHandler(w http.ResponseWriter, r *http.Request) {
 	logger := otelUtils.LoggerWithTraceID(r.Context(), ss.logger)
 
@@ -448,7 +488,7 @@ func (ss *StorageService) workspaceDeletePrefixHandler(w http.ResponseWriter, r 
 		return
 	}
 
-	infos, err := ss.storageClient.backend.list(canonicalWorkspacePrefix(prefix))
+	infos, err := ss.storageClient.backend.list(ss.workspaceBackendKey(canonicalWorkspacePrefix(prefix)))
 	if err != nil {
 		logger.Error(err, "error listing workspace objects for prefix delete", "prefix", prefix)
 		http.Error(w, "error deleting workspace objects", http.StatusInternalServerError)

--- a/pkg/storagesvc/workspace_test.go
+++ b/pkg/storagesvc/workspace_test.go
@@ -570,3 +570,95 @@ func TestArchivePrunerExcludesWorkspaceRoot(t *testing.T) {
 	}
 	assert.Contains(t, collected, orphanNativeID, "a plain orphan archive in the same cycle must still be pruned")
 }
+
+// fakeSubDirStorage is a minimal Storage stand-in that reports a configured
+// STORAGE_S3_SUB_DIR-shaped subDir, for pinning workspaceBackendKey's
+// subDir-join without needing a real S3/dockertest backend.
+type fakeSubDirStorage struct{ subDir string }
+
+func (f fakeSubDirStorage) getStorageType() StorageType                { return StorageTypeS3 }
+func (f fakeSubDirStorage) dial() (objectStore, error)                 { return nil, nil }
+func (f fakeSubDirStorage) getSubDir() string                          { return f.subDir }
+func (f fakeSubDirStorage) getContainerName() string                   { return "bucket" }
+func (f fakeSubDirStorage) getUploadFileName(_ string) (string, error) { return "", nil }
+
+// recordingObjectStore is a minimal objectStore stand-in that records the
+// keys/prefixes it is called with, so a test can assert on exactly what key
+// shape reaches the "backend" without a real S3 endpoint.
+type recordingObjectStore struct {
+	putKeys      []string
+	listPrefixes []string
+	items        []objectInfo
+}
+
+func (r *recordingObjectStore) put(name string, rd io.Reader, _ int64) (string, error) {
+	r.putKeys = append(r.putKeys, name)
+	if _, err := io.Copy(io.Discard, rd); err != nil {
+		return "", err
+	}
+	return name, nil
+}
+func (r *recordingObjectStore) open(string) (io.ReadCloser, error) {
+	return io.NopCloser(strings.NewReader("")), nil
+}
+func (r *recordingObjectStore) size(string) (int64, error) { return 0, nil }
+func (r *recordingObjectStore) remove(string) error        { return nil }
+func (r *recordingObjectStore) list(prefix string) ([]objectInfo, error) {
+	r.listPrefixes = append(r.listPrefixes, prefix)
+	return r.items, nil
+}
+func (r *recordingObjectStore) exists(string) (bool, error) { return true, nil }
+
+// TestWorkspaceBackendKeyJoinsStorageSubDir pins the fix for the S3 subDir
+// bypass finding: on a backend configured with STORAGE_S3_SUB_DIR, workspace
+// put/list must fold that subDir into the actual backend key/prefix exactly
+// as the archive path does via Storage.getUploadFileName — while the WIRE id
+// (the PUT/GET/DELETE query param and every list response id) stays exactly
+// the caller-chosen "_workspace_/..." shape, unaware that a subDir exists at
+// all. No real S3/dockertest is needed: a fake objectStore records the keys
+// it was actually called with.
+func TestWorkspaceBackendKeyJoinsStorageSubDir(t *testing.T) {
+	fakeBackend := &recordingObjectStore{}
+	sc := &StorageClient{
+		logger:  logr.Discard(),
+		config:  &storageConfig{storage: fakeSubDirStorage{subDir: "some/prefix"}},
+		backend: fakeBackend,
+	}
+	ss := MakeStorageService(logr.Discard(), sc, nil, nil, 0)
+
+	wireID := "_workspace_/team-a/agentX/sess1/artifact.txt"
+	putTarget := "/v1/workspace?id=" + url.QueryEscape(wireID)
+	putReq := httptest.NewRequest(http.MethodPut, putTarget, strings.NewReader("hello"))
+	rrPut := httptest.NewRecorder()
+	ss.workspacePutHandler(rrPut, putReq)
+	require.Equal(t, http.StatusOK, rrPut.Code, rrPut.Body.String())
+	require.Len(t, fakeBackend.putKeys, 1)
+	assert.Equal(t, "some/prefix/"+wireID, fakeBackend.putKeys[0],
+		"backend key must fold in STORAGE_S3_SUB_DIR the same way the archive path's getUploadFileName does")
+
+	// The PUT response reports only the byte size — the wire id never
+	// appears in it, so there is nothing there for subDir to leak into.
+	var putResp workspacePutResponse
+	require.NoError(t, json.Unmarshal(rrPut.Body.Bytes(), &putResp))
+	assert.Equal(t, int64(len("hello")), putResp.Size)
+
+	// list: the prefix reaching backend.list must ALSO be subDir-joined (with
+	// the trailing "/" preserved — see workspaceBackendKey), but results must
+	// normalize back to the caller's un-joined wire id.
+	wirePrefix := "_workspace_/team-a/agentX/sess1/"
+	fakeBackend.items = []objectInfo{{id: "some/prefix/" + wireID, size: 5}}
+	listTarget := "/v1/workspace/list?prefix=" + url.QueryEscape(wirePrefix)
+	listReq := httptest.NewRequest(http.MethodGet, listTarget, nil)
+	rrList := httptest.NewRecorder()
+	ss.workspaceListHandler(rrList, listReq)
+	require.Equal(t, http.StatusOK, rrList.Code, rrList.Body.String())
+	require.Len(t, fakeBackend.listPrefixes, 1)
+	assert.Equal(t, "some/prefix/"+wirePrefix, fakeBackend.listPrefixes[0],
+		"list prefix must be subDir-joined with the trailing slash preserved")
+
+	var listResp workspaceListResponse
+	require.NoError(t, json.Unmarshal(rrList.Body.Bytes(), &listResp))
+	require.Len(t, listResp.Items, 1)
+	assert.Equal(t, wireID, listResp.Items[0].ID,
+		"the wire id in the list response must be unchanged — subDir is a storage-layout detail invisible to callers")
+}

--- a/pkg/storagesvc/workspace_test.go
+++ b/pkg/storagesvc/workspace_test.go
@@ -1,0 +1,572 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package storagesvc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	hmacauth "github.com/fission/fission/pkg/auth/hmac"
+	fClient "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	"github.com/fission/fission/pkg/utils/httpmux"
+)
+
+// newWorkspaceTestServer builds the workspace + archive routes on a mux
+// wrapped with the real namespace-scoped HMAC verifier (mirroring
+// TestArchiveAuthzHandlers), with a small, test-controlled spoolThreshold so
+// callers can exercise both the in-memory and spooled verifier body paths
+// without writing multi-megabyte payloads.
+func newWorkspaceTestServer(t *testing.T, spoolThreshold int64) (r http.Handler, sc *StorageClient, storage Storage, master []byte, now time.Time) {
+	t.Helper()
+	master = []byte("storagesvc-test-master-key-long-enough")
+	now = time.Unix(1715000123, 0)
+
+	storage = NewLocalStorage(t.TempDir())
+	sc, err := MakeStorageClient(logr.Discard(), storage)
+	require.NoError(t, err)
+	ss := MakeStorageService(logr.Discard(), sc, master, nil, 0)
+
+	m := httpmux.New(httpmux.WithMiddleware(hmacauth.ServiceVerifierNamespaceFromHeader(master, nil, hmacauth.ServiceStoragesvc,
+		hmacauth.VerifierOpts{SkewSec: 60, Now: func() time.Time { return now }, SpoolThresholdBytes: spoolThreshold})))
+	m.HandleFunc("/v1/archive", ss.getOrListHandler).Methods(http.MethodGet)
+	m.HandleFunc("/v1/archive", ss.deleteHandler).Methods(http.MethodDelete)
+	m.HandleFunc("/v1/archive", ss.infoHandler).Methods(http.MethodHead)
+	m.HandleFunc("/v1/workspace", ss.workspacePutHandler).Methods(http.MethodPut)
+	m.HandleFunc("/v1/workspace", ss.workspaceGetHandler).Methods(http.MethodGet)
+	m.HandleFunc("/v1/workspace", ss.workspaceDeleteHandler).Methods(http.MethodDelete)
+	m.HandleFunc("/v1/workspace/list", ss.workspaceListHandler).Methods(http.MethodGet)
+	m.HandleFunc("/v1/workspace/prefix", ss.workspaceDeletePrefixHandler).Methods(http.MethodDelete)
+	return m.Handler(), sc, storage, master, now
+}
+
+// signedWorkspaceRequest builds a raw-body request signed with key, optionally
+// carrying the X-Fission-Auth-Namespace header (nsHeader == "" omits it).
+func signedWorkspaceRequest(t *testing.T, method, target string, body []byte, key []byte, ts int64, nsHeader string) *http.Request {
+	t.Helper()
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = bytes.NewReader(body)
+	}
+	req := httptest.NewRequest(method, target, reqBody)
+	sig := hmacauth.Sign(key, method, req.URL.RequestURI(), body, ts)
+	req.Header.Set(hmacauth.HeaderTimestamp, strconv.FormatInt(ts, 10))
+	req.Header.Set(hmacauth.HeaderSignature, sig)
+	if nsHeader != "" {
+		req.Header.Set(hmacauth.HeaderNamespace, nsHeader)
+	}
+	return req
+}
+
+// TestValidateWorkspaceID covers the per-segment validation table: dot/dotdot,
+// empty, leading underscore, overlong segment/total, bad charset, missing
+// marker, too few segments, and the crafted traversal id from the plan
+// ("_workspace_/ns/agent/sess/../../../_tenant_/x") that must be rejected
+// outright (a literal ".." segment) rather than resolved via path.Clean.
+func TestValidateWorkspaceID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"valid minimal (no path)", "_workspace_/team-a/agentX/sess1", false},
+		{"valid with nested path", "_workspace_/team-a/agentX/sess1/dir/artifact.txt", false},
+		{"missing marker", "team-a/agentX/sess1/artifact.txt", true},
+		{"too few segments", "_workspace_/team-a/agentX", true},
+		{"dot segment", "_workspace_/team-a/./sess1/x", true},
+		{"dotdot segment", "_workspace_/team-a/agentX/../sess1/x", true},
+		{"empty segment", "_workspace_/team-a//sess1/x", true},
+		{"leading underscore segment", "_workspace_/team-a/agentX/_sess1/x", true},
+		{"bad charset", "_workspace_/team-a/agentX/sess1/art@fact.txt", true},
+		{"overlong segment", "_workspace_/" + strings.Repeat("a", 129) + "/agentX/sess1/x", true},
+		{"overlong total", "_workspace_/team-a/agentX/sess1/" + strings.Repeat("a", 1100), true},
+		{"crafted traversal escaping the marker", "_workspace_/ns/agent/sess/../../../_tenant_/x", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWorkspaceID(tc.id)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateWorkspacePrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"valid with trailing slash", "_workspace_/team-a/agentX/sess1/", false},
+		{"valid without trailing slash", "_workspace_/team-a/agentX/sess1", false},
+		{"valid deeper than session", "_workspace_/team-a/agentX/sess1/nested/", false},
+		{"missing marker", "team-a/agentX/sess1/", true},
+		{"too few segments (agent-wide)", "_workspace_/team-a/agentX/", true},
+		{"too few segments (namespace-wide)", "_workspace_/team-a/", true},
+		{"dotdot segment", "_workspace_/team-a/agentX/../sess1/", true},
+		{"overlong", "_workspace_/team-a/agentX/" + strings.Repeat("a", 1100), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateWorkspacePrefix(tc.prefix)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCanonicalWorkspacePrefix(t *testing.T) {
+	assert.Equal(t, "_workspace_/ns/agent/sess1/", canonicalWorkspacePrefix("_workspace_/ns/agent/sess1"))
+	assert.Equal(t, "_workspace_/ns/agent/sess1/", canonicalWorkspacePrefix("_workspace_/ns/agent/sess1/"))
+}
+
+// TestIsWorkspaceID locks the segment-based detection used to seal the
+// archive routes and the pruner candidate list: it must find the marker
+// regardless of what backend-specific prefix precedes it (a local absolute
+// container path, an S3 STORAGE_S3_SUB_DIR prefix) and regardless of a
+// traversal that resolves back onto the marker after path.Clean.
+func TestIsWorkspaceID(t *testing.T) {
+	assert.True(t, isWorkspaceID("_workspace_/ns/agent/sess/x"))
+	assert.True(t, isWorkspaceID("/data/fission-functions/_workspace_/ns/agent/sess/x"), "local absolute container path")
+	assert.True(t, isWorkspaceID("sub/dir/_workspace_/ns/agent/sess/x"), "s3 subDir-prefixed key")
+	assert.True(t, isWorkspaceID("_workspace_/ns/agent/sess/../../../_tenant_/x"), "resolves onto the marker after cleaning")
+	assert.False(t, isWorkspaceID("550e8400-e29b-41d4-a716-446655440000"))
+	assert.False(t, isWorkspaceID(archiveTenantMarker+"/team-a/550e8400-e29b-41d4-a716-446655440000"))
+}
+
+func TestNormalizeWorkspaceID(t *testing.T) {
+	id, ok := normalizeWorkspaceID("/data/fission-functions/_workspace_/ns/agent/sess/x")
+	require.True(t, ok)
+	assert.Equal(t, "_workspace_/ns/agent/sess/x", id)
+
+	id, ok = normalizeWorkspaceID("_workspace_/ns/agent/sess/x")
+	require.True(t, ok)
+	assert.Equal(t, "_workspace_/ns/agent/sess/x", id)
+
+	_, ok = normalizeWorkspaceID("550e8400-e29b-41d4-a716-446655440000")
+	assert.False(t, ok)
+}
+
+// TestWorkspacePutGetRoundTrip exercises a byte round-trip for a small
+// (in-memory verifier path) and a >spool-threshold (spooled verifier path)
+// body, checking both the PUT response's reported size and the GET's
+// Content-Length + body bytes.
+func TestWorkspacePutGetRoundTrip(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 16) // small threshold to force spooling for the large case
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+	id := "_workspace_/team-a/agentX/sess1/artifact.txt"
+	target := "/v1/workspace?id=" + url.QueryEscape(id)
+
+	cases := []struct {
+		name    string
+		payload []byte
+	}{
+		{"small in-memory body", []byte("hello")},
+		{"large spooled body", bytes.Repeat([]byte("x"), 64)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			putReq := signedWorkspaceRequest(t, http.MethodPut, target, tc.payload, keyMaster, now.Unix(), "")
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, putReq)
+			require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+			var putResp workspacePutResponse
+			require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &putResp))
+			assert.Equal(t, int64(len(tc.payload)), putResp.Size)
+
+			getReq := signedWorkspaceRequest(t, http.MethodGet, target, nil, keyMaster, now.Unix(), "")
+			rr2 := httptest.NewRecorder()
+			r.ServeHTTP(rr2, getReq)
+			require.Equal(t, http.StatusOK, rr2.Code)
+			assert.Equal(t, tc.payload, rr2.Body.Bytes())
+			assert.Equal(t, strconv.Itoa(len(tc.payload)), rr2.Header().Get("Content-Length"))
+		})
+	}
+}
+
+func TestWorkspaceGetMissingIsNotFound(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 0)
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+	target := "/v1/workspace?id=" + url.QueryEscape("_workspace_/team-a/agentX/sess1/never-put.txt")
+	req := signedWorkspaceRequest(t, http.MethodGet, target, nil, keyMaster, now.Unix(), "")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// TestWorkspaceDeleteIdempotent verifies a second DELETE of an already-deleted
+// (or never-existing) object still returns 200 — the purge callers (a later
+// slice of this feature) may race or retry.
+func TestWorkspaceDeleteIdempotent(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 0)
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+	target := "/v1/workspace?id=" + url.QueryEscape("_workspace_/team-a/agentX/sess1/gone.txt")
+
+	put := signedWorkspaceRequest(t, http.MethodPut, target, []byte("bye"), keyMaster, now.Unix(), "")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, put)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	for i := range 2 {
+		del := signedWorkspaceRequest(t, http.MethodDelete, target, nil, keyMaster, now.Unix(), "")
+		rrDel := httptest.NewRecorder()
+		r.ServeHTTP(rrDel, del)
+		assert.Equal(t, http.StatusOK, rrDel.Code, "delete #%d must be idempotent", i+1)
+	}
+
+	get := signedWorkspaceRequest(t, http.MethodGet, target, nil, keyMaster, now.Unix(), "")
+	rrGet := httptest.NewRecorder()
+	r.ServeHTTP(rrGet, get)
+	assert.Equal(t, http.StatusNotFound, rrGet.Code)
+}
+
+// TestWorkspaceHTTPPathTraversalRejected exercises validateWorkspaceID's
+// rejection through the actual PUT handler, including the crafted
+// `?id=_workspace_/ns/agent/sess/../../../_tenant_/x` case from the plan.
+func TestWorkspaceHTTPPathTraversalRejected(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 0)
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+
+	ids := []string{
+		"_workspace_/ns/agent/sess/../../../_tenant_/x",
+		"_workspace_/ns/agent/sess/..",
+		"_workspace_/ns/agent/sess/.",
+		"_workspace_/ns/agent/sess/_hidden",
+		"_workspace_/ns/agent",
+	}
+	for _, id := range ids {
+		t.Run(id, func(t *testing.T) {
+			target := "/v1/workspace?id=" + url.QueryEscape(id)
+			put := signedWorkspaceRequest(t, http.MethodPut, target, []byte("x"), keyMaster, now.Unix(), "")
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, put)
+			assert.Equal(t, http.StatusBadRequest, rr.Code)
+		})
+	}
+}
+
+// TestWorkspacePrefixListAndDelete seeds two objects under one session and one
+// under a sibling session, verifies list returns exactly the session's items
+// WITH sizes, then verifies prefix-delete removes exactly those two,
+// idempotently (a second delete reports 0), leaving the sibling session
+// untouched.
+func TestWorkspacePrefixListAndDelete(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 0)
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+
+	put := func(id string, payload []byte) {
+		t.Helper()
+		target := "/v1/workspace?id=" + url.QueryEscape(id)
+		req := signedWorkspaceRequest(t, http.MethodPut, target, payload, keyMaster, now.Unix(), "")
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	sessPrefix := "_workspace_/team-a/agentX/sess1/"
+	put(sessPrefix+"a.txt", []byte("aaa"))
+	put(sessPrefix+"nested/b.txt", []byte("bb"))
+	otherSession := "_workspace_/team-a/agentX/sess2/c.txt"
+	put(otherSession, []byte("cccc"))
+
+	listTarget := "/v1/workspace/list?prefix=" + url.QueryEscape(sessPrefix)
+	listReq := signedWorkspaceRequest(t, http.MethodGet, listTarget, nil, keyMaster, now.Unix(), "")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, listReq)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var listResp workspaceListResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &listResp))
+	require.Len(t, listResp.Items, 2)
+	byID := map[string]int64{}
+	for _, it := range listResp.Items {
+		byID[it.ID] = it.Size
+	}
+	assert.Equal(t, int64(3), byID[sessPrefix+"a.txt"])
+	assert.Equal(t, int64(2), byID[sessPrefix+"nested/b.txt"])
+	assert.NotContains(t, byID, otherSession)
+
+	delTarget := "/v1/workspace/prefix?prefix=" + url.QueryEscape(sessPrefix)
+	delReq := signedWorkspaceRequest(t, http.MethodDelete, delTarget, nil, keyMaster, now.Unix(), "")
+	rrDel := httptest.NewRecorder()
+	r.ServeHTTP(rrDel, delReq)
+	require.Equal(t, http.StatusOK, rrDel.Code)
+	var delResp workspaceDeletePrefixResponse
+	require.NoError(t, json.Unmarshal(rrDel.Body.Bytes(), &delResp))
+	assert.Equal(t, 2, delResp.Deleted)
+
+	delReq2 := signedWorkspaceRequest(t, http.MethodDelete, delTarget, nil, keyMaster, now.Unix(), "")
+	rrDel2 := httptest.NewRecorder()
+	r.ServeHTTP(rrDel2, delReq2)
+	require.Equal(t, http.StatusOK, rrDel2.Code)
+	var delResp2 workspaceDeletePrefixResponse
+	require.NoError(t, json.Unmarshal(rrDel2.Body.Bytes(), &delResp2))
+	assert.Equal(t, 0, delResp2.Deleted, "prefix delete must be idempotent")
+
+	getOther := signedWorkspaceRequest(t, http.MethodGet, "/v1/workspace?id="+url.QueryEscape(otherSession), nil, keyMaster, now.Unix(), "")
+	rrOther := httptest.NewRecorder()
+	r.ServeHTTP(rrOther, getOther)
+	assert.Equal(t, http.StatusOK, rrOther.Code, "sibling session must be untouched")
+}
+
+// TestWorkspacePrefixDeleteDoesNotBleedIntoSiblingSessionByName is the
+// boundary regression for canonicalWorkspacePrefix: a session name that is a
+// literal string-prefix of another ("sess1" vs "sess12") must NOT let an
+// un-slashed prefix-delete/list of the former reach the latter. Without
+// canonicalizing to a trailing "/" before backend.list, plain string-prefix
+// matching would treat "sess1" as a prefix of "sess12/...".
+func TestWorkspacePrefixDeleteDoesNotBleedIntoSiblingSessionByName(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 0)
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+
+	put := func(id string, payload []byte) {
+		t.Helper()
+		target := "/v1/workspace?id=" + url.QueryEscape(id)
+		req := signedWorkspaceRequest(t, http.MethodPut, target, payload, keyMaster, now.Unix(), "")
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		require.Equal(t, http.StatusOK, rr.Code)
+	}
+
+	victimID := "_workspace_/team-a/agentX/sess1/a.txt"
+	siblingID := "_workspace_/team-a/agentX/sess12/b.txt"
+	put(victimID, []byte("victim"))
+	put(siblingID, []byte("sibling"))
+
+	// A caller-supplied prefix WITHOUT a trailing slash — validateWorkspacePrefix
+	// accepts this form (see TestValidateWorkspacePrefix); the handler must
+	// still canonicalize it before matching.
+	noSlashPrefix := "_workspace_/team-a/agentX/sess1"
+
+	listTarget := "/v1/workspace/list?prefix=" + url.QueryEscape(noSlashPrefix)
+	listReq := signedWorkspaceRequest(t, http.MethodGet, listTarget, nil, keyMaster, now.Unix(), "")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, listReq)
+	require.Equal(t, http.StatusOK, rr.Code)
+	var listResp workspaceListResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &listResp))
+	ids := make([]string, 0, len(listResp.Items))
+	for _, it := range listResp.Items {
+		ids = append(ids, it.ID)
+	}
+	assert.Contains(t, ids, victimID)
+	assert.NotContains(t, ids, siblingID, "list(%q) must not bleed into sibling session sess12", noSlashPrefix)
+
+	delTarget := "/v1/workspace/prefix?prefix=" + url.QueryEscape(noSlashPrefix)
+	delReq := signedWorkspaceRequest(t, http.MethodDelete, delTarget, nil, keyMaster, now.Unix(), "")
+	rrDel := httptest.NewRecorder()
+	r.ServeHTTP(rrDel, delReq)
+	require.Equal(t, http.StatusOK, rrDel.Code)
+	var delResp workspaceDeletePrefixResponse
+	require.NoError(t, json.Unmarshal(rrDel.Body.Bytes(), &delResp))
+	assert.Equal(t, 1, delResp.Deleted, "only sess1's own object must be deleted")
+
+	getSibling := signedWorkspaceRequest(t, http.MethodGet, "/v1/workspace?id="+url.QueryEscape(siblingID), nil, keyMaster, now.Unix(), "")
+	rrSibling := httptest.NewRecorder()
+	r.ServeHTTP(rrSibling, getSibling)
+	assert.Equal(t, http.StatusOK, rrSibling.Code, "sess12's object must survive a sess1 prefix delete")
+}
+
+// TestWorkspaceRoutesThroughProductionWiring exercises makeHandler() itself
+// (not the hand-built test mux every other test in this file uses), so a
+// wiring mistake in the m.HandleFunc registrations — wrong path, wrong
+// method — is caught even though it wouldn't affect any other test here.
+func TestWorkspaceRoutesThroughProductionWiring(t *testing.T) {
+	master := []byte("storagesvc-test-master-key-long-enough")
+	storage := NewLocalStorage(t.TempDir())
+	sc, err := MakeStorageClient(logr.Discard(), storage)
+	require.NoError(t, err)
+	ss := MakeStorageService(logr.Discard(), sc, master, nil, 0)
+	handler := ss.makeHandler()
+
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+	id := "_workspace_/team-a/agentX/sess1/wired.txt"
+	target := "/v1/workspace?id=" + url.QueryEscape(id)
+	payload := []byte("production wiring check")
+	ts := time.Now().Unix()
+
+	putReq := signedWorkspaceRequest(t, http.MethodPut, target, payload, keyMaster, ts, "")
+	rrPut := httptest.NewRecorder()
+	handler.ServeHTTP(rrPut, putReq)
+	require.Equal(t, http.StatusOK, rrPut.Code, rrPut.Body.String())
+
+	getReq := signedWorkspaceRequest(t, http.MethodGet, target, nil, keyMaster, ts, "")
+	rrGet := httptest.NewRecorder()
+	handler.ServeHTTP(rrGet, getReq)
+	require.Equal(t, http.StatusOK, rrGet.Code)
+	assert.Equal(t, payload, rrGet.Body.Bytes())
+}
+
+// TestWorkspaceRejectsNamespaceScopedSigner verifies every workspace route
+// 403s a request authenticated as a namespace-scoped (tenant) principal —
+// agentruntime, holding the master-derived key, is the sole legitimate
+// caller.
+func TestWorkspaceRejectsNamespaceScopedSigner(t *testing.T) {
+	r, _, _, master, now := newWorkspaceTestServer(t, 0)
+	keyTenant := hmacauth.DeriveServiceKeyNS(master, hmacauth.ServiceStoragesvc, "team-a")
+
+	idTarget := "/v1/workspace?id=" + url.QueryEscape("_workspace_/team-a/agentX/sess1/x.txt")
+	listTarget := "/v1/workspace/list?prefix=" + url.QueryEscape("_workspace_/team-a/agentX/sess1/")
+	prefixTarget := "/v1/workspace/prefix?prefix=" + url.QueryEscape("_workspace_/team-a/agentX/sess1/")
+
+	cases := []struct {
+		name, method, target string
+		body                 []byte
+	}{
+		{"put", http.MethodPut, idTarget, []byte("x")},
+		{"get", http.MethodGet, idTarget, nil},
+		{"delete", http.MethodDelete, idTarget, nil},
+		{"list", http.MethodGet, listTarget, nil},
+		{"prefix delete", http.MethodDelete, prefixTarget, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := signedWorkspaceRequest(t, tc.method, tc.target, tc.body, keyTenant, now.Unix(), "team-a")
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+			assert.Equal(t, http.StatusForbidden, rr.Code)
+		})
+	}
+}
+
+// TestArchiveRoutesSealWorkspaceIDs is blocker 2's regression test: a
+// workspace object planted directly in storage must be unreachable through
+// every archive route (GET/HEAD/DELETE), for BOTH the master and a
+// tenant-scoped signer, and must never appear in the archive list — while a
+// genuine legacy archive is unaffected by any of this.
+func TestArchiveRoutesSealWorkspaceIDs(t *testing.T) {
+	r, sc, storage, master, now := newWorkspaceTestServer(t, 0)
+	keyMaster := hmacauth.DeriveServiceKey(master, hmacauth.ServiceStoragesvc)
+	keyTenant := hmacauth.DeriveServiceKeyNS(master, hmacauth.ServiceStoragesvc, "team-a")
+
+	// Plant a workspace object directly through the backend (bypassing the
+	// workspace routes, so this test does not depend on PUT working) and a
+	// legacy archive for a control assertion.
+	wsID := "_workspace_/team-a/agentX/sess1/secret.txt"
+	_, err := sc.backend.put(wsID, strings.NewReader("workspace secret"), 17)
+	require.NoError(t, err)
+	legacyName, err := storage.getUploadFileName("")
+	require.NoError(t, err)
+	legacyID, err := sc.backend.put(legacyName, strings.NewReader("legacy archive"), 14)
+	require.NoError(t, err)
+
+	do := func(method, target string, key []byte, nsHeader string) *httptest.ResponseRecorder {
+		req := signedWorkspaceRequest(t, method, target, nil, key, now.Unix(), nsHeader)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		return rr
+	}
+
+	target := "/v1/archive?id=" + url.QueryEscape(wsID)
+	cases := []struct {
+		name, method string
+		key          []byte
+		ns           string
+	}{
+		{"master GET", http.MethodGet, keyMaster, ""},
+		{"master HEAD", http.MethodHead, keyMaster, ""},
+		{"master DELETE", http.MethodDelete, keyMaster, ""},
+		{"tenant GET", http.MethodGet, keyTenant, "team-a"},
+		{"tenant HEAD", http.MethodHead, keyTenant, "team-a"},
+		{"tenant DELETE", http.MethodDelete, keyTenant, "team-a"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := do(tc.method, target, tc.key, tc.ns)
+			assert.Equal(t, http.StatusNotFound, rr.Code)
+		})
+	}
+
+	t.Run("archive list excludes the workspace id but keeps the legacy one", func(t *testing.T) {
+		listRR := do(http.MethodGet, "/v1/archive", keyMaster, "")
+		require.Equal(t, http.StatusOK, listRR.Code)
+		var ids []string
+		require.NoError(t, json.Unmarshal(listRR.Body.Bytes(), &ids))
+		assert.Contains(t, ids, legacyID)
+		assert.NotContains(t, ids, wsID)
+		for _, id := range ids {
+			assert.False(t, isWorkspaceID(id), "archive list must never contain a workspace id: %q", id)
+		}
+	})
+
+	t.Run("the workspace object itself is untouched by the DELETE attempts above", func(t *testing.T) {
+		wsGet := do(http.MethodGet, "/v1/workspace?id="+url.QueryEscape(wsID), keyMaster, "")
+		assert.Equal(t, http.StatusOK, wsGet.Code)
+	})
+}
+
+// TestArchivePrunerExcludesWorkspaceRoot is the two-way pruner test: a
+// workspace object must be ABSENT from the orphan-candidate set (never sent
+// for deletion) while a plain orphan archive in the SAME cycle is still
+// pruned — a one-way test could pass by breaking the pruner (e.g. an
+// exclusion bug that drops everything) rather than by correctly excluding
+// only workspace ids. Runs on the LOCAL backend, where candidate ids are
+// ABSOLUTE container paths, so the segment-based filter (not a naive
+// HasPrefix) is what is actually exercised.
+func TestArchivePrunerExcludesWorkspaceRoot(t *testing.T) {
+	storage := NewLocalStorage(t.TempDir())
+	sc, err := MakeStorageClient(logr.Discard(), storage)
+	require.NoError(t, err)
+
+	wsID := "_workspace_/team-a/agentX/sess1/artifact.txt"
+	wsNativeID, err := sc.backend.put(wsID, strings.NewReader("workspace payload"), 18)
+	require.NoError(t, err)
+
+	orphanName, err := storage.getUploadFileName("") // legacy unscoped uuid id
+	require.NoError(t, err)
+	orphanNativeID, err := sc.backend.put(orphanName, strings.NewReader("orphan archive"), 14)
+	require.NoError(t, err)
+
+	// Both objects predate the pruner's "too recently modified" grace window
+	// (1 minute) so both are real candidates.
+	old := time.Now().Add(-2 * time.Minute)
+	require.NoError(t, os.Chtimes(wsNativeID, old, old))
+	require.NoError(t, os.Chtimes(orphanNativeID, old, old))
+
+	pruner := &ArchivePruner{
+		logger:        logr.Discard(),
+		crdClient:     fClient.NewSimpleClientset(), // no Packages: everything is a candidate
+		archiveChan:   make(chan string),
+		storageClient: sc,
+		pruneInterval: time.Minute,
+	}
+
+	var collected []string
+	collectDone := make(chan struct{})
+	go func() {
+		defer close(collectDone)
+		for id := range pruner.archiveChan {
+			collected = append(collected, id)
+		}
+	}()
+
+	pruner.getOrphanArchives(context.Background())
+	close(pruner.archiveChan)
+	<-collectDone
+
+	assert.NotContains(t, collected, wsNativeID, "the pruner must never treat the workspace object as an orphan archive")
+	for _, id := range collected {
+		assert.False(t, isWorkspaceID(id), "pruner sent a workspace-marked id for deletion: %q", id)
+	}
+	assert.Contains(t, collected, orphanNativeID, "a plain orphan archive in the same cycle must still be pruned")
+}

--- a/test/helm/agentruntime_chart_test.go
+++ b/test/helm/agentruntime_chart_test.go
@@ -244,6 +244,22 @@ func TestAgentRuntimeChartExecutorURL(t *testing.T) {
 	})
 }
 
+// TestAgentRuntimeChartStoragesvcURL checks the workspace-purge slice's chart
+// wiring: the agentruntime Deployment always carries STORAGESVC_URL, mirroring
+// buildermgr's own --storageSvcUrl VALUE
+// (charts/fission-all/templates/buildermgr/deployment.yaml) as an ENV rather
+// than a container arg. Unlike AGENT_RUNTIME_URL on the executor (which is
+// gated on agentRuntime.enabled), storagesvc is a core, always-deployed
+// component with no enabled gate to condition on, so this env is unconditional.
+func TestAgentRuntimeChartStoragesvcURL(t *testing.T) {
+	docs := render(t,
+		"--set", "agentRuntime.enabled=true", "--set", "agentRuntime.allowInsecure=true",
+		"--set", "statestore.enabled=true", "--set", "statestore.mode=embedded")
+	env := containerEnv(t, deployment(t, docs, svcinfo.SvcAgentRuntime))
+	assert.Equal(t, "http://storagesvc.fission", env["STORAGESVC_URL"],
+		"agentruntime's workspace routes must be handed storagesvc's ClusterIP Service URL, mirroring buildermgr's --storageSvcUrl value")
+}
+
 // TestAgentRuntimeChartInternalAuthEnvs is a verify-only assertion (no chart
 // change needed): the agentruntime Deployment already carries
 // FISSION_INTERNAL_AUTH_SECRET under default values, wired via

--- a/test/helm/agentruntime_chart_test.go
+++ b/test/helm/agentruntime_chart_test.go
@@ -95,6 +95,24 @@ func TestAgentRuntimeChartNetworkPolicy(t *testing.T) {
 		assert.Contains(t, ports, int32(8894), "ingress must admit the agent runtime dispatch port 8894")
 		assert.Empty(t, np.Spec.Ingress[0].From, "the policy is deliberately permissive: no from-allowlist")
 	})
+
+	// storagesvc netpol coverage: the workspace proxy (every PUT/GET/DELETE/
+	// LIST) and the sweeper's archive-time prefix purge both call storagesvc
+	// on port 8000 from the agentruntime pod. Missing this row is the
+	// BLOCKER final-review.md finding 1 — every workspace call is silently
+	// dropped under networkPolicy.enabled=true (the kind-ci profile forces
+	// this on), which is exactly the "silent i/o timeout in CI" shape
+	// TestWorkflowChart pins for the workflow engine's own two allowlists.
+	t.Run("storagesvc networkpolicy admits svc:agentruntime", func(t *testing.T) {
+		docs := render(t,
+			"--set", "networkPolicy.enabled=true",
+			"--set", "agentRuntime.enabled=true", "--set", "agentRuntime.allowInsecure=true",
+			"--set", "statestore.enabled=true", "--set", "statestore.mode=embedded")
+		ssNP := networkPolicy(t, docs, "storagesvc-allow-internal")
+		assert.True(t, npAllowsFromSvc(ssNP, svcinfo.SvcAgentRuntime),
+			"the workspace proxy and the sweeper's prefix purge both call storagesvc on port 8000; "+
+				"a missing row is a silent i/o timeout in CI (networkPolicy.enabled under kind-ci)")
+	})
 }
 
 // TestAgentRuntimeChartPoolRBAC guards Task 19's RBAC lockstep: pool

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -1367,33 +1367,59 @@ type workspaceTurnDTO struct {
 // IdentityOrJWTOwnWorkspace consumes the identical claims headers a spawn
 // dispatch does.
 //
-// Four things are asserted, in order:
+// Auth-posture gate (checked FIRST, before any turn is ever dispatched): this
+// test framework has no way to mint or sign a JWT (JWT_SIGNING_KEY is not
+// exposed to the test env at all, and the identity-bearer HMAC token derived
+// via hmacauth.DeriveAgentIdentityKey below is a DIFFERENT credential the JWT
+// verifier does not accept), and identityOrJWT (identity.go) delegates
+// unconditionally to the JWT middleware whenever a request carries NEITHER
+// identity claim header — so on a cluster where authz IS enabled
+// (authentication.enabled, JWT_SIGNING_KEY set), EVERY route on this mux,
+// including the very first turn dispatch below, 401s outright and this test
+// cannot run at all. Rather than fail confusingly deep into the test the
+// moment that becomes true, the probe below detects it up front and skips
+// the whole test: secured-mode agent-runtime end-to-end coverage is the same
+// named follow-up docs/superpowers/plans/2026-08-25-agent-runtime-identity.md
+// already deferred ("no secured-mode e2e (serial-suite env-flip is a named
+// follow-up)"), not built here.
+//
+// On the (CI-default) pass-through posture this actually runs under, three
+// things are asserted, in order:
 //
 //  1. PUT/GET round-trip: the fixture's reported artifactSha256Put and
 //     artifactSha256Got are equal, non-empty, and neither is the fixture's
 //     "error:<code>" failure sentinel — proving the bytes this test's turn
 //     wrote actually came back unchanged through storagesvc.
 //  2. LIST reflects the write: the session's artifact list contains
-//     "notes/summary.txt" with a positive size.
-//  3. Cross-agent 403: a DIFFERENT agent's own (real, derived) identity
-//     token must not read this agent's workspace — see the
-//     "posture probe" comment below for why this branch is conditional on
-//     the cluster's auth posture, and TestWorkspaceRoutes_CrossAgentForbidden/
-//     TestWorkspaceRoutes_CrossNamespaceForbidden (pkg/agentruntime/
-//     workspace_test.go) for the unconditional coverage of the same
-//     authorization rule against the production mountWorkspaceRoutes wiring.
-//  4. Nonexistent session -> 404: a workspace list on a session id that was
+//     "notes/summary.txt" with size >= artifactMinBytes.
+//  3. Nonexistent session -> 404: a workspace list on a session id that was
 //     never dispatched must 404 (the GC-anchor existence check,
-//     requireSession in workspace.go) — reachable regardless of auth
-//     posture, since it runs after auth succeeds in every configuration.
+//     requireSession in workspace.go).
+//
+// Cross-agent 403 (a DIFFERENT agent's own identity must not read this
+// agent's workspace) is NOT live-asserted here: the auth-posture gate above
+// means this test only ever runs on a cluster where authz is disabled, and on
+// that posture no request — with any headers, valid or forged — can ever be
+// rejected 403 by this deployment (asserting 403 there would flake; asserting
+// 200 there would wrongly pin "authorization is a no-op" as expected
+// behavior). The rule itself is proven unconditionally at the unit level by
+// pkg/agentruntime/workspace_test.go's TestWorkspaceRoutes_CrossAgentForbidden
+// and TestWorkspaceRoutes_CrossNamespaceForbidden, which exercise the
+// production mountWorkspaceRoutes wiring and a real IdentityVerifier against
+// a real *http.ServeMux; a live secured-cluster check is the same
+// "secured-mode serial e2e" follow-up named above.
 //
 // Archive-purge (the sweeper deleting a session's workspace objects at
-// record archive) is NOT asserted here: this suite has no short-ArchiveAfter
-// agent fixture to converge on within a reasonable poll budget, and the
-// purge is already exercised end-to-end at the unit level
+// record archive) is also NOT asserted here. A short-ArchiveAfter window can
+// be set on this test's own function (flag.FnAgentArchiveAfter, wired into
+// `fn update --agent`), so a live convergence path does technically exist —
+// but no test in this suite exercises that flag today, so there is no
+// established precedent here for how long that convergence actually takes
+// (and thus no basis for calling it "cheap" within this test's polling
+// budget). Given the plan explicitly grants discretion on this point, this
+// test relies on unit coverage instead
 // (pkg/agentruntime/sweeper_test.go's TestSweeperArchivePurgesWorkspace and
-// its siblings) — see this plan's Task 4 brief, which explicitly allows
-// "unit coverage suffices" for this specific assertion.
+// its siblings) rather than being the one to establish that precedent.
 func TestAgentRuntimeWorkspace(t *testing.T) {
 	t.Parallel()
 
@@ -1429,6 +1455,45 @@ func TestAgentRuntimeWorkspace(t *testing.T) {
 
 	base := f.AgentRuntimeBaseURL()
 	turnURL := base + "/agents/" + ns.Name + "/" + fnName
+
+	// EARLY auth-posture probe — BEFORE any turn is dispatched (see this
+	// test's doc comment for why). A plain, header-free GET against the
+	// workspace list route for a session id that has never been dispatched
+	// distinguishes exactly three outcomes:
+	//   - 401: authz is enabled (JWT required) and this framework cannot
+	//     authenticate — skip the whole test now.
+	//   - 503: STORAGESVC_URL is unset on this deployment (workspace routes
+	//     answer workspaceDisabledMsg, workspace.go) — skip the whole test;
+	//     this is not the chart's default (STORAGESVC_URL is always set,
+	//     storagesvc.go's deployment template has no enable/disable gate) but
+	//     is possible on a hand-managed install.
+	//   - 404: pass-through — auth was a no-op, and requireSession correctly
+	//     reports the probe's session id as never having existed. This is
+	//     the only outcome the rest of this test proceeds under.
+	// Any other status is a genuine, unexpected failure worth failing loudly
+	// on rather than silently skipping or silently proceeding.
+	probeSessionID := "workspace-posture-probe-" + ns.ID
+	probeURL := base + "/workspace/" + ns.Name + "/" + fnName + "/" + probeSessionID
+	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	require.NoErrorf(t, err, "building auth-posture probe request")
+	probeResp, err := f.HTTPClient().Do(probeReq)
+	require.NoErrorf(t, err, "GET %s (auth-posture probe)", probeURL)
+	_ = probeResp.Body.Close()
+	switch probeResp.StatusCode {
+	case http.StatusUnauthorized:
+		t.Skipf("agent runtime on this cluster requires a JWT (authz enabled) and this test framework has no "+
+			"way to mint or sign one, so it cannot dispatch even the first turn here (GET %s got 401); "+
+			"secured-mode agent-runtime end-to-end coverage is the named 'secured-mode serial e2e' follow-up "+
+			"(docs/superpowers/plans/2026-08-25-agent-runtime-identity.md), not built here", probeURL)
+	case http.StatusServiceUnavailable:
+		t.Skipf("agent runtime's session workspace routes are disabled on this cluster (STORAGESVC_URL unset, "+
+			"GET %s got 503); skipping", probeURL)
+	case http.StatusNotFound:
+		// Pass-through posture: proceed.
+	default:
+		t.Fatalf("auth-posture probe GET %s: want 401 (authz enabled), 404 (pass-through), or 503 "+
+			"(workspace disabled), got %d", probeURL, probeResp.StatusCode)
+	}
 
 	// Turn 1: no session header, no artifact flag. Mints the session this
 	// whole test hangs off of (mirrors TestAgentRuntimeSpawnParentage's own
@@ -1511,126 +1576,20 @@ func TestAgentRuntimeWorkspace(t *testing.T) {
 	}, 180*time.Second, 2*time.Second)
 	require.NotEmptyf(t, payload.ArtifactSha256Put, "artifact turn on session %s never completed the PUT/GET/LIST beat", sessionID)
 
+	// Cross-agent 403 is NOT live-asserted here — see this test's doc
+	// comment: the auth-posture probe above already proved this cluster is
+	// running without authz enabled, so no request can ever be rejected 403
+	// by this deployment. The rule itself is covered unconditionally by
+	// pkg/agentruntime/workspace_test.go's TestWorkspaceRoutes_CrossAgentForbidden
+	// and TestWorkspaceRoutes_CrossNamespaceForbidden.
+
+	// Nonexistent session -> 404. master is used only to ALSO send agent A's
+	// own (real, valid) identity headers when available — harmless and a
+	// slightly more realistic caller shape on pass-through, but not required
+	// for this assertion: requireSession (workspace.go) runs after auth
+	// succeeds either way, and the session id below was never dispatched, so
+	// the GC-anchor existence check must 404 it regardless.
 	master := f.InternalAuthSecret()
-	listURL := base + "/workspace/" + ns.Name + "/" + fnName + "/" + sessionID
-
-	// Posture probe: identityOrJWT (identity.go) delegates unconditionally
-	// to the JWT middleware whenever a request carries NEITHER identity
-	// claim header, regardless of whether the server-side IdentityVerifier
-	// itself is nil — so a plain, header-free GET's 401-vs-200 split is
-	// exactly authz.Enabled() (main.go only builds the IdentityVerifier when
-	// authz IS enabled). In this suite's default install
-	// (agentRuntime.allowInsecure=true, authentication.enabled=false — see
-	// requireAgentRuntimeReachable's doc comment) authz is disabled and this
-	// probe returns 200: the workspace routes run fully unauthenticated, so
-	// no request — with any headers, valid or forged — can be rejected with
-	// 403 by this cluster today. Sending a mismatched identity in that
-	// posture would get 200, not 403; asserting 403 there would flake, and
-	// asserting 200 there would wrongly pin "authorization is a no-op" as
-	// expected behavior. Skip the live-cluster check in that posture instead
-	// — the authorization rule itself is fully covered at the unit level
-	// (see this test's doc comment).
-	var authEnforced bool
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
-		defer cancel()
-		req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, listURL, nil)
-		if !assert.NoErrorf(c, err, "building posture probe request") {
-			return
-		}
-		resp, err := f.HTTPClient().Do(req)
-		if !assert.NoErrorf(c, err, "GET %s (posture probe)", listURL) {
-			return
-		}
-		defer resp.Body.Close()
-		if !assert.Truef(c, resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized,
-			"posture probe GET %s returned unexpected status %d (want 200 pass-through or 401 authz-enabled)", listURL, resp.StatusCode) {
-			return
-		}
-		authEnforced = resp.StatusCode == http.StatusUnauthorized
-	}, 60*time.Second, 2*time.Second)
-
-	if authEnforced && len(master) > 0 {
-		// A second, distinct agent-enabled Function: verifyClaims' revocation
-		// check (identity.go) requires the CLAIMED agent to be live in the
-		// AgentView, so a cross-agent 403 needs a real, independently derived
-		// identity — not just an arbitrary claimed name. It never needs to
-		// handle a turn (it only has to be reconciled into the view), so no
-		// WaitForFunction-then-dispatch round trip is needed for it, just a
-		// poll on the registry's agent list.
-		otherAgent := "agent-workspace-other-" + ns.ID
-		ns.CreateFunction(t, ctx, framework.FunctionOptions{
-			Name: otherAgent,
-			Env:  envName,
-			Code: framework.WriteTestData(t, "nodejs/hello/hello.js"),
-		})
-		ns.WaitForFunction(t, ctx, otherAgent)
-		ns.CLI(t, ctx, "fn", "update", "--name", otherAgent, "--agent")
-
-		agentsURL := base + "/registry/agents"
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
-			defer cancel()
-			body, status, err := getRegistry(attemptCtx, f, agentsURL)
-			if !assert.NoErrorf(c, err, "GET %s", agentsURL) {
-				return
-			}
-			if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", agentsURL, body) {
-				return
-			}
-			var listPayload struct {
-				Agents []struct {
-					Namespace string `json:"namespace"`
-					Name      string `json:"name"`
-				} `json:"agents"`
-			}
-			if !assert.NoErrorf(c, json.Unmarshal(body, &listPayload), "decoding %s body %q", agentsURL, body) {
-				return
-			}
-			live := false
-			for _, a := range listPayload.Agents {
-				if a.Namespace == ns.Name && a.Name == otherAgent {
-					live = true
-				}
-			}
-			assert.Truef(c, live, "agent %s/%s not yet live in the registry", ns.Name, otherAgent)
-		}, 60*time.Second, 2*time.Second)
-
-		otherToken := hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, ns.Name, otherAgent))
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
-			attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
-			defer cancel()
-			req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, listURL, nil)
-			if !assert.NoErrorf(c, err, "building cross-agent request") {
-				return
-			}
-			req.Header.Set("Authorization", "Bearer "+otherToken)
-			req.Header.Set(agentruntime.HeaderIdentityNamespace, ns.Name)
-			req.Header.Set(agentruntime.HeaderIdentityName, otherAgent)
-			resp, err := f.HTTPClient().Do(req)
-			if !assert.NoErrorf(c, err, "GET %s with agent %s's own identity", listURL, otherAgent) {
-				return
-			}
-			defer resp.Body.Close()
-			assert.Equalf(c, http.StatusForbidden, resp.StatusCode,
-				"agent %s must not read agent %s's workspace with its own (valid, live) identity token, got %d",
-				otherAgent, fnName, resp.StatusCode)
-		}, 60*time.Second, 2*time.Second)
-	} else {
-		t.Logf("agent runtime is running without authz enabled on this cluster (pass-through/AGENT_ALLOW_INSECURE) — "+
-			"skipping the live cross-agent 403 check; the authorization rule itself is proven at the unit level by "+
-			"pkg/agentruntime/workspace_test.go's TestWorkspaceRoutes_CrossAgentForbidden and "+
-			"TestWorkspaceRoutes_CrossNamespaceForbidden, which exercise the production mountWorkspaceRoutes wiring "+
-			"and a real IdentityVerifier against a real *http.ServeMux (authEnforced=%v, internalAuthSecretSet=%v)",
-			authEnforced, len(master) > 0)
-	}
-
-	// Nonexistent session -> 404: reachable regardless of auth posture, since
-	// requireSession (workspace.go) runs AFTER auth succeeds either way — a
-	// pass-through cluster admits the request with no headers at all, a
-	// secured one admits it because these are agent A's own valid claims for
-	// its own path. Either way the session id below was never dispatched, so
-	// the GC-anchor existence check must 404 it.
 	missingSessionID := "workspace-missing-" + ns.ID
 	missingURL := base + "/workspace/" + ns.Name + "/" + fnName + "/" + missingSessionID
 	require.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/test/integration/suites/common/agentruntime_test.go
+++ b/test/integration/suites/common/agentruntime_test.go
@@ -1328,6 +1328,334 @@ func TestAgentRuntimeTraceContextPropagation(t *testing.T) {
 		sentSpanID)
 }
 
+// artifactMinBytes mirrors the agentspawn fixture's ARTIFACT_MIN_BYTES
+// (test/integration/testdata/nodejs/agentspawn/spawn.js): the artifact beat
+// pads its generated content to AT LEAST this many bytes, so the workspace
+// list's reported size for it must be at least this large too.
+const artifactMinBytes = 3072
+
+// workspaceArtifactItemDTO is one entry of workspaceTurnDTO.ArtifactList
+// (workspace.go's workspaceListItemResp wire shape).
+type workspaceArtifactItemDTO struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// workspaceTurnDTO decodes the artifact-beat fields the agentspawn fixture
+// (test/integration/testdata/nodejs/agentspawn/spawn.js) echoes on a turn
+// whose body carried {"artifact":true} — see that fixture's artifactBeat doc
+// comment for the wire contract, including the "error:<code>"
+// failure-reporting shape this test must recognize rather than treat as a
+// legitimate sha256/list value.
+type workspaceTurnDTO struct {
+	ArtifactSha256Put string                     `json:"artifactSha256Put"`
+	ArtifactSha256Got string                     `json:"artifactSha256Got"`
+	ArtifactList      []workspaceArtifactItemDTO `json:"artifactList"`
+}
+
+// TestAgentRuntimeWorkspace exercises the G12 session workspace API
+// (pkg/agentruntime/workspace.go) end-to-end against a real cluster: Task 4
+// of docs/superpowers/plans/2026-08-26-agent-runtime-workspace.md.
+//
+// It reuses the agentspawn fixture (test/integration/testdata/nodejs/
+// agentspawn/spawn.js), which now also answers a turn body carrying
+// {"artifact":true} by PUTting a generated few-KiB text artifact to its OWN
+// session workspace at "notes/summary.txt", GETting it straight back, and
+// listing the session — using the SAME fetcher-written identity credential
+// (readAgentCredentials/authHeaders) TestAgentRuntimeSpawnParentage's
+// injection-chain proof already covers, since workspace.go's
+// IdentityOrJWTOwnWorkspace consumes the identical claims headers a spawn
+// dispatch does.
+//
+// Four things are asserted, in order:
+//
+//  1. PUT/GET round-trip: the fixture's reported artifactSha256Put and
+//     artifactSha256Got are equal, non-empty, and neither is the fixture's
+//     "error:<code>" failure sentinel — proving the bytes this test's turn
+//     wrote actually came back unchanged through storagesvc.
+//  2. LIST reflects the write: the session's artifact list contains
+//     "notes/summary.txt" with a positive size.
+//  3. Cross-agent 403: a DIFFERENT agent's own (real, derived) identity
+//     token must not read this agent's workspace — see the
+//     "posture probe" comment below for why this branch is conditional on
+//     the cluster's auth posture, and TestWorkspaceRoutes_CrossAgentForbidden/
+//     TestWorkspaceRoutes_CrossNamespaceForbidden (pkg/agentruntime/
+//     workspace_test.go) for the unconditional coverage of the same
+//     authorization rule against the production mountWorkspaceRoutes wiring.
+//  4. Nonexistent session -> 404: a workspace list on a session id that was
+//     never dispatched must 404 (the GC-anchor existence check,
+//     requireSession in workspace.go) — reachable regardless of auth
+//     posture, since it runs after auth succeeds in every configuration.
+//
+// Archive-purge (the sweeper deleting a session's workspace objects at
+// record archive) is NOT asserted here: this suite has no short-ArchiveAfter
+// agent fixture to converge on within a reasonable poll budget, and the
+// purge is already exercised end-to-end at the unit level
+// (pkg/agentruntime/sweeper_test.go's TestSweeperArchivePurgesWorkspace and
+// its siblings) — see this plan's Task 4 brief, which explicitly allows
+// "unit coverage suffices" for this specific assertion.
+func TestAgentRuntimeWorkspace(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "nodejs-agent-workspace-" + ns.ID
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	fnName := "agent-workspace-" + ns.ID
+	ns.CreateFunction(t, ctx, framework.FunctionOptions{
+		Name: fnName,
+		Env:  envName,
+		Code: framework.WriteTestData(t, "nodejs/agentspawn/spawn.js"),
+		// spawn.js needs these even for a turn that never spawns (it builds
+		// parentRef from them unconditionally) — same as
+		// TestAgentRuntimeTraceContextPropagation's setup.
+		EnvVars: []string{
+			"SELF_NAMESPACE=" + ns.Name,
+			"SELF_AGENT_NAME=" + fnName,
+		},
+	})
+	ns.WaitForFunction(t, ctx, fnName)
+	// Same CLI-update workaround as the other tests in this file
+	// (FunctionOptions has no Agent field yet).
+	ns.CLI(t, ctx, "fn", "update", "--name", fnName, "--agent")
+
+	base := f.AgentRuntimeBaseURL()
+	turnURL := base + "/agents/" + ns.Name + "/" + fnName
+
+	// Turn 1: no session header, no artifact flag. Mints the session this
+	// whole test hangs off of (mirrors TestAgentRuntimeSpawnParentage's own
+	// first turn).
+	var sessionID string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, "", "", `{}`)
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "root turn to %s", turnURL) {
+			return
+		}
+		sid := resp.Header.Get(agentruntime.HeaderSession)
+		if !assert.NotEmpty(c, sid, "root turn must mint a session id via %s", agentruntime.HeaderSession) {
+			return
+		}
+		sessionID = sid
+	}, 180*time.Second, 2*time.Second)
+	require.NotEmpty(t, sessionID, "root turn never minted a session id")
+
+	// Turn 2 on the minted session: {"artifact":true} runs the fixture's
+	// PUT/GET/LIST beat against its OWN workspace. Re-issuing the WHOLE turn
+	// on every retry attempt (not just polling a read-only endpoint
+	// afterwards) mirrors TestAgentRuntimeSpawnParentage's spawn-turn loop —
+	// a transient storagesvc hiccup on one attempt gets a fresh attempt
+	// rather than stranding this loop on a single try.
+	var payload workspaceTurnDTO
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postAgentTurn(attemptCtx, f, turnURL, sessionID, "", `{"artifact":true}`)
+		if !assert.NoErrorf(c, err, "POST %s (artifact turn)", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "artifact turn to %s", turnURL) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoErrorf(c, err, "reading artifact turn response body") {
+			return
+		}
+		var p workspaceTurnDTO
+		if !assert.NoErrorf(c, json.Unmarshal(body, &p), "decoding artifact turn response body %q", body) {
+			return
+		}
+		if !assert.NotEmptyf(c, p.ArtifactSha256Put, "fixture reported no artifactSha256Put at all (body=%s)", body) {
+			return
+		}
+		if !assert.Falsef(c, strings.HasPrefix(p.ArtifactSha256Put, "error:"),
+			"artifact PUT failed: %s (body=%s)", p.ArtifactSha256Put, body) {
+			return
+		}
+		if !assert.Falsef(c, strings.HasPrefix(p.ArtifactSha256Got, "error:"),
+			"artifact GET failed: %s (body=%s)", p.ArtifactSha256Got, body) {
+			return
+		}
+		if !assert.Equalf(c, p.ArtifactSha256Put, p.ArtifactSha256Got,
+			"artifact PUT/GET sha256 mismatch: put=%s got=%s (body=%s)", p.ArtifactSha256Put, p.ArtifactSha256Got, body) {
+			return
+		}
+		found := false
+		for _, it := range p.ArtifactList {
+			// >= artifactMinBytes (not just >0): the fixture pads its content
+			// to AT LEAST ARTIFACT_MIN_BYTES (spawn.js), so this pins the
+			// actually-stored size rather than merely "something nonempty was
+			// written".
+			if it.Path == "notes/summary.txt" && it.Size >= artifactMinBytes {
+				found = true
+			}
+		}
+		if !assert.Truef(c, found, "artifact list must contain notes/summary.txt with size >= %d, got %+v (body=%s)", artifactMinBytes, p.ArtifactList, body) {
+			return
+		}
+		payload = p
+	}, 180*time.Second, 2*time.Second)
+	require.NotEmptyf(t, payload.ArtifactSha256Put, "artifact turn on session %s never completed the PUT/GET/LIST beat", sessionID)
+
+	master := f.InternalAuthSecret()
+	listURL := base + "/workspace/" + ns.Name + "/" + fnName + "/" + sessionID
+
+	// Posture probe: identityOrJWT (identity.go) delegates unconditionally
+	// to the JWT middleware whenever a request carries NEITHER identity
+	// claim header, regardless of whether the server-side IdentityVerifier
+	// itself is nil — so a plain, header-free GET's 401-vs-200 split is
+	// exactly authz.Enabled() (main.go only builds the IdentityVerifier when
+	// authz IS enabled). In this suite's default install
+	// (agentRuntime.allowInsecure=true, authentication.enabled=false — see
+	// requireAgentRuntimeReachable's doc comment) authz is disabled and this
+	// probe returns 200: the workspace routes run fully unauthenticated, so
+	// no request — with any headers, valid or forged — can be rejected with
+	// 403 by this cluster today. Sending a mismatched identity in that
+	// posture would get 200, not 403; asserting 403 there would flake, and
+	// asserting 200 there would wrongly pin "authorization is a no-op" as
+	// expected behavior. Skip the live-cluster check in that posture instead
+	// — the authorization rule itself is fully covered at the unit level
+	// (see this test's doc comment).
+	var authEnforced bool
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, listURL, nil)
+		if !assert.NoErrorf(c, err, "building posture probe request") {
+			return
+		}
+		resp, err := f.HTTPClient().Do(req)
+		if !assert.NoErrorf(c, err, "GET %s (posture probe)", listURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Truef(c, resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusUnauthorized,
+			"posture probe GET %s returned unexpected status %d (want 200 pass-through or 401 authz-enabled)", listURL, resp.StatusCode) {
+			return
+		}
+		authEnforced = resp.StatusCode == http.StatusUnauthorized
+	}, 60*time.Second, 2*time.Second)
+
+	if authEnforced && len(master) > 0 {
+		// A second, distinct agent-enabled Function: verifyClaims' revocation
+		// check (identity.go) requires the CLAIMED agent to be live in the
+		// AgentView, so a cross-agent 403 needs a real, independently derived
+		// identity — not just an arbitrary claimed name. It never needs to
+		// handle a turn (it only has to be reconciled into the view), so no
+		// WaitForFunction-then-dispatch round trip is needed for it, just a
+		// poll on the registry's agent list.
+		otherAgent := "agent-workspace-other-" + ns.ID
+		ns.CreateFunction(t, ctx, framework.FunctionOptions{
+			Name: otherAgent,
+			Env:  envName,
+			Code: framework.WriteTestData(t, "nodejs/hello/hello.js"),
+		})
+		ns.WaitForFunction(t, ctx, otherAgent)
+		ns.CLI(t, ctx, "fn", "update", "--name", otherAgent, "--agent")
+
+		agentsURL := base + "/registry/agents"
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+			defer cancel()
+			body, status, err := getRegistry(attemptCtx, f, agentsURL)
+			if !assert.NoErrorf(c, err, "GET %s", agentsURL) {
+				return
+			}
+			if !assert.Equalf(c, http.StatusOK, status, "GET %s (body=%s)", agentsURL, body) {
+				return
+			}
+			var listPayload struct {
+				Agents []struct {
+					Namespace string `json:"namespace"`
+					Name      string `json:"name"`
+				} `json:"agents"`
+			}
+			if !assert.NoErrorf(c, json.Unmarshal(body, &listPayload), "decoding %s body %q", agentsURL, body) {
+				return
+			}
+			live := false
+			for _, a := range listPayload.Agents {
+				if a.Namespace == ns.Name && a.Name == otherAgent {
+					live = true
+				}
+			}
+			assert.Truef(c, live, "agent %s/%s not yet live in the registry", ns.Name, otherAgent)
+		}, 60*time.Second, 2*time.Second)
+
+		otherToken := hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, ns.Name, otherAgent))
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+			defer cancel()
+			req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, listURL, nil)
+			if !assert.NoErrorf(c, err, "building cross-agent request") {
+				return
+			}
+			req.Header.Set("Authorization", "Bearer "+otherToken)
+			req.Header.Set(agentruntime.HeaderIdentityNamespace, ns.Name)
+			req.Header.Set(agentruntime.HeaderIdentityName, otherAgent)
+			resp, err := f.HTTPClient().Do(req)
+			if !assert.NoErrorf(c, err, "GET %s with agent %s's own identity", listURL, otherAgent) {
+				return
+			}
+			defer resp.Body.Close()
+			assert.Equalf(c, http.StatusForbidden, resp.StatusCode,
+				"agent %s must not read agent %s's workspace with its own (valid, live) identity token, got %d",
+				otherAgent, fnName, resp.StatusCode)
+		}, 60*time.Second, 2*time.Second)
+	} else {
+		t.Logf("agent runtime is running without authz enabled on this cluster (pass-through/AGENT_ALLOW_INSECURE) — "+
+			"skipping the live cross-agent 403 check; the authorization rule itself is proven at the unit level by "+
+			"pkg/agentruntime/workspace_test.go's TestWorkspaceRoutes_CrossAgentForbidden and "+
+			"TestWorkspaceRoutes_CrossNamespaceForbidden, which exercise the production mountWorkspaceRoutes wiring "+
+			"and a real IdentityVerifier against a real *http.ServeMux (authEnforced=%v, internalAuthSecretSet=%v)",
+			authEnforced, len(master) > 0)
+	}
+
+	// Nonexistent session -> 404: reachable regardless of auth posture, since
+	// requireSession (workspace.go) runs AFTER auth succeeds either way — a
+	// pass-through cluster admits the request with no headers at all, a
+	// secured one admits it because these are agent A's own valid claims for
+	// its own path. Either way the session id below was never dispatched, so
+	// the GC-anchor existence check must 404 it.
+	missingSessionID := "workspace-missing-" + ns.ID
+	missingURL := base + "/workspace/" + ns.Name + "/" + fnName + "/" + missingSessionID
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, registryAttemptTimeout)
+		defer cancel()
+		req, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, missingURL, nil)
+		if !assert.NoErrorf(c, err, "building nonexistent-session request") {
+			return
+		}
+		if len(master) > 0 {
+			selfToken := hmacauth.EncodeKeyForEnv(hmacauth.DeriveAgentIdentityKey(master, ns.Name, fnName))
+			req.Header.Set("Authorization", "Bearer "+selfToken)
+			req.Header.Set(agentruntime.HeaderIdentityNamespace, ns.Name)
+			req.Header.Set(agentruntime.HeaderIdentityName, fnName)
+		}
+		resp, err := f.HTTPClient().Do(req)
+		if !assert.NoErrorf(c, err, "GET %s (nonexistent session)", missingURL) {
+			return
+		}
+		defer resp.Body.Close()
+		assert.Equalf(c, http.StatusNotFound, resp.StatusCode,
+			"workspace list on a never-dispatched session must 404, got %d", resp.StatusCode)
+	}, 60*time.Second, 2*time.Second)
+}
+
 // nextSSEFrame reads one SSE message from r: comment lines (starting with
 // ':', e.g. the ": keepalive" lines events.go's ServeHTTP writes) are
 // skipped entirely, then an "event:" line and a "data:" line are read up to

--- a/test/integration/testdata/nodejs/agentspawn/spawn.js
+++ b/test/integration/testdata/nodejs/agentspawn/spawn.js
@@ -49,6 +49,18 @@
 // X-Fission-Agent-Auth-Namespace / X-Fission-Agent-Auth-Name claims headers
 // (pkg/agentruntime/identity.go) -- see readAgentCredentials()/authHeaders()
 // below for the fallback order and the dev-placeholder edge case.
+//
+// Session workspace beat (G12, Task 4 of the workspace plan): on a turn
+// whose body carries {"artifact":true} this fixture PUTs a generated few-KiB
+// text artifact to its OWN session workspace at "notes/summary.txt"
+// (pkg/agentruntime/workspace.go), GETs it straight back, and lists the
+// session — the SAME identity credential/authHeaders() plumbing above
+// authenticates these calls, since workspace.go's own-workspace check
+// requires the IDENTICAL claims a spawn dispatch already carries (namespace
+// AND agent, not just namespace). Best-effort like spawnChild above: a
+// failed PUT/GET/LIST never fails this turn's own 200, it only reports
+// "error:<code>" in the corresponding response field(s) — see
+// artifactBeat's doc comment.
 
 'use strict';
 
@@ -201,6 +213,120 @@ async function spawnChild(parentRef, stepKey) {
   }
 }
 
+// ARTIFACT_PATH is the fixed within-session path this beat round-trips,
+// matching the demo fixture's own choice (demo/agent-boardroom/fixtures/
+// support-desk.js) and the integration test's assertion
+// (agentruntime_test.go).
+const ARTIFACT_PATH = 'notes/summary.txt';
+// ARTIFACT_MIN_BYTES bounds the generated content to "a few KiB" (Task 4's
+// brief) -- well under AGENT_MAX_ARTIFACT_BYTES' 32MiB default, so this beat
+// never needs to reason about the quota-rejection paths (workspace_test.go's
+// TestWorkspacePut_OverCap413_NothingStored etc. already cover those at the
+// unit level).
+const ARTIFACT_MIN_BYTES = 3072;
+
+// workspaceURL builds the wire URL for one of the four session workspace
+// routes (workspace.go's mountWorkspaceRoutes): the three path-scoped verbs
+// when path is given, the list route when it is omitted.
+function workspaceURL(ns, agent, sessionID, path) {
+  const base = `${AGENT_RUNTIME_URL}/workspace/${encodeURIComponent(ns)}/${encodeURIComponent(agent)}/${encodeURIComponent(sessionID)}`;
+  return path ? `${base}/${path}` : base;
+}
+
+// buildArtifactContent deterministically generates a few-KiB text artifact
+// from the session id and turn number -- no randomness, so a re-run against
+// the SAME session/turn produces byte-identical content (harmless either
+// way, since the PUT/GET sha256 comparison this beat reports only ever
+// compares against ITS OWN write within the same turn).
+function buildArtifactContent(sessionID, turn) {
+  const line = `session ${sessionID} turn ${turn}: session workspace (G12) artifact demo beat -- PUT/GET/LIST round-trip through pkg/agentruntime/workspace.go.\n`;
+  let out = '';
+  while (out.length < ARTIFACT_MIN_BYTES) {
+    out += line;
+  }
+  return out;
+}
+
+// errTag extracts a short, loggable/reportable tag from an artifact-beat
+// error: the HTTP status code when putArtifact/getArtifact/listArtifacts
+// threw a "status:<code>" Error (see those functions below), otherwise the
+// error's own code/name -- never its full message, mirroring
+// readAgentCredentials' token-leak guard (irrelevant here, but keeping the
+// same shape avoids a second convention for "how do we stringify an error"
+// in this file).
+function errTag(err) {
+  const m = /^status:(\d+)$/.exec(err && err.message);
+  return m ? m[1] : (err && (err.code || err.name)) || 'network';
+}
+
+async function putArtifact(ns, agent, sessionID, content) {
+  const res = await fetch(workspaceURL(ns, agent, sessionID, ARTIFACT_PATH), {
+    method: 'PUT',
+    headers: Object.assign({ 'Content-Type': 'text/plain' }, authHeaders()),
+    body: content,
+  });
+  if (!res.ok) {
+    throw new Error(`status:${res.status}`);
+  }
+  await res.json(); // drain/validate the {path,size} body; size is not needed here.
+  return crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+}
+
+async function getArtifact(ns, agent, sessionID) {
+  const res = await fetch(workspaceURL(ns, agent, sessionID, ARTIFACT_PATH), { headers: authHeaders() });
+  if (!res.ok) {
+    throw new Error(`status:${res.status}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+async function listArtifacts(ns, agent, sessionID) {
+  const res = await fetch(workspaceURL(ns, agent, sessionID, ''), { headers: authHeaders() });
+  if (!res.ok) {
+    throw new Error(`status:${res.status}`);
+  }
+  const data = await res.json();
+  return Array.isArray(data.items) ? data.items : [];
+}
+
+// artifactBeat runs the PUT -> GET -> LIST sequence and returns the wire
+// shape this turn's response echoes: artifactSha256Put/artifactSha256Got are
+// the literal string "error:<code>" on failure (never thrown -- see this
+// file's header comment), and artifactList is always an array; a LIST
+// failure reports as a single sentinel item {path:"error:<code>",size:0}
+// rather than changing the field's type, so a caller-side JSON decoder never
+// has to handle two different shapes for the same field.
+async function artifactBeat(ns, agent, sessionID, turn) {
+  const content = buildArtifactContent(sessionID, turn);
+
+  let put = 'error:unknown';
+  try {
+    put = await putArtifact(ns, agent, sessionID, content);
+  } catch (err) {
+    console.error(`agentspawn: artifact PUT (session ${sessionID}) failed: ${err}`);
+    put = `error:${errTag(err)}`;
+  }
+
+  let got = 'error:unknown';
+  try {
+    got = await getArtifact(ns, agent, sessionID);
+  } catch (err) {
+    console.error(`agentspawn: artifact GET (session ${sessionID}) failed: ${err}`);
+    got = `error:${errTag(err)}`;
+  }
+
+  let list = [{ path: 'error:unknown', size: 0 }];
+  try {
+    list = await listArtifacts(ns, agent, sessionID);
+  } catch (err) {
+    console.error(`agentspawn: artifact LIST (session ${sessionID}) failed: ${err}`);
+    list = [{ path: `error:${errTag(err)}`, size: 0 }];
+  }
+
+  return { artifactSha256Put: put, artifactSha256Got: got, artifactList: list };
+}
+
 module.exports = async function (context) {
   const req = context.request;
   const sessionID = req.headers[SESSION_HEADER] || 'unknown';
@@ -236,6 +362,7 @@ module.exports = async function (context) {
     }
   }
   const shouldSpawn = !!(body && typeof body === 'object' && body.spawn === true);
+  const shouldArtifact = !!(body && typeof body === 'object' && body.artifact === true);
 
   // spawned is reported whenever this turn spawned, REGARDLESS of whether
   // the inner dispatch call itself succeeded -- the derivation never fails,
@@ -254,6 +381,17 @@ module.exports = async function (context) {
     spawnBody = result.error ? `<network error: ${result.error}>` : result.body;
   }
 
+  // artifact* fields are only populated when this turn actually ran the
+  // beat (shouldArtifact) -- null on every other turn, rather than running
+  // the beat unconditionally on every turn this fixture ever handles. This
+  // fixture (unlike support-desk.js) tracks no per-session turn count, so
+  // buildArtifactContent's turn argument is a fixed 0 -- it only needs to be
+  // SOME string, not an accurate counter.
+  let artifact = { artifactSha256Put: null, artifactSha256Got: null, artifactList: null };
+  if (shouldArtifact) {
+    artifact = await artifactBeat(SELF_NAMESPACE, SELF_AGENT_NAME, sessionID, 0);
+  }
+
   return {
     status: 200,
     body: JSON.stringify({
@@ -266,6 +404,9 @@ module.exports = async function (context) {
       agentTokenNamespace: agentTokenNamespace,
       agentTokenAgent: agentTokenAgent,
       traceparentSeen: traceparentSeen,
+      artifactSha256Put: artifact.artifactSha256Put,
+      artifactSha256Got: artifact.artifactSha256Got,
+      artifactList: artifact.artifactList,
     }),
     headers: { 'Content-Type': 'application/json' },
   };


### PR DESCRIPTION
Stack position 7 (#3701 ← #3703 ← #3704 ← #3705 ← #3706 ← this). Session-scoped file storage for agent functions — artifacts too big for the statestore's 256KiB KV cap — with lifecycle tied to session archive.

## Architecture

**agentruntime is the workspace API** (proxy): pods authenticate with the G16 identity bearer, which only agentruntime can verify *with revocation* (the live AgentView); it signs through (master `ServiceStoragesvc` HMAC) to a new internal-only storagesvc surface. A bearer path on storagesvc would have minted a third authz-code copy and honored tokens for dead agents.

- **storagesvc `/v1/workspace`** (PUT/GET/DELETE/list/prefix-delete, raw bodies, streamed, master-signer-only): caller-chosen ids under a reserved `_workspace_` root — **pruner-excluded** (the archive pruner deletes anything matching no Package URL within ~an hour; exclusion is segment-based because local candidate ids are absolute paths and S3 keys may be subDir-prefixed) and **sealed off from the archive routes** (the legacy grandfather would otherwise have served/deleted workspace objects to tenant signers). Backend keys join `STORAGE_S3_SUB_DIR` (shared-bucket isolation); wire ids don't.
- **agentruntime `/workspace/{ns}/{name}/{session}/{path...}`**: identity bearer with **own-workspace** authorization (ns AND agent equality — a deliberate, documented widening of G16's dispatch-only identity surface); JWT callers keep namespace scope. **A live session record is required (404 otherwise) — it is the GC anchor**: the sweeper purges the prefix at archive, so a recordless workspace file would be collected by nothing, ever.
- **Quotas on the session record** (storagesvc has none): 32MiB/artifact (over-read-detected 413 — never a silently truncated store), 256MiB + 1000 artifacts/session (pre-check → write → CAS-settle; delta-accounted via an existence probe; **fail-closed on every PUT-side race** including the shrink race the first fix round introduced and the second removed). One documented fail-open exception: racing same-path DELETEs can double-decrement (self-inflicted, bounded, named in code + README — exact settle would need per-path serialization).
- **Sweeper purge** at archive (between the archive CAS and the state-keyspace early return, so state-less agents purge too); log-don't-retry; orphan residue for TTL'd-out unswept records joins the named orphan-sweep follow-up.
- **NetPol**: storagesvc's allowlist gains the agentruntime pod (final-review blocker — without it, netpol-enabled installs silently drop every workspace call and orphan every archived workspace).
- **Demo + integration**: support-desk artifact beat; put→get sha equality, list, no-session 404 in-cluster; the test skips explicitly on secured installs (cross-agent 403 is unit-owned until the named secured-mode serial e2e).

## Accepted residues (documented in code)
DELETE-side double-decrement (above); concurrent same-new-path phantom `ArtifactCount` (+N-1 bound); probe-failure treated as create; in-flight-PUT-vs-purge orphan; shrink reclaim = DELETE+PUT.

Process: reviewed plan (REVISE: 2 blockers — the objectStore seam misname and the archive-route grandfather hole), 4 SDD tasks (Task 2 adversarially reviewed, 2 fix rounds; Task 4 spec-FAIL closed by the explicit-skip ruling), final review FIX-FIRST (the netpol blocker) → fix round → CLEAN re-review. Three machine-sleep interrupts recovered mid-run.