### PR TITLE
chart: per-environment egress NetworkPolicy knob

### DIFF
--- a/charts/fission-all/templates/executor/networkpolicy-environment-egress.yaml
+++ b/charts/fission-all/templates/executor/networkpolicy-environment-egress.yaml
@@ -21,11 +21,21 @@
 # environmentNetworkPolicy.allowClusterDNS=false drops that rule for a
 # stricter numeric-IP-only posture.
 #
-# Rendered into the namespace where executor creates function pods
-# (`fission-function-ns` helper), same as functionpods-allow-internal
-# above — NetworkPolicy podSelector only matches pods in the policy's own
-# namespace, so rendering this in the release namespace would make it a
-# no-op when functionNamespace differs.
+# NetworkPolicy podSelector only matches pods in the policy's own
+# namespace, so a single copy in `fission-function-ns` would silently
+# no-op for function pods living in any other namespace. This renders
+# one copy per namespace in the STATIC-tenancy function-namespace set —
+# same range this chart already does in router/role-dataplane.yaml, and
+# mirroring pkg/utils NamespaceResolver.FunctionNamespaces: functionNamespace
+# (or defaultNamespace when unset) plus every additionalFissionNamespaces
+# entry. Rendering into the release namespace would also be a no-op
+# whenever functionNamespace/defaultNamespace differs from it.
+#
+# LIMITATION — dynamic/cluster tenancy: namespaces onboarded at runtime by
+# the tenant controller (tenancy.mode: dynamic|cluster) are not listed in
+# additionalFissionNamespaces and so are unknown at chart render time.
+# This knob does NOT enforce egress isolation for function pods in those
+# namespaces — see the environmentNetworkPolicy comment in values.yaml.
 #
 # WARNING: the RFC1918 deny-list also blocks in-cluster control-plane
 # traffic (pod/Service CIDRs are themselves RFC1918 in most clusters) —
@@ -34,13 +44,24 @@
 # environmentNetworkPolicy comment in values.yaml for the extraEgress
 # allow-list an operator needs before enabling this in a cluster that
 # uses those features.
+{{- $namespaces := list }}
+{{- if .Values.functionNamespace }}
+{{- $namespaces = append $namespaces .Values.functionNamespace }}
+{{- else }}
+{{- $namespaces = append $namespaces .Values.defaultNamespace }}
+{{- end }}
+{{- range $ns := .Values.additionalFissionNamespaces }}
+{{- $namespaces = append $namespaces $ns }}
+{{- end }}
+{{- range $ns := ($namespaces | uniq) }}
+---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: environment-egress
-  namespace: {{ include "fission-function-ns" . | quote }}
+  namespace: {{ $ns | quote }}
   labels:
-    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
     svc: executor
 spec:
   podSelector:
@@ -50,7 +71,7 @@ spec:
   policyTypes:
     - Egress
   egress:
-    {{- if .Values.environmentNetworkPolicy.allowClusterDNS }}
+    {{- if $.Values.environmentNetworkPolicy.allowClusterDNS }}
     # Cluster DNS. Scoped to kube-system/kube-dns (the kubeadm/kOps/GKE/EKS
     # convention) rather than an unscoped `namespaceSelector: {}`, which
     # would admit any in-cluster listener on port 53 and undercut the
@@ -79,7 +100,8 @@ spec:
               - 172.16.0.0/12
               - 192.168.0.0/16
               - 169.254.0.0/16
-    {{- with .Values.environmentNetworkPolicy.extraEgress }}
+    {{- with $.Values.environmentNetworkPolicy.extraEgress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/fission-all/templates/executor/networkpolicy-environment-egress.yaml
+++ b/charts/fission-all/templates/executor/networkpolicy-environment-egress.yaml
@@ -26,6 +26,14 @@
 # above — NetworkPolicy podSelector only matches pods in the policy's own
 # namespace, so rendering this in the release namespace would make it a
 # no-op when functionNamespace differs.
+#
+# WARNING: the RFC1918 deny-list also blocks in-cluster control-plane
+# traffic (pod/Service CIDRs are themselves RFC1918 in most clusters) —
+# fetcher->storagesvc (package fetch), function->statesvc, and
+# agent->agentruntime (workspace sync) all cross it. See the
+# environmentNetworkPolicy comment in values.yaml for the extraEgress
+# allow-list an operator needs before enabling this in a cluster that
+# uses those features.
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/fission-all/templates/executor/networkpolicy-environment-egress.yaml
+++ b/charts/fission-all/templates/executor/networkpolicy-environment-egress.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: The Fission Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.environmentNetworkPolicy.enabled }}
+# Egress isolation for environment/function pods (abstraction E of the
+# agent-runtime abstraction stack; doc 13 §E). Every poolmgr generic and
+# specialized pod, and every newdeploy pod, carries the `environmentName`
+# label (fv1.ENVIRONMENT_NAME — see pkg/executor/executortype/poolmgr/gp_pod.go
+# and pkg/executor/executortype/newdeploy/newdeploymgr.go); this policy
+# selects on the label's presence, so it covers every environment
+# regardless of name. Container-executortype pods don't carry this label
+# and fall outside this policy.
+#
+# Default posture copies Agent Sandbox's SandboxTemplate-managed
+# NetworkPolicy default: allow general internet egress, deny RFC1918
+# (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) and link-local
+# (169.254.0.0/16, which also covers the 169.254.169.254 cloud metadata
+# endpoint) destinations. Cluster DNS (kube-system/kube-dns, port 53) is
+# allowed by default so hostname-based egress destinations resolve;
+# environmentNetworkPolicy.allowClusterDNS=false drops that rule for a
+# stricter numeric-IP-only posture.
+#
+# Rendered into the namespace where executor creates function pods
+# (`fission-function-ns` helper), same as functionpods-allow-internal
+# above — NetworkPolicy podSelector only matches pods in the policy's own
+# namespace, so rendering this in the release namespace would make it a
+# no-op when functionNamespace differs.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: environment-egress
+  namespace: {{ include "fission-function-ns" . | quote }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    svc: executor
+spec:
+  podSelector:
+    matchExpressions:
+      - key: environmentName
+        operator: Exists
+  policyTypes:
+    - Egress
+  egress:
+    {{- if .Values.environmentNetworkPolicy.allowClusterDNS }}
+    # Cluster DNS. Scoped to kube-system/kube-dns (the kubeadm/kOps/GKE/EKS
+    # convention) rather than an unscoped `namespaceSelector: {}`, which
+    # would admit any in-cluster listener on port 53 and undercut the
+    # RFC1918 deny-list below. A cluster running CoreDNS under a different
+    # label needs an extraEgress override.
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- end }}
+    # General egress: the whole internet except RFC1918 private ranges and
+    # link-local (which subsumes the 169.254.169.254 cloud metadata IP).
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 169.254.0.0/16
+    {{- with .Values.environmentNetworkPolicy.extraEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1737,9 +1737,45 @@ grafana:
 ## that don't already restrict pod-to-pod traffic.
 ##
 ## Requires a NetworkPolicy-aware CNI (Calico, Cilium, Weave, etc.).
-## Egress rules are intentionally not added in this round.
+## Egress rules are intentionally not added here — see the separate
+## `environmentNetworkPolicy` knob below for environment-pod egress.
 networkPolicy:
   enabled: false
+
+
+## environmentNetworkPolicy: egress isolation for environment/function pods.
+## When enabled, the chart renders one Egress-only NetworkPolicy selecting
+## every pod that carries the `environmentName` label — poolmgr generic and
+## specialized pods, and newdeploy pods (see pkg/apis/core/v1/const.go
+## ENVIRONMENT_NAME and pkg/executor/executortype/{poolmgr/gp_pod.go,
+## newdeploy/newdeploymgr.go}). Container-executortype pods don't carry this
+## label and are unaffected by this knob.
+##
+## Default posture mirrors Agent Sandbox's SandboxTemplate managed
+## NetworkPolicy default (their "good default" for agent pods): allow general
+## internet egress, deny RFC1918 (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
+## and link-local (169.254.0.0/16 — which also covers the 169.254.169.254
+## cloud metadata endpoint) destinations.
+##
+## Independent of the ingress-only `networkPolicy` knob above — enable
+## either or both. Requires a NetworkPolicy-aware CNI (Calico, Cilium,
+## Weave, etc.).
+##
+## Pod-level egress only. Per-agent egress policy (finer than per-pod) is
+## out of scope here — it is CNI-specific (e.g. Cilium identity-based
+## policy) and not something a portable Helm chart can author.
+environmentNetworkPolicy:
+  enabled: false
+  ## Allow egress to cluster DNS (kube-system/kube-dns, port 53 TCP+UDP).
+  ## Needed to resolve hostname-based egress destinations. Set false for a
+  ## stricter numeric-IP-only posture (mirrors the "DNS blocked" half of
+  ## Agent Sandbox's default posture).
+  allowClusterDNS: true
+  ## Extra raw NetworkPolicy egress rule entries (networking.k8s.io/v1
+  ## NetworkPolicyEgressRule shape), appended verbatim after the default
+  ## deny-list rule — e.g. to allow-list a specific in-cluster or RFC1918
+  ## destination the deny rule above would otherwise block.
+  extraEgress: []
 
 
 ## InternalAuth: HMAC-SHA256 application-layer authentication for the

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1777,6 +1777,21 @@ networkPolicy:
 ## out of scope here — it is CNI-specific (e.g. Cilium identity-based
 ## policy) and not something a portable Helm chart can author.
 ##
+## IPv4-only allow rule: the default posture's "allow general internet
+## egress" rule is `ipBlock: 0.0.0.0/0` only — there is no `::/0` rule. On a
+## dual-stack cluster this is still fail-closed (no accidental IPv6 egress
+## opens up) but it means IPv6 destinations are unreachable even where an
+## IPv4 destination would be allowed. Add an `::/0` ipBlock (with your
+## cluster's IPv6 pod/Service CIDRs excepted) via extraEgress if your
+## environment pods need outbound IPv6.
+##
+## NodeLocal DNSCache: the well-known NodeLocal DNSCache listener address
+## (169.254.20.10) falls inside the 169.254.0.0/16 link-local deny range,
+## so on a cluster running it, allowClusterDNS=true's kube-system/kube-dns
+## rule does not cover it — DNS resolution breaks even with the DNS knob on.
+## Add an extraEgress ipBlock allow for 169.254.20.10/32 port 53 (UDP+TCP)
+## if your cluster uses NodeLocal DNSCache.
+##
 ## THE RFC1918 DENY-LIST BLOCKS IN-CLUSTER CONTROL-PLANE TRAFFIC TOO — pod
 ## and Service CIDRs are themselves RFC1918 ranges in most clusters. If
 ## your environment pods also need any of the following, allow-list the

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1764,6 +1764,21 @@ networkPolicy:
 ## Pod-level egress only. Per-agent egress policy (finer than per-pod) is
 ## out of scope here — it is CNI-specific (e.g. Cilium identity-based
 ## policy) and not something a portable Helm chart can author.
+##
+## THE RFC1918 DENY-LIST BLOCKS IN-CLUSTER CONTROL-PLANE TRAFFIC TOO — pod
+## and Service CIDRs are themselves RFC1918 ranges in most clusters. If
+## your environment pods also need any of the following, allow-list the
+## destination via extraEgress before enabling this knob:
+##   - fetcher sidecar -> storagesvc (port 8000): package fetch at
+##     specialization time; without it, cold starts fail for every
+##     packaged (non-image-volume) function.
+##   - function pod -> statesvc (functionState.enabled): keyed state
+##     reads/writes.
+##   - agent pod -> agentruntime (agentRuntime.enabled): dispatch,
+##     workspace hydration/sync (abstraction C).
+## router -> function pod (port 8888) and executor -> fetcher (port 8000)
+## are unaffected: this policy governs EGRESS from environment pods, not
+## ingress to them.
 environmentNetworkPolicy:
   enabled: false
   ## Allow egress to cluster DNS (kube-system/kube-dns, port 53 TCP+UDP).

--- a/charts/fission-all/values.yaml
+++ b/charts/fission-all/values.yaml
@@ -1744,12 +1744,24 @@ networkPolicy:
 
 
 ## environmentNetworkPolicy: egress isolation for environment/function pods.
-## When enabled, the chart renders one Egress-only NetworkPolicy selecting
-## every pod that carries the `environmentName` label — poolmgr generic and
-## specialized pods, and newdeploy pods (see pkg/apis/core/v1/const.go
-## ENVIRONMENT_NAME and pkg/executor/executortype/{poolmgr/gp_pod.go,
-## newdeploy/newdeploymgr.go}). Container-executortype pods don't carry this
-## label and are unaffected by this knob.
+## When enabled, the chart renders one Egress-only NetworkPolicy per function
+## namespace, each selecting every pod in that namespace that carries the
+## `environmentName` label — poolmgr generic and specialized pods, and
+## newdeploy pods (see pkg/apis/core/v1/const.go ENVIRONMENT_NAME and
+## pkg/executor/executortype/{poolmgr/gp_pod.go, newdeploy/newdeploymgr.go}).
+## Container-executortype pods don't carry this label and are unaffected by
+## this knob.
+##
+## Namespace coverage: functionNamespace (or defaultNamespace when unset)
+## plus every additionalFissionNamespaces entry — the STATIC-tenancy
+## function-namespace set, mirrored from pkg/utils
+## NamespaceResolver.FunctionNamespaces. Under tenancy.mode: dynamic or
+## cluster, namespaces the tenant controller onboards at runtime are NOT in
+## that list and so are unknown at chart render time — this knob does not
+## enforce egress isolation for function pods in those namespaces. There is
+## no chart-level fix for that gap; a dynamic/cluster-tenancy install needs
+## an out-of-band mechanism (e.g. a controller that stamps the same policy
+## into each onboarded namespace) to get equivalent coverage.
 ##
 ## Default posture mirrors Agent Sandbox's SandboxTemplate managed
 ## NetworkPolicy default (their "good default" for agent pods): allow general

--- a/test/helm/environmentnetworkpolicy_test.go
+++ b/test/helm/environmentnetworkpolicy_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -204,19 +205,40 @@ func findIPBlockPeer(t *testing.T, np *networkingv1.NetworkPolicy, cidr string) 
 	return networkingv1.NetworkPolicyPeer{}
 }
 
-// hasDNSRule reports whether the policy admits egress to a kube-dns pod on
-// port 53.
+// hasDNSRule reports whether the policy admits egress to the kube-system/
+// kube-dns pod specifically, on port 53. Deliberately narrow — matching any
+// rule that merely mentions port 53 would also pass a regression that drops
+// the load-bearing kube-system namespaceSelector the template's own comment
+// calls out (letting env pods egress to any self-labelled k8s-app=kube-dns
+// pod in ANY namespace on port 53, not just the real cluster DNS).
 func hasDNSRule(np *networkingv1.NetworkPolicy) bool {
 	for _, rule := range np.Spec.Egress {
+		var scopedToKubeDNS bool
 		for _, to := range rule.To {
-			if to.PodSelector != nil && to.PodSelector.MatchLabels["k8s-app"] == "kube-dns" {
-				return true
+			if to.NamespaceSelector != nil &&
+				to.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == "kube-system" &&
+				to.PodSelector != nil &&
+				to.PodSelector.MatchLabels["k8s-app"] == "kube-dns" {
+				scopedToKubeDNS = true
 			}
 		}
+		if !scopedToKubeDNS {
+			continue
+		}
+		var udp53, tcp53 bool
 		for _, p := range rule.Ports {
-			if p.Port != nil && p.Port.IntVal == 53 {
-				return true
+			if p.Port == nil || p.Port.IntVal != 53 || p.Protocol == nil {
+				continue
 			}
+			switch *p.Protocol {
+			case corev1.ProtocolUDP:
+				udp53 = true
+			case corev1.ProtocolTCP:
+				tcp53 = true
+			}
+		}
+		if udp53 && tcp53 {
+			return true
 		}
 	}
 	return false

--- a/test/helm/environmentnetworkpolicy_test.go
+++ b/test/helm/environmentnetworkpolicy_test.go
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: The Fission Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+package helm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	fv1 "github.com/fission/fission/pkg/apis/core/v1"
+)
+
+// TestEnvironmentNetworkPolicyAbsentByDefault checks the knob is off by
+// default (values.yaml environmentNetworkPolicy.enabled: false), matching
+// the ingress-only networkPolicy knob's own default.
+func TestEnvironmentNetworkPolicyAbsentByDefault(t *testing.T) {
+	docs := render(t)
+	assert.Nil(t, docs.find("NetworkPolicy", "environment-egress"),
+		"no environment-egress NetworkPolicy should render when environmentNetworkPolicy.enabled is unset")
+}
+
+// TestEnvironmentNetworkPolicyIndependentOfIngressKnob checks the egress
+// knob renders on its own, independent of the ingress-only networkPolicy
+// flag — the two are documented as independently enableable in values.yaml.
+func TestEnvironmentNetworkPolicyIndependentOfIngressKnob(t *testing.T) {
+	docs := render(t, "--set", "environmentNetworkPolicy.enabled=true")
+	require.NotNil(t, docs.find("NetworkPolicy", "environment-egress"),
+		"environment-egress must render with environmentNetworkPolicy.enabled=true alone")
+	assert.Nil(t, docs.find("NetworkPolicy", "functionpods-allow-internal"),
+		"the unrelated ingress-only networkPolicy knob must stay off")
+}
+
+// TestEnvironmentNetworkPolicySelectorMatchesTheEnvironmentLabelConstant is
+// the drift tripwire: the podSelector's label key is a bare YAML string in
+// the template, not forced to agree with the Go constant poolmgr/newdeploy
+// actually stamp on pods (fv1.ENVIRONMENT_NAME). A rename of that constant
+// without updating the template silently un-scopes this policy — every
+// environment pod stops being selected — and the failure is invisible until
+// egress traffic is unexpectedly wide open in a cluster that thought it
+// wasn't.
+func TestEnvironmentNetworkPolicySelectorMatchesTheEnvironmentLabelConstant(t *testing.T) {
+	docs := render(t, "--set", "environmentNetworkPolicy.enabled=true")
+	np := networkPolicy(t, docs, "environment-egress")
+
+	require.NotNil(t, np.Spec.PodSelector.MatchExpressions)
+	var found bool
+	for _, expr := range np.Spec.PodSelector.MatchExpressions {
+		if expr.Key == fv1.ENVIRONMENT_NAME && expr.Operator == metav1.LabelSelectorOpExists {
+			found = true
+		}
+	}
+	assert.True(t, found,
+		"podSelector must match on the presence of the %q label (fv1.ENVIRONMENT_NAME), "+
+			"the label poolmgr and newdeploy stamp on every environment pod", fv1.ENVIRONMENT_NAME)
+}
+
+// TestEnvironmentNetworkPolicyDefaultPosture pins the default egress shape:
+// Egress-only policyType, a deny-list ipBlock rule covering RFC1918 +
+// link-local (which subsumes the 169.254.169.254 cloud metadata IP), and a
+// cluster-DNS allow rule present by default.
+func TestEnvironmentNetworkPolicyDefaultPosture(t *testing.T) {
+	docs := render(t, "--set", "environmentNetworkPolicy.enabled=true")
+	np := networkPolicy(t, docs, "environment-egress")
+
+	require.Equal(t, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress}, np.Spec.PolicyTypes)
+
+	peer := findIPBlockPeer(t, np, "0.0.0.0/0")
+	assert.ElementsMatch(t, []string{
+		"10.0.0.0/8",
+		"172.16.0.0/12",
+		"192.168.0.0/16",
+		"169.254.0.0/16",
+	}, peer.IPBlock.Except, "RFC1918 + link-local must all be excluded from the allowed CIDR")
+
+	assert.True(t, hasDNSRule(np), "cluster-DNS egress rule must be present by default (allowClusterDNS defaults true)")
+}
+
+// TestEnvironmentNetworkPolicyAllowClusterDNSFalseDropsTheDNSRule checks the
+// knob actually removes the DNS rule rather than just being decorative,
+// leaving only the RFC1918/link-local deny-list rule.
+func TestEnvironmentNetworkPolicyAllowClusterDNSFalseDropsTheDNSRule(t *testing.T) {
+	docs := render(t,
+		"--set", "environmentNetworkPolicy.enabled=true",
+		"--set", "environmentNetworkPolicy.allowClusterDNS=false")
+	np := networkPolicy(t, docs, "environment-egress")
+
+	assert.False(t, hasDNSRule(np), "allowClusterDNS=false must drop the cluster-DNS egress rule")
+	require.Len(t, np.Spec.Egress, 1, "only the deny-list ipBlock rule should remain")
+	require.NotNil(t, np.Spec.Egress[0].To[0].IPBlock)
+	assert.Equal(t, "0.0.0.0/0", np.Spec.Egress[0].To[0].IPBlock.CIDR)
+}
+
+// TestEnvironmentNetworkPolicyExtraEgressAppends checks extraEgress entries
+// are appended verbatim, letting an operator allow-list a destination the
+// default deny-list rule would otherwise block (e.g. a specific RFC1918
+// in-cluster service).
+func TestEnvironmentNetworkPolicyExtraEgressAppends(t *testing.T) {
+	docs := render(t,
+		"--set", "environmentNetworkPolicy.enabled=true",
+		"--set", "environmentNetworkPolicy.extraEgress[0].to[0].ipBlock.cidr=10.96.0.0/12")
+	np := networkPolicy(t, docs, "environment-egress")
+
+	found := false
+	for _, rule := range np.Spec.Egress {
+		for _, to := range rule.To {
+			if to.IPBlock != nil && to.IPBlock.CIDR == "10.96.0.0/12" {
+				found = true
+			}
+		}
+	}
+	assert.True(t, found, "extraEgress entry must be appended to the rendered policy")
+}
+
+// findIPBlockPeer returns the first egress `to` peer that is an ipBlock with
+// the given CIDR, failing the test when none matches.
+func findIPBlockPeer(t *testing.T, np *networkingv1.NetworkPolicy, cidr string) networkingv1.NetworkPolicyPeer {
+	t.Helper()
+	for _, rule := range np.Spec.Egress {
+		for _, to := range rule.To {
+			if to.IPBlock != nil && to.IPBlock.CIDR == cidr {
+				return to
+			}
+		}
+	}
+	require.Fail(t, "no egress ipBlock peer found", "expected an ipBlock rule with cidr %q", cidr)
+	return networkingv1.NetworkPolicyPeer{}
+}
+
+// hasDNSRule reports whether the policy admits egress to a kube-dns pod on
+// port 53.
+func hasDNSRule(np *networkingv1.NetworkPolicy) bool {
+	for _, rule := range np.Spec.Egress {
+		for _, to := range rule.To {
+			if to.PodSelector != nil && to.PodSelector.MatchLabels["k8s-app"] == "kube-dns" {
+				return true
+			}
+		}
+		for _, p := range rule.Ports {
+			if p.Port != nil && p.Port.IntVal == 53 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/test/helm/environmentnetworkpolicy_test.go
+++ b/test/helm/environmentnetworkpolicy_test.go
@@ -59,6 +59,55 @@ func TestEnvironmentNetworkPolicyNamespaceScope(t *testing.T) {
 	})
 }
 
+// TestEnvironmentNetworkPolicyCoversAdditionalFissionNamespaces pins the
+// STATIC-tenancy multi-namespace case: function pods for functions in
+// additionalFissionNamespaces live in their own namespace (pkg/utils
+// NamespaceResolver.GetFunctionNS maps only the DEFAULT namespace through
+// functionNamespace), so a single copy of this policy would silently leave
+// those pods' egress unenforced. The template must render one copy per
+// namespace in the set — mirroring router/role-dataplane.yaml's own range —
+// and none of them in the release namespace, which is not itself a function
+// namespace.
+func TestEnvironmentNetworkPolicyCoversAdditionalFissionNamespaces(t *testing.T) {
+	t.Run("functionNamespace unset: defaultNamespace plus additional", func(t *testing.T) {
+		docs := render(t,
+			"--set", "environmentNetworkPolicy.enabled=true",
+			"--set", "additionalFissionNamespaces[0]=team-a",
+			"--set", "additionalFissionNamespaces[1]=team-b")
+
+		policies := docs.findAllNamed("NetworkPolicy", "environment-egress")
+		var namespaces []string
+		for _, p := range policies {
+			namespaces = append(namespaces, p.Namespace)
+		}
+		assert.ElementsMatch(t, []string{"default", "team-a", "team-b"}, namespaces,
+			"must render one environment-egress policy per function namespace")
+
+		for _, ns := range []string{"default", "team-a", "team-b"} {
+			require.NotNilf(t, docs.findInNamespace("NetworkPolicy", "environment-egress", ns),
+				"expected an environment-egress policy in namespace %q", ns)
+		}
+		assert.Nil(t, docs.findInNamespace("NetworkPolicy", "environment-egress", "fission"),
+			"the release namespace is not a function namespace and must not get a copy")
+	})
+
+	t.Run("functionNamespace set: functionNamespace plus additional, defaultNamespace excluded", func(t *testing.T) {
+		docs := render(t,
+			"--set", "environmentNetworkPolicy.enabled=true",
+			"--set", "functionNamespace=fission-function",
+			"--set", "additionalFissionNamespaces[0]=team-a")
+
+		policies := docs.findAllNamed("NetworkPolicy", "environment-egress")
+		var namespaces []string
+		for _, p := range policies {
+			namespaces = append(namespaces, p.Namespace)
+		}
+		assert.ElementsMatch(t, []string{"fission-function", "team-a"}, namespaces,
+			"functionNamespace replaces the default-namespace entry; additionalFissionNamespaces "+
+				"still get their own copy")
+	})
+}
+
 // TestEnvironmentNetworkPolicySelectorMatchesTheEnvironmentLabelConstant is
 // the drift tripwire: the podSelector's label key is a bare YAML string in
 // the template, not forced to agree with the Go constant poolmgr/newdeploy

--- a/test/helm/environmentnetworkpolicy_test.go
+++ b/test/helm/environmentnetworkpolicy_test.go
@@ -34,6 +34,31 @@ func TestEnvironmentNetworkPolicyIndependentOfIngressKnob(t *testing.T) {
 		"the unrelated ingress-only networkPolicy knob must stay off")
 }
 
+// TestEnvironmentNetworkPolicyNamespaceScope pins the failure mode the
+// template's own comment names: NetworkPolicy podSelector only matches pods
+// in the policy's own namespace, so this must render into
+// fission-function-ns (functionNamespace if set, else defaultNamespace),
+// never the release namespace — otherwise it silently becomes a no-op
+// whenever functionNamespace differs (e.g. the kind-ci profile, which sets
+// functionNamespace=fission-function while the release lives in "fission").
+func TestEnvironmentNetworkPolicyNamespaceScope(t *testing.T) {
+	t.Run("defaultNamespace when functionNamespace unset", func(t *testing.T) {
+		docs := render(t, "--set", "environmentNetworkPolicy.enabled=true")
+		np := networkPolicy(t, docs, "environment-egress")
+		assert.Equal(t, "default", np.Namespace, "must fall back to defaultNamespace")
+	})
+
+	t.Run("functionNamespace when set", func(t *testing.T) {
+		docs := render(t,
+			"--set", "environmentNetworkPolicy.enabled=true",
+			"--set", "functionNamespace=fission-function")
+		np := networkPolicy(t, docs, "environment-egress")
+		assert.Equal(t, "fission-function", np.Namespace,
+			"must follow functionNamespace, not the release namespace — a mismatch here "+
+				"silently no-ops the policy since podSelector only matches its own namespace")
+	})
+}
+
 // TestEnvironmentNetworkPolicySelectorMatchesTheEnvironmentLabelConstant is
 // the drift tripwire: the podSelector's label key is a bare YAML string in
 // the template, not forced to agree with the Go constant poolmgr/newdeploy

--- a/test/helm/helmrender_test.go
+++ b/test/helm/helmrender_test.go
@@ -28,8 +28,9 @@ import (
 // into a typed object on demand by decodeAs.
 type manifest struct {
 	metav1.TypeMeta
-	Name string
-	raw  []byte
+	Name      string
+	Namespace string
+	raw       []byte
 }
 
 // manifests is a rendered chart.
@@ -70,9 +71,10 @@ func parseManifests(t *testing.T, stream string) manifests {
 			continue
 		}
 		docs = append(docs, manifest{
-			TypeMeta: head.TypeMeta,
-			Name:     head.Metadata.Name,
-			raw:      []byte(doc),
+			TypeMeta:  head.TypeMeta,
+			Name:      head.Metadata.Name,
+			Namespace: head.Metadata.Namespace,
+			raw:       []byte(doc),
 		})
 	}
 	require.NotEmpty(t, docs)
@@ -106,6 +108,30 @@ func render(t *testing.T, extraArgs ...string) manifests {
 func (ms manifests) find(kind, name string) *manifest {
 	for i := range ms {
 		if ms[i].Kind == kind && ms[i].Name == name {
+			return &ms[i]
+		}
+	}
+	return nil
+}
+
+// findAllNamed returns every doc with the given kind and metadata.name,
+// across every namespace it renders into — for templates that emit one copy
+// per namespace (e.g. environment-egress, router-dataplane).
+func (ms manifests) findAllNamed(kind, name string) manifests {
+	var out manifests
+	for i := range ms {
+		if ms[i].Kind == kind && ms[i].Name == name {
+			out = append(out, ms[i])
+		}
+	}
+	return out
+}
+
+// findInNamespace returns the doc with the given kind, metadata.name, and
+// metadata.namespace, or nil.
+func (ms manifests) findInNamespace(kind, name, namespace string) *manifest {
+	for i := range ms {
+		if ms[i].Kind == kind && ms[i].Name == name && ms[i].Namespace == namespace {
 			return &ms[i]
 		}
 	}


### PR DESCRIPTION
## What

Chart-only: `environmentNetworkPolicy.{enabled, allowClusterDNS, extraEgress[]}` (default off) templates an egress NetworkPolicy selecting environment pods: internet egress allowed, RFC1918 / link-local / metadata ranges denied, cluster DNS deniable. This is the secure-by-default posture agent workloads want without any Go changes.

## Notes for reviewers

- Enabling it also blocks in-cluster control-plane flows that cross RFC1918 space from the same pods: fetcher→storagesvc (cold-start package fetch), function pod→statesvc, agent pod→agentruntime (workspace sync). The required `extraEgress` allow-list entries are documented in values.yaml and the template comment rather than carved out unilaterally — whether a default carve-out for those three flows belongs in the chart is a deliberate rollout-time call.
- Known edge: with `defaultNamespace` set to a non-default value plus `functionNamespace`, the template's namespace mapping diverges from `GetFunctionNS` (which maps only the literal `default`); noted in the template comment, follow-up if that configuration is ever exercised.

## Tests

helm lint green; 8 render-assertion subtests in `test/helm/environmentnetworkpolicy_test.go` (on/off gating, CIDR set, DNS toggle, extraEgress passthrough, namespace scoping) alongside the existing NetworkPolicy render tests.