### PR TITLE
cli: fission agent create --template interpreter — exec-verb scaffold

### DIFF
--- a/pkg/fission-cli/cmd/agent/command.go
+++ b/pkg/fission-cli/cmd/agent/command.go
@@ -49,13 +49,19 @@ func Commands() *cobra.Command {
 	}, Create, flag.FlagSet{
 		Required: []flag.Flag{flag.FnName},
 		Optional: []flag.Flag{
-			flag.FnEnvName, flag.FnAgentLang, flag.PkgCode,
+			flag.FnEnvName, flag.FnAgentLang, flag.FnAgentTemplate, flag.PkgCode,
 			agentCreateStateFlag, flag.FnStateKeyspace, flag.FnStateMaxKeys,
 			flag.FnStateMaxValueBytes, flag.FnStateTTL,
 			flag.FnStateStickySource, flag.FnStateStickyName,
 			agentCreateAgentFlag, flag.FnAgentSessionSource, flag.FnAgentSessionName,
 			flag.FnAgentIdleAfter, flag.FnAgentArchiveAfter, flag.FnAgentMaxSessions,
 			flag.FnAgentHistoryTrim,
+			// MCP exposure (PR-1): --expose-as-mcp lets the scaffolded handler
+			// (interpreter template in particular) be called as an MCP tool.
+			// function.GetToolConfig (exported for this) applies the same
+			// flag-merge semantics `fn create`/`fn update` use.
+			flag.FnExposeAsMCP, flag.FnToolDescription,
+			flag.FnToolInputSchema, flag.FnToolName,
 			flag.SpecSave,
 		},
 	})

--- a/pkg/fission-cli/cmd/agent/create.go
+++ b/pkg/fission-cli/cmd/agent/create.go
@@ -381,7 +381,7 @@ func buildFunction(input cli.Input, name, fnNamespace, envName, tmplKind string,
 func printNextSteps(w io.Writer, name, namespace, envName, codePath, specDir, tmplKind string, toSpec, envExists bool) {
 	fmt.Fprintf(w, "\nScaffolded %s\n\n", codePath)
 
-	// Trust statement (doc 14 PR-1 section): env-scrubbing keeps ACCIDENTAL
+	// Trust statement: env-scrubbing keeps ACCIDENTAL
 	// credential leakage out of exec'd code, but it is not a sandbox -- a
 	// process in the same container can still read the pod's own token
 	// files, so exec'd code runs at the agent's own trust level. Printed

--- a/pkg/fission-cli/cmd/agent/create.go
+++ b/pkg/fission-cli/cmd/agent/create.go
@@ -48,12 +48,19 @@ const (
 
 // interpreterMaxTimeoutSeconds is the interpreter template's own hard
 // ceiling on the request-carried `timeoutSeconds` (see
-// templates/interpreter.{js,py}.tmpl's MAX_TIMEOUT_SECONDS -- pinned
-// against this exact value by templates_test.go's
-// TestRender_Interpreter_TimeoutCeiling). The scaffolded Function's own
-// FunctionTimeout is set to match (see buildFunction) so the platform's
-// own request timeout never kills a full-length exec call before the
-// template's own timeout does.
+// templates/interpreter.{js,py}.tmpl's MAX_TIMEOUT_SECONDS). This constant
+// and the template's are independent literals -- templates_test.go's
+// TestRender_Interpreter_TimeoutCeiling only pins the template's own value
+// in isolation, so it is create_test.go's
+// TestAgentCreate_TemplateInterpreter_DirectMode that asserts the rendered
+// template actually contains "MAX_TIMEOUT_SECONDS = <this constant>",
+// closing the gap a change to only one side would otherwise leave silent.
+// The scaffolded Function's own FunctionTimeout is set to match (see
+// buildFunction) so the platform's own request timeout does not kill a
+// full-length exec call substantially ahead of the template's own timeout;
+// at the exact ceiling the two race (the platform's clock starts first),
+// so this is a "close together", not a strict "template always wins",
+// guarantee.
 const interpreterMaxTimeoutSeconds = 300
 
 // scaffoldFunctionTimeout mirrors `fn create`'s own --fntimeout default of

--- a/pkg/fission-cli/cmd/agent/create.go
+++ b/pkg/fission-cli/cmd/agent/create.go
@@ -131,7 +131,19 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 		}
 	}
 
-	// 2. Render the handler and write it to disk, refusing to clobber an
+	// 2. Validate --tool-* flags (e.g. an unreadable --tool-input-schema
+	// file) BEFORE any side effect below -- the same "validate before
+	// touching disk/cluster" discipline step 1's duplicate-name check
+	// applies, and what `fn create` gets for free by validating tool config
+	// in complete() before create() runs. Read only here; buildFunction
+	// (step 6) receives the already-validated result so a bad flag never
+	// strands a scaffolded handler file or an uploaded-but-orphaned Package.
+	toolCfg, err := function.GetToolConfig(input, nil)
+	if err != nil {
+		return err
+	}
+
+	// 3. Render the handler and write it to disk, refusing to clobber an
 	// existing file (an idempotent re-run must point at a different --code,
 	// never silently overwrite someone's edited handler).
 	rendered, ext, err := templates.Render(tmplKind, lang, name)
@@ -152,7 +164,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	}
 	console.Info(fmt.Sprintf("Scaffolded %s handler: %s", lang, codePath))
 
-	// 3. --spec mode: auto-init a fresh spec directory when none exists yet
+	// 4. --spec mode: auto-init a fresh spec directory when none exists yet
 	// (spec.go's save() precondition, spec.go:140-142, is what every write
 	// below hits otherwise: "couldn't find specs, run `fission spec init`
 	// first"). A directory that already has fission-deployment-config.yaml
@@ -164,14 +176,14 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 		}
 	}
 
-	// 4. Environment existence: warn, don't create (fn-create precedent,
+	// 5. Environment existence: warn, don't create (fn-create precedent,
 	// cmd/function/create.go:507-542).
 	envExists, err := opts.checkEnvironment(input, name, envName, fnNamespace, userProvidedNS, toSpec, specDir, specIgnore)
 	if err != nil {
 		return err
 	}
 
-	// 5. Compose the shipped pipeline: build (and, in direct mode, upload)
+	// 6. Compose the shipped pipeline: build (and, in direct mode, upload)
 	// the Package from the handler file just written. noZip=true and a
 	// single-file deployArchiveFiles mirrors `fn create --code`'s own path
 	// (cmd/function/create.go:548-554).
@@ -181,10 +193,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 		return fmt.Errorf("error creating package: %w", err)
 	}
 
-	fn, err := buildFunction(input, name, fnNamespace, envName, tmplKind, pkgMeta)
-	if err != nil {
-		return err
-	}
+	fn := buildFunction(input, name, fnNamespace, envName, tmplKind, pkgMeta, toolCfg)
 	if toSpec {
 		fn.Namespace = userProvidedNS
 		fn.Spec.Package.PackageRef.Namespace = userProvidedNS
@@ -292,6 +301,10 @@ func (opts *CreateSubCommand) checkEnvironment(input cli.Input, fnName, envName,
 // --expose-as-mcp/--tool-* flag-merge helper `fn create`/`fn update` use --
 // so a scaffolded interpreter can be registered as an MCP tool with no
 // second implementation of that flag handling to drift out of sync.
+// toolCfg is computed by the caller, BEFORE any side effect (handler-file
+// write, Package create/upload), so a bad --tool-input-schema path fails
+// fast instead of stranding an orphaned Package or handler file (its only
+// failure mode is os.ReadFile on that flag) -- see the call site's step 2.
 //
 // tmplKind selects the scaffolded Function's own FunctionTimeout:
 // interpreterTemplate gets interpreterMaxTimeoutSeconds (300, matching the
@@ -299,7 +312,7 @@ func (opts *CreateSubCommand) checkEnvironment(input cli.Input, fnName, envName,
 // platform's request timeout is never what kills a full-length exec call;
 // every other template keeps scaffoldFunctionTimeout (60, `fn create`'s own
 // default).
-func buildFunction(input cli.Input, name, fnNamespace, envName, tmplKind string, pkgMeta *metav1.ObjectMeta) (*fv1.Function, error) {
+func buildFunction(input cli.Input, name, fnNamespace, envName, tmplKind string, pkgMeta *metav1.ObjectMeta, toolCfg *fv1.ToolConfig) *fv1.Function {
 	stateCfg := function.GetStateConfig(input, nil)
 	if stateCfg != nil {
 		if stateCfg.Keyspace == "" {
@@ -313,11 +326,6 @@ func buildFunction(input cli.Input, name, fnNamespace, envName, tmplKind string,
 		}
 	}
 	agentCfg := function.GetAgentConfig(input, nil)
-
-	toolCfg, err := function.GetToolConfig(input, nil)
-	if err != nil {
-		return nil, err
-	}
 
 	fnTimeout := scaffoldFunctionTimeout
 	if tmplKind == interpreterTemplate {
@@ -348,7 +356,7 @@ func buildFunction(input cli.Input, name, fnNamespace, envName, tmplKind string,
 			Agent:           agentCfg,
 			Tool:            toolCfg,
 		},
-	}, nil
+	}
 }
 
 // printNextSteps writes the scaffold's <10-minute-to-first-turn punch list:

--- a/pkg/fission-cli/cmd/agent/create.go
+++ b/pkg/fission-cli/cmd/agent/create.go
@@ -35,6 +35,27 @@ import (
 // dummy/unit-test Input, when a test never sets it at all.
 const defaultLang = "node"
 
+// defaultTemplate / interpreterTemplate are `--template`'s recognized
+// values (PR-1, abstraction A / Q35 resolution): the same
+// dummy/unit-test-Input caveat as defaultLang applies -- a real CLI
+// invocation gets defaultTemplate from flag.FnAgentTemplate's
+// DefaultString, but a test Input that never sets --template needs this
+// fallback applied explicitly.
+const (
+	defaultTemplate     = "agent"
+	interpreterTemplate = "interpreter"
+)
+
+// interpreterMaxTimeoutSeconds is the interpreter template's own hard
+// ceiling on the request-carried `timeoutSeconds` (see
+// templates/interpreter.{js,py}.tmpl's MAX_TIMEOUT_SECONDS -- pinned
+// against this exact value by templates_test.go's
+// TestRender_Interpreter_TimeoutCeiling). The scaffolded Function's own
+// FunctionTimeout is set to match (see buildFunction) so the platform's
+// own request timeout never kills a full-length exec call before the
+// template's own timeout does.
+const interpreterMaxTimeoutSeconds = 300
+
 // scaffoldFunctionTimeout mirrors `fn create`'s own --fntimeout default of
 // 60 (flag.FnExecutionTimeout's DefaultInt, cmd/function's flag.go). This
 // command intentionally exposes no --fntimeout/--concurrency/--executortype
@@ -66,6 +87,11 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	lang := input.String(flagkey.FnAgentLang)
 	if lang == "" {
 		lang = defaultLang
+	}
+
+	tmplKind := input.String(flagkey.FnAgentTemplate)
+	if tmplKind == "" {
+		tmplKind = defaultTemplate
 	}
 
 	envName := input.String(flagkey.FnEnvironmentName)
@@ -108,7 +134,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 	// 2. Render the handler and write it to disk, refusing to clobber an
 	// existing file (an idempotent re-run must point at a different --code,
 	// never silently overwrite someone's edited handler).
-	rendered, ext, err := templates.Render(lang, name)
+	rendered, ext, err := templates.Render(tmplKind, lang, name)
 	if err != nil {
 		return err
 	}
@@ -155,7 +181,10 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 		return fmt.Errorf("error creating package: %w", err)
 	}
 
-	fn := buildFunction(input, name, fnNamespace, envName, pkgMeta)
+	fn, err := buildFunction(input, name, fnNamespace, envName, tmplKind, pkgMeta)
+	if err != nil {
+		return err
+	}
 	if toSpec {
 		fn.Namespace = userProvidedNS
 		fn.Spec.Package.PackageRef.Namespace = userProvidedNS
@@ -173,7 +202,7 @@ func (opts *CreateSubCommand) do(input cli.Input) error {
 		fmt.Fprintf(input.Stdout(), "function '%s' created\n", fn.Name)
 	}
 
-	printNextSteps(input.Stdout(), name, fnNamespace, envName, codePath, specDir, toSpec, envExists)
+	printNextSteps(input.Stdout(), name, fnNamespace, envName, codePath, specDir, tmplKind, toSpec, envExists)
 	return nil
 }
 
@@ -258,7 +287,19 @@ func (opts *CreateSubCommand) checkEnvironment(input cli.Input, fnName, envName,
 // such built-in default -- it is opt-in, so a scaffold that wants the demo's
 // "the router lands on the same pod the dispatcher predicts" property has to
 // set it explicitly.
-func buildFunction(input cli.Input, name, fnNamespace, envName string, pkgMeta *metav1.ObjectMeta) *fv1.Function {
+//
+// MCP exposure (PR-1) reuses function.GetToolConfig -- the SAME
+// --expose-as-mcp/--tool-* flag-merge helper `fn create`/`fn update` use --
+// so a scaffolded interpreter can be registered as an MCP tool with no
+// second implementation of that flag handling to drift out of sync.
+//
+// tmplKind selects the scaffolded Function's own FunctionTimeout:
+// interpreterTemplate gets interpreterMaxTimeoutSeconds (300, matching the
+// interpreter template's own request-timeoutSeconds ceiling) so the
+// platform's request timeout is never what kills a full-length exec call;
+// every other template keeps scaffoldFunctionTimeout (60, `fn create`'s own
+// default).
+func buildFunction(input cli.Input, name, fnNamespace, envName, tmplKind string, pkgMeta *metav1.ObjectMeta) (*fv1.Function, error) {
 	stateCfg := function.GetStateConfig(input, nil)
 	if stateCfg != nil {
 		if stateCfg.Keyspace == "" {
@@ -272,6 +313,16 @@ func buildFunction(input cli.Input, name, fnNamespace, envName string, pkgMeta *
 		}
 	}
 	agentCfg := function.GetAgentConfig(input, nil)
+
+	toolCfg, err := function.GetToolConfig(input, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fnTimeout := scaffoldFunctionTimeout
+	if tmplKind == interpreterTemplate {
+		fnTimeout = interpreterMaxTimeoutSeconds
+	}
 
 	return &fv1.Function{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: fnNamespace},
@@ -291,26 +342,48 @@ func buildFunction(input cli.Input, name, fnNamespace, envName string, pkgMeta *
 				},
 				StrategyType: fv1.StrategyTypeExecution,
 			},
-			FunctionTimeout: scaffoldFunctionTimeout,
+			FunctionTimeout: fnTimeout,
 			Resources:       apiv1.ResourceRequirements{},
 			State:           stateCfg,
 			Agent:           agentCfg,
+			Tool:            toolCfg,
 		},
-	}
+	}, nil
 }
 
 // printNextSteps writes the scaffold's <10-minute-to-first-turn punch list:
-// the file it wrote, how to get the resource(s) onto a cluster (conditional
-// on --spec), the env-create line when checkEnvironment found none
-// (conditional, and always step 1 when present -- Global Constraints item
-// 6), the dispatch curl (POST /agents/<ns>/<name> + the platform's session
-// header, pinned via fv1.DefaultAgentSessionHeader/svcinfo rather than
-// retyped literals -- the same contract-drift discipline Task 1's tests
-// apply), and where to look afterwards. This is a spec'd, golden-tested
-// deliverable (create_test.go) -- keep any wording change here in sync with
-// the golden strings there.
-func printNextSteps(w io.Writer, name, namespace, envName, codePath, specDir string, toSpec, envExists bool) {
-	fmt.Fprintf(w, "\nScaffolded %s\n\nNext steps:\n", codePath)
+// the file it wrote, the interpreter template's trust-boundary note
+// (conditional on tmplKind, PR-1), how to get the resource(s) onto a
+// cluster (conditional on --spec), the env-create line when
+// checkEnvironment found none (conditional, and always step 1 when present
+// -- Global Constraints item 6), the dispatch curl (POST /agents/<ns>/<name>
+// + the platform's session header, pinned via
+// fv1.DefaultAgentSessionHeader/svcinfo rather than retyped literals -- the
+// same contract-drift discipline Task 1's tests apply; the exec verb's own
+// wire-contract body for the interpreter template), and where to look
+// afterwards. This is a spec'd, golden-tested deliverable (create_test.go)
+// -- keep any wording change here in sync with the golden strings there.
+func printNextSteps(w io.Writer, name, namespace, envName, codePath, specDir, tmplKind string, toSpec, envExists bool) {
+	fmt.Fprintf(w, "\nScaffolded %s\n\n", codePath)
+
+	// Trust statement (doc 14 PR-1 section): env-scrubbing keeps ACCIDENTAL
+	// credential leakage out of exec'd code, but it is not a sandbox -- a
+	// process in the same container can still read the pod's own token
+	// files, so exec'd code runs at the agent's own trust level. Printed
+	// here (and repeated in the template's own header comment) rather than
+	// only in the PR description, so it survives however someone gets to
+	// this scaffold.
+	if tmplKind == interpreterTemplate {
+		fmt.Fprintf(w,
+			"exec contract: this handler runs the turn body's \"code\" or \"command\" at\n"+
+				"the agent's OWN trust level (env-scrubbed, not sandboxed) -- fine for\n"+
+				"run-your-own-code tools, not for adversarial or multi-tenant code. For\n"+
+				"one more layer of isolation, pair it with:\n"+
+				"    fission env create --name %s --image ghcr.io/fission/%s-env --runtime-class gvisor\n\n",
+			envName, envName)
+	}
+
+	fmt.Fprintf(w, "Next steps:\n")
 
 	step := 1
 	if !envExists {
@@ -326,15 +399,22 @@ func printNextSteps(w io.Writer, name, namespace, envName, codePath, specDir str
 	}
 	step++
 
+	// The interpreter template ignores an empty body's absent code/command
+	// (it 400s), so its example turn carries a working exec payload instead
+	// of the agent template's empty '{}'.
+	turnBody := "{}"
+	if tmplKind == interpreterTemplate {
+		turnBody = `{"command": "echo hello"}`
+	}
 	fmt.Fprintf(w,
 		"  %d. Port-forward the agent runtime and dispatch a turn:\n"+
 			"       kubectl -n %s port-forward svc/%s %d:%d\n"+
 			"       curl -i -X POST http://127.0.0.1:%d/agents/%s/%s \\\n"+
 			"         -H 'Content-Type: application/json' \\\n"+
 			"         -H '%s: %s-demo-1' \\\n"+
-			"         -d '{}'\n",
+			"         -d '%s'\n",
 		step, fissionNamespace(), svcinfo.SvcAgentRuntime, svcinfo.PortAgentRuntime, svcinfo.PortAgentRuntime,
-		svcinfo.PortAgentRuntime, namespace, name, fv1.DefaultAgentSessionHeader, name)
+		svcinfo.PortAgentRuntime, namespace, name, fv1.DefaultAgentSessionHeader, name, turnBody)
 	step++
 
 	fmt.Fprintf(w, "  %d. Inspect sessions:\n       fission agent sessions list --name %s --tree\n", step, name)

--- a/pkg/fission-cli/cmd/agent/create.go
+++ b/pkg/fission-cli/cmd/agent/create.go
@@ -389,13 +389,24 @@ func printNextSteps(w io.Writer, name, namespace, envName, codePath, specDir, tm
 	// only in the PR description, so it survives however someone gets to
 	// this scaffold.
 	if tmplKind == interpreterTemplate {
+		// The applicable command depends on whether checkEnvironment found
+		// envName already registered: `env create ... --image ...` only
+		// makes sense when the Environment does not exist yet -- once it
+		// does, gvisor is applied with `env update`, which needs no --image
+		// guess at all (a real concern for a user-supplied --env whose
+		// image this scaffold cannot know; it only happens to be correct
+		// for the default node/python env names).
+		gvisorCmd := fmt.Sprintf("fission env update --name %s --runtime-class gvisor", envName)
+		if !envExists {
+			gvisorCmd = fmt.Sprintf("fission env create --name %s --image ghcr.io/fission/%s-env --runtime-class gvisor", envName, envName)
+		}
 		fmt.Fprintf(w,
 			"exec contract: this handler runs the turn body's \"code\" or \"command\" at\n"+
 				"the agent's OWN trust level (env-scrubbed, not sandboxed) -- fine for\n"+
 				"run-your-own-code tools, not for adversarial or multi-tenant code. For\n"+
 				"one more layer of isolation, pair it with:\n"+
-				"    fission env create --name %s --image ghcr.io/fission/%s-env --runtime-class gvisor\n\n",
-			envName, envName)
+				"    %s\n\n",
+			gvisorCmd)
 	}
 
 	fmt.Fprintf(w, "Next steps:\n")

--- a/pkg/fission-cli/cmd/agent/create_test.go
+++ b/pkg/fission-cli/cmd/agent/create_test.go
@@ -483,7 +483,7 @@ func TestAgentCreate_TemplateInterpreter_NextStepsGolden(t *testing.T) {
 			"the agent's OWN trust level (env-scrubbed, not sandboxed) -- fine for\n"+
 			"run-your-own-code tools, not for adversarial or multi-tenant code. For\n"+
 			"one more layer of isolation, pair it with:\n"+
-			"    fission env create --name node --image ghcr.io/fission/node-env --runtime-class gvisor\n\n"+
+			"    fission env update --name node --runtime-class gvisor\n\n"+
 			"Next steps:\n"+
 			"  1. Function default/myinterp is already created.\n"+
 			"  2. Port-forward the agent runtime and dispatch a turn:\n"+
@@ -498,6 +498,27 @@ func TestAgentCreate_TemplateInterpreter_NextStepsGolden(t *testing.T) {
 		svcinfo.PortAgentRuntime, fv1.DefaultAgentSessionHeader,
 	)
 	assert.Contains(t, out, want)
+}
+
+// TestAgentCreate_TemplateInterpreter_EnvMissing_GvisorSuggestsCreate is the
+// env-missing control for TestAgentCreate_TemplateInterpreter_NextStepsGolden:
+// when checkEnvironment found no Environment yet, the gvisor pairing
+// suggestion must be `env create ... --runtime-class gvisor` (an image is
+// needed to create anything), not the `env update` form the env-exists case
+// uses.
+func TestAgentCreate_TemplateInterpreter_EnvMissing_GvisorSuggestsCreate(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	setAgentCreateClient(t, ns) // no Environment object: env missing
+
+	in := baseCreateInput("myinterp")
+	in.SetString(flagkey.FnAgentTemplate, "interpreter")
+	in.SetBool(flagkey.SpecSave, true)
+
+	out := captureStdout(t, func() error { return Create(in) })
+	assert.Contains(t, out, "fission env create --name node --image ghcr.io/fission/node-env --runtime-class gvisor")
+	assert.NotContains(t, out, "env update --name node --runtime-class gvisor")
 }
 
 // --- MCP exposure (PR-1: FnExposeAsMCP/FnToolDescription/FnToolInputSchema/FnToolName) ---

--- a/pkg/fission-cli/cmd/agent/create_test.go
+++ b/pkg/fission-cli/cmd/agent/create_test.go
@@ -525,3 +525,36 @@ func TestAgentCreate_NoExposeAsMCP_LeavesToolNil(t *testing.T) {
 	require.NoError(t, err)
 	assert.Nil(t, fn.Spec.Tool)
 }
+
+// TestAgentCreate_BadToolInputSchema_LeavesNoSideEffects pins the fix for a
+// review finding on this command: function.GetToolConfig's only failure
+// mode (os.ReadFile on --tool-input-schema, cmd/function/create.go) must be
+// validated BEFORE any side effect, exactly like the direct-mode duplicate
+// check (TestAgentCreate_DirectMode_DuplicateFunctionLeavesNoOrphanFile) --
+// otherwise a bad path would fail after the handler file was written and
+// (direct mode) the Package already created/uploaded, stranding both.
+func TestAgentCreate_BadToolInputSchema_LeavesNoSideEffects(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	cs := setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myinterp")
+	in.SetBool(flagkey.FnExposeAsMCP, true)
+	in.SetString(flagkey.FnToolInputSchema, filepath.Join(dir, "does-not-exist.json"))
+
+	err := Create(in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does-not-exist.json")
+
+	assert.NoFileExists(t, filepath.Join(dir, "myinterp.js"), "a bad --tool-input-schema must be validated before the handler file is written")
+
+	pkgs, err := cs.CoreV1().Packages(ns).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, pkgs.Items, "a bad --tool-input-schema must be validated before any Package is created")
+
+	fns, err := cs.CoreV1().Functions(ns).List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, fns.Items, "a bad --tool-input-schema must be validated before any Function is created")
+}

--- a/pkg/fission-cli/cmd/agent/create_test.go
+++ b/pkg/fission-cli/cmd/agent/create_test.go
@@ -369,7 +369,21 @@ func TestAgentCreate_TemplateInterpreter_DirectMode(t *testing.T) {
 	assert.Equal(t, interpreterMaxTimeoutSeconds, fn.Spec.FunctionTimeout,
 		"interpreter template's FunctionTimeout must match its own exec-timeout ceiling")
 
-	assert.FileExists(t, filepath.Join(dir, "myinterp.js"))
+	handlerPath := filepath.Join(dir, "myinterp.js")
+	assert.FileExists(t, handlerPath)
+
+	// Closes the gap TestRender_Interpreter_TimeoutCeiling
+	// (templates/templates_test.go) leaves open: that test only pins the
+	// template's own MAX_TIMEOUT_SECONDS literal in isolation, so a change
+	// to interpreterMaxTimeoutSeconds alone (with the template's literal
+	// left at 300) would break no test while silently decoupling
+	// FunctionTimeout from the template's actual exec-timeout ceiling. This
+	// asserts the rendered template's constant equals this Go const
+	// directly.
+	handlerSrc, err := os.ReadFile(handlerPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(handlerSrc), fmt.Sprintf("MAX_TIMEOUT_SECONDS = %d", interpreterMaxTimeoutSeconds),
+		"rendered interpreter template's timeout ceiling must match interpreterMaxTimeoutSeconds")
 }
 
 // TestAgentCreate_TemplateAgent_DefaultFunctionTimeout is the control for
@@ -417,6 +431,13 @@ func TestAgentCreate_TemplateInterpreter_LangPython(t *testing.T) {
 	var fn fv1.Function
 	require.NoError(t, yaml.Unmarshal(docs[2], &fn))
 	assert.Equal(t, interpreterMaxTimeoutSeconds, fn.Spec.FunctionTimeout)
+
+	// Same cross-pin as TestAgentCreate_TemplateInterpreter_DirectMode, for
+	// the python side of the template pair -- js was already checked there.
+	handlerSrc, err := os.ReadFile(filepath.Join(dir, "pyinterp.py"))
+	require.NoError(t, err)
+	assert.Contains(t, string(handlerSrc), fmt.Sprintf("MAX_TIMEOUT_SECONDS = %d", interpreterMaxTimeoutSeconds),
+		"rendered python interpreter template's timeout ceiling must match interpreterMaxTimeoutSeconds")
 }
 
 // TestAgentCreate_TemplateUnsupported: an invalid --template surfaces

--- a/pkg/fission-cli/cmd/agent/create_test.go
+++ b/pkg/fission-cli/cmd/agent/create_test.go
@@ -342,3 +342,186 @@ func TestAgentCreate_DirectMode_EnvMissing_WarnsAndCreates(t *testing.T) {
 	)
 	assert.Contains(t, out, want)
 }
+
+// --- --template interpreter (PR-1, abstraction A / Q35 resolution) --------
+
+// TestAgentCreate_TemplateInterpreter_DirectMode exercises the interpreter
+// template end to end through the same pipeline TestAgentCreate_DirectMode
+// covers for the default (agent) template: the scaffolded Function must
+// carry the interpreter's own FunctionTimeout ceiling
+// (interpreterMaxTimeoutSeconds, matching the template's own
+// MAX_TIMEOUT_SECONDS) rather than the agent template's
+// scaffoldFunctionTimeout.
+func TestAgentCreate_TemplateInterpreter_DirectMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	cs := setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myinterp")
+	in.SetString(flagkey.FnAgentTemplate, "interpreter")
+	out := captureStdout(t, func() error { return Create(in) })
+	assert.Contains(t, out, "function 'myinterp' created")
+
+	fn, err := cs.CoreV1().Functions(ns).Get(context.Background(), "myinterp", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, interpreterMaxTimeoutSeconds, fn.Spec.FunctionTimeout,
+		"interpreter template's FunctionTimeout must match its own exec-timeout ceiling")
+
+	assert.FileExists(t, filepath.Join(dir, "myinterp.js"))
+}
+
+// TestAgentCreate_TemplateAgent_DefaultFunctionTimeout is the control for
+// TestAgentCreate_TemplateInterpreter_DirectMode: the default (agent)
+// template must keep `fn create`'s own scaffoldFunctionTimeout, not the
+// interpreter's wider ceiling.
+func TestAgentCreate_TemplateAgent_DefaultFunctionTimeout(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	cs := setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myagent")
+	_ = captureStdout(t, func() error { return Create(in) })
+
+	fn, err := cs.CoreV1().Functions(ns).Get(context.Background(), "myagent", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, scaffoldFunctionTimeout, fn.Spec.FunctionTimeout)
+}
+
+// TestAgentCreate_TemplateInterpreter_LangPython mirrors
+// TestAgentCreate_LangPython for the interpreter template: --spec mode,
+// python handler, correct file extension and Package environment.
+func TestAgentCreate_TemplateInterpreter_LangPython(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setAgentCreateClient(t, "default")
+
+	in := baseCreateInput("pyinterp")
+	in.SetString(flagkey.FnAgentLang, "python")
+	in.SetString(flagkey.FnAgentTemplate, "interpreter")
+	in.SetBool(flagkey.SpecSave, true)
+
+	_ = captureStdout(t, func() error { return Create(in) })
+
+	assert.FileExists(t, filepath.Join(dir, "pyinterp.py"))
+
+	docs := readYAMLDocs(t, filepath.Join(dir, "specs", "agent-pyinterp.yaml"))
+	require.Len(t, docs, 3)
+	var pkg fv1.Package
+	require.NoError(t, yaml.Unmarshal(docs[1], &pkg))
+	assert.Equal(t, "python", pkg.Spec.Environment.Name)
+
+	var fn fv1.Function
+	require.NoError(t, yaml.Unmarshal(docs[2], &fn))
+	assert.Equal(t, interpreterMaxTimeoutSeconds, fn.Spec.FunctionTimeout)
+}
+
+// TestAgentCreate_TemplateUnsupported: an invalid --template surfaces
+// templates.Render's own "unsupported agent template" error, and (like
+// TestAgentCreate_RefusesExistingHandlerFile's sibling W6 concern) must be
+// checked BEFORE any file is written -- Render's kind lookup runs before
+// name validation or any disk write.
+func TestAgentCreate_TemplateUnsupported(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	setAgentCreateClient(t, "default")
+
+	in := baseCreateInput("myagent")
+	in.SetString(flagkey.FnAgentTemplate, "wizard")
+	err := Create(in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported agent template")
+
+	assert.NoFileExists(t, filepath.Join(dir, "myagent.js"))
+}
+
+// TestAgentCreate_TemplateInterpreter_NextStepsGolden pins the interpreter
+// template's next-steps output: the trust-boundary block (doc 14 PR-1's
+// "Trust statement", including the --runtime-class gvisor recommendation)
+// and the exec-contract example turn body, in the env-already-exists /
+// direct-mode shape (mirrors TestAgentCreate_EnvPresent_NextStepsGolden).
+func TestAgentCreate_TemplateInterpreter_NextStepsGolden(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	t.Setenv("FISSION_NAMESPACE", "")
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myinterp")
+	in.SetString(flagkey.FnAgentTemplate, "interpreter")
+
+	out := captureStdout(t, func() error { return Create(in) })
+
+	want := fmt.Sprintf(
+		"\nScaffolded myinterp.js\n\n"+
+			"exec contract: this handler runs the turn body's \"code\" or \"command\" at\n"+
+			"the agent's OWN trust level (env-scrubbed, not sandboxed) -- fine for\n"+
+			"run-your-own-code tools, not for adversarial or multi-tenant code. For\n"+
+			"one more layer of isolation, pair it with:\n"+
+			"    fission env create --name node --image ghcr.io/fission/node-env --runtime-class gvisor\n\n"+
+			"Next steps:\n"+
+			"  1. Function default/myinterp is already created.\n"+
+			"  2. Port-forward the agent runtime and dispatch a turn:\n"+
+			"       kubectl -n fission port-forward svc/%s %d:%d\n"+
+			"       curl -i -X POST http://127.0.0.1:%d/agents/default/myinterp \\\n"+
+			"         -H 'Content-Type: application/json' \\\n"+
+			"         -H '%s: myinterp-demo-1' \\\n"+
+			"         -d '{\"command\": \"echo hello\"}'\n"+
+			"  3. Inspect sessions:\n"+
+			"       fission agent sessions list --name myinterp --tree\n",
+		svcinfo.SvcAgentRuntime, svcinfo.PortAgentRuntime, svcinfo.PortAgentRuntime,
+		svcinfo.PortAgentRuntime, fv1.DefaultAgentSessionHeader,
+	)
+	assert.Contains(t, out, want)
+}
+
+// --- MCP exposure (PR-1: FnExposeAsMCP/FnToolDescription/FnToolInputSchema/FnToolName) ---
+
+// TestAgentCreate_ExposeAsMCP_SetsToolConfig wires --expose-as-mcp through
+// function.GetToolConfig (exported by PR-1) onto the scaffolded Function,
+// exactly as `fn create --expose-as-mcp` does -- the doc 14 PR-1 section's
+// "MCP exposure" requirement.
+func TestAgentCreate_ExposeAsMCP_SetsToolConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	cs := setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myinterp")
+	in.SetString(flagkey.FnAgentTemplate, "interpreter")
+	in.SetBool(flagkey.FnExposeAsMCP, true)
+	in.SetString(flagkey.FnToolDescription, "runs code or a shell command and returns its output")
+	in.SetString(flagkey.FnToolName, "code_exec")
+
+	_ = captureStdout(t, func() error { return Create(in) })
+
+	fn, err := cs.CoreV1().Functions(ns).Get(context.Background(), "myinterp", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, fn.Spec.Tool, "--expose-as-mcp must set FunctionSpec.Tool")
+	assert.Equal(t, "runs code or a shell command and returns its output", fn.Spec.Tool.Description)
+	assert.Equal(t, "code_exec", fn.Spec.Tool.ToolName)
+}
+
+// TestAgentCreate_NoExposeAsMCP_LeavesToolNil is the control: without
+// --expose-as-mcp the scaffolded Function must carry a nil Tool, exactly
+// like a plain `fn create` (presence of FunctionSpec.Tool is itself the on
+// switch -- ToolConfig's own doc comment, types.go).
+func TestAgentCreate_NoExposeAsMCP_LeavesToolNil(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+	const ns = "default"
+	env := &fv1.Environment{Name: "node", Namespace: ns}
+	cs := setAgentCreateClient(t, ns, env)
+
+	in := baseCreateInput("myagent")
+	_ = captureStdout(t, func() error { return Create(in) })
+
+	fn, err := cs.CoreV1().Functions(ns).Get(context.Background(), "myagent", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Nil(t, fn.Spec.Tool)
+}

--- a/pkg/fission-cli/cmd/agent/create_test.go
+++ b/pkg/fission-cli/cmd/agent/create_test.go
@@ -460,8 +460,8 @@ func TestAgentCreate_TemplateUnsupported(t *testing.T) {
 }
 
 // TestAgentCreate_TemplateInterpreter_NextStepsGolden pins the interpreter
-// template's next-steps output: the trust-boundary block (doc 14 PR-1's
-// "Trust statement", including the --runtime-class gvisor recommendation)
+// template's next-steps output: the trust-boundary block (the
+// trust statement, including the --runtime-class gvisor recommendation)
 // and the exec-contract example turn body, in the env-already-exists /
 // direct-mode shape (mirrors TestAgentCreate_EnvPresent_NextStepsGolden).
 func TestAgentCreate_TemplateInterpreter_NextStepsGolden(t *testing.T) {
@@ -525,8 +525,8 @@ func TestAgentCreate_TemplateInterpreter_EnvMissing_GvisorSuggestsCreate(t *test
 
 // TestAgentCreate_ExposeAsMCP_SetsToolConfig wires --expose-as-mcp through
 // function.GetToolConfig (exported by PR-1) onto the scaffolded Function,
-// exactly as `fn create --expose-as-mcp` does -- the doc 14 PR-1 section's
-// "MCP exposure" requirement.
+// exactly as `fn create --expose-as-mcp` does -- the scaffold's
+// MCP-exposure contract.
 func TestAgentCreate_ExposeAsMCP_SetsToolConfig(t *testing.T) {
 	dir := t.TempDir()
 	t.Chdir(dir)

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
@@ -1,0 +1,257 @@
+'use strict';
+
+// {{.Name}} -- an interpreter agent handler, scaffolded by
+// `fission agent create --template interpreter`.
+//
+// WHAT THIS FILE IS
+// ------------------
+// This implements the "exec" verb (abstraction A, PR-1): a turn's body is
+// { "code": "..." } (interpreted with `node -e`) or { "command": "..." }
+// (run through a shell) -- exactly one of the two -- and the reply is
+// { stdout, stderr, exitCode, durationMs, truncated }. It is an ordinary
+// Fission function (module.exports takes one `context` argument and
+// returns {status, body, headers}) that the agent runtime calls once per
+// turn like any other agent handler, so it runs through the normal
+// dispatch path -- no new platform code, no new environment image.
+//
+// TRUST BOUNDARY -- READ BEFORE USE
+// ----------------------------------
+// The subprocess environment below is an ALLOW-LIST, not a filtered copy:
+// the child starts with nothing and gets only PATH/HOME/LANG/etc, so
+// FISSION_* vars (state/agent token PATHS, runtime URLs) are never passed
+// through -- that keeps ACCIDENTAL credential leakage out of exec'd code.
+// It is NOT a sandbox: a process in the SAME CONTAINER can still read the
+// pod's token files directly, so exec'd code runs at the agent's own trust
+// level. That is fine for run-your-own-code tools (an analyst's own
+// interpreter, a calculator tool) -- it is NOT a boundary for adversarial
+// or multi-tenant code, which needs a dedicated pod per session (a Tier C
+// bare-Sandbox executor), not this template. Pair this environment with
+// `fission env create ... --runtime-class gvisor` for one more layer of
+// isolation before running code you did not write yourself.
+
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// The dispatcher stamps the session header on every forwarded call (see
+// pkg/agentruntime/dispatcher.go); this template reads it only to name the
+// per-session scratch directory, and always answers with the default
+// yield (below) so a session-scoped call never self-re-invokes. Node
+// lower-cases incoming header names.
+const SESSION_HEADER = 'x-fission-session';
+const YIELD_HEADER = 'X-Fission-Agent-Yield';
+
+// DEFAULT_TIMEOUT_SECONDS / MAX_TIMEOUT_SECONDS -- the request-carried
+// timeoutSeconds is clamped into (0, MAX_TIMEOUT_SECONDS]; a request that
+// omits it (or sends a non-positive value) gets DEFAULT_TIMEOUT_SECONDS.
+// MAX_TIMEOUT_SECONDS is also this scaffold's own FunctionTimeout (see
+// `fission agent create`'s next-steps output), so a full-length exec call
+// is never killed by the platform's own request timeout first.
+const DEFAULT_TIMEOUT_SECONDS = 60;
+const MAX_TIMEOUT_SECONDS = 300;
+
+// MAX_OUTPUT_BYTES caps stdout/stderr EACH (aligns with the state API's
+// MaxValueBytes default, DefaultStateMaxValueBytes, pkg/apis/core/v1/const.go)
+// -- overflow sets truncated:true, it never turns into an error response.
+const MAX_OUTPUT_BYTES = 256 * 1024;
+
+// ALLOWED_ENV_VARS: see the trust-boundary note above -- this is the
+// complete list of names copied into the child's environment. Nothing
+// outside it reaches the subprocess, however this pod's own environment
+// grows in the future.
+const ALLOWED_ENV_VARS = ['PATH', 'HOME', 'LANG', 'LC_ALL', 'TZ'];
+
+function allowedEnv() {
+  const env = {};
+  for (const key of ALLOWED_ENV_VARS) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+  return env;
+}
+
+// outputBuffer accumulates chunks up to MAX_OUTPUT_BYTES; further bytes are
+// dropped at push time (not merely trimmed once collection ends), so a
+// runaway process cannot hold arbitrarily large buffers in memory before
+// the cap is applied.
+function outputBuffer() {
+  let bytes = 0;
+  let truncated = false;
+  const chunks = [];
+  return {
+    push(chunk) {
+      if (truncated) {
+        return;
+      }
+      const remaining = MAX_OUTPUT_BYTES - bytes;
+      if (chunk.length > remaining) {
+        chunks.push(chunk.subarray(0, remaining));
+        bytes += remaining;
+        truncated = true;
+        return;
+      }
+      chunks.push(chunk);
+      bytes += chunk.length;
+    },
+    text() {
+      return Buffer.concat(chunks).toString('utf8');
+    },
+    truncated() {
+      return truncated;
+    },
+  };
+}
+
+// runExec spawns argv[0](...argv[1:]) in cwd with the allow-listed
+// environment, killing the WHOLE process group (detached: true + a
+// negative pid to process.kill) if it outlives timeoutSeconds -- a shell
+// running `command` can fork children of its own, and only killing the
+// direct child would leave those running.
+function runExec(argv, cwd, timeoutSeconds) {
+  return new Promise((resolve) => {
+    const start = Date.now();
+    const stdout = outputBuffer();
+    const stderr = outputBuffer();
+    let timedOut = false;
+
+    const child = spawn(argv[0], argv.slice(1), {
+      cwd,
+      env: allowedEnv(),
+      detached: true,
+    });
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      try {
+        process.kill(-child.pid, 'SIGKILL');
+      } catch (err) {
+        // Process already exited between the timer firing and the kill --
+        // nothing left to clean up.
+      }
+    }, timeoutSeconds * 1000);
+
+    child.stdout.on('data', (chunk) => stdout.push(chunk));
+    child.stderr.on('data', (chunk) => stderr.push(chunk));
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve({
+        stdoutText: stdout.text(),
+        stderrText: stderr.text() + '\n[exec: failed to start: ' + err.message + ']',
+        truncated: stdout.truncated() || stderr.truncated(),
+        exitCode: -1,
+        durationMs: Date.now() - start,
+      });
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        resolve({
+          stdoutText: stdout.text(),
+          stderrText: stderr.text() + '\n[exec: killed after exceeding ' + timeoutSeconds + 's timeout]',
+          truncated: stdout.truncated() || stderr.truncated(),
+          exitCode: -1,
+          durationMs: Date.now() - start,
+        });
+        return;
+      }
+      resolve({
+        stdoutText: stdout.text(),
+        stderrText: stderr.text(),
+        truncated: stdout.truncated() || stderr.truncated(),
+        exitCode: code === null ? -1 : code,
+        durationMs: Date.now() - start,
+      });
+    });
+  });
+}
+
+function parseBody(raw) {
+  if (raw && typeof raw === 'object') {
+    return raw;
+  }
+  if (typeof raw === 'string' && raw.length > 0) {
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      return {};
+    }
+  }
+  return {};
+}
+
+function clampTimeout(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) {
+    return DEFAULT_TIMEOUT_SECONDS;
+  }
+  return Math.min(n, MAX_TIMEOUT_SECONDS);
+}
+
+// --- The turn --------------------------------------------------------------
+module.exports = async function (context) {
+  const req = context.request;
+  const sessionID = (req.headers[SESSION_HEADER] || '').trim();
+  // A call with no session header (the MCP fast lane -- tools/call goes
+  // straight to the router internal listener, bypassing the dispatcher --
+  // or a bare direct invocation) is stateless exec: a fresh, uniquely-named
+  // scratch dir per call rather than one keyed on a session that does not
+  // exist here.
+  const scratchName = sessionID || 'stateless-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+  const scratchDir = path.join(os.tmpdir(), 'exec', scratchName);
+
+  const headers = { 'Content-Type': 'application/json', [YIELD_HEADER]: 'waiting' };
+
+  const body = parseBody(req.body);
+  const hasCode = typeof body.code === 'string';
+  const hasCommand = typeof body.command === 'string';
+  if (hasCode === hasCommand) {
+    return {
+      status: 400,
+      headers,
+      body: JSON.stringify({ error: 'exactly one of "code" or "command" is required' }),
+    };
+  }
+
+  const timeoutSeconds = clampTimeout(body.timeoutSeconds);
+
+  try {
+    fs.rmSync(scratchDir, { recursive: true, force: true });
+  } catch (err) {
+    // Nothing to clean up yet -- fine.
+  }
+  fs.mkdirSync(scratchDir, { recursive: true });
+
+  let result;
+  try {
+    if (hasCode) {
+      result = await runExec([process.execPath, '-e', body.code], scratchDir, timeoutSeconds);
+    } else {
+      result = await runExec(['/bin/sh', '-c', body.command], scratchDir, timeoutSeconds);
+    }
+  } finally {
+    try {
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    } catch (err) {
+      // Best-effort cleanup -- a leftover scratch dir is not worth failing
+      // the turn over.
+    }
+  }
+
+  const reply = {
+    stdout: result.stdoutText,
+    stderr: result.stderrText,
+    exitCode: result.exitCode,
+    durationMs: result.durationMs,
+    truncated: result.truncated,
+  };
+
+  return {
+    status: 200,
+    headers,
+    body: JSON.stringify(reply),
+  };
+};

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
@@ -183,6 +183,34 @@ function parseBody(raw) {
   return {};
 }
 
+// SESSION_ID_CHARSET_RE mirrors the dispatcher's own sessionIDPattern
+// (pkg/agentruntime/dispatcher.go) exactly. This template is reached two
+// ways: through the dispatcher, which already validates X-Fission-Session
+// against that pattern before forwarding it, but ALSO directly against the
+// router internal listener (a bare `fission function test`/curl, or the MCP
+// fast lane) -- a path with no dispatcher in front of it at all, where the
+// header is whatever the caller sent, unconstrained by any pattern.
+// Re-validating here is what makes safeScratchName's guard hold on BOTH
+// paths rather than only the one that happens to enforce it upstream.
+const SESSION_ID_CHARSET_RE = /^[A-Za-z0-9._-]{1,128}$/;
+
+// safeScratchName mirrors pkg/agentruntime/workspace.go's
+// validateWorkspaceSegment. This template turns sessionID into a path
+// SEGMENT (path.join(os.tmpdir(), 'exec', scratchName)), so a value of "."
+// resolves to $TMPDIR/exec itself, ".." resolves to $TMPDIR itself, and
+// anything containing "/" (never possible through the dispatcher, but
+// possible on the direct path above) can walk arbitrarily far outside
+// $TMPDIR/exec -- all of which get fs.rmSync({recursive:true})'d at the
+// start and end of every turn, wiping sibling sessions' scratch dirs or
+// worse on a shared warm-pool pod. Falls back to a fresh uniquely-named
+// scratch dir instead of erroring the turn.
+function safeScratchName(sessionID) {
+  if (sessionID === '.' || sessionID === '..' || !SESSION_ID_CHARSET_RE.test(sessionID)) {
+    return 'stateless-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+  }
+  return sessionID;
+}
+
 function clampTimeout(value) {
   const n = Number(value);
   if (!Number.isFinite(n) || n <= 0) {
@@ -200,7 +228,9 @@ module.exports = async function (context) {
   // or a bare direct invocation) is stateless exec: a fresh, uniquely-named
   // scratch dir per call rather than one keyed on a session that does not
   // exist here.
-  const scratchName = sessionID || 'stateless-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+  const scratchName = sessionID
+    ? safeScratchName(sessionID)
+    : 'stateless-' + Date.now() + '-' + Math.random().toString(36).slice(2);
   const scratchDir = path.join(os.tmpdir(), 'exec', scratchName);
 
   const headers = { 'Content-Type': 'application/json', [YIELD_HEADER]: 'waiting' };

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -31,6 +31,7 @@
 import json
 import math
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -119,14 +120,24 @@ def _run_exec(argv, cwd, timeout_seconds):
     # WHOLE tree (a shell plus whatever it launches) can be killed on
     # timeout via os.killpg, not just the direct child.
     start = time.monotonic()
-    proc = subprocess.Popen(
-        argv,
-        cwd=cwd,
-        env=_allowed_env(),
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        start_new_session=True,
-    )
+    try:
+        proc = subprocess.Popen(
+            argv,
+            cwd=cwd,
+            env=_allowed_env(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+    except OSError as err:
+        # argv[0] missing (e.g. no /bin/sh or python3 in the image) or not
+        # executable -- mirrors the JS template's spawn() 'error' handler:
+        # map the failure into the {stdout,stderr,exitCode,durationMs,
+        # truncated} reply instead of letting it raise past main() as an
+        # uncaught 500.
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return '', '[exec: failed to start: %s]' % err, -1, duration_ms, False
+
     stdout_buf = _OutputBuffer()
     stderr_buf = _OutputBuffer()
     stdout_thread = threading.Thread(target=_drain, args=(proc.stdout, stdout_buf))
@@ -159,6 +170,36 @@ def _run_exec(argv, cwd, timeout_seconds):
     return stdout_text, stderr_text, exit_code, duration_ms, stdout_buf.truncated or stderr_buf.truncated
 
 
+# _SESSION_ID_CHARSET_RE mirrors the dispatcher's own sessionIDPattern
+# (pkg/agentruntime/dispatcher.go) exactly. This template is reached two
+# ways: through the dispatcher, which already validates X-Fission-Session
+# against that pattern before forwarding it, but ALSO directly against the
+# router internal listener (a bare `fission function test`/curl, or the MCP
+# fast lane) -- a path with no dispatcher in front of it at all, where the
+# header is whatever the caller sent, unconstrained by any pattern. Re-
+# validating here (fullmatch, not match+'$', since '$' also matches just
+# before a trailing newline) is what makes the guard below hold on BOTH
+# paths rather than only the one that happens to enforce it upstream.
+_SESSION_ID_CHARSET_RE = re.compile(r'[A-Za-z0-9._-]{1,128}')
+
+
+def _safe_scratch_name(session_id):
+    # This template turns session_id into a path SEGMENT
+    # ($TMPDIR/exec/<segment>), so a value of "." resolves to $TMPDIR/exec
+    # itself, ".." resolves to $TMPDIR itself, and anything containing "/"
+    # (never possible through the dispatcher, but possible on the direct
+    # path above) can walk arbitrarily far outside $TMPDIR/exec -- all of
+    # which get shutil.rmtree'd at the start and end of every turn, wiping
+    # sibling sessions' scratch dirs or worse on a shared warm-pool pod.
+    # pkg/agentruntime/workspace.go's validateWorkspaceSegment applies the
+    # same charset + "."/".." rejection for the same reason on the
+    # platform's own workspace routes; mirrored here by falling back to a
+    # fresh uniquely-named scratch dir instead of erroring the turn.
+    if session_id in ('.', '..') or not _SESSION_ID_CHARSET_RE.fullmatch(session_id):
+        return 'stateless-%s' % uuid.uuid4().hex
+    return session_id
+
+
 def _clamp_timeout(value):
     try:
         seconds = float(value)
@@ -185,12 +226,18 @@ def main():
     # or a bare direct invocation) is stateless exec: a fresh, uniquely-named
     # scratch dir per call rather than one keyed on a session that does not
     # exist here.
-    scratch_name = session_id or ('stateless-%s' % uuid.uuid4().hex)
+    scratch_name = _safe_scratch_name(session_id) if session_id else ('stateless-%s' % uuid.uuid4().hex)
     scratch_dir = os.path.join(tempfile.gettempdir(), 'exec', scratch_name)
 
     headers = {'Content-Type': 'application/json', YIELD_HEADER: 'waiting'}
 
-    payload = request.get_json(silent=True) or {}
+    payload = request.get_json(silent=True)
+    # A syntactically valid but non-object JSON body ([1,2], "x", 42) parses
+    # truthy; without this guard the payload.get(...) calls below raise an
+    # uncaught AttributeError (non-dicts have no .get), turning a malformed
+    # request into a 500 instead of the exactly-one-of contract's 400.
+    if not isinstance(payload, dict):
+        payload = {}
     has_code = isinstance(payload.get('code'), str)
     has_command = isinstance(payload.get('command'), str)
     if has_code == has_command:

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -1,0 +1,176 @@
+# {{.Name}} -- an interpreter agent handler, scaffolded by
+# `fission agent create --template interpreter`.
+#
+# WHAT THIS FILE IS
+# ------------------
+# This implements the "exec" verb (abstraction A, PR-1): a turn's body is
+# {"code": "..."} (interpreted with `python3 -c`) or {"command": "..."}
+# (run through a shell) -- exactly one of the two -- and the reply is
+# {stdout, stderr, exitCode, durationMs, truncated}. It is an ordinary
+# Fission Python function (the environment calls main() with no arguments
+# for every request, github.com/fission/environments python/server.py)
+# that the agent runtime calls once per turn like any other agent handler,
+# so it runs through the normal dispatch path -- no new platform code, no
+# new environment image.
+#
+# TRUST BOUNDARY -- READ BEFORE USE
+# ----------------------------------
+# The subprocess environment below is an ALLOW-LIST, not a filtered copy:
+# the child starts with nothing and gets only PATH/HOME/LANG/etc, so
+# FISSION_* vars (state/agent token paths, runtime URLs) are never passed
+# through -- that keeps ACCIDENTAL credential leakage out of exec'd code.
+# It is NOT a sandbox: a process in the SAME CONTAINER can still read the
+# pod's token files directly, so exec'd code runs at the agent's own trust
+# level. That is fine for run-your-own-code tools (an analyst's own
+# interpreter, a calculator tool) -- it is NOT a boundary for adversarial
+# or multi-tenant code, which needs a dedicated pod per session (a Tier C
+# bare-Sandbox executor), not this template. Pair this environment with
+# `fission env create ... --runtime-class gvisor` for one more layer of
+# isolation before running code you did not write yourself.
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+import uuid
+
+from flask import request
+
+# The dispatcher stamps the session header on every forwarded call (see
+# pkg/agentruntime/dispatcher.go); this template reads it only to name the
+# per-session scratch directory, and always answers with the default yield
+# (below) so a session-scoped call never self-re-invokes. flask.request.headers
+# is a case-insensitive mapping (Werkzeug EnvironHeaders).
+SESSION_HEADER = 'X-Fission-Session'
+YIELD_HEADER = 'X-Fission-Agent-Yield'
+
+# DEFAULT_TIMEOUT_SECONDS / MAX_TIMEOUT_SECONDS -- the request-carried
+# timeoutSeconds is clamped into (0, MAX_TIMEOUT_SECONDS]; a request that
+# omits it (or sends a non-positive value) gets DEFAULT_TIMEOUT_SECONDS.
+# MAX_TIMEOUT_SECONDS is also this scaffold's own FunctionTimeout (see
+# `fission agent create`'s next-steps output), so a full-length exec call
+# is never killed by the platform's own request timeout first.
+DEFAULT_TIMEOUT_SECONDS = 60
+MAX_TIMEOUT_SECONDS = 300
+
+# MAX_OUTPUT_BYTES caps stdout/stderr EACH (aligns with the state API's
+# MaxValueBytes default, DefaultStateMaxValueBytes, pkg/apis/core/v1/const.go)
+# -- overflow sets truncated=True, it never turns into an error response.
+MAX_OUTPUT_BYTES = 256 * 1024
+
+# ALLOWED_ENV_VARS: see the trust-boundary note above -- this is the
+# complete list of names copied into the child's environment. Nothing
+# outside it reaches the subprocess, however this pod's own environment
+# grows in the future.
+ALLOWED_ENV_VARS = ['PATH', 'HOME', 'LANG', 'LC_ALL', 'TZ']
+
+
+def _allowed_env():
+    return {k: os.environ[k] for k in ALLOWED_ENV_VARS if k in os.environ}
+
+
+def _clip(data):
+    if data is None:
+        data = b''
+    truncated = len(data) > MAX_OUTPUT_BYTES
+    if truncated:
+        data = data[:MAX_OUTPUT_BYTES]
+    return data.decode('utf-8', errors='replace'), truncated
+
+
+def _run_exec(argv, cwd, timeout_seconds):
+    # start_new_session=True puts the child in its own process group so the
+    # WHOLE tree (a shell plus whatever it launches) can be killed on
+    # timeout via os.killpg, not just the direct child.
+    start = time.monotonic()
+    proc = subprocess.Popen(
+        argv,
+        cwd=cwd,
+        env=_allowed_env(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+    timed_out = False
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout_seconds)
+    except subprocess.TimeoutExpired:
+        timed_out = True
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        stdout, stderr = proc.communicate()
+    duration_ms = int((time.monotonic() - start) * 1000)
+
+    stdout_text, stdout_truncated = _clip(stdout)
+    stderr_text, stderr_truncated = _clip(stderr)
+    if timed_out:
+        stderr_text += '\n[exec: killed after exceeding %ds timeout]' % int(timeout_seconds)
+        exit_code = -1
+    else:
+        exit_code = proc.returncode
+
+    return stdout_text, stderr_text, exit_code, duration_ms, stdout_truncated or stderr_truncated
+
+
+def _clamp_timeout(value):
+    try:
+        seconds = float(value)
+        if seconds <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+    return min(seconds, MAX_TIMEOUT_SECONDS)
+
+
+# --- The turn --------------------------------------------------------------
+#
+# Flask's documented view-return-value contract accepts (body, status,
+# headers) tuples -- see agent.py.tmpl's comment for the citation -- which
+# is what sets YIELD_HEADER on the response below.
+def main():
+    session_id = request.headers.get(SESSION_HEADER, '').strip()
+    # A call with no session header (the MCP fast lane -- tools/call goes
+    # straight to the router internal listener, bypassing the dispatcher --
+    # or a bare direct invocation) is stateless exec: a fresh, uniquely-named
+    # scratch dir per call rather than one keyed on a session that does not
+    # exist here.
+    scratch_name = session_id or ('stateless-%s' % uuid.uuid4().hex)
+    scratch_dir = os.path.join(tempfile.gettempdir(), 'exec', scratch_name)
+
+    headers = {'Content-Type': 'application/json', YIELD_HEADER: 'waiting'}
+
+    payload = request.get_json(silent=True) or {}
+    has_code = isinstance(payload.get('code'), str)
+    has_command = isinstance(payload.get('command'), str)
+    if has_code == has_command:
+        return json.dumps({'error': 'exactly one of "code" or "command" is required'}), 400, headers
+
+    timeout_seconds = _clamp_timeout(payload.get('timeoutSeconds'))
+
+    shutil.rmtree(scratch_dir, ignore_errors=True)
+    os.makedirs(scratch_dir, exist_ok=True)
+
+    try:
+        if has_code:
+            argv = ['python3', '-c', payload['code']]
+        else:
+            argv = ['/bin/sh', '-c', payload['command']]
+        stdout_text, stderr_text, exit_code, duration_ms, truncated = _run_exec(argv, scratch_dir, timeout_seconds)
+    finally:
+        # Best-effort cleanup -- a leftover scratch dir is not worth failing
+        # the turn over.
+        shutil.rmtree(scratch_dir, ignore_errors=True)
+
+    reply = {
+        'stdout': stdout_text,
+        'stderr': stderr_text,
+        'exitCode': exit_code,
+        'durationMs': duration_ms,
+        'truncated': truncated,
+    }
+    return json.dumps(reply), 200, headers

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -146,17 +146,41 @@ def _run_exec(argv, cwd, timeout_seconds):
     stderr_thread.start()
 
     timed_out = False
+
+    def _kill_group():
+        # The child's pgid == its pid (start_new_session), and the GROUP can
+        # outlive the direct child (a backgrounded grandchild keeps running
+        # after the shell exits), so signal by the saved pid -- os.getpgid on
+        # an already-reaped child raises before the kill ever happens.
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+    deadline = start + timeout_seconds
     try:
         proc.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
         timed_out = True
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+        _kill_group()
         proc.wait()
-    stdout_thread.join()
-    stderr_thread.join()
+    # The direct child exiting is NOT the end of the turn: a backgrounded
+    # grandchild (sh -c 'daemon &' exits instantly) inherits the stdout/
+    # stderr pipes and keeps the drain threads reading past the deadline.
+    # Bound the drains by the SAME deadline and kill the whole group on
+    # overrun -- that is what "kill the whole process group on expiry"
+    # means, and it matches the JS template, whose 'close' event also waits
+    # for the pipes and whose timer kills the group regardless of the
+    # direct child's state.
+    for drain_thread in (stdout_thread, stderr_thread):
+        drain_thread.join(timeout=max(0.0, deadline - time.monotonic()))
+    if stdout_thread.is_alive() or stderr_thread.is_alive():
+        timed_out = True
+        _kill_group()
+        # Post-SIGKILL the pipe writers are gone and the drains see EOF; the
+        # short grace only covers a straggler thread being scheduled late.
+        stdout_thread.join(timeout=5)
+        stderr_thread.join(timeout=5)
     duration_ms = int((time.monotonic() - start) * 1000)
 
     stdout_text = stdout_buf.text()

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -29,6 +29,7 @@
 # isolation before running code you did not write yourself.
 
 import json
+import math
 import os
 import shutil
 import signal
@@ -120,9 +121,13 @@ def _run_exec(argv, cwd, timeout_seconds):
 def _clamp_timeout(value):
     try:
         seconds = float(value)
-        if seconds <= 0:
-            raise ValueError
     except (TypeError, ValueError):
+        return DEFAULT_TIMEOUT_SECONDS
+    # math.isfinite rejects NaN and +/-inf -- float('nan') <= 0 is False, so
+    # a NaN would otherwise sail past a bare `seconds <= 0` guard and reach
+    # subprocess timeouts as-is, raising an uncaught ValueError instead of
+    # the {stdout,stderr,exitCode,durationMs,truncated} contract.
+    if not math.isfinite(seconds) or seconds <= 0:
         return DEFAULT_TIMEOUT_SECONDS
     return min(seconds, MAX_TIMEOUT_SECONDS)
 

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -35,6 +35,7 @@ import shutil
 import signal
 import subprocess
 import tempfile
+import threading
 import time
 import uuid
 
@@ -73,13 +74,44 @@ def _allowed_env():
     return {k: os.environ[k] for k in ALLOWED_ENV_VARS if k in os.environ}
 
 
-def _clip(data):
-    if data is None:
-        data = b''
-    truncated = len(data) > MAX_OUTPUT_BYTES
-    if truncated:
-        data = data[:MAX_OUTPUT_BYTES]
-    return data.decode('utf-8', errors='replace'), truncated
+class _OutputBuffer:
+    # Mirrors the JS template's outputBuffer: chunks are dropped at PUSH
+    # time once MAX_OUTPUT_BYTES is reached, not merely trimmed once
+    # collection ends -- so a runaway child cannot hold arbitrarily large
+    # stdout/stderr buffers in memory before the cap is applied (unlike
+    # subprocess.communicate(), which buffers the whole stream first).
+    def __init__(self):
+        self._chunks = []
+        self._bytes = 0
+        self.truncated = False
+
+    def push(self, chunk):
+        if self.truncated or not chunk:
+            return
+        remaining = MAX_OUTPUT_BYTES - self._bytes
+        if len(chunk) > remaining:
+            chunk = chunk[:remaining]
+            self.truncated = True
+        self._chunks.append(chunk)
+        self._bytes += len(chunk)
+
+    def text(self):
+        return b''.join(self._chunks).decode('utf-8', errors='replace')
+
+
+def _drain(pipe, buf):
+    # Keeps reading (and, past the cap, discarding) until the pipe closes,
+    # even after buf.truncated -- otherwise an unread pipe fills its OS
+    # buffer and blocks the child, which would hang the whole exec instead
+    # of honoring MAX_OUTPUT_BYTES.
+    try:
+        while True:
+            chunk = pipe.read(65536)
+            if not chunk:
+                break
+            buf.push(chunk)
+    finally:
+        pipe.close()
 
 
 def _run_exec(argv, cwd, timeout_seconds):
@@ -95,27 +127,36 @@ def _run_exec(argv, cwd, timeout_seconds):
         stderr=subprocess.PIPE,
         start_new_session=True,
     )
+    stdout_buf = _OutputBuffer()
+    stderr_buf = _OutputBuffer()
+    stdout_thread = threading.Thread(target=_drain, args=(proc.stdout, stdout_buf))
+    stderr_thread = threading.Thread(target=_drain, args=(proc.stderr, stderr_buf))
+    stdout_thread.start()
+    stderr_thread.start()
+
     timed_out = False
     try:
-        stdout, stderr = proc.communicate(timeout=timeout_seconds)
+        proc.wait(timeout=timeout_seconds)
     except subprocess.TimeoutExpired:
         timed_out = True
         try:
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
         except ProcessLookupError:
             pass
-        stdout, stderr = proc.communicate()
+        proc.wait()
+    stdout_thread.join()
+    stderr_thread.join()
     duration_ms = int((time.monotonic() - start) * 1000)
 
-    stdout_text, stdout_truncated = _clip(stdout)
-    stderr_text, stderr_truncated = _clip(stderr)
+    stdout_text = stdout_buf.text()
+    stderr_text = stderr_buf.text()
     if timed_out:
         stderr_text += '\n[exec: killed after exceeding %ds timeout]' % int(timeout_seconds)
         exit_code = -1
     else:
         exit_code = proc.returncode
 
-    return stdout_text, stderr_text, exit_code, duration_ms, stdout_truncated or stderr_truncated
+    return stdout_text, stderr_text, exit_code, duration_ms, stdout_buf.truncated or stderr_buf.truncated
 
 
 def _clamp_timeout(value):

--- a/pkg/fission-cli/cmd/agent/templates/templates.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates.go
@@ -54,10 +54,20 @@ import (
 )
 
 //go:embed agent.js.tmpl
-var nodeTemplateSrc string
+var nodeAgentTemplateSrc string
 
 //go:embed agent.py.tmpl
-var pythonTemplateSrc string
+var pythonAgentTemplateSrc string
+
+// interpreter.{js,py}.tmpl (PR-1, abstraction A / Q35 resolution): the
+// stateless exec verb -- code/command in, stdout/stderr/exit out -- see
+// their own doc comments for the wire contract.
+//
+//go:embed interpreter.js.tmpl
+var nodeInterpreterTemplateSrc string
+
+//go:embed interpreter.py.tmpl
+var pythonInterpreterTemplateSrc string
 
 // templateData is the substitution set every template receives. Name is the
 // scaffolded function's name; it appears only in a header comment and a
@@ -73,16 +83,23 @@ type langTemplate struct {
 	ext string
 }
 
-// languages is the supported `--lang` values. Keyed by the same lowercase
-// strings the CLI flag accepts.
-var languages = map[string]langTemplate{
-	"node":   {src: nodeTemplateSrc, ext: "js"},
-	"python": {src: pythonTemplateSrc, ext: "py"},
+// kinds is the supported `--template` x `--lang` matrix. Keyed by the same
+// lowercase strings the CLI flags accept.
+var kinds = map[string]map[string]langTemplate{
+	"agent": {
+		"node":   {src: nodeAgentTemplateSrc, ext: "js"},
+		"python": {src: pythonAgentTemplateSrc, ext: "py"},
+	},
+	"interpreter": {
+		"node":   {src: nodeInterpreterTemplateSrc, ext: "js"},
+		"python": {src: pythonInterpreterTemplateSrc, ext: "py"},
+	},
 }
 
-// Render renders the embedded handler template for lang ("node" or
-// "python") with name substituted in, and returns the rendered bytes plus
-// the file extension (no leading dot) the caller should write them under.
+// Render renders the embedded handler template for kind ("agent" or
+// "interpreter") and lang ("node" or "python") with name substituted in,
+// and returns the rendered bytes plus the file extension (no leading dot)
+// the caller should write them under.
 //
 // name is validated against Fission's own Kubernetes-name charset
 // (fv1.ValidateKubeName, the same DNS-1123-label check `fn create` et al.
@@ -92,30 +109,35 @@ var languages = map[string]langTemplate{
 // handler file to disk BEFORE any k8s-side validation runs (the k8s API
 // only rejects an invalid name once the Package/Function object is
 // created, several steps later) -- so Render must be safe to call with an
-// adversarial name on its own. Both templates interpolate {{.Name}} inside
-// JS backtick template literals and Python %-format single-quoted strings
-// (log-line prefixes); an unvalidated name containing a backtick or a
-// single quote breaks out of those literals and lands arbitrary text in
-// LIVE, non-comment code in the scaffolded file -- confirmed exploitable in
-// review, not theoretical. A DNS-1123 label (lowercase alphanumeric/'-',
-// alphanumeric start/end, <=63 chars) cannot contain a backtick, quote,
-// `{{`, or a newline, so validating here closes the injection regardless of
-// what any caller does or forgets to do upstream.
-func Render(lang, name string) ([]byte, string, error) {
-	lt, ok := languages[lang]
+// adversarial name on its own. Every template interpolates {{.Name}} inside
+// JS backtick template literals and/or Python %-format single-quoted
+// strings (log-line/comment prefixes); an unvalidated name containing a
+// backtick or a single quote breaks out of those literals and lands
+// arbitrary text in LIVE, non-comment code in the scaffolded file --
+// confirmed exploitable in review, not theoretical. A DNS-1123 label
+// (lowercase alphanumeric/'-', alphanumeric start/end, <=63 chars) cannot
+// contain a backtick, quote, `{{`, or a newline, so validating here closes
+// the injection regardless of what any caller does or forgets to do
+// upstream.
+func Render(kind, lang, name string) ([]byte, string, error) {
+	langs, ok := kinds[kind]
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported agent template %q (want \"agent\" or \"interpreter\")", kind)
+	}
+	lt, ok := langs[lang]
 	if !ok {
 		return nil, "", fmt.Errorf("unsupported agent handler language %q (want \"node\" or \"python\")", lang)
 	}
 	if err := fv1.ValidateKubeName("name", name); err != nil {
 		return nil, "", fmt.Errorf("invalid agent name %q: %w", name, err)
 	}
-	tmpl, err := template.New(lang).Parse(lt.src)
+	tmpl, err := template.New(kind + "/" + lang).Parse(lt.src)
 	if err != nil {
-		return nil, "", fmt.Errorf("parsing %s handler template: %w", lang, err)
+		return nil, "", fmt.Errorf("parsing %s/%s handler template: %w", kind, lang, err)
 	}
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, templateData{Name: name}); err != nil {
-		return nil, "", fmt.Errorf("rendering %s handler template: %w", lang, err)
+		return nil, "", fmt.Errorf("rendering %s/%s handler template: %w", kind, lang, err)
 	}
 	return buf.Bytes(), lt.ext, nil
 }

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -359,8 +359,8 @@ func TestRender_Interpreter_HeaderNames(t *testing.T) {
 	}
 }
 
-// TestRender_Interpreter_ExecContractKeys pins every JSON key doc 14's PR-1
-// section spells out in the exec verb's wire contract (both the request
+// TestRender_Interpreter_ExecContractKeys pins every JSON key of the exec
+// verb's wire contract (both the request
 // keys, code/command/timeoutSeconds, and the response keys,
 // stdout/stderr/exitCode/durationMs/truncated) -- this contract has no
 // shared Go struct on either side ("zero new platform Go" is the whole
@@ -369,23 +369,32 @@ func TestRender_Interpreter_HeaderNames(t *testing.T) {
 func TestRender_Interpreter_ExecContractKeys(t *testing.T) {
 	t.Parallel()
 
-	wireKeys := []string{
-		"code", "command", "timeoutSeconds",
-		"stdout", "stderr", "exitCode", "durationMs", "truncated",
+	// Anchored on the wire-touching forms (request-key reads and
+	// response-literal keys), not bare words: "code"/"stdout" etc. also
+	// occur in comment prose, so a bare Contains would keep passing after
+	// the actual contract site was renamed.
+	wireForms := map[string][]string{
+		"node": {
+			`body.code`, `body.command`, `body.timeoutSeconds`,
+			`stdout: `, `stderr: `, `exitCode: `, `durationMs: `, `truncated: `,
+		},
+		"python": {
+			`payload.get('code')`, `payload.get('command')`, `payload.get('timeoutSeconds')`,
+			`'stdout':`, `'stderr':`, `'exitCode':`, `'durationMs':`, `'truncated':`,
+		},
 	}
-	for _, lang := range []string{"node", "python"} {
+	for lang, forms := range wireForms {
 		out, _ := render(t, "interpreter", lang)
 		text := string(out)
-		for _, key := range wireKeys {
-			assert.Contains(t, text, key, "%s: missing exec-contract key %q", lang, key)
+		for _, form := range forms {
+			assert.Contains(t, text, form, "%s: missing exec-contract wire form %q", lang, form)
 		}
 	}
 }
 
 // TestRender_Interpreter_TimeoutCeiling pins the request-carried
-// timeoutSeconds default (60) and hard ceiling (300) doc 14's PR-1 section
-// specifies ("timeoutSeconds default 60, clamped to a template constant
-// ceiling (300)").
+// timeoutSeconds default (60) and hard ceiling (300) the exec
+// contract specifies.
 func TestRender_Interpreter_TimeoutCeiling(t *testing.T) {
 	t.Parallel()
 	for _, lang := range []string{"node", "python"} {
@@ -417,7 +426,7 @@ func TestRender_Interpreter_TimeoutRejectsNonFinite(t *testing.T) {
 
 // TestRender_Interpreter_OutputCapMatchesStateDefault pins the stdout/stderr
 // cap to fv1.DefaultStateMaxValueBytes (pkg/apis/core/v1/const.go) rather
-// than a re-typed 262144 literal -- doc 14's PR-1 section requires the two
+// than a re-typed 262144 literal -- the two must
 // stay aligned ("stdout/stderr each capped at 256 KiB (aligns with state
 // MaxValueBytes default)"). Both templates spell the cap as the expression
 // `256 * 1024` rather than the raw byte count, so this both checks that
@@ -439,7 +448,7 @@ func TestRender_Interpreter_OutputCapMatchesStateDefault(t *testing.T) {
 var allowedEnvVarsListRe = regexp.MustCompile(`ALLOWED_ENV_VARS = \[([^\]]*)\]`)
 
 // TestRender_Interpreter_EnvAllowlistExcludesFissionVars is the static
-// (non-cluster) half of doc 14's env-scrub requirement ("Subprocess env is
+// (non-cluster) half of the env-scrub requirement ("Subprocess env is
 // allow-listed ... never pass-through -- FISSION_* vars ... are scrubbed"):
 // it asserts the allow-list itself never names a FISSION_-prefixed
 // variable, so the subprocess's environment cannot contain one BY
@@ -473,7 +482,7 @@ func TestRender_Interpreter_EnvAllowlistExcludesFissionVars(t *testing.T) {
 }
 
 // TestRender_Interpreter_TrustStatementMentionsGvisor pins the interpreter
-// template's own trust-boundary comment against the doc 14 PR-1 section's
+// template's own trust-boundary comment against the
 // requirement that the scaffold recommend `--runtime-class gvisor` for
 // stronger isolation before running untrusted code.
 func TestRender_Interpreter_TrustStatementMentionsGvisor(t *testing.T) {

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -483,3 +483,60 @@ func TestRender_Interpreter_TrustStatementMentionsGvisor(t *testing.T) {
 		assert.Contains(t, string(out), "--runtime-class gvisor", "%s: trust-boundary comment missing the gvisor recommendation", lang)
 	}
 }
+
+// TestRender_Interpreter_ScratchNameGuardsTraversal pins the review fix for
+// the dispatcher's sessionIDPattern (^[A-Za-z0-9._-]{1,128}$,
+// pkg/agentruntime/dispatcher.go) legitimately admitting the exact strings
+// "." and ".." as a caller-supplied session id: since both templates turn
+// the session id into a scratch-dir path SEGMENT
+// ($TMPDIR/exec/<segment>), an unguarded "." or ".." resolves to
+// $TMPDIR/exec or $TMPDIR itself -- both of which get recursively removed
+// at the start and end of every turn. This also has to hold on the direct
+// (no-dispatcher) invocation path, where nothing upstream enforces
+// sessionIDPattern's charset at all -- so both templates must re-validate
+// the FULL charset here, not just reject the two degenerate values, and
+// fall back to a fresh scratch name on anything that fails either check.
+func TestRender_Interpreter_ScratchNameGuardsTraversal(t *testing.T) {
+	t.Parallel()
+
+	pyOut, _ := render(t, "interpreter", "python")
+	assert.Contains(t, string(pyOut), "session_id in ('.', '..')",
+		"python: scratch-dir name must guard against the exact session ids \".\" and \"..\"")
+	assert.Contains(t, string(pyOut), "_SESSION_ID_CHARSET_RE.fullmatch(session_id)",
+		"python: scratch-dir name must also be re-validated against the full session-id charset (the dispatcher's sessionIDPattern is not enforced on the direct-invocation path)")
+
+	jsOut, _ := render(t, "interpreter", "node")
+	assert.Contains(t, string(jsOut), "sessionID === '.' || sessionID === '..'",
+		"node: scratch-dir name must guard against the exact session ids \".\" and \"..\"")
+	assert.Contains(t, string(jsOut), "SESSION_ID_CHARSET_RE.test(sessionID)",
+		"node: scratch-dir name must also be re-validated against the full session-id charset (the dispatcher's sessionIDPattern is not enforced on the direct-invocation path)")
+}
+
+// TestRender_Interpreter_PythonRejectsNonObjectBody pins the review fix for
+// a syntactically valid but non-object JSON body ([1,2], "x", 42): parsed
+// via request.get_json(silent=True) it comes back truthy, so without an
+// isinstance guard payload.get(...) raises an uncaught AttributeError (a
+// 500) instead of the exactly-one-of contract's 400. The node template
+// already survives this via parseBody/typeof checks, so only python needs
+// the pin.
+func TestRender_Interpreter_PythonRejectsNonObjectBody(t *testing.T) {
+	t.Parallel()
+	out, _ := render(t, "interpreter", "python")
+	assert.Contains(t, string(out), "isinstance(payload, dict)",
+		"python: a non-object JSON body must be coerced to {} before payload.get(...) is called")
+}
+
+// TestRender_Interpreter_PythonHandlesSpawnFailure pins the review fix
+// making subprocess.Popen failure (e.g. a missing /bin/sh or python3
+// binary) symmetric with the node template's spawn() 'error' handler: both
+// must map the failure into the {stdout,stderr,exitCode,durationMs,
+// truncated} reply instead of letting it raise past the turn as an
+// uncaught 500.
+func TestRender_Interpreter_PythonHandlesSpawnFailure(t *testing.T) {
+	t.Parallel()
+	out, _ := render(t, "interpreter", "python")
+	assert.Contains(t, string(out), "except OSError as err:",
+		"python: _run_exec must catch a failed Popen and answer the exec contract, not raise")
+	assert.Contains(t, string(out), "failed to start",
+		"python: a failed Popen should report the same 'failed to start' note the node template uses")
+}

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
 	"github.com/fission/fission/pkg/executor/util"
 	"github.com/fission/fission/pkg/fetcher"
 
@@ -39,18 +41,31 @@ func commentPrefix(lang string) string {
 	return "//"
 }
 
-// render is a small helper: render lang's template and require success.
-func render(t *testing.T, lang string) ([]byte, string) {
+// render is a small helper: render kind/lang's template and require success.
+func render(t *testing.T, kind, lang string) ([]byte, string) {
 	t.Helper()
-	out, ext, err := Render(lang, "widget")
+	out, ext, err := Render(kind, lang, "widget")
 	require.NoError(t, err)
 	require.NotEmpty(t, out)
 	return out, ext
 }
 
+// renderAgent is the pre-PR-1 default-kind shorthand every test below that
+// predates the --template flag still uses.
+func renderAgent(t *testing.T, lang string) ([]byte, string) {
+	t.Helper()
+	return render(t, "agent", lang)
+}
+
 func TestRender_UnsupportedLanguage(t *testing.T) {
 	t.Parallel()
-	_, _, err := Render("ruby", "widget")
+	_, _, err := Render("agent", "ruby", "widget")
+	require.Error(t, err)
+}
+
+func TestRender_UnsupportedTemplateKind(t *testing.T) {
+	t.Parallel()
+	_, _, err := Render("wizard", "node", "widget")
 	require.Error(t, err)
 }
 
@@ -81,35 +96,48 @@ func TestRender_RejectsUnsafeNames(t *testing.T) {
 		{name: "uppercase (not DNS-1123, but worth covering)", payload: "Widget"},
 		{name: "empty", payload: ""},
 	}
-	for _, lang := range []string{"node", "python"} {
-		for _, tc := range cases {
-			t.Run(lang+"/"+tc.name, func(t *testing.T) {
-				t.Parallel()
-				out, _, err := Render(lang, tc.payload)
-				require.Error(t, err, "Render must reject unsafe name %q", tc.payload)
-				assert.Empty(t, out, "Render must not return partial output on a rejected name")
-			})
+	// Both kinds share ValidateKubeName as the actual gate (it runs before
+	// either template is even parsed), but the loop covers "agent" AND
+	// "interpreter" anyway: agent's own backtick/single-quote cases are the
+	// documented regression, and running the full matrix against
+	// interpreter too catches any future template that grows its own
+	// live-code interpolation of {{.Name}} without a matching test.
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			for _, tc := range cases {
+				t.Run(kind+"/"+lang+"/"+tc.name, func(t *testing.T) {
+					t.Parallel()
+					out, _, err := Render(kind, lang, tc.payload)
+					require.Error(t, err, "Render must reject unsafe name %q", tc.payload)
+					assert.Empty(t, out, "Render must not return partial output on a rejected name")
+				})
+			}
 		}
 	}
 }
 
 func TestRender_Extensions(t *testing.T) {
 	t.Parallel()
-	_, ext := render(t, "node")
-	assert.Equal(t, "js", ext)
-	_, ext = render(t, "python")
-	assert.Equal(t, "py", ext)
+	for _, kind := range []string{"agent", "interpreter"} {
+		_, ext := render(t, kind, "node")
+		assert.Equal(t, "js", ext)
+		_, ext = render(t, kind, "python")
+		assert.Equal(t, "py", ext)
+	}
 }
 
 func TestRender_NoTemplateArtifacts(t *testing.T) {
 	t.Parallel()
-	for _, lang := range []string{"node", "python"} {
-		out, _ := render(t, lang)
-		text := string(out)
-		assert.NotContains(t, text, "{{", "%s template left an unrendered placeholder", lang)
-		// render(t, lang) passes name "widget" -- confirm substitution
-		// actually ran, not merely that the placeholder syntax is gone.
-		assert.Contains(t, text, "widget", "%s: Name substitution did not run", lang)
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			out, _ := render(t, kind, lang)
+			text := string(out)
+			assert.NotContains(t, text, "{{", "%s/%s template left an unrendered placeholder", kind, lang)
+			// render(t, kind, lang) passes name "widget" -- confirm
+			// substitution actually ran, not merely that the placeholder
+			// syntax is gone.
+			assert.Contains(t, text, "widget", "%s/%s: Name substitution did not run", kind, lang)
+		}
 	}
 }
 
@@ -134,7 +162,7 @@ func TestRender_HeaderNames(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.lang, func(t *testing.T) {
 			t.Parallel()
-			out, _ := render(t, tc.lang)
+			out, _ := renderAgent(t, tc.lang)
 			text := string(out)
 
 			session, turns := agentruntime.HeaderSession, agentruntime.HeaderTurns
@@ -161,7 +189,7 @@ func TestRender_HeaderNames(t *testing.T) {
 func TestRender_StateHeaderNames(t *testing.T) {
 	t.Parallel()
 	for _, lang := range []string{"node", "python"} {
-		out, _ := render(t, lang)
+		out, _ := renderAgent(t, lang)
 		text := string(out)
 		assert.Contains(t, text, stateapi.HeaderNamespace, "%s: missing state namespace header", lang)
 		assert.Contains(t, text, stateapi.HeaderKeyspace, "%s: missing state keyspace header", lang)
@@ -182,7 +210,7 @@ func TestRender_StateEnvVarNames(t *testing.T) {
 	require.NotEmpty(t, envVars, "STATESVC_URL was set; StateAPIEnvVars must not return nil")
 
 	for _, lang := range []string{"node", "python"} {
-		out, _ := render(t, lang)
+		out, _ := renderAgent(t, lang)
 		text := string(out)
 		for _, ev := range envVars {
 			assert.Contains(t, text, ev.Name, "%s: missing state env var %s", lang, ev.Name)
@@ -211,7 +239,7 @@ func TestRender_StateCredentialsFieldNames(t *testing.T) {
 	}
 
 	for _, lang := range []string{"node", "python"} {
-		out, _ := render(t, lang)
+		out, _ := renderAgent(t, lang)
 		text := string(out)
 		for _, name := range fieldNames {
 			assert.Contains(t, text, name, "%s: missing StateCredentials field %q", lang, name)
@@ -226,65 +254,213 @@ func TestRender_StateCredentialsFieldNames(t *testing.T) {
 func TestRender_YieldDefaultsToWaiting(t *testing.T) {
 	t.Parallel()
 
-	for _, lang := range []string{"node", "python"} {
-		t.Run(lang, func(t *testing.T) {
-			t.Parallel()
-			out, _ := render(t, lang)
-			text := string(out)
-			prefix := commentPrefix(lang)
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			t.Run(kind+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				out, _ := render(t, kind, lang)
+				text := string(out)
+				prefix := commentPrefix(lang)
 
-			var activeWaiting bool
-			for _, line := range strings.Split(text, "\n") {
-				trimmed := strings.TrimSpace(line)
-				isCode := trimmed != "" && !strings.HasPrefix(trimmed, prefix)
+				var activeWaiting bool
+				for _, line := range strings.Split(text, "\n") {
+					trimmed := strings.TrimSpace(line)
+					isCode := trimmed != "" && !strings.HasPrefix(trimmed, prefix)
 
-				if strings.Contains(line, agentruntime.YieldContinue) {
-					// "continue" must never appear in the ACTIVE code path
-					// (a scaffold that yielded it by default would
-					// self-re-invoke forever on a fresh install).
-					assert.False(t, isCode,
-						"%s: %q value found outside a comment: %q", lang, agentruntime.YieldContinue, line)
+					if strings.Contains(line, agentruntime.YieldContinue) {
+						// "continue" must never appear in the ACTIVE code path
+						// (a scaffold that yielded it by default would
+						// self-re-invoke forever on a fresh install).
+						assert.False(t, isCode,
+							"%s/%s: %q value found outside a comment: %q", kind, lang, agentruntime.YieldContinue, line)
+					}
+					if isCode && strings.Contains(line, agentruntime.YieldWaiting) {
+						activeWaiting = true
+					}
 				}
-				if isCode && strings.Contains(line, agentruntime.YieldWaiting) {
-					activeWaiting = true
-				}
-			}
-			assert.True(t, activeWaiting,
-				"%s: no active (non-comment) line yields %q", lang, agentruntime.YieldWaiting)
-		})
+				assert.True(t, activeWaiting,
+					"%s/%s: no active (non-comment) line yields %q", kind, lang, agentruntime.YieldWaiting)
+			})
+		}
 	}
 }
 
-// TestRender_NodeSyntax runs `node --check` against the rendered Node
-// template. Skipped (with a note) when node is not on PATH.
+// TestRender_NodeSyntax runs `node --check` against every rendered Node
+// template (both --template kinds). Skipped (with a note) when node is not
+// on PATH.
 func TestRender_NodeSyntax(t *testing.T) {
 	nodeBin, err := exec.LookPath("node")
 	if err != nil {
 		t.Skip("node not found on PATH; skipping node --check")
 	}
 
-	out, _ := render(t, "node")
-	path := t.TempDir() + "/agent.js"
-	require.NoError(t, os.WriteFile(path, out, 0o600))
+	for _, kind := range []string{"agent", "interpreter"} {
+		out, _ := render(t, kind, "node")
+		path := t.TempDir() + "/" + kind + ".js"
+		require.NoError(t, os.WriteFile(path, out, 0o600))
 
-	cmd := exec.Command(nodeBin, "--check", path)
-	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "node --check failed: %s", output)
+		cmd := exec.Command(nodeBin, "--check", path)
+		output, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "%s: node --check failed: %s", kind, output)
+	}
 }
 
-// TestRender_PythonSyntax runs `python3 -m py_compile` against the rendered
-// Python template. Skipped (with a note) when python3 is not on PATH.
+// TestRender_PythonSyntax runs `python3 -m py_compile` against every
+// rendered Python template (both --template kinds). Skipped (with a note)
+// when python3 is not on PATH.
 func TestRender_PythonSyntax(t *testing.T) {
 	pyBin, err := exec.LookPath("python3")
 	if err != nil {
 		t.Skip("python3 not found on PATH; skipping py_compile")
 	}
 
-	out, _ := render(t, "python")
-	path := t.TempDir() + "/agent.py"
-	require.NoError(t, os.WriteFile(path, out, 0o600))
+	for _, kind := range []string{"agent", "interpreter"} {
+		out, _ := render(t, kind, "python")
+		path := t.TempDir() + "/" + kind + ".py"
+		require.NoError(t, os.WriteFile(path, out, 0o600))
 
-	cmd := exec.Command(pyBin, "-m", "py_compile", path)
-	output, err := cmd.CombinedOutput()
-	require.NoErrorf(t, err, "python3 -m py_compile failed: %s", output)
+		cmd := exec.Command(pyBin, "-m", "py_compile", path)
+		output, err := cmd.CombinedOutput()
+		require.NoErrorf(t, err, "%s: python3 -m py_compile failed: %s", kind, output)
+	}
+}
+
+// --- interpreter template tripwires (PR-1, abstraction A / Q35) -----------
+
+// TestRender_Interpreter_HeaderNames pins the interpreter template against
+// the SAME dispatcher constants TestRender_HeaderNames pins the agent
+// template against -- it reads the session header (to name its scratch
+// dir) and always sets the yield header, but never touches the turns
+// header (it carries no per-turn counter).
+func TestRender_Interpreter_HeaderNames(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		lang        string
+		foldToLower bool
+	}{
+		{lang: "node", foldToLower: true},
+		{lang: "python", foldToLower: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.lang, func(t *testing.T) {
+			t.Parallel()
+			out, _ := render(t, "interpreter", tc.lang)
+			text := string(out)
+
+			session := agentruntime.HeaderSession
+			if tc.foldToLower {
+				text = strings.ToLower(text)
+				session = strings.ToLower(session)
+			}
+			assert.Contains(t, text, session, "%s: session header const not found", tc.lang)
+			assert.Contains(t, string(out), agentruntime.HeaderYield, "%s: yield header const not found", tc.lang)
+		})
+	}
+}
+
+// TestRender_Interpreter_ExecContractKeys pins every JSON key doc 14's PR-1
+// section spells out in the exec verb's wire contract (both the request
+// keys, code/command/timeoutSeconds, and the response keys,
+// stdout/stderr/exitCode/durationMs/truncated) -- this contract has no
+// shared Go struct on either side ("zero new platform Go" is the whole
+// point of a template-only exec verb), so the rendered template text is
+// the only place these key literals live; this test is the drift guard.
+func TestRender_Interpreter_ExecContractKeys(t *testing.T) {
+	t.Parallel()
+
+	wireKeys := []string{
+		"code", "command", "timeoutSeconds",
+		"stdout", "stderr", "exitCode", "durationMs", "truncated",
+	}
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, "interpreter", lang)
+		text := string(out)
+		for _, key := range wireKeys {
+			assert.Contains(t, text, key, "%s: missing exec-contract key %q", lang, key)
+		}
+	}
+}
+
+// TestRender_Interpreter_TimeoutCeiling pins the request-carried
+// timeoutSeconds default (60) and hard ceiling (300) doc 14's PR-1 section
+// specifies ("timeoutSeconds default 60, clamped to a template constant
+// ceiling (300)").
+func TestRender_Interpreter_TimeoutCeiling(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, "interpreter", lang)
+		text := string(out)
+		assert.Contains(t, text, "DEFAULT_TIMEOUT_SECONDS = 60", "%s: default timeout constant not found or changed", lang)
+		assert.Contains(t, text, "MAX_TIMEOUT_SECONDS = 300", "%s: timeout ceiling constant not found or changed", lang)
+	}
+}
+
+// TestRender_Interpreter_OutputCapMatchesStateDefault pins the stdout/stderr
+// cap to fv1.DefaultStateMaxValueBytes (pkg/apis/core/v1/const.go) rather
+// than a re-typed 262144 literal -- doc 14's PR-1 section requires the two
+// stay aligned ("stdout/stderr each capped at 256 KiB (aligns with state
+// MaxValueBytes default)"). Both templates spell the cap as the expression
+// `256 * 1024` rather than the raw byte count, so this both checks that
+// expression is present and that it still equals the platform constant.
+func TestRender_Interpreter_OutputCapMatchesStateDefault(t *testing.T) {
+	t.Parallel()
+	require.EqualValues(t, 256*1024, fv1.DefaultStateMaxValueBytes,
+		"platform's DefaultStateMaxValueBytes moved off 256KiB; update the interpreter templates' MAX_OUTPUT_BYTES to match")
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, "interpreter", lang)
+		assert.Contains(t, string(out), "256 * 1024", "%s: output-cap expression not found", lang)
+	}
+}
+
+// allowedEnvVarsListRe extracts the ALLOWED_ENV_VARS literal (a single-line
+// ['A', 'B', ...] / ["A", "B", ...] list in both templates) so
+// TestRender_Interpreter_EnvAllowlistExcludesFissionVars can inspect its
+// entries without re-parsing JS or Python.
+var allowedEnvVarsListRe = regexp.MustCompile(`ALLOWED_ENV_VARS = \[([^\]]*)\]`)
+
+// TestRender_Interpreter_EnvAllowlistExcludesFissionVars is the static
+// (non-cluster) half of doc 14's env-scrub requirement ("Subprocess env is
+// allow-listed ... never pass-through -- FISSION_* vars ... are scrubbed"):
+// it asserts the allow-list itself never names a FISSION_-prefixed
+// variable, so the subprocess's environment cannot contain one BY
+// CONSTRUCTION regardless of what this pod's own environment carries. The
+// dynamic half (actually exec `env` against a live pod and assert no
+// FISSION_ keys come back) is
+// test/integration/suites/common/agent_exec_test.go's env-scrub case.
+func TestRender_Interpreter_EnvAllowlistExcludesFissionVars(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, "interpreter", lang)
+		text := string(out)
+
+		match := allowedEnvVarsListRe.FindStringSubmatch(text)
+		require.Lenf(t, match, 2, "%s: ALLOWED_ENV_VARS list literal not found", lang)
+
+		var names []string
+		for _, entry := range strings.Split(match[1], ",") {
+			name := strings.Trim(strings.TrimSpace(entry), `'"`)
+			if name != "" {
+				names = append(names, name)
+			}
+		}
+		require.NotEmpty(t, names, "%s: ALLOWED_ENV_VARS list is empty", lang)
+		assert.Contains(t, names, "PATH", "%s: allow-list should carry PATH", lang)
+		for _, name := range names {
+			assert.False(t, strings.HasPrefix(name, "FISSION_"),
+				"%s: ALLOWED_ENV_VARS must never allow-list a FISSION_ var (found %q)", lang, name)
+		}
+	}
+}
+
+// TestRender_Interpreter_TrustStatementMentionsGvisor pins the interpreter
+// template's own trust-boundary comment against the doc 14 PR-1 section's
+// requirement that the scaffold recommend `--runtime-class gvisor` for
+// stronger isolation before running untrusted code.
+func TestRender_Interpreter_TrustStatementMentionsGvisor(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, "interpreter", lang)
+		assert.Contains(t, string(out), "--runtime-class gvisor", "%s: trust-boundary comment missing the gvisor recommendation", lang)
+	}
 }

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -396,6 +396,25 @@ func TestRender_Interpreter_TimeoutCeiling(t *testing.T) {
 	}
 }
 
+// TestRender_Interpreter_TimeoutRejectsNonFinite pins each language's own
+// guard against a non-finite `timeoutSeconds` (NaN, +/-Inf): a bare `<= 0`
+// comparison never catches NaN (float('nan') <= 0 is False in Python,
+// Number.isFinite(NaN) still gates it in JS only because that check exists),
+// so a request carrying {"timeoutSeconds": "nan"} would otherwise reach the
+// subprocess timeout as-is and crash the turn with an uncaught error instead
+// of the {stdout,stderr,exitCode,durationMs,truncated} contract. The Python
+// template must call math.isfinite; the JS template must call
+// Number.isFinite -- this is the drift guard for both.
+func TestRender_Interpreter_TimeoutRejectsNonFinite(t *testing.T) {
+	t.Parallel()
+
+	pyOut, _ := render(t, "interpreter", "python")
+	assert.Contains(t, string(pyOut), "math.isfinite(seconds)", "python: _clamp_timeout must reject non-finite values via math.isfinite")
+
+	jsOut, _ := render(t, "interpreter", "node")
+	assert.Contains(t, string(jsOut), "Number.isFinite(n)", "node: clampTimeout must reject non-finite values via Number.isFinite")
+}
+
 // TestRender_Interpreter_OutputCapMatchesStateDefault pins the stdout/stderr
 // cap to fv1.DefaultStateMaxValueBytes (pkg/apis/core/v1/const.go) rather
 // than a re-typed 262144 literal -- doc 14's PR-1 section requires the two

--- a/pkg/fission-cli/cmd/function/create.go
+++ b/pkg/fission-cli/cmd/function/create.go
@@ -243,14 +243,17 @@ func GetAgentConfig(input cli.Input, existing *fv1.AgentConfig) *fv1.AgentConfig
 	return ac
 }
 
-// getToolConfig builds a ToolConfig from the --expose-as-mcp / --tool-* flags,
+// GetToolConfig builds a ToolConfig from the --expose-as-mcp / --tool-* flags,
 // or nil when --expose-as-mcp is not set (the function is not advertised as an
 // MCP tool). It merges onto existing (the function's current Tool, or nil on
 // create), overwriting only the fields whose flag was explicitly set — so an
 // `fn update --expose-as-mcp` that omits --tool-name/--tool-input-schema keeps
 // the previously-set values instead of clearing them. The --tool-input-schema
 // flag points at a JSON Schema file whose raw contents are stored verbatim.
-func getToolConfig(input cli.Input, existing *fv1.ToolConfig) (*fv1.ToolConfig, error) {
+// Exported (same in-place rename pattern as GetStateConfig/GetAgentConfig)
+// so `fission agent create` (PR-1) can wire --expose-as-mcp onto its
+// scaffolded Function without duplicating this flag-merge logic.
+func GetToolConfig(input cli.Input, existing *fv1.ToolConfig) (*fv1.ToolConfig, error) {
 	if !input.Bool(flagkey.FnExposeAsMCP) {
 		return nil, nil
 	}
@@ -585,7 +588,7 @@ func (opts *CreateSubCommand) complete(input cli.Input) error {
 		return err
 	}
 
-	toolConfig, err := getToolConfig(input, nil)
+	toolConfig, err := GetToolConfig(input, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/fission-cli/cmd/function/update.go
+++ b/pkg/fission-cli/cmd/function/update.go
@@ -119,7 +119,7 @@ func (opts *UpdateSubCommand) complete(input cli.Input) error {
 	// --expose-as-mcp toggles the MCP tool config; when off it clears it. The
 	// other --tool-* flags merge onto the existing config (only set fields change).
 	if input.IsSet(flagkey.FnExposeAsMCP) {
-		toolConfig, err := getToolConfig(input, function.Spec.Tool)
+		toolConfig, err := GetToolConfig(input, function.Spec.Tool)
 		if err != nil {
 			return err
 		}

--- a/pkg/fission-cli/flag/flag.go
+++ b/pkg/fission-cli/flag/flag.go
@@ -276,6 +276,11 @@ var (
 	// below (same "code" flag key, same meaning: a single handler file path).
 	FnAgentLang = Flag{Type: String, Name: flagkey.FnAgentLang, Usage: "Scaffolded handler language: node or python", DefaultString: "node"}
 
+	// `fission agent create --template` (PR-1, abstraction A / Q35 resolution):
+	// "agent" scaffolds the stateful session-driven handler (default); "interpreter"
+	// scaffolds the exec verb (code/command in, stdout/stderr/exit out).
+	FnAgentTemplate = Flag{Type: String, Name: flagkey.FnAgentTemplate, Usage: "Scaffold template: agent (stateful, session-driven; default) or interpreter (stateless code/command exec verb)", DefaultString: "agent"}
+
 	// `fission agent sessions` introspection CLI (slice 4).
 	AgentSession      = Flag{Type: String, Name: flagkey.AgentSession, Usage: "Session id"}
 	AgentToken        = Flag{Type: String, Name: flagkey.AgentToken, Usage: "Bearer token for the agent runtime (defaults to FISSION_AGENT_TOKEN; unset works only when agentRuntime.allowInsecure is set)"}

--- a/pkg/fission-cli/flag/key/key.go
+++ b/pkg/fission-cli/flag/key/key.go
@@ -169,6 +169,12 @@ const (
 	// path), so only --lang is genuinely new here.
 	FnAgentLang = "lang"
 
+	// `fission agent create --template` (PR-1, abstraction A / Q35): selects
+	// which embedded handler template is scaffolded -- "agent" (the
+	// stateful, session-driven default) or "interpreter" (the stateless
+	// exec verb, pkg/fission-cli/cmd/agent/templates/interpreter.{js,py}.tmpl).
+	FnAgentTemplate = "template"
+
 	// `fission agent sessions` introspection CLI (slice 4).
 	AgentSession      = "session"
 	AgentToken        = "agent-token"

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build integration
+
+package common_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/fission/fission/pkg/agentruntime"
+	"github.com/fission/fission/test/integration/framework"
+)
+
+// execTurnReply is the exec verb's response contract (doc 14 PR-1 section):
+// {"stdout": "...", "stderr": "...", "exitCode": 0, "durationMs": 12,
+// "truncated": false}. This has no shared Go struct on either side ("zero
+// new platform Go" is the point of a template-only exec verb) -- it exists
+// only to decode the wire response in this test.
+type execTurnReply struct {
+	Stdout     string `json:"stdout"`
+	Stderr     string `json:"stderr"`
+	ExitCode   int    `json:"exitCode"`
+	DurationMs int64  `json:"durationMs"`
+	Truncated  bool   `json:"truncated"`
+}
+
+// postExecTurn POSTs one turn carrying an arbitrary JSON payload (the exec
+// verb's request body), unlike postTurn (agentruntime_test.go) which always
+// sends "{}". Carries sessionID on agentruntime.HeaderSession when
+// non-empty. The caller is responsible for closing the response body on a
+// nil error.
+func postExecTurn(ctx context.Context, f *framework.Framework, turnURL, sessionID string, payload []byte) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, turnURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set(agentruntime.HeaderSession, sessionID)
+	}
+	return f.HTTPClient().Do(req)
+}
+
+// dispatchExecTurn POSTs payload to turnURL (carrying sessionID when
+// non-empty) and decodes a 200 response as execTurnReply, retrying inside
+// EventuallyWithT so a cold pod / a still-converging agentruntime
+// reconciler (same rationale as postTurn's callers throughout
+// agentruntime_test.go) doesn't flake the assertion that follows.
+func dispatchExecTurn(t *testing.T, ctx context.Context, f *framework.Framework, turnURL, sessionID string, payload []byte) (execTurnReply, string) {
+	t.Helper()
+
+	var reply execTurnReply
+	var gotSessionID string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postExecTurn(attemptCtx, f, turnURL, sessionID, payload)
+		if !assert.NoErrorf(c, err, "POST %s", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "exec turn to %s", turnURL) {
+			return
+		}
+		sid := resp.Header.Get(agentruntime.HeaderSession)
+		if !assert.NotEmpty(c, sid, "exec turn must carry a session id via %s", agentruntime.HeaderSession) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoErrorf(c, err, "reading exec turn response body") {
+			return
+		}
+		if !assert.NoErrorf(c, json.Unmarshal(body, &reply), "decoding exec turn reply %q", body) {
+			return
+		}
+		gotSessionID = sid
+	}, 180*time.Second, 2*time.Second)
+	return reply, gotSessionID
+}
+
+// TestAgentExec exercises the PR-1 (abstraction A, Q35 resolution) exec
+// verb end to end: `fission agent create --template interpreter` scaffolds
+// a handler that runs {"code": ...} / {"command": ...} turn bodies and
+// answers {stdout, stderr, exitCode, durationMs, truncated} -- through the
+// normal agent-runtime dispatch path, with zero platform-side awareness of
+// this contract. Subtests cover the four cases doc 14's PR-1 Files section
+// calls for: a basic exec, the timeout ceiling, output truncation, and the
+// env-scrub guarantee.
+func TestAgentExec(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "agent-exec-node-" + ns.ID
+	fnName := "agent-exec-" + ns.ID
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	workdir := t.TempDir()
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "init")
+		ns.CLI(t, ctx, "agent", "create", "--name", fnName, "--env", envName, "--template", "interpreter", "--spec")
+		ns.CLI(t, ctx, "spec", "apply")
+	})
+
+	turnURL := f.AgentRuntimeBaseURL() + "/agents/" + ns.Name + "/" + fnName
+
+	// First turn establishes the session every other subtest reuses --
+	// mirrors TestAgentCreateScaffold/TestAgentRuntimeSessionDispatch's
+	// no-session-header first call.
+	basicReply, sessionID := dispatchExecTurn(t, ctx, f, turnURL, "", []byte(`{"code": "console.log(1 + 1)"}`))
+	require.NotEmpty(t, sessionID, "scaffolded interpreter never minted a session id")
+
+	t.Run("code executes and returns stdout/exitCode", func(t *testing.T) {
+		assert.Equal(t, "2\n", basicReply.Stdout)
+		assert.Empty(t, basicReply.Stderr)
+		assert.Equal(t, 0, basicReply.ExitCode)
+		assert.False(t, basicReply.Truncated)
+		assert.GreaterOrEqual(t, basicReply.DurationMs, int64(0))
+	})
+
+	t.Run("command form executes through a shell", func(t *testing.T) {
+		reply, sid := dispatchExecTurn(t, ctx, f, turnURL, sessionID, []byte(`{"command": "echo hello-from-exec"}`))
+		assert.Equal(t, sessionID, sid)
+		assert.Equal(t, "hello-from-exec\n", reply.Stdout)
+		assert.Equal(t, 0, reply.ExitCode)
+	})
+
+	// Timeout case: a 5s sleep with a 1s ceiling must be killed (the WHOLE
+	// process group, not merely the shell) and reported as exitCode -1 with
+	// a note in stderr -- doc 14's "kill the whole process group on expiry,
+	// report exitCode: -1 + stderr note".
+	t.Run("timeout kills the process and reports exitCode -1", func(t *testing.T) {
+		start := time.Now()
+		reply, _ := dispatchExecTurn(t, ctx, f, turnURL, sessionID, []byte(`{"command": "sleep 5", "timeoutSeconds": 1}`))
+		elapsed := time.Since(start)
+
+		assert.Equal(t, -1, reply.ExitCode)
+		assert.Contains(t, reply.Stderr, "timeout")
+		// The process must actually have been killed near the 1s ceiling,
+		// not run to completion (5s) before the reply came back -- a
+		// generous upper bound (well under the sleep's own 5s) distinguishes
+		// "killed early" from "timeout is decorative".
+		assert.Lessf(t, elapsed, 4*time.Second, "exec did not appear to be killed at the timeout ceiling (took %s)", elapsed)
+	})
+
+	// Truncation case: ask Node to write more than the 256KiB (262144-byte)
+	// per-stream cap and confirm truncated:true plus a stdout capped at
+	// EXACTLY that many bytes -- doc 14's "stdout/stderr each capped at 256
+	// KiB ... overflow sets truncated: true, never errors".
+	t.Run("output over 256KiB is truncated, not errored", func(t *testing.T) {
+		const overCap = 300000 // > 262144
+		payload, err := json.Marshal(map[string]any{
+			"code": "process.stdout.write('a'.repeat(" + strconv.Itoa(overCap) + "))",
+		})
+		require.NoError(t, err)
+
+		reply, _ := dispatchExecTurn(t, ctx, f, turnURL, sessionID, payload)
+		assert.True(t, reply.Truncated, "writing %d bytes of stdout must set truncated:true", overCap)
+		assert.Equal(t, 0, reply.ExitCode)
+		assert.Len(t, reply.Stdout, 256*1024, "truncated stdout must be capped at exactly 256KiB")
+	})
+
+	// Env-scrub case: the exec'd process must see NONE of this pod's
+	// FISSION_* vars (state/agent token paths, runtime URLs) -- doc 14's
+	// "Subprocess env is allow-listed ... never pass-through". Dumping
+	// process.env as JSON (rather than shelling out to `env`, which isn't
+	// guaranteed present in every runtime image) is the code-form exec
+	// path, exercised for its own sake as well.
+	t.Run("subprocess env is scrubbed of FISSION_ vars", func(t *testing.T) {
+		reply, _ := dispatchExecTurn(t, ctx, f, turnURL, sessionID, []byte(`{"code": "console.log(JSON.stringify(process.env))"}`))
+		require.Equal(t, 0, reply.ExitCode, "stderr: %s", reply.Stderr)
+
+		var env map[string]string
+		require.NoErrorf(t, json.Unmarshal([]byte(reply.Stdout), &env), "decoding process.env dump %q", reply.Stdout)
+		for k := range env {
+			assert.Falsef(t, strings.HasPrefix(k, "FISSION_"), "exec'd subprocess env must never carry a FISSION_ var, found %q", k)
+		}
+	})
+}

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -151,17 +151,21 @@ func TestAgentExec(t *testing.T) {
 	// a note in stderr -- doc 14's "kill the whole process group on expiry,
 	// report exitCode: -1 + stderr note".
 	t.Run("timeout kills the process and reports exitCode -1", func(t *testing.T) {
-		start := time.Now()
 		reply, _ := dispatchExecTurn(t, ctx, f, turnURL, sessionID, []byte(`{"command": "sleep 5", "timeoutSeconds": 1}`))
-		elapsed := time.Since(start)
 
 		assert.Equal(t, -1, reply.ExitCode)
 		assert.Contains(t, reply.Stderr, "timeout")
 		// The process must actually have been killed near the 1s ceiling,
-		// not run to completion (5s) before the reply came back -- a
-		// generous upper bound (well under the sleep's own 5s) distinguishes
-		// "killed early" from "timeout is decorative".
-		assert.Lessf(t, elapsed, 4*time.Second, "exec did not appear to be killed at the timeout ceiling (took %s)", elapsed)
+		// not run to completion (the sleep's own 5s), before the reply came
+		// back. reply.DurationMs is measured template-side around the
+		// subprocess call itself (see interpreter.{js,py}.tmpl) -- unlike a
+		// wall-clock measurement wrapped around dispatchExecTurn's own
+		// retrying poller (turnAttemptTimeout up to 60s per attempt, on a
+		// 2s EventuallyWithT interval), it is immune to an unrelated
+		// transient dispatch retry inflating the elapsed time and flaking
+		// this assertion.
+		assert.GreaterOrEqualf(t, reply.DurationMs, int64(900), "exec returned before the 1s timeout ceiling (durationMs=%d)", reply.DurationMs)
+		assert.Lessf(t, reply.DurationMs, int64(4000), "exec did not appear to be killed at the timeout ceiling, not run to the sleep's own 5s (durationMs=%d)", reply.DurationMs)
 	})
 
 	// Truncation case: ask Node to write more than the 256KiB (262144-byte)

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/fission/fission/test/integration/framework"
 )
 
-// execTurnReply is the exec verb's response contract (doc 14 PR-1 section):
+// execTurnReply is the exec verb's response contract:
 // {"stdout": "...", "stderr": "...", "exitCode": 0, "durationMs": 12,
 // "truncated": false}. This has no shared Go struct on either side ("zero
 // new platform Go" is the point of a template-only exec verb) -- it exists
@@ -96,8 +96,7 @@ func dispatchExecTurn(t *testing.T, ctx context.Context, f *framework.Framework,
 // a handler that runs {"code": ...} / {"command": ...} turn bodies and
 // answers {stdout, stderr, exitCode, durationMs, truncated} -- through the
 // normal agent-runtime dispatch path, with zero platform-side awareness of
-// this contract. Subtests cover the four cases doc 14's PR-1 Files section
-// calls for: a basic exec, the timeout ceiling, output truncation, and the
+// this contract. Subtests cover four contract cases: a basic exec, the timeout ceiling, output truncation, and the
 // env-scrub guarantee.
 func TestAgentExec(t *testing.T) {
 	t.Parallel()
@@ -148,7 +147,7 @@ func TestAgentExec(t *testing.T) {
 
 	// Timeout case: a 5s sleep with a 1s ceiling must be killed (the WHOLE
 	// process group, not merely the shell) and reported as exitCode -1 with
-	// a note in stderr -- doc 14's "kill the whole process group on expiry,
+	// a note in stderr -- the contract's "kill the whole process group on expiry,
 	// report exitCode: -1 + stderr note".
 	t.Run("timeout kills the process and reports exitCode -1", func(t *testing.T) {
 		reply, _ := dispatchExecTurn(t, ctx, f, turnURL, sessionID, []byte(`{"command": "sleep 5", "timeoutSeconds": 1}`))
@@ -170,7 +169,7 @@ func TestAgentExec(t *testing.T) {
 
 	// Truncation case: ask Node to write more than the 256KiB (262144-byte)
 	// per-stream cap and confirm truncated:true plus a stdout capped at
-	// EXACTLY that many bytes -- doc 14's "stdout/stderr each capped at 256
+	// EXACTLY that many bytes -- the contract's "stdout/stderr each capped at 256
 	// KiB ... overflow sets truncated: true, never errors".
 	t.Run("output over 256KiB is truncated, not errored", func(t *testing.T) {
 		const overCap = 300000 // > 262144
@@ -186,7 +185,7 @@ func TestAgentExec(t *testing.T) {
 	})
 
 	// Env-scrub case: the exec'd process must see NONE of this pod's
-	// FISSION_* vars (state/agent token paths, runtime URLs) -- doc 14's
+	// FISSION_* vars (state/agent token paths, runtime URLs) -- the contract's
 	// "Subprocess env is allow-listed ... never pass-through". Dumping
 	// process.env as JSON (rather than shelling out to `env`, which isn't
 	// guaranteed present in every runtime image) is the code-form exec


### PR DESCRIPTION
## What

A blessed interpreter scaffold: `fission agent create --name pyexec --env python --template interpreter` generates an agent handler implementing the exec verb — `{"code"|"command", "timeoutSeconds"}` in, `{stdout, stderr, exitCode, durationMs, truncated}` out — running through the normal agent dispatch path. Zero new platform Go, zero new images: the interpreter is handler logic shipped exactly like the existing scaffold templates.

## Contract

- Exactly one of `code` (run via the language runtime) or `command` (via `/bin/sh -c`).
- `timeoutSeconds` default 60, ceiling 300; on expiry the WHOLE process group is killed (both templates verified against the backgrounded-grandchild case: `sh -c 'daemon &'` cannot hold the turn open past the deadline).
- stdout/stderr each capped at 256 KiB (pinned to `fv1.DefaultStateMaxValueBytes`, not a re-typed literal); overflow sets `truncated: true`, never errors.
- Subprocess env is an allow-list (PATH/HOME/LANG/LC_ALL/TZ) — `FISSION_*` vars never pass through.
- `--expose-as-mcp` + `--tool-*` flags (newly registered on `agent create`; `function.GetToolConfig` exported in place) set `FunctionSpec.Tool` so the interpreter doubles as an MCP `code_exec` tool; a tools/call without a session header is stateless exec.

## Trust boundary (documented in the scaffold's next-steps output)

Env-scrubbing prevents accidental credential leakage; it is not a sandbox — exec'd code runs at the agent's own trust level (same container, token files readable). Right for run-your-own-code tools; adversarial multi-tenant code needs per-session pods (future executor work). The scaffold recommends pairing with `fission env create ... --runtime-class gvisor`.

## Tests

- Template tripwires anchored on wire forms (request-key reads + response-literal keys), header/state-header constants, timeout ceiling, env-allow-list, non-finite timeout guards, name-injection rejection (exploit-shaped cases), FunctionTimeout↔template-ceiling pin.
- Integration (`agent_exec_test.go`): basic exec, timeout group-kill with exitCode -1 + stderr note, 256 KiB truncation, env-scrub — first live run happens in this PR's CI.

## Notes for reviewers

- The templates assume `/bin/sh`, `sleep`, `echo` exist in the runtime image (same assumption as existing shell fixtures).
- Follow-up (not in this PR): a python-lang integration leg skip-gated on `PYTHON_RUNTIME_IMAGE` — the python template's timeout path is currently pinned by direct verification and static tripwires; a live leg would pin it in CI.
- Follow-up: per-turn unique subdir under the session scratch dir to remove a concurrent same-session direct-invocation race (robustness only).