### PR TITLE
templates: session workspace hydration for scaffolded agents

### DIFF
--- a/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
@@ -15,7 +15,9 @@
 // contract it implements -- then replace the TODO in the middle with real
 // agent logic (call an LLM, run a tool, whatever your agent does).
 
+const crypto = require('crypto');
 const fs = require('fs');
+const path = require('path');
 
 // The dispatcher stamps two request headers on every forwarded call (see
 // pkg/agentruntime/dispatcher.go), and reads one response header back:
@@ -106,6 +108,309 @@ async function saveState(sessionID, state) {
     throw new Error(`state PUT ${sessionID} failed: ${res.status}`);
   }
 }
+
+// --- Optional: session workspace hydration/sync (PR-2, abstraction C) ------
+//
+// This is the SAME hydrate/sync helper `fission agent create --template
+// interpreter` wires in automatically for its exec verb -- here it is
+// opt-in: nothing below calls it, module.exports above still only
+// loads/saves state. If your own agent logic maintains files on disk (a
+// scratch dir it manages itself, analogous to interpreter.js.tmpl's
+// $TMPDIR/exec/<session>) and you want those files to survive this pod
+// being replaced (idle eviction, an executor roll, a crash), call these two
+// functions yourself:
+//
+//   const manifest = loadWorkspaceManifest(myDir);
+//   let warnings = await hydrateWorkspace(myDir, sessionID, manifest);   // turn start
+//   // ... your own logic, using myDir as a working directory ...
+//   warnings = warnings.concat(await syncWorkspace(myDir, sessionID, manifest)); // turn end
+//   saveWorkspaceManifest(myDir, manifest);
+//
+// Report `warnings` however your agent reports failures -- never drop them
+// silently (the shipped design's own stance on a failed sync, restated in
+// this block's own doc comment below).
+
+// --- Workspace hydration/sync (PR-2, abstraction C) -------------------------
+//
+// The executor injects FISSION_AGENT_RUNTIME_URL / FISSION_AGENT_TOKEN_PATH
+// whenever the agent runtime feature is enabled cluster-wide
+// (pkg/executor/util/agentenv.go's AgentAPIEnvVars) -- the SAME credential
+// file (pkg/fetcher/agenttoken.go's AgentCredentials, written at specialize
+// time) that authenticates this pod's own dispatch/spawn calls also
+// authenticates its session workspace calls, just against a stricter
+// own-workspace-only authorization rule (pkg/agentruntime/identity.go). The
+// file is {"namespace": "...", "agent": "...", "token": "..."}.
+const WORKSPACE_URL = process.env.FISSION_AGENT_RUNTIME_URL || '';
+const WORKSPACE_TOKEN_PATH = process.env.FISSION_AGENT_TOKEN_PATH || '';
+
+// HEADER_IDENTITY_NAMESPACE / HEADER_IDENTITY_NAME carry the claimed
+// (namespace, agent) identity alongside the bearer token -- verification
+// recomputes the derived key from exactly these two claims, so a bearer with
+// no claim headers (or the wrong ones) 401s (pkg/agentruntime/identity.go's
+// HeaderIdentityNamespace/HeaderIdentityName).
+const HEADER_IDENTITY_NAMESPACE = 'X-Fission-Agent-Auth-Namespace';
+const HEADER_IDENTITY_NAME = 'X-Fission-Agent-Auth-Name';
+
+// WORKSPACE_MANIFEST_FILENAME is a hash manifest kept in the scratch dir
+// itself (never synced -- excluded from every sync walk by name below) that
+// is what lets a second turn on the SAME warm pod skip re-uploading anything
+// unchanged since the last successful hydrate/sync of that path.
+const WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json';
+
+// WORKSPACE_MAX_WARNINGS caps how many entries workspaceWarnings can carry --
+// see appendWorkspaceWarning.
+const WORKSPACE_MAX_WARNINGS = 20;
+
+let workspaceCreds = null;
+if (WORKSPACE_URL && WORKSPACE_TOKEN_PATH) {
+  try {
+    workspaceCreds = JSON.parse(fs.readFileSync(WORKSPACE_TOKEN_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`{{.Name}}: could not read agent identity token file ${WORKSPACE_TOKEN_PATH}: ${err.code || err.name}`);
+  }
+}
+
+const WORKSPACE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+// validWorkspaceRelPath mirrors pkg/agentruntime/workspace.go's
+// validateWorkspaceSegment: every '/'-split segment must be non-empty, not
+// '.'/'..', not start with '_' (reserved for the platform's own
+// "_workspace_" root marker -- this also has the useful side effect of
+// silently excluding this template's own manifest file, and any similarly
+// named dotfile, from sync), and drawn from the same charset. A path failing
+// this is skipped entirely -- never synced, never a fatal error for the
+// turn.
+function validWorkspaceRelPath(rel) {
+  if (!rel) {
+    return false;
+  }
+  return rel
+    .split('/')
+    .every((seg) => seg !== '' && seg !== '.' && seg !== '..' && !seg.startsWith('_') && WORKSPACE_SEGMENT_RE.test(seg));
+}
+
+function workspaceHeaders(extra) {
+  return Object.assign(
+    {
+      Authorization: `Bearer ${workspaceCreds.token}`,
+      [HEADER_IDENTITY_NAMESPACE]: workspaceCreds.namespace,
+      [HEADER_IDENTITY_NAME]: workspaceCreds.agent,
+    },
+    extra,
+  );
+}
+
+// workspaceSessionURL builds the LIST route (NO trailing slash -- the
+// shipped route 400s a trailing-slash request by design, workspace.go's
+// validateWorkspacePath doc comment); GET/PUT append '/' + rel themselves.
+function workspaceSessionURL(sessionID) {
+  return `${WORKSPACE_URL}/workspace/${workspaceCreds.namespace}/${workspaceCreds.agent}/${sessionID}`;
+}
+
+function workspaceManifestPath(scratchDir) {
+  return path.join(scratchDir, WORKSPACE_MANIFEST_FILENAME);
+}
+
+function loadWorkspaceManifest(scratchDir) {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(workspaceManifestPath(scratchDir), 'utf8'));
+    return manifest && typeof manifest === 'object' ? manifest : {};
+  } catch (err) {
+    return {};
+  }
+}
+
+function saveWorkspaceManifest(scratchDir, manifest) {
+  const manifestPath = workspaceManifestPath(scratchDir);
+  const tmpPath = manifestPath + '.tmp';
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(manifest));
+    fs.renameSync(tmpPath, manifestPath);
+  } catch (err) {
+    console.error(`{{.Name}}: could not save workspace manifest: ${err.code || err.name}`);
+  }
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+// appendWorkspaceWarning caps warnings -- a scratch dir full of failures (a
+// pip/npm install that wrote thousands of files past the per-session quota,
+// say) cannot blow up the turn reply the way MAX_OUTPUT_BYTES caps
+// stdout/stderr -- the silent-failure rule requires reporting a failure, not
+// reporting an unbounded number of them.
+function appendWorkspaceWarning(warnings, message) {
+  if (warnings.length < WORKSPACE_MAX_WARNINGS) {
+    warnings.push(message);
+  } else if (warnings.length === WORKSPACE_MAX_WARNINGS) {
+    warnings.push('... additional workspace warnings suppressed');
+  }
+}
+
+// hydrateWorkspace lists the session's workspace and downloads any file
+// missing locally or whose local size does not match the remote listing --
+// lazy: a file already resident with a matching size is assumed unchanged
+// (the common case on a warm pod serving a later turn of the same session,
+// where this costs exactly one LIST call and nothing else).
+async function hydrateWorkspace(scratchDir, sessionID, manifest) {
+  const warnings = [];
+  if (!workspaceCreds) {
+    return warnings;
+  }
+  let items;
+  try {
+    const res = await fetch(workspaceSessionURL(sessionID), { headers: workspaceHeaders() });
+    if (!res.ok) {
+      throw new Error(`list failed: HTTP ${res.status}`);
+    }
+    items = (await res.json()).items || [];
+  } catch (err) {
+    appendWorkspaceWarning(warnings, `workspace hydrate: listing failed: ${err.message || err}`);
+    return warnings;
+  }
+
+  for (const item of items) {
+    const rel = item && item.path;
+    const size = item && item.size;
+    if (typeof rel !== 'string' || typeof size !== 'number' || !validWorkspaceRelPath(rel)) {
+      continue;
+    }
+    const localPath = path.join(scratchDir, ...rel.split('/'));
+    try {
+      const st = fs.statSync(localPath);
+      if (st.isFile() && st.size === size) {
+        continue;
+      }
+    } catch (err) {
+      // Not present locally yet -- fall through to download.
+    }
+    try {
+      const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, { headers: workspaceHeaders() });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = Buffer.from(await res.arrayBuffer());
+      fs.mkdirSync(path.dirname(localPath), { recursive: true });
+      fs.writeFileSync(localPath, data);
+      const st = fs.statSync(localPath);
+      // A freshly hydrated file is, by definition, in sync with the
+      // workspace it just came from -- recording it here means the sync
+      // pass that follows this same turn's exec does not immediately
+      // re-upload a file nothing has touched.
+      manifest[rel] = { size: st.size, mtimeMs: st.mtimeMs, sha256: sha256File(localPath) };
+    } catch (err) {
+      appendWorkspaceWarning(warnings, `workspace hydrate: ${rel}: ${err.message || err}`);
+    }
+  }
+  return warnings;
+}
+
+// syncWorkspace walks scratchDir and PUTs any file new or changed since the
+// last successful hydrate/sync of that same path -- mtime+size compare,
+// content hash only on ambiguity (matching size, differing mtime). Delete-
+// on-absence is OFF: a path that disappeared locally is dropped from the
+// local manifest (bookkeeping only) but is NEVER DELETEd from the
+// workspace -- sync is additive-only by design.
+async function syncWorkspace(scratchDir, sessionID, manifest) {
+  const warnings = [];
+  if (!workspaceCreds) {
+    return warnings;
+  }
+
+  const seen = new Set();
+
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      return;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        // Skipped, not followed: exec'd code could otherwise link a
+        // scratch-dir path at a pod credential file and have ITS bytes
+        // uploaded to a workspace this agent's sibling sessions can read --
+        // see the trust-boundary comment at the top of this file.
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const rel = path.relative(scratchDir, entryPath).split(path.sep).join('/');
+      if (rel === WORKSPACE_MANIFEST_FILENAME || rel === WORKSPACE_MANIFEST_FILENAME + '.tmp' || !validWorkspaceRelPath(rel)) {
+        continue;
+      }
+      let st;
+      try {
+        st = fs.statSync(entryPath);
+      } catch (err) {
+        continue;
+      }
+      seen.add(rel);
+
+      const prev = manifest[rel];
+      if (prev && prev.size === st.size && prev.mtimeMs === st.mtimeMs) {
+        continue; // skip-clean: unchanged since the last successful sync/hydrate
+      }
+
+      let digest = null;
+      if (prev && prev.size === st.size) {
+        // Ambiguous: same size, different mtime -- hash before deciding this
+        // is a genuine change rather than a touch.
+        digest = sha256File(entryPath);
+        if (digest === prev.sha256) {
+          manifest[rel] = { size: st.size, mtimeMs: st.mtimeMs, sha256: digest };
+          continue;
+        }
+      }
+
+      let data;
+      try {
+        data = fs.readFileSync(entryPath);
+      } catch (err) {
+        appendWorkspaceWarning(warnings, `workspace sync: ${rel}: ${err.message || err}`);
+        continue;
+      }
+      if (digest === null) {
+        digest = crypto.createHash('sha256').update(data).digest('hex');
+      }
+
+      try {
+        const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, {
+          method: 'PUT',
+          headers: workspaceHeaders(),
+          body: data,
+        });
+        if (!res.ok) {
+          appendWorkspaceWarning(warnings, `workspace sync: ${rel}: HTTP ${res.status}`);
+          continue;
+        }
+      } catch (err) {
+        appendWorkspaceWarning(warnings, `workspace sync: ${rel}: ${err.message || err}`);
+        continue;
+      }
+      manifest[rel] = { size: st.size, mtimeMs: st.mtimeMs, sha256: digest };
+    }
+  }
+
+  await walk(scratchDir);
+
+  for (const rel of Object.keys(manifest)) {
+    if (!seen.has(rel)) {
+      delete manifest[rel];
+    }
+  }
+  return warnings;
+}
+// --- End workspace hydration/sync helper ------------------------------------
+
 
 // --- The turn --------------------------------------------------------------
 module.exports = async function (context) {

--- a/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
@@ -161,6 +161,22 @@ const WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json';
 // see appendWorkspaceWarning.
 const WORKSPACE_MAX_WARNINGS = 20;
 
+// WORKSPACE_REQUEST_TIMEOUT_MS bounds every hydrate/sync HTTP call so a
+// stalled agent-runtime connection cannot burn the whole turn's
+// FunctionTimeout before exec even starts (mirrors the Python helper's
+// WORKSPACE_REQUEST_TIMEOUT_SECONDS -- requests has no default timeout and
+// neither does fetch).
+const WORKSPACE_REQUEST_TIMEOUT_MS = 30000;
+
+// WORKSPACE_MAX_ARTIFACT_BYTES is a best-effort client-side mirror of the
+// server's default per-artifact cap (pkg/agentruntime/main.go's
+// defaultMaxArtifactBytes, overridable there via AGENT_MAX_ARTIFACT_BYTES --
+// not discoverable from the client, so this is a default, not an enforced
+// contract). Skipping an oversized file before reading it avoids pulling a
+// multi-GB scratch file fully into this process's memory only to earn a
+// guaranteed 413 from the server.
+const WORKSPACE_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024;
+
 let workspaceCreds = null;
 if (WORKSPACE_URL && WORKSPACE_TOKEN_PATH) {
   try {
@@ -176,10 +192,12 @@ const WORKSPACE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
 // validateWorkspaceSegment: every '/'-split segment must be non-empty, not
 // '.'/'..', not start with '_' (reserved for the platform's own
 // "_workspace_" root marker -- this also has the useful side effect of
-// silently excluding this template's own manifest file, and any similarly
-// named dotfile, from sync), and drawn from the same charset. A path failing
-// this is skipped entirely -- never synced, never a fatal error for the
-// turn.
+// silently excluding directories that start with '_' from sync), and drawn
+// from the same charset. This rule does NOT exclude this template's own
+// manifest file -- WORKSPACE_MANIFEST_FILENAME starts with '.', not '_', and
+// passes this check; the manifest is kept out of hydrate/sync by the
+// explicit name checks below instead. A path failing this is skipped
+// entirely -- never synced, never a fatal error for the turn.
 function validWorkspaceRelPath(rel) {
   if (!rel) {
     return false;
@@ -255,12 +273,25 @@ function appendWorkspaceWarning(warnings, message) {
 // where this costs exactly one LIST call and nothing else).
 async function hydrateWorkspace(scratchDir, sessionID, manifest) {
   const warnings = [];
+  if (!WORKSPACE_URL) {
+    // Feature not enabled cluster-wide -- silence is correct here, there is
+    // nothing to warn about.
+    return warnings;
+  }
   if (!workspaceCreds) {
+    // Feature IS enabled but this pod's own identity credentials could not
+    // be read at module load -- distinct from the feature-off case above,
+    // and per the silent-failure rule this must be visible in the turn
+    // result rather than only in the pod's own startup log.
+    appendWorkspaceWarning(warnings, 'workspace hydrate: agent identity credentials unavailable, skipped');
     return warnings;
   }
   let items;
   try {
-    const res = await fetch(workspaceSessionURL(sessionID), { headers: workspaceHeaders() });
+    const res = await fetch(workspaceSessionURL(sessionID), {
+      headers: workspaceHeaders(),
+      signal: AbortSignal.timeout(WORKSPACE_REQUEST_TIMEOUT_MS),
+    });
     if (!res.ok) {
       throw new Error(`list failed: HTTP ${res.status}`);
     }
@@ -273,7 +304,16 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
   for (const item of items) {
     const rel = item && item.path;
     const size = item && item.size;
-    if (typeof rel !== 'string' || typeof size !== 'number' || !validWorkspaceRelPath(rel)) {
+    if (
+      typeof rel !== 'string' ||
+      typeof size !== 'number' ||
+      !validWorkspaceRelPath(rel) ||
+      rel === WORKSPACE_MANIFEST_FILENAME ||
+      rel === WORKSPACE_MANIFEST_FILENAME + '.tmp'
+    ) {
+      // The manifest itself is never a hydrate target -- downloading a
+      // same-named workspace artifact over the local manifest would corrupt
+      // this pod's own skip-clean bookkeeping.
       continue;
     }
     const localPath = path.join(scratchDir, ...rel.split('/'));
@@ -286,7 +326,10 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
       // Not present locally yet -- fall through to download.
     }
     try {
-      const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, { headers: workspaceHeaders() });
+      const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, {
+        headers: workspaceHeaders(),
+        signal: AbortSignal.timeout(WORKSPACE_REQUEST_TIMEOUT_MS),
+      });
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
@@ -314,11 +357,21 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
 // workspace -- sync is additive-only by design.
 async function syncWorkspace(scratchDir, sessionID, manifest) {
   const warnings = [];
+  if (!WORKSPACE_URL) {
+    // Feature not enabled cluster-wide -- silence is correct here, there is
+    // nothing to warn about.
+    return warnings;
+  }
   if (!workspaceCreds) {
+    // Feature IS enabled but this pod's own identity credentials could not
+    // be read at module load -- every exec-written file this turn is about
+    // to go unsynced, which the silent-failure rule requires surfacing.
+    appendWorkspaceWarning(warnings, 'workspace sync: agent identity credentials unavailable, skipped');
     return warnings;
   }
 
   const seen = new Set();
+  let skippedNames = 0;
 
   async function walk(dir) {
     let entries;
@@ -344,7 +397,16 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
         continue;
       }
       const rel = path.relative(scratchDir, entryPath).split(path.sep).join('/');
-      if (rel === WORKSPACE_MANIFEST_FILENAME || rel === WORKSPACE_MANIFEST_FILENAME + '.tmp' || !validWorkspaceRelPath(rel)) {
+      if (rel === WORKSPACE_MANIFEST_FILENAME || rel === WORKSPACE_MANIFEST_FILENAME + '.tmp') {
+        continue;
+      }
+      if (!validWorkspaceRelPath(rel)) {
+        // Silent per-file, but counted -- see the aggregated warning below
+        // this walk. A name-invalid file (spaces, unicode, a leading '_')
+        // is not an error, just not syncable; per-file warnings here would
+        // drown the warning cap in noise from something like a stray
+        // '_scratch' directory.
+        skippedNames++;
         continue;
       }
       let st;
@@ -358,6 +420,18 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
       const prev = manifest[rel];
       if (prev && prev.size === st.size && prev.mtimeMs === st.mtimeMs) {
         continue; // skip-clean: unchanged since the last successful sync/hydrate
+      }
+
+      if (st.size > WORKSPACE_MAX_ARTIFACT_BYTES) {
+        // Skip before EITHER a hashing or an upload read -- reading a
+        // multi-GB scratch file fully into memory only to earn a
+        // guaranteed 413 risks OOMing a warm-pool pod shared with sibling
+        // sessions.
+        appendWorkspaceWarning(
+          warnings,
+          `workspace sync: ${rel}: ${st.size} bytes exceeds the ${WORKSPACE_MAX_ARTIFACT_BYTES}-byte per-artifact cap, skipped`,
+        );
+        continue;
       }
 
       let digest = null;
@@ -387,6 +461,7 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
           method: 'PUT',
           headers: workspaceHeaders(),
           body: data,
+          signal: AbortSignal.timeout(WORKSPACE_REQUEST_TIMEOUT_MS),
         });
         if (!res.ok) {
           appendWorkspaceWarning(warnings, `workspace sync: ${rel}: HTTP ${res.status}`);
@@ -401,6 +476,10 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
   }
 
   await walk(scratchDir);
+
+  if (skippedNames > 0) {
+    appendWorkspaceWarning(warnings, `workspace sync: ${skippedNames} file(s) skipped: names not syncable to the workspace`);
+  }
 
   for (const rel of Object.keys(manifest)) {
     if (!seen.has(rel)) {

--- a/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.js.tmpl
@@ -177,10 +177,25 @@ const WORKSPACE_REQUEST_TIMEOUT_MS = 30000;
 // guaranteed 413 from the server.
 const WORKSPACE_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024;
 
+// WORKSPACE_CREDS_FIELDS are the keys workspaceHeaders/workspaceSessionURL
+// dereference unconditionally -- validated below so a corrupt-but-valid-JSON
+// token file (e.g. `{}`) degrades to "credentials unavailable" (a warning,
+// never a fatal error for the turn) instead of leaving workspaceCreds truthy
+// and sending "Bearer undefined" on every hydrate/sync call (mirrors the
+// Python helper's _WORKSPACE_CREDS_FIELDS check).
+const WORKSPACE_CREDS_FIELDS = ['token', 'namespace', 'agent'];
+
 let workspaceCreds = null;
 if (WORKSPACE_URL && WORKSPACE_TOKEN_PATH) {
   try {
-    workspaceCreds = JSON.parse(fs.readFileSync(WORKSPACE_TOKEN_PATH, 'utf8'));
+    const parsed = JSON.parse(fs.readFileSync(WORKSPACE_TOKEN_PATH, 'utf8'));
+    if (parsed && typeof parsed === 'object' && WORKSPACE_CREDS_FIELDS.every((k) => k in parsed)) {
+      workspaceCreds = parsed;
+    } else {
+      console.error(
+        `{{.Name}}: agent identity token file ${WORKSPACE_TOKEN_PATH} is malformed (missing ${WORKSPACE_CREDS_FIELDS.join(', ')})`,
+      );
+    }
   } catch (err) {
     console.error(`{{.Name}}: could not read agent identity token file ${WORKSPACE_TOKEN_PATH}: ${err.code || err.name}`);
   }
@@ -324,6 +339,21 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
       }
     } catch (err) {
       // Not present locally yet -- fall through to download.
+    }
+    try {
+      const lst = fs.lstatSync(localPath);
+      if (lst.isSymbolicLink() || !lst.isFile()) {
+        // A local path that already exists but is a symlink (or otherwise
+        // not a regular file -- exec'd code planted it there) would have
+        // fs.writeFileSync below follow the symlink and overwrite its
+        // TARGET with hydrated workspace bytes, or block forever on a FIFO
+        // -- skip and report instead of writing through it. Mirrors the
+        // sync walk's symlink guard.
+        appendWorkspaceWarning(warnings, `workspace hydrate: ${rel}: local path exists and is not a regular file, skipped`);
+        continue;
+      }
+    } catch (err) {
+      // Not present locally yet -- fine, this is a fresh write.
     }
     try {
       const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, {

--- a/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
@@ -19,6 +19,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 
 from flask import request
 import requests
@@ -288,12 +289,24 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
         res = requests.get(_workspace_session_url(session_id), headers=_workspace_headers(),
                             timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
         res.raise_for_status()
-        items = res.json().get('items', [])
+        payload = res.json()
+        # A non-dict listing body (server bug, or something in front of it
+        # rewriting the response) degrades to "nothing to hydrate" rather
+        # than an AttributeError escaping this function -- mirrors the JS
+        # helper's `(await res.json()).items || []`, which is equally inert
+        # against a non-object payload.
+        items = payload.get('items', []) if isinstance(payload, dict) else []
     except (requests.RequestException, ValueError) as err:
         _append_workspace_warning(warnings, 'workspace hydrate: listing failed: %s' % err)
         return warnings
 
     for item in items:
+        if not isinstance(item, dict):
+            # A non-dict entry in the listing (tampered or malformed server
+            # response) is simply not hydratable -- mirrors the JS helper's
+            # `item && item.path`, which is equally inert against a
+            # non-object item.
+            continue
         rel = item.get('path')
         size = item.get('size')
         if (not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel)
@@ -308,6 +321,19 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
                 continue
         except OSError:
             pass
+        if os.path.islink(local_path) or (os.path.lexists(local_path) and not os.path.isfile(local_path)):
+            # A local path that already exists but is a symlink (or
+            # otherwise not a regular file -- a FIFO, socket, or device that
+            # exec'd code created at this exact relative path) would have
+            # the open(local_path, 'wb') below follow the symlink and
+            # overwrite its TARGET with hydrated workspace bytes, or hang
+            # forever waiting for a reader (FIFO) -- same failure class the
+            # sync walk's symlink/regular-file guards exist for, just
+            # triggered from the opposite direction. Skip and report rather
+            # than write through it or wedge the turn.
+            _append_workspace_warning(
+                warnings, 'workspace hydrate: %s: local path exists and is not a regular file, skipped' % rel)
+            continue
         try:
             get_res = requests.get(_workspace_session_url(session_id) + '/' + rel, headers=_workspace_headers(),
                                     timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
@@ -372,9 +398,25 @@ def _sync_workspace(scratch_dir, session_id, manifest):
                 st = os.stat(local_path)
             except OSError:
                 continue
+            if not stat.S_ISREG(st.st_mode):
+                # os.walk's `files` list is every non-directory dirent, not
+                # just regular files -- a FIFO or socket exec'd code created
+                # in the scratch dir lands here too, and the plain
+                # open(local_path, 'rb') a few lines down blocks forever on
+                # a FIFO with no writer, wedging the turn outside the exec
+                # timeout's kill mechanism. Silent skip, not counted in
+                # skipped_names, mirroring the JS walk's entry.isFile() guard.
+                continue
             seen.add(rel)
 
             prev = manifest.get(rel)
+            if not isinstance(prev, dict):
+                # A tampered or hand-edited manifest value that is not
+                # dict-shaped would otherwise raise AttributeError on the
+                # .get() calls below -- treat it as "no prior record" rather
+                # than 500ing the turn (mirrors the JS helper, where
+                # prev.size on a non-object simply reads as undefined).
+                prev = None
             if prev and prev.get('size') == st.st_size and prev.get('mtime_ns') == st.st_mtime_ns:
                 continue  # skip-clean: unchanged since the last successful sync/hydrate
 

--- a/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
@@ -154,11 +154,32 @@ WORKSPACE_MAX_WARNINGS = 20
 
 WORKSPACE_REQUEST_TIMEOUT_SECONDS = 30
 
+# WORKSPACE_MAX_ARTIFACT_BYTES is a best-effort client-side mirror of the
+# server's default per-artifact cap (pkg/agentruntime/main.go's
+# defaultMaxArtifactBytes, overridable there via AGENT_MAX_ARTIFACT_BYTES --
+# not discoverable from the client, so this is a default, not an enforced
+# contract). Skipping an oversized file before reading it avoids pulling a
+# multi-GB scratch file fully into this process's memory only to earn a
+# guaranteed 413 from the server.
+WORKSPACE_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
+
+# _WORKSPACE_CREDS_FIELDS are the keys _workspace_headers/_workspace_session_url
+# dereference unconditionally -- validated below so a corrupt-but-valid-JSON
+# token file degrades to "credentials unavailable" (a warning, never a fatal
+# error for the turn) instead of a KeyError/TypeError escaping _hydrate_workspace
+# / _sync_workspace uncaught.
+_WORKSPACE_CREDS_FIELDS = ('token', 'namespace', 'agent')
+
 _workspace_creds = None
 if WORKSPACE_URL and WORKSPACE_TOKEN_PATH:
     try:
         with open(WORKSPACE_TOKEN_PATH) as f:
             _workspace_creds = json.load(f)
+        if not (isinstance(_workspace_creds, dict)
+                and all(k in _workspace_creds for k in _WORKSPACE_CREDS_FIELDS)):
+            print('{{.Name}}: agent identity token file %s is malformed (missing %s)' % (
+                WORKSPACE_TOKEN_PATH, ', '.join(_WORKSPACE_CREDS_FIELDS)))
+            _workspace_creds = None
     except (OSError, ValueError) as err:
         print('{{.Name}}: could not read agent identity token file %s: %s' % (WORKSPACE_TOKEN_PATH, err))
 
@@ -170,8 +191,10 @@ def _valid_workspace_relpath(rel):
     # '/'-split segment must be non-empty, not '.'/'..', not start with '_'
     # (reserved for the platform's own "_workspace_" root marker -- this also
     # has the useful side effect of silently excluding directories like
-    # "__pycache__" from sync, not just this template's own manifest file),
-    # and drawn from the same charset. A path failing this is skipped
+    # "__pycache__" from sync). This rule does NOT exclude this template's
+    # own manifest file -- WORKSPACE_MANIFEST_FILENAME starts with '.', not
+    # '_', and passes this check; the manifest is kept out of hydrate/sync by
+    # the explicit name checks below instead. A path failing this is skipped
     # entirely -- never synced, never a fatal error for the turn.
     if not rel:
         return False
@@ -249,7 +272,17 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
     # case on a warm pod serving a later turn of the same session, where
     # this costs exactly one LIST call and nothing else.
     warnings = []
+    if not WORKSPACE_URL:
+        # Feature not enabled cluster-wide -- silence is correct here, there
+        # is nothing to warn about.
+        return warnings
     if not _workspace_creds:
+        # Feature IS enabled but this pod's own identity credentials could
+        # not be read (or were malformed) at module load -- distinct from
+        # the feature-off case above, and per the silent-failure rule this
+        # must be visible in the turn result rather than only in the pod's
+        # own startup log.
+        _append_workspace_warning(warnings, 'workspace hydrate: agent identity credentials unavailable, skipped')
         return warnings
     try:
         res = requests.get(_workspace_session_url(session_id), headers=_workspace_headers(),
@@ -263,7 +296,11 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
     for item in items:
         rel = item.get('path')
         size = item.get('size')
-        if not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel):
+        if (not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel)
+                or rel in (WORKSPACE_MANIFEST_FILENAME, WORKSPACE_MANIFEST_FILENAME + '.tmp')):
+            # The manifest itself is never a hydrate target -- downloading a
+            # same-named workspace artifact over the local manifest would
+            # corrupt this pod's own skip-clean bookkeeping.
             continue
         local_path = os.path.join(scratch_dir, *rel.split('/'))
         try:
@@ -297,10 +334,20 @@ def _sync_workspace(scratch_dir, session_id, manifest):
     # local manifest (bookkeeping only) but is NEVER DELETEd from the
     # workspace -- sync is additive-only by design.
     warnings = []
+    if not WORKSPACE_URL:
+        # Feature not enabled cluster-wide -- silence is correct here, there
+        # is nothing to warn about.
+        return warnings
     if not _workspace_creds:
+        # Feature IS enabled but this pod's own identity credentials could
+        # not be read (or were malformed) at module load -- every
+        # exec-written file this turn is about to go unsynced, which the
+        # silent-failure rule requires surfacing.
+        _append_workspace_warning(warnings, 'workspace sync: agent identity credentials unavailable, skipped')
         return warnings
 
     seen = set()
+    skipped_names = 0
     for root, _dirs, files in os.walk(scratch_dir):
         for fname in files:
             local_path = os.path.join(root, fname)
@@ -311,7 +358,15 @@ def _sync_workspace(scratch_dir, session_id, manifest):
             # link a scratch-dir path at a pod credential file and have ITS
             # bytes uploaded to a workspace this agent's sibling sessions can
             # read -- see the trust-boundary comment at the top of this file.
-            if os.path.islink(local_path) or not _valid_workspace_relpath(rel):
+            if os.path.islink(local_path):
+                continue
+            if not _valid_workspace_relpath(rel):
+                # Silent per-file, but counted -- see the aggregated warning
+                # below this walk. A name-invalid file (spaces, unicode, a
+                # leading '_') is not an error, just not syncable; per-file
+                # warnings here would drown the warning cap in noise from
+                # something like a stray "__pycache__" directory.
+                skipped_names += 1
                 continue
             try:
                 st = os.stat(local_path)
@@ -322,6 +377,17 @@ def _sync_workspace(scratch_dir, session_id, manifest):
             prev = manifest.get(rel)
             if prev and prev.get('size') == st.st_size and prev.get('mtime_ns') == st.st_mtime_ns:
                 continue  # skip-clean: unchanged since the last successful sync/hydrate
+
+            if st.st_size > WORKSPACE_MAX_ARTIFACT_BYTES:
+                # Skip before EITHER a hashing or an upload read -- reading a
+                # multi-GB scratch file fully into memory only to earn a
+                # guaranteed 413 risks OOMing a warm-pool pod shared with
+                # sibling sessions.
+                _append_workspace_warning(
+                    warnings,
+                    'workspace sync: %s: %d bytes exceeds the %d-byte per-artifact cap, skipped' % (
+                        rel, st.st_size, WORKSPACE_MAX_ARTIFACT_BYTES))
+                continue
 
             digest = None
             if prev and prev.get('size') == st.st_size:
@@ -351,6 +417,10 @@ def _sync_workspace(scratch_dir, session_id, manifest):
                 _append_workspace_warning(warnings, 'workspace sync: %s: %s' % (rel, err))
                 continue
             manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': digest}
+
+    if skipped_names:
+        _append_workspace_warning(
+            warnings, 'workspace sync: %d file(s) skipped: names not syncable to the workspace' % skipped_names)
 
     for rel in list(manifest):
         if rel not in seen:

--- a/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/agent.py.tmpl
@@ -15,8 +15,10 @@
 # contract it implements -- then replace the TODO in main() with real agent
 # logic (call an LLM, run a tool, whatever your agent does).
 
+import hashlib
 import json
 import os
+import re
 
 from flask import request
 import requests
@@ -97,6 +99,264 @@ def _save_state(session_id, state):
         data=json.dumps(state),
     )
     res.raise_for_status()
+
+
+# --- Optional: session workspace hydration/sync (PR-2, abstraction C) ------
+#
+# This is the SAME hydrate/sync helper `fission agent create --template
+# interpreter` wires in automatically for its exec verb -- here it is
+# opt-in: nothing below calls it, main() above still only loads/saves state.
+# If your own agent logic maintains files on disk (a scratch dir it manages
+# itself, analogous to interpreter.py.tmpl's $TMPDIR/exec/<session>) and you
+# want those files to survive this pod being replaced (idle eviction, an
+# executor roll, a crash), call these two functions yourself:
+#
+#   manifest = _load_workspace_manifest(my_dir)
+#   warnings = _hydrate_workspace(my_dir, session_id, manifest)   # turn start
+#   ... your own logic, using my_dir as a working directory ...
+#   warnings += _sync_workspace(my_dir, session_id, manifest)     # turn end
+#   _save_workspace_manifest(my_dir, manifest)
+#
+# Report `warnings` however your agent reports failures -- never drop them
+# silently (the shipped design's own stance on a failed sync, restated in
+# this block's own doc comment below).
+
+# --- Workspace hydration/sync (PR-2, abstraction C) -------------------------
+#
+# The executor injects FISSION_AGENT_RUNTIME_URL / FISSION_AGENT_TOKEN_PATH
+# whenever the agent runtime feature is enabled cluster-wide
+# (pkg/executor/util/agentenv.go's AgentAPIEnvVars) -- the SAME credential
+# file (pkg/fetcher/agenttoken.go's AgentCredentials, written at specialize
+# time) that authenticates this pod's own dispatch/spawn calls also
+# authenticates its session workspace calls, just against a stricter
+# own-workspace-only authorization rule (pkg/agentruntime/identity.go). The
+# file is {"namespace": "...", "agent": "...", "token": "..."}.
+WORKSPACE_URL = os.environ.get('FISSION_AGENT_RUNTIME_URL', '')
+WORKSPACE_TOKEN_PATH = os.environ.get('FISSION_AGENT_TOKEN_PATH', '')
+
+# HEADER_IDENTITY_NAMESPACE / HEADER_IDENTITY_NAME carry the claimed
+# (namespace, agent) identity alongside the bearer token -- verification
+# recomputes the derived key from exactly these two claims, so a bearer with
+# no claim headers (or the wrong ones) 401s (pkg/agentruntime/identity.go's
+# HeaderIdentityNamespace/HeaderIdentityName).
+HEADER_IDENTITY_NAMESPACE = 'X-Fission-Agent-Auth-Namespace'
+HEADER_IDENTITY_NAME = 'X-Fission-Agent-Auth-Name'
+
+# WORKSPACE_MANIFEST_FILENAME is a hash manifest kept in the scratch dir
+# itself (never synced -- excluded from every sync walk by name below) that
+# is what lets a second turn on the SAME warm pod skip re-uploading anything
+# unchanged since the last successful hydrate/sync of that path.
+WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json'
+
+# WORKSPACE_MAX_WARNINGS caps how many entries workspaceWarnings can carry --
+# see _append_workspace_warning.
+WORKSPACE_MAX_WARNINGS = 20
+
+WORKSPACE_REQUEST_TIMEOUT_SECONDS = 30
+
+_workspace_creds = None
+if WORKSPACE_URL and WORKSPACE_TOKEN_PATH:
+    try:
+        with open(WORKSPACE_TOKEN_PATH) as f:
+            _workspace_creds = json.load(f)
+    except (OSError, ValueError) as err:
+        print('{{.Name}}: could not read agent identity token file %s: %s' % (WORKSPACE_TOKEN_PATH, err))
+
+_WORKSPACE_SEGMENT_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+
+
+def _valid_workspace_relpath(rel):
+    # Mirrors pkg/agentruntime/workspace.go's validateWorkspaceSegment: every
+    # '/'-split segment must be non-empty, not '.'/'..', not start with '_'
+    # (reserved for the platform's own "_workspace_" root marker -- this also
+    # has the useful side effect of silently excluding directories like
+    # "__pycache__" from sync, not just this template's own manifest file),
+    # and drawn from the same charset. A path failing this is skipped
+    # entirely -- never synced, never a fatal error for the turn.
+    if not rel:
+        return False
+    for seg in rel.split('/'):
+        if seg in ('', '.', '..') or seg.startswith('_') or not _WORKSPACE_SEGMENT_RE.match(seg):
+            return False
+    return True
+
+
+def _workspace_headers(extra=None):
+    headers = {
+        'Authorization': 'Bearer %s' % _workspace_creds['token'],
+        HEADER_IDENTITY_NAMESPACE: _workspace_creds['namespace'],
+        HEADER_IDENTITY_NAME: _workspace_creds['agent'],
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def _workspace_session_url(session_id):
+    # NO trailing slash -- the shipped route 400s a trailing-slash request
+    # by design (workspace.go's validateWorkspacePath doc comment).
+    return '%s/workspace/%s/%s/%s' % (
+        WORKSPACE_URL, _workspace_creds['namespace'], _workspace_creds['agent'], session_id)
+
+
+def _workspace_manifest_path(scratch_dir):
+    return os.path.join(scratch_dir, WORKSPACE_MANIFEST_FILENAME)
+
+
+def _load_workspace_manifest(scratch_dir):
+    try:
+        with open(_workspace_manifest_path(scratch_dir)) as f:
+            manifest = json.load(f)
+        return manifest if isinstance(manifest, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_workspace_manifest(scratch_dir, manifest):
+    path = _workspace_manifest_path(scratch_dir)
+    tmp_path = path + '.tmp'
+    try:
+        with open(tmp_path, 'w') as f:
+            json.dump(manifest, f)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        print('{{.Name}}: could not save workspace manifest: %s' % err)
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _append_workspace_warning(warnings, message):
+    # Capped so a scratch dir full of failures (a pip/npm install that wrote
+    # thousands of files past the per-session quota, say) cannot blow up the
+    # turn reply the way MAX_OUTPUT_BYTES caps stdout/stderr -- the
+    # silent-failure rule requires reporting a failure, not reporting an
+    # unbounded number of them.
+    if len(warnings) < WORKSPACE_MAX_WARNINGS:
+        warnings.append(message)
+    elif len(warnings) == WORKSPACE_MAX_WARNINGS:
+        warnings.append('... additional workspace warnings suppressed')
+
+
+def _hydrate_workspace(scratch_dir, session_id, manifest):
+    # Lazy: a file already resident locally with a size matching the remote
+    # listing is assumed unchanged and is NOT re-downloaded -- the common
+    # case on a warm pod serving a later turn of the same session, where
+    # this costs exactly one LIST call and nothing else.
+    warnings = []
+    if not _workspace_creds:
+        return warnings
+    try:
+        res = requests.get(_workspace_session_url(session_id), headers=_workspace_headers(),
+                            timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
+        res.raise_for_status()
+        items = res.json().get('items', [])
+    except (requests.RequestException, ValueError) as err:
+        _append_workspace_warning(warnings, 'workspace hydrate: listing failed: %s' % err)
+        return warnings
+
+    for item in items:
+        rel = item.get('path')
+        size = item.get('size')
+        if not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel):
+            continue
+        local_path = os.path.join(scratch_dir, *rel.split('/'))
+        try:
+            if os.path.isfile(local_path) and os.path.getsize(local_path) == size:
+                continue
+        except OSError:
+            pass
+        try:
+            get_res = requests.get(_workspace_session_url(session_id) + '/' + rel, headers=_workspace_headers(),
+                                    timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
+            get_res.raise_for_status()
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            with open(local_path, 'wb') as f:
+                f.write(get_res.content)
+        except (requests.RequestException, OSError) as err:
+            _append_workspace_warning(warnings, 'workspace hydrate: %s: %s' % (rel, err))
+            continue
+        st = os.stat(local_path)
+        # A freshly hydrated file is, by definition, in sync with the
+        # workspace it just came from -- recording it here means the sync
+        # pass that follows this same turn's exec does not immediately
+        # re-upload a file nothing has touched.
+        manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': _sha256_file(local_path)}
+    return warnings
+
+
+def _sync_workspace(scratch_dir, session_id, manifest):
+    # mtime+size compare, content hash only on ambiguity (matching size,
+    # differing mtime) -- see this section's module doc comment. Delete-on-
+    # absence is OFF: a path that disappeared locally is dropped from the
+    # local manifest (bookkeeping only) but is NEVER DELETEd from the
+    # workspace -- sync is additive-only by design.
+    warnings = []
+    if not _workspace_creds:
+        return warnings
+
+    seen = set()
+    for root, _dirs, files in os.walk(scratch_dir):
+        for fname in files:
+            local_path = os.path.join(root, fname)
+            rel = os.path.relpath(local_path, scratch_dir).replace(os.sep, '/')
+            if rel in (WORKSPACE_MANIFEST_FILENAME, WORKSPACE_MANIFEST_FILENAME + '.tmp'):
+                continue
+            # Symlinks are skipped, not followed: exec'd code could otherwise
+            # link a scratch-dir path at a pod credential file and have ITS
+            # bytes uploaded to a workspace this agent's sibling sessions can
+            # read -- see the trust-boundary comment at the top of this file.
+            if os.path.islink(local_path) or not _valid_workspace_relpath(rel):
+                continue
+            try:
+                st = os.stat(local_path)
+            except OSError:
+                continue
+            seen.add(rel)
+
+            prev = manifest.get(rel)
+            if prev and prev.get('size') == st.st_size and prev.get('mtime_ns') == st.st_mtime_ns:
+                continue  # skip-clean: unchanged since the last successful sync/hydrate
+
+            digest = None
+            if prev and prev.get('size') == st.st_size:
+                # Ambiguous: same size, different mtime -- hash before
+                # deciding this is a genuine change rather than a touch.
+                digest = _sha256_file(local_path)
+                if digest == prev.get('sha256'):
+                    manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': digest}
+                    continue
+
+            try:
+                with open(local_path, 'rb') as f:
+                    data = f.read()
+            except OSError as err:
+                _append_workspace_warning(warnings, 'workspace sync: %s: %s' % (rel, err))
+                continue
+            if digest is None:
+                digest = hashlib.sha256(data).hexdigest()
+
+            try:
+                put_res = requests.put(_workspace_session_url(session_id) + '/' + rel, headers=_workspace_headers(),
+                                        data=data, timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
+                if not put_res.ok:
+                    _append_workspace_warning(warnings, 'workspace sync: %s: HTTP %d' % (rel, put_res.status_code))
+                    continue
+            except requests.RequestException as err:
+                _append_workspace_warning(warnings, 'workspace sync: %s: %s' % (rel, err))
+                continue
+            manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': digest}
+
+    for rel in list(manifest):
+        if rel not in seen:
+            del manifest[rel]
+    return warnings
+# --- End workspace hydration/sync helper ------------------------------------
 
 
 # --- The turn --------------------------------------------------------------

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
@@ -407,6 +407,7 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
   }
   return warnings;
 }
+// --- End workspace hydration/sync helper ------------------------------------
 
 // outputBuffer accumulates chunks up to MAX_OUTPUT_BYTES; further bytes are
 // dropped at push time (not merely trimmed once collection ends), so a

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
@@ -27,9 +27,65 @@
 // or multi-tenant code, which needs a dedicated pod per session (a Tier C
 // bare-Sandbox executor), not this template. Pair this environment with
 // `fission env create ... --runtime-class gvisor` for one more layer of
-// isolation before running code you did not write yourself.
+// isolation before running code you did not write yourself. The same
+// accidental-leakage posture applies to workspace sync below: a symlink
+// written into the scratch dir pointing at, say, the pod's token file would
+// get its TARGET's bytes uploaded to a workspace sibling sessions of this
+// same agent can read (see the workspace hydration/sync section) -- that is
+// why the sync walk below skips symlinks outright rather than following them.
+//
+// WORKING DIRECTORY AND WORKSPACE HYDRATION/SYNC (PR-2, abstraction C)
+// ----------------------------------------------------------------------
+// For a STATELESS call (no session header -- the MCP fast lane or a bare
+// direct invocation), the working directory is still a fresh scratch dir,
+// wiped before and best-effort removed after every call: there is no session
+// to key a workspace on, so nothing here changes for that path.
+//
+// For a SESSIONFUL call, the scratch dir ($TMPDIR/exec/<session>) is no
+// longer wiped at the start or end of a turn. Instead:
+//   - Turn start: HYDRATE -- list the session's G12 workspace
+//     (pkg/agentruntime/workspace.go) and download any file that is missing
+//     locally or whose local size does not match the remote size. On a warm
+//     pod where nothing changed since the last turn this is one LIST call
+//     and no downloads (lazy).
+//   - Turn end: SYNC -- walk the scratch dir and PUT any file that is new or
+//     has changed since the last successful hydrate/sync of that same path
+//     (compared via size+mtime, falling back to a content hash only when
+//     size+mtime alone is ambiguous -- see syncWorkspace). A hash manifest
+//     file kept in the scratch dir (never itself synced) is what lets a
+//     second turn on the SAME warm pod skip re-uploading anything unchanged.
+// This is what makes a file exec'd code writes survive a pod respecialize:
+// the scratch dir itself is pod-local and gone the moment the pod is, but
+// the workspace copy persists in storagesvc and rehydrates onto whichever
+// pod serves the session's next turn.
+//
+// Sync is ADDITIVE ONLY: a file deleted locally is never DELETEd from the
+// workspace (workspace.go's DELETE stays an explicit app-level call your own
+// code would have to make) -- this mirrors the shipped design's own
+// "workspace is additive" stance. A failed hydrate or sync (network error,
+// a 413 over one of the shipped quotas -- 32MiB/artifact, 256MiB + 1000
+// artifacts/session) is never silently dropped: it is collected into the
+// turn's `workspaceWarnings` reply field instead (capped so a runaway
+// directory full of failures cannot blow the reply up the same way
+// MAX_OUTPUT_BYTES caps stdout/stderr).
+//
+// Security note (restated from the shipped design, workspace.go): the
+// identity token's boundary is per-(namespace, agent), not per-session -- a
+// session can read a SIBLING session's artifacts of this same agent. Hydrate
+// is scoped to THIS session's own workspace by convention (the session id in
+// the URL), not by any server-side enforcement narrower than the agent
+// itself; per-session tokens remain a documented future slice, not something
+// this template can provide on its own.
+//
+// MAX_TIMEOUT_SECONDS (below) doubles as this scaffold's FunctionTimeout
+// (see `fission agent create`'s next-steps output) -- a turn whose exec runs
+// the full 300s ceiling leaves NO headroom for the sync step that follows
+// it. A long-running exec workload should lower its own timeoutSeconds well
+// under the ceiling if it also wants sync to reliably complete inside the
+// same request.
 
 const { spawn } = require('child_process');
+const crypto = require('crypto');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -70,6 +126,286 @@ function allowedEnv() {
     }
   }
   return env;
+}
+
+// --- Workspace hydration/sync (PR-2, abstraction C) -------------------------
+//
+// The executor injects FISSION_AGENT_RUNTIME_URL / FISSION_AGENT_TOKEN_PATH
+// whenever the agent runtime feature is enabled cluster-wide
+// (pkg/executor/util/agentenv.go's AgentAPIEnvVars) -- the SAME credential
+// file (pkg/fetcher/agenttoken.go's AgentCredentials, written at specialize
+// time) that authenticates this pod's own dispatch/spawn calls also
+// authenticates its session workspace calls, just against a stricter
+// own-workspace-only authorization rule (pkg/agentruntime/identity.go). The
+// file is {"namespace": "...", "agent": "...", "token": "..."}.
+const WORKSPACE_URL = process.env.FISSION_AGENT_RUNTIME_URL || '';
+const WORKSPACE_TOKEN_PATH = process.env.FISSION_AGENT_TOKEN_PATH || '';
+
+// HEADER_IDENTITY_NAMESPACE / HEADER_IDENTITY_NAME carry the claimed
+// (namespace, agent) identity alongside the bearer token -- verification
+// recomputes the derived key from exactly these two claims, so a bearer with
+// no claim headers (or the wrong ones) 401s (pkg/agentruntime/identity.go's
+// HeaderIdentityNamespace/HeaderIdentityName).
+const HEADER_IDENTITY_NAMESPACE = 'X-Fission-Agent-Auth-Namespace';
+const HEADER_IDENTITY_NAME = 'X-Fission-Agent-Auth-Name';
+
+// WORKSPACE_MANIFEST_FILENAME is a hash manifest kept in the scratch dir
+// itself (never synced -- excluded from every sync walk by name below) that
+// is what lets a second turn on the SAME warm pod skip re-uploading anything
+// unchanged since the last successful hydrate/sync of that path.
+const WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json';
+
+// WORKSPACE_MAX_WARNINGS caps how many entries workspaceWarnings can carry --
+// see appendWorkspaceWarning.
+const WORKSPACE_MAX_WARNINGS = 20;
+
+let workspaceCreds = null;
+if (WORKSPACE_URL && WORKSPACE_TOKEN_PATH) {
+  try {
+    workspaceCreds = JSON.parse(fs.readFileSync(WORKSPACE_TOKEN_PATH, 'utf8'));
+  } catch (err) {
+    console.error(`{{.Name}}: could not read agent identity token file ${WORKSPACE_TOKEN_PATH}: ${err.code || err.name}`);
+  }
+}
+
+const WORKSPACE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
+
+// validWorkspaceRelPath mirrors pkg/agentruntime/workspace.go's
+// validateWorkspaceSegment: every '/'-split segment must be non-empty, not
+// '.'/'..', not start with '_' (reserved for the platform's own
+// "_workspace_" root marker -- this also has the useful side effect of
+// silently excluding this template's own manifest file, and any similarly
+// named dotfile, from sync), and drawn from the same charset. A path failing
+// this is skipped entirely -- never synced, never a fatal error for the
+// turn.
+function validWorkspaceRelPath(rel) {
+  if (!rel) {
+    return false;
+  }
+  return rel
+    .split('/')
+    .every((seg) => seg !== '' && seg !== '.' && seg !== '..' && !seg.startsWith('_') && WORKSPACE_SEGMENT_RE.test(seg));
+}
+
+function workspaceHeaders(extra) {
+  return Object.assign(
+    {
+      Authorization: `Bearer ${workspaceCreds.token}`,
+      [HEADER_IDENTITY_NAMESPACE]: workspaceCreds.namespace,
+      [HEADER_IDENTITY_NAME]: workspaceCreds.agent,
+    },
+    extra,
+  );
+}
+
+// workspaceSessionURL builds the LIST route (NO trailing slash -- the
+// shipped route 400s a trailing-slash request by design, workspace.go's
+// validateWorkspacePath doc comment); GET/PUT append '/' + rel themselves.
+function workspaceSessionURL(sessionID) {
+  return `${WORKSPACE_URL}/workspace/${workspaceCreds.namespace}/${workspaceCreds.agent}/${sessionID}`;
+}
+
+function workspaceManifestPath(scratchDir) {
+  return path.join(scratchDir, WORKSPACE_MANIFEST_FILENAME);
+}
+
+function loadWorkspaceManifest(scratchDir) {
+  try {
+    const manifest = JSON.parse(fs.readFileSync(workspaceManifestPath(scratchDir), 'utf8'));
+    return manifest && typeof manifest === 'object' ? manifest : {};
+  } catch (err) {
+    return {};
+  }
+}
+
+function saveWorkspaceManifest(scratchDir, manifest) {
+  const manifestPath = workspaceManifestPath(scratchDir);
+  const tmpPath = manifestPath + '.tmp';
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(manifest));
+    fs.renameSync(tmpPath, manifestPath);
+  } catch (err) {
+    console.error(`{{.Name}}: could not save workspace manifest: ${err.code || err.name}`);
+  }
+}
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+// appendWorkspaceWarning caps warnings -- a scratch dir full of failures (a
+// pip/npm install that wrote thousands of files past the per-session quota,
+// say) cannot blow up the turn reply the way MAX_OUTPUT_BYTES caps
+// stdout/stderr -- the silent-failure rule requires reporting a failure, not
+// reporting an unbounded number of them.
+function appendWorkspaceWarning(warnings, message) {
+  if (warnings.length < WORKSPACE_MAX_WARNINGS) {
+    warnings.push(message);
+  } else if (warnings.length === WORKSPACE_MAX_WARNINGS) {
+    warnings.push('... additional workspace warnings suppressed');
+  }
+}
+
+// hydrateWorkspace lists the session's workspace and downloads any file
+// missing locally or whose local size does not match the remote listing --
+// lazy: a file already resident with a matching size is assumed unchanged
+// (the common case on a warm pod serving a later turn of the same session,
+// where this costs exactly one LIST call and nothing else).
+async function hydrateWorkspace(scratchDir, sessionID, manifest) {
+  const warnings = [];
+  if (!workspaceCreds) {
+    return warnings;
+  }
+  let items;
+  try {
+    const res = await fetch(workspaceSessionURL(sessionID), { headers: workspaceHeaders() });
+    if (!res.ok) {
+      throw new Error(`list failed: HTTP ${res.status}`);
+    }
+    items = (await res.json()).items || [];
+  } catch (err) {
+    appendWorkspaceWarning(warnings, `workspace hydrate: listing failed: ${err.message || err}`);
+    return warnings;
+  }
+
+  for (const item of items) {
+    const rel = item && item.path;
+    const size = item && item.size;
+    if (typeof rel !== 'string' || typeof size !== 'number' || !validWorkspaceRelPath(rel)) {
+      continue;
+    }
+    const localPath = path.join(scratchDir, ...rel.split('/'));
+    try {
+      const st = fs.statSync(localPath);
+      if (st.isFile() && st.size === size) {
+        continue;
+      }
+    } catch (err) {
+      // Not present locally yet -- fall through to download.
+    }
+    try {
+      const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, { headers: workspaceHeaders() });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = Buffer.from(await res.arrayBuffer());
+      fs.mkdirSync(path.dirname(localPath), { recursive: true });
+      fs.writeFileSync(localPath, data);
+      const st = fs.statSync(localPath);
+      // A freshly hydrated file is, by definition, in sync with the
+      // workspace it just came from -- recording it here means the sync
+      // pass that follows this same turn's exec does not immediately
+      // re-upload a file nothing has touched.
+      manifest[rel] = { size: st.size, mtimeMs: st.mtimeMs, sha256: sha256File(localPath) };
+    } catch (err) {
+      appendWorkspaceWarning(warnings, `workspace hydrate: ${rel}: ${err.message || err}`);
+    }
+  }
+  return warnings;
+}
+
+// syncWorkspace walks scratchDir and PUTs any file new or changed since the
+// last successful hydrate/sync of that same path -- mtime+size compare,
+// content hash only on ambiguity (matching size, differing mtime). Delete-
+// on-absence is OFF: a path that disappeared locally is dropped from the
+// local manifest (bookkeeping only) but is NEVER DELETEd from the
+// workspace -- sync is additive-only by design.
+async function syncWorkspace(scratchDir, sessionID, manifest) {
+  const warnings = [];
+  if (!workspaceCreds) {
+    return warnings;
+  }
+
+  const seen = new Set();
+
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (err) {
+      return;
+    }
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        // Skipped, not followed: exec'd code could otherwise link a
+        // scratch-dir path at a pod credential file and have ITS bytes
+        // uploaded to a workspace this agent's sibling sessions can read --
+        // see the trust-boundary comment at the top of this file.
+        continue;
+      }
+      if (entry.isDirectory()) {
+        await walk(entryPath);
+        continue;
+      }
+      if (!entry.isFile()) {
+        continue;
+      }
+      const rel = path.relative(scratchDir, entryPath).split(path.sep).join('/');
+      if (rel === WORKSPACE_MANIFEST_FILENAME || rel === WORKSPACE_MANIFEST_FILENAME + '.tmp' || !validWorkspaceRelPath(rel)) {
+        continue;
+      }
+      let st;
+      try {
+        st = fs.statSync(entryPath);
+      } catch (err) {
+        continue;
+      }
+      seen.add(rel);
+
+      const prev = manifest[rel];
+      if (prev && prev.size === st.size && prev.mtimeMs === st.mtimeMs) {
+        continue; // skip-clean: unchanged since the last successful sync/hydrate
+      }
+
+      let digest = null;
+      if (prev && prev.size === st.size) {
+        // Ambiguous: same size, different mtime -- hash before deciding this
+        // is a genuine change rather than a touch.
+        digest = sha256File(entryPath);
+        if (digest === prev.sha256) {
+          manifest[rel] = { size: st.size, mtimeMs: st.mtimeMs, sha256: digest };
+          continue;
+        }
+      }
+
+      let data;
+      try {
+        data = fs.readFileSync(entryPath);
+      } catch (err) {
+        appendWorkspaceWarning(warnings, `workspace sync: ${rel}: ${err.message || err}`);
+        continue;
+      }
+      if (digest === null) {
+        digest = crypto.createHash('sha256').update(data).digest('hex');
+      }
+
+      try {
+        const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, {
+          method: 'PUT',
+          headers: workspaceHeaders(),
+          body: data,
+        });
+        if (!res.ok) {
+          appendWorkspaceWarning(warnings, `workspace sync: ${rel}: HTTP ${res.status}`);
+          continue;
+        }
+      } catch (err) {
+        appendWorkspaceWarning(warnings, `workspace sync: ${rel}: ${err.message || err}`);
+        continue;
+      }
+      manifest[rel] = { size: st.size, mtimeMs: st.mtimeMs, sha256: digest };
+    }
+  }
+
+  await walk(scratchDir);
+
+  for (const rel of Object.keys(manifest)) {
+    if (!seen.has(rel)) {
+      delete manifest[rel];
+    }
+  }
+  return warnings;
 }
 
 // outputBuffer accumulates chunks up to MAX_OUTPUT_BYTES; further bytes are
@@ -200,9 +536,13 @@ const SESSION_ID_CHARSET_RE = /^[A-Za-z0-9._-]{1,128}$/;
 // resolves to $TMPDIR/exec itself, ".." resolves to $TMPDIR itself, and
 // anything containing "/" (never possible through the dispatcher, but
 // possible on the direct path above) can walk arbitrarily far outside
-// $TMPDIR/exec -- all of which get fs.rmSync({recursive:true})'d at the
-// start and end of every turn, wiping sibling sessions' scratch dirs or
-// worse on a shared warm-pool pod. Falls back to a fresh uniquely-named
+// $TMPDIR/exec -- a STATELESS scratch dir (this function returned a fresh
+// fallback name rather than sessionID itself) still gets
+// fs.rmSync({recursive:true})'d at the start and end of every call; a
+// SESSIONFUL one is no longer wiped at all (see module.exports below), so an
+// unguarded traversal there would instead silently and repeatedly
+// hydrate/sync through a sibling session's or the pod's own unrelated
+// directory on every future turn. Falls back to a fresh uniquely-named
 // scratch dir instead of erroring the turn.
 function safeScratchName(sessionID) {
   if (sessionID === '.' || sessionID === '..' || !SESSION_ID_CHARSET_RE.test(sessionID)) {
@@ -227,10 +567,16 @@ module.exports = async function (context) {
   // straight to the router internal listener, bypassing the dispatcher --
   // or a bare direct invocation) is stateless exec: a fresh, uniquely-named
   // scratch dir per call rather than one keyed on a session that does not
-  // exist here.
+  // exist here. isSession additionally requires safeScratchName to have
+  // returned sessionID UNCHANGED -- its fallback branch means sessionID
+  // failed validation (the direct-invocation path has no dispatcher
+  // enforcing sessionIDPattern upstream), and a scratch dir named after a
+  // fabricated fallback id is not a real session's workspace to hydrate from
+  // or sync to.
   const scratchName = sessionID
     ? safeScratchName(sessionID)
     : 'stateless-' + Date.now() + '-' + Math.random().toString(36).slice(2);
+  const isSession = Boolean(sessionID) && scratchName === sessionID;
   const scratchDir = path.join(os.tmpdir(), 'exec', scratchName);
 
   const headers = { 'Content-Type': 'application/json', [YIELD_HEADER]: 'waiting' };
@@ -248,12 +594,26 @@ module.exports = async function (context) {
 
   const timeoutSeconds = clampTimeout(body.timeoutSeconds);
 
-  try {
-    fs.rmSync(scratchDir, { recursive: true, force: true });
-  } catch (err) {
-    // Nothing to clean up yet -- fine.
+  let workspaceWarnings = [];
+  let manifest = {};
+  if (isSession) {
+    // SESSIONFUL: the scratch dir is deliberately NOT wiped -- see the
+    // "Workspace hydration/sync" comment at the top of this file. It may
+    // already exist (a later turn on the same warm pod) or not (the
+    // session's very first turn, or a fresh pod after respecialize).
+    fs.mkdirSync(scratchDir, { recursive: true });
+    manifest = loadWorkspaceManifest(scratchDir);
+    workspaceWarnings = workspaceWarnings.concat(await hydrateWorkspace(scratchDir, sessionID, manifest));
+  } else {
+    // STATELESS: unchanged from PR-1 -- fresh scratch dir, best-effort
+    // removed after the call, no workspace involvement at all.
+    try {
+      fs.rmSync(scratchDir, { recursive: true, force: true });
+    } catch (err) {
+      // Nothing to clean up yet -- fine.
+    }
+    fs.mkdirSync(scratchDir, { recursive: true });
   }
-  fs.mkdirSync(scratchDir, { recursive: true });
 
   let result;
   try {
@@ -263,12 +623,19 @@ module.exports = async function (context) {
       result = await runExec(['/bin/sh', '-c', body.command], scratchDir, timeoutSeconds);
     }
   } finally {
-    try {
-      fs.rmSync(scratchDir, { recursive: true, force: true });
-    } catch (err) {
-      // Best-effort cleanup -- a leftover scratch dir is not worth failing
-      // the turn over.
+    if (!isSession) {
+      try {
+        fs.rmSync(scratchDir, { recursive: true, force: true });
+      } catch (err) {
+        // Best-effort cleanup -- a leftover scratch dir is not worth
+        // failing the turn over.
+      }
     }
+  }
+
+  if (isSession) {
+    workspaceWarnings = workspaceWarnings.concat(await syncWorkspace(scratchDir, sessionID, manifest));
+    saveWorkspaceManifest(scratchDir, manifest);
   }
 
   const reply = {
@@ -277,6 +644,7 @@ module.exports = async function (context) {
     exitCode: result.exitCode,
     durationMs: result.durationMs,
     truncated: result.truncated,
+    workspaceWarnings: workspaceWarnings,
   };
 
   return {

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
@@ -175,10 +175,25 @@ const WORKSPACE_REQUEST_TIMEOUT_MS = 30000;
 // guaranteed 413 from the server.
 const WORKSPACE_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024;
 
+// WORKSPACE_CREDS_FIELDS are the keys workspaceHeaders/workspaceSessionURL
+// dereference unconditionally -- validated below so a corrupt-but-valid-JSON
+// token file (e.g. `{}`) degrades to "credentials unavailable" (a warning,
+// never a fatal error for the turn) instead of leaving workspaceCreds truthy
+// and sending "Bearer undefined" on every hydrate/sync call (mirrors the
+// Python helper's _WORKSPACE_CREDS_FIELDS check).
+const WORKSPACE_CREDS_FIELDS = ['token', 'namespace', 'agent'];
+
 let workspaceCreds = null;
 if (WORKSPACE_URL && WORKSPACE_TOKEN_PATH) {
   try {
-    workspaceCreds = JSON.parse(fs.readFileSync(WORKSPACE_TOKEN_PATH, 'utf8'));
+    const parsed = JSON.parse(fs.readFileSync(WORKSPACE_TOKEN_PATH, 'utf8'));
+    if (parsed && typeof parsed === 'object' && WORKSPACE_CREDS_FIELDS.every((k) => k in parsed)) {
+      workspaceCreds = parsed;
+    } else {
+      console.error(
+        `{{.Name}}: agent identity token file ${WORKSPACE_TOKEN_PATH} is malformed (missing ${WORKSPACE_CREDS_FIELDS.join(', ')})`,
+      );
+    }
   } catch (err) {
     console.error(`{{.Name}}: could not read agent identity token file ${WORKSPACE_TOKEN_PATH}: ${err.code || err.name}`);
   }
@@ -322,6 +337,21 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
       }
     } catch (err) {
       // Not present locally yet -- fall through to download.
+    }
+    try {
+      const lst = fs.lstatSync(localPath);
+      if (lst.isSymbolicLink() || !lst.isFile()) {
+        // A local path that already exists but is a symlink (or otherwise
+        // not a regular file -- exec'd code planted it there) would have
+        // fs.writeFileSync below follow the symlink and overwrite its
+        // TARGET with hydrated workspace bytes, or block forever on a FIFO
+        // -- skip and report instead of writing through it. Mirrors the
+        // sync walk's symlink guard.
+        appendWorkspaceWarning(warnings, `workspace hydrate: ${rel}: local path exists and is not a regular file, skipped`);
+        continue;
+      }
+    } catch (err) {
+      // Not present locally yet -- fine, this is a fresh write.
     }
     try {
       const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, {

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.js.tmpl
@@ -159,6 +159,22 @@ const WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json';
 // see appendWorkspaceWarning.
 const WORKSPACE_MAX_WARNINGS = 20;
 
+// WORKSPACE_REQUEST_TIMEOUT_MS bounds every hydrate/sync HTTP call so a
+// stalled agent-runtime connection cannot burn the whole turn's
+// FunctionTimeout before exec even starts (mirrors the Python helper's
+// WORKSPACE_REQUEST_TIMEOUT_SECONDS -- requests has no default timeout and
+// neither does fetch).
+const WORKSPACE_REQUEST_TIMEOUT_MS = 30000;
+
+// WORKSPACE_MAX_ARTIFACT_BYTES is a best-effort client-side mirror of the
+// server's default per-artifact cap (pkg/agentruntime/main.go's
+// defaultMaxArtifactBytes, overridable there via AGENT_MAX_ARTIFACT_BYTES --
+// not discoverable from the client, so this is a default, not an enforced
+// contract). Skipping an oversized file before reading it avoids pulling a
+// multi-GB scratch file fully into this process's memory only to earn a
+// guaranteed 413 from the server.
+const WORKSPACE_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024;
+
 let workspaceCreds = null;
 if (WORKSPACE_URL && WORKSPACE_TOKEN_PATH) {
   try {
@@ -174,10 +190,12 @@ const WORKSPACE_SEGMENT_RE = /^[A-Za-z0-9._-]+$/;
 // validateWorkspaceSegment: every '/'-split segment must be non-empty, not
 // '.'/'..', not start with '_' (reserved for the platform's own
 // "_workspace_" root marker -- this also has the useful side effect of
-// silently excluding this template's own manifest file, and any similarly
-// named dotfile, from sync), and drawn from the same charset. A path failing
-// this is skipped entirely -- never synced, never a fatal error for the
-// turn.
+// silently excluding directories that start with '_' from sync), and drawn
+// from the same charset. This rule does NOT exclude this template's own
+// manifest file -- WORKSPACE_MANIFEST_FILENAME starts with '.', not '_', and
+// passes this check; the manifest is kept out of hydrate/sync by the
+// explicit name checks below instead. A path failing this is skipped
+// entirely -- never synced, never a fatal error for the turn.
 function validWorkspaceRelPath(rel) {
   if (!rel) {
     return false;
@@ -253,12 +271,25 @@ function appendWorkspaceWarning(warnings, message) {
 // where this costs exactly one LIST call and nothing else).
 async function hydrateWorkspace(scratchDir, sessionID, manifest) {
   const warnings = [];
+  if (!WORKSPACE_URL) {
+    // Feature not enabled cluster-wide -- silence is correct here, there is
+    // nothing to warn about.
+    return warnings;
+  }
   if (!workspaceCreds) {
+    // Feature IS enabled but this pod's own identity credentials could not
+    // be read at module load -- distinct from the feature-off case above,
+    // and per the silent-failure rule this must be visible in the turn
+    // result rather than only in the pod's own startup log.
+    appendWorkspaceWarning(warnings, 'workspace hydrate: agent identity credentials unavailable, skipped');
     return warnings;
   }
   let items;
   try {
-    const res = await fetch(workspaceSessionURL(sessionID), { headers: workspaceHeaders() });
+    const res = await fetch(workspaceSessionURL(sessionID), {
+      headers: workspaceHeaders(),
+      signal: AbortSignal.timeout(WORKSPACE_REQUEST_TIMEOUT_MS),
+    });
     if (!res.ok) {
       throw new Error(`list failed: HTTP ${res.status}`);
     }
@@ -271,7 +302,16 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
   for (const item of items) {
     const rel = item && item.path;
     const size = item && item.size;
-    if (typeof rel !== 'string' || typeof size !== 'number' || !validWorkspaceRelPath(rel)) {
+    if (
+      typeof rel !== 'string' ||
+      typeof size !== 'number' ||
+      !validWorkspaceRelPath(rel) ||
+      rel === WORKSPACE_MANIFEST_FILENAME ||
+      rel === WORKSPACE_MANIFEST_FILENAME + '.tmp'
+    ) {
+      // The manifest itself is never a hydrate target -- downloading a
+      // same-named workspace artifact over the local manifest would corrupt
+      // this pod's own skip-clean bookkeeping.
       continue;
     }
     const localPath = path.join(scratchDir, ...rel.split('/'));
@@ -284,7 +324,10 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
       // Not present locally yet -- fall through to download.
     }
     try {
-      const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, { headers: workspaceHeaders() });
+      const res = await fetch(`${workspaceSessionURL(sessionID)}/${rel}`, {
+        headers: workspaceHeaders(),
+        signal: AbortSignal.timeout(WORKSPACE_REQUEST_TIMEOUT_MS),
+      });
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
@@ -312,11 +355,21 @@ async function hydrateWorkspace(scratchDir, sessionID, manifest) {
 // workspace -- sync is additive-only by design.
 async function syncWorkspace(scratchDir, sessionID, manifest) {
   const warnings = [];
+  if (!WORKSPACE_URL) {
+    // Feature not enabled cluster-wide -- silence is correct here, there is
+    // nothing to warn about.
+    return warnings;
+  }
   if (!workspaceCreds) {
+    // Feature IS enabled but this pod's own identity credentials could not
+    // be read at module load -- every exec-written file this turn is about
+    // to go unsynced, which the silent-failure rule requires surfacing.
+    appendWorkspaceWarning(warnings, 'workspace sync: agent identity credentials unavailable, skipped');
     return warnings;
   }
 
   const seen = new Set();
+  let skippedNames = 0;
 
   async function walk(dir) {
     let entries;
@@ -342,7 +395,16 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
         continue;
       }
       const rel = path.relative(scratchDir, entryPath).split(path.sep).join('/');
-      if (rel === WORKSPACE_MANIFEST_FILENAME || rel === WORKSPACE_MANIFEST_FILENAME + '.tmp' || !validWorkspaceRelPath(rel)) {
+      if (rel === WORKSPACE_MANIFEST_FILENAME || rel === WORKSPACE_MANIFEST_FILENAME + '.tmp') {
+        continue;
+      }
+      if (!validWorkspaceRelPath(rel)) {
+        // Silent per-file, but counted -- see the aggregated warning below
+        // this walk. A name-invalid file (spaces, unicode, a leading '_')
+        // is not an error, just not syncable; per-file warnings here would
+        // drown the warning cap in noise from something like a stray
+        // '_scratch' directory.
+        skippedNames++;
         continue;
       }
       let st;
@@ -356,6 +418,18 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
       const prev = manifest[rel];
       if (prev && prev.size === st.size && prev.mtimeMs === st.mtimeMs) {
         continue; // skip-clean: unchanged since the last successful sync/hydrate
+      }
+
+      if (st.size > WORKSPACE_MAX_ARTIFACT_BYTES) {
+        // Skip before EITHER a hashing or an upload read -- reading a
+        // multi-GB scratch file fully into memory only to earn a
+        // guaranteed 413 risks OOMing a warm-pool pod shared with sibling
+        // sessions.
+        appendWorkspaceWarning(
+          warnings,
+          `workspace sync: ${rel}: ${st.size} bytes exceeds the ${WORKSPACE_MAX_ARTIFACT_BYTES}-byte per-artifact cap, skipped`,
+        );
+        continue;
       }
 
       let digest = null;
@@ -385,6 +459,7 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
           method: 'PUT',
           headers: workspaceHeaders(),
           body: data,
+          signal: AbortSignal.timeout(WORKSPACE_REQUEST_TIMEOUT_MS),
         });
         if (!res.ok) {
           appendWorkspaceWarning(warnings, `workspace sync: ${rel}: HTTP ${res.status}`);
@@ -399,6 +474,10 @@ async function syncWorkspace(scratchDir, sessionID, manifest) {
   }
 
   await walk(scratchDir);
+
+  if (skippedNames > 0) {
+    appendWorkspaceWarning(warnings, `workspace sync: ${skippedNames} file(s) skipped: names not syncable to the workspace`);
+  }
 
   for (const rel of Object.keys(manifest)) {
     if (!seen.has(rel)) {

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -367,6 +367,7 @@ def _sync_workspace(scratch_dir, session_id, manifest):
         if rel not in seen:
             del manifest[rel]
     return warnings
+# --- End workspace hydration/sync helper ------------------------------------
 
 
 class _OutputBuffer:

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -165,11 +165,32 @@ WORKSPACE_MAX_WARNINGS = 20
 
 WORKSPACE_REQUEST_TIMEOUT_SECONDS = 30
 
+# WORKSPACE_MAX_ARTIFACT_BYTES is a best-effort client-side mirror of the
+# server's default per-artifact cap (pkg/agentruntime/main.go's
+# defaultMaxArtifactBytes, overridable there via AGENT_MAX_ARTIFACT_BYTES --
+# not discoverable from the client, so this is a default, not an enforced
+# contract). Skipping an oversized file before reading it avoids pulling a
+# multi-GB scratch file fully into this process's memory only to earn a
+# guaranteed 413 from the server.
+WORKSPACE_MAX_ARTIFACT_BYTES = 32 * 1024 * 1024
+
+# _WORKSPACE_CREDS_FIELDS are the keys _workspace_headers/_workspace_session_url
+# dereference unconditionally -- validated below so a corrupt-but-valid-JSON
+# token file degrades to "credentials unavailable" (a warning, never a fatal
+# error for the turn) instead of a KeyError/TypeError escaping _hydrate_workspace
+# / _sync_workspace uncaught.
+_WORKSPACE_CREDS_FIELDS = ('token', 'namespace', 'agent')
+
 _workspace_creds = None
 if WORKSPACE_URL and WORKSPACE_TOKEN_PATH:
     try:
         with open(WORKSPACE_TOKEN_PATH) as f:
             _workspace_creds = json.load(f)
+        if not (isinstance(_workspace_creds, dict)
+                and all(k in _workspace_creds for k in _WORKSPACE_CREDS_FIELDS)):
+            print('{{.Name}}: agent identity token file %s is malformed (missing %s)' % (
+                WORKSPACE_TOKEN_PATH, ', '.join(_WORKSPACE_CREDS_FIELDS)))
+            _workspace_creds = None
     except (OSError, ValueError) as err:
         print('{{.Name}}: could not read agent identity token file %s: %s' % (WORKSPACE_TOKEN_PATH, err))
 
@@ -181,8 +202,10 @@ def _valid_workspace_relpath(rel):
     # '/'-split segment must be non-empty, not '.'/'..', not start with '_'
     # (reserved for the platform's own "_workspace_" root marker -- this also
     # has the useful side effect of silently excluding directories like
-    # "__pycache__" from sync, not just this template's own manifest file),
-    # and drawn from the same charset. A path failing this is skipped
+    # "__pycache__" from sync). This rule does NOT exclude this template's
+    # own manifest file -- WORKSPACE_MANIFEST_FILENAME starts with '.', not
+    # '_', and passes this check; the manifest is kept out of hydrate/sync by
+    # the explicit name checks below instead. A path failing this is skipped
     # entirely -- never synced, never a fatal error for the turn.
     if not rel:
         return False
@@ -260,7 +283,17 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
     # case on a warm pod serving a later turn of the same session, where
     # this costs exactly one LIST call and nothing else.
     warnings = []
+    if not WORKSPACE_URL:
+        # Feature not enabled cluster-wide -- silence is correct here, there
+        # is nothing to warn about.
+        return warnings
     if not _workspace_creds:
+        # Feature IS enabled but this pod's own identity credentials could
+        # not be read (or were malformed) at module load -- distinct from
+        # the feature-off case above, and per the silent-failure rule this
+        # must be visible in the turn result rather than only in the pod's
+        # own startup log.
+        _append_workspace_warning(warnings, 'workspace hydrate: agent identity credentials unavailable, skipped')
         return warnings
     try:
         res = requests.get(_workspace_session_url(session_id), headers=_workspace_headers(),
@@ -274,7 +307,11 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
     for item in items:
         rel = item.get('path')
         size = item.get('size')
-        if not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel):
+        if (not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel)
+                or rel in (WORKSPACE_MANIFEST_FILENAME, WORKSPACE_MANIFEST_FILENAME + '.tmp')):
+            # The manifest itself is never a hydrate target -- downloading a
+            # same-named workspace artifact over the local manifest would
+            # corrupt this pod's own skip-clean bookkeeping.
             continue
         local_path = os.path.join(scratch_dir, *rel.split('/'))
         try:
@@ -308,10 +345,20 @@ def _sync_workspace(scratch_dir, session_id, manifest):
     # local manifest (bookkeeping only) but is NEVER DELETEd from the
     # workspace -- sync is additive-only by design.
     warnings = []
+    if not WORKSPACE_URL:
+        # Feature not enabled cluster-wide -- silence is correct here, there
+        # is nothing to warn about.
+        return warnings
     if not _workspace_creds:
+        # Feature IS enabled but this pod's own identity credentials could
+        # not be read (or were malformed) at module load -- every
+        # exec-written file this turn is about to go unsynced, which the
+        # silent-failure rule requires surfacing.
+        _append_workspace_warning(warnings, 'workspace sync: agent identity credentials unavailable, skipped')
         return warnings
 
     seen = set()
+    skipped_names = 0
     for root, _dirs, files in os.walk(scratch_dir):
         for fname in files:
             local_path = os.path.join(root, fname)
@@ -322,7 +369,15 @@ def _sync_workspace(scratch_dir, session_id, manifest):
             # link a scratch-dir path at a pod credential file and have ITS
             # bytes uploaded to a workspace this agent's sibling sessions can
             # read -- see the trust-boundary comment at the top of this file.
-            if os.path.islink(local_path) or not _valid_workspace_relpath(rel):
+            if os.path.islink(local_path):
+                continue
+            if not _valid_workspace_relpath(rel):
+                # Silent per-file, but counted -- see the aggregated warning
+                # below this walk. A name-invalid file (spaces, unicode, a
+                # leading '_') is not an error, just not syncable; per-file
+                # warnings here would drown the warning cap in noise from
+                # something like a stray "__pycache__" directory.
+                skipped_names += 1
                 continue
             try:
                 st = os.stat(local_path)
@@ -333,6 +388,17 @@ def _sync_workspace(scratch_dir, session_id, manifest):
             prev = manifest.get(rel)
             if prev and prev.get('size') == st.st_size and prev.get('mtime_ns') == st.st_mtime_ns:
                 continue  # skip-clean: unchanged since the last successful sync/hydrate
+
+            if st.st_size > WORKSPACE_MAX_ARTIFACT_BYTES:
+                # Skip before EITHER a hashing or an upload read -- reading a
+                # multi-GB scratch file fully into memory only to earn a
+                # guaranteed 413 risks OOMing a warm-pool pod shared with
+                # sibling sessions.
+                _append_workspace_warning(
+                    warnings,
+                    'workspace sync: %s: %d bytes exceeds the %d-byte per-artifact cap, skipped' % (
+                        rel, st.st_size, WORKSPACE_MAX_ARTIFACT_BYTES))
+                continue
 
             digest = None
             if prev and prev.get('size') == st.st_size:
@@ -362,6 +428,10 @@ def _sync_workspace(scratch_dir, session_id, manifest):
                 _append_workspace_warning(warnings, 'workspace sync: %s: %s' % (rel, err))
                 continue
             manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': digest}
+
+    if skipped_names:
+        _append_workspace_warning(
+            warnings, 'workspace sync: %d file(s) skipped: names not syncable to the workspace' % skipped_names)
 
     for rel in list(manifest):
         if rel not in seen:

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -90,6 +90,7 @@ import os
 import re
 import shutil
 import signal
+import stat
 import subprocess
 import tempfile
 import threading
@@ -299,12 +300,24 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
         res = requests.get(_workspace_session_url(session_id), headers=_workspace_headers(),
                             timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
         res.raise_for_status()
-        items = res.json().get('items', [])
+        payload = res.json()
+        # A non-dict listing body (server bug, or something in front of it
+        # rewriting the response) degrades to "nothing to hydrate" rather
+        # than an AttributeError escaping this function -- mirrors the JS
+        # helper's `(await res.json()).items || []`, which is equally inert
+        # against a non-object payload.
+        items = payload.get('items', []) if isinstance(payload, dict) else []
     except (requests.RequestException, ValueError) as err:
         _append_workspace_warning(warnings, 'workspace hydrate: listing failed: %s' % err)
         return warnings
 
     for item in items:
+        if not isinstance(item, dict):
+            # A non-dict entry in the listing (tampered or malformed server
+            # response) is simply not hydratable -- mirrors the JS helper's
+            # `item && item.path`, which is equally inert against a
+            # non-object item.
+            continue
         rel = item.get('path')
         size = item.get('size')
         if (not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel)
@@ -319,6 +332,19 @@ def _hydrate_workspace(scratch_dir, session_id, manifest):
                 continue
         except OSError:
             pass
+        if os.path.islink(local_path) or (os.path.lexists(local_path) and not os.path.isfile(local_path)):
+            # A local path that already exists but is a symlink (or
+            # otherwise not a regular file -- a FIFO, socket, or device that
+            # exec'd code created at this exact relative path) would have
+            # the open(local_path, 'wb') below follow the symlink and
+            # overwrite its TARGET with hydrated workspace bytes, or hang
+            # forever waiting for a reader (FIFO) -- same failure class the
+            # sync walk's symlink/regular-file guards exist for, just
+            # triggered from the opposite direction. Skip and report rather
+            # than write through it or wedge the turn.
+            _append_workspace_warning(
+                warnings, 'workspace hydrate: %s: local path exists and is not a regular file, skipped' % rel)
+            continue
         try:
             get_res = requests.get(_workspace_session_url(session_id) + '/' + rel, headers=_workspace_headers(),
                                     timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
@@ -383,9 +409,25 @@ def _sync_workspace(scratch_dir, session_id, manifest):
                 st = os.stat(local_path)
             except OSError:
                 continue
+            if not stat.S_ISREG(st.st_mode):
+                # os.walk's `files` list is every non-directory dirent, not
+                # just regular files -- a FIFO or socket exec'd code created
+                # in the scratch dir lands here too, and the plain
+                # open(local_path, 'rb') a few lines down blocks forever on
+                # a FIFO with no writer, wedging the turn outside the exec
+                # timeout's kill mechanism. Silent skip, not counted in
+                # skipped_names, mirroring the JS walk's entry.isFile() guard.
+                continue
             seen.add(rel)
 
             prev = manifest.get(rel)
+            if not isinstance(prev, dict):
+                # A tampered or hand-edited manifest value that is not
+                # dict-shaped would otherwise raise AttributeError on the
+                # .get() calls below -- treat it as "no prior record" rather
+                # than 500ing the turn (mirrors the JS helper, where
+                # prev.size on a non-object simply reads as undefined).
+                prev = None
             if prev and prev.get('size') == st.st_size and prev.get('mtime_ns') == st.st_mtime_ns:
                 continue  # skip-clean: unchanged since the last successful sync/hydrate
 

--- a/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
+++ b/pkg/fission-cli/cmd/agent/templates/interpreter.py.tmpl
@@ -26,8 +26,64 @@
 # or multi-tenant code, which needs a dedicated pod per session (a Tier C
 # bare-Sandbox executor), not this template. Pair this environment with
 # `fission env create ... --runtime-class gvisor` for one more layer of
-# isolation before running code you did not write yourself.
+# isolation before running code you did not write yourself. The same
+# accidental-leakage posture applies to workspace sync below: a symlink
+# written into the scratch dir pointing at, say, the pod's token file would
+# get its TARGET's bytes uploaded to a workspace sibling sessions of this
+# same agent can read (see the workspace hydration/sync section) -- that is
+# why the sync walk below skips symlinks outright rather than following them.
+#
+# WORKING DIRECTORY AND WORKSPACE HYDRATION/SYNC (PR-2, abstraction C)
+# ----------------------------------------------------------------------
+# For a STATELESS call (no session header -- the MCP fast lane or a bare
+# direct invocation), the working directory is still a fresh scratch dir,
+# wiped before and best-effort removed after every call: there is no session
+# to key a workspace on, so nothing here changes for that path.
+#
+# For a SESSIONFUL call, the scratch dir ($TMPDIR/exec/<session>) is no
+# longer wiped at the start or end of a turn. Instead:
+#   - Turn start: HYDRATE -- list the session's G12 workspace
+#     (pkg/agentruntime/workspace.go) and download any file that is missing
+#     locally or whose local size does not match the remote size. On a warm
+#     pod where nothing changed since the last turn this is one LIST call
+#     and no downloads (lazy).
+#   - Turn end: SYNC -- walk the scratch dir and PUT any file that is new or
+#     has changed since the last successful hydrate/sync of that same path
+#     (compared via size+mtime, falling back to a content hash only when
+#     size+mtime alone is ambiguous -- see _sync_workspace). A hash manifest
+#     file kept in the scratch dir (never itself synced) is what lets a
+#     second turn on the SAME warm pod skip re-uploading anything unchanged.
+# This is what makes a file exec'd code writes survive a pod respecialize:
+# the scratch dir itself is pod-local and gone the moment the pod is, but
+# the workspace copy persists in storagesvc and rehydrates onto whichever
+# pod serves the session's next turn.
+#
+# Sync is ADDITIVE ONLY: a file deleted locally is never DELETEd from the
+# workspace (workspace.go's DELETE stays an explicit app-level call your own
+# code would have to make) -- this mirrors the shipped design's own
+# "workspace is additive" stance. A failed hydrate or sync (network error,
+# a 413 over one of the shipped quotas -- 32MiB/artifact, 256MiB + 1000
+# artifacts/session) is never silently dropped: it is collected into the
+# turn's `workspaceWarnings` reply field instead (capped so a runaway
+# directory full of failures cannot blow the reply up the same way
+# MAX_OUTPUT_BYTES caps stdout/stderr).
+#
+# Security note (restated from the shipped design, workspace.go): the
+# identity token's boundary is per-(namespace, agent), not per-session -- a
+# session can read a SIBLING session's artifacts of this same agent. Hydrate
+# is scoped to THIS session's own workspace by convention (the session id in
+# the URL), not by any server-side enforcement narrower than the agent
+# itself; per-session tokens remain a documented future slice, not something
+# this template can provide on its own.
+#
+# MAX_TIMEOUT_SECONDS (below) doubles as this scaffold's FunctionTimeout
+# (see `fission agent create`'s next-steps output) -- a turn whose exec runs
+# the full 300s ceiling leaves NO headroom for the sync step that follows
+# it. A long-running exec workload should lower its own timeoutSeconds well
+# under the ceiling if it also wants sync to reliably complete inside the
+# same request.
 
+import hashlib
 import json
 import math
 import os
@@ -41,6 +97,7 @@ import time
 import uuid
 
 from flask import request
+import requests
 
 # The dispatcher stamps the session header on every forwarded call (see
 # pkg/agentruntime/dispatcher.go); this template reads it only to name the
@@ -73,6 +130,243 @@ ALLOWED_ENV_VARS = ['PATH', 'HOME', 'LANG', 'LC_ALL', 'TZ']
 
 def _allowed_env():
     return {k: os.environ[k] for k in ALLOWED_ENV_VARS if k in os.environ}
+
+
+# --- Workspace hydration/sync (PR-2, abstraction C) -------------------------
+#
+# The executor injects FISSION_AGENT_RUNTIME_URL / FISSION_AGENT_TOKEN_PATH
+# whenever the agent runtime feature is enabled cluster-wide
+# (pkg/executor/util/agentenv.go's AgentAPIEnvVars) -- the SAME credential
+# file (pkg/fetcher/agenttoken.go's AgentCredentials, written at specialize
+# time) that authenticates this pod's own dispatch/spawn calls also
+# authenticates its session workspace calls, just against a stricter
+# own-workspace-only authorization rule (pkg/agentruntime/identity.go). The
+# file is {"namespace": "...", "agent": "...", "token": "..."}.
+WORKSPACE_URL = os.environ.get('FISSION_AGENT_RUNTIME_URL', '')
+WORKSPACE_TOKEN_PATH = os.environ.get('FISSION_AGENT_TOKEN_PATH', '')
+
+# HEADER_IDENTITY_NAMESPACE / HEADER_IDENTITY_NAME carry the claimed
+# (namespace, agent) identity alongside the bearer token -- verification
+# recomputes the derived key from exactly these two claims, so a bearer with
+# no claim headers (or the wrong ones) 401s (pkg/agentruntime/identity.go's
+# HeaderIdentityNamespace/HeaderIdentityName).
+HEADER_IDENTITY_NAMESPACE = 'X-Fission-Agent-Auth-Namespace'
+HEADER_IDENTITY_NAME = 'X-Fission-Agent-Auth-Name'
+
+# WORKSPACE_MANIFEST_FILENAME is a hash manifest kept in the scratch dir
+# itself (never synced -- excluded from every sync walk by name below) that
+# is what lets a second turn on the SAME warm pod skip re-uploading anything
+# unchanged since the last successful hydrate/sync of that path.
+WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json'
+
+# WORKSPACE_MAX_WARNINGS caps how many entries workspaceWarnings can carry --
+# see _append_workspace_warning.
+WORKSPACE_MAX_WARNINGS = 20
+
+WORKSPACE_REQUEST_TIMEOUT_SECONDS = 30
+
+_workspace_creds = None
+if WORKSPACE_URL and WORKSPACE_TOKEN_PATH:
+    try:
+        with open(WORKSPACE_TOKEN_PATH) as f:
+            _workspace_creds = json.load(f)
+    except (OSError, ValueError) as err:
+        print('{{.Name}}: could not read agent identity token file %s: %s' % (WORKSPACE_TOKEN_PATH, err))
+
+_WORKSPACE_SEGMENT_RE = re.compile(r'^[A-Za-z0-9._-]+$')
+
+
+def _valid_workspace_relpath(rel):
+    # Mirrors pkg/agentruntime/workspace.go's validateWorkspaceSegment: every
+    # '/'-split segment must be non-empty, not '.'/'..', not start with '_'
+    # (reserved for the platform's own "_workspace_" root marker -- this also
+    # has the useful side effect of silently excluding directories like
+    # "__pycache__" from sync, not just this template's own manifest file),
+    # and drawn from the same charset. A path failing this is skipped
+    # entirely -- never synced, never a fatal error for the turn.
+    if not rel:
+        return False
+    for seg in rel.split('/'):
+        if seg in ('', '.', '..') or seg.startswith('_') or not _WORKSPACE_SEGMENT_RE.match(seg):
+            return False
+    return True
+
+
+def _workspace_headers(extra=None):
+    headers = {
+        'Authorization': 'Bearer %s' % _workspace_creds['token'],
+        HEADER_IDENTITY_NAMESPACE: _workspace_creds['namespace'],
+        HEADER_IDENTITY_NAME: _workspace_creds['agent'],
+    }
+    if extra:
+        headers.update(extra)
+    return headers
+
+
+def _workspace_session_url(session_id):
+    # NO trailing slash -- the shipped route 400s a trailing-slash request
+    # by design (workspace.go's validateWorkspacePath doc comment).
+    return '%s/workspace/%s/%s/%s' % (
+        WORKSPACE_URL, _workspace_creds['namespace'], _workspace_creds['agent'], session_id)
+
+
+def _workspace_manifest_path(scratch_dir):
+    return os.path.join(scratch_dir, WORKSPACE_MANIFEST_FILENAME)
+
+
+def _load_workspace_manifest(scratch_dir):
+    try:
+        with open(_workspace_manifest_path(scratch_dir)) as f:
+            manifest = json.load(f)
+        return manifest if isinstance(manifest, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save_workspace_manifest(scratch_dir, manifest):
+    path = _workspace_manifest_path(scratch_dir)
+    tmp_path = path + '.tmp'
+    try:
+        with open(tmp_path, 'w') as f:
+            json.dump(manifest, f)
+        os.replace(tmp_path, path)
+    except OSError as err:
+        print('{{.Name}}: could not save workspace manifest: %s' % err)
+
+
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(65536), b''):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _append_workspace_warning(warnings, message):
+    # Capped so a scratch dir full of failures (a pip/npm install that wrote
+    # thousands of files past the per-session quota, say) cannot blow up the
+    # turn reply the way MAX_OUTPUT_BYTES caps stdout/stderr -- the
+    # silent-failure rule requires reporting a failure, not reporting an
+    # unbounded number of them.
+    if len(warnings) < WORKSPACE_MAX_WARNINGS:
+        warnings.append(message)
+    elif len(warnings) == WORKSPACE_MAX_WARNINGS:
+        warnings.append('... additional workspace warnings suppressed')
+
+
+def _hydrate_workspace(scratch_dir, session_id, manifest):
+    # Lazy: a file already resident locally with a size matching the remote
+    # listing is assumed unchanged and is NOT re-downloaded -- the common
+    # case on a warm pod serving a later turn of the same session, where
+    # this costs exactly one LIST call and nothing else.
+    warnings = []
+    if not _workspace_creds:
+        return warnings
+    try:
+        res = requests.get(_workspace_session_url(session_id), headers=_workspace_headers(),
+                            timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
+        res.raise_for_status()
+        items = res.json().get('items', [])
+    except (requests.RequestException, ValueError) as err:
+        _append_workspace_warning(warnings, 'workspace hydrate: listing failed: %s' % err)
+        return warnings
+
+    for item in items:
+        rel = item.get('path')
+        size = item.get('size')
+        if not isinstance(rel, str) or not isinstance(size, int) or not _valid_workspace_relpath(rel):
+            continue
+        local_path = os.path.join(scratch_dir, *rel.split('/'))
+        try:
+            if os.path.isfile(local_path) and os.path.getsize(local_path) == size:
+                continue
+        except OSError:
+            pass
+        try:
+            get_res = requests.get(_workspace_session_url(session_id) + '/' + rel, headers=_workspace_headers(),
+                                    timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
+            get_res.raise_for_status()
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            with open(local_path, 'wb') as f:
+                f.write(get_res.content)
+        except (requests.RequestException, OSError) as err:
+            _append_workspace_warning(warnings, 'workspace hydrate: %s: %s' % (rel, err))
+            continue
+        st = os.stat(local_path)
+        # A freshly hydrated file is, by definition, in sync with the
+        # workspace it just came from -- recording it here means the sync
+        # pass that follows this same turn's exec does not immediately
+        # re-upload a file nothing has touched.
+        manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': _sha256_file(local_path)}
+    return warnings
+
+
+def _sync_workspace(scratch_dir, session_id, manifest):
+    # mtime+size compare, content hash only on ambiguity (matching size,
+    # differing mtime) -- see this section's module doc comment. Delete-on-
+    # absence is OFF: a path that disappeared locally is dropped from the
+    # local manifest (bookkeeping only) but is NEVER DELETEd from the
+    # workspace -- sync is additive-only by design.
+    warnings = []
+    if not _workspace_creds:
+        return warnings
+
+    seen = set()
+    for root, _dirs, files in os.walk(scratch_dir):
+        for fname in files:
+            local_path = os.path.join(root, fname)
+            rel = os.path.relpath(local_path, scratch_dir).replace(os.sep, '/')
+            if rel in (WORKSPACE_MANIFEST_FILENAME, WORKSPACE_MANIFEST_FILENAME + '.tmp'):
+                continue
+            # Symlinks are skipped, not followed: exec'd code could otherwise
+            # link a scratch-dir path at a pod credential file and have ITS
+            # bytes uploaded to a workspace this agent's sibling sessions can
+            # read -- see the trust-boundary comment at the top of this file.
+            if os.path.islink(local_path) or not _valid_workspace_relpath(rel):
+                continue
+            try:
+                st = os.stat(local_path)
+            except OSError:
+                continue
+            seen.add(rel)
+
+            prev = manifest.get(rel)
+            if prev and prev.get('size') == st.st_size and prev.get('mtime_ns') == st.st_mtime_ns:
+                continue  # skip-clean: unchanged since the last successful sync/hydrate
+
+            digest = None
+            if prev and prev.get('size') == st.st_size:
+                # Ambiguous: same size, different mtime -- hash before
+                # deciding this is a genuine change rather than a touch.
+                digest = _sha256_file(local_path)
+                if digest == prev.get('sha256'):
+                    manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': digest}
+                    continue
+
+            try:
+                with open(local_path, 'rb') as f:
+                    data = f.read()
+            except OSError as err:
+                _append_workspace_warning(warnings, 'workspace sync: %s: %s' % (rel, err))
+                continue
+            if digest is None:
+                digest = hashlib.sha256(data).hexdigest()
+
+            try:
+                put_res = requests.put(_workspace_session_url(session_id) + '/' + rel, headers=_workspace_headers(),
+                                        data=data, timeout=WORKSPACE_REQUEST_TIMEOUT_SECONDS)
+                if not put_res.ok:
+                    _append_workspace_warning(warnings, 'workspace sync: %s: HTTP %d' % (rel, put_res.status_code))
+                    continue
+            except requests.RequestException as err:
+                _append_workspace_warning(warnings, 'workspace sync: %s: %s' % (rel, err))
+                continue
+            manifest[rel] = {'size': st.st_size, 'mtime_ns': st.st_mtime_ns, 'sha256': digest}
+
+    for rel in list(manifest):
+        if rel not in seen:
+            del manifest[rel]
+    return warnings
 
 
 class _OutputBuffer:
@@ -212,9 +506,13 @@ def _safe_scratch_name(session_id):
     # ($TMPDIR/exec/<segment>), so a value of "." resolves to $TMPDIR/exec
     # itself, ".." resolves to $TMPDIR itself, and anything containing "/"
     # (never possible through the dispatcher, but possible on the direct
-    # path above) can walk arbitrarily far outside $TMPDIR/exec -- all of
-    # which get shutil.rmtree'd at the start and end of every turn, wiping
-    # sibling sessions' scratch dirs or worse on a shared warm-pool pod.
+    # path above) can walk arbitrarily far outside $TMPDIR/exec -- a
+    # STATELESS scratch dir (this function returned a fresh fallback name
+    # rather than session_id itself) still gets shutil.rmtree'd at the start
+    # and end of every call; a SESSIONFUL one is no longer wiped at all (see
+    # main()), so an unguarded traversal there would instead silently and
+    # repeatedly hydrate/sync through a sibling session's or the pod's own
+    # unrelated directory on every future turn.
     # pkg/agentruntime/workspace.go's validateWorkspaceSegment applies the
     # same charset + "."/".." rejection for the same reason on the
     # platform's own workspace routes; mirrored here by falling back to a
@@ -249,8 +547,14 @@ def main():
     # straight to the router internal listener, bypassing the dispatcher --
     # or a bare direct invocation) is stateless exec: a fresh, uniquely-named
     # scratch dir per call rather than one keyed on a session that does not
-    # exist here.
+    # exist here. is_session additionally requires _safe_scratch_name to have
+    # returned session_id UNCHANGED -- its fallback branch means session_id
+    # failed validation (the direct-invocation path has no dispatcher
+    # enforcing sessionIDPattern upstream), and a scratch dir named after a
+    # fabricated fallback id is not a real session's workspace to hydrate
+    # from or sync to.
     scratch_name = _safe_scratch_name(session_id) if session_id else ('stateless-%s' % uuid.uuid4().hex)
+    is_session = bool(session_id) and scratch_name == session_id
     scratch_dir = os.path.join(tempfile.gettempdir(), 'exec', scratch_name)
 
     headers = {'Content-Type': 'application/json', YIELD_HEADER: 'waiting'}
@@ -269,8 +573,21 @@ def main():
 
     timeout_seconds = _clamp_timeout(payload.get('timeoutSeconds'))
 
-    shutil.rmtree(scratch_dir, ignore_errors=True)
-    os.makedirs(scratch_dir, exist_ok=True)
+    workspace_warnings = []
+    manifest = {}
+    if is_session:
+        # SESSIONFUL: the scratch dir is deliberately NOT wiped -- see the
+        # "Workspace hydration/sync" comment at the top of this file. It may
+        # already exist (a later turn on the same warm pod) or not (the
+        # session's very first turn, or a fresh pod after respecialize).
+        os.makedirs(scratch_dir, exist_ok=True)
+        manifest = _load_workspace_manifest(scratch_dir)
+        workspace_warnings += _hydrate_workspace(scratch_dir, session_id, manifest)
+    else:
+        # STATELESS: unchanged from PR-1 -- fresh scratch dir, best-effort
+        # removed after the call, no workspace involvement at all.
+        shutil.rmtree(scratch_dir, ignore_errors=True)
+        os.makedirs(scratch_dir, exist_ok=True)
 
     try:
         if has_code:
@@ -279,9 +596,14 @@ def main():
             argv = ['/bin/sh', '-c', payload['command']]
         stdout_text, stderr_text, exit_code, duration_ms, truncated = _run_exec(argv, scratch_dir, timeout_seconds)
     finally:
-        # Best-effort cleanup -- a leftover scratch dir is not worth failing
-        # the turn over.
-        shutil.rmtree(scratch_dir, ignore_errors=True)
+        if not is_session:
+            # Best-effort cleanup -- a leftover scratch dir is not worth
+            # failing the turn over.
+            shutil.rmtree(scratch_dir, ignore_errors=True)
+
+    if is_session:
+        workspace_warnings += _sync_workspace(scratch_dir, session_id, manifest)
+        _save_workspace_manifest(scratch_dir, manifest)
 
     reply = {
         'stdout': stdout_text,
@@ -289,5 +611,6 @@ def main():
         'exitCode': exit_code,
         'durationMs': duration_ms,
         'truncated': truncated,
+        'workspaceWarnings': workspace_warnings,
     }
     return json.dumps(reply), 200, headers

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -252,17 +252,22 @@ func TestRender_StateCredentialsFieldNames(t *testing.T) {
 // comments -- a scaffold that defaulted to "continue" would self-re-invoke
 // forever on a fresh install (constraints.md's "Yield story" ruling).
 //
-// The check below looks for the QUOTED form ('continue', single-quoted --
+// The check below looks for the QUOTED forms ('continue' and "continue" --
 // how both languages spell the yield VALUE everywhere it appears in these
 // templates, live or commented) rather than the bare word: PR-2's
 // hydrate/sync helper legitimately uses `continue` as Python's and JS's own
 // loop-control keyword throughout its walk/list loops, in ACTIVE code, and a
 // bare-word search would misidentify every one of those as this yield value
-// leaking into the active path.
+// leaking into the active path. Both quote forms are checked so a future
+// active-code yield spelled with double quotes doesn't slip past this the
+// way the bare-word check would have missed the loop keyword.
 func TestRender_YieldDefaultsToWaiting(t *testing.T) {
 	t.Parallel()
 
-	quotedContinue := "'" + agentruntime.YieldContinue + "'"
+	quotedContinueForms := []string{
+		"'" + agentruntime.YieldContinue + "'",
+		"\"" + agentruntime.YieldContinue + "\"",
+	}
 	for _, kind := range []string{"agent", "interpreter"} {
 		for _, lang := range []string{"node", "python"} {
 			t.Run(kind+"/"+lang, func(t *testing.T) {
@@ -276,13 +281,15 @@ func TestRender_YieldDefaultsToWaiting(t *testing.T) {
 					trimmed := strings.TrimSpace(line)
 					isCode := trimmed != "" && !strings.HasPrefix(trimmed, prefix)
 
-					if strings.Contains(line, quotedContinue) {
-						// The quoted yield VALUE must never appear in the
-						// ACTIVE code path (a scaffold that yielded it by
-						// default would self-re-invoke forever on a fresh
-						// install).
-						assert.False(t, isCode,
-							"%s/%s: %q value found outside a comment: %q", kind, lang, agentruntime.YieldContinue, line)
+					for _, quotedContinue := range quotedContinueForms {
+						if strings.Contains(line, quotedContinue) {
+							// The quoted yield VALUE must never appear in the
+							// ACTIVE code path (a scaffold that yielded it by
+							// default would self-re-invoke forever on a fresh
+							// install).
+							assert.False(t, isCode,
+								"%s/%s: %q value found outside a comment: %q", kind, lang, agentruntime.YieldContinue, line)
+						}
 					}
 					if isCode && strings.Contains(line, agentruntime.YieldWaiting) {
 						activeWaiting = true
@@ -759,20 +766,30 @@ func TestRender_Workspace_AdditiveOnly(t *testing.T) {
 	}
 }
 
-// TestRender_Workspace_SkipsSymlinks pins the review-motivated symlink guard
-// in the sync walk: a symlink written into the scratch dir must be SKIPPED,
-// not followed and uploaded -- see the trust-boundary comment at the top of
-// interpreter.{js,py}.tmpl for why (a link at a pod credential file would
-// otherwise get its target's bytes synced to a workspace this agent's
-// sibling sessions can read).
+// TestRender_Workspace_SkipsSymlinks pins the review-motivated symlink guards
+// on BOTH sides of the helper: the sync walk must SKIP a symlink written into
+// the scratch dir rather than follow and upload it, and hydrate must SKIP
+// writing through a local path that is already a symlink rather than follow
+// it and overwrite its TARGET with hydrated workspace bytes -- see the
+// trust-boundary comment at the top of interpreter.{js,py}.tmpl for why (a
+// link at a pod credential file would otherwise get its target's bytes
+// synced to, or overwritten from, a workspace this agent's sibling sessions
+// can read). The two sites use distinct mechanisms in each language, so each
+// gets its own assertion rather than one shared substring that either site
+// alone could satisfy.
 func TestRender_Workspace_SkipsSymlinks(t *testing.T) {
 	t.Parallel()
 	for _, kind := range []string{"agent", "interpreter"} {
 		out, _ := render(t, kind, "python")
-		assert.Contains(t, string(out), "os.path.islink(local_path)", "%s/python: sync walk must skip symlinks", kind)
+		text := string(out)
+		assert.Contains(t, text, "if os.path.islink(local_path):", "%s/python: sync walk must skip symlinks", kind)
+		assert.Contains(t, text, "os.path.islink(local_path) or (", "%s/python: hydrate must skip writing through a local symlink", kind)
 
 		out, _ = render(t, kind, "node")
-		assert.Contains(t, string(out), "entry.isSymbolicLink()", "%s/node: sync walk must skip symlinks", kind)
+		text = string(out)
+		assert.Contains(t, text, "entry.isSymbolicLink()", "%s/node: sync walk must skip symlinks", kind)
+		assert.Contains(t, text, "fs.lstatSync(localPath)", "%s/node: hydrate must lstat before writing to detect a local symlink", kind)
+		assert.Contains(t, text, "lst.isSymbolicLink()", "%s/node: hydrate must skip writing through a local symlink", kind)
 	}
 }
 

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -797,6 +797,28 @@ func TestRender_Workspace_SkipCleanUsesManifest(t *testing.T) {
 	}
 }
 
+// TestRender_Workspace_HydrateExcludesManifest pins a review-motivated fix:
+// the hydrate loop, like the sync walk (TestRender_Workspace_SkipCleanUsesManifest),
+// must never treat the manifest filename as an ordinary workspace artifact --
+// a same-named remote artifact would otherwise get downloaded over the local
+// manifest every turn and poison skip-clean decisions. Checked in both kinds
+// since the byte-identical helper block means a fix to one without the other
+// would itself be the regression this guards against.
+func TestRender_Workspace_HydrateExcludesManifest(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"agent", "interpreter"} {
+		out, _ := render(t, kind, "python")
+		assert.Contains(t, string(out),
+			"or rel in (WORKSPACE_MANIFEST_FILENAME, WORKSPACE_MANIFEST_FILENAME + '.tmp')",
+			"%s/python: hydrate loop must exclude the manifest filename by name", kind)
+
+		out, _ = render(t, kind, "node")
+		assert.Contains(t, string(out),
+			"rel === WORKSPACE_MANIFEST_FILENAME ||\n      rel === WORKSPACE_MANIFEST_FILENAME + '.tmp'",
+			"%s/node: hydrate loop must exclude the manifest filename by name", kind)
+	}
+}
+
 // TestRender_Interpreter_Workspace_WiredIntoTurn pins that the interpreter
 // template (unlike agent.*.tmpl's opt-in copy) actually CALLS the helper
 // from main()/module.exports for a sessionful turn, and gates it on

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -251,9 +251,18 @@ func TestRender_StateCredentialsFieldNames(t *testing.T) {
 // "waiting" and that YieldContinue's value ("continue") appears only inside
 // comments -- a scaffold that defaulted to "continue" would self-re-invoke
 // forever on a fresh install (constraints.md's "Yield story" ruling).
+//
+// The check below looks for the QUOTED form ('continue', single-quoted --
+// how both languages spell the yield VALUE everywhere it appears in these
+// templates, live or commented) rather than the bare word: PR-2's
+// hydrate/sync helper legitimately uses `continue` as Python's and JS's own
+// loop-control keyword throughout its walk/list loops, in ACTIVE code, and a
+// bare-word search would misidentify every one of those as this yield value
+// leaking into the active path.
 func TestRender_YieldDefaultsToWaiting(t *testing.T) {
 	t.Parallel()
 
+	quotedContinue := "'" + agentruntime.YieldContinue + "'"
 	for _, kind := range []string{"agent", "interpreter"} {
 		for _, lang := range []string{"node", "python"} {
 			t.Run(kind+"/"+lang, func(t *testing.T) {
@@ -267,10 +276,11 @@ func TestRender_YieldDefaultsToWaiting(t *testing.T) {
 					trimmed := strings.TrimSpace(line)
 					isCode := trimmed != "" && !strings.HasPrefix(trimmed, prefix)
 
-					if strings.Contains(line, agentruntime.YieldContinue) {
-						// "continue" must never appear in the ACTIVE code path
-						// (a scaffold that yielded it by default would
-						// self-re-invoke forever on a fresh install).
+					if strings.Contains(line, quotedContinue) {
+						// The quoted yield VALUE must never appear in the
+						// ACTIVE code path (a scaffold that yielded it by
+						// default would self-re-invoke forever on a fresh
+						// install).
 						assert.False(t, isCode,
 							"%s/%s: %q value found outside a comment: %q", kind, lang, agentruntime.YieldContinue, line)
 					}
@@ -548,4 +558,287 @@ func TestRender_Interpreter_PythonHandlesSpawnFailure(t *testing.T) {
 		"python: _run_exec must catch a failed Popen and answer the exec contract, not raise")
 	assert.Contains(t, string(out), "failed to start",
 		"python: a failed Popen should report the same 'failed to start' note the node template uses")
+}
+
+// --- workspace hydration/sync tripwires (PR-2, abstraction C) --------------
+//
+// Unlike the PR-1 exec-contract tripwires above (interpreter-only, since the
+// exec verb is interpreter-only), every test below loops over BOTH kinds:
+// interpreter.{js,py}.tmpl wire the hydrate/sync helper into the exec turn
+// automatically, and agent.{js,py}.tmpl carry the SAME helper block as an
+// opt-in call (doc 14's "workspaceSync in interpreter.*.tmpl + exported into
+// agent.*.tmpl" placement) -- a drift in either copy is a real regression.
+
+// workspaceHelperBlock extracts the text between this template's
+// BEGIN/END marker comments (see interpreter.{js,py}.tmpl and
+// agent.{js,py}.tmpl) so TestRender_Workspace_HelperBlockIdenticalAcrossKinds
+// can diff the two kinds' copies directly, and other tests below can scope
+// their assertions to the helper block alone rather than the whole file.
+func workspaceHelperBlock(t *testing.T, text, lang string) string {
+	t.Helper()
+	prefix := "#"
+	if lang == "node" {
+		prefix = "//"
+	}
+	begin := prefix + " --- Workspace hydration/sync (PR-2, abstraction C) "
+	end := prefix + " --- End workspace hydration/sync helper "
+	start := strings.Index(text, begin)
+	require.GreaterOrEqualf(t, start, 0, "%s: BEGIN marker for the workspace helper block not found", lang)
+	stop := strings.Index(text, end)
+	require.GreaterOrEqualf(t, stop, start, "%s: END marker for the workspace helper block not found after BEGIN", lang)
+	return text[start:stop]
+}
+
+// TestRender_Workspace_HelperBlockIdenticalAcrossKinds pins doc 14's PR-2
+// "Placement" requirement directly: agent.*.tmpl's opt-in copy of the
+// hydrate/sync helper must be BYTE-IDENTICAL to interpreter.*.tmpl's wired-in
+// copy, per language -- the strongest guard against the two silently
+// drifting apart (a fix applied to one kind's copy and forgotten in the
+// other).
+func TestRender_Workspace_HelperBlockIdenticalAcrossKinds(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		t.Run(lang, func(t *testing.T) {
+			t.Parallel()
+			interpOut, _ := render(t, "interpreter", lang)
+			agentOut, _ := render(t, "agent", lang)
+			interpBlock := workspaceHelperBlock(t, string(interpOut), lang)
+			agentBlock := workspaceHelperBlock(t, string(agentOut), lang)
+			assert.Equal(t, interpBlock, agentBlock,
+				"%s: the workspace hydrate/sync helper block must be byte-identical between interpreter.*.tmpl and agent.*.tmpl", lang)
+		})
+	}
+}
+
+// TestRender_Workspace_IdentityHeaderNames pins the hydrate/sync helper's
+// outbound auth headers against pkg/agentruntime/identity.go's EXPORTED
+// HeaderIdentityNamespace/HeaderIdentityName -- these are headers the
+// template SETS on its own outgoing hydrate/sync requests (like the state
+// helper's X-Fission-State-* headers, TestRender_StateHeaderNames), so they
+// are checked exact-case, no folding, in every kind x lang combination.
+func TestRender_Workspace_IdentityHeaderNames(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			t.Run(kind+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				out, _ := render(t, kind, lang)
+				text := string(out)
+				assert.Contains(t, text, agentruntime.HeaderIdentityNamespace,
+					"%s/%s: missing identity namespace claim header", kind, lang)
+				assert.Contains(t, text, agentruntime.HeaderIdentityName,
+					"%s/%s: missing identity name claim header", kind, lang)
+			})
+		}
+	}
+}
+
+// TestRender_Workspace_EnvVarNames pins the hydrate/sync helper against
+// pkg/executor/util.AgentAPIEnvVars's actual injected names
+// (FISSION_AGENT_RUNTIME_URL / FISSION_AGENT_TOKEN_PATH) rather than re-typed
+// literals -- same drift-guard shape as TestRender_StateEnvVarNames, against
+// the agent identity env vars instead of the state ones.
+func TestRender_Workspace_EnvVarNames(t *testing.T) {
+	t.Setenv("AGENT_RUNTIME_URL", "http://agentruntime.fission:8888")
+
+	envVars := util.AgentAPIEnvVars("/userfunc")
+	require.NotEmpty(t, envVars, "AGENT_RUNTIME_URL was set; AgentAPIEnvVars must not return nil")
+
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			out, _ := render(t, kind, lang)
+			text := string(out)
+			for _, ev := range envVars {
+				assert.Containsf(t, text, ev.Name, "%s/%s: missing agent identity env var %s", kind, lang, ev.Name)
+			}
+		}
+	}
+}
+
+// TestRender_Workspace_CredentialsFieldNames pins the hydrate/sync helper's
+// token-file field access against fetcher.AgentCredentials's actual JSON
+// tags (agenttoken.go) via reflection, rather than hand-typed "namespace" /
+// "agent" / "token" strings that could silently drift from the fetcher's
+// real wire struct -- mirrors TestRender_StateCredentialsFieldNames.
+func TestRender_Workspace_CredentialsFieldNames(t *testing.T) {
+	t.Parallel()
+
+	typ := reflect.TypeOf(fetcher.AgentCredentials{})
+	require.Positive(t, typ.NumField())
+
+	var fieldNames []string
+	for i := range typ.NumField() {
+		tag := typ.Field(i).Tag.Get("json")
+		require.NotEmpty(t, tag, "field %s has no json tag", typ.Field(i).Name)
+		name, _, _ := strings.Cut(tag, ",")
+		require.NotEmpty(t, name)
+		fieldNames = append(fieldNames, name)
+	}
+
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			out, _ := render(t, kind, lang)
+			text := string(out)
+			for _, name := range fieldNames {
+				assert.Containsf(t, text, name, "%s/%s: missing AgentCredentials field %q", kind, lang, name)
+			}
+		}
+	}
+}
+
+// TestRender_Workspace_RouteShape pins the hydrate/sync helper's URL
+// construction against the shipped route shape
+// (pkg/agentruntime/workspace.go's mountWorkspaceRoutes):
+// "/workspace/{namespace}/{name}/{session}" for LIST (no trailing slash --
+// the shipped route 400s a trailing-slash request by design) and
+// "/workspace/{namespace}/{name}/{session}/{path...}" for GET/PUT. This
+// contract has no shared Go struct on the template side ("the SDK for
+// scaffolded agents is the template" -- doc 14's PR-2 Placement note), so
+// the rendered text is the only place these literals live.
+func TestRender_Workspace_RouteShape(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			t.Run(kind+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				out, _ := render(t, kind, lang)
+				text := string(out)
+				assert.Contains(t, text, "/workspace/", "%s/%s: missing /workspace/ route segment", kind, lang)
+				// The LIST url-builder function must not itself append a
+				// trailing slash or a path segment -- it is reused, with
+				// "/" + rel appended by the CALLER, for GET/PUT.
+				if lang == "python" {
+					assert.Contains(t, text, "'%s/workspace/%s/%s/%s' % (\n        WORKSPACE_URL, _workspace_creds['namespace'], _workspace_creds['agent'], session_id)",
+						"python: LIST url-builder must build exactly /workspace/{ns}/{agent}/{session} with no trailing slash")
+				} else {
+					assert.Contains(t, text, "`${WORKSPACE_URL}/workspace/${workspaceCreds.namespace}/${workspaceCreds.agent}/${sessionID}`",
+						"node: LIST url-builder must build exactly /workspace/{ns}/{agent}/{session} with no trailing slash")
+				}
+			})
+		}
+	}
+}
+
+// TestRender_Workspace_WarningsKey pins the interpreter template's turn
+// reply wire key doc 14's PR-2 section calls for ("a failed sync is
+// reported in the turn result ... surfaces as a structured warning field")
+// -- unlike PR-1's exec-contract keys this has no shared struct either, so
+// the rendered text is the drift guard. agent.*.tmpl is NOT checked here:
+// its helper is opt-in and never wired into a reply of its own.
+func TestRender_Workspace_WarningsKey(t *testing.T) {
+	t.Parallel()
+	for _, lang := range []string{"node", "python"} {
+		out, _ := render(t, "interpreter", lang)
+		assert.Contains(t, string(out), "workspaceWarnings", "%s: missing workspaceWarnings reply key", lang)
+	}
+}
+
+// TestRender_Workspace_AdditiveOnly pins doc 14's "delete-on-absence off by
+// default (workspace is additive; explicit DELETE stays an app call)" rule:
+// neither kind's helper block may issue an HTTP DELETE against the workspace
+// routes. Scoped to the helper block (not the whole file) so a comment that
+// merely MENTIONS "DELETE" in prose (as this block's own doc comment does)
+// cannot false-negative the check by coincidence elsewhere in the file.
+func TestRender_Workspace_AdditiveOnly(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"agent", "interpreter"} {
+		for _, lang := range []string{"node", "python"} {
+			t.Run(kind+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				out, _ := render(t, kind, lang)
+				block := workspaceHelperBlock(t, string(out), lang)
+				if lang == "python" {
+					assert.NotContains(t, block, "requests.delete(",
+						"%s/%s: workspace helper must never issue a DELETE (sync is additive-only)", kind, lang)
+				} else {
+					assert.NotContains(t, block, "method: 'DELETE'",
+						"%s/%s: workspace helper must never issue a DELETE (sync is additive-only)", kind, lang)
+				}
+			})
+		}
+	}
+}
+
+// TestRender_Workspace_SkipsSymlinks pins the review-motivated symlink guard
+// in the sync walk: a symlink written into the scratch dir must be SKIPPED,
+// not followed and uploaded -- see the trust-boundary comment at the top of
+// interpreter.{js,py}.tmpl for why (a link at a pod credential file would
+// otherwise get its target's bytes synced to a workspace this agent's
+// sibling sessions can read).
+func TestRender_Workspace_SkipsSymlinks(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"agent", "interpreter"} {
+		out, _ := render(t, kind, "python")
+		assert.Contains(t, string(out), "os.path.islink(local_path)", "%s/python: sync walk must skip symlinks", kind)
+
+		out, _ = render(t, kind, "node")
+		assert.Contains(t, string(out), "entry.isSymbolicLink()", "%s/node: sync walk must skip symlinks", kind)
+	}
+}
+
+// TestRender_Workspace_SkipCleanUsesManifest pins the "hash manifest kept in
+// the scratch dir; second turn on the same warm pod re-syncs nothing when
+// nothing changed" requirement: the sync walk must compare against a
+// previously recorded manifest entry (size+mtime) before ever falling back
+// to a content hash, and the manifest file itself must never be a candidate
+// for sync (excluded by name).
+func TestRender_Workspace_SkipCleanUsesManifest(t *testing.T) {
+	t.Parallel()
+	for _, kind := range []string{"agent", "interpreter"} {
+		out, _ := render(t, kind, "python")
+		text := string(out)
+		assert.Contains(t, text, "WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json'", "%s/python: manifest filename constant missing", kind)
+		assert.Contains(t, text, "skip-clean: unchanged since the last successful sync/hydrate", "%s/python: skip-clean short-circuit missing", kind)
+
+		out, _ = render(t, kind, "node")
+		text = string(out)
+		assert.Contains(t, text, "WORKSPACE_MANIFEST_FILENAME = '.fission-workspace-manifest.json'", "%s/node: manifest filename constant missing", kind)
+		assert.Contains(t, text, "skip-clean: unchanged since the last successful sync/hydrate", "%s/node: skip-clean short-circuit missing", kind)
+	}
+}
+
+// TestRender_Interpreter_Workspace_WiredIntoTurn pins that the interpreter
+// template (unlike agent.*.tmpl's opt-in copy) actually CALLS the helper
+// from main()/module.exports for a sessionful turn, and gates it on
+// is_session -- a stateless call (no session header, or one that failed
+// _safe_scratch_name's own charset check) must never hydrate/sync.
+func TestRender_Interpreter_Workspace_WiredIntoTurn(t *testing.T) {
+	t.Parallel()
+
+	// Call-site literals (not the helper functions' own `def`/`function`
+	// signature lines, which are present in BOTH kinds by design -- see
+	// TestRender_Workspace_HelperBlockIdenticalAcrossKinds) that only a
+	// wired-in caller, not merely a definition, would produce.
+	pyHydrateCall := "workspace_warnings += _hydrate_workspace(scratch_dir, session_id, manifest)"
+	pySyncCall := "workspace_warnings += _sync_workspace(scratch_dir, session_id, manifest)"
+	jsHydrateCall := "workspaceWarnings.concat(await hydrateWorkspace(scratchDir, sessionID, manifest))"
+	jsSyncCall := "workspaceWarnings.concat(await syncWorkspace(scratchDir, sessionID, manifest))"
+
+	pyOut, _ := render(t, "interpreter", "python")
+	pyText := string(pyOut)
+	assert.Contains(t, pyText, "is_session = bool(session_id) and scratch_name == session_id",
+		"python: main() must gate hydrate/sync on a validated session id")
+	assert.Contains(t, pyText, pyHydrateCall, "python: main() must call _hydrate_workspace at turn start")
+	assert.Contains(t, pyText, pySyncCall, "python: main() must call _sync_workspace at turn end")
+
+	jsOut, _ := render(t, "interpreter", "node")
+	jsText := string(jsOut)
+	assert.Contains(t, jsText, "const isSession = Boolean(sessionID) && scratchName === sessionID;",
+		"node: module.exports must gate hydrate/sync on a validated session id")
+	assert.Contains(t, jsText, jsHydrateCall, "node: module.exports must call hydrateWorkspace at turn start")
+	assert.Contains(t, jsText, jsSyncCall, "node: module.exports must call syncWorkspace at turn end")
+
+	// And the agent.*.tmpl copy must NOT be wired into anything -- it is
+	// opt-in only (doc 14's PR-2 Placement note): the helper function
+	// DEFINITIONS are present (asserted identical above), but no CALL site
+	// invoking them from module-level code should be.
+	agentPyOut, _ := render(t, "agent", "python")
+	agentPyText := string(agentPyOut)
+	assert.NotContains(t, agentPyText, pyHydrateCall, "python: agent.py.tmpl must not call the helper itself -- it is opt-in")
+	assert.NotContains(t, agentPyText, pySyncCall, "python: agent.py.tmpl must not call the helper itself -- it is opt-in")
+
+	agentJsOut, _ := render(t, "agent", "node")
+	agentJsText := string(agentJsOut)
+	assert.NotContains(t, agentJsText, jsHydrateCall, "node: agent.js.tmpl must not call the helper itself -- it is opt-in")
+	assert.NotContains(t, agentJsText, jsSyncCall, "node: agent.js.tmpl must not call the helper itself -- it is opt-in")
 }

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -686,7 +686,7 @@ func TestRender_Workspace_CredentialsFieldNames(t *testing.T) {
 	}
 }
 
-// TestRender_Workspace_RouteShape pins the hydrate/sync helper's URL
+// TestRender_Workspace_ListURLNoTrailingSlash pins the hydrate/sync helper's URL
 // construction against the shipped route shape
 // (pkg/agentruntime/workspace.go's mountWorkspaceRoutes):
 // "/workspace/{namespace}/{name}/{session}" for LIST (no trailing slash --
@@ -695,7 +695,7 @@ func TestRender_Workspace_CredentialsFieldNames(t *testing.T) {
 // contract has no shared Go struct on the template side ("the SDK for
 // scaffolded agents is the template" -- doc 14's PR-2 Placement note), so
 // the rendered text is the only place these literals live.
-func TestRender_Workspace_RouteShape(t *testing.T) {
+func TestRender_Workspace_ListURLNoTrailingSlash(t *testing.T) {
 	t.Parallel()
 	for _, kind := range []string{"agent", "interpreter"} {
 		for _, lang := range []string{"node", "python"} {

--- a/pkg/fission-cli/cmd/agent/templates/templates_test.go
+++ b/pkg/fission-cli/cmd/agent/templates/templates_test.go
@@ -573,8 +573,8 @@ func TestRender_Interpreter_PythonHandlesSpawnFailure(t *testing.T) {
 // exec verb is interpreter-only), every test below loops over BOTH kinds:
 // interpreter.{js,py}.tmpl wire the hydrate/sync helper into the exec turn
 // automatically, and agent.{js,py}.tmpl carry the SAME helper block as an
-// opt-in call (doc 14's "workspaceSync in interpreter.*.tmpl + exported into
-// agent.*.tmpl" placement) -- a drift in either copy is a real regression.
+// opt-in call (the "workspaceSync in interpreter.*.tmpl, exported into
+// agent.*.tmpl as an opt-in call" placement rule) -- a drift in either copy is a real regression.
 
 // workspaceHelperBlock extracts the text between this template's
 // BEGIN/END marker comments (see interpreter.{js,py}.tmpl and
@@ -596,8 +596,8 @@ func workspaceHelperBlock(t *testing.T, text, lang string) string {
 	return text[start:stop]
 }
 
-// TestRender_Workspace_HelperBlockIdenticalAcrossKinds pins doc 14's PR-2
-// "Placement" requirement directly: agent.*.tmpl's opt-in copy of the
+// TestRender_Workspace_HelperBlockIdenticalAcrossKinds pins the helper's placement
+// rule directly: agent.*.tmpl's opt-in copy of the
 // hydrate/sync helper must be BYTE-IDENTICAL to interpreter.*.tmpl's wired-in
 // copy, per language -- the strongest guard against the two silently
 // drifting apart (a fix applied to one kind's copy and forgotten in the
@@ -700,7 +700,7 @@ func TestRender_Workspace_CredentialsFieldNames(t *testing.T) {
 // the shipped route 400s a trailing-slash request by design) and
 // "/workspace/{namespace}/{name}/{session}/{path...}" for GET/PUT. This
 // contract has no shared Go struct on the template side ("the SDK for
-// scaffolded agents is the template" -- doc 14's PR-2 Placement note), so
+// scaffolded agents IS the template"), so
 // the rendered text is the only place these literals live.
 func TestRender_Workspace_ListURLNoTrailingSlash(t *testing.T) {
 	t.Parallel()
@@ -727,7 +727,7 @@ func TestRender_Workspace_ListURLNoTrailingSlash(t *testing.T) {
 }
 
 // TestRender_Workspace_WarningsKey pins the interpreter template's turn
-// reply wire key doc 14's PR-2 section calls for ("a failed sync is
+// reply wire key the hydration contract calls for ("a failed sync is
 // reported in the turn result ... surfaces as a structured warning field")
 // -- unlike PR-1's exec-contract keys this has no shared struct either, so
 // the rendered text is the drift guard. agent.*.tmpl is NOT checked here:
@@ -740,7 +740,7 @@ func TestRender_Workspace_WarningsKey(t *testing.T) {
 	}
 }
 
-// TestRender_Workspace_AdditiveOnly pins doc 14's "delete-on-absence off by
+// TestRender_Workspace_AdditiveOnly pins the "delete-on-absence off by
 // default (workspace is additive; explicit DELETE stays an app call)" rule:
 // neither kind's helper block may issue an HTTP DELETE against the workspace
 // routes. Scoped to the helper block (not the whole file) so a comment that
@@ -868,7 +868,7 @@ func TestRender_Interpreter_Workspace_WiredIntoTurn(t *testing.T) {
 	assert.Contains(t, jsText, jsSyncCall, "node: module.exports must call syncWorkspace at turn end")
 
 	// And the agent.*.tmpl copy must NOT be wired into anything -- it is
-	// opt-in only (doc 14's PR-2 Placement note): the helper function
+	// opt-in only (the placement rule above): the helper function
 	// DEFINITIONS are present (asserted identical above), but no CALL site
 	// invoking them from module-level code should be.
 	agentPyOut, _ := render(t, "agent", "python")

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -9,7 +9,10 @@ package common_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"strconv"
@@ -19,6 +22,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/fission/fission/pkg/agentruntime"
 	"github.com/fission/fission/test/integration/framework"
@@ -26,15 +30,27 @@ import (
 
 // execTurnReply is the exec verb's response contract:
 // {"stdout": "...", "stderr": "...", "exitCode": 0, "durationMs": 12,
-// "truncated": false}. This has no shared Go struct on either side ("zero
-// new platform Go" is the point of a template-only exec verb) -- it exists
-// only to decode the wire response in this test.
+// "truncated": false}, extended by doc 14's PR-2 section with
+// workspaceWarnings (the hydrate/sync helper's failure-reporting field).
+// This has no shared Go struct on either side ("zero new platform Go" is the
+// point of a template-only exec verb) -- it exists only to decode the wire
+// response in this test.
 type execTurnReply struct {
-	Stdout     string `json:"stdout"`
-	Stderr     string `json:"stderr"`
-	ExitCode   int    `json:"exitCode"`
-	DurationMs int64  `json:"durationMs"`
-	Truncated  bool   `json:"truncated"`
+	Stdout            string   `json:"stdout"`
+	Stderr            string   `json:"stderr"`
+	ExitCode          int      `json:"exitCode"`
+	DurationMs        int64    `json:"durationMs"`
+	Truncated         bool     `json:"truncated"`
+	WorkspaceWarnings []string `json:"workspaceWarnings"`
+}
+
+// sha256Hex is the "hashes equal" check doc 14's PR-2 acceptance criterion
+// asks for verbatim ("the doc-13 mcp-server-sandbox persistence demo pattern
+// (write -> suspend-equivalent -> read back, hashes equal) passes on
+// Fission").
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
 }
 
 // postExecTurn POSTs one turn carrying an arbitrary JSON payload (the exec
@@ -200,4 +216,199 @@ func TestAgentExec(t *testing.T) {
 			assert.Falsef(t, strings.HasPrefix(k, "FISSION_"), "exec'd subprocess env must never carry a FISSION_ var, found %q", k)
 		}
 	})
+}
+
+// hostnameContent is the turn payload both halves of
+// TestAgentExecWorkspaceHydration decode from stdout: the exec'd code's own
+// os.hostname() (never the pod's HOSTNAME env var, which ALLOWED_ENV_VARS
+// deliberately excludes -- see interpreter.js.tmpl's trust-boundary comment)
+// plus, on turn 2 only, the file content read back.
+type hostnameContent struct {
+	Hostname string `json:"hostname"`
+	Content  string `json:"content"`
+}
+
+// TestAgentExecWorkspaceHydration exercises the PR-2 (abstraction C)
+// hydrate/sync helper end to end: a file an exec turn writes into its
+// scratch dir must survive the specialized pod being killed and a
+// respecialize onto a DIFFERENT pod, because it was synced to the session's
+// G12 workspace at turn 1's end and hydrated back down at turn 2's start --
+// doc 14's PR-2 acceptance criterion (the doc-13 mcp-server-sandbox
+// persistence demo pattern: write -> suspend-equivalent -> read back, hashes
+// equal).
+//
+// The discriminating assertion is NOT merely "turn 2 reads the file" --
+// os.hostname() must differ between the two turns, proving turn 2 actually
+// ran on a new pod with no local disk continuity from turn 1, rather than a
+// lingering Terminating pod quietly serving the request and passing this
+// test for the wrong reason.
+func TestAgentExecWorkspaceHydration(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	f := framework.Connect(t)
+	image := f.Images().RequireNode(t)
+
+	requireAgentRuntimeReachable(t, ctx, f)
+
+	ns := f.NewTestNamespace(t)
+	envName := "agent-workspace-hydrate-node-" + ns.ID
+	fnName := "agent-workspace-hydrate-" + ns.ID
+
+	ns.CreateEnv(t, ctx, framework.EnvOptions{Name: envName, Image: image})
+
+	workdir := t.TempDir()
+	ns.WithCWD(t, workdir, func() {
+		ns.CLI(t, ctx, "spec", "init")
+		ns.CLI(t, ctx, "agent", "create", "--name", fnName, "--env", envName, "--template", "interpreter", "--spec")
+		ns.CLI(t, ctx, "spec", "apply")
+	})
+
+	base := f.AgentRuntimeBaseURL()
+	turnURL := base + "/agents/" + ns.Name + "/" + fnName
+
+	// Auth-posture probe -- same three-outcome rationale as
+	// TestAgentRuntimeWorkspace's own probe (401 authz-enabled / 503
+	// workspace disabled via STORAGESVC_URL unset / 404 pass-through). Run
+	// BEFORE dispatching any turn: on a hand-managed install that doesn't
+	// wire STORAGESVC_URL, hydrate/sync degrade gracefully turn-side (no
+	// warnings surfaced as failures, just a no-op), so skipping here rather
+	// than discovering it later as a confusing hostname-never-changed
+	// failure is the honest signal.
+	probeSessionID := "exec-workspace-posture-probe-" + ns.ID
+	probeURL := base + "/workspace/" + ns.Name + "/" + fnName + "/" + probeSessionID
+	probeReq, err := http.NewRequestWithContext(ctx, http.MethodGet, probeURL, nil)
+	require.NoErrorf(t, err, "building auth-posture probe request")
+	probeResp, err := f.HTTPClient().Do(probeReq)
+	require.NoErrorf(t, err, "GET %s (auth-posture probe)", probeURL)
+	_ = probeResp.Body.Close()
+	switch probeResp.StatusCode {
+	case http.StatusUnauthorized:
+		t.Skipf("agent runtime on this cluster requires a JWT (authz enabled) and this test framework has no "+
+			"way to mint or sign one, so it cannot dispatch even the first turn here (GET %s got 401); skipping", probeURL)
+	case http.StatusServiceUnavailable:
+		t.Skipf("agent runtime's session workspace routes are disabled on this cluster (STORAGESVC_URL unset, "+
+			"GET %s got 503); skipping", probeURL)
+	case http.StatusNotFound:
+		// Pass-through posture: proceed.
+	default:
+		t.Fatalf("auth-posture probe GET %s: want 401 (authz enabled), 404 (pass-through), or 503 "+
+			"(workspace disabled), got %d", probeURL, probeResp.StatusCode)
+	}
+
+	const fileContent = "hydration-proof-payload"
+
+	// Turn 1: write a file under a subdirectory (notes/summary.txt, not the
+	// scratch dir root) and report which pod ran it. No session header --
+	// mints the session, mirroring TestAgentExec's own first turn.
+	writeCode := fmt.Sprintf(`
+const fs = require('fs');
+const os = require('os');
+fs.mkdirSync('notes', { recursive: true });
+fs.writeFileSync('notes/summary.txt', %q);
+console.log(JSON.stringify({ hostname: os.hostname() }));
+`, fileContent)
+	writePayload, err := json.Marshal(map[string]any{"code": writeCode})
+	require.NoError(t, err)
+
+	writeReply, sessionID := dispatchExecTurn(t, ctx, f, turnURL, "", writePayload)
+	require.NotEmpty(t, sessionID, "scaffolded interpreter never minted a session id")
+	require.Equalf(t, 0, writeReply.ExitCode, "turn 1 exec failed: stderr=%s", writeReply.Stderr)
+	assert.Emptyf(t, writeReply.WorkspaceWarnings, "turn 1's sync must not warn: %v", writeReply.WorkspaceWarnings)
+
+	var before hostnameContent
+	require.NoErrorf(t, json.Unmarshal([]byte(writeReply.Stdout), &before), "decoding turn 1 stdout %q", writeReply.Stdout)
+	require.NotEmpty(t, before.Hostname, "turn 1 did not report a hostname")
+
+	// Kill the specialized pod. This is what makes the next turn's pod
+	// GENUINELY new: poolmgr respecializes a fresh pod, with an empty
+	// $TMPDIR/exec/<session> -- the only way turn 2 can read
+	// notes/summary.txt back is if it was hydrated down from the session
+	// workspace turn 1 synced it to.
+	podsBefore, err := ns.SpecializedFunctionPods(ctx, fnName)
+	require.NoError(t, err)
+	require.NotEmptyf(t, podsBefore, "turn 1 must have specialized a pod for %q", fnName)
+	killedName, killedUID := podsBefore[0].Name, podsBefore[0].UID
+	require.NoErrorf(t, f.KubeClient().CoreV1().Pods(ns.Name).Delete(ctx, killedName, metav1.DeleteOptions{}),
+		"delete specialized pod %q", killedName)
+
+	// Wait for the killed pod's UID to actually be gone before dispatching
+	// turn 2 -- a still-Terminating pod could otherwise serve turn 2 and
+	// mask a hydration bug behind a false "different hostname never even
+	// got exercised" pass.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cur, lerr := ns.SpecializedFunctionPods(ctx, fnName)
+		if !assert.NoError(c, lerr) {
+			return
+		}
+		for _, p := range cur {
+			assert.NotEqualf(c, killedUID, p.UID, "killed pod %q must be fully gone before turn 2", killedName)
+		}
+	}, 2*time.Minute, 2*time.Second)
+
+	// Turn 2, same session: read the file back and report which pod ran it.
+	// Re-issuing the WHOLE turn on every retry (not polling a read-only
+	// endpoint) mirrors TestAgentRuntimeWorkspace's own artifact-turn loop --
+	// the respecialize + hydrate window can need more than one attempt.
+	readCode := `
+const fs = require('fs');
+const os = require('os');
+let data;
+try {
+  data = fs.readFileSync('notes/summary.txt', 'utf8');
+} catch (err) {
+  data = 'MISSING: ' + err.message;
+}
+console.log(JSON.stringify({ hostname: os.hostname(), content: data }));
+`
+	readPayload, err := json.Marshal(map[string]any{"code": readCode})
+	require.NoError(t, err)
+
+	var after hostnameContent
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		attemptCtx, cancel := context.WithTimeout(ctx, turnAttemptTimeout)
+		defer cancel()
+		resp, err := postExecTurn(attemptCtx, f, turnURL, sessionID, readPayload)
+		if !assert.NoErrorf(c, err, "POST %s (turn 2)", turnURL) {
+			return
+		}
+		defer resp.Body.Close()
+		if !assert.Equalf(c, http.StatusOK, resp.StatusCode, "turn 2 to %s", turnURL) {
+			return
+		}
+		body, err := io.ReadAll(resp.Body)
+		if !assert.NoErrorf(c, err, "reading turn 2 response body") {
+			return
+		}
+		var reply execTurnReply
+		if !assert.NoErrorf(c, json.Unmarshal(body, &reply), "decoding turn 2 reply %q", body) {
+			return
+		}
+		if !assert.Equalf(c, 0, reply.ExitCode, "turn 2 exec failed: stderr=%s", reply.Stderr) {
+			return
+		}
+		var info hostnameContent
+		if !assert.NoErrorf(c, json.Unmarshal([]byte(reply.Stdout), &info), "decoding turn 2 stdout %q", reply.Stdout) {
+			return
+		}
+		// The discriminating assertion: a genuinely NEW pod (different
+		// hostname) that still reads back the ORIGINAL content proves
+		// hydration ran -- not merely that some pod happened to still have
+		// the file on local disk.
+		if !assert.NotEqualf(c, before.Hostname, info.Hostname,
+			"turn 2 must run on a DIFFERENT pod than turn 1 (both report hostname %q)", info.Hostname) {
+			return
+		}
+		if !assert.Equalf(c, fileContent, info.Content, "hydrated file content mismatch (got %q)", info.Content) {
+			return
+		}
+		after = info
+	}, 3*time.Minute, 2*time.Second)
+	require.NotEmpty(t, after.Hostname, "turn 2 never succeeded on a different pod")
+
+	// doc 14's PR-2 acceptance criterion, verbatim: "hashes equal".
+	assert.Equal(t, sha256Hex(fileContent), sha256Hex(after.Content),
+		"hydrated content's sha256 must match what turn 1 wrote")
 }

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/fission/fission/pkg/agentruntime"
 	"github.com/fission/fission/test/integration/framework"
@@ -322,29 +323,39 @@ console.log(JSON.stringify({ hostname: os.hostname() }));
 	require.NoErrorf(t, json.Unmarshal([]byte(writeReply.Stdout), &before), "decoding turn 1 stdout %q", writeReply.Stdout)
 	require.NotEmpty(t, before.Hostname, "turn 1 did not report a hostname")
 
-	// Kill the specialized pod. This is what makes the next turn's pod
-	// GENUINELY new: poolmgr respecializes a fresh pod, with an empty
-	// $TMPDIR/exec/<session> -- the only way turn 2 can read
-	// notes/summary.txt back is if it was hydrated down from the session
-	// workspace turn 1 synced it to.
+	// Kill EVERY specialized pod, not just the first listed -- a racing
+	// router retry can leave more than one specialized pod for this
+	// function (the same caveat pool_warm_survival_test.go and
+	// provisioned_concurrency_test.go both document), and turn 1's actual
+	// reply could have come from any of them. Deleting only one risks
+	// killing the wrong pod, leaving turn 2 free to land on the SAME
+	// survivor and report the SAME hostname -- a false negative that looks
+	// like a hydration bug but is really a pod-selection bug in the test.
+	// This is what makes the next turn's pod GENUINELY new: poolmgr
+	// respecializes a fresh pod, with an empty $TMPDIR/exec/<session> -- the
+	// only way turn 2 can read notes/summary.txt back is if it was hydrated
+	// down from the session workspace turn 1 synced it to.
 	podsBefore, err := ns.SpecializedFunctionPods(ctx, fnName)
 	require.NoError(t, err)
 	require.NotEmptyf(t, podsBefore, "turn 1 must have specialized a pod for %q", fnName)
-	killedName, killedUID := podsBefore[0].Name, podsBefore[0].UID
-	require.NoErrorf(t, f.KubeClient().CoreV1().Pods(ns.Name).Delete(ctx, killedName, metav1.DeleteOptions{}),
-		"delete specialized pod %q", killedName)
+	killedUIDs := make(map[types.UID]bool, len(podsBefore))
+	for _, p := range podsBefore {
+		killedUIDs[p.UID] = true
+		require.NoErrorf(t, f.KubeClient().CoreV1().Pods(ns.Name).Delete(ctx, p.Name, metav1.DeleteOptions{}),
+			"delete specialized pod %q", p.Name)
+	}
 
-	// Wait for the killed pod's UID to actually be gone before dispatching
-	// turn 2 -- a still-Terminating pod could otherwise serve turn 2 and
-	// mask a hydration bug behind a false "different hostname never even
-	// got exercised" pass.
+	// Wait for every killed UID to actually be gone before dispatching turn
+	// 2 -- a still-Terminating pod could otherwise serve turn 2 and mask a
+	// hydration bug behind a false "different hostname never even got
+	// exercised" pass.
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		cur, lerr := ns.SpecializedFunctionPods(ctx, fnName)
 		if !assert.NoError(c, lerr) {
 			return
 		}
 		for _, p := range cur {
-			assert.NotEqualf(c, killedUID, p.UID, "killed pod %q must be fully gone before turn 2", killedName)
+			assert.Falsef(c, killedUIDs[p.UID], "killed pod %q (uid %s) must be fully gone before turn 2", p.Name, p.UID)
 		}
 	}, 2*time.Minute, 2*time.Second)
 

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -419,7 +419,12 @@ console.log(JSON.stringify({ hostname: os.hostname(), content: data }));
 	}, 3*time.Minute, 2*time.Second)
 	require.NotEmpty(t, after.Hostname, "turn 2 never succeeded on a different pod")
 
-	// doc 14's PR-2 acceptance criterion, verbatim: "hashes equal".
+	// doc 14's PR-2 acceptance criterion, verbatim: "hashes equal". This is
+	// documentation, not an independent check -- the Equalf on fileContent
+	// vs info.Content inside the EventuallyWithT loop above already requires
+	// byte-for-byte equality, so these hashes can never differ once this
+	// line is reached; it exists to make the assertion read the same way
+	// the spec states it.
 	assert.Equal(t, sha256Hex(fileContent), sha256Hex(after.Content),
 		"hydrated content's sha256 must match what turn 1 wrote")
 }

--- a/test/integration/suites/common/agent_exec_test.go
+++ b/test/integration/suites/common/agent_exec_test.go
@@ -31,7 +31,7 @@ import (
 
 // execTurnReply is the exec verb's response contract:
 // {"stdout": "...", "stderr": "...", "exitCode": 0, "durationMs": 12,
-// "truncated": false}, extended by doc 14's PR-2 section with
+// "truncated": false}, extended by the hydration helper with
 // workspaceWarnings (the hydrate/sync helper's failure-reporting field).
 // This has no shared Go struct on either side ("zero new platform Go" is the
 // point of a template-only exec verb) -- it exists only to decode the wire
@@ -45,9 +45,9 @@ type execTurnReply struct {
 	WorkspaceWarnings []string `json:"workspaceWarnings"`
 }
 
-// sha256Hex is the "hashes equal" check doc 14's PR-2 acceptance criterion
-// asks for verbatim ("the doc-13 mcp-server-sandbox persistence demo pattern
-// (write -> suspend-equivalent -> read back, hashes equal) passes on
+// sha256Hex is the "hashes equal" check the hydration acceptance
+// criterion asks for (the mcp-server-sandbox persistence demo pattern:
+// write -> suspend-equivalent -> read back, hashes equal, running on
 // Fission").
 func sha256Hex(s string) string {
 	sum := sha256.Sum256([]byte(s))
@@ -234,9 +234,8 @@ type hostnameContent struct {
 // scratch dir must survive the specialized pod being killed and a
 // respecialize onto a DIFFERENT pod, because it was synced to the session's
 // G12 workspace at turn 1's end and hydrated back down at turn 2's start --
-// doc 14's PR-2 acceptance criterion (the doc-13 mcp-server-sandbox
-// persistence demo pattern: write -> suspend-equivalent -> read back, hashes
-// equal).
+// the hydration acceptance criterion (the mcp-server-sandbox persistence
+// demo pattern: write -> suspend-equivalent -> read back, hashes equal).
 //
 // The discriminating assertion is NOT merely "turn 2 reads the file" --
 // os.hostname() must differ between the two turns, proving turn 2 actually
@@ -419,7 +418,7 @@ console.log(JSON.stringify({ hostname: os.hostname(), content: data }));
 	}, 3*time.Minute, 2*time.Second)
 	require.NotEmpty(t, after.Hostname, "turn 2 never succeeded on a different pod")
 
-	// doc 14's PR-2 acceptance criterion, verbatim: "hashes equal". This is
+	// The acceptance criterion, verbatim: "hashes equal". This is
 	// documentation, not an independent check -- the Equalf on fileContent
 	// vs info.Content inside the EventuallyWithT loop above already requires
 	// byte-for-byte equality, so these hashes can never differ once this


### PR DESCRIPTION
## What

Stacked on #3711. The scaffolded templates gain a hydrate/sync helper against the session artifact workspace: at turn start the exec scratch dir is lazily hydrated from the session's workspace (one LIST, downloads only for missing/size-mismatched files); at turn end new/changed files are PUT back (size+mtime compare, content hash only on ambiguity, manifest-keyed so a warm pod re-syncs nothing unchanged). Template/SDK-side only — no new platform Go, no new AgentConfig fields.

This is what makes a file exec'd code writes survive a pod respecialize: pod-local scratch dies with the pod; the workspace copy rehydrates onto whichever pod serves the next turn.

## Semantics

- Additive-only: local deletion never DELETEs from the workspace (explicit app call stays the delete path) — a tripwire asserts no DELETE in the helper block.
- Failures are never silent: hydrate/sync errors and quota 413s land in a capped `workspaceWarnings` reply field.
- Auth: the pod's agent-identity credential — bearer token plus both claim headers — pinned by tripwires against the platform constants.
- Sync walk skips symlinks (a planted symlink at the pod's token file would otherwise upload its target's bytes); hydrate writes are guarded the same way.
- The helper block is byte-identical between interpreter.*.tmpl (wired in) and agent.*.tmpl (exported, opt-in call only) — asserted by test.

## Security note

The identity token's boundary is per-(namespace, agent): a session can read sibling-session artifacts of the same agent. Hydration is per-session by convention, not enforcement; per-session tokens remain a tracked follow-up.

## Tests

Tripwires for route shape (list URL has no trailing slash — the shipped route 400s one), identity header names, warnings key, additive-only, helper-block identity, opt-in-only wiring. Integration: write via exec → kill every specialized pod → next turn on a different pod reads identical content (hash-equal) — first live run in CI.

## Notes for reviewers

- Sessionful scratch dirs are no longer wiped between turns by design (skip-clean needs the manifest); a warm pod accumulates scratch dirs until it dies — follow-up: idle-scratch reaper.
- When `FISSION_AGENT_RUNTIME_URL` is unset (workspace feature not deployed) the helper degrades to no-remote-backing; scratch still persists for the pod's lifetime.