### PR TITLE
cli: fission agent create — one-command agent scaffold (G17 in-repo half)

### DIFF
--- a/demo/agent-boardroom/README.md
+++ b/demo/agent-boardroom/README.md
@@ -110,6 +110,11 @@ It stays here for now so the whole stack (fixtures, specs, load driver) is self-
    list (`--agents-url`, `--namespace`, `--agent`, `--environment`,
    `--concurrency`, `--timeout`).
 
+**Scaffold your own agent:** `fission agent create --name my-agent --env node` generates a working handler + Package + Function in one command
+(add `--spec` to write it under `specs/` instead of applying directly).
+Run `fission agent create --help` for the full flag reference —
+a fission.io quickstart page lands at release cut.
+
 ## Swarm beat
 
 `architect` (`fixtures/architect.js` / `specs/architect.yaml`) is a second agent function:

--- a/pkg/fission-cli/cmd/agent/command.go
+++ b/pkg/fission-cli/cmd/agent/command.go
@@ -2,12 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Package agent implements the `fission agent` command group: discover and
-// inspect agent-declared functions (FunctionSpec.Agent != nil), and inspect
-// their sessions via `fission agent sessions` (sessions.go), which talks to
-// the agentruntime's RegistryAPI introspection endpoints (slice 4).
-// Session archival is not implemented here; creation is
-// `fission fn create --agent ...`.
+// Package agent implements the `fission agent` command group: scaffold an
+// agent (create.go), discover and inspect agent-declared functions
+// (FunctionSpec.Agent != nil), and inspect their sessions via `fission agent
+// sessions` (sessions.go), which talks to the agentruntime's RegistryAPI
+// introspection endpoints (slice 4). Session archival is not implemented
+// here. Creation is `fission agent create ...` (a one-command scaffold: a
+// handler template plus the Package/Function it needs) or, for a function
+// that already has code, `fission fn create --agent ...`.
 package agent
 
 import (
@@ -17,8 +19,39 @@ import (
 	"github.com/fission/fission/pkg/fission-cli/flag"
 )
 
+// agentCreateStateFlag / agentCreateAgentFlag default ON: unlike `fn create`,
+// where --state/--agent are explicit opt-ins onto an otherwise plain
+// function, `agent create`'s entire purpose is scaffolding an agent, so
+// State and Agent are on by default here, and --state=false/--agent=false
+// opts back out (mirroring the shared helpers' own off-switch semantics,
+// cmd/function/create.go's GetStateConfig/GetAgentConfig). These are local
+// copies of the shared flag.FnState/flag.FnAgent descriptors with a
+// different DefaultBool -- the shared vars themselves must keep their
+// default-off behavior for `fn create`.
+var (
+	agentCreateStateFlag = func() flag.Flag { f := flag.FnState; f.DefaultBool = true; return f }()
+	agentCreateAgentFlag = func() flag.Flag { f := flag.FnAgent; f.DefaultBool = true; return f }()
+)
+
 // Commands returns the `fission agent` command group.
 func Commands() *cobra.Command {
+	createCmd := wrapper.SubCommand(&cobra.Command{
+		Use:   "create",
+		Short: "Scaffold a working stateful agent: handler template + Package + Function, in one command",
+	}, Create, flag.FlagSet{
+		Required: []flag.Flag{flag.FnName},
+		Optional: []flag.Flag{
+			flag.FnEnvName, flag.FnAgentLang, flag.PkgCode,
+			agentCreateStateFlag, flag.FnStateKeyspace, flag.FnStateMaxKeys,
+			flag.FnStateMaxValueBytes, flag.FnStateTTL,
+			flag.FnStateStickySource, flag.FnStateStickyName,
+			agentCreateAgentFlag, flag.FnAgentSessionSource, flag.FnAgentSessionName,
+			flag.FnAgentIdleAfter, flag.FnAgentArchiveAfter, flag.FnAgentMaxSessions,
+			flag.FnAgentHistoryTrim,
+			flag.SpecSave,
+		},
+	})
+
 	listCmd := wrapper.SubCommand(&cobra.Command{
 		Use:   "list",
 		Short: "List functions declared as agents",
@@ -27,12 +60,13 @@ func Commands() *cobra.Command {
 	})
 	// Namespace comes from the global flag.Namespace, exactly like
 	// `fission fn tools` (cmd/function/command.go:274-279) — there is no
-	// flag.NamespaceFunction; do not invent one.
+	// flag.NamespaceFunction; do not invent one. `create` above and
+	// `sessions` (sessions.go) both read it the same way.
 
 	command := &cobra.Command{
 		Use:   "agent",
-		Short: "Inspect agent-declared functions",
+		Short: "Inspect and scaffold agent-declared functions",
 	}
-	command.AddCommand(listCmd, SessionCommands())
+	command.AddCommand(createCmd, listCmd, SessionCommands())
 	return command
 }

--- a/pkg/fission-cli/cmd/agent/create.go
+++ b/pkg/fission-cli/cmd/agent/create.go
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	apiv1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	ferror "github.com/fission/fission/pkg/error"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/cli"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	"github.com/fission/fission/pkg/fission-cli/cmd/agent/templates"
+	"github.com/fission/fission/pkg/fission-cli/cmd/function"
+	_package "github.com/fission/fission/pkg/fission-cli/cmd/package"
+	"github.com/fission/fission/pkg/fission-cli/cmd/spec"
+	"github.com/fission/fission/pkg/fission-cli/console"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	"github.com/fission/fission/pkg/fission-cli/util"
+	"github.com/fission/fission/pkg/svcinfo"
+)
+
+// defaultLang is `--lang`'s fallback when the flag carries no value -- both
+// when a real CLI invocation leaves the (DefaultString: "node") flag
+// untouched, and, since flag.FlagSet.Optional isn't consulted by the
+// dummy/unit-test Input, when a test never sets it at all.
+const defaultLang = "node"
+
+// scaffoldFunctionTimeout mirrors `fn create`'s own --fntimeout default of
+// 60 (flag.FnExecutionTimeout's DefaultInt, cmd/function's flag.go). This
+// command intentionally exposes no --fntimeout/--concurrency/--executortype
+// flags (a minimal, opinionated scaffold): FunctionTimeout is hardcoded here
+// rather than left at Go's zero value, which would produce a Function with
+// no timeout at all; Concurrency/RequestsPerPod/RetainPods are deliberately
+// left at zero to match the demo shape (demo/agent-boardroom/specs/
+// support-desk.yaml carries none of those keys either).
+const scaffoldFunctionTimeout = 60
+
+type CreateSubCommand struct {
+	cmd.CommandActioner
+}
+
+// Create implements `fission agent create`: it writes one of Task 1's
+// embedded handler templates to disk, then composes `fn create`'s shipped
+// pipeline (_package.CreatePackage, function.GetStateConfig/GetAgentConfig,
+// spec.SaveOrDry) around it to produce a working Package + Function --
+// State (keyed on the function name, sticky on the session header) and
+// Agent -- in one command, in both direct and --spec modes. See
+// docs/superpowers/plans/2026-08-26-agent-runtime-scaffold.md Task 2.
+func Create(input cli.Input) error {
+	return (&CreateSubCommand{}).do(input)
+}
+
+func (opts *CreateSubCommand) do(input cli.Input) error {
+	name := input.String(flagkey.FnName)
+
+	lang := input.String(flagkey.FnAgentLang)
+	if lang == "" {
+		lang = defaultLang
+	}
+
+	envName := input.String(flagkey.FnEnvironmentName)
+	if envName == "" {
+		// The demo's own Environment/handler-language naming convention
+		// (demo/agent-boardroom/specs/support-desk.yaml: environment name
+		// "node" for the node handler) -- and the same string the
+		// env-missing next-steps line derives its
+		// ghcr.io/fission/<env>-env image name from.
+		envName = lang
+	}
+
+	toSpec := input.Bool(flagkey.SpecSave)
+	specDir := util.GetSpecDir(input)
+	specIgnore := util.GetSpecIgnore(input)
+	specFile := ""
+	if toSpec {
+		specFile = fmt.Sprintf("agent-%s.yaml", name)
+	}
+
+	userProvidedNS, fnNamespace, err := opts.GetResourceNamespace(input)
+	if err != nil {
+		return fmt.Errorf("error retrieving namespace information: %w", err)
+	}
+
+	// 1. Render the handler and write it to disk, refusing to clobber an
+	// existing file (an idempotent re-run must point at a different --code,
+	// never silently overwrite someone's edited handler).
+	rendered, ext, err := templates.Render(lang, name)
+	if err != nil {
+		return err
+	}
+	codePath := input.String(flagkey.PkgCode)
+	if codePath == "" {
+		codePath = fmt.Sprintf("%s.%s", name, ext)
+	}
+	if _, statErr := os.Stat(codePath); statErr == nil {
+		return fmt.Errorf("refusing to overwrite existing file %q; pass --%s to scaffold at a different path", codePath, flagkey.PkgCode)
+	} else if !os.IsNotExist(statErr) {
+		return fmt.Errorf("checking handler file %q: %w", codePath, statErr)
+	}
+	if err := os.WriteFile(codePath, rendered, 0o644); err != nil { //nolint:gosec // a scaffolded handler is meant to be read by its author, not secret
+		return fmt.Errorf("writing handler file %q: %w", codePath, err)
+	}
+	console.Info(fmt.Sprintf("Scaffolded %s handler: %s", lang, codePath))
+
+	// 2. --spec mode: auto-init a fresh spec directory when none exists yet
+	// (spec.go's save() precondition, spec.go:140-142, is what every write
+	// below hits otherwise: "couldn't find specs, run `fission spec init`
+	// first"). A directory that already has fission-deployment-config.yaml
+	// is used silently and never touched -- this only mints one when it is
+	// genuinely absent.
+	if toSpec {
+		if err := ensureSpecInitialized(input, specDir); err != nil {
+			return err
+		}
+	}
+
+	// 3. Environment existence: warn, don't create (fn-create precedent,
+	// cmd/function/create.go:507-542).
+	envExists, err := opts.checkEnvironment(input, name, envName, fnNamespace, userProvidedNS, toSpec, specDir, specIgnore)
+	if err != nil {
+		return err
+	}
+
+	// 4. Direct mode only: refuse a duplicate function name up front, same
+	// check `fn create` runs (cmd/function/create.go:414-422).
+	if !toSpec {
+		fn, err := opts.Client().FissionClientSet.CoreV1().Functions(fnNamespace).Get(input.Context(), name, metav1.GetOptions{})
+		if err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		} else if fn.Name != "" && fn.Namespace != "" {
+			return errors.New("a function with the same name already exists")
+		}
+	}
+
+	// 5. Compose the shipped pipeline: build (and, in direct mode, upload)
+	// the Package from the handler file just written. noZip=true and a
+	// single-file deployArchiveFiles mirrors `fn create --code`'s own path
+	// (cmd/function/create.go:548-554).
+	pkgMeta, err := _package.CreatePackage(input, opts.Client(), "", fnNamespace, envName,
+		nil, []string{codePath}, "", specDir, specFile, true, userProvidedNS, "")
+	if err != nil {
+		return fmt.Errorf("error creating package: %w", err)
+	}
+
+	fn := buildFunction(input, name, fnNamespace, envName, pkgMeta)
+	if toSpec {
+		fn.Namespace = userProvidedNS
+		fn.Spec.Package.PackageRef.Namespace = userProvidedNS
+		fn.Spec.Environment.Namespace = userProvidedNS
+	}
+
+	if handled, err := spec.SaveOrDry(input, fn, specFile); handled {
+		if err != nil {
+			return err
+		}
+	} else {
+		if _, err := opts.Client().FissionClientSet.CoreV1().Functions(fn.Namespace).Create(input.Context(), fn, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("error creating function: %w", err)
+		}
+		fmt.Fprintf(input.Stdout(), "function '%s' created\n", fn.Name)
+	}
+
+	printNextSteps(input.Stdout(), name, fnNamespace, envName, codePath, specDir, toSpec, envExists)
+	return nil
+}
+
+// ensureSpecInitialized runs the equivalent of `fission spec init` when
+// specDir has no fission-deployment-config.yaml yet, printing a note so the
+// auto-init isn't a silent side effect. A directory that already has one is
+// left completely untouched -- spec.Init itself refuses to run against an
+// existing config (spec/init.go:90-92), so this check exists to skip the
+// call (and its note) entirely rather than let that refusal surface as an
+// error on every normal re-run.
+func ensureSpecInitialized(input cli.Input, specDir string) error {
+	configPath := filepath.Join(specDir, "fission-deployment-config.yaml")
+	if _, err := os.Stat(configPath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("checking for an existing spec directory %q: %w", specDir, err)
+	}
+	console.Info(fmt.Sprintf("no spec directory found at %q; running the equivalent of `fission spec init`", specDir))
+	if err := spec.Init(input); err != nil {
+		return fmt.Errorf("auto-initializing the spec directory: %w", err)
+	}
+	return nil
+}
+
+// checkEnvironment reports whether envName exists, warning (never erroring,
+// never creating) when it does not -- the same warn-don't-create contract
+// `fn create` applies for both its spec (cmd/function/create.go:516-532) and
+// direct (:533-541) modes.
+func (opts *CreateSubCommand) checkEnvironment(input cli.Input, fnName, envName, fnNamespace, userProvidedNS string, toSpec bool, specDir, specIgnore string) (bool, error) {
+	if toSpec {
+		fr, err := spec.ReadSpecs(specDir, specIgnore, false)
+		if err != nil {
+			return false, fmt.Errorf("error reading spec in '%s': %w", specDir, err)
+		}
+		exists, err := fr.ExistsInSpecs(&fv1.Environment{
+			ObjectMeta: metav1.ObjectMeta{Name: envName, Namespace: userProvidedNS},
+		})
+		if err != nil {
+			return false, err
+		}
+		if !exists {
+			console.Warn(fmt.Sprintf("Function '%s' references unknown Environment '%s', please create it before applying spec", fnName, envName))
+		}
+		return exists, nil
+	}
+
+	_, err := opts.Client().FissionClientSet.CoreV1().Environments(fnNamespace).Get(input.Context(), envName, metav1.GetOptions{})
+	if err != nil {
+		// fn create's own env-missing check (create.go:536) only recognizes a
+		// ferror.Error with Code ErrorNotFound -- but a typed clientset (the
+		// fake one these tests use, AND, confirmed against a live cluster
+		// while building this command, the real one too) returns a plain
+		// k8s.io/apimachinery StatusError, which that assertion never
+		// matches. Left as fn create left it, "not found" would silently
+		// become a hard error instead of a warning, making half of Global
+		// Constraints item 6 (env-missing -> warn, never block) unreachable.
+		// k8serrors.IsNotFound is checked first, then the ferror.Error form
+		// is still recognized as a belt-and-suspenders fallback in case some
+		// other client path really does wrap errors that way.
+		if k8serrors.IsNotFound(err) {
+			console.Warn(fmt.Sprintf("Environment \"%s\" does not exist. Please create the environment before invoking the agent. \nFor example: `fission env create --name %s --namespace %s --image ghcr.io/fission/%s-env`\n", envName, envName, fnNamespace, envName))
+			return false, nil
+		}
+		if e, ok := err.(ferror.Error); ok && e.Code == ferror.ErrorNotFound {
+			console.Warn(fmt.Sprintf("Environment \"%s\" does not exist. Please create the environment before invoking the agent. \nFor example: `fission env create --name %s --namespace %s --image ghcr.io/fission/%s-env`\n", envName, envName, fnNamespace, envName))
+			return false, nil
+		}
+		return false, fmt.Errorf("error retrieving environment information: %w", err)
+	}
+	return true, nil
+}
+
+// buildFunction assembles the scaffolded Function: an env reference to the
+// just-created Package, plus the demo shape's State (keyspace = the
+// function name, sticky routing on the platform's session header) and Agent
+// blocks -- built through the SHARED function.GetStateConfig/GetAgentConfig
+// helpers so this command's on/off and merge semantics never drift from
+// `fn create`/`fn update`'s. Keyspace/Sticky are filled in here, on top of
+// the helper's result, only when the corresponding --state* flag was left
+// unset: unlike the session id (whose nil default already IS the platform's
+// X-Fission-Session header, fv1 types.go:1522-1524), sticky routing has no
+// such built-in default -- it is opt-in, so a scaffold that wants the demo's
+// "the router lands on the same pod the dispatcher predicts" property has to
+// set it explicitly.
+func buildFunction(input cli.Input, name, fnNamespace, envName string, pkgMeta *metav1.ObjectMeta) *fv1.Function {
+	stateCfg := function.GetStateConfig(input, nil)
+	if stateCfg != nil {
+		if stateCfg.Keyspace == "" {
+			stateCfg.Keyspace = name
+		}
+		if stateCfg.Sticky == nil {
+			stateCfg.Sticky = &fv1.StickyConfig{
+				Source: fv1.StickySourceHeader,
+				Name:   fv1.DefaultAgentSessionHeader,
+			}
+		}
+	}
+	agentCfg := function.GetAgentConfig(input, nil)
+
+	return &fv1.Function{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: fnNamespace},
+		Spec: fv1.FunctionSpec{
+			Environment: fv1.EnvironmentReference{Name: envName, Namespace: fnNamespace},
+			Package: fv1.FunctionPackageRef{
+				PackageRef: fv1.PackageRef{
+					Namespace:       pkgMeta.Namespace,
+					Name:            pkgMeta.Name,
+					ResourceVersion: pkgMeta.ResourceVersion,
+				},
+			},
+			InvokeStrategy: fv1.InvokeStrategy{
+				ExecutionStrategy: fv1.ExecutionStrategy{
+					ExecutorType:          fv1.ExecutorTypePoolmgr,
+					SpecializationTimeout: fv1.DefaultSpecializationTimeOut,
+				},
+				StrategyType: fv1.StrategyTypeExecution,
+			},
+			FunctionTimeout: scaffoldFunctionTimeout,
+			Resources:       apiv1.ResourceRequirements{},
+			State:           stateCfg,
+			Agent:           agentCfg,
+		},
+	}
+}
+
+// printNextSteps writes the scaffold's <10-minute-to-first-turn punch list:
+// the file it wrote, how to get the resource(s) onto a cluster (conditional
+// on --spec), the env-create line when checkEnvironment found none
+// (conditional, and always step 1 when present -- Global Constraints item
+// 6), the dispatch curl (POST /agents/<ns>/<name> + the platform's session
+// header, pinned via fv1.DefaultAgentSessionHeader/svcinfo rather than
+// retyped literals -- the same contract-drift discipline Task 1's tests
+// apply), and where to look afterwards. This is a spec'd, golden-tested
+// deliverable (create_test.go) -- keep any wording change here in sync with
+// the golden strings there.
+func printNextSteps(w io.Writer, name, namespace, envName, codePath, specDir string, toSpec, envExists bool) {
+	fmt.Fprintf(w, "\nScaffolded %s\n\nNext steps:\n", codePath)
+
+	step := 1
+	if !envExists {
+		fmt.Fprintf(w, "  %d. Create the environment (not found in namespace %q):\n       fission env create --name %s --image ghcr.io/fission/%s-env\n",
+			step, namespace, envName, envName)
+		step++
+	}
+
+	if toSpec {
+		fmt.Fprintf(w, "  %d. Apply the spec:\n       fission spec apply --specdir %s\n", step, specDir)
+	} else {
+		fmt.Fprintf(w, "  %d. Function %s/%s is already created.\n", step, namespace, name)
+	}
+	step++
+
+	fmt.Fprintf(w,
+		"  %d. Port-forward the agent runtime and dispatch a turn:\n"+
+			"       kubectl -n %s port-forward svc/%s %d:%d\n"+
+			"       curl -i -X POST http://127.0.0.1:%d/agents/%s/%s \\\n"+
+			"         -H 'Content-Type: application/json' \\\n"+
+			"         -H '%s: %s-demo-1' \\\n"+
+			"         -d '{}'\n",
+		step, fissionNamespace(), svcinfo.SvcAgentRuntime, svcinfo.PortAgentRuntime, svcinfo.PortAgentRuntime,
+		svcinfo.PortAgentRuntime, namespace, name, fv1.DefaultAgentSessionHeader, name)
+	step++
+
+	fmt.Fprintf(w, "  %d. Inspect sessions:\n       fission agent sessions list --name %s --tree\n", step, name)
+}

--- a/pkg/fission-cli/cmd/agent/create_test.go
+++ b/pkg/fission-cli/cmd/agent/create_test.go
@@ -1,0 +1,325 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+	"github.com/fission/fission/pkg/fission-cli/cliwrapper/driver/dummy"
+	"github.com/fission/fission/pkg/fission-cli/cmd"
+	spectypes "github.com/fission/fission/pkg/fission-cli/cmd/spec/types"
+	flagkey "github.com/fission/fission/pkg/fission-cli/flag/key"
+	fissionfake "github.com/fission/fission/pkg/generated/clientset/versioned/fake"
+	"github.com/fission/fission/pkg/svcinfo"
+)
+
+// setAgentCreateClient installs a fresh fake Fission clientset as the
+// package-level default client (the same sync.Once-guarded seam
+// list_test.go's TestAgentListOutput uses) and returns it so a test can
+// query what Create actually wrote. NewSimpleClientset, not NewClientset:
+// the field-managed tracker NewClientset uses for server-side-apply support
+// doesn't have CRD type conversion (https://github.com/kubernetes/kubernetes/issues/126850,
+// cited in the fake package's own doc comment) and fails every Create call
+// here with "no type found matching ...Package" -- NewSimpleClientset's
+// plain object tracker (as its doc comment says: "processes creates,
+// updates and deletions as-is, without ... field management") has no such
+// requirement.
+func setAgentCreateClient(t *testing.T, ns string, objs ...runtime.Object) *fissionfake.Clientset {
+	t.Helper()
+	cs := fissionfake.NewSimpleClientset(objs...)
+	cmd.ResetClientsetForTest()
+	cmd.SetClientset(cmd.Client{FissionClientSet: cs, Namespace: ns})
+	t.Cleanup(cmd.ResetClientsetForTest)
+	return cs
+}
+
+// baseCreateInput builds a dummy.Cli carrying the flags a real CLI
+// invocation would already have via flag.FlagSet's DefaultBool/DefaultString
+// (dummy.Cli has no notion of registered-flag defaults, see
+// cliwrapper/driver/dummy/dummy.go's doc comment and
+// cmd/function/agentconfig_test.go's identical pattern), so tests set them
+// explicitly to mirror agentCreateStateFlag/agentCreateAgentFlag's
+// DefaultBool: true (command.go) and flag.FnAgentLang's DefaultString: "node"
+// (flag.go).
+func baseCreateInput(name string) dummy.Cli {
+	in := dummy.TestFlagSet()
+	in.SetString(flagkey.FnName, name)
+	in.SetBool(flagkey.FnState, true)
+	in.SetBool(flagkey.FnAgent, true)
+	return in
+}
+
+// readYAMLDocs splits a spec file into its "---"-separated documents, in
+// the order save() (spec.go) wrote them: ArchiveUploadSpec, then Package,
+// then Function (CreatePackage/CreateArchive write the first two;
+// spec.SaveOrDry writes the Function last).
+func readYAMLDocs(t *testing.T, path string) [][]byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var docs [][]byte
+	for _, part := range strings.Split(string(data), "\n---\n") {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		docs = append(docs, []byte(part))
+	}
+	return docs
+}
+
+func TestAgentCreate_SpecMode_AutoInit(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setAgentCreateClient(t, "default")
+
+	in := baseCreateInput("myagent")
+	in.SetBool(flagkey.SpecSave, true)
+
+	out := captureStdout(t, func() error { return Create(in) })
+	assert.Contains(t, out, "running the equivalent of `fission spec init`")
+
+	assert.FileExists(t, filepath.Join(dir, "specs", "fission-deployment-config.yaml"))
+	assert.FileExists(t, filepath.Join(dir, "myagent.js"))
+
+	docs := readYAMLDocs(t, filepath.Join(dir, "specs", "agent-myagent.yaml"))
+	require.Len(t, docs, 3, "want ArchiveUploadSpec, Package, Function")
+
+	var aus spectypes.ArchiveUploadSpec
+	require.NoError(t, yaml.Unmarshal(docs[0], &aus))
+	assert.Equal(t, "ArchiveUploadSpec", aus.Kind)
+
+	var pkg fv1.Package
+	require.NoError(t, yaml.Unmarshal(docs[1], &pkg))
+	assert.Equal(t, "Package", pkg.Kind)
+	assert.Equal(t, "node", pkg.Spec.Environment.Name)
+
+	var fn fv1.Function
+	require.NoError(t, yaml.Unmarshal(docs[2], &fn))
+	assert.Equal(t, "Function", fn.Kind)
+	assert.Equal(t, "myagent", fn.Name)
+	require.NotNil(t, fn.Spec.Agent, "the --state/--agent DefaultBool: true shape must carry an Agent block")
+	require.NotNil(t, fn.Spec.State)
+	assert.Equal(t, "myagent", fn.Spec.State.Keyspace, "keyspace defaults to the function name")
+	require.NotNil(t, fn.Spec.State.Sticky, "sticky routing on the session header is the demo shape")
+	assert.Equal(t, fv1.StickySourceHeader, fn.Spec.State.Sticky.Source)
+	assert.Equal(t, fv1.DefaultAgentSessionHeader, fn.Spec.State.Sticky.Name)
+}
+
+func TestAgentCreate_SpecMode_ExistingConfigUntouched(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setAgentCreateClient(t, "default")
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "specs"), 0o700))
+	configPath := filepath.Join(dir, "specs", "fission-deployment-config.yaml")
+	original := "apiVersion: fission.io/v1\nkind: DeploymentConfig\nname: foreign-app\nuid: foreign-uid\n"
+	require.NoError(t, os.WriteFile(configPath, []byte(original), 0o600))
+
+	in := baseCreateInput("myagent")
+	in.SetBool(flagkey.SpecSave, true)
+
+	out := captureStdout(t, func() error { return Create(in) })
+	assert.NotContains(t, out, "fission spec init", "an existing config must never be touched or re-initialized")
+
+	got, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	assert.Equal(t, original, string(got), "the foreign config's bytes are untouched")
+
+	assert.FileExists(t, filepath.Join(dir, "specs", "agent-myagent.yaml"), "the new spec is appended to the same spec set")
+}
+
+func TestAgentCreate_RefusesExistingHandlerFile(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setAgentCreateClient(t, "default")
+
+	handlerPath := filepath.Join(dir, "myagent.js")
+	const handwritten = "// hand-written, do not clobber\n"
+	require.NoError(t, os.WriteFile(handlerPath, []byte(handwritten), 0o644))
+
+	in := baseCreateInput("myagent")
+	err := Create(in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "myagent.js")
+	assert.Contains(t, err.Error(), "refusing to overwrite")
+
+	got, err := os.ReadFile(handlerPath)
+	require.NoError(t, err)
+	assert.Equal(t, handwritten, string(got), "the existing file must be left untouched")
+
+	assert.NoDirExists(t, filepath.Join(dir, "specs"), "the refusal happens before any spec/package/function side effect")
+}
+
+func TestAgentCreate_DirectMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	cs := setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myagent")
+	out := captureStdout(t, func() error { return Create(in) })
+	assert.Contains(t, out, "function 'myagent' created")
+
+	fn, err := cs.CoreV1().Functions(ns).Get(context.Background(), "myagent", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, fn.Spec.Agent)
+	require.NotNil(t, fn.Spec.State)
+	assert.Equal(t, "node", fn.Spec.Environment.Name)
+	assert.Equal(t, "myagent", fn.Spec.State.Keyspace)
+
+	pkg, err := cs.CoreV1().Packages(ns).Get(context.Background(), fn.Spec.Package.PackageRef.Name, metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "node", pkg.Spec.Environment.Name)
+
+	assert.FileExists(t, filepath.Join(dir, "myagent.js"))
+}
+
+func TestAgentCreate_LangPython(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setAgentCreateClient(t, "default")
+
+	in := baseCreateInput("pyagent")
+	in.SetString(flagkey.FnAgentLang, "python")
+	in.SetBool(flagkey.SpecSave, true)
+
+	_ = captureStdout(t, func() error { return Create(in) })
+
+	assert.FileExists(t, filepath.Join(dir, "pyagent.py"))
+
+	docs := readYAMLDocs(t, filepath.Join(dir, "specs", "agent-pyagent.yaml"))
+	require.Len(t, docs, 3)
+	var pkg fv1.Package
+	require.NoError(t, yaml.Unmarshal(docs[1], &pkg))
+	assert.Equal(t, "python", pkg.Spec.Environment.Name, "--env unset defaults to --lang")
+}
+
+// TestAgentCreate_EnvMissing_NextStepsGolden exercises the --spec path (a
+// pure local ReadSpecs/ExistsInSpecs check, see checkEnvironment): the
+// referenced Environment is not declared anywhere in specs/, so the
+// next-steps block's step 1 must be the exact env-create line (Global
+// Constraints item 6), and step 2 must be the "apply the spec" line (toSpec
+// case).
+func TestAgentCreate_EnvMissing_NextStepsGolden(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("FISSION_NAMESPACE", "")
+	setAgentCreateClient(t, "default")
+
+	in := baseCreateInput("myagent")
+	in.SetBool(flagkey.SpecSave, true)
+
+	out := captureStdout(t, func() error { return Create(in) })
+
+	want := fmt.Sprintf(
+		"\nScaffolded myagent.js\n\nNext steps:\n"+
+			"  1. Create the environment (not found in namespace \"default\"):\n"+
+			"       fission env create --name node --image ghcr.io/fission/node-env\n"+
+			"  2. Apply the spec:\n"+
+			"       fission spec apply --specdir specs\n"+
+			"  3. Port-forward the agent runtime and dispatch a turn:\n"+
+			"       kubectl -n fission port-forward svc/%s %d:%d\n"+
+			"       curl -i -X POST http://127.0.0.1:%d/agents/default/myagent \\\n"+
+			"         -H 'Content-Type: application/json' \\\n"+
+			"         -H '%s: myagent-demo-1' \\\n"+
+			"         -d '{}'\n"+
+			"  4. Inspect sessions:\n"+
+			"       fission agent sessions list --name myagent --tree\n",
+		svcinfo.SvcAgentRuntime, svcinfo.PortAgentRuntime, svcinfo.PortAgentRuntime,
+		svcinfo.PortAgentRuntime, fv1.DefaultAgentSessionHeader,
+	)
+	assert.Contains(t, out, want)
+}
+
+// TestAgentCreate_EnvPresent_NextStepsGolden exercises direct mode with the
+// Environment already registered: no env-create step, and step 1 reports the
+// function as already created (not "apply the spec").
+func TestAgentCreate_EnvPresent_NextStepsGolden(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("FISSION_NAMESPACE", "")
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myagent")
+
+	out := captureStdout(t, func() error { return Create(in) })
+
+	want := fmt.Sprintf(
+		"\nScaffolded myagent.js\n\nNext steps:\n"+
+			"  1. Function default/myagent is already created.\n"+
+			"  2. Port-forward the agent runtime and dispatch a turn:\n"+
+			"       kubectl -n fission port-forward svc/%s %d:%d\n"+
+			"       curl -i -X POST http://127.0.0.1:%d/agents/default/myagent \\\n"+
+			"         -H 'Content-Type: application/json' \\\n"+
+			"         -H '%s: myagent-demo-1' \\\n"+
+			"         -d '{}'\n"+
+			"  3. Inspect sessions:\n"+
+			"       fission agent sessions list --name myagent --tree\n",
+		svcinfo.SvcAgentRuntime, svcinfo.PortAgentRuntime, svcinfo.PortAgentRuntime,
+		svcinfo.PortAgentRuntime, fv1.DefaultAgentSessionHeader,
+	)
+	assert.Contains(t, out, want)
+}
+
+// TestAgentCreate_DirectMode_EnvMissing_WarnsAndCreates is the regression
+// test for checkEnvironment's k8serrors.IsNotFound fix: a typed clientset
+// Get on a missing Environment returns a plain k8s.io/apimachinery
+// StatusError (confirmed against both the fake clientset here and, while
+// building this command, a real cluster), which the ferror.Error-typed
+// check fn create uses (create.go:536) never matches -- left unfixed, this
+// would silently turn "environment not found" into a hard error instead of
+// the warn-don't-create the Global Constraints require, in direct mode
+// only (the --spec path's checkEnvironment branch uses ExistsInSpecs, no
+// clientset error involved, so it never had this gap).
+func TestAgentCreate_DirectMode_EnvMissing_WarnsAndCreates(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("FISSION_NAMESPACE", "")
+	const ns = "default"
+	cs := setAgentCreateClient(t, ns) // no Environment object: env missing
+
+	in := baseCreateInput("myagent")
+	out := captureStdout(t, func() error { return Create(in) })
+
+	assert.Contains(t, out, "Environment \"node\" does not exist")
+	assert.Contains(t, out, "function 'myagent' created", "env-missing warns, it does not block")
+
+	fn, err := cs.CoreV1().Functions(ns).Get(context.Background(), "myagent", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, fn.Spec.Agent)
+
+	want := fmt.Sprintf(
+		"\nScaffolded myagent.js\n\nNext steps:\n"+
+			"  1. Create the environment (not found in namespace \"default\"):\n"+
+			"       fission env create --name node --image ghcr.io/fission/node-env\n"+
+			"  2. Function default/myagent is already created.\n"+
+			"  3. Port-forward the agent runtime and dispatch a turn:\n"+
+			"       kubectl -n fission port-forward svc/%s %d:%d\n"+
+			"       curl -i -X POST http://127.0.0.1:%d/agents/default/myagent \\\n"+
+			"         -H 'Content-Type: application/json' \\\n"+
+			"         -H '%s: myagent-demo-1' \\\n"+
+			"         -d '{}'\n"+
+			"  4. Inspect sessions:\n"+
+			"       fission agent sessions list --name myagent --tree\n",
+		svcinfo.SvcAgentRuntime, svcinfo.PortAgentRuntime, svcinfo.PortAgentRuntime,
+		svcinfo.PortAgentRuntime, fv1.DefaultAgentSessionHeader,
+	)
+	assert.Contains(t, out, want)
+}

--- a/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
@@ -1,0 +1,168 @@
+'use strict';
+
+// {{.Name}} -- a Fission agent handler, scaffolded by `fission agent create`.
+//
+// WHAT THIS FILE IS
+// ------------------
+// An agent function is an ordinary Fission function (module.exports takes
+// one `context` argument and returns {status, body, headers}, exactly like
+// any other Node handler) that the agent runtime (pkg/agentruntime) calls
+// once per "turn" of a session. The runtime adds a session id to every
+// call and expects the function to say, via a response header, whether the
+// session should go idle after this turn or be re-invoked immediately.
+//
+// Read this top to bottom once -- every section explains the piece of the
+// contract it implements -- then replace the TODO in the middle with real
+// agent logic (call an LLM, run a tool, whatever your agent does).
+
+const fs = require('fs');
+
+// The dispatcher stamps two request headers on every forwarded call (see
+// pkg/agentruntime/dispatcher.go), and reads one response header back:
+//   X-Fission-Session      the session id this turn belongs to (minted on
+//                          the session's first turn, stable after that)
+//   X-Fission-Agent-Turns  how many turns this session had BEFORE this one
+//   X-Fission-Agent-Yield  set in the RESPONSE: 'waiting' ends this turn and
+//                          idles the session (the default below); 'continue'
+//                          re-invokes it again immediately -- see the
+//                          commented-out block at the bottom before using it.
+// Node lower-cases incoming header names; the response header keeps its
+// natural case since we are the one setting it.
+const SESSION_HEADER = 'x-fission-session';
+const TURNS_HEADER = 'x-fission-agent-turns';
+const YIELD_HEADER = 'X-Fission-Agent-Yield';
+
+// --- Load/save session state --------------------------------------------
+//
+// RFC-0023's state API gives every function-as-agent its own namespaced KV
+// keyspace. The executor injects two env vars ONLY when functionState is
+// enabled cluster-wide (pkg/executor/util/stateenv.go):
+//   FISSION_STATE_URL          statesvc base URL, e.g. http://statesvc.fission:8892
+//   FISSION_STATE_TOKEN_PATH   path to a JSON credentials file the fetcher
+//                              writes at specialize time
+// The credentials file is {"namespace":"...","keyspace":"...","token":"..."}
+// (pkg/fetcher/statetoken.go's StateCredentials) -- namespace/keyspace are
+// claims, token is the bearer that proves them.
+const STATE_URL = process.env.FISSION_STATE_URL || '';
+const TOKEN_PATH = process.env.FISSION_STATE_TOKEN_PATH || '';
+
+let stateCreds = null;
+if (STATE_URL && TOKEN_PATH) {
+  try {
+    stateCreds = JSON.parse(fs.readFileSync(TOKEN_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`{{.Name}}: could not read state token file ${TOKEN_PATH}: ${err.code || err.name}`);
+  }
+}
+
+// memoryFallback keeps this scaffold WORKING before functionState is turned
+// on (or on a dev cluster with no statestore): it is pod-local and lost on
+// every recycle/scale event, so replace it with the real state API before
+// relying on session memory in production.
+const memoryFallback = new Map();
+
+function stateHeaders(extra) {
+  return Object.assign(
+    {
+      Authorization: `Bearer ${stateCreds.token}`,
+      'X-Fission-State-Namespace': stateCreds.namespace,
+      'X-Fission-State-Keyspace': stateCreds.keyspace,
+    },
+    extra,
+  );
+}
+
+async function loadState(sessionID) {
+  if (!stateCreds) {
+    return memoryFallback.get(sessionID) || {};
+  }
+  const res = await fetch(`${STATE_URL}/v1/state/${encodeURIComponent(sessionID)}`, {
+    headers: stateHeaders(),
+  });
+  if (res.status === 404) {
+    return {};
+  }
+  if (!res.ok) {
+    throw new Error(`state GET ${sessionID} failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+async function saveState(sessionID, state) {
+  if (!stateCreds) {
+    memoryFallback.set(sessionID, state);
+    return;
+  }
+  const res = await fetch(`${STATE_URL}/v1/state/${encodeURIComponent(sessionID)}`, {
+    method: 'PUT',
+    headers: stateHeaders({ 'Content-Type': 'application/json' }),
+    body: JSON.stringify(state),
+  });
+  if (!res.ok) {
+    throw new Error(`state PUT ${sessionID} failed: ${res.status}`);
+  }
+}
+
+// --- The turn --------------------------------------------------------------
+module.exports = async function (context) {
+  const req = context.request;
+  const sessionID = req.headers[SESSION_HEADER] || 'unknown';
+  // turn is the session's turn count BEFORE this call -- stable across any
+  // at-least-once redelivery of the SAME turn, unlike a locally-incremented
+  // counter would be.
+  const turn = parseInt(req.headers[TURNS_HEADER], 10) || 0;
+
+  let state;
+  try {
+    state = await loadState(sessionID);
+  } catch (err) {
+    console.error(`{{.Name}}: loading state for session ${sessionID} failed: ${err}`);
+    state = {};
+  }
+
+  // TODO: replace this with your agent's actual turn logic. For now the
+  // scaffold just records the turn count so you have something to curl and
+  // see change.
+  state.turns = turn + 1;
+
+  try {
+    await saveState(sessionID, state);
+  } catch (err) {
+    console.error(`{{.Name}}: saving state for session ${sessionID} failed: ${err}`);
+  }
+
+  const reply = { session: sessionID, turn: state.turns, state: state };
+
+  return {
+    status: 200,
+    body: JSON.stringify(reply),
+    headers: {
+      'Content-Type': 'application/json',
+      // Default: end this turn, go idle. Read the block below before ever
+      // changing this to 'continue'.
+      [YIELD_HEADER]: 'waiting',
+    },
+  };
+
+  // --- Chaining turns without waiting for a new request -------------------
+  //
+  // 'continue' instead of 'waiting' re-invokes THIS session again almost
+  // immediately (via the runtime's wake queue), with no external caller
+  // sending a new request -- for a multi-step "thinking" loop where one
+  // external message should produce several internal turns. Two things
+  // first: (1) it self-perpetuates -- a handler that ALWAYS yields
+  // 'continue' never stops on its own, so guard it with real termination
+  // logic (a step counter, a tool result, an LLM "done" signal); (2) the
+  // platform caps you anyway via AGENT_MAX_CONTINUATIONS
+  // (pkg/agentruntime/main.go, default 1000, cluster-wide) -- but 1000
+  // turns of wasted compute is still not something you want to hit.
+  //
+  // return {
+  //   status: 200,
+  //   body: JSON.stringify(reply),
+  //   headers: {
+  //     'Content-Type': 'application/json',
+  //     [YIELD_HEADER]: state.turns < 3 ? 'continue' : 'waiting',
+  //   },
+  // };
+};

--- a/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
@@ -74,7 +74,11 @@ function stateHeaders(extra) {
 
 async function loadState(sessionID) {
   if (!stateCreds) {
-    return memoryFallback.get(sessionID) || {};
+    // Copy out, don't return the stored reference -- a caller that mutates
+    // the returned object without ever reaching saveState (an early return
+    // added later, say) must not silently mutate memoryFallback's stored
+    // copy too.
+    return Object.assign({}, memoryFallback.get(sessionID));
   }
   const res = await fetch(`${STATE_URL}/v1/state/${encodeURIComponent(sessionID)}`, {
     headers: stateHeaders(),

--- a/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
@@ -1,0 +1,156 @@
+# {{.Name}} -- a Fission agent handler, scaffolded by `fission agent create`.
+#
+# WHAT THIS FILE IS
+# ------------------
+# An agent function is an ordinary Fission Python function: the environment
+# loads this module and calls main() with no arguments for every request
+# (github.com/fission/environments python/server.py, FuncApp._load_v2 /
+# userfunc_call -- confirmed there, since no in-repo fixture shows this).
+# What makes it an AGENT is the agent runtime (pkg/agentruntime) calling it
+# once per "turn" of a session: it adds a session id to the request and
+# expects the handler to say, via a response header, whether the session
+# should go idle after this turn or be re-invoked immediately.
+#
+# Read this top to bottom once -- every section explains the piece of the
+# contract it implements -- then replace the TODO in main() with real agent
+# logic (call an LLM, run a tool, whatever your agent does).
+
+import json
+import os
+
+from flask import request
+import requests
+
+# The dispatcher stamps two request headers on every forwarded call (see
+# pkg/agentruntime/dispatcher.go), and reads one response header back:
+#   X-Fission-Session      the session id this turn belongs to (minted on
+#                          the session's first turn, stable after that)
+#   X-Fission-Agent-Turns  how many turns this session had BEFORE this one
+#   X-Fission-Agent-Yield  set in the RESPONSE: 'waiting' ends this turn and
+#                          idles the session (the default below); 'continue'
+#                          re-invokes it again immediately -- see the
+#                          commented-out block at the bottom before using it.
+# flask.request.headers is a case-insensitive mapping (Werkzeug
+# EnvironHeaders), so these are spelled exactly like the dispatcher's
+# constants.
+SESSION_HEADER = 'X-Fission-Session'
+TURNS_HEADER = 'X-Fission-Agent-Turns'
+YIELD_HEADER = 'X-Fission-Agent-Yield'
+
+# --- Load/save session state -----------------------------------------
+#
+# RFC-0023's state API gives every function-as-agent its own namespaced KV
+# keyspace. The executor injects two env vars ONLY when functionState is
+# enabled cluster-wide (pkg/executor/util/stateenv.go):
+#   FISSION_STATE_URL          statesvc base URL, e.g. http://statesvc.fission:8892
+#   FISSION_STATE_TOKEN_PATH   path to a JSON credentials file the fetcher
+#                              writes at specialize time
+# The credentials file is {"namespace": "...", "keyspace": "...", "token": "..."}
+# (pkg/fetcher/statetoken.go's StateCredentials) -- namespace/keyspace are
+# claims, token is the bearer that proves them.
+STATE_URL = os.environ.get('FISSION_STATE_URL', '')
+TOKEN_PATH = os.environ.get('FISSION_STATE_TOKEN_PATH', '')
+
+_state_creds = None
+if STATE_URL and TOKEN_PATH:
+    try:
+        with open(TOKEN_PATH) as f:
+            _state_creds = json.load(f)
+    except (OSError, ValueError) as err:
+        print('{{.Name}}: could not read state token file %s: %s' % (TOKEN_PATH, err))
+
+# _memory_fallback keeps this scaffold WORKING before functionState is
+# turned on (or on a dev cluster with no statestore): it is pod-local and
+# lost on every recycle/scale event, so replace it with the real state API
+# before relying on session memory in production.
+_memory_fallback = {}
+
+
+def _state_headers(extra=None):
+    headers = {
+        'Authorization': 'Bearer %s' % _state_creds['token'],
+        'X-Fission-State-Namespace': _state_creds['namespace'],
+        'X-Fission-State-Keyspace': _state_creds['keyspace'],
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def _load_state(session_id):
+    if not _state_creds:
+        return dict(_memory_fallback.get(session_id, {}))
+    res = requests.get('%s/v1/state/%s' % (STATE_URL, session_id), headers=_state_headers())
+    if res.status_code == 404:
+        return {}
+    res.raise_for_status()
+    return res.json()
+
+
+def _save_state(session_id, state):
+    if not _state_creds:
+        _memory_fallback[session_id] = state
+        return
+    res = requests.put(
+        '%s/v1/state/%s' % (STATE_URL, session_id),
+        headers=_state_headers({'Content-Type': 'application/json'}),
+        data=json.dumps(state),
+    )
+    res.raise_for_status()
+
+
+# --- The turn --------------------------------------------------------------
+#
+# Flask's documented view-return-value contract
+# (https://flask.palletsprojects.com/en/stable/quickstart/#about-responses)
+# accepts (body, status), (body, headers), or (body, status, headers) tuples
+# -- returning the third form below is what sets YIELD_HEADER on the
+# response.
+def main():
+    session_id = request.headers.get(SESSION_HEADER, 'unknown')
+    # turn is the session's turn count BEFORE this call -- stable across any
+    # at-least-once redelivery of the SAME turn, unlike a locally-
+    # incremented counter would be.
+    try:
+        turn = int(request.headers.get(TURNS_HEADER, '0'))
+    except ValueError:
+        turn = 0
+
+    try:
+        state = _load_state(session_id)
+    except requests.RequestException as err:
+        print('{{.Name}}: loading state for session %s failed: %s' % (session_id, err))
+        state = {}
+
+    # TODO: replace this with your agent's actual turn logic. For now the
+    # scaffold just records the turn count so you have something to curl
+    # and see change.
+    state['turns'] = turn + 1
+
+    try:
+        _save_state(session_id, state)
+    except requests.RequestException as err:
+        print('{{.Name}}: saving state for session %s failed: %s' % (session_id, err))
+
+    reply = {'session': session_id, 'turn': state['turns'], 'state': state}
+
+    # Default: end this turn, go idle. Read the block below before ever
+    # changing this to 'continue'.
+    headers = {'Content-Type': 'application/json', YIELD_HEADER: 'waiting'}
+    return json.dumps(reply), 200, headers
+
+    # --- Chaining turns without waiting for a new request ------------------
+    #
+    # 'continue' instead of 'waiting' re-invokes THIS session again almost
+    # immediately (via the runtime's wake queue), with no external caller
+    # sending a new request -- for a multi-step "thinking" loop where one
+    # external message should produce several internal turns. Two things
+    # first: (1) it self-perpetuates -- a handler that ALWAYS yields
+    # 'continue' never stops on its own, so guard it with real termination
+    # logic (a step counter, a tool result, an LLM "done" signal); (2) the
+    # platform caps you anyway via AGENT_MAX_CONTINUATIONS
+    # (pkg/agentruntime/main.go, default 1000, cluster-wide) -- but 1000
+    # turns of wasted compute is still not something you want to hit.
+    #
+    # headers[YIELD_HEADER] = 'continue' if state['turns'] < 3 else 'waiting'
+    # return json.dumps(reply), 200, headers

--- a/pkg/fission-cli/cmd/agent/templates/templates.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates.go
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package templates embeds the handler files `fission agent create`
+// scaffolds (G17 DX slice, see docs/superpowers/plans/2026-08-26-agent-runtime-scaffold.md
+// Task 1). Render fills in the one placeholder every template carries (the
+// scaffolded function's name, used only in a header comment and in a couple
+// of log-line prefixes) and returns the rendered bytes plus the file
+// extension the caller should write them under.
+//
+// Why .tmpl, not .js/.py: the Makefile's LICENSE_FILES glob (`make license`
+// / `make license-check`, see Makefile's "License headers" section) matches
+// `*.py` and `*.go` and does NOT prune this templates directory, so a raw
+// `agent.py` sitting here would be treated as an in-repo Fission source file
+// missing an SPDX header. These are not Fission source — they are USER code
+// written into someone else's project by the scaffold — so they must never
+// carry an SPDX header. `.tmpl` is outside the glob's extension list, which
+// is exactly the exemption we want; this file (templates.go) is the actual
+// Fission source here and DOES carry the header above.
+//
+// Python handler contract (verify-first, per plan review -- no in-repo
+// fixture shows Flask header access or a header-carrying response, unlike
+// the Node handler shape which test/integration/testdata/nodejs/* and
+// demo/agent-boardroom/fixtures/support-desk.js already demonstrate):
+//   - def main() taking no arguments is the entrypoint Fission's Python
+//     environment calls: github.com/fission/environments python/server.py,
+//     FuncApp._load_v2 resolves the handler symbol and FuncApp.userfunc_call
+//     invokes it as self.userfunc(*args) with no positional args for the
+//     '/' route.
+//   - Header access is Flask's global `request` proxy:
+//     github.com/fission/examples python/requestdata.py
+//     ("from flask import request" ... "request.headers").
+//   - A response can be a (body, status) tuple:
+//     github.com/fission/examples python/statuscode.py ("return \"Not
+//     Found\\n\", 404"). The three-element (body, status, headers) form
+//     needed to set the yield header is Flask's own documented contract, not
+//     something either fixture exercises:
+//     https://flask.palletsprojects.com/en/stable/quickstart/#about-responses
+//     -- "If a tuple is returned the items in the tuple can provide extra
+//     information. Such tuples have to be in the form (response, status),
+//     (response, headers), or (response, status, headers)."
+//   - requests (github.com/fission/environments python/requirements.txt)
+//     is present in the image, so the template uses it rather than urllib.
+package templates
+
+import (
+	"bytes"
+	_ "embed"
+	"fmt"
+	"text/template"
+)
+
+//go:embed agent.js.tmpl
+var nodeTemplateSrc string
+
+//go:embed agent.py.tmpl
+var pythonTemplateSrc string
+
+// templateData is the substitution set every template receives. Name is the
+// scaffolded function's name; it appears only in a header comment and a
+// couple of log-line prefixes, never in anything the wire contract checks.
+type templateData struct {
+	Name string
+}
+
+// langTemplate pairs an embedded template source with the file extension
+// (no leading dot) the rendered handler should be written under.
+type langTemplate struct {
+	src string
+	ext string
+}
+
+// languages is the supported `--lang` values. Keyed by the same lowercase
+// strings the CLI flag accepts.
+var languages = map[string]langTemplate{
+	"node":   {src: nodeTemplateSrc, ext: "js"},
+	"python": {src: pythonTemplateSrc, ext: "py"},
+}
+
+// Render renders the embedded handler template for lang ("node" or
+// "python") with name substituted in, and returns the rendered bytes plus
+// the file extension (no leading dot) the caller should write them under.
+func Render(lang, name string) ([]byte, string, error) {
+	lt, ok := languages[lang]
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported agent handler language %q (want \"node\" or \"python\")", lang)
+	}
+	tmpl, err := template.New(lang).Parse(lt.src)
+	if err != nil {
+		return nil, "", fmt.Errorf("parsing %s handler template: %w", lang, err)
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, templateData{Name: name}); err != nil {
+		return nil, "", fmt.Errorf("rendering %s handler template: %w", lang, err)
+	}
+	return buf.Bytes(), lt.ext, nil
+}

--- a/pkg/fission-cli/cmd/agent/templates/templates.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates.go
@@ -49,6 +49,8 @@ import (
 	_ "embed"
 	"fmt"
 	"text/template"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 )
 
 //go:embed agent.js.tmpl
@@ -81,10 +83,31 @@ var languages = map[string]langTemplate{
 // Render renders the embedded handler template for lang ("node" or
 // "python") with name substituted in, and returns the rendered bytes plus
 // the file extension (no leading dot) the caller should write them under.
+//
+// name is validated against Fission's own Kubernetes-name charset
+// (fv1.ValidateKubeName, the same DNS-1123-label check `fn create` et al.
+// run against a resource name) BEFORE it is interpolated into either
+// template. This is defense-in-depth, not the only gate: Task 2's `agent
+// create` handler validates the name too, but it writes the rendered
+// handler file to disk BEFORE any k8s-side validation runs (the k8s API
+// only rejects an invalid name once the Package/Function object is
+// created, several steps later) -- so Render must be safe to call with an
+// adversarial name on its own. Both templates interpolate {{.Name}} inside
+// JS backtick template literals and Python %-format single-quoted strings
+// (log-line prefixes); an unvalidated name containing a backtick or a
+// single quote breaks out of those literals and lands arbitrary text in
+// LIVE, non-comment code in the scaffolded file -- confirmed exploitable in
+// review, not theoretical. A DNS-1123 label (lowercase alphanumeric/'-',
+// alphanumeric start/end, <=63 chars) cannot contain a backtick, quote,
+// `{{`, or a newline, so validating here closes the injection regardless of
+// what any caller does or forgets to do upstream.
 func Render(lang, name string) ([]byte, string, error) {
 	lt, ok := languages[lang]
 	if !ok {
 		return nil, "", fmt.Errorf("unsupported agent handler language %q (want \"node\" or \"python\")", lang)
+	}
+	if err := fv1.ValidateKubeName("name", name); err != nil {
+		return nil, "", fmt.Errorf("invalid agent name %q: %w", name, err)
 	}
 	tmpl, err := template.New(lang).Parse(lt.src)
 	if err != nil {

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -27,6 +27,7 @@ import (
 	// literals, so a header rename there breaks this test, not a silent
 	// scaffold that talks past the real dispatcher.
 	"github.com/fission/fission/pkg/agentruntime"
+	"github.com/fission/fission/pkg/statesvc/stateapi"
 )
 
 // commentPrefix returns the line-comment marker for a rendered language, so
@@ -51,6 +52,45 @@ func TestRender_UnsupportedLanguage(t *testing.T) {
 	t.Parallel()
 	_, _, err := Render("ruby", "widget")
 	require.Error(t, err)
+}
+
+// TestRender_RejectsUnsafeNames is the regression test for the
+// code-injection finding from Task 1 review: {{.Name}} is interpolated
+// inside JS backtick template literals and Python %-format single-quoted
+// strings in both templates, so an unvalidated name containing a backtick
+// or a single quote can break out of the string literal and land arbitrary
+// text in LIVE, non-comment code (confirmed exploitable against the
+// pre-fix build: a name of the shape
+// "x`); require('child_process').execSync('touch /tmp/PWNED'); console.log(`"
+// rendered with the injected call sitting outside any comment). Render must
+// reject every name below with an error and MUST NOT emit any of the
+// injected payload text into the rendered bytes -- Task 2 also validates
+// the name, but it writes the scaffolded file to disk before any k8s-side
+// validation runs, so Render has to be safe standing alone.
+func TestRender_RejectsUnsafeNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		payload string
+	}{
+		{name: "backtick breakout (JS)", payload: "x`); require('child_process').execSync('touch /tmp/PWNED'); console.log(`"},
+		{name: "single-quote breakout (Python)", payload: "x'); __import__('os').system('touch /tmp/PWNED'); print('"},
+		{name: "go-template metachars", payload: "widget{{.Name}}"},
+		{name: "embedded newline", payload: "widget\ninjected := 1"},
+		{name: "uppercase (not DNS-1123, but worth covering)", payload: "Widget"},
+		{name: "empty", payload: ""},
+	}
+	for _, lang := range []string{"node", "python"} {
+		for _, tc := range cases {
+			t.Run(lang+"/"+tc.name, func(t *testing.T) {
+				t.Parallel()
+				out, _, err := Render(lang, tc.payload)
+				require.Error(t, err, "Render must reject unsafe name %q", tc.payload)
+				assert.Empty(t, out, "Render must not return partial output on a rejected name")
+			})
+		}
+	}
 }
 
 func TestRender_Extensions(t *testing.T) {
@@ -109,6 +149,22 @@ func TestRender_HeaderNames(t *testing.T) {
 			// HeaderYield is set verbatim (not folded) in both templates.
 			assert.Contains(t, string(out), agentruntime.HeaderYield, "%s: yield header const not found", tc.lang)
 		})
+	}
+}
+
+// TestRender_StateHeaderNames pins the templates' state-scope claim headers
+// against pkg/statesvc/stateapi's exported consts (stateapi.go:25-26) rather
+// than the re-typed "X-Fission-State-Namespace" / "X-Fission-State-Keyspace"
+// literals both templates used to carry unpinned -- same drift class as
+// TestRender_HeaderNames, just against statesvc's wire contract instead of
+// the dispatcher's.
+func TestRender_StateHeaderNames(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, lang)
+		text := string(out)
+		assert.Contains(t, text, stateapi.HeaderNamespace, "%s: missing state namespace header", lang)
+		assert.Contains(t, text, stateapi.HeaderKeyspace, "%s: missing state keyspace header", lang)
 	}
 }
 

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package templates
+
+import (
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/executor/util"
+	"github.com/fission/fission/pkg/fetcher"
+
+	// Test-only imports of platform packages the shipped CLI binary never
+	// links against (pkg/fission-cli/cmd/agent/sessions.go:94-95 states the
+	// no-import-of-pkg/agentruntime convention that binds the binary). A
+	// _test.go file is excluded from the non-test build, so importing
+	// agentruntime here to read its exported header constants cannot pull
+	// the runtime into `fission`'s binary -- it only pins these templates
+	// against dispatcher.go's actual constants instead of re-typed string
+	// literals, so a header rename there breaks this test, not a silent
+	// scaffold that talks past the real dispatcher.
+	"github.com/fission/fission/pkg/agentruntime"
+)
+
+// commentPrefix returns the line-comment marker for a rendered language, so
+// tests can tell an explanatory mention of a yield value from a live one.
+func commentPrefix(lang string) string {
+	if lang == "python" {
+		return "#"
+	}
+	return "//"
+}
+
+// render is a small helper: render lang's template and require success.
+func render(t *testing.T, lang string) ([]byte, string) {
+	t.Helper()
+	out, ext, err := Render(lang, "widget")
+	require.NoError(t, err)
+	require.NotEmpty(t, out)
+	return out, ext
+}
+
+func TestRender_UnsupportedLanguage(t *testing.T) {
+	t.Parallel()
+	_, _, err := Render("ruby", "widget")
+	require.Error(t, err)
+}
+
+func TestRender_Extensions(t *testing.T) {
+	t.Parallel()
+	_, ext := render(t, "node")
+	assert.Equal(t, "js", ext)
+	_, ext = render(t, "python")
+	assert.Equal(t, "py", ext)
+}
+
+func TestRender_NoTemplateArtifacts(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, lang)
+		text := string(out)
+		assert.NotContains(t, text, "{{", "%s template left an unrendered placeholder", lang)
+		// render(t, lang) passes name "widget" -- confirm substitution
+		// actually ran, not merely that the placeholder syntax is gone.
+		assert.Contains(t, text, "widget", "%s: Name substitution did not run", lang)
+	}
+}
+
+// TestRender_HeaderNames pins the templates against the dispatcher's
+// EXPORTED header constants (pkg/agentruntime/dispatcher.go) rather than
+// re-typed literals: a header rename there fails this test instead of
+// silently drifting the scaffold out of sync with the real wire contract.
+// The Node template reads request headers via Node's lower-cased header
+// map, so it is checked case-insensitively; the yield header is one this
+// template SETS on its own response, so it keeps the constant's natural
+// case and is checked exactly.
+func TestRender_HeaderNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		lang        string
+		foldToLower bool
+	}{
+		{lang: "node", foldToLower: true},
+		{lang: "python", foldToLower: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.lang, func(t *testing.T) {
+			t.Parallel()
+			out, _ := render(t, tc.lang)
+			text := string(out)
+
+			session, turns := agentruntime.HeaderSession, agentruntime.HeaderTurns
+			if tc.foldToLower {
+				text = strings.ToLower(text)
+				session = strings.ToLower(session)
+				turns = strings.ToLower(turns)
+			}
+			assert.Contains(t, text, session, "%s: session header const not found", tc.lang)
+			assert.Contains(t, text, turns, "%s: turns header const not found", tc.lang)
+
+			// HeaderYield is set verbatim (not folded) in both templates.
+			assert.Contains(t, string(out), agentruntime.HeaderYield, "%s: yield header const not found", tc.lang)
+		})
+	}
+}
+
+// TestRender_StateEnvVarNames pins the templates against
+// pkg/executor/util's StateAPIEnvVars, whose injected names
+// (FISSION_STATE_URL / FISSION_STATE_TOKEN_PATH) are string literals with
+// no exported consts (stateenv.go:33-34) -- this is the zero-prod-change
+// drift tripwire the plan review called for: the names below are read from
+// the SAME function the executor calls in production, under t.Setenv, so a
+// literal rename there fails this test without touching any prod code path.
+func TestRender_StateEnvVarNames(t *testing.T) {
+	t.Setenv("STATESVC_URL", "http://statesvc.fission:8892")
+
+	envVars := util.StateAPIEnvVars("/userfunc")
+	require.NotEmpty(t, envVars, "STATESVC_URL was set; StateAPIEnvVars must not return nil")
+
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, lang)
+		text := string(out)
+		for _, ev := range envVars {
+			assert.Contains(t, text, ev.Name, "%s: missing state env var %s", lang, ev.Name)
+		}
+	}
+}
+
+// TestRender_StateCredentialsFieldNames pins the templates' state-token
+// field access against fetcher.StateCredentials's actual JSON tags
+// (statetoken.go:29-33) via reflection, rather than hand-typed "namespace"
+// / "keyspace" / "token" strings that could silently drift from the
+// fetcher's real wire struct.
+func TestRender_StateCredentialsFieldNames(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeOf(fetcher.StateCredentials{})
+	require.Positive(t, typ.NumField())
+
+	var fieldNames []string
+	for i := range typ.NumField() {
+		tag := typ.Field(i).Tag.Get("json")
+		require.NotEmpty(t, tag, "field %s has no json tag", typ.Field(i).Name)
+		name, _, _ := strings.Cut(tag, ",")
+		require.NotEmpty(t, name)
+		fieldNames = append(fieldNames, name)
+	}
+
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, lang)
+		text := string(out)
+		for _, name := range fieldNames {
+			assert.Contains(t, text, name, "%s: missing StateCredentials field %q", lang, name)
+		}
+	}
+}
+
+// TestRender_YieldDefaultsToWaiting asserts the ACTIVE code path yields
+// "waiting" and that YieldContinue's value ("continue") appears only inside
+// comments -- a scaffold that defaulted to "continue" would self-re-invoke
+// forever on a fresh install (constraints.md's "Yield story" ruling).
+func TestRender_YieldDefaultsToWaiting(t *testing.T) {
+	t.Parallel()
+
+	for _, lang := range []string{"node", "python"} {
+		t.Run(lang, func(t *testing.T) {
+			t.Parallel()
+			out, _ := render(t, lang)
+			text := string(out)
+			prefix := commentPrefix(lang)
+
+			var activeWaiting bool
+			for _, line := range strings.Split(text, "\n") {
+				trimmed := strings.TrimSpace(line)
+				isCode := trimmed != "" && !strings.HasPrefix(trimmed, prefix)
+
+				if strings.Contains(line, agentruntime.YieldContinue) {
+					// "continue" must never appear in the ACTIVE code path
+					// (a scaffold that yielded it by default would
+					// self-re-invoke forever on a fresh install).
+					assert.False(t, isCode,
+						"%s: %q value found outside a comment: %q", lang, agentruntime.YieldContinue, line)
+				}
+				if isCode && strings.Contains(line, agentruntime.YieldWaiting) {
+					activeWaiting = true
+				}
+			}
+			assert.True(t, activeWaiting,
+				"%s: no active (non-comment) line yields %q", lang, agentruntime.YieldWaiting)
+		})
+	}
+}
+
+// TestRender_NodeSyntax runs `node --check` against the rendered Node
+// template. Skipped (with a note) when node is not on PATH.
+func TestRender_NodeSyntax(t *testing.T) {
+	nodeBin, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node not found on PATH; skipping node --check")
+	}
+
+	out, _ := render(t, "node")
+	path := t.TempDir() + "/agent.js"
+	require.NoError(t, os.WriteFile(path, out, 0o600))
+
+	cmd := exec.Command(nodeBin, "--check", path)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "node --check failed: %s", output)
+}
+
+// TestRender_PythonSyntax runs `python3 -m py_compile` against the rendered
+// Python template. Skipped (with a note) when python3 is not on PATH.
+func TestRender_PythonSyntax(t *testing.T) {
+	pyBin, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skip("python3 not found on PATH; skipping py_compile")
+	}
+
+	out, _ := render(t, "python")
+	path := t.TempDir() + "/agent.py"
+	require.NoError(t, os.WriteFile(path, out, 0o600))
+
+	cmd := exec.Command(pyBin, "-m", "py_compile", path)
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "python3 -m py_compile failed: %s", output)
+}

--- a/pkg/fission-cli/cmd/function/agentconfig_test.go
+++ b/pkg/fission-cli/cmd/function/agentconfig_test.go
@@ -22,7 +22,7 @@ func TestGetAgentConfig(t *testing.T) {
 	t.Run("FnAgent unset -> nil returned", func(t *testing.T) {
 		t.Parallel()
 		in := dummy.TestFlagSet()
-		ac := getAgentConfig(in, nil)
+		ac := GetAgentConfig(in, nil)
 		assert.Nil(t, ac)
 	})
 
@@ -30,7 +30,7 @@ func TestGetAgentConfig(t *testing.T) {
 		t.Parallel()
 		in := dummy.TestFlagSet()
 		in.SetBool(flagkey.FnAgent, true)
-		ac := getAgentConfig(in, nil)
+		ac := GetAgentConfig(in, nil)
 		assert.Equal(t, &fv1.AgentConfig{}, ac)
 	})
 
@@ -40,7 +40,7 @@ func TestGetAgentConfig(t *testing.T) {
 		in.SetBool(flagkey.FnAgent, true)
 		in.SetString(flagkey.FnAgentSessionSource, string(fv1.SessionSourceQueryParam))
 		in.SetString(flagkey.FnAgentSessionName, "sid")
-		ac := getAgentConfig(in, nil)
+		ac := GetAgentConfig(in, nil)
 		assert.Equal(t, &fv1.AgentConfig{
 			Session: &fv1.AgentSessionConfig{Source: fv1.SessionSourceQueryParam, Name: "sid"},
 		}, ac)
@@ -53,7 +53,7 @@ func TestGetAgentConfig(t *testing.T) {
 		in.SetDuration(flagkey.FnAgentIdleAfter, 10*time.Minute)
 		in.SetDuration(flagkey.FnAgentArchiveAfter, 48*time.Hour)
 		in.SetInt(flagkey.FnAgentMaxSessions, 25)
-		ac := getAgentConfig(in, nil)
+		ac := GetAgentConfig(in, nil)
 		assert.Equal(t, &fv1.AgentConfig{
 			IdleAfter:    &metav1.Duration{Duration: 10 * time.Minute},
 			ArchiveAfter: &metav1.Duration{Duration: 48 * time.Hour},
@@ -72,7 +72,7 @@ func TestGetAgentConfig(t *testing.T) {
 		in := dummy.TestFlagSet()
 		in.SetBool(flagkey.FnAgent, true)
 		in.SetInt(flagkey.FnAgentMaxSessions, 50)
-		ac := getAgentConfig(in, existing)
+		ac := GetAgentConfig(in, existing)
 		assert.Equal(t, &fv1.AgentConfig{
 			Session:      &fv1.AgentSessionConfig{Source: fv1.SessionSourceHeader, Name: "X-Custom-Session"},
 			IdleAfter:    &metav1.Duration{Duration: 5 * time.Minute},
@@ -87,7 +87,7 @@ func TestGetAgentConfig(t *testing.T) {
 		in := dummy.TestFlagSet()
 		in.SetBool(flagkey.FnAgent, true)
 		in.SetBool(flagkey.FnAgentHistoryTrim, true)
-		ac := getAgentConfig(in, nil)
+		ac := GetAgentConfig(in, nil)
 		assert.Equal(t, &fv1.AgentConfig{HistoryTrimBelowCheckpoint: true}, ac)
 	})
 
@@ -96,7 +96,7 @@ func TestGetAgentConfig(t *testing.T) {
 		existing := &fv1.AgentConfig{HistoryTrimBelowCheckpoint: true}
 		in := dummy.TestFlagSet()
 		in.SetBool(flagkey.FnAgent, true)
-		ac := getAgentConfig(in, existing)
+		ac := GetAgentConfig(in, existing)
 		assert.True(t, ac.HistoryTrimBelowCheckpoint, "unset flag must not clear the existing value on update")
 	})
 }

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -164,11 +164,11 @@ func getStreamingConfig(input cli.Input) *fv1.StreamingConfig {
 	}
 }
 
-// getStateConfig builds the RFC-0023 StateConfig from the --state* flags,
+// GetStateConfig builds the RFC-0023 StateConfig from the --state* flags,
 // merging onto existing (the function's current config, or nil on create) so
 // an `fn update --state` that sets only one field keeps the rest. nil when
 // --state is not set. Bounds/charset are validated server-side.
-func getStateConfig(input cli.Input, existing *fv1.StateConfig) *fv1.StateConfig {
+func GetStateConfig(input cli.Input, existing *fv1.StateConfig) *fv1.StateConfig {
 	if !input.Bool(flagkey.FnState) {
 		return nil
 	}
@@ -202,14 +202,14 @@ func getStateConfig(input cli.Input, existing *fv1.StateConfig) *fv1.StateConfig
 	return sc
 }
 
-// getAgentConfig maps the --agent* flags onto fv1.AgentConfig, merging onto
+// GetAgentConfig maps the --agent* flags onto fv1.AgentConfig, merging onto
 // existing so an update only overwrites explicitly-set flags. --agent=false
-// clears the config (mirrors getStateConfig / --state=false); an update that
+// clears the config (mirrors GetStateConfig / --state=false); an update that
 // omits --agent entirely never calls this function (see the input.IsSet
 // guard in update.go), so existing is left untouched in that case. Field
 // bounds are validated server-side by the Function admission webhook (CLI
 // stays thin).
-func getAgentConfig(input cli.Input, existing *fv1.AgentConfig) *fv1.AgentConfig {
+func GetAgentConfig(input cli.Input, existing *fv1.AgentConfig) *fv1.AgentConfig {
 	if !input.Bool(flagkey.FnAgent) {
 		return nil
 	}
@@ -621,8 +621,8 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 			IdleTimeout:            &fnIdleTimeout,
 			Streaming:              getStreamingConfig(input),
 			Tool:                   toolConfig,
-			State:                  getStateConfig(input, nil),
-			Agent:                  getAgentConfig(input, nil),
+			State:                  GetStateConfig(input, nil),
+			Agent:                  GetAgentConfig(input, nil),
 			Invocation:             invocation,
 			Versioning:             versioningConfig,
 			ProvisionedConcurrency: provisionedConcurrency,

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -130,13 +130,13 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	// retains the keyspace data — see statesvc's reconciler). The other
 	// --state-* flags merge onto the existing config (only set fields change).
 	if input.IsSet(flagkey.FnState) {
-		function.Spec.State = getStateConfig(input, function.Spec.State)
+		function.Spec.State = GetStateConfig(input, function.Spec.State)
 	}
 
 	// --agent toggles the agent config; the other --agent-* flags merge onto
 	// the existing config (only set fields change).
 	if input.IsSet(flagkey.FnAgent) {
-		function.Spec.Agent = getAgentConfig(input, function.Spec.Agent)
+		function.Spec.Agent = GetAgentConfig(input, function.Spec.Agent)
 	}
 
 	// The --async-* flags merge onto the existing InvocationConfig (only set fields

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -272,6 +272,10 @@ var (
 	FnAgentMaxSessions   = Flag{Type: Int, Name: flagkey.FnAgentMaxSessions, Usage: "Max live sessions for this agent, enforced atomically on session creation (0 = unlimited)"}
 	FnAgentHistoryTrim   = Flag{Type: Bool, Name: flagkey.FnAgentHistoryTrim, Usage: "Let the agent runtime's sweeper trim this agent's session fact logs below each session's committed checkpoint (requires --state)"}
 
+	// `fission agent create` scaffold (Task 2, G17 DX). --code reuses PkgCode
+	// below (same "code" flag key, same meaning: a single handler file path).
+	FnAgentLang = Flag{Type: String, Name: flagkey.FnAgentLang, Usage: "Scaffolded handler language: node or python", DefaultString: "node"}
+
 	// `fission agent sessions` introspection CLI (slice 4).
 	AgentSession      = Flag{Type: String, Name: flagkey.AgentSession, Usage: "Session id"}
 	AgentToken        = Flag{Type: String, Name: flagkey.AgentToken, Usage: "Bearer token for the agent runtime (defaults to FISSION_AGENT_TOKEN; unset works only when agentRuntime.allowInsecure is set)"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -164,6 +164,11 @@ const (
 	FnAgentMaxSessions   = "agent-max-sessions"
 	FnAgentHistoryTrim   = "agent-history-trim"
 
+	// `fission agent create` scaffold (Task 2, G17 DX). --code reuses
+	// PkgCode's "code" key below (same meaning: the single handler file's
+	// path), so only --lang is genuinely new here.
+	FnAgentLang = "lang"
+
 	// `fission agent sessions` introspection CLI (slice 4).
 	AgentSession      = "session"
 	AgentToken        = "agent-token"

--- a/test/integration/suites/common/agent_create_scaffold_test.go
+++ b/test/integration/suites/common/agent_create_scaffold_test.go
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/agentruntime"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// TestAgentCreateScaffold exercises G17's in-repo DX half end to end:
+// `fission agent create --spec` followed by `fission spec apply` must
+// produce a WORKING stateful agent, not just CR objects that happen to
+// decode. It dispatches one real turn against the scaffolded handler and
+// checks the echoed reply against the exact JSON contract Task 1's node
+// template implements (pkg/fission-cli/cmd/agent/templates/agent.js.tmpl):
+// {"session": <id>, "turn": <n>, "state": {...}}, plus the default
+// X-Fission-Agent-Yield: waiting the template always sets.
+//
+// Follows the proven spec-integration pattern (TestSpecMultifile,
+// spec_multifile_test.go): the CLI's spec subcommands resolve ./specs (and
+// any --deploy/--code glob) relative to cwd, with no --specdir override, so
+// the whole spec sequence runs inside ns.WithCWD.
+//
+// The node Environment is created directly via the framework's CreateEnv
+// helper -- the same pattern every other test in agentruntime_test.go uses
+// for `--agent`-enabled functions -- rather than through a spec file.
+// `agent create --spec`'s checkEnvironment only consults the spec SET
+// (spec.ReadSpecs + FissionResources.ExistsInSpecs) for its "environment
+// not found" warning, and spec.go's own Validate has a standing TODO for
+// functions -> environments dangling refs, so an Environment that exists on
+// the cluster but not in this test's spec set is sufficient for both `spec
+// apply` and the scaffolded pod's specialization to succeed; `agent create`
+// just prints an inaccurate-but-harmless "environment not found" next-steps
+// line in that case, which this test does not assert on (create_test.go's
+// golden tests own that wording).
+//
+// State is on by default for `agent create` (command.go's
+// agentCreateStateFlag), so the scaffolded Function carries Spec.State --
+// but this needs no functionState/statesvc setup on the cluster: the node
+// template's loadState/saveState fall back to an in-memory map whenever
+// FISSION_STATE_URL/FISSION_STATE_TOKEN_PATH are absent (which they are
+// unless STATESVC_URL is set on the executor -- util.StateAPIEnvVars
+// returns nil and injects nothing, keeping the pod byte-identical to a
+// stateless one), so the turn below succeeds regardless of whether
+// statesvc is deployed on this install.
+func TestAgentCreateScaffold(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "agent-scaffold-node-" + ns.ID
+	fnName := "agent-scaffold-" + ns.ID
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	workdir := t.TempDir()
+
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "init")
+		ns.CLI(t, ctx, "agent", "create", "--name", fnName, "--env", envName, "--spec")
+		ns.CLI(t, ctx, "spec", "apply")
+	})
+
+	turnURL := f.AgentRuntimeBaseURL() + "/agents/" + ns.Name + "/" + fnName
+
+	// One turn: no session header. The dispatcher mints a session id (the
+	// scaffolded handler never mints its own), and by the time this returns
+	// 200 the agentruntime replica's reconciler has also caught up with the
+	// Function admission -- poll until 200 to absorb both that convergence
+	// and the function's cold start, same shape as
+	// TestAgentRuntimeSessionDispatch's first turn.
+	var sessionID string
+	var turnBody []byte
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postTurn(attemptCtx, f, turnURL, "")
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "turn to %s", turnURL) {
+			return
+		}
+		sid := resp.Header.Get(agentruntime.HeaderSession)
+		if !assert.NotEmpty(c, sid, "turn must mint a session id via %s", agentruntime.HeaderSession) {
+			return
+		}
+		assert.Equalf(c, agentruntime.YieldWaiting, resp.Header.Get(agentruntime.HeaderYield),
+			"the scaffolded template always sets %s to the default %q", agentruntime.HeaderYield, agentruntime.YieldWaiting)
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoErrorf(c, err, "reading turn response body") {
+			return
+		}
+		sessionID = sid
+		turnBody = body
+	}, 180*time.Second, 2*time.Second)
+	require.NotEmpty(t, sessionID, "scaffolded agent never minted a session id")
+
+	// The reply body itself is the DX proof: the scaffolded handler actually
+	// ran (not just "the platform accepted the Function"), echoing the
+	// dispatcher-minted session id and a turn count derived from the
+	// X-Fission-Agent-Turns header (turns-before-this-call + 1 -- see
+	// agent.js.tmpl's module.exports).
+	var reply struct {
+		Session string `json:"session"`
+		Turn    int    `json:"turn"`
+	}
+	require.NoErrorf(t, json.Unmarshal(turnBody, &reply), "decoding scaffolded agent's reply body %q", turnBody)
+	assert.Equal(t, sessionID, reply.Session,
+		"the scaffolded template must echo the dispatcher-minted session id in its own reply body")
+	assert.Equal(t, 1, reply.Turn,
+		"the scaffolded template's first turn must report turn:1 (0 turns-before-this-call + 1)")
+
+	// `fission agent sessions list` renders its table via os.Stdout directly
+	// (util.PrintObjects/PrintItems), not the cobra Out buffer ns.CLI
+	// captures -- CLICaptureStdoutBestEffort is the framework's
+	// error-returning variant for exactly that class of subcommand (see its
+	// doc comment: "archive get-url" etc.). Wrapped in EventuallyWithT for
+	// the same reason every registry read elsewhere in this suite is: the
+	// CLI's `sessions list` opens its OWN port-forward
+	// (pkg/fission-cli/util/portless.go), a separate dial from the turn
+	// above, and on a multi-replica install (or a still-converging
+	// reconciler) that dial can land on a replica whose AgentView has not
+	// yet observed this session -- retrying absorbs that instead of a
+	// single-shot read racing the reconciler.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		listOut, err := ns.CLICaptureStdoutBestEffort(t, ctx, "agent", "sessions", "list", "--name", fnName)
+		if !assert.NoErrorf(c, err, "agent sessions list --name %s\n%s", fnName, listOut) {
+			return
+		}
+		assert.Containsf(c, listOut, sessionID, "agent sessions list --name %s must show session %s", fnName, sessionID)
+	}, 60*time.Second, 3*time.Second)
+}


### PR DESCRIPTION
Stack position 8 (#3701 ← #3703 ← #3704 ← #3705 ← #3706 ← #3707 ← this). The DX slice: `fission agent create --name X --env node` scaffolds a working stateful agent — handler + Package + Function (Agent+State blocks) — in one command. Cluster → running agent in well under 10 minutes.

## What

- **Embedded handler templates** (node + python), distilled from the turn-loop skeleton + the state read/write essentials, heavily commented as the tutorial: session id from `X-Fission-Session`, turn count from `X-Fission-Agent-Turns`, state load/save via `FISSION_STATE_URL` + the token file (with an in-memory fallback so the scaffold works before statestore is wired), JSON reply, yield `waiting` (never `continue` — a continue default would self-re-invoke forever on a fresh install; the chain semantics live in a commented block). Python contract verified against the env repo docs, not guessed from node.
- **`fission agent create`**: writes the template, then composes `fn create`'s *exact* shipped pipeline (`CreatePackage`/`CreateArchive`, the shared `getStateConfig`/`getAgentConfig` — export-renamed in place, no forked copy) into `--spec` (auto-init if needed, 3-doc append) or direct (clientset) modes; conditional next-steps output carries the <10-min path (env-missing → leads with the `fission env create` line).
- **Contract-drift tripwires** (the slice's discriminating tests): the templates are pinned against *platform sources* — dispatcher header consts (imported test-only), env-var names via `util.StateAPIEnvVars` under `t.Setenv`, `fetcher.StateCredentials` json tags — so a future header/env rename breaks THIS build instead of shipping a silently dead scaffold.
- **Integration**: `ns.WithCWD` → `agent create --spec` → `spec apply` → dispatch a turn → assert the scaffolded handler's `{session, turn}` echo + `yield: waiting`.

## Security note (review-caught)
The first template cut interpolated `--name` unescaped into JS backtick / Python format strings — an adversarial name injected live code into the scaffolded file. Fixed: `Render` validates the name via `fv1.ValidateKubeName` before any interpolation or disk write; every name-derived path uses the validated name. Also fixed (in new code) a latent `ferror.Error`-vs-`StatusError` type-assertion bug inherited from `fn create`'s env-missing path; the identical original is flagged as a follow-up, untouched.

## Deferred
statesvc `/v1/state/<id>` path lacks a drift tripwire (memory-fallback keeps the scaffold working regardless; a `stateapi` path const closes it later); the LangGraph checkpointer + examples gallery are the sibling-repo (`fission/examples`) half of G17, a separate arc. No fission.io quickstart page (release-cut-gated; `--help` + the README pointer for now).

Process: reviewed plan (REVISE: 2 blockers — env-var names are literals not consts so tests assert via the util helpers; `EnvName` collided with `--name`, the right symbol is `FnEnvName`), 3 SDD tasks all PASS (Task 1's injection hole caught by its own review before Task 2 could wire the name through), final SHIP.